### PR TITLE
Security hardening and code quality improvements

### DIFF
--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -16,8 +16,10 @@ public static class GitHelper
     public static List<string> GetChangedFilesFromCommit(string projectRoot, string commitId)
     {
         // Validate commit ID to prevent argument injection (only hex + common ref chars allowed)
+        // Reject values starting with "-" to prevent git option injection even without "--" separator
         // コミットIDをバリデーションし引数インジェクションを防止（16進数+一般的な参照文字のみ許可）
-        if (!Regex.IsMatch(commitId, @"^[a-zA-Z0-9_./^~\-]+$"))
+        // "-"で始まる値も拒否し、"--"セパレータなしでもgitオプション注入を防止
+        if (commitId.StartsWith('-') || !Regex.IsMatch(commitId, @"^[a-zA-Z0-9_./^~\-]+$"))
             throw new ArgumentException($"Invalid commit ID: {commitId}");
 
         var psi = new ProcessStartInfo

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -150,8 +150,9 @@ public class DbReader
 
         var sql = @"
             SELECT f.path, f.lang, f.size, f.lines,
-                   (SELECT COUNT(*) FROM symbols s WHERE s.file_id = f.id) as symbol_count
+                   COUNT(s.id) as symbol_count
             FROM files f
+            LEFT JOIN symbols s ON s.file_id = f.id
             WHERE 1=1";
 
         if (query != null)
@@ -159,7 +160,7 @@ public class DbReader
         if (lang != null)
             sql += " AND f.lang = @lang";
 
-        sql += " ORDER BY f.path LIMIT @limit";
+        sql += " GROUP BY f.id ORDER BY f.path LIMIT @limit";
 
         cmd.CommandText = sql;
         if (query != null)

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -183,7 +183,7 @@ public class DbWriter
             // Only create a batch transaction when not already inside an outer transaction
             // 外部トランザクション内でない場合のみバッチトランザクションを作成
             var ownTxn = !IsInTransaction();
-            var transaction = ownTxn ? _conn.BeginTransaction() : null;
+            using var transaction = ownTxn ? _conn.BeginTransaction() : null;
 
             for (int j = i; j < end; j++)
             {
@@ -211,7 +211,6 @@ public class DbWriter
             }
 
             transaction?.Commit();
-            transaction?.Dispose();
         }
     }
 
@@ -227,7 +226,7 @@ public class DbWriter
             // Only create a batch transaction when not already inside an outer transaction
             // 外部トランザクション内でない場合のみバッチトランザクションを作成
             var ownTxn = !IsInTransaction();
-            var transaction = ownTxn ? _conn.BeginTransaction() : null;
+            using var transaction = ownTxn ? _conn.BeginTransaction() : null;
 
             for (int j = i; j < end; j++)
             {
@@ -244,7 +243,6 @@ public class DbWriter
             }
 
             transaction?.Commit();
-            transaction?.Dispose();
         }
     }
 

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -20,21 +20,43 @@ public class DbWriter
 
     /// <summary>
     /// Begin a transaction for grouping multiple operations atomically.
+    /// Returns a TransactionScope that automatically decrements the depth counter on Dispose.
     /// 複数操作をアトミックにまとめるためのトランザクションを開始する。
+    /// Dispose時に自動的にdepthカウンタを減算するTransactionScopeを返す。
     /// </summary>
-    public SqliteTransaction BeginTransaction()
+    public TransactionScope BeginTransaction()
     {
         _transactionDepth++;
-        return _conn.BeginTransaction();
+        var txn = _conn.BeginTransaction();
+        return new TransactionScope(txn, this);
     }
 
     /// <summary>
-    /// Notify that the outer transaction has ended (committed or rolled back).
-    /// 外部トランザクション終了を通知する。
+    /// RAII wrapper that ensures _transactionDepth is decremented even if an exception occurs.
+    /// 例外発生時にも_transactionDepthが確実に減算されるRAIIラッパー。
     /// </summary>
-    public void EndTransaction()
+    public sealed class TransactionScope : IDisposable
     {
-        if (_transactionDepth > 0) _transactionDepth--;
+        private readonly SqliteTransaction _transaction;
+        private readonly DbWriter _writer;
+        private bool _disposed;
+
+        internal TransactionScope(SqliteTransaction transaction, DbWriter writer)
+        {
+            _transaction = transaction;
+            _writer = writer;
+        }
+
+        public void Commit() => _transaction.Commit();
+        public void Rollback() => _transaction.Rollback();
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _transaction.Dispose();
+            if (_writer._transactionDepth > 0) _writer._transactionDepth--;
+        }
     }
 
     /// <summary>

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -76,15 +76,18 @@ public static class SymbolExtractor
         ],
         ["c"] =
         [
-            // C function: return_type func_name( / C関数: 戻り値型 関数名(
-            ("function", new Regex(@"^(?!.*\b(?:if|else|for|while|switch|return|sizeof|typedef)\b)(?:\w+[\s*]+)+(?<name>\w+)\s*\(", RegexOptions.Compiled)),
+            // C function: return_type func_name( — exclude lines starting with control keywords
+            // C関数: 戻り値型 関数名( — 行頭が制御キーワードの行を除外
+            ("function", new Regex(@"^(?!\s*(?:if|else|for|while|switch|return|sizeof|typedef)\s*[\(\{;])(?:\w+[\s*]+)+(?<name>\w+)\s*\(", RegexOptions.Compiled)),
             // typedef struct / typedef struct
             ("class",    new Regex(@"^\s*(?:typedef\s+)?struct\s+(?<name>\w+)", RegexOptions.Compiled)),
             ("class",    new Regex(@"^\s*(?:typedef\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled)),
         ],
         ["cpp"] =
         [
-            ("function", new Regex(@"^(?!.*\b(?:if|else|for|while|switch|return|sizeof|typedef|using|namespace)\b)(?:\w+[\s*&]+)+(?<name>\w+)\s*\(", RegexOptions.Compiled)),
+            // C++ function — exclude lines starting with control keywords
+            // C++関数 — 行頭が制御キーワードの行を除外
+            ("function", new Regex(@"^(?!\s*(?:if|else|for|while|switch|return|sizeof|typedef|using|namespace)\s*[\(\{;<])(?:\w+[\s*&]+)+(?<name>\w+)\s*\(", RegexOptions.Compiled)),
             ("class",    new Regex(@"^\s*(?:class|struct)\s+(?<name>\w+)", RegexOptions.Compiled)),
             ("class",    new Regex(@"^\s*namespace\s+(?<name>\w+)", RegexOptions.Compiled)),
             ("class",    new Regex(@"^\s*(?:typedef\s+)?enum\s+(?:class\s+)?(?<name>\w+)", RegexOptions.Compiled)),

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -296,6 +296,13 @@ int RunUpdateMode(DbWriter writer, FileIndexer indexer, string projectRoot, stri
         {
             var absPath = Path.IsPathRooted(f) ? f : Path.GetFullPath(Path.Combine(projectRoot, f));
             var relPath = Path.GetRelativePath(projectRoot, absPath).Replace('\\', '/');
+            // Prevent path traversal outside project root / プロジェクトルート外へのパストラバーサルを防止
+            if (relPath.StartsWith(".."))
+            {
+                if (!jsonOutput)
+                    Console.Error.WriteLine($"  [WARN] Skipping file outside project root: {f}");
+                continue;
+            }
             targetPaths.Add(relPath);
         }
     }

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -340,25 +340,18 @@ int RunUpdateMode(DbWriter writer, FileIndexer indexer, string projectRoot, stri
             // Wrap clean + upsert + insert in a transaction for atomicity
             // clean + upsert + insert をトランザクションでアトミックに実行
             using var txn = writer.BeginTransaction();
-            try
-            {
-                var fileId = writer.UpsertFile(record);
+            var fileId = writer.UpsertFile(record);
 
-                var chunks = ChunkSplitter.Split(fileId, content);
-                writer.InsertChunks(chunks);
+            var chunks = ChunkSplitter.Split(fileId, content);
+            writer.InsertChunks(chunks);
 
-                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
-                writer.InsertSymbols(symbols);
-                txn.Commit();
+            var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
+            writer.InsertSymbols(symbols);
+            txn.Commit();
 
-                updated++;
-                if (verbose && !jsonOutput)
-                    Console.WriteLine($"  [OK  ] {relPath} ({chunks.Count} chunks, {symbols.Count} symbols)");
-            }
-            finally
-            {
-                writer.EndTransaction();
-            }
+            updated++;
+            if (verbose && !jsonOutput)
+                Console.WriteLine($"  [OK  ] {relPath} ({chunks.Count} chunks, {symbols.Count} symbols)");
         }
         catch (Exception ex)
         {
@@ -472,24 +465,17 @@ int RunFullScan(DbWriter writer, FileIndexer indexer, string projectRoot, string
             // Wrap clean + upsert + insert in a transaction for atomicity
             // clean + upsert + insert をトランザクションでアトミックに実行
             using var txn = writer.BeginTransaction();
-            try
-            {
-                var fileId = writer.UpsertFile(record);
+            var fileId = writer.UpsertFile(record);
 
-                var chunks = ChunkSplitter.Split(fileId, content);
-                writer.InsertChunks(chunks);
+            var chunks = ChunkSplitter.Split(fileId, content);
+            writer.InsertChunks(chunks);
 
-                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
-                writer.InsertSymbols(symbols);
-                txn.Commit();
+            var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
+            writer.InsertSymbols(symbols);
+            txn.Commit();
 
-                if (verbose && !jsonOutput)
-                    Console.WriteLine($"  [OK  ] {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols)");
-            }
-            finally
-            {
-                writer.EndTransaction();
-            }
+            if (verbose && !jsonOutput)
+                Console.WriteLine($"  [OK  ] {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols)");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
This PR addresses several security vulnerabilities and improves code quality through better resource management and validation.

## Key Changes

### Security Fixes
- **Path Traversal Prevention**: Added validation in `RunUpdateMode` to reject file paths that traverse outside the project root (paths starting with `..`)
- **Git Argument Injection Prevention**: Enhanced `GitHelper.GetChangedFilesFromCommit()` to reject commit IDs starting with `-`, preventing git option injection even without `--` separator
- **Symbol Extraction Regex Improvements**: Updated C and C++ function detection patterns to use `^\s*` anchoring instead of negative lookahead, more reliably excluding control flow statements at line start

### Resource Management Improvements
- **Transaction Scope Wrapper**: Replaced manual `BeginTransaction()` / `EndTransaction()` pattern with a `TransactionScope` IDisposable wrapper that automatically decrements the transaction depth counter, ensuring proper cleanup even when exceptions occur
- **Removed Redundant Try-Finally Blocks**: Simplified transaction handling in `RunUpdateMode` and `RunFullScan` by leveraging the new `TransactionScope` pattern
- **Fixed Resource Leaks**: Changed batch transaction variables to use `using` declarations in `InsertChunks()` and `InsertSymbols()` to ensure proper disposal

### Query Optimization
- **Improved SQL Query**: Refactored `DbReader.ListFiles()` to use `LEFT JOIN` with `COUNT()` instead of a correlated subquery for better performance and correctness with `GROUP BY`

## Implementation Details
- The new `TransactionScope` class wraps `SqliteTransaction` and provides `Commit()` and `Rollback()` methods while automatically managing the depth counter on disposal
- Path validation uses a simple `StartsWith("..")` check after converting to relative paths
- Git validation now performs two checks: explicit rejection of `-` prefix, then regex validation for allowed characters

https://claude.ai/code/session_013qyxjpDnAVxxapYMEHeoFx