### PR TITLE
Add installer mirror override and bootstrap fallback guidance

### DIFF
--- a/CLOUD_BOOTSTRAP_PROMPT.md
+++ b/CLOUD_BOOTSTRAP_PROMPT.md
@@ -27,6 +27,20 @@ curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh 
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
+If `raw.githubusercontent.com` is blocked in your environment, run the
+repo-local installer instead and pin an explicit version (example:
+`v1.11.0`) to avoid the extra latest-release API lookup:
+
+```bash
+bash ./install.sh v1.11.0
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+If release downloads are blocked from `github.com`, point the installer at a
+reachable GitHub mirror/proxy by setting:
+`CDIDX_GITHUB_BASE_URL` and `CDIDX_GITHUB_API_BASE_URL` before running
+`install.sh`.
+
 The installer downloads the latest release tarball, verifies SHA256, and
 copies the binary **plus the adjacent runtime assets** (`version.json` and
 `libe_sqlite3.so` on Linux / `libe_sqlite3.dylib` on macOS) into
@@ -166,6 +180,19 @@ any destructive action.
 curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
+
+もし環境の制約で `raw.githubusercontent.com` に到達できない場合は、リポジトリ
+内の `install.sh` を直接実行し、`latest` API 参照を避けるため明示バージョン
+（例: `v1.11.0`）を指定してください:
+
+```bash
+bash ./install.sh v1.11.0
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+`github.com` からのリリース取得自体がブロックされる環境では、`install.sh`
+実行前に `CDIDX_GITHUB_BASE_URL` と `CDIDX_GITHUB_API_BASE_URL` を設定して、
+到達可能な GitHub mirror/proxy 経由に切り替えてください。
 
 インストーラは最新リリースの tarball をダウンロードし、SHA256 を検証して、
 バイナリに加え**隣接ランタイム資産**（`version.json`、Linux は

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 REPO="Widthdom/CodeIndex"
 INSTALL_DIR="${CDIDX_INSTALL_DIR:-$HOME/.local/bin}"
 BINARY_NAME="cdidx"
+GITHUB_BASE_URL="${CDIDX_GITHUB_BASE_URL:-https://github.com}"
+GITHUB_API_BASE_URL="${CDIDX_GITHUB_API_BASE_URL:-https://api.github.com}"
 TMPDIR_CLEANUP=""
 STAGE_DIR_CLEANUP=""
 BACKUP_DIR_CLEANUP=""
@@ -105,7 +107,7 @@ fetch_latest_release_version() {
     need_cmd curl
     need_cmd mktemp
 
-    local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    local api_url="${GITHUB_API_BASE_URL}/repos/${REPO}/releases/latest"
     local response_file
     if ! response_file="$(mktemp)"; then
         error "Failed to create temporary file for latest-release lookup."
@@ -416,7 +418,7 @@ download_and_install() {
     need_cmd mktemp
 
     local archive_name="CodeIndex-${RID}.tar.gz"
-    local base_url="https://github.com/${REPO}/releases/download/${VERSION}"
+    local base_url="${GITHUB_BASE_URL}/${REPO}/releases/download/${VERSION}"
     local archive_url="${base_url}/${archive_name}"
     local checksums_url="${base_url}/sha256sums.txt"
 
@@ -580,6 +582,11 @@ check_path() {
 # --- Main / メイン ---
 
 main() {
+    # Normalize optional base URL overrides by removing a trailing slash.
+    # 末尾スラッシュ付きでも URL 連結が壊れないようにする。
+    GITHUB_BASE_URL="${GITHUB_BASE_URL%/}"
+    GITHUB_API_BASE_URL="${GITHUB_API_BASE_URL%/}"
+
     info "cdidx installer"
     detect_platform
     info "Detected platform: ${RID}"


### PR DESCRIPTION
### Motivation
- Network-restricted environments can block `raw.githubusercontent.com` or `github.com`, causing the one-line installer to fail with HTTP 403 or CONNECT proxy errors.
- Provide a non-destructive workaround so users can install `cdidx` from a reachable GitHub mirror/proxy or by running the repo-local installer with an explicit version.

### Description
- Added optional environment overrides in `install.sh`: `CDIDX_GITHUB_BASE_URL` and `CDIDX_GITHUB_API_BASE_URL` with sensible defaults.
- Switched the latest-release API and release-asset URL construction to use the new `GITHUB_API_BASE_URL` and `GITHUB_BASE_URL` variables and normalize trailing slashes before use.
- Updated `CLOUD_BOOTSTRAP_PROMPT.md` (English and Japanese sections) to document running `bash ./install.sh v1.11.0` as a local fallback and to instruct setting the `CDIDX_GITHUB_BASE_URL` / `CDIDX_GITHUB_API_BASE_URL` env vars for mirror/proxy installs.
- Change is non-destructive and preserves existing behavior when the new environment variables are not set.

### Testing
- Ran the published one-liner `curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash` and observed an HTTP 403 from this environment (failed).
- Ran the repo-local `bash ./install.sh v1.11.0` and observed a CONNECT proxy 403 when attempting to download the release (failed).
- Ran `CDIDX_GITHUB_BASE_URL="https://example.com" CDIDX_GITHUB_API_BASE_URL="https://example.com/api" bash ./install.sh v1.11.0` and confirmed the installer constructed URLs using the configured override host while the download still failed due to the environment's outbound restrictions (override wiring verified).
- Committed the changes and produced a PR message summarizing the modification (no further automated CI run performed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a8f44cb08325b0faaf714bb3e177)