### PR TITLE
Add "Why SQLite?" rationale to developer guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Added
+
+- **"Why SQLite?" section in developer guide** — Documents the rationale for choosing SQLite over alternatives (PostgreSQL, DuckDB, LiteDB, Tantivy, vector DBs), what makes it the right fit, and when it would not be enough. Both English and Japanese sections. Affected: `DEVELOPER_GUIDE.md`.
+
 ### [1.3.0] - 2026-04-11
 
 #### Added
@@ -250,6 +254,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 追加
+
+- **開発者ガイドに「なぜSQLiteなのか？」セクションを追加** — PostgreSQL、DuckDB、LiteDB、Tantivy、ベクトルDB等の代替案との比較を含め、SQLiteを採用した理由、SQLiteが最適な根拠、SQLiteでは足りなくなるケースを文書化。英語・日本語の両セクション。対象: `DEVELOPER_GUIDE.md`。
 
 ### [1.3.0] - 2026-04-11
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -194,6 +194,40 @@ On small projects, `grep` works fine. But as a codebase grows to tens of thousan
 | Finding all usages of a function by name | **cdidx** (`symbols` table) |
 | Searching binary files or non-code content | `grep` |
 
+## Why SQLite?
+
+Given that a database is the right approach, why SQLite specifically rather than PostgreSQL, DuckDB, LiteDB, or a dedicated search engine like Tantivy?
+
+**The short answer: SQLite is the only option that keeps cdidx a zero-dependency, zero-configuration, single-file CLI tool.**
+
+### Alternatives considered
+
+| Alternative | Strength | Why it doesn't fit cdidx |
+|---|---|---|
+| **PostgreSQL / MySQL** | Concurrency, scalability, advanced FTS | Requires a running server. Users would need to install and manage a database before using cdidx — this destroys the `dotnet tool install -g cdidx` experience. |
+| **DuckDB** | Fast analytical (OLAP) queries, columnar storage | No built-in full-text search. cdidx's workload is OLTP (insert + keyword search), not analytics. .NET bindings are less mature than `Microsoft.Data.Sqlite`. |
+| **LiteDB** | .NET-native embedded NoSQL, schema-free | No FTS. The relational structure of symbols → references → callers/callees is a natural fit for SQL joins, not document queries. |
+| **Tantivy / Lucene** | Purpose-built full-text search with superior ranking | Handles only the search side. Relational data (symbols, references, file metadata) would need a separate store, creating a two-storage sync problem. |
+| **Vector DBs** (Qdrant, Chroma) | Semantic / embedding-based search | Requires an embedding model (adds a large dependency or API calls). Keyword and structural queries are weak. Could complement SQLite in the future but cannot replace it. |
+
+### What makes SQLite the right fit
+
+1. **Zero configuration** — No server process, no connection strings, no ports. `cdidx index .` just works.
+2. **Single-file database** — The entire index lives in `.cdidx/codeindex.db`. Copy, delete, or move it like any file.
+3. **Cross-platform** — Identical behavior on Windows, macOS, and Linux without platform-specific setup.
+4. **One NuGet dependency** — `Microsoft.Data.Sqlite` is the only production dependency. This minimizes supply-chain risk and binary size.
+5. **FTS5 built-in** — Full-text search is a native SQLite extension with inverted indexes, phrase queries, and ranking — no external search engine required.
+6. **Relational + FTS in one engine** — Symbols, references, chunks, and file metadata live alongside the FTS index in the same database. Joins, triggers, and transactions keep everything consistent without cross-system synchronization.
+7. **WAL mode** — Write-Ahead Logging allows concurrent reads during indexing and supports the MCP server serving queries while a background index runs.
+8. **Incremental by nature** — SQLite transactions, `ON CONFLICT DO UPDATE`, and timestamp comparison make incremental indexing straightforward.
+
+### When SQLite would not be enough
+
+- **Massive monorepos (1M+ files):** SQLite's single-writer model could become a bottleneck. Sharding by project (cdidx already uses per-project databases) mitigates this, but true parallel writes would need a server database.
+- **Semantic search:** Embedding-based similarity search would benefit from a vector index. The `sqlite-vec` extension could add this without leaving SQLite, or a hybrid architecture (SQLite + external vector store) could be considered.
+
+For the current use case — a local CLI tool that indexes a single project for keyword search and symbol navigation — SQLite hits the sweet spot of simplicity, performance, and capability.
+
 ## FTS5 full-text search
 
 [FTS5](https://www.sqlite.org/fts5.html) (Full-Text Search 5) is a SQLite extension that provides an **inverted index** for full-text search: it maps each token (word) to a list of documents containing it, enabling O(1) lookups by keyword rather than scanning every row.
@@ -675,6 +709,40 @@ files 1──N symbol_references
 | AIエージェントによる複数回のコード検索 | **cdidx** |
 | 関数名で全使用箇所を検索 | **cdidx**（`symbols`テーブル） |
 | バイナリファイルや非コードコンテンツの検索 | `grep` |
+
+## なぜSQLiteなのか？
+
+データベースが正しいアプローチだとして、なぜPostgreSQL、DuckDB、LiteDB、Tantivy等の専用検索エンジンではなくSQLiteなのか？
+
+**端的に言えば、cdidxを「依存ゼロ・設定ゼロ・単一ファイル」のCLIツールとして維持できるのはSQLiteだけだからです。**
+
+### 検討した代替案
+
+| 代替案 | 強み | cdidxに適さない理由 |
+|---|---|---|
+| **PostgreSQL / MySQL** | 並行性、スケーラビリティ、高度なFTS | サーバープロセスが必須。cdidxを使う前にDBのインストールと管理が必要になり、`dotnet tool install -g cdidx` で即使える体験が壊れる。 |
+| **DuckDB** | 高速な分析（OLAP）クエリ、カラムナストレージ | 全文検索が未搭載。cdidxのワークロードはOLTP（挿入＋キーワード検索）であり分析ではない。.NETバインディングも `Microsoft.Data.Sqlite` ほど成熟していない。 |
+| **LiteDB** | .NETネイティブの組み込みNoSQL、スキーマフリー | FTSなし。symbols → references → callers/callees のリレーショナル構造はSQLのJOINが自然であり、ドキュメントクエリでは扱いにくい。 |
+| **Tantivy / Lucene** | 全文検索専用で高精度なランキング | 検索のみを扱う。リレーショナルデータ（シンボル、参照、ファイルメタデータ）には別のストレージが必要になり、2ストレージの同期問題が発生する。 |
+| **ベクトルDB** (Qdrant, Chroma) | セマンティック/埋め込みベース検索 | 埋め込みモデルが必要（大きな依存やAPI呼び出しが増える）。キーワード検索や構造化クエリが弱い。将来SQLiteを補完する可能性はあるが、置き換えはできない。 |
+
+### SQLiteが最適な理由
+
+1. **設定不要** — サーバープロセス、接続文字列、ポート設定が一切不要。`cdidx index .` だけで動く。
+2. **単一ファイルDB** — インデックス全体が `.cdidx/codeindex.db` に収まる。コピー、削除、移動が通常のファイル操作で完結。
+3. **クロスプラットフォーム** — Windows、macOS、Linuxで同一の動作。プラットフォーム固有のセットアップ不要。
+4. **NuGet依存は1個だけ** — `Microsoft.Data.Sqlite` のみ。サプライチェーンリスクとバイナリサイズを最小限に抑える。
+5. **FTS5が組み込み** — 全文検索は転置インデックス、フレーズクエリ、ランキングを備えたSQLiteネイティブ拡張。外部検索エンジン不要。
+6. **リレーショナル＋FTSが1エンジンで完結** — シンボル、参照、チャンク、ファイルメタデータがFTSインデックスと同じDB内に共存。JOIN、トリガー、トランザクションでクロスシステム同期なしに整合性を維持。
+7. **WALモード** — Write-Ahead Loggingによりインデックス中も並行読み取りが可能。MCPサーバーがバックグラウンドインデックス中にクエリを返すケースを支える。
+8. **インクリメンタル更新に適した基盤** — SQLiteのトランザクション、`ON CONFLICT DO UPDATE`、タイムスタンプ比較でインクリメンタルインデックスを自然に実現。
+
+### SQLiteでは足りなくなるケース
+
+- **超大規模monorepo（100万ファイル超）:** SQLiteのsingle-writerモデルがボトルネックになりうる。プロジェクト単位のDB分割（cdidxは既にプロジェクト別DB）で緩和できるが、真の並列書き込みにはサーバーDBが必要。
+- **セマンティック検索:** 埋め込みベースの類似検索にはベクトルインデックスが有利。`sqlite-vec` 拡張でSQLiteを離れずに対応する方法か、ハイブリッド構成（SQLite＋外部ベクトルストア）を検討できる。
+
+現在のユースケース — 単一プロジェクトをキーワード検索とシンボルナビゲーション用にインデックスするローカルCLIツール — において、SQLiteはシンプルさ・パフォーマンス・機能のバランスが最適です。
 
 ## FTS5 全文検索
 


### PR DESCRIPTION
## Summary

- **New "Why SQLite?" section in DEVELOPER_GUIDE.md** — Documents why SQLite was chosen over PostgreSQL, DuckDB, LiteDB, Tantivy, and vector DBs with a comparison table, 8 concrete advantages (zero config, single-file DB, cross-platform, one NuGet dependency, FTS5 built-in, relational+FTS in one engine, WAL mode, incremental-friendly), and guidance on when SQLite would not be enough (massive monorepos, semantic search).
- **Bilingual** — Both English and Japanese sections added, placed between the existing "Why a database instead of grep?" and "FTS5" sections.
- **CHANGELOG updated** — Entry added under `[Unreleased]` in both English and Japanese sections.

## Test plan

- [ ] Verify Markdown renders correctly (tables, headings, bold, code spans)
- [ ] Confirm English and Japanese sections are consistent in content and structure
- [ ] Verify no existing content was modified or displaced

https://claude.ai/code/session_011VqdH3Efqa7goUYLTcaV3j