### PR TITLE
Harden installer payload layout resolution and require runtime assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Fixed
 - **`unused` no longer crashes with "data is NULL at ordinal 5" on legacy indexes (#49)** — When older cdidx binaries added the `start_line` / `end_line` symbol columns but left existing rows with NULL, `cdidx unused` crashed because `GetUnusedSymbols` called `GetInt32` on those NULL ordinals. The symbol-column SQL helper now wraps fallback-aware reads in `COALESCE(s.<col>, <fallback>)`, and `GetUnusedSymbols` additionally defends each read with `IsDBNull` so a fully-legacy row falls back to `s.line`. Affected: `DbReader.cs`, `DbSymbolReader.cs`, `DbReaderTests.cs`.
+- **`install.sh` now fails fast when release archives are missing required runtime assets** — The installer now detects either a flat archive layout or a single top-level payload directory, then requires the OS-specific runtime assets (`version.json` + `libe_sqlite3.so` on Linux, `version.json` + `libe_sqlite3.dylib` on macOS). If required files are missing, installation aborts with a clear error instead of silently installing a partially broken binary. Affected: `install.sh`.
 
 ### [1.8.1] - 2026-04-13
 
@@ -588,6 +589,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### 修正
 - **`unused` がレガシーインデックスで「data is NULL at ordinal 5」でクラッシュしなくなった (#49)** — 古い cdidx バイナリが symbols の `start_line` / `end_line` カラムを追加しただけで既存行を NULL のまま残していた場合、`cdidx unused` は `GetInt32` が NULL を読めずクラッシュしていた。シンボルカラム SQL ヘルパーを `COALESCE(s.<col>, <fallback>)` で包み、さらに `GetUnusedSymbols` の読み出しも `IsDBNull` でガードして、完全にレガシーな行は `s.line` にフォールバックするようにした。対象: `DbReader.cs`、`DbSymbolReader.cs`、`DbReaderTests.cs`。
+- **`install.sh` が必須ランタイム資産欠落時に即時失敗するよう修正** — インストーラは、アーカイブ直下レイアウトと単一トップレベルディレクトリ配下レイアウトのどちらにも対応したうえで、OS ごとの必須資産（Linux: `version.json` + `libe_sqlite3.so`、macOS: `version.json` + `libe_sqlite3.dylib`）を必須チェックする。必須ファイルが欠けている場合は、部分的に壊れたインストールを黙って進めず、明確なエラーで中断する。対象: `install.sh`。
 
 ### [1.8.1] - 2026-04-13
 

--- a/install.sh
+++ b/install.sh
@@ -166,9 +166,26 @@ download_and_install() {
     info "Extracting..."
     tar xzf "${tmpdir}/${archive_name}" -C "$extract_dir"
 
+    # Resolve extraction root. Most releases extract files at archive root,
+    # but some repacks may wrap them in a single top-level directory.
+    # 展開ルートを解決。通常はアーカイブ直下だが、再パック時に
+    # 単一トップレベルディレクトリで包まれる場合にも対応する。
+    local payload_root="$extract_dir"
+    if [ ! -f "${payload_root}/${BINARY_NAME}" ]; then
+        local top_dirs
+        top_dirs="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d | wc -l | awk '{print $1}')"
+        if [ "$top_dirs" = "1" ]; then
+            payload_root="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+        fi
+    fi
+
+    if [ ! -f "${payload_root}/${BINARY_NAME}" ]; then
+        error "Archive does not contain ${BINARY_NAME} at an expected location."
+    fi
+
     # Install binary / バイナリをインストール
     mkdir -p "$INSTALL_DIR"
-    cp "${extract_dir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+    cp "${payload_root}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
     # Install runtime assets alongside the binary.
@@ -183,11 +200,19 @@ download_and_install() {
     # - ネイティブ SQLite ライブラリ（Linux は libe_sqlite3.so、macOS は
     #   libe_sqlite3.dylib）は P/Invoke 解決のためバイナリの隣に必要で、
     #   無いと起動直後に DllNotFoundException で全コマンドが落ちる。
+    local required_assets="version.json"
+    if [ "$OS_NAME" = "linux" ]; then
+        required_assets="${required_assets} libe_sqlite3.so"
+    elif [ "$OS_NAME" = "osx" ]; then
+        required_assets="${required_assets} libe_sqlite3.dylib"
+    fi
+
     local asset
-    for asset in version.json libe_sqlite3.so libe_sqlite3.dylib; do
-        if [ -f "${extract_dir}/${asset}" ]; then
-            cp "${extract_dir}/${asset}" "${INSTALL_DIR}/${asset}"
+    for asset in $required_assets; do
+        if [ ! -f "${payload_root}/${asset}" ]; then
+            error "Archive is missing required runtime asset: ${asset}"
         fi
+        cp "${payload_root}/${asset}" "${INSTALL_DIR}/${asset}"
     done
 
     info "Installed cdidx to ${INSTALL_DIR}/${BINARY_NAME}"


### PR DESCRIPTION
### Motivation
- Prevent silent partial installs when release tarballs use a wrapped top-level directory or omit runtime assets, which caused `cdidx --version` to report `v0.0.0` and commands to crash with `DllNotFoundException`.
- Make the one-line installer robust across repackaged archives and ensure the native SQLite library and `version.json` are present next to the binary so runtime P/Invoke and version reporting work.

### Description
- Update `install.sh` to detect the extracted payload root as either a flat layout or a single top-level directory and error if `cdidx` is not found in the resolved payload root.
- Require `version.json` plus the OS-specific native SQLite library (`libe_sqlite3.so` on Linux, `libe_sqlite3.dylib` on macOS) to be present in the archive and fail fast with a clear error when any required asset is missing.
- Copy runtime assets from the resolved payload root into the install directory so `cdidx --version` and P/Invoke loading work correctly.
- Add entries to `CHANGELOG.md` (English and Japanese `[Unreleased]` sections) documenting the installer fail-fast behavior when runtime assets are missing.

### Testing
- Ran a syntax check with `bash -n install.sh`, which completed successfully.
- Attempted the published one-liner smoke flow (`curl ... | bash` and subsequent `cdidx` smoke commands), but outbound access to raw GitHub content is blocked in this environment (HTTP 403), so end-to-end smoke verification against the published release could not be performed here.
- Verified the modified `install.sh` code paths are syntactically valid via local shell checks; runtime behavior will be validated by CI/release workflow that exercises the installer against real artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc20981784832590cd42c8f169d207)