### PR TITLE
Preserve raw bytes during indexing, validate without double-read, and surface MCP readiness markers (closes #74)

### DIFF
--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -327,7 +327,7 @@ public static class IndexCommandRunner
                     continue;
                 }
 
-                var (record, content, warning) = indexer.BuildRecord(absPath);
+                var (record, content, rawBytes, warning) = indexer.BuildRecordWithRawBytes(absPath);
 
                 if (warning != null && !options.Json)
                     ConsoleUi.PrintWarning(warning);
@@ -350,7 +350,6 @@ public static class IndexCommandRunner
                 var references = ReferenceExtractor.Extract(fileId, record.Lang, content, symbols);
                 writer.InsertReferences(references);
                 // Validate content for encoding issues / エンコーディング問題を検証
-                var rawBytes = File.ReadAllBytes(absPath);
                 var issues = FileIndexer.ValidateContent(record.Path, rawBytes, content);
                 writer.InsertIssues(fileId, issues);
                 txn.Commit();
@@ -481,7 +480,7 @@ public static class IndexCommandRunner
             }
             try
             {
-                var (record, content, warning) = indexer.BuildRecord(filePath);
+                var (record, content, rawBytes, warning) = indexer.BuildRecordWithRawBytes(filePath);
 
                 if (warning != null && !options.Json)
                     ConsoleUi.PrintWarning(warning);
@@ -509,7 +508,6 @@ public static class IndexCommandRunner
                 var references = ReferenceExtractor.Extract(fileId, record.Lang, content, symbols);
                 writer.InsertReferences(references);
                 // Validate content for encoding issues / エンコーディング問題を検証
-                var rawBytes = File.ReadAllBytes(filePath);
                 var issues = FileIndexer.ValidateContent(record.Path, rawBytes, content);
                 writer.InsertIssues(fileId, issues);
                 txn.Commit();

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -218,6 +218,18 @@ public class FileIndexer
     /// </summary>
     public (FileRecord record, string content, string? warning) BuildRecord(string absolutePath)
     {
+        var (record, content, _, warning) = BuildRecordWithRawBytes(absolutePath);
+        return (record, content, warning);
+    }
+
+    /// <summary>
+    /// Build a FileRecord and return both decoded content and raw bytes.
+    /// Callers can run encoding validation without a second file read.
+    /// FileRecordを構築し、デコード済み内容とraw bytesを返す。
+    /// 呼び出し側は再読込なしでエンコーディング検証できる。
+    /// </summary>
+    public (FileRecord record, string content, byte[] rawBytes, string? warning) BuildRecordWithRawBytes(string absolutePath)
+    {
         var relativePath = Path.GetRelativePath(_projectRoot, absolutePath);
         var info = new FileInfo(absolutePath);
 
@@ -263,7 +275,7 @@ public class FileIndexer
             Modified = info.LastWriteTimeUtc,
         };
 
-        return (record, content, warning);
+        return (record, content, bytes, warning);
     }
 
     /// <summary>

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Reflection;
 using CodeIndex.Cli;
 using CodeIndex.Database;
 using CodeIndex.Indexer;
@@ -126,6 +127,20 @@ public partial class McpServer
             return $"No {label} found. Call-graph queries are not indexed for '{lang}'.";
 
         return $"No {label} found.";
+    }
+
+    /// <summary>
+    /// Best-effort invocation for optional readiness markers.
+    /// Works with older builds (method absent) and newer split-readiness builds.
+    /// 任意のreadinessマーカーをベストエフォートで呼び出す。
+    /// 旧ビルド（メソッド未定義）と新split-readinessビルドの両方で動作。
+    /// </summary>
+    private static void TryInvokeDbWriterMarker(DbWriter writer, string methodName)
+    {
+        var method = typeof(DbWriter).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
+        if (method is null || method.GetParameters().Length != 0)
+            return;
+        method.Invoke(writer, null);
     }
 
     private JsonNode ExecuteSearch(JsonNode? id, JsonNode? args)
@@ -929,7 +944,7 @@ public partial class McpServer
         {
             try
             {
-                var (record, content, _) = indexer.BuildRecord(filePath);
+                var (record, content, rawBytes, _) = indexer.BuildRecordWithRawBytes(filePath);
                 var existingId = writer.GetUnchangedFileId(record.Path, record.Modified, record.Checksum);
                 if (existingId != null)
                 {
@@ -946,6 +961,10 @@ public partial class McpServer
                 writer.InsertSymbols(symbols);
                 var references = ReferenceExtractor.Extract(fileId, record.Lang, content, symbols);
                 writer.InsertReferences(references);
+                // Keep MCP index parity with CLI index: persist file-level validation issues too.
+                // MCPインデックスもCLIインデックスと同等に、ファイル検証issueを保存する。
+                var issues = FileIndexer.ValidateContent(record.Path, rawBytes, content);
+                writer.InsertIssues(fileId, issues);
                 txn.Commit();
             }
             catch
@@ -953,6 +972,14 @@ public partial class McpServer
                 errors++;
             }
             processed++;
+        }
+
+        if (errors == 0)
+        {
+            // Forward-compatible with split readiness flags introduced in #75 lineage.
+            // #75系で導入される分離readinessフラグにも前方互換で対応する。
+            TryInvokeDbWriterMarker(writer, "MarkGraphReady");
+            TryInvokeDbWriterMarker(writer, "MarkIssuesReady");
         }
 
         writer.OptimizeFts();

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -726,6 +726,46 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void ToolsCall_Index_PopulatesValidateIssuesLikeCliIndex()
+    {
+        var fixtureDir = Path.Combine(Path.GetFullPath("."), $"mcp_index_fixture_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(fixtureDir);
+        var filePath = Path.Combine(fixtureDir, "bom_sample.cs");
+        try
+        {
+            File.WriteAllBytes(filePath, [0xEF, 0xBB, 0xBF, (byte)'c', (byte)'l', (byte)'a', (byte)'s', (byte)'s', (byte)' ', (byte)'A', (byte)' ', (byte)'{', (byte)'}', (byte)'\n']);
+
+            var indexRequest = new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 1,
+                ["method"] = "tools/call",
+                ["params"] = new JsonObject
+                {
+                    ["name"] = "index",
+                    ["arguments"] = new JsonObject
+                    {
+                        ["path"] = fixtureDir
+                    }
+                }
+            };
+            var indexResponse = _server.HandleMessage(indexRequest)!;
+            Assert.False(indexResponse["result"]!["isError"]?.GetValue<bool>() ?? false);
+
+            var validateRequest = JsonNode.Parse("""{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"validate","arguments":{}}}""")!;
+            var validateResponse = _server.HandleMessage(validateRequest)!;
+            var issues = validateResponse["result"]!["structuredContent"]!["issues"]!.AsArray();
+
+            Assert.Contains(issues, issue => issue!["kind"]!.GetValue<string>() == "bom");
+        }
+        finally
+        {
+            if (Directory.Exists(fixtureDir))
+                Directory.Delete(fixtureDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ToolsCall_UnknownTool_ReturnsError()
     {
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"nonexistent","arguments":{}}}""")!;


### PR DESCRIPTION
## Summary

Consolidates the #74 follow-up work (originally split across #76 / #77 / #78) into a single PR. The prior commit on this branch has been replaced with the CI-passing superset; #77 and #78 are closed.

- **Eliminate double file I/O**: `FileIndexer.BuildRecordWithRawBytes` returns `(record, content, rawBytes, warning)` in one read. `BuildRecord` becomes a thin wrapper for legacy callers. `ValidateContent` no longer needs a second `File.ReadAllBytes`, and `rawBytes`/`content` are now internally consistent (derived from the same read).
- **MCP ↔ CLI validation parity (#74 item 2)**: MCP `ExecuteIndex` now calls `FileIndexer.ValidateContent` and persists issues via `writer.InsertIssues(...)`, so MCP-built DBs populate `file_issues` the same way CLI-built DBs do.
- **Forward-compatible readiness markers**: after a successful MCP index run (`errors == 0`), `TryInvokeDbWriterMarker` uses reflection to call `MarkGraphReady` / `MarkIssuesReady` when those methods exist on `DbWriter`. This lets this PR work regardless of whether #75 (which introduces the split readiness bitmap) merges first or second — once #75 lands, MCP-built DBs correctly stamp both `GraphReadyFlag` and `IssuesReadyFlag` so `validate` stops reporting `IssuesTableAvailable=false` on the data it just populated.

## Test plan

- [x] `ToolsCall_Index_PopulatesValidateIssuesLikeCliIndex` — creates a BOM fixture, runs MCP `index`, then MCP `validate`, and asserts a `bom` issue appears. Locks in #74 item 2 regression coverage.
- [x] Existing MCP / indexer test suites continue to pass.

## Notes

- The reflection shim in `TryInvokeDbWriterMarker` is intentionally defensive for the interleaved merge order with #75. Once both land, that shim can be replaced with direct calls in a follow-up cleanup.