### PR TITLE
Add cross-language feature expansion guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Added
+
+- **Cross-language feature expansion guidelines** — `SELF_IMPROVEMENT.md` now instructs AI agents to actively check whether language-specific enhancements (especially C# ↔ Java) can be ported to structurally similar languages. Also covers TypeScript/JavaScript, Kotlin/Java, and C/C++ pairs. Affected: `SELF_IMPROVEMENT.md`.
+
 ### [1.3.0] - 2026-04-11
 
 #### Added
@@ -250,6 +254,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 追加
+
+- **言語横展開の指針** — `SELF_IMPROVEMENT.md` に、ある言語向けの強化（特に C# ↔ Java）を構文的に近い言語にも横展開するよう AI エージェントに指示するガイドラインを追加。TypeScript/JavaScript、Kotlin/Java、C/C++ のペアも対象。対象: `SELF_IMPROVEMENT.md`。
 
 ### [1.3.0] - 2026-04-11
 

--- a/SELF_IMPROVEMENT.md
+++ b/SELF_IMPROVEMENT.md
@@ -201,6 +201,15 @@ Do not use one search strategy for every language.
 - When proposing new language-specific features, state clearly which languages are in scope and why.
 - When a heuristic is language-specific, document the limitation in README and tests.
 
+## Cross-Language Feature Expansion
+
+When enhancing symbol extraction, reference extraction, or language-specific heuristics for one language, actively check whether the same improvement applies to structurally similar languages — especially C# and Java, which share many syntactic patterns (classes, interfaces, generics, annotations/attributes, access modifiers, method signatures).
+
+- After implementing or refining a C# pattern, review the corresponding Java patterns in `SymbolExtractor.cs` and `ReferenceExtractor.cs` and apply the same improvement where the syntax permits.
+- The same principle applies in reverse (Java → C#) and to other language pairs with strong overlap (TypeScript/JavaScript, Kotlin/Java, C/C++).
+- Do not force a pattern onto a language where it does not fit. If the syntax diverges enough to make the port unreliable, skip it and document why.
+- When the expansion is straightforward, include it in the same commit as the original enhancement so the languages stay in sync. When it requires non-trivial adaptation, make it a separate follow-up commit.
+
 ## Platform-Aware Guidance
 
 Do not assume path handling, process cleanup, or file deletion behaves the same on every OS.
@@ -443,6 +452,15 @@ dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json
 - C#、Java、Go、Rust、TypeScript/JavaScript、Python、Kotlin、Ruby、C/C++、PHP、Swift と、Markdown、YAML、JSON、TOML、Shell、SQL、HTML/CSS、Vue、Svelte、Terraform は分けて考えてください。
 - 新しい言語依存機能を提案するときは、どの言語を対象にするのか、その理由を明記してください。
 - ヒューリスティックが言語依存なら、README とテストに制限事項を残してください。
+
+## 言語横展開の指針
+
+ある言語のシンボル抽出、参照抽出、言語固有ヒューリスティックを強化したとき、構文的に近い言語にも同じ改善が当てはまらないか能動的に確認してください。特に C# と Java は共通の構文パターンが多い（クラス、インターフェース、ジェネリクス、アノテーション/属性、アクセス修飾子、メソッドシグネチャ）ため、横展開しやすい組み合わせです。
+
+- C# 向けのパターンを実装・改良したら、`SymbolExtractor.cs` と `ReferenceExtractor.cs` の対応する Java パターンを確認し、構文が許す範囲で同じ改善を適用してください。
+- 逆方向（Java → C#）や、重なりの大きい他の言語ペア（TypeScript/JavaScript、Kotlin/Java、C/C++）にも同じ考え方が当てはまります。
+- 構文が十分に異なり、移植すると信頼性が下がる場合は無理をせず、見送った理由を残してください。
+- 横展開が素直にできるなら、元の強化と同じコミットに含めて言語間の同期を保ちます。非自明な適応が必要な場合は、別のフォローアップコミットにしてください。
 
 ## プラットフォーム差分を前提にする指針
 


### PR DESCRIPTION
## Summary

- Added "Cross-Language Feature Expansion" / "言語横展開の指針" section to `SELF_IMPROVEMENT.md` (both English and Japanese)
- When enhancing language-specific patterns (especially C#), AI agents should actively check whether the same improvement applies to structurally similar languages like Java
- Also covers other high-overlap pairs: TypeScript/JavaScript, Kotlin/Java, C/C++
- Emphasizes not forcing patterns where syntax diverges — skip and document why
- Straightforward expansions go in the same commit; non-trivial ones get a follow-up commit

## Test plan

- [x] No code changes — documentation only
- [x] CHANGELOG.md updated (English + Japanese `[Unreleased]`)
- [x] Both English and Japanese sections added and consistent

https://claude.ai/code/session_01BMnTAeN8nYiLDodSMEyCeC