### PR TITLE
Improve CLI UX: human-readable default, spinner, aligned verbose tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ dotnet run --project src/CodeIndex -- <command> [options]
 cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--json]
 cdidx <projectPath>                          # shorthand for 'index'
 
-# Query (default output: JSON lines for AI consumption)
-cdidx search <query> [--db <path>] [--limit <n>] [--lang <lang>] [--json|--no-json]
+# Query (default output: human-readable; use --json for AI consumption)
+cdidx search <query> [--db <path>] [--limit <n>] [--lang <lang>] [--json]
 cdidx symbols [query] [--kind <kind>] [--lang <lang>] [--limit <n>]
 cdidx files [query] [--lang <lang>] [--limit <n>]
 cdidx status [--json]
@@ -50,7 +50,7 @@ tests/CodeIndex.Tests/
 - **Batch commits** — 500 records per transaction for write performance.
 - **FTS5** — `fts_chunks` virtual table mirrors `chunks.content` for full-text search.
 - **Regex symbol extraction** — Intentionally simple. Accuracy is secondary to speed and portability.
-- **JSON-first for queries** — search/symbols/files default to JSON lines output (AI-friendly). Use `--no-json` for human-readable.
+- **Human-readable default** — All commands default to human-readable output. Use `--json` for machine-readable JSON lines (AI-friendly).
 - **Structured exit codes** — 0=success, 1=usage error, 2=not found, 3=database error.
 
 ## Conventions
@@ -82,8 +82,8 @@ dotnet run --project src/CodeIndex -- <command> [options]
 cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--json]
 cdidx <projectPath>                          # 'index'の省略形
 
-# クエリ（デフォルト出力: AI向けJSONライン）
-cdidx search <query> [--db <path>] [--limit <n>] [--lang <lang>] [--json|--no-json]
+# クエリ（デフォルト出力: 人間向け; --jsonでAI向け出力）
+cdidx search <query> [--db <path>] [--limit <n>] [--lang <lang>] [--json]
 cdidx symbols [query] [--kind <kind>] [--lang <lang>] [--limit <n>]
 cdidx files [query] [--lang <lang>] [--limit <n>]
 cdidx status [--json]
@@ -113,7 +113,7 @@ tests/CodeIndex.Tests/
 - **バッチコミット** — 書き込み性能のため1トランザクション500レコード。
 - **FTS5** — `fts_chunks`仮想テーブルが`chunks.content`をミラーして全文検索を提供。
 - **正規表現シンボル抽出** — 意図的にシンプル。速度とポータビリティを精度より優先。
-- **クエリはJSONファースト** — search/symbols/filesはデフォルトでJSONライン出力（AI向け）。`--no-json`で人間向け出力。
+- **人間向けがデフォルト** — 全コマンドのデフォルト出力は人間向け。`--json`でAI向けJSONライン出力に切り替え。
 - **構造化終了コード** — 0=成功、1=引数エラー、2=未検出、3=DBエラー。
 
 ## コーディング規約

--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ Languages:
 
 ## How it works
 
-cdidx scans your project directory, splits each source file into overlapping chunks, and stores everything in a SQLite database with FTS5 full-text search. Incremental mode (default) compares each file's last-modified timestamp against the database and skips unchanged files entirely, so re-indexing after a branch switch only processes the files that actually differ.
+cdidx scans your project directory, splits each source file into overlapping chunks, and stores everything in a SQLite database with FTS5 full-text search. Incremental mode (default) first purges database entries for files that no longer exist on disk, then checks each file's last-modified timestamp against the database — only files whose timestamp exactly matches are skipped, and any difference (newer or older) triggers re-indexing. Newly appeared files are indexed as new entries. This means re-indexing after a branch switch only processes the files that actually differ.
 
 ## Git branch switching
 
-The database reflects the working tree at the time of the last index. After switching branches, simply re-run `cdidx .` — only files whose timestamps differ from the database are re-indexed, so the update is proportional to the number of changed files, not the total project size.
+The database reflects the working tree at the time of the last index. After switching branches, simply re-run `cdidx .` — files that no longer exist on disk are purged from the database, newly appeared files are indexed, and existing files are re-indexed only when their timestamp differs. The update is proportional to the number of changed files, not the total project size.
 
 | Situation | What happens |
 |---|---|
@@ -588,11 +588,11 @@ Languages:
 
 ## 動作の仕組み
 
-cdidxはプロジェクトディレクトリを走査し、各ソースファイルを重複を持つチャンクに分割し、FTS5全文検索付きのSQLiteデータベースに格納します。インクリメンタルモード（デフォルト）では各ファイルの最終更新タイムスタンプをDB内の値と比較し、変更のないファイルは処理をスキップするため、ブランチ切り替え後の再インデックスでは実際に差分のあるファイルだけが処理されます。
+cdidxはプロジェクトディレクトリを走査し、各ソースファイルを重複を持つチャンクに分割し、FTS5全文検索付きのSQLiteデータベースに格納します。インクリメンタルモード（デフォルト）では各ファイルの最終更新タイムスタンプをDB内の値と比較し、完全一致するファイルのみスキップします。タイムスタンプが異なれば（新しくても古くても）再インデックスされるため、ブランチ切り替え後も正確にインデックスが更新されます。
 
 ## Gitブランチ切り替え
 
-データベースはインデックス実行時のワーキングツリーを反映します。ブランチ切り替え後は `cdidx .` を再実行してください。タイムスタンプが変わったファイルだけを再インデックスするため、更新量はプロジェクト全体のサイズではなく変更ファイル数に比例します。
+データベースはインデックス実行時のワーキングツリーを反映します。ブランチ切り替え後は `cdidx .` を再実行してください。ディスク上から消えたファイルはDBからパージされ、新たに現れたファイルはインデックスに追加され、既存ファイルはタイムスタンプが異なる場合のみ再インデックスされます。更新量はプロジェクト全体のサイズではなく変更ファイル数に比例します。
 
 | 状況 | 動作 |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ cdidx ./myproject --verbose     # show per-file details
 Default output:
 
 ```
-Scanning...
+⠹ Scanning...
   Found 42 files
 
 Indexing...
-  [=================>        ] 67%
+  ████████████████████░░░░░░░░░░░░  67.0%  [28/42]
 
 Done.
   Files   : 42
@@ -102,11 +102,13 @@ Done.
 With `--verbose`, each file also shows a status tag so you can see exactly what happened:
 
 ```
-  [OK]   src/app.cs (12 chunks, 5 symbols)   — indexed successfully
-  [SKIP] src/utils.cs                         — unchanged, skipped
-  [DEL]  src/old.cs                           — deleted from DB (file removed from disk)
-  [ERR]  src/bad.cs: <message>                — failed (includes stack trace in verbose)
+  [OK  ] src/app.cs (12 chunks, 5 symbols)
+  [SKIP] src/utils.cs
+  [DEL ] src/old.cs
+  [ERR ] src/bad.cs: <message>
 ```
+
+> `[OK  ]` = indexed successfully, `[SKIP]` = unchanged / skipped, `[DEL ]` = deleted from DB (file removed from disk), `[ERR ]` = failed (verbose mode includes stack trace)
 
 This is useful for debugging indexing issues or verifying which files were actually processed.
 
@@ -118,13 +120,7 @@ cdidx search "handleRequest" --lang go   # filter by language
 cdidx search "TODO" --limit 50           # more results
 ```
 
-Output (JSON lines — one result per line, machine-readable):
-
-```json
-{"path":"src/Auth/Login.cs","startLine":15,"endLine":30,"content":"public bool Authenticate(...)...","lang":"csharp","score":12.5}
-```
-
-Use `--no-json` for human-readable output:
+Output:
 
 ```
 src/Auth/Login.cs:15-30
@@ -133,6 +129,22 @@ src/Auth/Login.cs:15-30
       var hash = ComputeHash(pass);
       return _store.Verify(user, hash);
   ...
+
+src/Auth/TokenService.cs:42-58
+  public string GenerateToken(User user)
+  {
+      var claims = BuildClaims(user);
+      return _jwt.CreateToken(claims);
+  ...
+
+(2 results)
+```
+
+Use `--json` for machine-readable output (AI agents):
+
+```json
+{"path":"src/Auth/Login.cs","start_line":15,"end_line":30,"content":"public bool Authenticate(...)...","lang":"csharp","score":12.5}
+{"path":"src/Auth/TokenService.cs","start_line":42,"end_line":58,"content":"public string GenerateToken(...)...","lang":"csharp","score":9.8}
 ```
 
 ### Search symbols (functions, classes, etc.)
@@ -143,10 +155,13 @@ cdidx symbols --kind class             # all classes
 cdidx symbols --kind function --lang python
 ```
 
-Output (JSON lines):
+Output:
 
-```json
-{"name":"UserService","kind":"class","path":"src/Services/UserService.cs","line":8,"lang":"csharp"}
+```
+class      UserService                              src/Services/UserService.cs:8
+function   GetUserById                              src/Services/UserService.cs:24
+function   CreateUser                               src/Services/UserService.cs:45
+(3 symbols)
 ```
 
 ### List files
@@ -156,10 +171,13 @@ cdidx files                            # all indexed files
 cdidx files --lang csharp              # only C# files
 ```
 
-Output (JSON lines):
+Output:
 
-```json
-{"path":"src/Services/UserService.cs","lang":"csharp","lines":120}
+```
+csharp          120 lines  src/Services/UserService.cs
+csharp           85 lines  src/Controllers/UserController.cs
+csharp           42 lines  src/Models/User.cs
+(3 files)
 ```
 
 ### Check status
@@ -185,13 +203,12 @@ Languages:
 | Option | Applies to | Description |
 |---|---|---|
 | `--db <path>` | All commands | Database file path (default: `codeindex.db`) |
-| `--json` | All commands | JSON output (default for search/symbols/files) |
-| `--no-json` | Query commands | Force human-readable output |
+| `--json` | All commands | JSON output (for AI/machine use) |
 | `--limit <n>` | Query commands | Max results (default: 20) |
 | `--lang <lang>` | Query commands | Filter by language |
 | `--kind <kind>` | `symbols` | Filter by symbol kind (function/class/import) |
 | `--rebuild` | `index` | Delete existing DB and rebuild |
-| `--verbose` | `index` | Show per-file status (`[OK]`/`[SKIP]`/`[DEL]`/`[ERR]`) |
+| `--verbose` | `index` | Show per-file status (`[OK  ]`/`[SKIP]`/`[DEL ]`/`[ERR ]`) |
 | `--commits <id...>` | `index` | Update only files changed in specified commits |
 | `--files <path...>` | `index` | Update only the specified files |
 
@@ -262,7 +279,7 @@ AI agents that query the database directly via SQL need the `sqlite3` CLI.
 
 ## AI Integration
 
-cdidx is designed as an AI-first code search tool. All query commands output JSON lines by default, making them easy to parse programmatically.
+cdidx is designed as an AI-friendly code search tool. All query commands support `--json` for JSON lines output, making them easy to parse programmatically.
 
 ### Setup: Add to CLAUDE.md
 
@@ -433,11 +450,11 @@ cdidx ./myproject --verbose     # ファイルごとの詳細表示
 デフォルト出力:
 
 ```
-Scanning...
+⠹ Scanning...
   Found 42 files
 
 Indexing...
-  [=================>        ] 67%
+  ████████████████████░░░░░░░░░░░░  67.0%  [28/42]
 
 Done.
   Files   : 42
@@ -450,11 +467,13 @@ Done.
 `--verbose` を付けると、各ファイルにステータスタグも表示され、何が起きたか一目でわかります:
 
 ```
-  [OK]   src/app.cs (12 chunks, 5 symbols)   — インデックス成功
-  [SKIP] src/utils.cs                         — 未変更、スキップ
-  [DEL]  src/old.cs                           — DBから削除（ディスク上のファイルが消えたため）
-  [ERR]  src/bad.cs: <message>                — 失敗（verboseではスタックトレースも表示）
+  [OK  ] src/app.cs (12 chunks, 5 symbols)
+  [SKIP] src/utils.cs
+  [DEL ] src/old.cs
+  [ERR ] src/bad.cs: <message>
 ```
+
+> `[OK  ]` = インデックス成功、`[SKIP]` = 未変更・スキップ、`[DEL ]` = DBから削除（ディスク上のファイルが消えた）、`[ERR ]` = 失敗（verboseではスタックトレースも表示）
 
 インデックスの問題をデバッグしたり、どのファイルが実際に処理されたかを確認するのに便利です。
 
@@ -466,13 +485,7 @@ cdidx search "handleRequest" --lang go   # 言語でフィルタ
 cdidx search "TODO" --limit 50           # 結果数を増やす
 ```
 
-出力（JSONライン — 1行1結果、機械処理可能）:
-
-```json
-{"path":"src/Auth/Login.cs","startLine":15,"endLine":30,"content":"public bool Authenticate(...)...","lang":"csharp","score":12.5}
-```
-
-`--no-json` で人間向け出力:
+出力:
 
 ```
 src/Auth/Login.cs:15-30
@@ -481,6 +494,22 @@ src/Auth/Login.cs:15-30
       var hash = ComputeHash(pass);
       return _store.Verify(user, hash);
   ...
+
+src/Auth/TokenService.cs:42-58
+  public string GenerateToken(User user)
+  {
+      var claims = BuildClaims(user);
+      return _jwt.CreateToken(claims);
+  ...
+
+(2 results)
+```
+
+`--json` でAI/機械向け出力:
+
+```json
+{"path":"src/Auth/Login.cs","start_line":15,"end_line":30,"content":"public bool Authenticate(...)...","lang":"csharp","score":12.5}
+{"path":"src/Auth/TokenService.cs","start_line":42,"end_line":58,"content":"public string GenerateToken(...)...","lang":"csharp","score":9.8}
 ```
 
 ### シンボル検索（関数、クラスなど）
@@ -491,10 +520,13 @@ cdidx symbols --kind class             # すべてのクラス
 cdidx symbols --kind function --lang python
 ```
 
-出力（JSONライン）:
+出力:
 
-```json
-{"name":"UserService","kind":"class","path":"src/Services/UserService.cs","line":8,"lang":"csharp"}
+```
+class      UserService                              src/Services/UserService.cs:8
+function   GetUserById                              src/Services/UserService.cs:24
+function   CreateUser                               src/Services/UserService.cs:45
+(3 symbols)
 ```
 
 ### ファイル一覧
@@ -504,10 +536,13 @@ cdidx files                            # 全インデックス済みファイル
 cdidx files --lang csharp              # C#ファイルのみ
 ```
 
-出力（JSONライン）:
+出力:
 
-```json
-{"path":"src/Services/UserService.cs","lang":"csharp","lines":120}
+```
+csharp          120 lines  src/Services/UserService.cs
+csharp           85 lines  src/Controllers/UserController.cs
+csharp           42 lines  src/Models/User.cs
+(3 files)
 ```
 
 ### 状態確認
@@ -533,13 +568,12 @@ Languages:
 | オプション | 対象 | 説明 |
 |---|---|---|
 | `--db <path>` | 全コマンド | DBファイルパス（デフォルト: `codeindex.db`） |
-| `--json` | 全コマンド | JSON出力（search/symbols/filesはデフォルト） |
-| `--no-json` | クエリ系 | 人間向け出力を強制 |
+| `--json` | 全コマンド | JSON出力（AI/機械向け） |
 | `--limit <n>` | クエリ系 | 最大結果数（デフォルト: 20） |
 | `--lang <lang>` | クエリ系 | 言語でフィルタ |
 | `--kind <kind>` | `symbols` | シンボル種別でフィルタ（function/class/import） |
 | `--rebuild` | `index` | 既存DBを削除して再構築 |
-| `--verbose` | `index` | ファイルごとのステータス表示（`[OK]`/`[SKIP]`/`[DEL]`/`[ERR]`） |
+| `--verbose` | `index` | ファイルごとのステータス表示（`[OK  ]`/`[SKIP]`/`[DEL ]`/`[ERR ]`） |
 | `--commits <id...>` | `index` | 指定コミットの変更ファイルのみ更新 |
 | `--files <path...>` | `index` | 指定ファイルのみ更新 |
 
@@ -610,7 +644,7 @@ AIエージェントがDBを直接SQL検索する場合、`sqlite3` CLIが必要
 
 ## AIとの連携
 
-cdidxはAIファーストのコード検索ツールとして設計されています。すべてのクエリコマンドはデフォルトでJSONライン出力を行い、プログラムからのパースが容易です。
+cdidxはAI対応のコード検索ツールとして設計されています。すべてのクエリコマンドは `--json` でJSONライン出力に対応し、プログラムからのパースが容易です。
 
 ### セットアップ: CLAUDE.mdに追加
 

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -417,16 +417,30 @@ int RunFullScan(DbWriter writer, FileIndexer indexer, string projectRoot, string
         Console.WriteLine();
     }
 
+    CancellationTokenSource? purgeCts = null;
+    if (!jsonOutput)
+        purgeCts = StartSpinner("Cleaning up stale entries...", spinnerFrames);
     var purged = writer.PurgeStaleFiles(projectRoot);
+    StopSpinner(purgeCts);
     if (purged > 0 && !jsonOutput)
         Console.WriteLine($"  Purged {purged:N0} stale files (no longer on disk)");
 
-    if (!jsonOutput) Console.WriteLine("Indexing...");
+    CancellationTokenSource? indexCts = null;
+    if (!jsonOutput)
+        indexCts = StartSpinner("Indexing...", spinnerFrames);
     int processed = 0, skipped = 0, errors = 0;
     var errorList = new List<object>();
+    // Stop the indexing spinner before the first progress update / 最初のプログレス更新前にスピナーを停止
+    bool indexSpinnerStopped = false;
 
     foreach (var filePath in files)
     {
+        if (!indexSpinnerStopped)
+        {
+            StopSpinner(indexCts);
+            indexSpinnerStopped = true;
+            if (!jsonOutput) Console.WriteLine("Indexing...");
+        }
         try
         {
             var (record, content) = indexer.BuildRecord(filePath);
@@ -469,6 +483,13 @@ int RunFullScan(DbWriter writer, FileIndexer indexer, string projectRoot, string
 
         processed++;
         if (!jsonOutput) PrintProgress(processed, files.Count);
+    }
+
+    // If no files to process, stop the indexing spinner / ファイルがない場合はスピナーを停止
+    if (!indexSpinnerStopped)
+    {
+        StopSpinner(indexCts);
+        if (!jsonOutput) Console.WriteLine("Indexing...");
     }
 
     stopwatch.Stop();

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -41,41 +41,12 @@ if (args[0] is "--version" or "-V")
     return ExitSuccess;
 }
 
-// Easter eggs / イースターエッグ
-if (args.Any(a => a == "--sushi"))
+// Easter eggs — standalone only (no command/path given)
+// イースターエッグ — 単体実行時のみ（コマンド/パスなし）
+var easterEgg = args.FirstOrDefault(a => a is "--sushi" or "--coffee" or "--ramen" or "--wine" or "--beer" or "--matcha" or "--whisky");
+if (easterEgg != null && !args.Any(a => !a.StartsWith('-')))
 {
-    Console.WriteLine("\U0001f363 Indexing is like making sushi \u2014 patience yields perfection.");
-    Console.WriteLine("   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u306f\u5bff\u53f8\u4f5c\u308a\u306e\u3088\u3046\u306b \u2014 \u5fcd\u8010\u304c\u5b8c\u74a7\u3092\u751f\u3080\u3002");
-    return ExitSuccess;
-}
-if (args.Any(a => a == "--coffee"))
-{
-    Console.WriteLine("\u2615 Leave the indexing to me and go grab a coffee!");
-    Console.WriteLine("   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u306f\u4efb\u305b\u3066\u3001\u30b3\u30fc\u30d2\u30fc\u3067\u3082\u98f2\u3093\u3067\u304d\u3066\uff01");
-    return ExitSuccess;
-}
-if (args.Any(a => a == "--ramen"))
-{
-    Console.WriteLine("\U0001f35c Indexing in progress... perfect time for a bowl of ramen!");
-    Console.WriteLine("   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u4e2d\u2026\u30e9\u30fc\u30e1\u30f3\u4e00\u676f\u3044\u304b\u304c\uff1f");
-    return ExitSuccess;
-}
-if (args.Any(a => a == "--wine"))
-{
-    Console.WriteLine("\U0001f377 Crushing... Aging... Pouring... Sant\u00e9!");
-    Console.WriteLine("   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u306f\u30ef\u30a4\u30f3\u306e\u3088\u3046\u306b\u2014\u719f\u6210\u3092\u5f85\u3064\u4fa1\u5024\u304c\u3042\u308b\u3002");
-    return ExitSuccess;
-}
-if (args.Any(a => a == "--beer"))
-{
-    Console.WriteLine("\U0001f37a Tapping... Pouring... Foaming... Cheers!");
-    Console.WriteLine("   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u5b8c\u4e86\u307e\u3067\u3001\u4e7e\u676f\uff01");
-    return ExitSuccess;
-}
-if (args.Any(a => a == "--matcha"))
-{
-    Console.WriteLine("\U0001f375 Sifting... Pouring... Whisking... \u3069\u3046\u305e\uff01");
-    Console.WriteLine("   \u4e00\u670d\u306e\u62b9\u8336\u3067\u3082\u3044\u304b\u304c\u3067\u3059\u304b\uff1f");
+    PrintEasterEggMessage(easterEgg);
     return ExitSuccess;
 }
 
@@ -95,7 +66,7 @@ return args[0] switch
 // --- Search subcommand / 検索サブコマンド ---
 int RunSearch(string[] cmdArgs)
 {
-    var (dbPath, json, limit, lang, _, query) = ParseQueryArgs(cmdArgs, jsonDefault: true);
+    var (dbPath, json, limit, lang, _, query) = ParseQueryArgs(cmdArgs, jsonDefault: false);
     if (query == null)
     {
         Console.Error.WriteLine("Error: search requires a query argument");
@@ -139,7 +110,7 @@ int RunSearch(string[] cmdArgs)
 // --- Symbols subcommand / シンボルサブコマンド ---
 int RunSymbols(string[] cmdArgs)
 {
-    var (dbPath, json, limit, lang, kind, query) = ParseQueryArgs(cmdArgs, jsonDefault: true);
+    var (dbPath, json, limit, lang, kind, query) = ParseQueryArgs(cmdArgs, jsonDefault: false);
 
     return WithDb(dbPath, reader =>
     {
@@ -169,7 +140,7 @@ int RunSymbols(string[] cmdArgs)
 // --- Files subcommand / ファイルサブコマンド ---
 int RunFiles(string[] cmdArgs)
 {
-    var (dbPath, json, limit, lang, _, query) = ParseQueryArgs(cmdArgs, jsonDefault: true);
+    var (dbPath, json, limit, lang, _, query) = ParseQueryArgs(cmdArgs, jsonDefault: false);
 
     return WithDb(dbPath, reader =>
     {
@@ -228,7 +199,8 @@ int RunStatus(string[] cmdArgs)
 // --- Index subcommand (existing behavior) / インデックスサブコマンド（既存の動作） ---
 int RunIndex(string[] indexArgs)
 {
-    var (projectPath, dbPath, rebuild, verbose, jsonOutput, commits, updateFiles) = ParseIndexArgs(indexArgs);
+    var (projectPath, dbPath, rebuild, verbose, jsonOutput, commits, updateFiles, easterEgg) = ParseIndexArgs(indexArgs);
+    var spinnerFrames = GetSpinnerFrames(easterEgg);
 
     if (projectPath == null)
     {
@@ -284,31 +256,33 @@ int RunIndex(string[] indexArgs)
 
     if (isUpdateMode)
     {
-        return RunUpdateMode(writer, indexer, projectRoot, dbPath, verbose, jsonOutput, commits, updateFiles, stopwatch);
+        return RunUpdateMode(writer, indexer, projectRoot, dbPath, verbose, jsonOutput, commits, updateFiles, stopwatch, spinnerFrames);
     }
     else
     {
-        return RunFullScan(writer, indexer, projectRoot, dbPath, verbose, jsonOutput, stopwatch);
+        return RunFullScan(writer, indexer, projectRoot, dbPath, verbose, jsonOutput, stopwatch, spinnerFrames);
     }
 }
 
 // --- Update mode / 更新モード ---
 int RunUpdateMode(DbWriter writer, FileIndexer indexer, string projectRoot, string dbPath,
-    bool verbose, bool jsonOutput, List<string> commits, List<string> updateFiles, Stopwatch stopwatch)
+    bool verbose, bool jsonOutput, List<string> commits, List<string> updateFiles, Stopwatch stopwatch, string[] spinnerFrames)
 {
     var targetPaths = new HashSet<string>(StringComparer.Ordinal);
 
     // Resolve files from commit IDs / コミットIDから変更ファイルを解決
     if (commits.Count > 0)
     {
+        CancellationTokenSource? spinnerCts = null;
         if (!jsonOutput)
-            Console.WriteLine($"Resolving changed files from {commits.Count} commit(s)...");
+            spinnerCts = StartSpinner("Resolving changed files...", spinnerFrames);
         foreach (var commit in commits)
         {
             var changedFiles = GetChangedFilesFromCommit(projectRoot, commit);
             foreach (var f in changedFiles)
                 targetPaths.Add(f);
         }
+        StopSpinner(spinnerCts);
         if (!jsonOutput)
             Console.WriteLine($"  Found {targetPaths.Count} changed file(s) from git");
     }
@@ -340,7 +314,7 @@ int RunUpdateMode(DbWriter writer, FileIndexer indexer, string projectRoot, stri
                 {
                     removed++;
                     if (verbose && !jsonOutput)
-                        Console.WriteLine($"  [DEL]  {relPath}");
+                        Console.WriteLine($"  [DEL ] {relPath}");
                 }
                 else
                 {
@@ -371,7 +345,7 @@ int RunUpdateMode(DbWriter writer, FileIndexer indexer, string projectRoot, stri
 
             updated++;
             if (verbose && !jsonOutput)
-                Console.WriteLine($"  [OK]   {relPath} ({chunks.Count} chunks, {symbols.Count} symbols)");
+                Console.WriteLine($"  [OK  ] {relPath} ({chunks.Count} chunks, {symbols.Count} symbols)");
         }
         catch (Exception ex)
         {
@@ -380,9 +354,9 @@ int RunUpdateMode(DbWriter writer, FileIndexer indexer, string projectRoot, stri
             if (!jsonOutput)
             {
                 if (verbose)
-                    Console.Error.WriteLine($"  [ERR]  {relPath}: {ex.Message}\n{ex.StackTrace}");
+                    Console.Error.WriteLine($"  [ERR ] {relPath}: {ex.Message}\n{ex.StackTrace}");
                 else
-                    Console.Error.WriteLine($"  [ERR]  {relPath}: {ex.Message}");
+                    Console.Error.WriteLine($"  [ERR ] {relPath}: {ex.Message}");
             }
         }
     }
@@ -430,10 +404,13 @@ int RunUpdateMode(DbWriter writer, FileIndexer indexer, string projectRoot, stri
 
 // --- Full scan mode / フルスキャンモード ---
 int RunFullScan(DbWriter writer, FileIndexer indexer, string projectRoot, string dbPath,
-    bool verbose, bool jsonOutput, Stopwatch stopwatch)
+    bool verbose, bool jsonOutput, Stopwatch stopwatch, string[] spinnerFrames)
 {
-    if (!jsonOutput) Console.WriteLine("Scanning...");
+    CancellationTokenSource? spinnerCts = null;
+    if (!jsonOutput)
+        spinnerCts = StartSpinner("Scanning...", spinnerFrames);
     var files = indexer.ScanFiles();
+    StopSpinner(spinnerCts);
     if (!jsonOutput)
     {
         Console.WriteLine($"  Found {files.Count:N0} files");
@@ -475,7 +452,7 @@ int RunFullScan(DbWriter writer, FileIndexer indexer, string projectRoot, string
             writer.InsertSymbols(symbols);
 
             if (verbose && !jsonOutput)
-                Console.WriteLine($"  [OK]   {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols)");
+                Console.WriteLine($"  [OK  ] {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols)");
         }
         catch (Exception ex)
         {
@@ -484,9 +461,9 @@ int RunFullScan(DbWriter writer, FileIndexer indexer, string projectRoot, string
             if (!jsonOutput)
             {
                 if (verbose)
-                    Console.Error.WriteLine($"  [ERR]  {filePath}: {ex.Message}\n{ex.StackTrace}");
+                    Console.Error.WriteLine($"  [ERR ] {filePath}: {ex.Message}\n{ex.StackTrace}");
                 else
-                    Console.Error.WriteLine($"  [ERR]  {filePath}: {ex.Message}");
+                    Console.Error.WriteLine($"  [ERR ] {filePath}: {ex.Message}");
             }
         }
 
@@ -604,19 +581,20 @@ static (string dbPath, bool json, int limit, string? lang, string? kind, string?
         }
     }
 
-    // Default: JSON for search/symbols/files, human-readable for status
-    // デフォルト: search/symbols/filesはJSON、statusは人間向け
+    // Default: human-readable for all commands; use --json for machine output
+    // デフォルト: 全コマンド人間向け出力、--jsonで機械向け出力
     return (dbPath, json ?? jsonDefault, limit, lang, kind, query);
 }
 
 // Parse index subcommand arguments / インデックスサブコマンドの引数を解析
-static (string? projectPath, string dbPath, bool rebuild, bool verbose, bool json, List<string> commits, List<string> updateFiles) ParseIndexArgs(string[] args)
+static (string? projectPath, string dbPath, bool rebuild, bool verbose, bool json, List<string> commits, List<string> updateFiles, string? easterEgg) ParseIndexArgs(string[] args)
 {
     string? projectPath = null;
     string dbPath = "codeindex.db";
     bool rebuild = false;
     bool verbose = false;
     bool json = false;
+    string? easterEgg = null;
     var commits = new List<string>();
     var updateFiles = new List<string>();
 
@@ -645,7 +623,10 @@ static (string? projectPath, string dbPath, bool rebuild, bool verbose, bool jso
                     updateFiles.Add(args[++i]);
                 break;
             case "--help" or "-h":
-                return (null, dbPath, rebuild, verbose, json, commits, updateFiles);
+                return (null, dbPath, rebuild, verbose, json, commits, updateFiles, null);
+            case "--sushi" or "--coffee" or "--ramen" or "--wine" or "--beer" or "--matcha" or "--whisky":
+                easterEgg = args[i];
+                break;
             default:
                 if (!args[i].StartsWith('-'))
                     projectPath = args[i];
@@ -653,7 +634,7 @@ static (string? projectPath, string dbPath, bool rebuild, bool verbose, bool jso
         }
     }
 
-    return (projectPath, dbPath, rebuild, verbose, json, commits, updateFiles);
+    return (projectPath, dbPath, rebuild, verbose, json, commits, updateFiles, easterEgg);
 }
 
 // Print inline progress bar / インライン進捗バーを表示
@@ -764,7 +745,7 @@ static void PrintUsage()
     Console.WriteLine("Index options:");
     Console.WriteLine("  --db <path>                Database file path (default: codeindex.db)");
     Console.WriteLine("  --rebuild                  Delete existing DB and rebuild from scratch");
-    Console.WriteLine("  --verbose                  Show verbose output");
+    Console.WriteLine("  --verbose                  Show per-file status ([OK  ]/[SKIP]/[DEL ]/[ERR ])");
     Console.WriteLine("  --json                     Output results as JSON (for AI/machine use)");
     Console.WriteLine("  --commits <id> [id ...]    Update only files changed in the specified git commits");
     Console.WriteLine("  --files <path> [path ...]  Update only the specified files (relative or absolute)");
@@ -773,8 +754,7 @@ static void PrintUsage()
     Console.WriteLine();
     Console.WriteLine("Query options:");
     Console.WriteLine("  --db <path>                Database file path (default: codeindex.db)");
-    Console.WriteLine("  --json                     Output as JSON lines (default for search/symbols/files)");
-    Console.WriteLine("  --no-json                  Force human-readable output");
+    Console.WriteLine("  --json                     Output as JSON lines (for AI/machine use)");
     Console.WriteLine("  --limit <n>                Max results to return (default: 20)");
     Console.WriteLine("  --lang <lang>              Filter by language");
     Console.WriteLine("  --kind <kind>              Filter symbols by kind (function/class/import)");
@@ -789,11 +769,142 @@ static void PrintUsage()
     Console.WriteLine("  cdidx ./myproject --commits abc123 def456      Update files from commits");
     Console.WriteLine("  cdidx ./myproject --files src/app.cs           Update specific files");
     Console.WriteLine();
-    Console.WriteLine("Easter eggs:");
-    Console.WriteLine("  --sushi                    \U0001f363");
-    Console.WriteLine("  --coffee                   \u2615");
-    Console.WriteLine("  --ramen                    \U0001f35c");
-    Console.WriteLine("  --wine                     \U0001f377");
-    Console.WriteLine("  --beer                     \U0001f37a");
-    Console.WriteLine("  --matcha                   \U0001f375");
+    Console.WriteLine("Easter eggs (themed spinner when combined with index):");
+    Console.WriteLine("  --sushi                    \U0001f363 Slicing... Shaping... Itadakimasu!");
+    Console.WriteLine("  --coffee                   \u2615 Grinding... Heating... Brewing...");
+    Console.WriteLine("  --ramen                    \U0001f35c Boiling... Steaming... Itadakimasu!");
+    Console.WriteLine("  --wine                     \U0001f377 Crushing... Aging... Sant\u00e9!");
+    Console.WriteLine("  --beer                     \U0001f37a Tapping... Pouring... Cheers!");
+    Console.WriteLine("  --matcha                   \U0001f375 Sifting... Whisking... Douzo!");
+    Console.WriteLine("  --whisky                   \U0001f943 Mashing... Distilling... Slainte!");
+}
+
+// --- Spinner / スピナー ---
+
+// Default Braille spinner frames / デフォルトのブレイルスピナーフレーム
+static readonly string[] BrailleFrames = ["\u2807", "\u280b", "\u280f", "\u2838", "\u280f", "\u2839"];
+
+// Start spinner on a background thread, returns CancellationTokenSource to stop it
+// バックグラウンドスレッドでスピナーを開始。停止用のCancellationTokenSourceを返す
+// When themed frames are used (easter egg), the frame itself contains the full display text
+// テーマフレーム使用時（イースターエッグ）はフレーム自体が表示テキストを含む
+static CancellationTokenSource? StartSpinner(string message, string[] frames)
+{
+    bool isThemed = frames != BrailleFrames;
+
+    if (Console.IsOutputRedirected)
+    {
+        Console.WriteLine(message);
+        return null;
+    }
+
+    var cts = new CancellationTokenSource();
+    var ct = cts.Token;
+    Task.Run(() =>
+    {
+        int i = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            var frame = frames[i % frames.Length];
+            var line = isThemed ? $"\r{frame}" : $"\r{frame} {message}";
+            Console.Write(line);
+            Console.Out.Flush();
+            i++;
+            try { Task.Delay(100, ct).Wait(ct); } catch (OperationCanceledException) { break; }
+        }
+    }, ct);
+    return cts;
+}
+
+// Stop spinner and clear the line / スピナーを停止して行をクリア
+static void StopSpinner(CancellationTokenSource? cts)
+{
+    if (cts == null) return;
+    cts.Cancel();
+    // Small delay to let the spinner task exit / スピナータスク終了のための短い待機
+    Thread.Sleep(20);
+    if (!Console.IsOutputRedirected)
+    {
+        Console.Write($"\r{new string(' ', Console.WindowWidth > 0 ? Console.WindowWidth - 1 : 80)}\r");
+        Console.Out.Flush();
+    }
+}
+
+// Get spinner frames based on easter egg flag / イースターエッグフラグに基づくスピナーフレームを取得
+static string[] GetSpinnerFrames(string? easterEgg) => easterEgg switch
+{
+    "--sushi" =>
+    [
+        "\U0001f363 Slicing       ", "\U0001f363 Slicing.      ", "\U0001f363 Slicing..     ", "\U0001f363 Slicing...    ",
+        "\U0001f363 Shaping       ", "\U0001f363 Shaping.      ", "\U0001f363 Shaping..     ", "\U0001f363 Shaping...    ",
+        "\U0001f363 Pressing      ", "\U0001f363 Pressing.     ", "\U0001f363 Pressing..    ", "\U0001f363 Pressing...   ",
+        "\U0001f363 Itadakimasu!  ",
+    ],
+    "--coffee" =>
+    [
+        "\u2615 Grinding      ", "\u2615 Grinding.     ", "\u2615 Grinding..    ", "\u2615 Grinding...   ",
+        "\u2615 Heating       ", "\u2615 Heating.      ", "\u2615 Heating..     ", "\u2615 Heating...    ",
+        "\u2615 Brewing       ", "\u2615 Brewing.      ", "\u2615 Brewing..     ", "\u2615 Brewing...    ",
+    ],
+    "--ramen" =>
+    [
+        "\U0001f35c Boiling       ", "\U0001f35c Boiling.      ", "\U0001f35c Boiling..     ", "\U0001f35c Boiling...    ",
+        "\U0001f35c Steaming      ", "\U0001f35c Steaming.     ", "\U0001f35c Steaming..    ", "\U0001f35c Steaming...   ",
+        "\U0001f35c Slurping      ", "\U0001f35c Slurping.     ", "\U0001f35c Slurping..    ", "\U0001f35c Slurping...   ",
+        "\U0001f35c Itadakimasu!  ",
+    ],
+    "--wine" =>
+    [
+        "\U0001f377 Crushing      ", "\U0001f377 Crushing.     ", "\U0001f377 Crushing..    ", "\U0001f377 Crushing...   ",
+        "\U0001f377 Aging         ", "\U0001f377 Aging.        ", "\U0001f377 Aging..       ", "\U0001f377 Aging...      ",
+        "\U0001f377 Pouring       ", "\U0001f377 Pouring.      ", "\U0001f377 Pouring..     ", "\U0001f377 Pouring...    ",
+        "\U0001f377 Sant\u00e9!        ",
+    ],
+    "--beer" =>
+    [
+        "\U0001f37a Tapping       ", "\U0001f37a Tapping.      ", "\U0001f37a Tapping..     ", "\U0001f37a Tapping...    ",
+        "\U0001f37a Pouring       ", "\U0001f37a Pouring.      ", "\U0001f37a Pouring..     ", "\U0001f37a Pouring...    ",
+        "\U0001f37a Foaming       ", "\U0001f37a Foaming.      ", "\U0001f37a Foaming..     ", "\U0001f37a Foaming...    ",
+        "\U0001f37a Cheers!       ",
+    ],
+    "--matcha" =>
+    [
+        "\U0001f375 Sifting       ", "\U0001f375 Sifting.      ", "\U0001f375 Sifting..     ", "\U0001f375 Sifting...    ",
+        "\U0001f375 Pouring       ", "\U0001f375 Pouring.      ", "\U0001f375 Pouring..     ", "\U0001f375 Pouring...    ",
+        "\U0001f375 Whisking      ", "\U0001f375 Whisking.     ", "\U0001f375 Whisking..    ", "\U0001f375 Whisking...   ",
+        "\U0001f375 Douzo!        ",
+    ],
+    "--whisky" =>
+    [
+        "\U0001f943 Mashing       ", "\U0001f943 Mashing.      ", "\U0001f943 Mashing..     ", "\U0001f943 Mashing...    ",
+        "\U0001f943 Distilling    ", "\U0001f943 Distilling.   ", "\U0001f943 Distilling..  ", "\U0001f943 Distilling... ",
+        "\U0001f943 Aging         ", "\U0001f943 Aging.        ", "\U0001f943 Aging..       ", "\U0001f943 Aging...      ",
+        "\U0001f943 Slainte!      ",
+    ],
+    _ => BrailleFrames,
+};
+
+// Print easter egg message (standalone mode) / イースターエッグメッセージを表示（単体実行時）
+static void PrintEasterEggMessage(string flag)
+{
+    var (en, ja) = flag switch
+    {
+        "--sushi"  => ("\U0001f363 Indexing is like making sushi \u2014 patience yields perfection.",
+                       "   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u306f\u5bff\u53f8\u4f5c\u308a\u306e\u3088\u3046\u306b \u2014 \u5fcd\u8010\u304c\u5b8c\u74a7\u3092\u751f\u3080\u3002"),
+        "--coffee" => ("\u2615 Leave the indexing to me and go grab a coffee!",
+                       "   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u306f\u4efb\u305b\u3066\u3001\u30b3\u30fc\u30d2\u30fc\u3067\u3082\u98f2\u3093\u3067\u304d\u3066\uff01"),
+        "--ramen"  => ("\U0001f35c Indexing in progress... perfect time for a bowl of ramen!",
+                       "   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u4e2d\u2026\u30e9\u30fc\u30e1\u30f3\u4e00\u676f\u3044\u304b\u304c\uff1f"),
+        "--wine"   => ("\U0001f377 Crushing... Aging... Pouring... Sant\u00e9!",
+                       "   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u306f\u30ef\u30a4\u30f3\u306e\u3088\u3046\u306b\u2014\u719f\u6210\u3092\u5f85\u3064\u4fa1\u5024\u304c\u3042\u308b\u3002"),
+        "--beer"   => ("\U0001f37a Tapping... Pouring... Foaming... Cheers!",
+                       "   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u5b8c\u4e86\u307e\u3067\u3001\u4e7e\u676f\uff01"),
+        "--matcha" => ("\U0001f375 Sifting... Pouring... Whisking... \u3069\u3046\u305e\uff01",
+                       "   \u4e00\u670d\u306e\u62b9\u8336\u3067\u3082\u3044\u304b\u304c\u3067\u3059\u304b\uff1f"),
+        "--whisky" => ("\U0001f943 Mashing... Distilling... Aging... Slainte!",
+                       "   \u30a4\u30f3\u30c7\u30c3\u30af\u30b9\u306f\u30a6\u30a4\u30b9\u30ad\u30fc\u306e\u3088\u3046\u306b\u2014\u719f\u6210\u304c\u5927\u4e8b\u3002"),
+        _ => ("", ""),
+    };
+    Console.WriteLine(en);
+    Console.WriteLine(ja);
 }

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -595,6 +595,8 @@ static (string? projectPath, string dbPath, bool rebuild, bool verbose, bool jso
     bool verbose = false;
     bool json = false;
     string? easterEgg = null;
+    int spinnerFlagCount = 0;
+    bool randomSpinner = false;
     var commits = new List<string>();
     var updateFiles = new List<string>();
 
@@ -626,12 +628,32 @@ static (string? projectPath, string dbPath, bool rebuild, bool verbose, bool jso
                 return (null, dbPath, rebuild, verbose, json, commits, updateFiles, null);
             case "--sushi" or "--coffee" or "--ramen" or "--wine" or "--beer" or "--matcha" or "--whisky":
                 easterEgg = args[i];
+                spinnerFlagCount++;
+                break;
+            case "--random-spinner":
+                randomSpinner = true;
                 break;
             default:
                 if (!args[i].StartsWith('-'))
                     projectPath = args[i];
                 break;
         }
+    }
+
+    // Multiple spinner flags detected — fall back to matcha with a warning
+    // 複数のスピナーフラグ検出 — 警告を出して抹茶にフォールバック
+    if (spinnerFlagCount > 1)
+    {
+        Console.Error.WriteLine("\U0001f375 Simultaneous intake of beer and coffee is not recommended. How about some matcha instead?");
+        Console.Error.WriteLine("   \u30d3\u30fc\u30eb\u3068\u30b3\u30fc\u30d2\u30fc\u306e\u540c\u6642\u6442\u53d6\u306f\u304a\u3059\u3059\u3081\u3057\u307e\u305b\u3093\u3002\u62b9\u8336\u306f\u3044\u304b\u304c\uff1f");
+        easterEgg = "--matcha";
+    }
+
+    // --random-spinner picks a random theme / --random-spinnerでランダムテーマ選択
+    if (randomSpinner && easterEgg == null)
+    {
+        var themes = new[] { "--sushi", "--coffee", "--ramen", "--wine", "--beer", "--matcha", "--whisky" };
+        easterEgg = themes[Random.Shared.Next(themes.Length)];
     }
 
     return (projectPath, dbPath, rebuild, verbose, json, commits, updateFiles, easterEgg);
@@ -777,6 +799,7 @@ static void PrintUsage()
     Console.WriteLine("  --beer                     \U0001f37a Tapping... Pouring... Cheers!");
     Console.WriteLine("  --matcha                   \U0001f375 Sifting... Whisking... Douzo!");
     Console.WriteLine("  --whisky                   \U0001f943 Mashing... Distilling... Slainte!");
+    Console.WriteLine("  --random-spinner           \U0001f3b2 Pick a random theme");
 }
 
 // --- Spinner / スピナー ---

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -825,16 +825,15 @@ static void PrintUsage()
 
 // --- Spinner / スピナー ---
 
-// Default Braille spinner frames / デフォルトのブレイルスピナーフレーム
-static readonly string[] BrailleFrames = ["\u2807", "\u280b", "\u280f", "\u2838", "\u280f", "\u2839"];
-
 // Start spinner on a background thread, returns CancellationTokenSource to stop it
 // バックグラウンドスレッドでスピナーを開始。停止用のCancellationTokenSourceを返す
 // When themed frames are used (easter egg), the frame itself contains the full display text
 // テーマフレーム使用時（イースターエッグ）はフレーム自体が表示テキストを含む
 static CancellationTokenSource? StartSpinner(string message, string[] frames)
 {
-    bool isThemed = frames != BrailleFrames;
+    // Braille frames are single-char; themed frames are longer strings containing the display text
+    // ブレイルフレームは1文字、テーマフレームは表示テキストを含む長い文字列
+    bool isThemed = frames.Length > 0 && frames[0].Length > 2;
 
     if (Console.IsOutputRedirected)
     {
@@ -925,7 +924,8 @@ static string[] GetSpinnerFrames(string? easterEgg) => easterEgg switch
         "\U0001f943 Aging         ", "\U0001f943 Aging.        ", "\U0001f943 Aging..       ", "\U0001f943 Aging...      ",
         "\U0001f943 Slainte!      ",
     ],
-    _ => BrailleFrames,
+    // Default: Braille spinner / デフォルト: ブレイルスピナー
+    _ => ["\u2807", "\u280b", "\u280f", "\u2838", "\u280f", "\u2839"],
 };
 
 // Print easter egg message (standalone mode) / イースターエッグメッセージを表示（単体実行時）


### PR DESCRIPTION
- Change default output for search/symbols/files from JSON to human-readable
  (use --json for AI/machine output instead of --no-json for human output)
- Add Braille spinner (⠇⠋⠏⠸⠏⠹) during scanning/resolving phases
- Easter egg flags (--sushi, --coffee, --ramen, --wine, --beer, --matcha,
  --whisky) now theme the spinner with animated dot sequences when combined
  with index command; standalone behavior preserved
- Align verbose status tags to uniform 4-char width: [OK  ]/[SKIP]/[DEL ]/[ERR ]
- Update README progress bar to use █░ block characters matching actual output
- Update README examples: multiple results for search/symbols/files output,
  verbose tag descriptions moved to footnotes
- Update CLAUDE.md to reflect new defaults

https://claude.ai/code/session_0198VpPC2DeMRiv5j1yZdMWo