### PR TITLE
Prefer exact-case matches over path buckets in exact symbol ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Changed
+- **`--exact` ranking now prefers exact-case siblings first** — When multiple symbols or graph rows collapse to the same folded exact-match key (for example `ApiClient` and `apiClient`), `symbols` / `definition` / `references` / `callers` / `callees` still return every case-insensitive exact match, but now rank the row whose stored name exactly matches the caller's casing first instead of letting path order win. This keeps the intended symbol at rank 0 for AI follow-up flows without hiding the fold-sibling rows. Added regression coverage for both symbol lookup and graph readers. Affected: `src/CodeIndex/Database/DbSymbolReader.cs`, `src/CodeIndex/Database/DbReader.cs`, `tests/CodeIndex.Tests/DbReaderTests.cs`.
+
 ### [1.9.0] - 2026-04-14
 
 #### Added
@@ -599,6 +602,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 変更
+- **`--exact` の順位付けで完全一致 casing を先頭化** — `ApiClient` と `apiClient` のように folded exact-match key が同一になる複数行がある場合でも、`symbols` / `definition` / `references` / `callers` / `callees` は従来どおり大文字小文字を無視した完全一致の全行を返しつつ、呼び出し側の入力 casing と完全一致する行を path 順より優先して先頭に並べるようになった。fold sibling を隠さずに、AI の後続クエリで意図したシンボルを rank 0 に戻す。シンボル検索とグラフ reader の両方に回帰テストを追加。対象: `src/CodeIndex/Database/DbSymbolReader.cs`、`src/CodeIndex/Database/DbReader.cs`、`tests/CodeIndex.Tests/DbReaderTests.cs`。
 
 ### [1.9.0] - 2026-04-14
 

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -273,7 +273,7 @@ public partial class DbReader
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
-        sql += $" ORDER BY {PathBucketOrder}, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) LIKE lower(@rankingQueryPrefix) ESCAPE '\\' THEN 0 ELSE 1 END, f.path, r.line LIMIT @limit";
+        sql += $" ORDER BY {PathBucketOrder}, CASE WHEN @preferExactCase = 1 AND r.symbol_name = @rawQuery THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) LIKE lower(@rankingQueryPrefix) ESCAPE '\\' THEN 0 ELSE 1 END, f.path, r.line LIMIT @limit";
 
         cmd.CommandText = sql;
         if (query != null)
@@ -294,6 +294,8 @@ public partial class DbReader
             cmd.Parameters.AddWithValue("@rankingQuery", "");
             cmd.Parameters.AddWithValue("@rankingQueryPrefix", "%");
         }
+        cmd.Parameters.AddWithValue("@preferExactCase", exact && query != null ? 1 : 0);
+        cmd.Parameters.AddWithValue("@rawQuery", exact && query != null ? query : string.Empty);
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
@@ -351,7 +353,7 @@ public partial class DbReader
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
-        sql += $" GROUP BY f.path, f.lang, r.container_kind, r.container_name, r.symbol_name ORDER BY {PathBucketOrder}, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, reference_count DESC, f.path, first_line LIMIT @limit";
+        sql += $" GROUP BY f.path, f.lang, r.container_kind, r.container_name, r.symbol_name ORDER BY {PathBucketOrder}, CASE WHEN @preferExactCase = 1 AND r.symbol_name = @rawQuery THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, reference_count DESC, f.path, first_line LIMIT @limit";
 
         cmd.CommandText = sql;
         string callersQueryParam;
@@ -362,6 +364,8 @@ public partial class DbReader
         else
             callersQueryParam = query;
         cmd.Parameters.AddWithValue("@query", callersQueryParam);
+        cmd.Parameters.AddWithValue("@preferExactCase", exact ? 1 : 0);
+        cmd.Parameters.AddWithValue("@rawQuery", exact ? query : string.Empty);
         cmd.Parameters.AddWithValue("@rankingQuery", query.Trim());
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
@@ -418,7 +422,7 @@ public partial class DbReader
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
-        sql += $" GROUP BY f.path, f.lang, r.container_kind, r.container_name, r.symbol_name, r.reference_kind ORDER BY {PathBucketOrder}, CASE WHEN lower(r.container_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, reference_count DESC, f.path, first_line LIMIT @limit";
+        sql += $" GROUP BY f.path, f.lang, r.container_kind, r.container_name, r.symbol_name, r.reference_kind ORDER BY {PathBucketOrder}, CASE WHEN @preferExactCase = 1 AND r.container_name = @rawQuery THEN 0 ELSE 1 END, CASE WHEN lower(r.container_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, reference_count DESC, f.path, first_line LIMIT @limit";
 
         cmd.CommandText = sql;
         string calleesQueryParam;
@@ -429,6 +433,8 @@ public partial class DbReader
         else
             calleesQueryParam = query;
         cmd.Parameters.AddWithValue("@query", calleesQueryParam);
+        cmd.Parameters.AddWithValue("@preferExactCase", exact ? 1 : 0);
+        cmd.Parameters.AddWithValue("@rawQuery", exact ? query : string.Empty);
         cmd.Parameters.AddWithValue("@rankingQuery", query.Trim());
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -273,7 +273,7 @@ public partial class DbReader
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
-        sql += $" ORDER BY {PathBucketOrder}, CASE WHEN @preferExactCase = 1 AND r.symbol_name = @rawQuery THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) LIKE lower(@rankingQueryPrefix) ESCAPE '\\' THEN 0 ELSE 1 END, f.path, r.line LIMIT @limit";
+        sql += $" ORDER BY CASE WHEN @preferExactCase = 1 AND r.symbol_name = @rawQuery THEN 0 ELSE 1 END, {PathBucketOrder}, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) LIKE lower(@rankingQueryPrefix) ESCAPE '\\' THEN 0 ELSE 1 END, f.path, r.line LIMIT @limit";
 
         cmd.CommandText = sql;
         if (query != null)
@@ -353,7 +353,7 @@ public partial class DbReader
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
-        sql += $" GROUP BY f.path, f.lang, r.container_kind, r.container_name, r.symbol_name ORDER BY {PathBucketOrder}, CASE WHEN @preferExactCase = 1 AND r.symbol_name = @rawQuery THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, reference_count DESC, f.path, first_line LIMIT @limit";
+        sql += $" GROUP BY f.path, f.lang, r.container_kind, r.container_name, r.symbol_name ORDER BY CASE WHEN @preferExactCase = 1 AND r.symbol_name = @rawQuery THEN 0 ELSE 1 END, {PathBucketOrder}, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, reference_count DESC, f.path, first_line LIMIT @limit";
 
         cmd.CommandText = sql;
         string callersQueryParam;
@@ -422,7 +422,7 @@ public partial class DbReader
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
-        sql += $" GROUP BY f.path, f.lang, r.container_kind, r.container_name, r.symbol_name, r.reference_kind ORDER BY {PathBucketOrder}, CASE WHEN @preferExactCase = 1 AND r.container_name = @rawQuery THEN 0 ELSE 1 END, CASE WHEN lower(r.container_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, reference_count DESC, f.path, first_line LIMIT @limit";
+        sql += $" GROUP BY f.path, f.lang, r.container_kind, r.container_name, r.symbol_name, r.reference_kind ORDER BY CASE WHEN @preferExactCase = 1 AND r.container_name = @rawQuery THEN 0 ELSE 1 END, {PathBucketOrder}, CASE WHEN lower(r.container_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, reference_count DESC, f.path, first_line LIMIT @limit";
 
         cmd.CommandText = sql;
         string calleesQueryParam;

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -137,7 +137,7 @@ public partial class DbReader
         if (since != null && _fileColumns.Contains("modified"))
             sql += " AND f.modified >= @since";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
-        sql += $" ORDER BY {PathBucketOrder}, {VisibilityOrder}, CASE WHEN @preferExactCase = 1 AND s.name = @rawQuery THEN 0 ELSE 1 END, s.name, f.path, s.line LIMIT @limit";
+        sql += $" ORDER BY CASE WHEN @preferExactCase = 1 AND s.name = @rawQuery THEN 0 ELSE 1 END, {PathBucketOrder}, {VisibilityOrder}, s.name, f.path, s.line LIMIT @limit";
 
         cmd.CommandText = sql;
         if (effectiveQueries != null)

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -137,7 +137,7 @@ public partial class DbReader
         if (since != null && _fileColumns.Contains("modified"))
             sql += " AND f.modified >= @since";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
-        sql += $" ORDER BY {PathBucketOrder}, {VisibilityOrder}, s.name, f.path, s.line LIMIT @limit";
+        sql += $" ORDER BY {PathBucketOrder}, {VisibilityOrder}, CASE WHEN @preferExactCase = 1 AND s.name = @rawQuery THEN 0 ELSE 1 END, s.name, f.path, s.line LIMIT @limit";
 
         cmd.CommandText = sql;
         if (effectiveQueries != null)
@@ -154,6 +154,9 @@ public partial class DbReader
                 cmd.Parameters.AddWithValue($"@query{idx}", paramValue);
             }
         }
+        var preferExactCase = exact && effectiveQueries != null && effectiveQueries.Count == 1;
+        cmd.Parameters.AddWithValue("@preferExactCase", preferExactCase ? 1 : 0);
+        cmd.Parameters.AddWithValue("@rawQuery", preferExactCase ? effectiveQueries![0] : string.Empty);
         if (kind != null)
             cmd.Parameters.AddWithValue("@kind", kind);
         if (lang != null)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -366,7 +366,7 @@ public class DbReaderTests : IDisposable
     {
         InsertIndexedFile("src/a_case.py", "python",
             "def apiTwin():\n    return authenticate('a', 'b')\n");
-        InsertIndexedFile("src/z_case.py", "python",
+        InsertIndexedFile("tests/z_case.py", "python",
             "def ApiTwin():\n    return authenticate('a', 'b')\n");
 
         var symbols = _reader.SearchSymbols(new[] { "ApiTwin" }, limit: 10, exact: true)
@@ -384,6 +384,14 @@ public class DbReaderTests : IDisposable
             .Take(2)
             .ToList();
         Assert.Equal(new[] { "ApiTwin", "apiTwin" }, definitions);
+
+        var topSymbol = Assert.Single(_reader.SearchSymbols(new[] { "ApiTwin" }, limit: 1, exact: true));
+        Assert.Equal("ApiTwin", topSymbol.Name);
+        Assert.Equal("tests/z_case.py", topSymbol.Path);
+
+        var topDefinition = Assert.Single(_reader.GetDefinitions("ApiTwin", limit: 1, exact: true));
+        Assert.Equal("ApiTwin", topDefinition.Name);
+        Assert.Equal("tests/z_case.py", topDefinition.Path);
     }
 
     [Fact]
@@ -701,7 +709,7 @@ public class DbReaderTests : IDisposable
         InsertIndexedFile("src/a_case.py", "python",
             "def apiTwin():\n    authenticate('a', 'b')\n    return True\n\n" +
             "def lower_wrapper():\n    return apiTwin()\n");
-        InsertIndexedFile("src/z_case.py", "python",
+        InsertIndexedFile("tests/z_case.py", "python",
             "def ApiTwin():\n    authenticate('a', 'b')\n    return True\n\n" +
             "def upper_wrapper():\n    return ApiTwin()\n");
 
@@ -728,6 +736,18 @@ public class DbReaderTests : IDisposable
             .Take(2)
             .ToList();
         Assert.Equal(new[] { "ApiTwin", "apiTwin" }, callees);
+
+        var topReference = Assert.Single(_reader.SearchReferences("ApiTwin", limit: 1, exact: true));
+        Assert.Equal("ApiTwin", topReference.SymbolName);
+        Assert.Equal("tests/z_case.py", topReference.Path);
+
+        var topCaller = Assert.Single(_reader.GetCallers("ApiTwin", limit: 1, exact: true));
+        Assert.Equal("ApiTwin", topCaller.CalleeName);
+        Assert.Equal("tests/z_case.py", topCaller.Path);
+
+        var topCallee = Assert.Single(_reader.GetCallees("ApiTwin", limit: 1, exact: true));
+        Assert.Equal("ApiTwin", topCallee.CallerName);
+        Assert.Equal("tests/z_case.py", topCallee.Path);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -362,6 +362,31 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_ExactPrefersExactCaseOverFoldSibling()
+    {
+        InsertIndexedFile("src/a_case.py", "python",
+            "def apiTwin():\n    return authenticate('a', 'b')\n");
+        InsertIndexedFile("src/z_case.py", "python",
+            "def ApiTwin():\n    return authenticate('a', 'b')\n");
+
+        var symbols = _reader.SearchSymbols(new[] { "ApiTwin" }, limit: 10, exact: true)
+            .Where(r => r.Name is "ApiTwin" or "apiTwin")
+            .Select(r => r.Name)
+            .Distinct()
+            .Take(2)
+            .ToList();
+        Assert.Equal(new[] { "ApiTwin", "apiTwin" }, symbols);
+
+        var definitions = _reader.GetDefinitions("ApiTwin", limit: 10, exact: true)
+            .Where(r => r.Name is "ApiTwin" or "apiTwin")
+            .Select(r => r.Name)
+            .Distinct()
+            .Take(2)
+            .ToList();
+        Assert.Equal(new[] { "ApiTwin", "apiTwin" }, definitions);
+    }
+
+    [Fact]
     public void AllFoldedColumnsBackfilled_DetectsLegacyRowsWithNullFoldedValues()
     {
         // Regression for codex #86 review: the upgrade path must not stamp FoldReady when
@@ -668,6 +693,41 @@ public class DbReaderTests : IDisposable
         // Case-insensitive equality across all three.
         Assert.Single(_reader.SearchReferences("AUTHENTICATE", exact: true));
         Assert.Single(_reader.GetCallers("AUTHENTICATE", exact: true));
+    }
+
+    [Fact]
+    public void GraphReaders_ExactPrefersExactCaseOverFoldSibling()
+    {
+        InsertIndexedFile("src/a_case.py", "python",
+            "def apiTwin():\n    authenticate('a', 'b')\n    return True\n\n" +
+            "def lower_wrapper():\n    return apiTwin()\n");
+        InsertIndexedFile("src/z_case.py", "python",
+            "def ApiTwin():\n    authenticate('a', 'b')\n    return True\n\n" +
+            "def upper_wrapper():\n    return ApiTwin()\n");
+
+        var references = _reader.SearchReferences("ApiTwin", exact: true)
+            .Where(r => r.SymbolName is "ApiTwin" or "apiTwin")
+            .Select(r => r.SymbolName)
+            .Distinct()
+            .Take(2)
+            .ToList();
+        Assert.Equal(new[] { "ApiTwin", "apiTwin" }, references);
+
+        var callers = _reader.GetCallers("ApiTwin", exact: true)
+            .Where(r => r.CalleeName is "ApiTwin" or "apiTwin")
+            .Select(r => r.CalleeName)
+            .Distinct()
+            .Take(2)
+            .ToList();
+        Assert.Equal(new[] { "ApiTwin", "apiTwin" }, callers);
+
+        var callees = _reader.GetCallees("ApiTwin", exact: true)
+            .Where(r => r.CallerName is "ApiTwin" or "apiTwin")
+            .Select(r => r.CallerName)
+            .Distinct()
+            .Take(2)
+            .ToList();
+        Assert.Equal(new[] { "ApiTwin", "apiTwin" }, callees);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #94

  ## Summary

  - Exact-case ranking
    - Move the exact-case tie-breaker ahead of path-bucket ordering for `symbols`, `definition`, `references`, `callers`, and
  `callees`.
    - Keep folded exact-match behavior additive: all case-insensitive exact matches still return, but the row matching the
  caller's exact casing now ranks first.

  - Regression coverage
    - Add `limit: 1` regression tests that place the queried casing in `tests/` and a fold-sibling in `src/`.
    - Verify the queried casing wins for both symbol readers and graph readers even when path buckets would otherwise prefer the
  sibling row.

  ## Test plan

  - [x] `dotnet test --filter FullyQualifiedName~DbReaderTests`
  - [x] `dotnet test`
  - [x] `dotnet build`
  - [x] `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`