### PR TITLE
Fix .cdidx/ exclusion in git worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Fixed
 
-- **Git worktree support for `.cdidx/` exclusion** — In a git worktree, `.git` is a file (not a directory), so `AddToGitExclude` could not find `.git/info/exclude` and silently skipped writing — causing `.cdidx/` to appear as untracked. Fixed by adding `GitHelper.ResolveGitCommonDir()` which follows the worktree resolution chain: `.git` file → parse `gitdir:` to locate the worktree-specific dir (e.g. `.git/worktrees/<name>/`) → read `commondir` (`../..`) to resolve back to the shared `.git/` directory where `info/exclude` lives. Affected: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`.
+- **Git worktree support for `.cdidx/` exclusion** — In a git worktree, `.git` is a file (not a directory), so the worktree root has no `.git/info/exclude` and `AddToGitExclude` silently skipped writing — causing `.cdidx/` to appear as untracked. Fixed by adding `GitHelper.ResolveGitCommonDir()` which chases references to find the shared `.git/` directory: reads the `.git` file to get the `gitdir:` path (e.g. `.git/worktrees/<name>/`), then reads the `commondir` file at that location (`../..`) to resolve back to the shared `.git/` where `info/exclude` lives. Affected: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`.
 
 ### [1.0.2] - 2026-04-08
 
@@ -115,7 +115,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### 修正
 
-- **git worktreeでの`.cdidx/`除外対応** — git worktreeでは`.git`がディレクトリではなくファイルであるため、`AddToGitExclude`が`.git/info/exclude`を見つけられず書き込みをスキップしていた。結果として`.cdidx/`がuntrackedとして表示されていた。`GitHelper.ResolveGitCommonDir()`を追加し、worktreeの解決チェーンを辿るよう修正: `.git`ファイル → `gitdir:`を解析してworktree固有ディレクトリ（例: `.git/worktrees/<name>/`）を特定 → `commondir`（`../..`）を読んで`info/exclude`がある共通`.git/`ディレクトリに到達。対象: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`。
+- **git worktreeでの`.cdidx/`除外対応** — git worktreeでは`.git`がディレクトリではなくファイルであるため、worktreeルートには`.git/info/exclude`が存在せず`AddToGitExclude`が書き込みをスキップしていた。結果として`.cdidx/`がuntrackedとして表示されていた。`GitHelper.ResolveGitCommonDir()`を追加し、共通`.git/`ディレクトリを探すよう修正: `.git`ファイルから`gitdir:`パスを読み取り（例: `.git/worktrees/<name>/`）、そのディレクトリ内の`commondir`ファイル（中身は`../..`）を読んで`info/exclude`がある共通`.git/`に到達する。対象: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`。
 
 ### [1.0.2] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Fixed
 
-- **Git worktree support for `.cdidx/` exclusion** — `AddToGitExclude` now resolves the common git directory via the `.git` file and `commondir` in worktrees, so `.cdidx/` is correctly added to `.git/info/exclude` even when running inside a git worktree. Previously, the `.git` directory check failed because worktrees use a `.git` file instead. Extracted `ResolveGitCommonDir` to `GitHelper` for testability. Affected: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`.
+- **Git worktree support for `.cdidx/` exclusion** — In a git worktree, `.git` is a file (not a directory), so `AddToGitExclude` could not find `.git/info/exclude` and silently skipped writing — causing `.cdidx/` to appear as untracked. Fixed by adding `GitHelper.ResolveGitCommonDir()` which follows the worktree resolution chain: `.git` file → parse `gitdir:` to locate the worktree-specific dir (e.g. `.git/worktrees/<name>/`) → read `commondir` (`../..`) to resolve back to the shared `.git/` directory where `info/exclude` lives. Affected: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`.
 
 ### [1.0.2] - 2026-04-08
 
@@ -115,7 +115,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### 修正
 
-- **git worktreeでの`.cdidx/`除外対応** — `AddToGitExclude`がworktree内の`.git`ファイルと`commondir`を辿って共通gitディレクトリを解決するようになり、worktree内でも`.cdidx/`が正しく`.git/info/exclude`に追加されるようになった。従来はworktreeの`.git`がファイルであるためディレクトリチェックに失敗していた。テスト容易性のため`ResolveGitCommonDir`を`GitHelper`に抽出。対象: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`。
+- **git worktreeでの`.cdidx/`除外対応** — git worktreeでは`.git`がディレクトリではなくファイルであるため、`AddToGitExclude`が`.git/info/exclude`を見つけられず書き込みをスキップしていた。結果として`.cdidx/`がuntrackedとして表示されていた。`GitHelper.ResolveGitCommonDir()`を追加し、worktreeの解決チェーンを辿るよう修正: `.git`ファイル → `gitdir:`を解析してworktree固有ディレクトリ（例: `.git/worktrees/<name>/`）を特定 → `commondir`（`../..`）を読んで`info/exclude`がある共通`.git/`ディレクトリに到達。対象: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`。
 
 ### [1.0.2] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Fixed
+
+- **Git worktree support for `.cdidx/` exclusion** — `AddToGitExclude` now resolves the common git directory via the `.git` file and `commondir` in worktrees, so `.cdidx/` is correctly added to `.git/info/exclude` even when running inside a git worktree. Previously, the `.git` directory check failed because worktrees use a `.git` file instead. Extracted `ResolveGitCommonDir` to `GitHelper` for testability. Affected: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`.
+
 ### [1.0.2] - 2026-04-08
 
 #### Added
@@ -108,6 +112,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 修正
+
+- **git worktreeでの`.cdidx/`除外対応** — `AddToGitExclude`がworktree内の`.git`ファイルと`commondir`を辿って共通gitディレクトリを解決するようになり、worktree内でも`.cdidx/`が正しく`.git/info/exclude`に追加されるようになった。従来はworktreeの`.git`がファイルであるためディレクトリチェックに失敗していた。テスト容易性のため`ResolveGitCommonDir`を`GitHelper`に抽出。対象: `Cli/GitHelper.cs`, `Program.cs`, `GitHelperTests.cs`。
 
 ### [1.0.2] - 2026-04-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ tests/CodeIndex.Tests/
       │   └── exclude                 ← AddToGitExclude writes here
       └── 📂 worktrees/
           └── 📂 feature-branch/
-              └── commondir           ← contains "../.." (2 levels up = .git/)
+              └── commondir           ← contains "../.."
 
   /projects/my-app-feature/           ← worktree root
   ├── .git                            ← FILE containing "gitdir: /projects/my-app/.git/worktrees/feature-branch"
@@ -94,7 +94,8 @@ tests/CodeIndex.Tests/
   **Resolution chain in worktree:**
   1. Read `.git` file → `gitdir: /projects/my-app/.git/worktrees/feature-branch`
   2. Read `commondir` file at that path → `../..`
-  3. Resolve: `.git/worktrees/feature-branch` + `../..` = `.git/`
+  3. Resolve `../..` relative to `feature-branch/` dir:
+     `feature-branch/` → `..` → `worktrees/` → `..` → `.git/`
   4. Write to `.git/info/exclude`
 
 ## Conventions
@@ -241,7 +242,7 @@ tests/CodeIndex.Tests/
       │   └── exclude                 ← AddToGitExcludeがここに書き込む
       └── 📂 worktrees/
           └── 📂 feature-branch/
-              └── commondir           ← "../.."が入っている（2階層上 = .git/）
+              └── commondir           ← "../.."が入っている
 
   /projects/my-app-feature/           ← worktreeのルート
   ├── .git                            ← ファイル。中身は "gitdir: /projects/my-app/.git/worktrees/feature-branch"
@@ -252,7 +253,8 @@ tests/CodeIndex.Tests/
   **worktreeでの解決チェーン:**
   1. `.git`ファイルを読む → `gitdir: /projects/my-app/.git/worktrees/feature-branch`
   2. そのパスの`commondir`ファイルを読む → `../..`
-  3. 解決: `.git/worktrees/feature-branch` + `../..` = `.git/`
+  3. `../..`を`feature-branch/`ディレクトリ起点で解決:
+     `feature-branch/` → `..` → `worktrees/` → `..` → `.git/`
   4. `.git/info/exclude`に書き込む
 
 ## コーディング規約

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,21 +70,25 @@ tests/CodeIndex.Tests/
   ```
   # Normal repo — .git is a directory, info/exclude is right there
   /projects/my-app/                   ← project root
-    .git/                             ← directory
-      info/exclude                    ← AddToGitExclude writes here
-    .cdidx/codeindex.db
+  ├── 📂 .git/                        ← directory
+  │   └── 📂 info/
+  │       └── exclude                 ← AddToGitExclude writes here
+  └── 📂 .cdidx/
+      └── codeindex.db
 
   # Worktree — .git is a file, need to chase references to find info/exclude
   /projects/my-app/                   ← main repo root
-    .git/                             ← actual git directory (shared)
-      info/exclude                    ← AddToGitExclude writes here
-      worktrees/
-        feature-branch/
-          commondir                   ← contains "../.." (points back to .git/)
+  └── 📂 .git/                        ← actual git directory (shared)
+      ├── 📂 info/
+      │   └── exclude                 ← AddToGitExclude writes here
+      └── 📂 worktrees/
+          └── 📂 feature-branch/
+              └── commondir           ← contains "../.." (2 levels up = .git/)
 
   /projects/my-app-feature/           ← worktree root
-    .git                              ← FILE containing "gitdir: /projects/my-app/.git/worktrees/feature-branch"
-    .cdidx/codeindex.db
+  ├── .git                            ← FILE containing "gitdir: /projects/my-app/.git/worktrees/feature-branch"
+  └── 📂 .cdidx/
+      └── codeindex.db
   ```
 
   **Resolution chain in worktree:**
@@ -224,21 +228,25 @@ tests/CodeIndex.Tests/
   ```
   # 通常リポジトリ — .gitがディレクトリ、info/excludeはその直下
   /projects/my-app/                   ← プロジェクトルート
-    .git/                             ← ディレクトリ
-      info/exclude                    ← AddToGitExcludeがここに書き込む
-    .cdidx/codeindex.db
+  ├── 📂 .git/                        ← ディレクトリ
+  │   └── 📂 info/
+  │       └── exclude                 ← AddToGitExcludeがここに書き込む
+  └── 📂 .cdidx/
+      └── codeindex.db
 
   # worktree — .gitがファイル、参照を辿ってinfo/excludeを見つける
   /projects/my-app/                   ← 元リポジトリのルート
-    .git/                             ← 実体のgitディレクトリ（共有）
-      info/exclude                    ← AddToGitExcludeがここに書き込む
-      worktrees/
-        feature-branch/
-          commondir                   ← "../.."が入っている（.git/を指す）
+  └── 📂 .git/                        ← 実体のgitディレクトリ（共有）
+      ├── 📂 info/
+      │   └── exclude                 ← AddToGitExcludeがここに書き込む
+      └── 📂 worktrees/
+          └── 📂 feature-branch/
+              └── commondir           ← "../.."が入っている（2階層上 = .git/）
 
   /projects/my-app-feature/           ← worktreeのルート
-    .git                              ← ファイル。中身は "gitdir: /projects/my-app/.git/worktrees/feature-branch"
-    .cdidx/codeindex.db
+  ├── .git                            ← ファイル。中身は "gitdir: /projects/my-app/.git/worktrees/feature-branch"
+  └── 📂 .cdidx/
+      └── codeindex.db
   ```
 
   **worktreeでの解決チェーン:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ cdidx mcp [--db <path>]
 src/CodeIndex/
   Program.cs               — CLI entry point, subcommand routing, --json support, .git/info/exclude auto-add
   Cli/ConsoleUi.cs         — Spinner, progress bar, banner, easter egg, version, usage text
-  Cli/GitHelper.cs         — Git diff-tree helper for --commits option
+  Cli/GitHelper.cs         — Git helpers: diff-tree for --commits, worktree-aware common dir resolution
   Database/DbContext.cs     — SQLite connection, schema init (WAL, FTS5, triggers, busy_timeout)
   Database/DbWriter.cs      — UPSERT (ON CONFLICT DO UPDATE), batch insert, stale file purge
   Database/DbReader.cs      — Query operations (FTS search, symbol lookup, file listing, status)
@@ -64,7 +64,7 @@ tests/CodeIndex.Tests/
 - **Human-readable default** — All commands default to human-readable output. Use `--json` for machine-readable JSON lines (AI-friendly).
 - **Structured exit codes** — 0=success, 1=usage error, 2=not found, 3=database error.
 - **No direct Console output from library code** — `FileIndexer.BuildRecord()` returns warnings as a return value `(FileRecord, string, string?)` instead of writing to stderr. The caller (`Program.cs`) handles display, clearing the progress bar line first via `ConsoleUi.ClearProgressLine()`.
-- **`.cdidx/` directory** — Index files are stored in `.cdidx/codeindex.db` (not project root). The directory is auto-created on first `cdidx index` and auto-added to `.git/info/exclude` so users don't touch `.gitignore`. This is a standard Git mechanism (used by git-lfs, Husky, JetBrains IDEs, etc.).
+- **`.cdidx/` directory** — Index files are stored in `.cdidx/codeindex.db` (not project root). The directory is auto-created on first `cdidx index` and auto-added to `.git/info/exclude` so users don't touch `.gitignore`. In a git worktree, `.git` is a file (not a directory), so `GitHelper.ResolveGitCommonDir()` follows the chain: `.git` file → `gitdir:` → worktree-specific dir (`.git/worktrees/<name>/`) → `commondir` → shared `.git/` where `info/exclude` lives. This is a standard Git mechanism (used by git-lfs, Husky, JetBrains IDEs, etc.).
 
 ## Conventions
 
@@ -191,7 +191,7 @@ tests/CodeIndex.Tests/
 - **人間向けがデフォルト** — 全コマンドのデフォルト出力は人間向け。`--json`でAI向けJSONライン出力に切り替え。
 - **構造化終了コード** — 0=成功、1=引数エラー、2=未検出、3=DBエラー。
 - **ライブラリコードから直接Console出力しない** — `FileIndexer.BuildRecord()`は警告を戻り値`(FileRecord, string, string?)`で返す。表示は呼び出し元（`Program.cs`）が`ConsoleUi.ClearProgressLine()`でプログレスバーをクリアしてから行う。
-- **`.cdidx/`ディレクトリ** — インデックスファイルは`.cdidx/codeindex.db`に格納（プロジェクトルート直下ではない）。初回の`cdidx index`でディレクトリを自動作成し、`.git/info/exclude`に自動追加するためユーザーが`.gitignore`を編集する必要なし。Git標準の仕組み（git-lfs、Husky、JetBrains IDE等が利用）。
+- **`.cdidx/`ディレクトリ** — インデックスファイルは`.cdidx/codeindex.db`に格納（プロジェクトルート直下ではない）。初回の`cdidx index`でディレクトリを自動作成し、`.git/info/exclude`に自動追加するためユーザーが`.gitignore`を編集する必要なし。git worktreeでは`.git`がディレクトリではなくファイルのため、`GitHelper.ResolveGitCommonDir()`で解決チェーンを辿る: `.git`ファイル → `gitdir:` → worktree固有ディレクトリ（`.git/worktrees/<name>/`）→ `commondir` → `info/exclude`がある共通`.git/`。Git標準の仕組み（git-lfs、Husky、JetBrains IDE等が利用）。
 
 ## コーディング規約
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,34 @@ tests/CodeIndex.Tests/
 - **Human-readable default** — All commands default to human-readable output. Use `--json` for machine-readable JSON lines (AI-friendly).
 - **Structured exit codes** — 0=success, 1=usage error, 2=not found, 3=database error.
 - **No direct Console output from library code** — `FileIndexer.BuildRecord()` returns warnings as a return value `(FileRecord, string, string?)` instead of writing to stderr. The caller (`Program.cs`) handles display, clearing the progress bar line first via `ConsoleUi.ClearProgressLine()`.
-- **`.cdidx/` directory** — Index files are stored in `.cdidx/codeindex.db` (not project root). The directory is auto-created on first `cdidx index` and auto-added to `.git/info/exclude` so users don't touch `.gitignore`. In a git worktree, `.git` is a file (not a directory), so `GitHelper.ResolveGitCommonDir()` follows the chain: `.git` file → `gitdir:` → worktree-specific dir (`.git/worktrees/<name>/`) → `commondir` → shared `.git/` where `info/exclude` lives. This is a standard Git mechanism (used by git-lfs, Husky, JetBrains IDEs, etc.).
+- **`.cdidx/` directory** — Index files are stored in `.cdidx/codeindex.db` (not project root). The directory is auto-created on first `cdidx index` and auto-added to `.git/info/exclude` so users don't touch `.gitignore`. In a git worktree, `.git` is a file (not a directory), so `GitHelper.ResolveGitCommonDir()` follows the chain to find the shared `.git/` where `info/exclude` lives. This is a standard Git mechanism (used by git-lfs, Husky, JetBrains IDEs, etc.).
+
+  **Normal repo vs worktree structure:**
+  ```
+  # Normal repo — .git is a directory, info/exclude is right there
+  /projects/my-app/                   ← project root
+    .git/                             ← directory
+      info/exclude                    ← AddToGitExclude writes here
+    .cdidx/codeindex.db
+
+  # Worktree — .git is a file, need to chase references to find info/exclude
+  /projects/my-app/                   ← main repo root
+    .git/                             ← actual git directory (shared)
+      info/exclude                    ← AddToGitExclude writes here
+      worktrees/
+        feature-branch/
+          commondir                   ← contains "../.." (points back to .git/)
+
+  /projects/my-app-feature/           ← worktree root
+    .git                              ← FILE containing "gitdir: /projects/my-app/.git/worktrees/feature-branch"
+    .cdidx/codeindex.db
+  ```
+
+  **Resolution chain in worktree:**
+  1. Read `.git` file → `gitdir: /projects/my-app/.git/worktrees/feature-branch`
+  2. Read `commondir` file at that path → `../..`
+  3. Resolve: `.git/worktrees/feature-branch` + `../..` = `.git/`
+  4. Write to `.git/info/exclude`
 
 ## Conventions
 
@@ -191,7 +218,34 @@ tests/CodeIndex.Tests/
 - **人間向けがデフォルト** — 全コマンドのデフォルト出力は人間向け。`--json`でAI向けJSONライン出力に切り替え。
 - **構造化終了コード** — 0=成功、1=引数エラー、2=未検出、3=DBエラー。
 - **ライブラリコードから直接Console出力しない** — `FileIndexer.BuildRecord()`は警告を戻り値`(FileRecord, string, string?)`で返す。表示は呼び出し元（`Program.cs`）が`ConsoleUi.ClearProgressLine()`でプログレスバーをクリアしてから行う。
-- **`.cdidx/`ディレクトリ** — インデックスファイルは`.cdidx/codeindex.db`に格納（プロジェクトルート直下ではない）。初回の`cdidx index`でディレクトリを自動作成し、`.git/info/exclude`に自動追加するためユーザーが`.gitignore`を編集する必要なし。git worktreeでは`.git`がディレクトリではなくファイルのため、`GitHelper.ResolveGitCommonDir()`で解決チェーンを辿る: `.git`ファイル → `gitdir:` → worktree固有ディレクトリ（`.git/worktrees/<name>/`）→ `commondir` → `info/exclude`がある共通`.git/`。Git標準の仕組み（git-lfs、Husky、JetBrains IDE等が利用）。
+- **`.cdidx/`ディレクトリ** — インデックスファイルは`.cdidx/codeindex.db`に格納（プロジェクトルート直下ではない）。初回の`cdidx index`でディレクトリを自動作成し、`.git/info/exclude`に自動追加するためユーザーが`.gitignore`を編集する必要なし。git worktreeでは`.git`がディレクトリではなくファイルのため、`GitHelper.ResolveGitCommonDir()`で解決チェーンを辿って`info/exclude`がある共通`.git/`を見つける。Git標準の仕組み（git-lfs、Husky、JetBrains IDE等が利用）。
+
+  **通常リポジトリ vs worktreeの構造:**
+  ```
+  # 通常リポジトリ — .gitがディレクトリ、info/excludeはその直下
+  /projects/my-app/                   ← プロジェクトルート
+    .git/                             ← ディレクトリ
+      info/exclude                    ← AddToGitExcludeがここに書き込む
+    .cdidx/codeindex.db
+
+  # worktree — .gitがファイル、参照を辿ってinfo/excludeを見つける
+  /projects/my-app/                   ← 元リポジトリのルート
+    .git/                             ← 実体のgitディレクトリ（共有）
+      info/exclude                    ← AddToGitExcludeがここに書き込む
+      worktrees/
+        feature-branch/
+          commondir                   ← "../.."が入っている（.git/を指す）
+
+  /projects/my-app-feature/           ← worktreeのルート
+    .git                              ← ファイル。中身は "gitdir: /projects/my-app/.git/worktrees/feature-branch"
+    .cdidx/codeindex.db
+  ```
+
+  **worktreeでの解決チェーン:**
+  1. `.git`ファイルを読む → `gitdir: /projects/my-app/.git/worktrees/feature-branch`
+  2. そのパスの`commondir`ファイルを読む → `../..`
+  3. 解決: `.git/worktrees/feature-branch` + `../..` = `.git/`
+  4. `.git/info/exclude`に書き込む
 
 ## コーディング規約
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -384,7 +384,7 @@ See [Exit codes](README.md#exit-codes) in README.
       │   └── exclude                 ← write here
       └── 📂 worktrees/
           └── 📂 feature-branch/
-              └── commondir           ← contains "../.." (2 levels up = .git/)
+              └── commondir           ← contains "../.."
 
   /projects/my-app-feature/           ← worktree root
   ├── .git                            ← FILE: "gitdir: /projects/my-app/.git/worktrees/feature-branch"
@@ -392,7 +392,7 @@ See [Exit codes](README.md#exit-codes) in README.
       └── codeindex.db
   ```
 
-  Resolution: read `.git` file → parse `gitdir:` → read `commondir` at that path → resolve to shared `.git/` → write `info/exclude`.
+  Resolution: read `.git` file → parse `gitdir:` → read `commondir` file at that path → resolve `../..` relative to `feature-branch/` dir (`feature-branch/` → `..` → `worktrees/` → `..` → `.git/`) → write `info/exclude`.
 
 ## Coding conventions
 
@@ -795,7 +795,7 @@ READMEの[終了コード](README.md#終了コード)セクションを参照し
       └── codeindex.db
   ```
 
-  解決手順: `.git`ファイルを読む → `gitdir:`を解析 → そのパスの`commondir`を読む → 共通`.git/`に到達 → `info/exclude`に書き込む。
+  解決手順: `.git`ファイルを読む → `gitdir:`を解析 → そのパスの`commondir`ファイルを読む → `../..`を`feature-branch/`ディレクトリ起点で解決（`feature-branch/` → `..` → `worktrees/` → `..` → `.git/`）→ `info/exclude`に書き込む。
 
 ## コーディング規約
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -366,7 +366,29 @@ See [Exit codes](README.md#exit-codes) in README.
 - **Manual arg parsing** — `System.CommandLine` was removed to reduce dependencies. Simple switch-based parsing.
 - **SHA256 checksums** — Computed from raw file bytes and stored per file. Used as a fallback for change detection when timestamps differ (e.g. after `git checkout`).
 - **UTF-8 with fallback** — Invalid UTF-8 bytes are replaced with U+FFFD rather than failing the entire file.
-- **Worktree-aware git exclude** — `.cdidx/` is auto-added to `.git/info/exclude`. In a worktree, `.git` is a file (not a directory), so `GitHelper.ResolveGitCommonDir()` follows the resolution chain: `.git` file → `gitdir:` → worktree-specific dir (`.git/worktrees/<name>/`) → `commondir` → shared `.git/` where `info/exclude` lives.
+- **Worktree-aware git exclude** — `.cdidx/` is auto-added to `.git/info/exclude`. In a worktree, `.git` is a file (not a directory), so the worktree root has no `.git/info/exclude`. `GitHelper.ResolveGitCommonDir()` chases references to find the shared `.git/`:
+
+  ```
+  # Normal repo — .git is a directory
+  /projects/my-app/
+    .git/                             ← directory
+      info/exclude                    ← write here
+    .cdidx/codeindex.db
+
+  # Worktree — .git is a file
+  /projects/my-app/                   ← main repo
+    .git/                             ← shared git dir
+      info/exclude                    ← write here
+      worktrees/
+        feature-branch/
+          commondir                   ← contains "../.."
+
+  /projects/my-app-feature/           ← worktree root
+    .git                              ← FILE: "gitdir: /projects/my-app/.git/worktrees/feature-branch"
+    .cdidx/codeindex.db
+  ```
+
+  Resolution: read `.git` file → parse `gitdir:` → read `commondir` at that path → resolve to shared `.git/` → write `info/exclude`.
 
 ## Coding conventions
 
@@ -743,7 +765,29 @@ READMEの[終了コード](README.md#終了コード)セクションを参照し
 - **手動引数解析** — `System.CommandLine`は依存削減のため削除。シンプルなswitch文での解析。
 - **SHA256チェックサム** — ファイルのraw bytesから算出しファイルごとに保存。タイムスタンプが異なる場合の変更検出フォールバックとして使用（例: `git checkout`後）。
 - **UTF-8フォールバック** — 不正なUTF-8バイトはファイル全体を失敗させずU+FFFDに置換。
-- **worktree対応のgit exclude** — `.cdidx/`を`.git/info/exclude`に自動追加する。worktreeでは`.git`がディレクトリではなくファイルのため、`GitHelper.ResolveGitCommonDir()`で解決チェーンを辿る: `.git`ファイル → `gitdir:` → worktree固有ディレクトリ（`.git/worktrees/<name>/`）→ `commondir` → `info/exclude`がある共通`.git/`。
+- **worktree対応のgit exclude** — `.cdidx/`を`.git/info/exclude`に自動追加する。worktreeでは`.git`がディレクトリではなくファイルのため、worktreeルートには`.git/info/exclude`が存在しない。`GitHelper.ResolveGitCommonDir()`で参照を辿り共通`.git/`を見つける:
+
+  ```
+  # 通常リポジトリ — .gitがディレクトリ
+  /projects/my-app/
+    .git/                             ← ディレクトリ
+      info/exclude                    ← ここに書き込む
+    .cdidx/codeindex.db
+
+  # worktree — .gitがファイル
+  /projects/my-app/                   ← 元リポジトリ
+    .git/                             ← 共有gitディレクトリ
+      info/exclude                    ← ここに書き込む
+      worktrees/
+        feature-branch/
+          commondir                   ← "../.."が入っている
+
+  /projects/my-app-feature/           ← worktreeルート
+    .git                              ← ファイル: "gitdir: /projects/my-app/.git/worktrees/feature-branch"
+    .cdidx/codeindex.db
+  ```
+
+  解決手順: `.git`ファイルを読む → `gitdir:`を解析 → そのパスの`commondir`を読む → 共通`.git/`に到達 → `info/exclude`に書き込む。
 
 ## コーディング規約
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -17,7 +17,7 @@ src/CodeIndex/
   Program.cs                  — CLI entry point, subcommand routing
   Cli/
     ConsoleUi.cs              — Spinner, progress bar, banner, easter egg, version, usage text
-    GitHelper.cs              — Git diff-tree helper for --commits option
+    GitHelper.cs              — Git helpers: diff-tree for --commits, worktree-aware common dir resolution
   Database/
     DbContext.cs              — SQLite connection, WAL mode, schema init
     DbWriter.cs               — UPSERT, batch insert, stale file purge, FTS cleanup
@@ -366,6 +366,7 @@ See [Exit codes](README.md#exit-codes) in README.
 - **Manual arg parsing** — `System.CommandLine` was removed to reduce dependencies. Simple switch-based parsing.
 - **SHA256 checksums** — Computed from raw file bytes and stored per file. Used as a fallback for change detection when timestamps differ (e.g. after `git checkout`).
 - **UTF-8 with fallback** — Invalid UTF-8 bytes are replaced with U+FFFD rather than failing the entire file.
+- **Worktree-aware git exclude** — `.cdidx/` is auto-added to `.git/info/exclude`. In a worktree, `.git` is a file (not a directory), so `GitHelper.ResolveGitCommonDir()` follows the resolution chain: `.git` file → `gitdir:` → worktree-specific dir (`.git/worktrees/<name>/`) → `commondir` → shared `.git/` where `info/exclude` lives.
 
 ## Coding conventions
 
@@ -742,6 +743,7 @@ READMEの[終了コード](README.md#終了コード)セクションを参照し
 - **手動引数解析** — `System.CommandLine`は依存削減のため削除。シンプルなswitch文での解析。
 - **SHA256チェックサム** — ファイルのraw bytesから算出しファイルごとに保存。タイムスタンプが異なる場合の変更検出フォールバックとして使用（例: `git checkout`後）。
 - **UTF-8フォールバック** — 不正なUTF-8バイトはファイル全体を失敗させずU+FFFDに置換。
+- **worktree対応のgit exclude** — `.cdidx/`を`.git/info/exclude`に自動追加する。worktreeでは`.git`がディレクトリではなくファイルのため、`GitHelper.ResolveGitCommonDir()`で解決チェーンを辿る: `.git`ファイル → `gitdir:` → worktree固有ディレクトリ（`.git/worktrees/<name>/`）→ `commondir` → `info/exclude`がある共通`.git/`。
 
 ## コーディング規約
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -370,22 +370,26 @@ See [Exit codes](README.md#exit-codes) in README.
 
   ```
   # Normal repo — .git is a directory
-  /projects/my-app/
-    .git/                             ← directory
-      info/exclude                    ← write here
-    .cdidx/codeindex.db
+  /projects/my-app/                   ← project root
+  ├── 📂 .git/                        ← directory
+  │   └── 📂 info/
+  │       └── exclude                 ← write here
+  └── 📂 .cdidx/
+      └── codeindex.db
 
   # Worktree — .git is a file
   /projects/my-app/                   ← main repo
-    .git/                             ← shared git dir
-      info/exclude                    ← write here
-      worktrees/
-        feature-branch/
-          commondir                   ← contains "../.."
+  └── 📂 .git/                        ← shared git dir
+      ├── 📂 info/
+      │   └── exclude                 ← write here
+      └── 📂 worktrees/
+          └── 📂 feature-branch/
+              └── commondir           ← contains "../.." (2 levels up = .git/)
 
   /projects/my-app-feature/           ← worktree root
-    .git                              ← FILE: "gitdir: /projects/my-app/.git/worktrees/feature-branch"
-    .cdidx/codeindex.db
+  ├── .git                            ← FILE: "gitdir: /projects/my-app/.git/worktrees/feature-branch"
+  └── 📂 .cdidx/
+      └── codeindex.db
   ```
 
   Resolution: read `.git` file → parse `gitdir:` → read `commondir` at that path → resolve to shared `.git/` → write `info/exclude`.
@@ -769,22 +773,26 @@ READMEの[終了コード](README.md#終了コード)セクションを参照し
 
   ```
   # 通常リポジトリ — .gitがディレクトリ
-  /projects/my-app/
-    .git/                             ← ディレクトリ
-      info/exclude                    ← ここに書き込む
-    .cdidx/codeindex.db
+  /projects/my-app/                   ← プロジェクトルート
+  ├── 📂 .git/                        ← ディレクトリ
+  │   └── 📂 info/
+  │       └── exclude                 ← ここに書き込む
+  └── 📂 .cdidx/
+      └── codeindex.db
 
   # worktree — .gitがファイル
   /projects/my-app/                   ← 元リポジトリ
-    .git/                             ← 共有gitディレクトリ
-      info/exclude                    ← ここに書き込む
-      worktrees/
-        feature-branch/
-          commondir                   ← "../.."が入っている
+  └── 📂 .git/                        ← 共有gitディレクトリ
+      ├── 📂 info/
+      │   └── exclude                 ← ここに書き込む
+      └── 📂 worktrees/
+          └── 📂 feature-branch/
+              └── commondir           ← "../.."が入っている（2階層上 = .git/）
 
   /projects/my-app-feature/           ← worktreeルート
-    .git                              ← ファイル: "gitdir: /projects/my-app/.git/worktrees/feature-branch"
-    .cdidx/codeindex.db
+  ├── .git                            ← ファイル: "gitdir: /projects/my-app/.git/worktrees/feature-branch"
+  └── 📂 .cdidx/
+      └── codeindex.db
   ```
 
   解決手順: `.git`ファイルを読む → `gitdir:`を解析 → そのパスの`commondir`を読む → 共通`.git/`に到達 → `info/exclude`に書き込む。

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -10,6 +10,42 @@ namespace CodeIndex.Cli;
 public static class GitHelper
 {
     /// <summary>
+    /// Resolve the common git directory for a project root, handling both normal repos and worktrees.
+    /// プロジェクトルートの共通gitディレクトリを解決する。通常リポジトリとworktreeの両方に対応。
+    /// In a normal repo, .git is a directory and is returned directly.
+    /// In a worktree, .git is a file containing "gitdir: path/to/.git/worktrees/name".
+    /// The common dir is resolved via the "commondir" file inside the worktree git dir.
+    /// </summary>
+    public static string? ResolveGitCommonDir(string projectRoot)
+    {
+        var dotGit = Path.Combine(projectRoot, ".git");
+
+        // Normal repository: .git is a directory / 通常リポジトリ: .gitがディレクトリ
+        if (Directory.Exists(dotGit)) return dotGit;
+
+        // Worktree: .git is a file containing "gitdir: <path>" / worktree: .gitがファイルで "gitdir: <path>" を含む
+        if (!File.Exists(dotGit)) return null;
+
+        var gitFileContent = File.ReadAllText(dotGit).Trim();
+        if (!gitFileContent.StartsWith("gitdir:")) return null;
+
+        var worktreeGitDir = gitFileContent.Substring("gitdir:".Length).Trim();
+        if (!Path.IsPathRooted(worktreeGitDir))
+            worktreeGitDir = Path.GetFullPath(Path.Combine(projectRoot, worktreeGitDir));
+
+        // Read commondir to find the shared .git directory / commondirを読んで共有.gitディレクトリを見つける
+        var commonDirFile = Path.Combine(worktreeGitDir, "commondir");
+        if (File.Exists(commonDirFile))
+        {
+            var commonDirRelative = File.ReadAllText(commonDirFile).Trim();
+            return Path.GetFullPath(Path.Combine(worktreeGitDir, commonDirRelative));
+        }
+
+        // Fallback: use worktreeGitDir itself (e.g. submodules) / フォールバック: worktreeGitDir自体を使用
+        return worktreeGitDir;
+    }
+
+    /// <summary>
     /// Get changed files from a git commit.
     /// gitコミットから変更ファイルを取得する。
     /// </summary>

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -644,8 +644,8 @@ static void AddToGitExclude(string projectPath, string dbPath)
     try
     {
         var projectRoot = Path.GetFullPath(projectPath);
-        var gitDir = Path.Combine(projectRoot, ".git");
-        if (!Directory.Exists(gitDir)) return;
+        var gitDir = GitHelper.ResolveGitCommonDir(projectRoot);
+        if (gitDir == null) return;
 
         var excludeFile = Path.Combine(gitDir, "info", "exclude");
 

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -1,0 +1,124 @@
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+/// <summary>
+/// Tests for GitHelper.ResolveGitCommonDir.
+/// GitHelper.ResolveGitCommonDirのテスト。
+/// </summary>
+public class GitHelperTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public GitHelperTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void NormalRepo_ReturnsGitDirectory()
+    {
+        // Arrange: create a normal .git directory / 通常の.gitディレクトリを作成
+        var gitDir = Path.Combine(_tempDir, ".git");
+        Directory.CreateDirectory(gitDir);
+
+        // Act
+        var result = GitHelper.ResolveGitCommonDir(_tempDir);
+
+        // Assert
+        Assert.Equal(gitDir, result);
+    }
+
+    [Fact]
+    public void NoGitAtAll_ReturnsNull()
+    {
+        // No .git file or directory / .gitファイルもディレクトリもない
+        var result = GitHelper.ResolveGitCommonDir(_tempDir);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void WorktreeWithAbsolutePath_ResolvesCommonDir()
+    {
+        // Arrange: simulate a worktree structure / worktree構造をシミュレート
+        // Main repo .git dir
+        var mainGitDir = Path.Combine(_tempDir, "main_repo", ".git");
+        Directory.CreateDirectory(Path.Combine(mainGitDir, "info"));
+        Directory.CreateDirectory(Path.Combine(mainGitDir, "worktrees", "my-worktree"));
+
+        // commondir file inside the worktree git dir points to the main .git
+        var worktreeGitDir = Path.Combine(mainGitDir, "worktrees", "my-worktree");
+        File.WriteAllText(Path.Combine(worktreeGitDir, "commondir"), "../..");
+
+        // Worktree project directory with .git file
+        var worktreeRoot = Path.Combine(_tempDir, "worktree_checkout");
+        Directory.CreateDirectory(worktreeRoot);
+        File.WriteAllText(Path.Combine(worktreeRoot, ".git"), $"gitdir: {worktreeGitDir}");
+
+        // Act
+        var result = GitHelper.ResolveGitCommonDir(worktreeRoot);
+
+        // Assert: should resolve to the main .git directory
+        Assert.Equal(Path.GetFullPath(mainGitDir), Path.GetFullPath(result!));
+    }
+
+    [Fact]
+    public void WorktreeWithRelativePath_ResolvesCommonDir()
+    {
+        // Arrange: simulate worktree with relative gitdir path / 相対パスのgitdirでworktreeをシミュレート
+        var mainGitDir = Path.Combine(_tempDir, ".git");
+        Directory.CreateDirectory(Path.Combine(mainGitDir, "info"));
+        Directory.CreateDirectory(Path.Combine(mainGitDir, "worktrees", "feat-branch"));
+
+        var worktreeGitDir = Path.Combine(mainGitDir, "worktrees", "feat-branch");
+        File.WriteAllText(Path.Combine(worktreeGitDir, "commondir"), "../..");
+
+        // Worktree is a sibling directory
+        var worktreeRoot = Path.Combine(_tempDir, "worktree-feat");
+        Directory.CreateDirectory(worktreeRoot);
+        // Use relative path from worktree root to worktree git dir
+        File.WriteAllText(Path.Combine(worktreeRoot, ".git"),
+            $"gitdir: ../.git/worktrees/feat-branch");
+
+        // Act
+        var result = GitHelper.ResolveGitCommonDir(worktreeRoot);
+
+        // Assert
+        Assert.Equal(Path.GetFullPath(mainGitDir), Path.GetFullPath(result!));
+    }
+
+    [Fact]
+    public void GitFileWithInvalidContent_ReturnsNull()
+    {
+        // .git file exists but doesn't start with "gitdir:" / .gitファイルがあるが"gitdir:"で始まらない
+        File.WriteAllText(Path.Combine(_tempDir, ".git"), "some random content");
+
+        var result = GitHelper.ResolveGitCommonDir(_tempDir);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void WorktreeWithoutCommonDir_FallsBackToWorktreeGitDir()
+    {
+        // Arrange: worktree git dir exists but has no commondir file / commondirファイルがない場合のフォールバック
+        var worktreeGitDir = Path.Combine(_tempDir, "fake-git-dir");
+        Directory.CreateDirectory(worktreeGitDir);
+
+        var projectRoot = Path.Combine(_tempDir, "project");
+        Directory.CreateDirectory(projectRoot);
+        File.WriteAllText(Path.Combine(projectRoot, ".git"), $"gitdir: {worktreeGitDir}");
+
+        // Act
+        var result = GitHelper.ResolveGitCommonDir(projectRoot);
+
+        // Assert: falls back to the worktree git dir itself
+        Assert.Equal(Path.GetFullPath(worktreeGitDir), Path.GetFullPath(result!));
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix: `.cdidx/` appeared as untracked in git worktrees.** In a worktree, `.git` is a file (not a directory), so the worktree root has no `.git/info/exclude`. `AddToGitExclude` silently skipped writing, leaving the database visible to `git status`.
- **Added `GitHelper.ResolveGitCommonDir()`** which chases references to find the shared `.git/` directory where `info/exclude` lives:
  ```
  # Normal repo — .git is a directory
  /projects/my-app/
  ├── 📂 .git/                        ← directory
  │   └── 📂 info/
  │       └── exclude                 ← write here
  └── 📂 .cdidx/
      └── codeindex.db

  # Worktree — .git is a file
  /projects/my-app/                   ← main repo
  └── 📂 .git/                        ← shared git dir
      ├── 📂 info/
      │   └── exclude                 ← write here
      └── 📂 worktrees/
          └── 📂 feature-branch/
              └── commondir           ← contains "../.."

  /projects/my-app-feature/           ← worktree root
  ├── .git                            ← FILE: "gitdir: /projects/my-app/.git/worktrees/feature-branch"
  └── 📂 .cdidx/
      └── codeindex.db
  ```
  **Resolution chain:**
  1. Read `.git` file → `gitdir: .../worktrees/feature-branch`
  2. Read `commondir` file at that path → `../..`
  3. Resolve `../..` relative to `feature-branch/` dir:
     `feature-branch/` → `..` → `worktrees/` → `..` → `.git/`
  4. Write to `.git/info/exclude`
- **Tests:** 6 test cases covering normal repos, worktrees (absolute/relative paths), invalid `.git` files, and the `commondir`-missing fallback.
- **Docs:** Updated CHANGELOG, CLAUDE.md, DEVELOPER_GUIDE.md (EN + JP) with tree diagrams using box-drawing characters and 📂 folder icons.

## Test plan

- [ ] `dotnet test` passes (new `GitHelperTests` + existing tests)
- [ ] Run `cdidx index .` in a git worktree → verify `.cdidx/` is added to the main repo's `.git/info/exclude`
- [ ] Run `cdidx index .` in a normal repo → verify existing behavior unchanged

https://claude.ai/code/session_01Dzbagkt1A81dX9BsPWnso1