### PR TITLE
fix: set _committed flag after actual commit to ensure rollback on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Batch insert performance** — `InsertChunks()` and `InsertSymbols()` now prepare the SQL command once and reuse it across all rows, instead of creating a new command per row. This reduces per-row overhead from command parsing and parameter allocation. Affected: `Database/DbWriter.cs`.
 
+- **Update mode skips unchanged files** — `RunUpdateMode` (used with `--commits` and `--files` flags) now checks `GetUnchangedFileId()` before re-indexing, consistent with full scan mode. Previously, specifying an unchanged file via `--files` would always trigger a full re-index. Affected: `Program.cs`.
+
 #### Added
 
 - **Core indexing engine** — Scans project directories recursively, detecting 33 file extensions across 24 languages (Python, JavaScript, TypeScript, C#, Go, Rust, Java, Kotlin, Swift, Ruby, PHP, C/C++, SQL, HTML, CSS, SCSS, Vue, Svelte, Terraform, Shell, Markdown, YAML, JSON, TOML). Skips common non-source directories (`.git`, `node_modules`, `__pycache__`, `venv`, `dist`, `build`, `.next`, `.idea`, `vendor`, etc.) and lock files (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`). Affected: `Indexer/FileIndexer.cs`.
@@ -70,6 +72,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 #### 変更
 
 - **バッチ挿入のパフォーマンス改善** — `InsertChunks()`と`InsertSymbols()`でSQLコマンドを1回だけ準備し全行で再利用するよう変更。行ごとのコマンド生成・パラメータ割り当てのオーバーヘッドを削減。対象: `Database/DbWriter.cs`。
+
+- **更新モードで未変更ファイルをスキップ** — `RunUpdateMode`（`--commits`/`--files`使用時）でも`GetUnchangedFileId()`によるチェックを実施し、フルスキャンモードと動作を統一。以前は`--files`で未変更ファイルを指定すると常に再インデックスされていた。対象: `Program.cs`。
 
 #### 追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **TransactionScope.Commit() rollback safety** — Moved `_committed` flag assignment to after the actual commit/release operation. Previously, if `Commit()` or `RELEASE SAVEPOINT` threw an exception, the flag was already set to `true`, preventing `Dispose()` from rolling back the failed transaction. Affected: `Database/DbWriter.cs`.
 
+- **`--commits`/`--files` argument parsing** — Fixed greedy argument consumption that swallowed single-dash options (e.g. `-h`, `-V`) by treating them as commit IDs or file paths. The parser now stops at any argument starting with `-` instead of only `--`. Affected: `Program.cs`.
+
 #### Added
 
 - **Core indexing engine** — Scans project directories recursively, detecting 33 file extensions across 24 languages (Python, JavaScript, TypeScript, C#, Go, Rust, Java, Kotlin, Swift, Ruby, PHP, C/C++, SQL, HTML, CSS, SCSS, Vue, Svelte, Terraform, Shell, Markdown, YAML, JSON, TOML). Skips common non-source directories (`.git`, `node_modules`, `__pycache__`, `venv`, `dist`, `build`, `.next`, `.idea`, `vendor`, etc.) and lock files (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`). Affected: `Indexer/FileIndexer.cs`.
@@ -54,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 #### 修正
 
 - **TransactionScope.Commit()のロールバック安全性** — `_committed`フラグの設定を実際のコミット/リリース操作の後に移動。以前は`Commit()`や`RELEASE SAVEPOINT`が例外を投げた場合、フラグが既に`true`に設定されていたため`Dispose()`でロールバックされなかった。対象: `Database/DbWriter.cs`。
+
+- **`--commits`/`--files`引数解析** — 単一ハイフンのオプション（`-h`、`-V`等）をコミットIDやファイルパスとして誤って取り込む貪欲な引数消費を修正。パーサーが`--`だけでなく`-`で始まる引数でも停止するよう変更。対象: `Program.cs`。
 
 #### 追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **`--commits`/`--files` argument parsing** — Fixed greedy argument consumption that swallowed single-dash options (e.g. `-h`, `-V`) by treating them as commit IDs or file paths. The parser now stops at any argument starting with `-` instead of only `--`. Affected: `Program.cs`.
 
+- **Redundant rebuild logic** — Removed `File.Delete(dbPath)` before `DropAll()` in rebuild mode. The file deletion was redundant since `DropAll()` already drops and recreates all tables within the existing connection. Using `DropAll()` alone is cleaner and avoids unnecessary file-level operations. Affected: `Program.cs`.
+
 #### Added
 
 - **Core indexing engine** — Scans project directories recursively, detecting 33 file extensions across 24 languages (Python, JavaScript, TypeScript, C#, Go, Rust, Java, Kotlin, Swift, Ruby, PHP, C/C++, SQL, HTML, CSS, SCSS, Vue, Svelte, Terraform, Shell, Markdown, YAML, JSON, TOML). Skips common non-source directories (`.git`, `node_modules`, `__pycache__`, `venv`, `dist`, `build`, `.next`, `.idea`, `vendor`, etc.) and lock files (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`). Affected: `Indexer/FileIndexer.cs`.
@@ -58,6 +60,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **TransactionScope.Commit()のロールバック安全性** — `_committed`フラグの設定を実際のコミット/リリース操作の後に移動。以前は`Commit()`や`RELEASE SAVEPOINT`が例外を投げた場合、フラグが既に`true`に設定されていたため`Dispose()`でロールバックされなかった。対象: `Database/DbWriter.cs`。
 
 - **`--commits`/`--files`引数解析** — 単一ハイフンのオプション（`-h`、`-V`等）をコミットIDやファイルパスとして誤って取り込む貪欲な引数消費を修正。パーサーが`--`だけでなく`-`で始まる引数でも停止するよう変更。対象: `Program.cs`。
+
+- **冗長なリビルドロジック** — rebuildモードで`DropAll()`前の`File.Delete(dbPath)`を削除。`DropAll()`が既存の接続内で全テーブルを削除・再作成するためファイル削除は冗長だった。`DropAll()`のみの方がクリーンで不要なファイル操作を回避。対象: `Program.cs`。
 
 #### 追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Update mode skips unchanged files** — `RunUpdateMode` (used with `--commits` and `--files` flags) now checks `GetUnchangedFileId()` before re-indexing, consistent with full scan mode. Previously, specifying an unchanged file via `--files` would always trigger a full re-index. Affected: `Program.cs`.
 
+- **Simplified file deletion** — `DeleteFileByPath()` and `PurgeStaleFiles()` now rely on `ON DELETE CASCADE` and FTS triggers instead of manually deleting chunks and symbols before the file row. This reduces redundant queries and better leverages the existing schema design. Affected: `Database/DbWriter.cs`.
+
 #### Added
 
 - **Core indexing engine** — Scans project directories recursively, detecting 33 file extensions across 24 languages (Python, JavaScript, TypeScript, C#, Go, Rust, Java, Kotlin, Swift, Ruby, PHP, C/C++, SQL, HTML, CSS, SCSS, Vue, Svelte, Terraform, Shell, Markdown, YAML, JSON, TOML). Skips common non-source directories (`.git`, `node_modules`, `__pycache__`, `venv`, `dist`, `build`, `.next`, `.idea`, `vendor`, etc.) and lock files (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`). Affected: `Indexer/FileIndexer.cs`.
@@ -74,6 +76,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **バッチ挿入のパフォーマンス改善** — `InsertChunks()`と`InsertSymbols()`でSQLコマンドを1回だけ準備し全行で再利用するよう変更。行ごとのコマンド生成・パラメータ割り当てのオーバーヘッドを削減。対象: `Database/DbWriter.cs`。
 
 - **更新モードで未変更ファイルをスキップ** — `RunUpdateMode`（`--commits`/`--files`使用時）でも`GetUnchangedFileId()`によるチェックを実施し、フルスキャンモードと動作を統一。以前は`--files`で未変更ファイルを指定すると常に再インデックスされていた。対象: `Program.cs`。
+
+- **ファイル削除の簡素化** — `DeleteFileByPath()`と`PurgeStaleFiles()`がチャンクとシンボルを手動削除する代わりに`ON DELETE CASCADE`とFTSトリガーに委任するよう変更。冗長なクエリを削減し、既存のスキーマ設計をより活用。対象: `Database/DbWriter.cs`。
 
 #### 追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Fixed
+
+- **TransactionScope.Commit() rollback safety** — Moved `_committed` flag assignment to after the actual commit/release operation. Previously, if `Commit()` or `RELEASE SAVEPOINT` threw an exception, the flag was already set to `true`, preventing `Dispose()` from rolling back the failed transaction. Affected: `Database/DbWriter.cs`.
+
 #### Added
 
 - **Core indexing engine** — Scans project directories recursively, detecting 33 file extensions across 24 languages (Python, JavaScript, TypeScript, C#, Go, Rust, Java, Kotlin, Swift, Ruby, PHP, C/C++, SQL, HTML, CSS, SCSS, Vue, Svelte, Terraform, Shell, Markdown, YAML, JSON, TOML). Skips common non-source directories (`.git`, `node_modules`, `__pycache__`, `venv`, `dist`, `build`, `.next`, `.idea`, `vendor`, etc.) and lock files (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`). Affected: `Indexer/FileIndexer.cs`.
@@ -46,6 +50,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 修正
+
+- **TransactionScope.Commit()のロールバック安全性** — `_committed`フラグの設定を実際のコミット/リリース操作の後に移動。以前は`Commit()`や`RELEASE SAVEPOINT`が例外を投げた場合、フラグが既に`true`に設定されていたため`Dispose()`でロールバックされなかった。対象: `Database/DbWriter.cs`。
 
 #### 追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Redundant rebuild logic** — Removed `File.Delete(dbPath)` before `DropAll()` in rebuild mode. The file deletion was redundant since `DropAll()` already drops and recreates all tables within the existing connection. Using `DropAll()` alone is cleaner and avoids unnecessary file-level operations. Affected: `Program.cs`.
 
+#### Changed
+
+- **Batch insert performance** — `InsertChunks()` and `InsertSymbols()` now prepare the SQL command once and reuse it across all rows, instead of creating a new command per row. This reduces per-row overhead from command parsing and parameter allocation. Affected: `Database/DbWriter.cs`.
+
 #### Added
 
 - **Core indexing engine** — Scans project directories recursively, detecting 33 file extensions across 24 languages (Python, JavaScript, TypeScript, C#, Go, Rust, Java, Kotlin, Swift, Ruby, PHP, C/C++, SQL, HTML, CSS, SCSS, Vue, Svelte, Terraform, Shell, Markdown, YAML, JSON, TOML). Skips common non-source directories (`.git`, `node_modules`, `__pycache__`, `venv`, `dist`, `build`, `.next`, `.idea`, `vendor`, etc.) and lock files (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`). Affected: `Indexer/FileIndexer.cs`.
@@ -62,6 +66,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **`--commits`/`--files`引数解析** — 単一ハイフンのオプション（`-h`、`-V`等）をコミットIDやファイルパスとして誤って取り込む貪欲な引数消費を修正。パーサーが`--`だけでなく`-`で始まる引数でも停止するよう変更。対象: `Program.cs`。
 
 - **冗長なリビルドロジック** — rebuildモードで`DropAll()`前の`File.Delete(dbPath)`を削除。`DropAll()`が既存の接続内で全テーブルを削除・再作成するためファイル削除は冗長だった。`DropAll()`のみの方がクリーンで不要なファイル操作を回避。対象: `Program.cs`。
+
+#### 変更
+
+- **バッチ挿入のパフォーマンス改善** — `InsertChunks()`と`InsertSymbols()`でSQLコマンドを1回だけ準備し全行で再利用するよう変更。行ごとのコマンド生成・パラメータ割り当てのオーバーヘッドを削減。対象: `Database/DbWriter.cs`。
 
 #### 追加
 

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -340,24 +340,16 @@ public class DbWriter
 
     /// <summary>
     /// Delete a file and its associated data by relative path. Returns true if found.
+    /// CASCADE on chunks/symbols + FTS triggers handle all cleanup automatically.
     /// 相対パスでファイルと関連データを削除する。見つかればtrueを返す。
+    /// chunks/symbolsのCASCADE + FTSトリガーが全クリーンアップを自動処理する。
     /// </summary>
     public bool DeleteFileByPath(string relativePath)
     {
         using var cmd = _conn.CreateCommand();
-        cmd.CommandText = "SELECT id FROM files WHERE path = @path";
+        cmd.CommandText = "DELETE FROM files WHERE path = @path";
         cmd.Parameters.AddWithValue("@path", relativePath);
-        var result = cmd.ExecuteScalar();
-        if (result == null) return false;
-
-        var fileId = (long)result;
-        DeleteFileData(fileId);
-
-        using var cmd2 = _conn.CreateCommand();
-        cmd2.CommandText = "DELETE FROM files WHERE id = @id";
-        cmd2.Parameters.AddWithValue("@id", fileId);
-        cmd2.ExecuteNonQuery();
-        return true;
+        return cmd.ExecuteNonQuery() > 0;
     }
 
     /// <summary>
@@ -392,13 +384,16 @@ public class DbWriter
 
         // Delete all stale files in a single transaction for atomicity and performance
         // アトミック性とパフォーマンスのため、全古いファイルを1トランザクションで削除
+        // CASCADE on chunks/symbols + FTS triggers handle all cleanup automatically
+        // chunks/symbolsのCASCADE + FTSトリガーが全クリーンアップを自動処理する
         using var txn = BeginTransaction();
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM files WHERE id = @id";
+        var pId = cmd.Parameters.Add("@id", SqliteType.Integer);
+        cmd.Prepare();
         foreach (var id in staleIds)
         {
-            DeleteFileData(id);
-            using var cmd = _conn.CreateCommand();
-            cmd.CommandText = "DELETE FROM files WHERE id = @id";
-            cmd.Parameters.AddWithValue("@id", id);
+            pId.Value = id;
             cmd.ExecuteNonQuery();
         }
         txn.Commit();

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -250,26 +250,13 @@ public class DbWriter
 
     /// <summary>
     /// Insert chunks in batches (FTS index is populated automatically by triggers).
-    /// Reuses a single prepared statement for all rows to avoid per-row command overhead.
+    /// Reuses a prepared statement per batch to avoid per-row command overhead.
     /// チャンクをバッチ挿入する（FTSインデックスはトリガーにより自動で反映される）。
-    /// 行ごとのコマンド生成コストを回避するため、単一のプリペアドステートメントを再利用する。
+    /// バッチごとにプリペアドステートメントを再利用し、行ごとのコマンド生成コストを回避する。
     /// </summary>
     public void InsertChunks(IReadOnlyList<ChunkRecord> chunks)
     {
         if (chunks.Count == 0) return;
-
-        // Prepare the command once and reuse for all rows
-        // コマンドを1回だけ準備し、全行で再利用する
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
-            INSERT INTO chunks (file_id, chunk_index, start_line, end_line, content)
-            VALUES (@fid, @idx, @start, @end, @content)";
-        var pFid = cmd.Parameters.Add("@fid", SqliteType.Integer);
-        var pIdx = cmd.Parameters.Add("@idx", SqliteType.Integer);
-        var pStart = cmd.Parameters.Add("@start", SqliteType.Integer);
-        var pEnd = cmd.Parameters.Add("@end", SqliteType.Integer);
-        var pContent = cmd.Parameters.Add("@content", SqliteType.Text);
-        cmd.Prepare();
 
         for (int i = 0; i < chunks.Count; i += BatchSize)
         {
@@ -277,6 +264,19 @@ public class DbWriter
             // Only create a batch transaction when not already inside an outer transaction
             // 外部トランザクション内でない場合のみバッチトランザクションを作成
             using var transaction = !IsInTransaction() ? BeginTransaction() : null;
+
+            // Prepare after transaction starts so the command inherits the connection's transaction state
+            // トランザクション開始後に準備し、接続のトランザクション状態を引き継ぐ
+            using var cmd = _conn.CreateCommand();
+            cmd.CommandText = @"
+                INSERT INTO chunks (file_id, chunk_index, start_line, end_line, content)
+                VALUES (@fid, @idx, @start, @end, @content)";
+            var pFid = cmd.Parameters.Add("@fid", SqliteType.Integer);
+            var pIdx = cmd.Parameters.Add("@idx", SqliteType.Integer);
+            var pStart = cmd.Parameters.Add("@start", SqliteType.Integer);
+            var pEnd = cmd.Parameters.Add("@end", SqliteType.Integer);
+            var pContent = cmd.Parameters.Add("@content", SqliteType.Text);
+            cmd.Prepare();
 
             for (int j = i; j < end; j++)
             {
@@ -297,25 +297,13 @@ public class DbWriter
 
     /// <summary>
     /// Insert symbols in batches.
-    /// Reuses a single prepared statement for all rows to avoid per-row command overhead.
+    /// Reuses a prepared statement per batch to avoid per-row command overhead.
     /// シンボルをバッチ挿入する。
-    /// 行ごとのコマンド生成コストを回避するため、単一のプリペアドステートメントを再利用する。
+    /// バッチごとにプリペアドステートメントを再利用し、行ごとのコマンド生成コストを回避する。
     /// </summary>
     public void InsertSymbols(IReadOnlyList<SymbolRecord> symbols)
     {
         if (symbols.Count == 0) return;
-
-        // Prepare the command once and reuse for all rows
-        // コマンドを1回だけ準備し、全行で再利用する
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
-            INSERT INTO symbols (file_id, kind, name, line)
-            VALUES (@fid, @kind, @name, @line)";
-        var pFid = cmd.Parameters.Add("@fid", SqliteType.Integer);
-        var pKind = cmd.Parameters.Add("@kind", SqliteType.Text);
-        var pName = cmd.Parameters.Add("@name", SqliteType.Text);
-        var pLine = cmd.Parameters.Add("@line", SqliteType.Integer);
-        cmd.Prepare();
 
         for (int i = 0; i < symbols.Count; i += BatchSize)
         {
@@ -323,6 +311,18 @@ public class DbWriter
             // Only create a batch transaction when not already inside an outer transaction
             // 外部トランザクション内でない場合のみバッチトランザクションを作成
             using var transaction = !IsInTransaction() ? BeginTransaction() : null;
+
+            // Prepare after transaction starts so the command inherits the connection's transaction state
+            // トランザクション開始後に準備し、接続のトランザクション状態を引き継ぐ
+            using var cmd = _conn.CreateCommand();
+            cmd.CommandText = @"
+                INSERT INTO symbols (file_id, kind, name, line)
+                VALUES (@fid, @kind, @name, @line)";
+            var pFid = cmd.Parameters.Add("@fid", SqliteType.Integer);
+            var pKind = cmd.Parameters.Add("@kind", SqliteType.Text);
+            var pName = cmd.Parameters.Add("@name", SqliteType.Text);
+            var pLine = cmd.Parameters.Add("@line", SqliteType.Integer);
+            cmd.Prepare();
 
             for (int j = i; j < end; j++)
             {

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -250,10 +250,27 @@ public class DbWriter
 
     /// <summary>
     /// Insert chunks in batches (FTS index is populated automatically by triggers).
+    /// Reuses a single prepared statement for all rows to avoid per-row command overhead.
     /// チャンクをバッチ挿入する（FTSインデックスはトリガーにより自動で反映される）。
+    /// 行ごとのコマンド生成コストを回避するため、単一のプリペアドステートメントを再利用する。
     /// </summary>
     public void InsertChunks(IReadOnlyList<ChunkRecord> chunks)
     {
+        if (chunks.Count == 0) return;
+
+        // Prepare the command once and reuse for all rows
+        // コマンドを1回だけ準備し、全行で再利用する
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO chunks (file_id, chunk_index, start_line, end_line, content)
+            VALUES (@fid, @idx, @start, @end, @content)";
+        var pFid = cmd.Parameters.Add("@fid", SqliteType.Integer);
+        var pIdx = cmd.Parameters.Add("@idx", SqliteType.Integer);
+        var pStart = cmd.Parameters.Add("@start", SqliteType.Integer);
+        var pEnd = cmd.Parameters.Add("@end", SqliteType.Integer);
+        var pContent = cmd.Parameters.Add("@content", SqliteType.Text);
+        cmd.Prepare();
+
         for (int i = 0; i < chunks.Count; i += BatchSize)
         {
             int end = Math.Min(i + BatchSize, chunks.Count);
@@ -264,15 +281,11 @@ public class DbWriter
             for (int j = i; j < end; j++)
             {
                 var chunk = chunks[j];
-                using var cmd = _conn.CreateCommand();
-                cmd.CommandText = @"
-                    INSERT INTO chunks (file_id, chunk_index, start_line, end_line, content)
-                    VALUES (@fid, @idx, @start, @end, @content)";
-                cmd.Parameters.AddWithValue("@fid", chunk.FileId);
-                cmd.Parameters.AddWithValue("@idx", chunk.ChunkIndex);
-                cmd.Parameters.AddWithValue("@start", chunk.StartLine);
-                cmd.Parameters.AddWithValue("@end", chunk.EndLine);
-                cmd.Parameters.AddWithValue("@content", chunk.Content);
+                pFid.Value = chunk.FileId;
+                pIdx.Value = chunk.ChunkIndex;
+                pStart.Value = chunk.StartLine;
+                pEnd.Value = chunk.EndLine;
+                pContent.Value = chunk.Content;
                 // FTS index is populated automatically by fts_chunks_ai trigger
                 // FTSインデックスはfts_chunks_aiトリガーにより自動で反映される
                 cmd.ExecuteNonQuery();
@@ -284,10 +297,26 @@ public class DbWriter
 
     /// <summary>
     /// Insert symbols in batches.
+    /// Reuses a single prepared statement for all rows to avoid per-row command overhead.
     /// シンボルをバッチ挿入する。
+    /// 行ごとのコマンド生成コストを回避するため、単一のプリペアドステートメントを再利用する。
     /// </summary>
     public void InsertSymbols(IReadOnlyList<SymbolRecord> symbols)
     {
+        if (symbols.Count == 0) return;
+
+        // Prepare the command once and reuse for all rows
+        // コマンドを1回だけ準備し、全行で再利用する
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO symbols (file_id, kind, name, line)
+            VALUES (@fid, @kind, @name, @line)";
+        var pFid = cmd.Parameters.Add("@fid", SqliteType.Integer);
+        var pKind = cmd.Parameters.Add("@kind", SqliteType.Text);
+        var pName = cmd.Parameters.Add("@name", SqliteType.Text);
+        var pLine = cmd.Parameters.Add("@line", SqliteType.Integer);
+        cmd.Prepare();
+
         for (int i = 0; i < symbols.Count; i += BatchSize)
         {
             int end = Math.Min(i + BatchSize, symbols.Count);
@@ -298,14 +327,10 @@ public class DbWriter
             for (int j = i; j < end; j++)
             {
                 var symbol = symbols[j];
-                using var cmd = _conn.CreateCommand();
-                cmd.CommandText = @"
-                    INSERT INTO symbols (file_id, kind, name, line)
-                    VALUES (@fid, @kind, @name, @line)";
-                cmd.Parameters.AddWithValue("@fid", symbol.FileId);
-                cmd.Parameters.AddWithValue("@kind", symbol.Kind);
-                cmd.Parameters.AddWithValue("@name", symbol.Name);
-                cmd.Parameters.AddWithValue("@line", symbol.Line);
+                pFid.Value = symbol.FileId;
+                pKind.Value = symbol.Kind;
+                pName.Value = symbol.Name;
+                pLine.Value = symbol.Line;
                 cmd.ExecuteNonQuery();
             }
 

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -387,14 +387,14 @@ public class DbWriter
         // CASCADE on chunks/symbols + FTS triggers handle all cleanup automatically
         // chunks/symbolsのCASCADE + FTSトリガーが全クリーンアップを自動処理する
         using var txn = BeginTransaction();
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = "DELETE FROM files WHERE id = @id";
-        var pId = cmd.Parameters.Add("@id", SqliteType.Integer);
-        cmd.Prepare();
+        using var deleteCmd = _conn.CreateCommand();
+        deleteCmd.CommandText = "DELETE FROM files WHERE id = @id";
+        var pId = deleteCmd.Parameters.Add("@id", SqliteType.Integer);
+        deleteCmd.Prepare();
         foreach (var id in staleIds)
         {
             pId.Value = id;
-            cmd.ExecuteNonQuery();
+            deleteCmd.ExecuteNonQuery();
         }
         txn.Commit();
 

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -75,11 +75,13 @@ public class DbWriter
 
         public void Commit()
         {
-            _committed = true;
             if (_transaction != null)
                 _transaction.Commit();
             else
                 ExecuteSql($"RELEASE SAVEPOINT {_savepointName}");
+            // Set _committed after success so Dispose() will rollback if Commit/Release throws
+            // コミット/リリース成功後にフラグを立て、失敗時はDispose()でロールバックされるようにする
+            _committed = true;
         }
 
         public void Rollback()

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -241,12 +241,9 @@ int RunIndex(string[] indexArgs)
         return ExitUsageError;
     }
 
-    // Delete DB if rebuild mode / rebuildモードならDB削除
-    if (rebuild && File.Exists(dbPath))
-        File.Delete(dbPath);
-
     using var db = new DbContext(dbPath);
 
+    // Drop and recreate schema if rebuild mode / rebuildモードならスキーマを削除して再作成
     if (rebuild)
         db.DropAll();
 

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -671,13 +671,17 @@ static (string? projectPath, string dbPath, bool rebuild, bool verbose, bool jso
                 json = true;
                 break;
             case "--commits":
-                while (i + 1 < args.Length && !args[i + 1].StartsWith("--"))
+                // Consume subsequent arguments until we hit a flag (starts with '-')
+                // '-'で始まる引数が来るまで後続の引数をコミットIDとして取り込む
+                while (i + 1 < args.Length && !args[i + 1].StartsWith('-'))
                     commits.Add(args[++i]);
                 if (commits.Count == 0)
                     Console.Error.WriteLine("Warning: --commits specified but no commit IDs provided / --commits が指定されましたがコミットIDがありません");
                 break;
             case "--files":
-                while (i + 1 < args.Length && !args[i + 1].StartsWith("--"))
+                // Consume subsequent arguments until we hit a flag (starts with '-')
+                // '-'で始まる引数が来るまで後続の引数をファイルパスとして取り込む
+                while (i + 1 < args.Length && !args[i + 1].StartsWith('-'))
                     updateFiles.Add(args[++i]);
                 if (updateFiles.Count == 0)
                     Console.Error.WriteLine("Warning: --files specified but no file paths provided / --files が指定されましたがファイルパスがありません");

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -341,6 +341,17 @@ int RunUpdateMode(DbWriter writer, FileIndexer indexer, string projectRoot, stri
 
             var (record, content) = indexer.BuildRecord(absPath);
 
+            // Skip unchanged files (same logic as full scan mode)
+            // 未変更ファイルをスキップ（フルスキャンモードと同じロジック）
+            var existingId = writer.GetUnchangedFileId(record.Path, record.Modified, record.Checksum);
+            if (existingId != null)
+            {
+                skipped++;
+                if (verbose && !jsonOutput)
+                    Console.WriteLine($"  [SKIP] {relPath} (unchanged)");
+                continue;
+            }
+
             // Wrap clean + upsert + insert in a transaction for atomicity
             // clean + upsert + insert をトランザクションでアトミックに実行
             using var txn = writer.BeginTransaction();


### PR DESCRIPTION
TransactionScope.Commit() was setting _committed = true before calling
the underlying Commit() or RELEASE SAVEPOINT. If those operations threw,
Dispose() would not roll back because _committed was already true.

https://claude.ai/code/session_01UF8pGz18LkAM5sa8mEuaXN