### PR TITLE
Fix install.sh to copy bundled SQLite library and version.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Fixed
+- **`install.sh` now copies bundled SQLite native library and `version.json`** — The one-liner installer previously copied only the `cdidx` binary from the release tarball, leaving `libe_sqlite3.so` (or `libe_sqlite3.dylib` on macOS) and `version.json` behind. This caused every DB operation on a freshly installed cdidx to crash with `libe_sqlite3: cannot open shared object file`, and `cdidx --version` to silently fall back to reporting `v0.0.0`. The installer now copies every sibling runtime file shipped in the tarball next to the binary. Affected: `install.sh`.
+
 ### [1.8.0] - 2026-04-12
 
 #### Added
@@ -558,6 +561,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 修正
+- **`install.sh` が同梱の SQLite ネイティブライブラリと `version.json` もコピーするように** — これまでワンライナーインストーラーはリリース tarball から `cdidx` バイナリのみをコピーし、`libe_sqlite3.so`（macOS では `libe_sqlite3.dylib`）と `version.json` を残していた。その結果、インストール直後の cdidx は DB 操作のたびに `libe_sqlite3: cannot open shared object file` でクラッシュし、`cdidx --version` は静かに `v0.0.0` へフォールバックしていた。インストーラーは tarball に同梱されたランタイムファイルをバイナリと同じディレクトリへ配置するようになった。対象: `install.sh`。
 
 ### [1.8.0] - 2026-04-12
 

--- a/install.sh
+++ b/install.sh
@@ -163,9 +163,29 @@ download_and_install() {
     tar xzf "${tmpdir}/${archive_name}" -C "$tmpdir"
 
     # Install / インストール
+    # The tarball ships the cdidx binary together with its native SQLite
+    # companion (libe_sqlite3.so / libe_sqlite3.dylib) and version.json.
+    # All three files must live next to the binary, otherwise:
+    #   - cdidx crashes with "libe_sqlite3: cannot open shared object file"
+    #     on any DB operation.
+    #   - cdidx --version reports "v0.0.0" because version.json is missing.
+    # tarball には cdidx バイナリと共にネイティブ SQLite (libe_sqlite3.so /
+    # libe_sqlite3.dylib) と version.json が同梱される。これら 3 ファイルは
+    # バイナリと同じディレクトリに置かないと、DB 操作で
+    # "libe_sqlite3: cannot open shared object file" になり、
+    # version.json が無いと --version が "v0.0.0" に退化する。
     mkdir -p "$INSTALL_DIR"
     cp "${tmpdir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+
+    # Copy sibling runtime files (native SQLite library, version metadata).
+    # 同梱されたランタイムファイル（ネイティブ SQLite ライブラリ、バージョン情報）もコピー。
+    local sibling
+    for sibling in libe_sqlite3.so libe_sqlite3.dylib version.json; do
+        if [ -f "${tmpdir}/${sibling}" ]; then
+            cp "${tmpdir}/${sibling}" "${INSTALL_DIR}/${sibling}"
+        fi
+    done
 
     info "Installed cdidx to ${INSTALL_DIR}/${BINARY_NAME}"
 }


### PR DESCRIPTION
## Summary
The `install.sh` installer was only copying the `cdidx` binary from release tarballs, leaving behind critical runtime files. This caused freshly installed cdidx to crash on any database operation and report an incorrect version number.

## Changes
- **Enhanced `install.sh` installation logic** — Added a loop to copy all sibling runtime files (`libe_sqlite3.so`, `libe_sqlite3.dylib`, and `version.json`) from the extracted tarball to the installation directory alongside the binary
- **Added explanatory comments** — Documented why these files must be co-located with the binary (in both English and Japanese)
- **Updated CHANGELOG.md** — Documented the fix in both English and Japanese sections

## Implementation Details
The fix uses a simple loop that checks for the existence of each expected runtime file before copying it. This approach is defensive and handles both Linux (`.so`) and macOS (`.dylib`) variants gracefully. Files that don't exist in the tarball are silently skipped, ensuring the installer remains robust across different build configurations.

**Affected files:** `install.sh`, `CHANGELOG.md`

https://claude.ai/code/session_014HuS28NpLGoaNMF5cEzVoL