### PR TITLE
Fix markdown code fence formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ cdidx ./myproject --files src/app.cs src/utils.cs
 ```
 
 These options make it practical to keep the index up-to-date in real time, even on large codebases.
+````
 
 ### MCP Server (for Claude Code, Cursor, Windsurf, etc.)
 
@@ -1360,6 +1361,7 @@ cdidx ./myproject --files src/app.cs src/utils.cs
 ```
 
 これらのオプションにより、大規模コードベースでもリアルタイムにインデックスを最新に保つことが実用的になります。
+````
 
 ### MCP サーバー（Claude Code、Cursor、Windsurf 等に対応）
 


### PR DESCRIPTION
## Summary
This PR fixes malformed markdown code fence syntax in the README documentation by correcting improperly closed code blocks.

## Changes
- Added closing markdown code fence (`````) after the "real-time index" section in the English documentation
- Added closing markdown code fence (`````) after the corresponding Japanese translation section

## Details
The code blocks in both the English and Japanese sections of the README were missing proper closing fence markers. These additions ensure the markdown is properly formatted and will render correctly in documentation viewers and on platforms like GitHub.

https://claude.ai/code/session_013YquTSiycLAQ1Suefussyf