### PR TITLE
Stabilize release verify step against CDN race and re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,57 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
         run: |
-          gh release create "${TAG_NAME}" \
-            release-files/* \
-            --verify-tag \
-            --generate-notes
+          set -euo pipefail
+          # Idempotent on workflow re-runs: if a transient failure in a later
+          # step (e.g. CDN propagation race in the verify step) caused us to
+          # re-run from this point, the release with this tag already exists
+          # and `gh release create` would fail with
+          #   "a release with the same tag name already exists".
+          # In that case, upload any missing assets with --clobber instead so
+          # the release stays consistent without manual intervention.
+          # 再実行時の冪等性: 後続ステップの一時的失敗（例: verify ステップで
+          # CDN 伝播競合）でこのジョブが再実行された場合、同名タグの release
+          # は既に存在するため `gh release create` は
+          #   "a release with the same tag name already exists"
+          # で失敗する。その場合は不足アセットを --clobber 付きで upload し、
+          # release を手動介入なしに整合させる。
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Release ${TAG_NAME} already exists; uploading missing assets with --clobber."
+            gh release upload "${TAG_NAME}" release-files/* --clobber
+          else
+            gh release create "${TAG_NAME}" \
+              release-files/* \
+              --verify-tag \
+              --generate-notes
+          fi
+
+      - name: Wait for release assets to be downloadable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
+          ASSET_NAME: CodeIndex-linux-x64.tar.gz
+        run: |
+          set -euo pipefail
+          # gh release create returns once the GitHub API records the assets,
+          # but the public download URL (download/<tag>/<asset>) is served via
+          # a CDN that can lag a few seconds. Poll the actual download URL
+          # before running install.sh so the verify step doesn't 404 on a
+          # transient propagation gap.
+          # gh release create は API 反映直後に戻るが、download URL は CDN
+          # 経由で配信されるため数秒のラグが起きうる。install.sh が 404 で
+          # 落ちないよう、download URL 自体が取得可能になるまでポーリングする。
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG_NAME}/${ASSET_NAME}"
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            code="$(curl -fsSL -o /dev/null -w '%{http_code}' -I "$url" || true)"
+            if [ "$code" = "200" ]; then
+              echo "Asset reachable after $attempt attempt(s)."
+              exit 0
+            fi
+            echo "Attempt $attempt: HTTP $code, retrying in 5s..."
+            sleep 5
+          done
+          echo "Asset $url did not become reachable in time." >&2
+          exit 1
 
       - name: Verify install.sh against the published release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Fixed
+- **Release verify step waits for CDN-propagated download URL and `gh release create` is idempotent** — The `Verify install.sh against the published release` step in `.github/workflows/release.yml` previously called `install.sh` immediately after `gh release create`, which races the GitHub release download CDN. Asset URLs returned 404 for several seconds even though the API listed them, making the v1.10.0 release run fail despite the actual release being healthy. Added a preceding `Wait for release assets to be downloadable` step that polls the public `releases/download/<tag>/CodeIndex-linux-x64.tar.gz` URL with up to ten 5-second retries before the verify step runs. Also made `Create GitHub release` idempotent: when the same-tag release already exists (e.g. on a re-run after a transient verify failure), the step now uploads any missing assets via `gh release upload --clobber` instead of failing with `a release with the same tag name already exists`. Affected: `.github/workflows/release.yml`.
+
 ### [1.10.0] - 2026-04-15
 
 #### Added
@@ -638,6 +641,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 修正
+- **Release ワークフローの verify ステップを CDN 伝播待ち＋`gh release create` 冪等化** — `.github/workflows/release.yml` の `Verify install.sh against the published release` は `gh release create` 直後に `install.sh` を起動しており、GitHub Release の download CDN との競合で URL が数秒間 404 を返し、リリース自体は正常なのに verify が落ちることがあった（v1.10.0 で発生）。verify 前に `Wait for release assets to be downloadable` ステップを追加し、`releases/download/<tag>/CodeIndex-linux-x64.tar.gz` を 5 秒間隔で最大 10 回ポーリングしてから verify を回すようにした。あわせて `Create GitHub release` を冪等化し、同名タグの release が既に存在する場合は `gh release upload --clobber` で不足アセットのみ補完するため、verify ステップの再実行で `a release with the same tag name already exists` で落ちないようにした。対象: `.github/workflows/release.yml`。
 
 ### [1.10.0] - 2026-04-15
 


### PR DESCRIPTION
## Summary
- Fix the `Verify install.sh against the published release` step in `.github/workflows/release.yml` failing on transient GitHub release CDN propagation lag (observed on the v1.10.0 run: the verify step 404'd on the public download URL within the same second `gh release create` returned, even though all assets were uploaded successfully).
- Add a preceding `Wait for release assets to be downloadable` step that polls `releases/download/<tag>/CodeIndex-linux-x64.tar.gz` with up to ten 5-second retries before `install.sh` runs.
- Make `Create GitHub release` idempotent so re-running the workflow after a transient verify failure no longer fails with `a release with the same tag name already exists`. When the same-tag release exists, the step now uploads any missing assets via `gh release upload --clobber` instead of attempting `gh release create`.
- The release itself is healthy on these failures — only the post-publish self-check goes red. This change keeps future releases from showing a red badge for a transient propagation gap.

## Test plan
- [ ] Next release tag push hits the new wait step and the verify step succeeds without manual intervention.
- [ ] Re-running a release workflow run from `Create GitHub release` (e.g. via `gh run rerun --failed`) succeeds idempotently when the release with the same tag already exists.