### PR TITLE
Make Git exclude entries repo-relative for DB paths and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Fixed
 
-- **`.git/info/exclude` now always receives repository-relative patterns for DB paths** — Indexing no longer writes filesystem absolute paths when `--db` is absolute. DB directories outside the project root are skipped for auto-exclude, and worktree scenarios continue to resolve/write via the shared git common directory. Added regression tests for inside-project absolute paths, outside-project absolute paths, and worktree layouts. Affected: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
+- **`.git/info/exclude` now always receives repository-relative patterns for DB paths** — Indexing no longer writes filesystem absolute paths when `--db` is absolute. DB directories outside the project root are skipped for auto-exclude, and worktree scenarios continue to resolve/write via the shared git common directory. The auto-generated marker line is now English-only, and regression tests cover inside-project absolute paths, outside-project absolute paths, and worktree layouts. Affected: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.4] - 2026-04-09
 
@@ -155,7 +155,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### 修正
 
-- **DBパスの `.git/info/exclude` 追記を常にリポジトリ相対パターン化** — `--db` に絶対パスを渡した場合でも、インデックス時にファイルシステム絶対パスを書き込まないよう修正。project 外のDBディレクトリは自動除外対象からスキップし、worktree でも共有 git common directory 側へ正しく追記される挙動を維持。project 内絶対パス / project 外絶対パス / worktree 構成の回帰テストを追加。対象: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
+- **DBパスの `.git/info/exclude` 追記を常にリポジトリ相対パターン化** — `--db` に絶対パスを渡した場合でも、インデックス時にファイルシステム絶対パスを書き込まないよう修正。project 外のDBディレクトリは自動除外対象からスキップし、worktree でも共有 git common directory 側へ正しく追記される挙動を維持。自動生成マーカー行は英語のみとし、project 内絶対パス / project 外絶対パス / worktree 構成の回帰テストを追加。対象: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.4] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Sharpened cdidx positioning in docs and package metadata** — Repositioned README and NuGet package description around `cdidx` as an AI-native local code index for CLI and MCP workflows, added an upfront `cdidx` vs `rg` framing, and moved a copy-paste quick start into the README opening so the intended usage is clear within seconds. Affected: `README.md`, `src/CodeIndex/CodeIndex.csproj`.
 
+#### Fixed
+
+- **`.git/info/exclude` now always receives repository-relative patterns for DB paths** — Indexing no longer writes filesystem absolute paths when `--db` is absolute. DB directories outside the project root are skipped for auto-exclude, and worktree scenarios continue to resolve/write via the shared git common directory. Added regression tests for inside-project absolute paths, outside-project absolute paths, and worktree layouts. Affected: `Cli/IndexCommandRunner.cs`, `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
+
 ### [1.0.4] - 2026-04-09
 
 #### Changed
@@ -148,6 +152,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 #### 変更
 
 - **ドキュメントとパッケージ説明で cdidx の立ち位置を明確化** — README と NuGet パッケージ説明を、`cdidx` を CLI / MCP ワークフロー向けの AIネイティブなローカルコードインデックスとして打ち出す内容に整理し、冒頭に `cdidx` と `rg` の使い分けとコピペできるクイックスタートを追加して、用途が数秒で伝わるようにした。対象: `README.md`, `src/CodeIndex/CodeIndex.csproj`.
+
+#### 修正
+
+- **DBパスの `.git/info/exclude` 追記を常にリポジトリ相対パターン化** — `--db` に絶対パスを渡した場合でも、インデックス時にファイルシステム絶対パスを書き込まないよう修正。project 外のDBディレクトリは自動除外対象からスキップし、worktree でも共有 git common directory 側へ正しく追記される挙動を維持。project 内絶対パス / project 外絶対パス / worktree 構成の回帰テストを追加。対象: `Cli/IndexCommandRunner.cs`, `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.4] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Fixed
 
-- **`.git/info/exclude` now always receives repository-relative patterns for DB paths** — Indexing no longer writes filesystem absolute paths when `--db` is absolute. DB directories outside the project root are skipped for auto-exclude, and worktree scenarios continue to resolve/write via the shared git common directory. Added regression tests for inside-project absolute paths, outside-project absolute paths, and worktree layouts. Affected: `Cli/IndexCommandRunner.cs`, `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
+- **`.git/info/exclude` now always receives repository-relative patterns for DB paths** — Indexing no longer writes filesystem absolute paths when `--db` is absolute. DB directories outside the project root are skipped for auto-exclude, and worktree scenarios continue to resolve/write via the shared git common directory. Added regression tests for inside-project absolute paths, outside-project absolute paths, and worktree layouts. Affected: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.4] - 2026-04-09
 
@@ -155,7 +155,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### 修正
 
-- **DBパスの `.git/info/exclude` 追記を常にリポジトリ相対パターン化** — `--db` に絶対パスを渡した場合でも、インデックス時にファイルシステム絶対パスを書き込まないよう修正。project 外のDBディレクトリは自動除外対象からスキップし、worktree でも共有 git common directory 側へ正しく追記される挙動を維持。project 内絶対パス / project 外絶対パス / worktree 構成の回帰テストを追加。対象: `Cli/IndexCommandRunner.cs`, `Cli/GitHelper.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
+- **DBパスの `.git/info/exclude` 追記を常にリポジトリ相対パターン化** — `--db` に絶対パスを渡した場合でも、インデックス時にファイルシステム絶対パスを書き込まないよう修正。project 外のDBディレクトリは自動除外対象からスキップし、worktree でも共有 git common directory 側へ正しく追記される挙動を維持。project 内絶対パス / project 外絶対パス / worktree 構成の回帰テストを追加。対象: `Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`.
 
 ### [1.0.4] - 2026-04-09
 

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -510,10 +510,25 @@ public static class IndexCommandRunner
             if (gitDir == null) return;
 
             var excludeFile = Path.Combine(gitDir, "info", "exclude");
-            var dbDirRelative = Path.GetDirectoryName(dbPath);
-            var patterns = !string.IsNullOrEmpty(dbDirRelative)
-                ? new[] { $"{dbDirRelative}/" }
-                : new[] { Path.GetFileName(dbPath), $"{Path.GetFileName(dbPath)}-*" };
+            var dbAbsolutePath = Path.IsPathRooted(dbPath)
+                ? Path.GetFullPath(dbPath)
+                : Path.GetFullPath(Path.Combine(projectRoot, dbPath));
+            var dbDirAbsolute = Path.GetDirectoryName(dbAbsolutePath);
+            if (string.IsNullOrEmpty(dbDirAbsolute)) return;
+
+            var dbDirRelative = Path.GetRelativePath(projectRoot, dbDirAbsolute).Replace('\\', '/');
+            if (IsOutsideProjectRoot(dbDirRelative)) return;
+
+            string[] patterns;
+            if (dbDirRelative == ".")
+            {
+                var dbFileName = Path.GetFileName(dbAbsolutePath);
+                patterns = [dbFileName, $"{dbFileName}-*"];
+            }
+            else
+            {
+                patterns = [$"{dbDirRelative.TrimEnd('/')}/"];
+            }
 
             var existingContent = File.Exists(excludeFile) ? File.ReadAllText(excludeFile) : "";
             var existingLines = existingContent.Split('\n').Select(l => l.TrimEnd('\r')).ToHashSet();

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -541,7 +541,7 @@ public static class IndexCommandRunner
             using var sw = File.AppendText(excludeFile);
             if (existingContent.Length > 0 && !existingContent.EndsWith('\n'))
                 sw.WriteLine();
-            sw.WriteLine("# cdidx (CodeIndex) — auto-generated / 自動生成");
+            sw.WriteLine("# cdidx (CodeIndex) — auto-generated");
             foreach (var pattern in missing)
                 sw.WriteLine(pattern);
         }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -92,6 +92,89 @@ public class IndexCommandRunnerTests
         }
     }
 
+    [Fact]
+    public void Run_WithAbsoluteDbPathInsideProject_WritesRepoRelativePatternToGitExclude()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            RunGit(projectRoot, "init");
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+
+            var exitCode = IndexCommandRunner.Run([projectRoot, "--db", dbPath, "--json"], _jsonOptions);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var excludePath = Path.Combine(projectRoot, ".git", "info", "exclude");
+            var excludeContent = File.ReadAllText(excludePath);
+            Assert.Contains(".cdidx/", excludeContent);
+            Assert.DoesNotContain(dbPath.Replace('\\', '/'), excludeContent);
+        }
+        finally
+        {
+            Directory.Delete(projectRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Run_WithAbsoluteDbPathOutsideProject_DoesNotWriteAbsolutePathToGitExclude()
+    {
+        var projectRoot = CreateTempProject();
+        var outsideDir = Path.Combine(Path.GetTempPath(), $"cdidx_external_db_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(outsideDir);
+            RunGit(projectRoot, "init");
+            var dbPath = Path.Combine(outsideDir, "external.db");
+
+            var exitCode = IndexCommandRunner.Run([projectRoot, "--db", dbPath, "--json"], _jsonOptions);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var excludePath = Path.Combine(projectRoot, ".git", "info", "exclude");
+            var excludeContent = File.ReadAllText(excludePath);
+            Assert.DoesNotContain(dbPath.Replace('\\', '/'), excludeContent);
+            Assert.DoesNotContain("/external.db", excludeContent);
+        }
+        finally
+        {
+            if (Directory.Exists(outsideDir))
+                Directory.Delete(outsideDir, recursive: true);
+            Directory.Delete(projectRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Run_InWorktreeWithAbsoluteDbPathInsideProject_WritesRelativePatternToSharedExclude()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"cdidx_worktree_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        var mainGitDir = Path.Combine(tempRoot, "main", ".git");
+        var worktreeRoot = Path.Combine(tempRoot, "wt");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(mainGitDir, "info"));
+            var worktreeGitDir = Path.Combine(mainGitDir, "worktrees", "wt");
+            Directory.CreateDirectory(worktreeGitDir);
+            File.WriteAllText(Path.Combine(worktreeGitDir, "commondir"), "../..");
+
+            Directory.CreateDirectory(worktreeRoot);
+            File.WriteAllText(Path.Combine(worktreeRoot, ".git"), $"gitdir: {worktreeGitDir}");
+
+            var dbPath = Path.Combine(worktreeRoot, ".cdidx", "codeindex.db");
+            var exitCode = IndexCommandRunner.Run([worktreeRoot, "--db", dbPath, "--json"], _jsonOptions);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var sharedExcludePath = Path.Combine(mainGitDir, "info", "exclude");
+            var excludeContent = File.ReadAllText(sharedExcludePath);
+            Assert.Contains(".cdidx/", excludeContent);
+            Assert.DoesNotContain(dbPath.Replace('\\', '/'), excludeContent);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     private (int ExitCode, JsonElement Json) RunAndCaptureJson(string[] args)
     {
         lock (TestConsoleLock.Gate)
@@ -118,5 +201,28 @@ public class IndexCommandRunnerTests
         var projectRoot = Path.Combine(Path.GetTempPath(), $"cdidx_index_runner_{Guid.NewGuid():N}");
         Directory.CreateDirectory(projectRoot);
         return projectRoot;
+    }
+
+    private static void RunGit(string workDir, params string[] args)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var process = System.Diagnostics.Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start git process / gitプロセスの起動に失敗");
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {stderr.Trim()}");
     }
 }


### PR DESCRIPTION
### Motivation

- Avoid writing absolute database paths into Git exclude files and ensure ignore patterns are repository-relative, including worktree setups.
- Prevent accidental exclusion of files outside the project root by skipping DB paths that are not inside the repository.

### Description

- Compute an absolute DB path and a repo-relative directory with `Path.GetRelativePath(projectRoot, dbDirAbsolute)` and normalize to forward slashes. 
- Return early if the DB directory cannot be determined or is outside the project root via `IsOutsideProjectRoot`. 
- Write exclude patterns as either a repo-relative directory pattern (`"{dbDirRelative.TrimEnd('/')}/"`) or filename patterns when the DB is placed at the project root (`dbFileName` and `dbFileName-*`).
- Added unit tests and a helper `RunGit` in `IndexCommandRunnerTests` to validate behavior for DBs inside the repo, outside the repo, and in worktree/shared-repo scenarios.

### Testing

- Ran the `tests/CodeIndex.Tests::IndexCommandRunnerTests` unit tests (including the three new tests) and they passed. 
- Ran the test suite via `dotnet test` and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c6b1ed748325b58c87ce659cbd73)