### PR TITLE
Publish branch-built GHCR images; make installer mirrorable and add PATH troubleshooting; update docs and changelog

### DIFF
--- a/.github/workflows/container-branch.yml
+++ b/.github/workflows/container-branch.yml
@@ -1,0 +1,48 @@
+name: Branch Container (GHCR)
+
+on:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/cdidx
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Changed
+- **README Option A PATH troubleshooting for container/cloud shells** — Added explicit `~/.local/bin` PATH recovery steps (temporary + persistent bash example) to the one-liner installer sections in both English and Japanese so `cdidx: command not found` is easier to fix in minimal environments. Affected: `README.md`.
+- **Installer supports mirror endpoints for restricted AI containers** — `install.sh` now accepts `CDIDX_GITHUB_API_URL` and `CDIDX_RELEASE_BASE_URL` so users can route version lookup and release downloads through internal mirrors when direct GitHub access is blocked. Error messages now include concrete fallback commands (pin version, set mirror URLs). README Option A (EN/JP) now documents this flow and clarifies that PATH fixes apply after a successful install. Affected: `install.sh`, `README.md`.
+- **Branch container publishing to GHCR** — Added a branch-triggered GitHub Actions workflow that builds and pushes `cdidx` container images to GHCR (`ghcr.io/<owner>/cdidx:<branch>` and `:sha-<commit>`). Added a `Dockerfile` that builds `cdidx` from source and sets `cdidx --version` as the default command. README now documents opening a container directly from a branch image for AI workflows. Affected: `.github/workflows/container-branch.yml`, `Dockerfile`, `README.md`.
+
 ### [1.8.0] - 2026-04-12
 
 #### Added
@@ -558,6 +563,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 変更
+- **README 方法Aに PATH トラブルシュートを追記（コンテナ/クラウド向け）** — ワンライナーインストーラー節（英語・日本語）に、`~/.local/bin` が `PATH` にない環境での復旧手順（一時設定 + bash 永続化例）を追加。`cdidx: command not found` の初回つまずきを減らす。対象: `README.md`。
+- **制限付きAIコンテナ向けにインストーラーのミラー対応を追加** — `install.sh` が `CDIDX_GITHUB_API_URL` と `CDIDX_RELEASE_BASE_URL` を受け付けるようになり、GitHub 直アクセスがブロックされた環境でも内部ミラー経由でバージョン解決とリリース取得を行えるようになった。エラーメッセージに固定バージョン指定とミラー設定の具体例を追加。README 方法A（英日）にも反映し、PATH 対処は「インストール成功後」の手順であることを明確化。対象: `install.sh`、`README.md`。
+- **ブランチ起点のGHCRコンテナ公開を追加** — ブランチ push をトリガーに `cdidx` コンテナを GHCR（`ghcr.io/<owner>/cdidx:<branch>` と `:sha-<commit>`）へ公開する GitHub Actions ワークフローを追加。ソースから `cdidx` をビルドし、デフォルト実行を `cdidx --version` にした `Dockerfile` を追加。README に、AIワークフロー向けにブランチイメージを直接指定してコンテナを開く手順を追記。対象: `.github/workflows/container-branch.yml`、`Dockerfile`、`README.md`。
 
 ### [1.8.0] - 2026-04-12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY . .
+RUN dotnet publish src/CodeIndex/CodeIndex.csproj \
+    -c Release \
+    -r linux-x64 \
+    --self-contained true \
+    -p:PublishSingleFile=true \
+    -p:PublishTrimmed=true \
+    -o /out
+
+FROM ubuntu:24.04
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/cdidx /usr/local/bin/cdidx
+WORKDIR /workspace
+
+ENTRYPOINT ["cdidx"]
+CMD ["--version"]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,27 @@ curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/v1.5.0/install.s
 
 Supported platforms: `linux-x64`, `linux-arm64`, `osx-arm64` (glibc-based Linux only; Alpine/musl is not supported). Installs to `~/.local/bin` by default (override with `CDIDX_INSTALL_DIR`).
 
+If install fails with HTTP 403 in a managed container/proxy environment, GitHub endpoints may be blocked. Use a pinned version and mirror endpoints:
+
+```bash
+export CDIDX_GITHUB_API_URL="https://<your-mirror>/repos/Widthdom/CodeIndex"
+export CDIDX_RELEASE_BASE_URL="https://<your-mirror>/releases/download"
+curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash -s -- v1.8.0
+```
+
+If install succeeds but `cdidx` is still not found, your shell likely does not include `~/.local/bin` in `PATH` yet:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+cdidx --version
+```
+
+To make this permanent (bash):
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+```
+
 **Dockerfile example:**
 
 ```dockerfile
@@ -158,6 +179,21 @@ if ($path -notlike '*C:\Tools*') {
 ```
 
 Restart your terminal after adding to PATH.
+
+### Option D: Use GHCR image from a branch
+
+For AI/container workflows, you can open a container directly from a branch-built image on GHCR.
+
+After pushing your branch, GitHub Actions publishes:
+
+- `ghcr.io/<owner>/cdidx:<branch-name>`
+- `ghcr.io/<owner>/cdidx:sha-<commit>`
+
+Example:
+
+```bash
+docker run --rm ghcr.io/widthdom/cdidx:work --version
+```
 
 ### Verify
 
@@ -867,6 +903,27 @@ curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/v1.5.0/install.s
 
 対応プラットフォーム: `linux-x64`, `linux-arm64`, `osx-arm64`（glibc ベースの Linux のみ。Alpine/musl は非対応）。デフォルトで `~/.local/bin` にインストール（`CDIDX_INSTALL_DIR` で変更可）。
 
+管理されたコンテナ/プロキシ環境でインストール時に HTTP 403 が出る場合、GitHub エンドポイントがブロックされている可能性があります。固定バージョン + ミラー URL を使用してください:
+
+```bash
+export CDIDX_GITHUB_API_URL="https://<your-mirror>/repos/Widthdom/CodeIndex"
+export CDIDX_RELEASE_BASE_URL="https://<your-mirror>/releases/download"
+curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash -s -- v1.8.0
+```
+
+インストール自体は成功しているのに `cdidx` が見つからない場合は、シェルの `PATH` に `~/.local/bin` が入っていない可能性があります:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+cdidx --version
+```
+
+永続化する場合（bash）:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+```
+
 **Dockerfile の例:**
 
 ```dockerfile
@@ -938,6 +995,21 @@ if ($path -notlike '*C:\Tools*') {
 ```
 
 PATH追加後はターミナルを再起動してください。
+
+### 方法D: ブランチ由来のGHCRイメージを使う
+
+AI/コンテナ用途では、ブランチからビルドされた GHCR イメージを直接指定してコンテナを開けます。
+
+ブランチを push すると GitHub Actions が次を公開します:
+
+- `ghcr.io/<owner>/cdidx:<branch-name>`
+- `ghcr.io/<owner>/cdidx:sha-<commit>`
+
+例:
+
+```bash
+docker run --rm ghcr.io/widthdom/cdidx:work --version
+```
 
 ### 確認
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,8 @@ REPO="Widthdom/CodeIndex"
 INSTALL_DIR="${CDIDX_INSTALL_DIR:-$HOME/.local/bin}"
 BINARY_NAME="cdidx"
 TMPDIR_CLEANUP=""
+GITHUB_API_BASE="${CDIDX_GITHUB_API_URL:-https://api.github.com/repos/${REPO}}"
+RELEASE_BASE_URL="${CDIDX_RELEASE_BASE_URL:-https://github.com/${REPO}/releases/download}"
 
 # --- Helpers / ヘルパー ---
 
@@ -78,8 +80,21 @@ resolve_version() {
         info "Fetching latest release version..."
         need_cmd curl
         local api_response
-        api_response="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest")" \
-            || error "Failed to fetch latest release from GitHub API. Check your network connection."
+        api_response="$(curl -fsSL "${GITHUB_API_BASE}/releases/latest")" || {
+            error "Failed to fetch latest release metadata from ${GITHUB_API_BASE}/releases/latest.
+
+Possible causes:
+  - Network/proxy blocks GitHub API access (common in managed AI containers)
+  - Temporary connectivity issue
+
+Try one of these:
+  1) Pin a version explicitly (skips latest API call):
+       bash install.sh v1.8.0
+  2) Use a mirror endpoint:
+       export CDIDX_GITHUB_API_URL='https://<your-mirror>/repos/${REPO}'
+       export CDIDX_RELEASE_BASE_URL='https://<your-mirror>/releases/download'
+       bash install.sh v1.8.0"
+        }
 
         VERSION="$(printf '%s' "$api_response" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
 
@@ -118,7 +133,7 @@ download_and_install() {
     need_cmd mktemp
 
     local archive_name="CodeIndex-${RID}.tar.gz"
-    local base_url="https://github.com/${REPO}/releases/download/${VERSION}"
+    local base_url="${RELEASE_BASE_URL}/${VERSION}"
     local archive_url="${base_url}/${archive_name}"
     local checksums_url="${base_url}/sha256sums.txt"
 
@@ -128,11 +143,16 @@ download_and_install() {
 
     info "Downloading ${archive_name}..."
     curl -fsSL -o "${tmpdir}/${archive_name}" "$archive_url" \
-        || error "Failed to download $archive_url. Check that version $VERSION exists and has a ${RID} binary."
+        || error "Failed to download ${archive_url}.
+
+Check:
+  - Version exists and publishes ${RID}: ${VERSION}
+  - Network/proxy can access release assets
+  - If needed, set CDIDX_RELEASE_BASE_URL to an internal mirror"
 
     info "Downloading checksums..."
     curl -fsSL -o "${tmpdir}/sha256sums.txt" "$checksums_url" \
-        || error "Failed to download checksums from $checksums_url."
+        || error "Failed to download checksums from ${checksums_url}. If you use a mirror, ensure sha256sums.txt is also mirrored."
 
     # Verify checksum / チェックサム検証
     info "Verifying checksum..."


### PR DESCRIPTION
### Motivation

- Provide branch-built container images for AI/container workflows so users can run a branch-specific `cdidx` image from GHCR. 
- Make the one-line installer usable in restricted/containerized environments by allowing mirrored GitHub endpoints and clearer failure guidance. 
- Surface the installer and container changes in documentation and the changelog so users know how to pin, mirror, or run branch images.

### Description

- Add a GitHub Actions workflow ` .github/workflows/container-branch.yml` that builds and pushes branch and commit-tagged images to GHCR (`ghcr.io/<owner>/cdidx:<branch>` and `:sha-<commit>`). 
- Add a multi-stage `Dockerfile` that publishes the `cdidx` tool from source and sets `cdidx --version` as the default command. 
- Extend the one-line installer (`install.sh`) to accept `CDIDX_GITHUB_API_URL` and `CDIDX_RELEASE_BASE_URL` for mirror support and improve error messages with concrete fallback commands and checks; use these vars when resolving releases and downloading assets. 
- Update `README.md` with PATH troubleshooting for `~/.local/bin`, instructions for using mirrored endpoints when installing, and a new section documenting how to run branch-built GHCR images. 
- Update `CHANGELOG.md` with entries describing the installer mirror support, PATH troubleshooting, and branch container publishing.

### Testing

- No automated tests were added or run as part of this change; existing test suite and CI were not modified by these files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db04a7b63883258340a41d69c2713a)