### PR TITLE
installer: fail fast on missing runtime assets (bash 3.2 safe alternative to #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Fixed
 - **`unused` no longer crashes with "data is NULL at ordinal 5" on legacy indexes (#49)** — When older cdidx binaries added the `start_line` / `end_line` symbol columns but left existing rows with NULL, `cdidx unused` crashed because `GetUnusedSymbols` called `GetInt32` on those NULL ordinals. The symbol-column SQL helper now wraps fallback-aware reads in `COALESCE(s.<col>, <fallback>)`, and `GetUnusedSymbols` additionally defends each read with `IsDBNull` so a fully-legacy row falls back to `s.line`. Affected: `DbReader.cs`, `DbSymbolReader.cs`, `DbReaderTests.cs`.
+- **`install.sh` fails fast on missing runtime assets instead of silently installing a broken binary** — Previously the installer copied `version.json`, `libe_sqlite3.so`, and `libe_sqlite3.dylib` only "if present", so a tarball missing any of them would still complete "successfully" and then crash on first use (`cdidx --version` → `v0.0.0`, or `DllNotFoundException: e_sqlite3`). The installer now selects required assets by detected `$OS_NAME` (`version.json` + `libe_sqlite3.so` on Linux, `version.json` + `libe_sqlite3.dylib` on macOS) and aborts with a clear error if any are missing from the release tarball. The check intentionally avoids bash 4+ builtins (`mapfile`) and external `find` calls so the one-liner stays compatible with macOS `/bin/bash` 3.2, where `curl … | bash` runs. Addresses the same concern as #72 (codex) without introducing a macOS portability regression. Affected: `install.sh`.
 
 ### [1.8.1] - 2026-04-13
 
@@ -588,6 +589,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### 修正
 - **`unused` がレガシーインデックスで「data is NULL at ordinal 5」でクラッシュしなくなった (#49)** — 古い cdidx バイナリが symbols の `start_line` / `end_line` カラムを追加しただけで既存行を NULL のまま残していた場合、`cdidx unused` は `GetInt32` が NULL を読めずクラッシュしていた。シンボルカラム SQL ヘルパーを `COALESCE(s.<col>, <fallback>)` で包み、さらに `GetUnusedSymbols` の読み出しも `IsDBNull` でガードして、完全にレガシーな行は `s.line` にフォールバックするようにした。対象: `DbReader.cs`、`DbSymbolReader.cs`、`DbReaderTests.cs`。
+- **`install.sh` が必須ランタイム資産の欠落で即時失敗するよう修正（壊れたバイナリの黙ったインストールを防止）** — 旧実装は `version.json`・`libe_sqlite3.so`・`libe_sqlite3.dylib` を「あればコピー」する仕様で、tarball から欠落していてもインストールは「成功」扱いになり、初回起動で `cdidx --version` が `v0.0.0` を返す、あるいは `DllNotFoundException: e_sqlite3` で落ちる状態になっていた。検出済みの `$OS_NAME` に応じて必須資産を選び（Linux: `version.json` + `libe_sqlite3.so`、macOS: `version.json` + `libe_sqlite3.dylib`）、release tarball に欠落があれば明確なエラーで中断する。チェックは bash 4+ ビルトイン（`mapfile`）や外部 `find` を意図的に避け、`curl … | bash` が macOS の `/bin/bash` 3.2 で実行された場合にも壊れないようにしている。#72（codex 発）と同じ課題に、macOS 移植性を壊さずに対処する。対象: `install.sh`。
 
 ### [1.8.1] - 2026-04-13
 

--- a/install.sh
+++ b/install.sh
@@ -171,23 +171,42 @@ download_and_install() {
     cp "${extract_dir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
-    # Install runtime assets alongside the binary.
+    # Install runtime assets alongside the binary. Fail fast if any required
+    # asset is missing rather than silently installing a partially broken
+    # binary that will crash on first use.
     # - cdidx loads version.json via AppContext.BaseDirectory (the binary's dir),
     #   so without it `cdidx --version` reports v0.0.0.
     # - The native SQLite library (libe_sqlite3.so on Linux, libe_sqlite3.dylib
     #   on macOS) must live next to the binary for P/Invoke to resolve; without
     #   it every command crashes with DllNotFoundException at startup.
-    # ランタイム資産をバイナリの隣へ配置する。
+    # Required assets are OS-specific, so we match on $OS_NAME instead of
+    # "copy whatever happens to be in the archive". This keeps the installer
+    # compatible with bash 3.2 (the default /bin/bash on macOS) — no arrays,
+    # no `mapfile`, no `find` — and works for all currently published tarballs.
+    # ランタイム資産をバイナリの隣へ配置する。必須資産が欠落している場合は、
+    # 部分的に壊れたインストールを黙って進めず即時失敗させる（起動直後の
+    # クラッシュを防ぐため）。
     # - cdidx は AppContext.BaseDirectory（バイナリのディレクトリ）から
     #   version.json を読むため、これが無いと --version が v0.0.0 になる。
     # - ネイティブ SQLite ライブラリ（Linux は libe_sqlite3.so、macOS は
     #   libe_sqlite3.dylib）は P/Invoke 解決のためバイナリの隣に必要で、
     #   無いと起動直後に DllNotFoundException で全コマンドが落ちる。
+    # 必須資産は OS ごとに異なるため「アーカイブにあるものを何でも」ではなく
+    # $OS_NAME で分岐する。macOS の既定 /bin/bash 3.2 でも動くよう、配列・
+    # `mapfile`・`find` は使わず、現行リリースの tarball 配置前提で実装する。
+    local required_assets
+    case "$OS_NAME" in
+        linux) required_assets="version.json libe_sqlite3.so"   ;;
+        osx)   required_assets="version.json libe_sqlite3.dylib" ;;
+        *)     error "Internal error: unknown OS_NAME '$OS_NAME' for asset selection." ;;
+    esac
+
     local asset
-    for asset in version.json libe_sqlite3.so libe_sqlite3.dylib; do
-        if [ -f "${extract_dir}/${asset}" ]; then
-            cp "${extract_dir}/${asset}" "${INSTALL_DIR}/${asset}"
+    for asset in $required_assets; do
+        if [ ! -f "${extract_dir}/${asset}" ]; then
+            error "Required runtime asset missing from release tarball: ${asset}. Refusing to install a partially broken binary. Please report this at https://github.com/${REPO}/issues."
         fi
+        cp "${extract_dir}/${asset}" "${INSTALL_DIR}/${asset}"
     done
 
     info "Installed cdidx to ${INSTALL_DIR}/${BINARY_NAME}"


### PR DESCRIPTION
## Summary

- Make `install.sh` **fail fast** when the release tarball is missing required runtime assets, instead of silently installing a half-broken binary that crashes on first use (`cdidx --version` → `v0.0.0`, or `DllNotFoundException: e_sqlite3`).
- Select required assets by detected `$OS_NAME`: Linux needs `version.json` + `libe_sqlite3.so`; macOS needs `version.json` + `libe_sqlite3.dylib`.
- Stay **bash 3.2 compatible** — no `mapfile`, no `find`, no arrays. `curl … | bash` on macOS must keep working, since `/bin/bash` there is still 3.2.

## Relationship to #72

This PR addresses the same installer concern as #72 (codex-authored) but intentionally drops two pieces from it:

1. **`mapfile`-based binary discovery** — `mapfile` is a bash 4+ builtin. macOS's default `/bin/bash` is 3.2 for licensing reasons, and `curl … | bash` invokes `/bin/bash` directly. Landing #72 as-is would give macOS users `install.sh: mapfile: command not found` — a clean-install regression that this repo's bootstrap flow is explicitly written to catch. Confirmed in a Claude Cloud session (Linux) where #72's download-path was the _only_ thing that succeeded because `mapfile` exists there; macOS was never exercised.
2. **Wrapper-directory support (`find -mindepth 1 -maxdepth 2 …`)** — current release tarballs are flat. There is no wrapper-directory tarball in existence today, so the extra branch is a defense against a tarball layout that never shipped. If the release workflow ever changes to emit a wrapper, the contract belongs on the _producer_ side (the workflow), not as speculative tolerance in the consumer.

The **fail-fast-on-missing-asset** idea from #72 is genuinely valuable and is what this PR keeps.

## Why this matters for cloud agent sessions

The project's `CLOUD_BOOTSTRAP_PROMPT.md` instructs cloud Claude Code sessions (no local .NET SDK) to treat `install.sh` as their only way to get a working `cdidx`. That prompt explicitly says: "If `cdidx --version` reports `v0.0.0` … the installer placed a broken binary." Today the installer _can_ do exactly that silently. This PR closes that gap: the installer refuses to write a half-broken layout and points the user at the issue tracker.

A separate Codex-vs-Claude branch is **not** needed here:

- `CLOUD_BOOTSTRAP_PROMPT.md` is Claude-targeted (by title and opening line).
- Codex is routed to `CLAUDE.md` via `.codex/config.toml` (`project_doc_fallback_filenames = ["CLAUDE.md"]`).
- The concrete sandbox-escape wording that #72 wanted to add is agent-host-specific (Codex's "unsandboxed network execution" is not a knob that exists in the same form in Claude Cloud). Keeping that out of the shared doc avoids misleading readers of the other agent.
- The `install.sh` hardening itself is agent-neutral: it helps any installer caller (CI, local macOS user, Codex, Claude Cloud, plain curl-to-bash).

## Test plan

- [x] `bash -n install.sh` (syntax check) passes.
- [x] Unit-style test harness in a tmpdir confirms:
  - all required assets present → both copied into `INSTALL_DIR`.
  - Linux asset missing (`libe_sqlite3.so`) → installer aborts with explicit "Required runtime asset missing" error.
  - `$OS_NAME=osx` selects `libe_sqlite3.dylib`, not `libe_sqlite3.so`.
- [x] Confirmed unchanged behavior for current (flat) release tarball on Linux x64: `cdidx --version`, `cdidx . --db`, `cdidx status`, `cdidx search`, `cdidx mcp` all still pass the `CLOUD_BOOTSTRAP_PROMPT.md` smoke sequence.
- [ ] macOS smoke test (deferred to reviewer / CI — this environment is Linux-only). The intent of this PR is specifically that bash 3.2 cannot regress it.

## Not in this PR

- No change to `CLOUD_BOOTSTRAP_PROMPT.md`. The file is Claude-specific and a clean Claude Cloud run (this session) completed all five smoke tests. Codex-specific sandbox-escape guidance belongs in Codex-side tooling, not a Claude bootstrap file.
- No wrapper-directory tolerance in `install.sh`. If that layout is ever introduced, it should be introduced as a contract in `release.yml` (and covered by the existing end-to-end installer verification job there), not inferred on the installer side.

https://claude.ai/code/session_016Zz5J8xPoMHMfmjWQkyMEX