### PR TITLE
Add incremental index update via --commits and --files options

### DIFF
--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -152,6 +152,28 @@ public class DbWriter
     }
 
     /// <summary>
+    /// Delete a file and its associated data by relative path. Returns true if found.
+    /// 相対パスでファイルと関連データを削除する。見つかればtrueを返す。
+    /// </summary>
+    public bool DeleteFileByPath(string relativePath)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT id FROM files WHERE path = @path";
+        cmd.Parameters.AddWithValue("@path", relativePath);
+        var result = cmd.ExecuteScalar();
+        if (result == null) return false;
+
+        var fileId = (long)result;
+        DeleteFileData(fileId);
+
+        using var cmd2 = _conn.CreateCommand();
+        cmd2.CommandText = "DELETE FROM files WHERE id = @id";
+        cmd2.Parameters.AddWithValue("@id", fileId);
+        cmd2.ExecuteNonQuery();
+        return true;
+    }
+
+    /// <summary>
     /// Remove files from DB that no longer exist on disk (e.g. after branch switch).
     /// ディスク上に存在しなくなったファイルをDBから削除する（ブランチ切り替え対応）。
     /// </summary>

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -3,7 +3,7 @@ using CodeIndex.Database;
 using CodeIndex.Indexer;
 
 // Parse command-line arguments / コマンドライン引数を解析
-var (projectPath, dbPath, rebuild, verbose) = ParseArgs(args);
+var (projectPath, dbPath, rebuild, verbose, commits, updateFiles) = ParseArgs(args);
 
 if (projectPath == null)
 {
@@ -12,7 +12,8 @@ if (projectPath == null)
 }
 
 var stopwatch = Stopwatch.StartNew();
-var mode = rebuild ? "rebuild" : "incremental";
+var isUpdateMode = commits.Count > 0 || updateFiles.Count > 0;
+var mode = rebuild ? "rebuild" : isUpdateMode ? "update" : "incremental";
 
 Console.WriteLine("CodeIndex v1.0.0");
 Console.WriteLine("================");
@@ -24,6 +25,12 @@ Console.WriteLine();
 if (!Directory.Exists(projectPath))
 {
     Console.Error.WriteLine($"Error: directory not found: {projectPath}");
+    return 1;
+}
+
+if (rebuild && isUpdateMode)
+{
+    Console.Error.WriteLine("Error: --rebuild cannot be used with --commits or --files");
     return 1;
 }
 
@@ -40,92 +47,212 @@ db.InitializeSchema();
 
 var writer = new DbWriter(db.Connection);
 var indexer = new FileIndexer(projectPath);
+var projectRoot = Path.GetFullPath(projectPath);
 
-// Phase 1: Scan files / フェーズ1: ファイル走査
-Console.WriteLine("Scanning...");
-var files = indexer.ScanFiles();
-Console.WriteLine($"  Found {files.Count:N0} files");
-Console.WriteLine();
-
-// Phase 1.5: Purge stale files (handles branch switches)
-// フェーズ1.5: 古いファイルを削除（ブランチ切り替え対応）
-var purged = writer.PurgeStaleFiles(Path.GetFullPath(projectPath));
-if (purged > 0)
-    Console.WriteLine($"  Purged {purged:N0} stale files (no longer on disk)");
-
-// Phase 2: Index files / フェーズ2: ファイルインデックス
-Console.WriteLine("Indexing...");
-int processed = 0;
-int skipped = 0;
-int errors = 0;
-
-foreach (var filePath in files)
+if (isUpdateMode)
 {
-    try
-    {
-        var (record, content) = indexer.BuildRecord(filePath);
+    // Update mode: process only specified files
+    // 更新モード: 指定ファイルのみ処理
+    var targetPaths = new HashSet<string>(StringComparer.Ordinal);
 
-        // Incremental: skip unchanged files / インクリメンタル: 未変更ファイルをスキップ
-        var existingId = writer.GetUnchangedFileId(record.Path, record.Modified);
-        if (existingId != null)
+    // Resolve files from commit IDs / コミットIDから変更ファイルを解決
+    if (commits.Count > 0)
+    {
+        Console.WriteLine($"Resolving changed files from {commits.Count} commit(s)...");
+        foreach (var commit in commits)
         {
-            skipped++;
-            processed++;
+            var changedFiles = GetChangedFilesFromCommit(projectRoot, commit);
+            foreach (var f in changedFiles)
+                targetPaths.Add(f);
+        }
+        Console.WriteLine($"  Found {targetPaths.Count} changed file(s) from git");
+    }
+
+    // Resolve explicitly specified files / 明示的に指定されたファイルを解決
+    if (updateFiles.Count > 0)
+    {
+        foreach (var f in updateFiles)
+        {
+            var absPath = Path.IsPathRooted(f) ? f : Path.GetFullPath(Path.Combine(projectRoot, f));
+            var relPath = Path.GetRelativePath(projectRoot, absPath).Replace('\\', '/');
+            targetPaths.Add(relPath);
+        }
+    }
+
+    Console.WriteLine($"Updating {targetPaths.Count} file(s)...");
+    int updated = 0, removed = 0, skipped = 0, errors = 0;
+
+    foreach (var relPath in targetPaths)
+    {
+        var absPath = Path.Combine(projectRoot, relPath.Replace('/', Path.DirectorySeparatorChar));
+        try
+        {
+            if (!File.Exists(absPath))
+            {
+                // File deleted: remove from DB / ファイル削除済み: DBから除去
+                if (writer.DeleteFileByPath(relPath))
+                {
+                    removed++;
+                    if (verbose)
+                        Console.WriteLine($"  [DEL]  {relPath}");
+                }
+                else
+                {
+                    skipped++;
+                    if (verbose)
+                        Console.WriteLine($"  [SKIP] {relPath} (not in DB)");
+                }
+                continue;
+            }
+
+            // Check if file type is supported / サポート対象のファイル種別か確認
+            if (FileIndexer.DetectLanguage(absPath) == null)
+            {
+                skipped++;
+                if (verbose)
+                    Console.WriteLine($"  [SKIP] {relPath} (unsupported type)");
+                continue;
+            }
+
+            var (record, content) = indexer.BuildRecord(absPath);
+            var fileId = writer.UpsertFile(record);
+
+            // Delete old chunks/symbols before re-indexing
+            // 再インデックス前に古いチャンク・シンボルを削除
+            writer.DeleteFileData(fileId);
+
+            // Split into chunks / チャンクに分割
+            var chunks = ChunkSplitter.Split(fileId, content);
+            writer.InsertChunks(chunks);
+
+            // Extract symbols / シンボルを抽出
+            var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
+            writer.InsertSymbols(symbols);
+
+            updated++;
             if (verbose)
-                Console.WriteLine($"  [SKIP] {record.Path}");
-            PrintProgress(processed, files.Count);
-            continue;
+                Console.WriteLine($"  [OK]   {relPath} ({chunks.Count} chunks, {symbols.Count} symbols)");
+        }
+        catch (Exception ex)
+        {
+            errors++;
+            if (verbose)
+                Console.Error.WriteLine($"  [ERR]  {relPath}: {ex.Message}\n{ex.StackTrace}");
+            else
+                Console.Error.WriteLine($"  [ERR]  {relPath}: {ex.Message}");
+        }
+    }
+
+    Console.WriteLine();
+
+    // Summary / サマリー
+    stopwatch.Stop();
+    var (totalFiles, totalChunks, totalSymbols) = writer.GetCounts();
+
+    Console.WriteLine();
+    Console.WriteLine("Done.");
+    Console.WriteLine($"  Files   : {totalFiles:N0} (total in DB)");
+    Console.WriteLine($"  Chunks  : {totalChunks:N0}");
+    Console.WriteLine($"  Symbols : {totalSymbols:N0}");
+    Console.WriteLine($"  Updated : {updated:N0}");
+    if (removed > 0)
+        Console.WriteLine($"  Removed : {removed:N0}");
+    if (skipped > 0)
+        Console.WriteLine($"  Skipped : {skipped:N0}");
+    if (errors > 0)
+        Console.WriteLine($"  Errors  : {errors:N0}");
+    Console.WriteLine($"  Elapsed : {stopwatch.Elapsed:hh\\:mm\\:ss}");
+}
+else
+{
+    // Full scan mode (existing behavior) / フルスキャンモード（既存の動作）
+
+    // Phase 1: Scan files / フェーズ1: ファイル走査
+    Console.WriteLine("Scanning...");
+    var files = indexer.ScanFiles();
+    Console.WriteLine($"  Found {files.Count:N0} files");
+    Console.WriteLine();
+
+    // Phase 1.5: Purge stale files (handles branch switches)
+    // フェーズ1.5: 古いファイルを削除（ブランチ切り替え対応）
+    var purged = writer.PurgeStaleFiles(projectRoot);
+    if (purged > 0)
+        Console.WriteLine($"  Purged {purged:N0} stale files (no longer on disk)");
+
+    // Phase 2: Index files / フェーズ2: ファイルインデックス
+    Console.WriteLine("Indexing...");
+    int processed = 0;
+    int skipped = 0;
+    int errors = 0;
+
+    foreach (var filePath in files)
+    {
+        try
+        {
+            var (record, content) = indexer.BuildRecord(filePath);
+
+            // Incremental: skip unchanged files / インクリメンタル: 未変更ファイルをスキップ
+            var existingId = writer.GetUnchangedFileId(record.Path, record.Modified);
+            if (existingId != null)
+            {
+                skipped++;
+                processed++;
+                if (verbose)
+                    Console.WriteLine($"  [SKIP] {record.Path}");
+                PrintProgress(processed, files.Count);
+                continue;
+            }
+
+            // Upsert file record / ファイルレコードをUPSERT
+            var fileId = writer.UpsertFile(record);
+
+            // Delete old chunks/symbols before re-indexing
+            // 再インデックス前に古いチャンク・シンボルを削除
+            writer.DeleteFileData(fileId);
+
+            // Split into chunks / チャンクに分割
+            var chunks = ChunkSplitter.Split(fileId, content);
+            writer.InsertChunks(chunks);
+
+            // Extract symbols / シンボルを抽出
+            var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
+            writer.InsertSymbols(symbols);
+
+            if (verbose)
+                Console.WriteLine($"  [OK]   {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols)");
+        }
+        catch (Exception ex)
+        {
+            // Always count errors; show details in verbose mode
+            // エラーは常にカウント、詳細はverboseモードで表示
+            errors++;
+            if (verbose)
+                Console.Error.WriteLine($"  [ERR]  {filePath}: {ex.Message}\n{ex.StackTrace}");
+            else
+                Console.Error.WriteLine($"  [ERR]  {filePath}: {ex.Message}");
         }
 
-        // Upsert file record / ファイルレコードをUPSERT
-        var fileId = writer.UpsertFile(record);
-
-        // Delete old chunks/symbols before re-indexing
-        // 再インデックス前に古いチャンク・シンボルを削除
-        writer.DeleteFileData(fileId);
-
-        // Split into chunks / チャンクに分割
-        var chunks = ChunkSplitter.Split(fileId, content);
-        writer.InsertChunks(chunks);
-
-        // Extract symbols / シンボルを抽出
-        var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
-        writer.InsertSymbols(symbols);
-
-        if (verbose)
-            Console.WriteLine($"  [OK]   {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols)");
-    }
-    catch (Exception ex)
-    {
-        // Always count errors; show details in verbose mode
-        // エラーは常にカウント、詳細はverboseモードで表示
-        errors++;
-        if (verbose)
-            Console.Error.WriteLine($"  [ERR]  {filePath}: {ex.Message}\n{ex.StackTrace}");
-        else
-            Console.Error.WriteLine($"  [ERR]  {filePath}: {ex.Message}");
+        processed++;
+        PrintProgress(processed, files.Count);
     }
 
-    processed++;
-    PrintProgress(processed, files.Count);
+    Console.WriteLine();
+
+    // Summary / サマリー
+    stopwatch.Stop();
+    var (totalFiles, totalChunks, totalSymbols) = writer.GetCounts();
+
+    Console.WriteLine();
+    Console.WriteLine("Done.");
+    Console.WriteLine($"  Files   : {totalFiles:N0}");
+    Console.WriteLine($"  Chunks  : {totalChunks:N0}");
+    Console.WriteLine($"  Symbols : {totalSymbols:N0}");
+    if (skipped > 0)
+        Console.WriteLine($"  Skipped : {skipped:N0} (unchanged)");
+    if (errors > 0)
+        Console.WriteLine($"  Errors  : {errors:N0}");
+    Console.WriteLine($"  Elapsed : {stopwatch.Elapsed:hh\\:mm\\:ss}");
 }
-
-Console.WriteLine();
-
-// Summary / サマリー
-stopwatch.Stop();
-var (totalFiles, totalChunks, totalSymbols) = writer.GetCounts();
-
-Console.WriteLine();
-Console.WriteLine("Done.");
-Console.WriteLine($"  Files   : {totalFiles:N0}");
-Console.WriteLine($"  Chunks  : {totalChunks:N0}");
-Console.WriteLine($"  Symbols : {totalSymbols:N0}");
-if (skipped > 0)
-    Console.WriteLine($"  Skipped : {skipped:N0} (unchanged)");
-if (errors > 0)
-    Console.WriteLine($"  Errors  : {errors:N0}");
-Console.WriteLine($"  Elapsed : {stopwatch.Elapsed:hh\\:mm\\:ss}");
 
 return 0;
 
@@ -141,13 +268,43 @@ static void PrintProgress(int current, int total)
     }
 }
 
+// Get changed files from a git commit / gitコミットから変更ファイルを取得
+static List<string> GetChangedFilesFromCommit(string projectRoot, string commitId)
+{
+    var psi = new ProcessStartInfo
+    {
+        FileName = "git",
+        Arguments = $"diff-tree --no-commit-id -r --name-only {commitId}",
+        WorkingDirectory = projectRoot,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true,
+    };
+
+    using var process = Process.Start(psi)
+        ?? throw new InvalidOperationException("Failed to start git process / gitプロセスの起動に失敗");
+    var output = process.StandardOutput.ReadToEnd();
+    var error = process.StandardError.ReadToEnd();
+    process.WaitForExit();
+
+    if (process.ExitCode != 0)
+        throw new InvalidOperationException($"git diff-tree failed for commit {commitId}: {error.Trim()}");
+
+    return output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+        .Select(p => p.Replace('\\', '/'))
+        .ToList();
+}
+
 // Parse CLI arguments / CLI引数を解析
-static (string? projectPath, string dbPath, bool rebuild, bool verbose) ParseArgs(string[] args)
+static (string? projectPath, string dbPath, bool rebuild, bool verbose, List<string> commits, List<string> updateFiles) ParseArgs(string[] args)
 {
     string? projectPath = null;
     string dbPath = "codeindex.db";
     bool rebuild = false;
     bool verbose = false;
+    var commits = new List<string>();
+    var updateFiles = new List<string>();
 
     for (int i = 0; i < args.Length; i++)
     {
@@ -162,8 +319,20 @@ static (string? projectPath, string dbPath, bool rebuild, bool verbose) ParseArg
             case "--verbose":
                 verbose = true;
                 break;
+            case "--commits":
+                // Consume subsequent non-flag arguments as commit IDs
+                // 後続のフラグ以外の引数をコミットIDとして取得
+                while (i + 1 < args.Length && !args[i + 1].StartsWith("--"))
+                    commits.Add(args[++i]);
+                break;
+            case "--files":
+                // Consume subsequent non-flag arguments as file paths
+                // 後続のフラグ以外の引数をファイルパスとして取得
+                while (i + 1 < args.Length && !args[i + 1].StartsWith("--"))
+                    updateFiles.Add(args[++i]);
+                break;
             case "--help" or "-h":
-                return (null, dbPath, rebuild, verbose);
+                return (null, dbPath, rebuild, verbose, commits, updateFiles);
             default:
                 if (!args[i].StartsWith('-'))
                     projectPath = args[i];
@@ -171,7 +340,7 @@ static (string? projectPath, string dbPath, bool rebuild, bool verbose) ParseArg
         }
     }
 
-    return (projectPath, dbPath, rebuild, verbose);
+    return (projectPath, dbPath, rebuild, verbose, commits, updateFiles);
 }
 
 // Print usage information / 使い方を表示
@@ -182,11 +351,18 @@ static void PrintUsage()
     Console.WriteLine("Usage: codeindex <projectPath> [options]");
     Console.WriteLine();
     Console.WriteLine("Arguments:");
-    Console.WriteLine("  projectPath    Path to the project to index");
+    Console.WriteLine("  projectPath                Path to the project to index");
     Console.WriteLine();
     Console.WriteLine("Options:");
-    Console.WriteLine("  --db <path>    Output database file path (default: codeindex.db)");
-    Console.WriteLine("  --rebuild      Delete existing DB and rebuild from scratch");
-    Console.WriteLine("  --verbose      Show verbose output");
-    Console.WriteLine("  --help, -h     Show this help message");
+    Console.WriteLine("  --db <path>                Output database file path (default: codeindex.db)");
+    Console.WriteLine("  --rebuild                  Delete existing DB and rebuild from scratch");
+    Console.WriteLine("  --verbose                  Show verbose output");
+    Console.WriteLine("  --commits <id> [id ...]    Update only files changed in the specified git commits");
+    Console.WriteLine("  --files <path> [path ...]  Update only the specified files (relative or absolute)");
+    Console.WriteLine("  --help, -h                 Show this help message");
+    Console.WriteLine();
+    Console.WriteLine("Examples:");
+    Console.WriteLine("  codeindex ./myproject                           Full incremental index");
+    Console.WriteLine("  codeindex ./myproject --commits abc123 def456   Update files from commits");
+    Console.WriteLine("  codeindex ./myproject --files src/app.cs        Update specific files");
 }

--- a/tests/CodeIndex.Tests/UnitTest1.cs
+++ b/tests/CodeIndex.Tests/UnitTest1.cs
@@ -512,6 +512,60 @@ public class DatabaseTests : IDisposable
         Assert.Equal(0, symbols);
     }
 
+    [Fact]
+    public void DeleteFileByPath_RemovesFileAndData()
+    {
+        // Insert a file with chunks and symbols, then delete by path
+        // ファイルとチャンク・シンボルを挿入し、パスで削除
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/remove_me.py", Lang = "python", Size = 50, Lines = 5,
+            Modified = DateTime.UtcNow,
+        });
+
+        _writer.InsertChunks([new() { FileId = fileId, ChunkIndex = 0, StartLine = 1, EndLine = 5, Content = "def foo(): pass" }]);
+        _writer.InsertSymbols([new() { FileId = fileId, Kind = "function", Name = "foo", Line = 1 }]);
+
+        var result = _writer.DeleteFileByPath("src/remove_me.py");
+        Assert.True(result);
+
+        var (files, chunks, symbols) = _writer.GetCounts();
+        Assert.Equal(0, files);
+        Assert.Equal(0, chunks);
+        Assert.Equal(0, symbols);
+    }
+
+    [Fact]
+    public void DeleteFileByPath_ReturnsFalseIfNotFound()
+    {
+        // Deleting a non-existent path returns false
+        // 存在しないパスの削除はfalseを返す
+        var result = _writer.DeleteFileByPath("nonexistent/file.py");
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteFileByPath_DoesNotAffectOtherFiles()
+    {
+        // Deleting one file should not affect another
+        // 1ファイルの削除は他のファイルに影響しない
+        _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/keep.py", Lang = "python", Size = 50, Lines = 5,
+            Modified = DateTime.UtcNow,
+        });
+        _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/delete.py", Lang = "python", Size = 30, Lines = 3,
+            Modified = DateTime.UtcNow,
+        });
+
+        _writer.DeleteFileByPath("src/delete.py");
+
+        var (files, _, _) = _writer.GetCounts();
+        Assert.Equal(1, files);
+    }
+
     public void Dispose()
     {
         _db.Dispose();


### PR DESCRIPTION
Support partial index updates without rebuilding the entire DB:
- --commits <id> [id ...]: resolve changed files from git commits and update only those
- --files <path> [path ...]: update specific files by relative or absolute path
- Deleted files are automatically removed from the DB
- Added DeleteFileByPath method to DbWriter for targeted file removal
- Added 3 tests for DeleteFileByPath behavior

https://claude.ai/code/session_01Wd1qTQgyKrP5UU7ZFubwdd