### PR TITLE
Fix Unicode exact matching in impact BFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Fixed
+- **Impact exact-match BFS now uses the Unicode fold path (#93)** — `GetTransitiveCallers` no longer leaves `ResolveSymbolName` and `GetCallersExact` on ASCII-only equality while the rest of the `--exact` surface uses `name_folded`. When `FoldReadyFlag` is set, both helpers now query `symbols.name_folded` / `symbol_references.symbol_name_folded`; legacy or partial-backfill DBs still fall back to `COLLATE NOCASE`, matching the existing exact-reader degradation path. This closes the gap where `impact` / MCP `impact_analysis` could silently miss non-ASCII casing and width variants even though `definition` / `references` / `callers` / `inspect` already matched them. Added a regression test that drives BFS with a mixed fullwidth + non-ASCII query and a differently cased caller edge. Affected: `src/CodeIndex/Database/DbReader.cs`, `tests/CodeIndex.Tests/DbReaderTests.cs`. Closes #93.
+
 ### [1.9.0] - 2026-04-14
 
 #### Added
@@ -599,6 +602,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 修正
+- **impact の完全一致 BFS が Unicode fold 経路を使うよう修正 (#93)** — `GetTransitiveCallers` の内部で使う `ResolveSymbolName` と `GetCallersExact` が、他の `--exact` 系が `name_folded` を使っているのに ASCII-only 比較のまま取り残されていた問題を解消。`FoldReadyFlag` が立っている DB では `symbols.name_folded` / `symbol_references.symbol_name_folded` を使って一致判定し、legacy / partial-backfill DB では既存の exact reader と同じく `COLLATE NOCASE` に黙ってフォールバックする。これで `impact` / MCP `impact_analysis` だけが非 ASCII の casing 差分や全角/半角差分を silent miss するズレが無くなる。mixed な全角 + 非 ASCII クエリと casing 差のある caller edge を使う BFS 回帰テストも追加。対象: `src/CodeIndex/Database/DbReader.cs`、`tests/CodeIndex.Tests/DbReaderTests.cs`。Closes #93.
 
 ### [1.9.0] - 2026-04-14
 

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -466,17 +466,23 @@ public partial class DbReader
     /// </summary>
     private string ResolveSymbolName(string symbolName, string? lang)
     {
-        // Simple case-insensitive lookup preferring exact-case match.
+        // Exact lookup mirrors the leaf `--exact` readers: folded equality when FoldReady,
+        // ASCII `COLLATE NOCASE` fallback on legacy / partial-backfill DBs.
         // No path/test filters — definitions outside caller scope must still be found.
         // Only considers graph-supported languages to avoid resolving to unsupported ones.
-        // シンプルな case-insensitive 検索で完全一致を優先。graph 対応言語のみ対象。
+        // FoldReady なら folded equality、legacy DB では ASCII `COLLATE NOCASE` にフォールバック。
         using var cmd = _conn.CreateCommand();
         var supportedLangFilter = BuildGraphSupportedLanguagePredicate(cmd, "f", "resolveLang");
+        var nameCondition = _foldReady
+            ? "s.name_folded = @nameFolded"
+            : "s.name = @name COLLATE NOCASE";
         cmd.CommandText = @"SELECT s.name FROM symbols s JOIN files f ON s.file_id = f.id
-                            WHERE lower(s.name) = lower(@name)
+                            WHERE " + nameCondition + @"
                               AND " + supportedLangFilter + @"
                             ORDER BY CASE WHEN s.name = @name THEN 0 ELSE 1 END LIMIT 1";
         cmd.Parameters.AddWithValue("@name", symbolName);
+        if (_foldReady)
+            cmd.Parameters.AddWithValue("@nameFolded", NameFold.Fold(symbolName) ?? symbolName);
         using var reader = cmd.ExecuteTrackedReader();
         return reader.TrackedRead() ? reader.GetString(0) : symbolName;
     }
@@ -495,15 +501,17 @@ public partial class DbReader
 
         var supportedLangFilter = BuildGraphSupportedLanguagePredicate(cmd, "f", "callerLang");
 
-        // Case-insensitive exact match via lower() — prevents substring expansion while
-        // handling both case-insensitive languages (SQL, VB, PowerShell) and user queries
-        // that don't match the indexed casing. The symbol is pre-resolved through definitions
-        // via ResolveSymbolName, so this primarily catches references stored with different
-        // casing than the definition (e.g. constructor calls vs class names).
-        // lower() による case-insensitive 完全一致 — 部分文字列展開を防ぎつつ、
-        // case-insensitive 言語とケース違いのユーザクエリの両方に対応。
-        var nameCondition = @"
-              AND lower(r.symbol_name) = lower(@symbolName)";
+        // Exact caller matching mirrors the leaf `--exact` readers: folded equality when
+        // FoldReady, ASCII `COLLATE NOCASE` fallback on legacy / partial-backfill DBs.
+        // ResolveSymbolName() already normalizes the root symbol first, so this catches
+        // caller rows whose stored callee casing differs from the resolved definition.
+        // caller 側も leaf `--exact` と同じく FoldReady なら folded equality、legacy DB では
+        // `COLLATE NOCASE` fallback。definition と caller 行の casing 差もここで吸収する。
+        var nameCondition = _foldReady
+            ? @"
+              AND r.symbol_name_folded = @symbolNameFolded"
+            : @"
+              AND r.symbol_name = @symbolName COLLATE NOCASE";
 
         var sql = $@"
             SELECT f.path, f.lang, r.container_kind, r.container_name, r.symbol_name,
@@ -521,6 +529,8 @@ public partial class DbReader
 
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("@symbolName", symbolName);
+        if (_foldReady)
+            cmd.Parameters.AddWithValue("@symbolNameFolded", NameFold.Fold(symbolName) ?? symbolName);
         if (lang != null)
             cmd.Parameters.AddWithValue("@lang", lang);
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -671,6 +671,99 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void GetTransitiveCallers_ExactUsesUnicodeFoldForResolutionAndCallerMatch()
+    {
+        // Regression for #93: impact BFS used ASCII-only equality in both ResolveSymbolName()
+        // and GetCallersExact(), so a mixed fullwidth/non-ASCII query could miss even when
+        // the definition and caller rows were both present and fold-equivalent.
+        // #93 回帰: impact BFS の 2 箇所が ASCII-only 比較だったため、fullwidth と
+        // 非 ASCII 大文字を含むクエリで definition / caller が両方揃っていても取りこぼした。
+        var symbolFileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/intl.py",
+            Lang = "python",
+            Size = 48,
+            Lines = 2,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertChunks([new ChunkRecord
+        {
+            FileId = symbolFileId,
+            ChunkIndex = 0,
+            StartLine = 1,
+            EndLine = 2,
+            Content = "def café_init():\n    return True\n",
+        }]);
+        _writer.InsertSymbols([
+            new SymbolRecord
+            {
+                FileId = symbolFileId,
+                Kind = "function",
+                Name = "café_init",
+                Line = 1,
+                StartLine = 1,
+                EndLine = 2,
+                BodyStartLine = 2,
+                BodyEndLine = 2,
+                Signature = "def café_init():",
+            },
+        ]);
+
+        var callerFileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/bootstrap.py",
+            Lang = "python",
+            Size = 58,
+            Lines = 2,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertChunks([new ChunkRecord
+        {
+            FileId = callerFileId,
+            ChunkIndex = 0,
+            StartLine = 1,
+            EndLine = 2,
+            Content = "def bootstrap():\n    return CAFÉ_INIT()\n",
+        }]);
+        _writer.InsertSymbols([
+            new SymbolRecord
+            {
+                FileId = callerFileId,
+                Kind = "function",
+                Name = "bootstrap",
+                Line = 1,
+                StartLine = 1,
+                EndLine = 2,
+                BodyStartLine = 2,
+                BodyEndLine = 2,
+                Signature = "def bootstrap():",
+            },
+        ]);
+        _writer.InsertReferences([
+            new ReferenceRecord
+            {
+                FileId = callerFileId,
+                SymbolName = "CAFÉ_INIT",
+                ReferenceKind = "call",
+                Line = 2,
+                Column = 12,
+                Context = "return CAFÉ_INIT()",
+                ContainerKind = "function",
+                ContainerName = "bootstrap",
+            },
+        ]);
+
+        var (results, truncated) = _reader.GetTransitiveCallers("ＣＡＦÉ_ＩＮＩＴ", maxDepth: 1, limit: 10);
+
+        Assert.False(truncated);
+        var caller = Assert.Single(results);
+        Assert.Equal("src/bootstrap.py", caller.Path);
+        Assert.Equal("bootstrap", caller.CallerName);
+        Assert.Equal("CAFÉ_INIT", caller.CalleeName);
+        Assert.Equal(1, caller.Depth);
+    }
+
+    [Fact]
     public void GetDefinitions_ExactMatchesNameEquality()
     {
         var extraFileId = _writer.UpsertFile(new FileRecord


### PR DESCRIPTION
## Summary

  - route `impact` / MCP `impact_analysis` exact-name resolution through the same folded-name path used by the other `--exact`
  readers
  - keep the legacy fallback to `COLLATE NOCASE` when `FoldReady` is not available, so older or partial-backfill DBs still
  degrade safely
  - add a regression test covering a mixed fullwidth + non-ASCII query on the transitive caller BFS path
  - update the changelog for issue #93

  ## Test plan

  - [x] `dotnet test`
  - [x] `dotnet build`
  - [x] `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
  - [x] Verified the new `DbReaderTests` regression for Unicode-folded `GetTransitiveCallers`