### PR TITLE
Improve help output and stabilize --commits / --files update flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Changed
+
+- **Help banner only on successful help commands** — Explicit help commands such as `cdidx --help` and `cdidx index --help` still show the banner, but usage text shown for invocation errors now omits it. Help output also no longer lists themed spinner easter eggs, and now shows explicit `index --commits` and `index --files` workflows so update commands are easier to discover. Affected: `Program.cs`, `Cli/ConsoleUi.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/ConsoleUiTests.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
+
 ### [1.0.3] - 2026-04-09
 
 #### Changed
@@ -126,6 +130,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 変更
+
+- **成功した help のときだけバナーを表示** — `cdidx --help` や `cdidx index --help` のような明示的な help は従来どおりバナーを表示する一方、呼び出し失敗時に出す usage ではバナーを表示しないようにした。あわせて help 出力からテーマ付きスピナーのイースターエッグ一覧を除外し、`index --commits` / `index --files` の更新フローを明示して使い方を分かりやすくした。対象: `Program.cs`, `Cli/ConsoleUi.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/ConsoleUiTests.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.3] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 #### Fixed
 
 - **`--commits` update mode no longer crashes on `git diff-tree` invocation** — Fixed the git argument order used to resolve changed files from commit IDs, added `--root` so initial commits return their changed files, and converted commit-resolution failures into normal CLI errors instead of unhandled exceptions. Affected: `Cli/GitHelper.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+
 - **`--commits` handles merge commits** — Commit-based updates now ask `git diff-tree` to expand merge commits so their changed files are included instead of silently producing an empty update set. Affected: `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+
 - **`--files` no longer misclassifies project-local `..*` paths as outside the project** — Update mode now only rejects paths that actually resolve outside the project root (such as `../file.cs`), while allowing valid project-relative paths like `..hidden/file.cs`. Affected: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.3] - 2026-04-09
@@ -144,7 +146,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 #### 修正
 
 - **`--commits` 更新モードが `git diff-tree` 呼び出しで落ちる問題** — コミットIDから変更ファイルを解決する際の git 引数順を修正し、初回コミットでも変更ファイルを返せるよう `--root` を追加した。さらに commit 解決失敗時は未処理例外ではなく通常のCLIエラーとして返すようにした。対象: `Cli/GitHelper.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+
 - **`--commits` で merge commit を扱えない問題** — commit 指定更新で `git diff-tree` に merge commit 展開を指示し、変更ファイルが 0 件になって更新が空振りする問題を修正した。対象: `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+
 - **`--files` が project 内の `..*` パスを project 外と誤判定する問題** — update モードで project 外判定を実際に `../` で外へ出るパスのみに限定し、`..hidden/file.cs` のような project 内の相対パスを正しく更新対象にした。対象: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.3] - 2026-04-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Help banner only on successful help commands** — Explicit help commands such as `cdidx --help` and `cdidx index --help` still show the banner, but usage text shown for invocation errors now omits it. Help output also no longer lists themed spinner easter eggs, and now shows explicit `index --commits` and `index --files` workflows so update commands are easier to discover. Affected: `Program.cs`, `Cli/ConsoleUi.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/ConsoleUiTests.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
+#### Fixed
+
+- **`--commits` update mode no longer crashes on `git diff-tree` invocation** — Fixed the git argument order used to resolve changed files from commit IDs, added `--root` so initial commits return their changed files, and converted commit-resolution failures into normal CLI errors instead of unhandled exceptions. Affected: `Cli/GitHelper.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+- **`--commits` handles merge commits** — Commit-based updates now ask `git diff-tree` to expand merge commits so their changed files are included instead of silently producing an empty update set. Affected: `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+
 ### [1.0.3] - 2026-04-09
 
 #### Changed
@@ -134,6 +139,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 #### 変更
 
 - **成功した help のときだけバナーを表示** — `cdidx --help` や `cdidx index --help` のような明示的な help は従来どおりバナーを表示する一方、呼び出し失敗時に出す usage ではバナーを表示しないようにした。あわせて help 出力からテーマ付きスピナーのイースターエッグ一覧を除外し、`index --commits` / `index --files` の更新フローを明示して使い方を分かりやすくした。対象: `Program.cs`, `Cli/ConsoleUi.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/ConsoleUiTests.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
+
+#### 修正
+
+- **`--commits` 更新モードが `git diff-tree` 呼び出しで落ちる問題** — コミットIDから変更ファイルを解決する際の git 引数順を修正し、初回コミットでも変更ファイルを返せるよう `--root` を追加した。さらに commit 解決失敗時は未処理例外ではなく通常のCLIエラーとして返すようにした。対象: `Cli/GitHelper.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+- **`--commits` で merge commit を扱えない問題** — commit 指定更新で `git diff-tree` に merge commit 展開を指示し、変更ファイルが 0 件になって更新が空振りする問題を修正した。対象: `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
 
 ### [1.0.3] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **`--commits` update mode no longer crashes on `git diff-tree` invocation** — Fixed the git argument order used to resolve changed files from commit IDs, added `--root` so initial commits return their changed files, and converted commit-resolution failures into normal CLI errors instead of unhandled exceptions. Affected: `Cli/GitHelper.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
 - **`--commits` handles merge commits** — Commit-based updates now ask `git diff-tree` to expand merge commits so their changed files are included instead of silently producing an empty update set. Affected: `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+- **`--files` no longer misclassifies project-local `..*` paths as outside the project** — Update mode now only rejects paths that actually resolve outside the project root (such as `../file.cs`), while allowing valid project-relative paths like `..hidden/file.cs`. Affected: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.3] - 2026-04-09
 
@@ -144,6 +145,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **`--commits` 更新モードが `git diff-tree` 呼び出しで落ちる問題** — コミットIDから変更ファイルを解決する際の git 引数順を修正し、初回コミットでも変更ファイルを返せるよう `--root` を追加した。さらに commit 解決失敗時は未処理例外ではなく通常のCLIエラーとして返すようにした。対象: `Cli/GitHelper.cs`, `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
 - **`--commits` で merge commit を扱えない問題** — commit 指定更新で `git diff-tree` に merge commit 展開を指示し、変更ファイルが 0 件になって更新が空振りする問題を修正した。対象: `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/GitHelperTests.cs`.
+- **`--files` が project 内の `..*` パスを project 外と誤判定する問題** — update モードで project 外判定を実際に `../` で外へ出るパスのみに限定し、`..hidden/file.cs` のような project 内の相対パスを正しく更新対象にした。対象: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.3] - 2026-04-09
 

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -278,20 +278,33 @@ public static class ConsoleUi
     /// Print usage information.
     /// 使い方を表示する。
     /// </summary>
-    public static void PrintUsage()
+    public static void PrintUsage(bool showBanner = true)
     {
-        PrintBanner();
-        Console.WriteLine("Usage: cdidx <command> [options]");
+        if (showBanner)
+        {
+            PrintBanner();
+        }
+
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  cdidx <projectPath>");
+        Console.WriteLine("  cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--json]");
+        Console.WriteLine("  cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--json]");
+        Console.WriteLine("  cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--json]");
+        Console.WriteLine("  cdidx search <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--fts]");
+        Console.WriteLine("  cdidx symbols [query] [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--kind <kind>]");
+        Console.WriteLine("  cdidx files [query] [--db <path>] [--json] [--limit <n>] [--lang <lang>]");
+        Console.WriteLine("  cdidx status [--db <path>] [--json]");
+        Console.WriteLine("  cdidx mcp [--db <path>]");
         Console.WriteLine();
         Console.WriteLine("Commands:");
-        Console.WriteLine("  index <projectPath>        Index a project (default if path given)");
+        Console.WriteLine("  index <projectPath>        Build or update the index for a project");
         Console.WriteLine("  search <query>             Full-text search across indexed chunks");
         Console.WriteLine("  symbols [query]            Search symbols (functions, classes, imports)");
         Console.WriteLine("  files [query]              List indexed files");
         Console.WriteLine("  status                     Show database statistics");
         Console.WriteLine("  mcp                        Start MCP server (for AI tools: Claude, Cursor, etc.)");
         Console.WriteLine();
-        Console.WriteLine("Index options:");
+        Console.WriteLine("Index and update options:");
         Console.WriteLine("  --db <path>                Database file path (default for index: <projectPath>/.cdidx/codeindex.db)");
         Console.WriteLine("  --rebuild                  Delete existing DB and rebuild from scratch");
         Console.WriteLine("  --verbose                  Show per-file status ([OK  ]/[SKIP]/[DEL ]/[ERR ])");
@@ -300,6 +313,10 @@ public static class ConsoleUi
         Console.WriteLine("  --files <path> [path ...]  Update only the specified files (relative or absolute)");
         Console.WriteLine("  --help, -h                 Show this help message");
         Console.WriteLine("  --version, -V              Show version information");
+        Console.WriteLine();
+        Console.WriteLine("Update workflows:");
+        Console.WriteLine("  Use --commits with a project path to update only files changed by specific commits.");
+        Console.WriteLine("  Use --files with a project path to update only specific files.");
         Console.WriteLine();
         Console.WriteLine("Query options:");
         Console.WriteLine("  --db <path>                Database file path (default: .cdidx/codeindex.db in current directory)");
@@ -311,23 +328,14 @@ public static class ConsoleUi
         Console.WriteLine();
         Console.WriteLine("Examples:");
         Console.WriteLine("  cdidx ./myproject                             Index a project");
+        Console.WriteLine("  cdidx index ./myproject --commits abc123      Update DB from one commit");
+        Console.WriteLine("  cdidx index ./myproject --commits abc123 def456");
+        Console.WriteLine("                                              Update DB from multiple commits");
+        Console.WriteLine("  cdidx index ./myproject --files src/app.cs    Update specific files");
         Console.WriteLine("  cdidx search \"authenticate\"                    Full-text search");
         Console.WriteLine("  cdidx symbols UserService --kind class         Find class definitions");
         Console.WriteLine("  cdidx files --lang python                      List Python files");
         Console.WriteLine("  cdidx status --json                            DB stats as JSON");
-        Console.WriteLine();
-        Console.WriteLine("  cdidx ./myproject --commits abc123 def456      Update files from commits");
-        Console.WriteLine("  cdidx ./myproject --files src/app.cs           Update specific files");
-        Console.WriteLine();
-        Console.WriteLine("Easter eggs (themed spinner when combined with index):");
-        Console.WriteLine("  --sushi                    \U0001f363 Slicing... Shaping... Itadakimasu!");
-        Console.WriteLine("  --coffee                   \u2615 Grinding... Heating... Brewing...");
-        Console.WriteLine("  --ramen                    \U0001f35c Boiling... Steaming... Itadakimasu!");
-        Console.WriteLine("  --wine                     \U0001f377 Crushing... Aging... Sant\u00e9!");
-        Console.WriteLine("  --beer                     \U0001f37a Tapping... Pouring... Cheers!");
-        Console.WriteLine("  --matcha                   \U0001f375 Sifting... Whisking... Douzo!");
-        Console.WriteLine("  --whisky                   \U0001f943 Mashing... Distilling... Slainte!");
-        Console.WriteLine("  --random-spinner           \U0001f3b2 Pick a random theme");
     }
 
     // --- Helpers / ヘルパー ---

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -61,15 +61,19 @@ public static class GitHelper
         var psi = new ProcessStartInfo
         {
             FileName = "git",
-            // Use "--" to terminate options, preventing commitId from being parsed as a flag
-            // "--"でオプション終了を明示し、commitIdがフラグとして解釈されるのを防止
-            Arguments = $"diff-tree --no-commit-id -r --name-only -- {commitId}",
             WorkingDirectory = projectRoot,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
         };
+        psi.ArgumentList.Add("diff-tree");
+        psi.ArgumentList.Add("--no-commit-id");
+        psi.ArgumentList.Add("--root");
+        psi.ArgumentList.Add("-m");
+        psi.ArgumentList.Add("-r");
+        psi.ArgumentList.Add("--name-only");
+        psi.ArgumentList.Add(commitId);
 
         using var process = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start git process / gitプロセスの起動に失敗");

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -14,12 +14,19 @@ public static class IndexCommandRunner
     public static int Run(string[] indexArgs, JsonSerializerOptions jsonOptions)
     {
         var options = ParseArgs(indexArgs);
+
+        if (options.ShowHelp)
+        {
+            ConsoleUi.PrintUsage();
+            return CommandExitCodes.Success;
+        }
+
         var spinnerFrames = ConsoleUi.GetSpinnerFrames(options.EasterEgg);
         ConsoleUi.SetProgressTheme(options.EasterEgg);
 
         if (options.ProjectPath == null)
         {
-            ConsoleUi.PrintUsage();
+            ConsoleUi.PrintUsage(showBanner: false);
             return CommandExitCodes.UsageError;
         }
 
@@ -119,7 +126,7 @@ public static class IndexCommandRunner
                         Console.Error.WriteLine("Warning: --files specified but no file paths provided / --files が指定されましたがファイルパスがありません");
                     break;
                 case "--help" or "-h":
-                    return new IndexCommandOptions();
+                    return new IndexCommandOptions { ShowHelp = true };
                 case "--sushi" or "--coffee" or "--ramen" or "--wine" or "--beer" or "--matcha" or "--whisky":
                     easterEgg = args[i];
                     spinnerFlagCount++;
@@ -505,6 +512,7 @@ public static class IndexCommandRunner
 
 public sealed class IndexCommandOptions
 {
+    public bool ShowHelp { get; init; }
     public string? ProjectPath { get; init; }
     public string? DbPath { get; init; }
     public bool Rebuild { get; init; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -216,7 +216,7 @@ public static class IndexCommandRunner
             {
                 var absPath = Path.IsPathRooted(f) ? f : Path.GetFullPath(Path.Combine(projectRoot, f));
                 var relPath = Path.GetRelativePath(projectRoot, absPath).Replace('\\', '/');
-                if (relPath.StartsWith(".."))
+                if (IsOutsideProjectRoot(relPath))
                 {
                     if (!options.Json)
                         Console.Error.WriteLine($"  [WARN] Skipping file outside project root: {f}");
@@ -344,6 +344,9 @@ public static class IndexCommandRunner
 
         return CommandExitCodes.Success;
     }
+
+    private static bool IsOutsideProjectRoot(string relativePath) =>
+        relativePath == ".." || relativePath.StartsWith("../", StringComparison.Ordinal);
 
     private static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode)
     {

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -183,15 +183,29 @@ public static class IndexCommandRunner
         if (options.Commits.Count > 0)
         {
             CancellationTokenSource? spinnerCts = null;
-            if (!options.Json)
-                spinnerCts = ConsoleUi.StartSpinner("Resolving changed files...", spinnerFrames);
-            foreach (var commit in options.Commits)
+            try
             {
-                var changedFiles = GitHelper.GetChangedFilesFromCommit(projectRoot, commit);
-                foreach (var f in changedFiles)
-                    targetPaths.Add(f);
+                if (!options.Json)
+                    spinnerCts = ConsoleUi.StartSpinner("Resolving changed files...", spinnerFrames);
+                foreach (var commit in options.Commits)
+                {
+                    var changedFiles = GitHelper.GetChangedFilesFromCommit(projectRoot, commit);
+                    foreach (var f in changedFiles)
+                        targetPaths.Add(f);
+                }
             }
-            ConsoleUi.StopSpinner(spinnerCts);
+            catch (Exception ex)
+            {
+                return WriteCommandError(
+                    options.Json,
+                    jsonOptions,
+                    $"failed to resolve changed files from git commits: {ex.Message}",
+                    CommandExitCodes.UsageError);
+            }
+            finally
+            {
+                ConsoleUi.StopSpinner(spinnerCts);
+            }
             if (!options.Json)
                 Console.WriteLine($"  Found {targetPaths.Count} changed file(s) from git");
         }
@@ -329,6 +343,15 @@ public static class IndexCommandRunner
         }
 
         return CommandExitCodes.Success;
+    }
+
+    private static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode)
+    {
+        if (json)
+            Console.WriteLine(JsonSerializer.Serialize(new { status = "error", message }, jsonOptions));
+        else
+            Console.Error.WriteLine($"Error: {message}");
+        return exitCode;
     }
 
     private static int RunFullScan(

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -19,7 +19,7 @@ var jsonOptions = new JsonSerializerOptions
 
 if (args.Length == 0 || args[0] is "--help" or "-h")
 {
-    ConsoleUi.PrintUsage();
+    ConsoleUi.PrintUsage(showBanner: args.Length > 0);
     return args.Length == 0 ? CommandExitCodes.UsageError : CommandExitCodes.Success;
 }
 

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -1,0 +1,61 @@
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+/// <summary>
+/// Tests for console usage output.
+/// コンソールの使い方出力のテスト。
+/// </summary>
+public class ConsoleUiTests
+{
+    [Fact]
+    public void PrintUsage_WithBanner_IncludesAsciiArt()
+    {
+        var output = CaptureUsageOutput();
+
+        Assert.Contains("██████╗", output);
+        Assert.Contains("Usage:", output);
+        Assert.Contains("cdidx index <projectPath> --commits <id> [id ...]", output);
+    }
+
+    [Fact]
+    public void PrintUsage_WithoutBanner_HidesAsciiArtAndEasterEggFlags()
+    {
+        var output = CaptureUsageOutput(showBanner: false);
+
+        Assert.DoesNotContain("██████╗", output);
+        Assert.Contains("Usage:", output);
+        Assert.Contains("cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--json]", output);
+        Assert.DoesNotContain("Easter eggs", output);
+        Assert.DoesNotContain("--sushi", output);
+        Assert.DoesNotContain("--random-spinner", output);
+    }
+
+    [Fact]
+    public void PrintUsage_ShowsCommitUpdateWorkflowClearly()
+    {
+        var output = CaptureUsageOutput(showBanner: false);
+
+        Assert.Contains("Update workflows:", output);
+        Assert.Contains("Use --commits with a project path", output);
+        Assert.Contains("cdidx index ./myproject --commits abc123", output);
+    }
+
+    private static string CaptureUsageOutput(bool showBanner = true)
+    {
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+
+        try
+        {
+            Console.SetOut(writer);
+            ConsoleUi.PrintUsage(showBanner);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        return writer.ToString();
+    }
+}

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -43,19 +43,21 @@ public class ConsoleUiTests
 
     private static string CaptureUsageOutput(bool showBanner = true)
     {
-        var originalOut = Console.Out;
-        using var writer = new StringWriter();
-
-        try
+        lock (TestConsoleLock.Gate)
         {
-            Console.SetOut(writer);
-            ConsoleUi.PrintUsage(showBanner);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+            var originalOut = Console.Out;
+            using var writer = new StringWriter();
 
-        return writer.ToString();
+            try
+            {
+                Console.SetOut(writer);
+                ConsoleUi.PrintUsage(showBanner);
+                return writer.ToString();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
     }
 }

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using CodeIndex.Cli;
 
 namespace CodeIndex.Tests;
@@ -120,5 +121,108 @@ public class GitHelperTests : IDisposable
 
         // Assert: falls back to the worktree git dir itself
         Assert.Equal(Path.GetFullPath(worktreeGitDir), Path.GetFullPath(result!));
+    }
+
+    [Fact]
+    public void GetChangedFilesFromCommit_ReturnsFilesForRegularCommit()
+    {
+        var repoDir = CreateGitRepo();
+
+        File.WriteAllText(Path.Combine(repoDir, "tracked.txt"), "v1\n");
+        RunGit(repoDir, "add", "tracked.txt");
+        RunGit(repoDir, "commit", "-m", "initial");
+
+        File.WriteAllText(Path.Combine(repoDir, "tracked.txt"), "v2\n");
+        File.WriteAllText(Path.Combine(repoDir, "added.txt"), "new\n");
+        RunGit(repoDir, "add", "tracked.txt", "added.txt");
+        RunGit(repoDir, "commit", "-m", "update files");
+
+        var commitId = RunGit(repoDir, "rev-parse", "HEAD").Trim();
+
+        var changedFiles = GitHelper.GetChangedFilesFromCommit(repoDir, commitId);
+
+        Assert.Equal(["added.txt", "tracked.txt"], changedFiles.OrderBy(x => x).ToArray());
+    }
+
+    [Fact]
+    public void GetChangedFilesFromCommit_IncludesFilesForRootCommit()
+    {
+        var repoDir = CreateGitRepo();
+
+        File.WriteAllText(Path.Combine(repoDir, "first.txt"), "hello\n");
+        RunGit(repoDir, "add", "first.txt");
+        RunGit(repoDir, "commit", "-m", "initial");
+
+        var commitId = RunGit(repoDir, "rev-parse", "HEAD").Trim();
+
+        var changedFiles = GitHelper.GetChangedFilesFromCommit(repoDir, commitId);
+
+        Assert.Equal(["first.txt"], changedFiles);
+    }
+
+    [Fact]
+    public void GetChangedFilesFromCommit_ReturnsFilesForMergeCommit()
+    {
+        var repoDir = CreateGitRepo();
+
+        File.WriteAllText(Path.Combine(repoDir, "base.txt"), "base\n");
+        RunGit(repoDir, "add", "base.txt");
+        RunGit(repoDir, "commit", "-m", "base");
+
+        RunGit(repoDir, "switch", "-c", "feature");
+        File.WriteAllText(Path.Combine(repoDir, "feature.txt"), "feature\n");
+        RunGit(repoDir, "add", "feature.txt");
+        RunGit(repoDir, "commit", "-m", "feature change");
+
+        RunGit(repoDir, "switch", "master");
+        File.WriteAllText(Path.Combine(repoDir, "main.txt"), "main\n");
+        RunGit(repoDir, "add", "main.txt");
+        RunGit(repoDir, "commit", "-m", "main change");
+
+        RunGit(repoDir, "merge", "--no-ff", "feature", "-m", "merge feature");
+        var commitId = RunGit(repoDir, "rev-parse", "HEAD").Trim();
+
+        var changedFiles = GitHelper.GetChangedFilesFromCommit(repoDir, commitId);
+
+        Assert.Equal(["feature.txt", "main.txt"], changedFiles.OrderBy(x => x).ToArray());
+    }
+
+    private string CreateGitRepo()
+    {
+        var repoDir = Path.Combine(_tempDir, $"repo_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(repoDir);
+
+        RunGit(repoDir, "init");
+        RunGit(repoDir, "config", "user.name", "CodeIndex Tests");
+        RunGit(repoDir, "config", "user.email", "tests@example.com");
+
+        return repoDir;
+    }
+
+    private static string RunGit(string workDir, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start git process / gitプロセスの起動に失敗");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stderr.Trim()}");
+
+        return stdout;
     }
 }

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -20,7 +20,7 @@ public class GitHelperTests : IDisposable
     public void Dispose()
     {
         if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, recursive: true);
+            DeleteDirectoryRobust(_tempDir);
     }
 
     [Fact]
@@ -224,5 +224,40 @@ public class GitHelperTests : IDisposable
             throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stderr.Trim()}");
 
         return stdout;
+    }
+
+    private static void DeleteDirectoryRobust(string path)
+    {
+        ClearAttributes(path);
+
+        for (int attempt = 0; attempt < 5; attempt++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (UnauthorizedAccessException) when (attempt < 4)
+            {
+                Thread.Sleep(100);
+                ClearAttributes(path);
+            }
+            catch (IOException) when (attempt < 4)
+            {
+                Thread.Sleep(100);
+                ClearAttributes(path);
+            }
+        }
+    }
+
+    private static void ClearAttributes(string path)
+    {
+        foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+            File.SetAttributes(file, FileAttributes.Normal);
+
+        foreach (var dir in Directory.EnumerateDirectories(path, "*", SearchOption.AllDirectories))
+            File.SetAttributes(dir, FileAttributes.Normal);
+
+        File.SetAttributes(path, FileAttributes.Normal);
     }
 }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -9,6 +9,11 @@ namespace CodeIndex.Tests;
 /// </summary>
 public class IndexCommandRunnerTests
 {
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
     [Fact]
     public void ParseArgs_HelpFlagSetsShowHelp()
     {
@@ -21,8 +26,97 @@ public class IndexCommandRunnerTests
     [Fact]
     public void Run_HelpFlagReturnsSuccess()
     {
-        var exitCode = IndexCommandRunner.Run(["--help"], new JsonSerializerOptions());
+        int exitCode;
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            using var writer = new StringWriter();
+            try
+            {
+                Console.SetOut(writer);
+                exitCode = IndexCommandRunner.Run(["--help"], new JsonSerializerOptions());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
 
         Assert.Equal(CommandExitCodes.Success, exitCode);
+    }
+
+    [Fact]
+    public void Run_UpdateFiles_AllowsProjectRelativePathsStartingWithDotDotName()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            var hiddenDir = Path.Combine(projectRoot, "..hidden");
+            Directory.CreateDirectory(hiddenDir);
+            File.WriteAllText(Path.Combine(hiddenDir, "sample.cs"), "class Sample {}\n");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--files", "..hidden/sample.cs", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.Equal(1, json.GetProperty("summary").GetProperty("updated").GetInt32());
+            Assert.Equal(0, json.GetProperty("summary").GetProperty("errors").GetInt32());
+        }
+        finally
+        {
+            Directory.Delete(projectRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Run_UpdateFiles_SkipsPathsOutsideProjectRoot()
+    {
+        var projectRoot = CreateTempProject();
+        var outsideFile = Path.Combine(Directory.GetParent(projectRoot)!.FullName, $"outside_{Guid.NewGuid():N}.cs");
+        try
+        {
+            File.WriteAllText(outsideFile, "class Outside {}\n");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--files", $"../{Path.GetFileName(outsideFile)}", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.Equal(0, json.GetProperty("summary").GetProperty("updated").GetInt32());
+            Assert.Equal(0, json.GetProperty("summary").GetProperty("errors").GetInt32());
+        }
+        finally
+        {
+            if (File.Exists(outsideFile))
+                File.Delete(outsideFile);
+            Directory.Delete(projectRoot, recursive: true);
+        }
+    }
+
+    private (int ExitCode, JsonElement Json) RunAndCaptureJson(string[] args)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            using var writer = new StringWriter();
+
+            try
+            {
+                Console.SetOut(writer);
+                var exitCode = IndexCommandRunner.Run(args, _jsonOptions);
+                using var document = JsonDocument.Parse(writer.ToString());
+                return (exitCode, document.RootElement.Clone());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+
+    private static string CreateTempProject()
+    {
+        var projectRoot = Path.Combine(Path.GetTempPath(), $"cdidx_index_runner_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(projectRoot);
+        return projectRoot;
     }
 }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+/// <summary>
+/// Tests for indexing command argument handling.
+/// インデックスコマンドの引数処理テスト。
+/// </summary>
+public class IndexCommandRunnerTests
+{
+    [Fact]
+    public void ParseArgs_HelpFlagSetsShowHelp()
+    {
+        var options = IndexCommandRunner.ParseArgs(["--help"]);
+
+        Assert.True(options.ShowHelp);
+        Assert.Null(options.ProjectPath);
+    }
+
+    [Fact]
+    public void Run_HelpFlagReturnsSuccess()
+    {
+        var exitCode = IndexCommandRunner.Run(["--help"], new JsonSerializerOptions());
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+    }
+}

--- a/tests/CodeIndex.Tests/TestConsoleLock.cs
+++ b/tests/CodeIndex.Tests/TestConsoleLock.cs
@@ -1,0 +1,6 @@
+namespace CodeIndex.Tests;
+
+internal static class TestConsoleLock
+{
+    internal static readonly object Gate = new();
+}


### PR DESCRIPTION
## Summary

- Help output
- Show the banner only for explicit help commands, not for usage errors
- Remove easter egg flags from `--help`
- Make update workflows easier to discover by showing explicit `index --commits` and `index --files` usage/examples
- Tidy changelog bullet spacing for readability

- Commit-based updates
- Fix `git diff-tree` invocation for `--commits`
- Return normal CLI errors instead of crashing when commit resolution fails
- Include root commit changes and merge commit changes in commit-based updates

- File-based updates and tests
- Fix `--files` path validation so project-local paths like `..hidden/file.cs` are not treated as outside the project
- Keep rejecting paths that actually resolve outside the project root
- Add regression coverage for help output, commit-based updates, file-based updates, and shared console capture in tests

## Test plan

- [x] Run `dotnet test`
