### PR TITLE
Remove hardcoded version strings from csproj and tests

### DIFF
--- a/src/CodeIndex/CodeIndex.csproj
+++ b/src/CodeIndex/CodeIndex.csproj
@@ -12,7 +12,9 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>cdidx</ToolCommandName>
     <PackageId>cdidx</PackageId>
-    <Version>0.1.1</Version>
+    <VersionJsonPath>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '..', '..', 'version.json'))</VersionJsonPath>
+    <VersionJsonContent>$([System.IO.File]::ReadAllText('$(VersionJsonPath)'))</VersionJsonContent>
+    <Version>$([System.Text.RegularExpressions.Regex]::Match('$(VersionJsonContent)', '"version"\s*:\s*"([^"]+)"').Groups[1].Value)</Version>
     <Authors>Widthdom</Authors>
     <Description>Fast code indexer with FTS5 search for AI-powered coding. Index source code into SQLite and search by text, symbols, or files. / AIコーディング向け高速コードインデクサー。ソースコードをSQLiteにインデックスし、テキスト・シンボル・ファイルで検索。</Description>
     <PackageTags>code-search;indexer;sqlite;fts5;ai;mcp;developer-tools</PackageTags>

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using CodeIndex.Cli;
 using CodeIndex.Database;
 using CodeIndex.Mcp;
 using CodeIndex.Models;
@@ -55,7 +56,7 @@ public class McpServerTests : IDisposable
             Line = 1,
         }]);
 
-        _server = new McpServer(_dbPath, "0.1.1");
+        _server = new McpServer(_dbPath, ConsoleUi.LoadVersion());
     }
 
     // --- Protocol tests / プロトコルテスト ---
@@ -70,7 +71,7 @@ public class McpServerTests : IDisposable
         Assert.Equal(1, response["id"]!.GetValue<int>());
         Assert.Equal("2024-11-05", response["result"]!["protocolVersion"]!.GetValue<string>());
         Assert.Equal("cdidx", response["result"]!["serverInfo"]!["name"]!.GetValue<string>());
-        Assert.Equal("0.1.1", response["result"]!["serverInfo"]!["version"]!.GetValue<string>());
+        Assert.Equal(ConsoleUi.LoadVersion(), response["result"]!["serverInfo"]!["version"]!.GetValue<string>());
     }
 
     [Fact]


### PR DESCRIPTION
version.json is the single source of truth. The .csproj now reads it
via MSBuild property functions at build time, and McpServerTests uses
ConsoleUi.LoadVersion() instead of a literal "0.1.1".

version.jsonがバージョンの唯一の情報源。csprojはMSBuildプロパティ関数で
ビルド時に読み取り、McpServerTestsはConsoleUi.LoadVersion()を使用。

https://claude.ai/code/session_014E9PJ1wDRB8HbspoqpVTFL