### PR TITLE
installer: support configurable GitHub base URLs, add local-mirror self-test, and update cloud bootstrap docs

### DIFF
--- a/CLOUD_BOOTSTRAP_PROMPT.md
+++ b/CLOUD_BOOTSTRAP_PROMPT.md
@@ -27,6 +27,52 @@ curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh 
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
+If `raw.githubusercontent.com` is blocked in your environment, run the
+repo-local installer instead and pin an explicit version (example:
+`v1.11.0`) to avoid the extra latest-release API lookup:
+
+```bash
+bash ./install.sh v1.11.0
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+If release downloads are blocked from `github.com`, point the installer at a
+reachable GitHub mirror/proxy by setting:
+`CDIDX_GITHUB_BASE_URL` and `CDIDX_GITHUB_API_BASE_URL` before running
+`install.sh`.
+
+Do not assume "Claude Code cloud has no outbound restrictions" just because it
+works there. A more common difference is that each environment has different
+egress policy / proxy allow-lists. Before concluding root cause, compare:
+
+```bash
+env | grep -Ei '(^|_)(http|https)_proxy|no_proxy' || true
+curl -I https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh
+curl -I https://github.com/Widthdom/CodeIndex/releases/download/v1.11.0/CodeIndex-linux-x64.tar.gz
+```
+
+If one environment gets `200/302` and another gets `403` (or `CONNECT tunnel
+failed`), treat it as a network-policy difference first, not an installer bug.
+
+### Optional: zero-external-network install-path self-test
+
+If outbound traffic is blocked but you still want to verify installer logic
+end-to-end, host a **local mirror** on `127.0.0.1` and point
+`CDIDX_GITHUB_BASE_URL` to it. The installer still performs checksum
+verification and extraction exactly as in production; only the source host is
+local.
+
+You can run the built-in self-test mode:
+
+```bash
+bash ./install.sh --self-test-local-mirror v1.11.0
+```
+
+This mode uses a mock payload only to validate installer flow (download URL
+selection, checksum verification, extraction, placement). It is not a
+replacement for validating official release artifacts in a network-open
+environment.
+
 The installer downloads the latest release tarball, verifies SHA256, and
 copies the binary **plus the adjacent runtime assets** (`version.json` and
 `libe_sqlite3.so` on Linux / `libe_sqlite3.dylib` on macOS) into
@@ -166,6 +212,50 @@ any destructive action.
 curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
+
+もし環境の制約で `raw.githubusercontent.com` に到達できない場合は、リポジトリ
+内の `install.sh` を直接実行し、`latest` API 参照を避けるため明示バージョン
+（例: `v1.11.0`）を指定してください:
+
+```bash
+bash ./install.sh v1.11.0
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+`github.com` からのリリース取得自体がブロックされる環境では、`install.sh`
+実行前に `CDIDX_GITHUB_BASE_URL` と `CDIDX_GITHUB_API_BASE_URL` を設定して、
+到達可能な GitHub mirror/proxy 経由に切り替えてください。
+
+なお、「Claude Code cloud では通る」ことだけで
+「外向き制限が一切ない」とは断定しないでください。実際には環境ごとに
+egress policy や proxy の allow-list が異なるケースが多いです。結論前に、
+次を比較してください:
+
+```bash
+env | grep -Ei '(^|_)(http|https)_proxy|no_proxy' || true
+curl -I https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh
+curl -I https://github.com/Widthdom/CodeIndex/releases/download/v1.11.0/CodeIndex-linux-x64.tar.gz
+```
+
+片方が `200/302`、もう片方が `403`（または `CONNECT tunnel failed`）なら、
+まず installer 不具合よりネットワークポリシー差分を疑うべきです。
+
+### 任意: 外向きネットワーク不要のインストール経路 self-test
+
+外向き通信が塞がれていても installer の処理経路を end-to-end で検証したい場合、
+`127.0.0.1` 上に**ローカル mirror**を立てて
+`CDIDX_GITHUB_BASE_URL` を向ける方法が使えます。これでも checksum 検証・展開・
+配置の流れ自体は本番と同じで、取得元ホストだけをローカル化できます。
+
+組み込みの self-test モードは次のとおりです:
+
+```bash
+bash ./install.sh --self-test-local-mirror v1.11.0
+```
+
+このモードは installer の処理経路（取得URL選択・checksum 検証・展開・配置）
+を確認するための mock payload を使います。ネットワークが開いた環境での
+公式 release artifact 検証の代替ではありません。
 
 インストーラは最新リリースの tarball をダウンロードし、SHA256 を検証して、
 バイナリに加え**隣接ランタイム資産**（`version.json`、Linux は

--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,17 @@ set -euo pipefail
 REPO="Widthdom/CodeIndex"
 INSTALL_DIR="${CDIDX_INSTALL_DIR:-$HOME/.local/bin}"
 BINARY_NAME="cdidx"
+GITHUB_BASE_URL="${CDIDX_GITHUB_BASE_URL:-https://github.com}"
+GITHUB_API_BASE_URL="${CDIDX_GITHUB_API_BASE_URL:-https://api.github.com}"
+# Normalize optional base URL overrides by removing a trailing slash.
+# 末尾スラッシュ付きでも URL 連結が壊れないようにする。
+GITHUB_BASE_URL="${GITHUB_BASE_URL%/}"
+GITHUB_API_BASE_URL="${GITHUB_API_BASE_URL%/}"
 TMPDIR_CLEANUP=""
 STAGE_DIR_CLEANUP=""
 BACKUP_DIR_CLEANUP=""
+LOCAL_MIRROR_DIR_CLEANUP=""
+LOCAL_MIRROR_PID=""
 EXISTING_BIN=""
 EXISTING_VERSION=""
 EXPLICIT_VERSION_REQUESTED=0
@@ -35,6 +43,12 @@ cleanup() {
     fi
     if [ -n "$BACKUP_DIR_CLEANUP" ]; then
         rm -rf "$BACKUP_DIR_CLEANUP"
+    fi
+    if [ -n "$LOCAL_MIRROR_PID" ]; then
+        kill "$LOCAL_MIRROR_PID" > /dev/null 2>&1 || true
+    fi
+    if [ -n "$LOCAL_MIRROR_DIR_CLEANUP" ]; then
+        rm -rf "$LOCAL_MIRROR_DIR_CLEANUP"
     fi
 }
 trap cleanup EXIT
@@ -105,7 +119,7 @@ fetch_latest_release_version() {
     need_cmd curl
     need_cmd mktemp
 
-    local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    local api_url="${GITHUB_API_BASE_URL}/repos/${REPO}/releases/latest"
     local response_file
     if ! response_file="$(mktemp)"; then
         error "Failed to create temporary file for latest-release lookup."
@@ -416,7 +430,7 @@ download_and_install() {
     need_cmd mktemp
 
     local archive_name="CodeIndex-${RID}.tar.gz"
-    local base_url="https://github.com/${REPO}/releases/download/${VERSION}"
+    local base_url="${GITHUB_BASE_URL}/${REPO}/releases/download/${VERSION}"
     local archive_url="${base_url}/${archive_name}"
     local checksums_url="${base_url}/sha256sums.txt"
 
@@ -577,6 +591,73 @@ check_path() {
     esac
 }
 
+run_local_mirror_self_test() {
+    need_cmd python3
+    need_cmd tar
+    need_cmd mktemp
+    need_cmd awk
+    need_cmd sleep
+
+    local rehearsal_version="${1:-v1.11.0}"
+    case "$rehearsal_version" in
+        v*) ;;
+        *)  rehearsal_version="v${rehearsal_version}" ;;
+    esac
+    local rehearsal_version_no_prefix="${rehearsal_version#v}"
+    local local_mirror_port="${CDIDX_LOCAL_MIRROR_PORT:-18765}"
+    local local_mirror_root
+    local local_release_base
+    local local_payload_dir
+    local checksum
+
+    if ! local_mirror_root="$(mktemp -d /tmp/cdidx-local-mirror.XXXXXX)"; then
+        error "Failed to create local mirror directory for self-test."
+    fi
+    LOCAL_MIRROR_DIR_CLEANUP="$local_mirror_root"
+
+    local_release_base="${local_mirror_root}/${REPO}/releases/download/${rehearsal_version}"
+    local_payload_dir="${local_release_base}/payload"
+    mkdir -p "$local_payload_dir"
+
+    cat > "${local_payload_dir}/${BINARY_NAME}" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${BINARY_NAME} ${rehearsal_version}"
+  exit 0
+fi
+echo "mock ${BINARY_NAME} (${rehearsal_version}) for local mirror self-test" >&2
+exit 2
+EOF
+    chmod +x "${local_payload_dir}/${BINARY_NAME}"
+    printf '{"version":"%s"}\n' "$rehearsal_version_no_prefix" > "${local_payload_dir}/version.json"
+    : > "${local_payload_dir}/libe_sqlite3.so"
+
+    (
+        cd "$local_payload_dir"
+        tar czf ../CodeIndex-linux-x64.tar.gz "${BINARY_NAME}" version.json libe_sqlite3.so
+    )
+
+    if command -v sha256sum > /dev/null 2>&1; then
+        checksum="$(sha256sum "${local_release_base}/CodeIndex-linux-x64.tar.gz" | awk '{print $1}')"
+    elif command -v shasum > /dev/null 2>&1; then
+        checksum="$(shasum -a 256 "${local_release_base}/CodeIndex-linux-x64.tar.gz" | awk '{print $1}')"
+    elif command -v openssl > /dev/null 2>&1; then
+        checksum="$(openssl dgst -sha256 "${local_release_base}/CodeIndex-linux-x64.tar.gz" | awk '{print $NF}')"
+    else
+        error "No checksum tool found (need sha256sum, shasum, or openssl) for local mirror self-test."
+    fi
+    printf '%s  CodeIndex-linux-x64.tar.gz\n' "$checksum" > "${local_release_base}/sha256sums.txt"
+
+    python3 -m http.server "$local_mirror_port" --directory "$local_mirror_root" > /tmp/cdidx-local-mirror-http.log 2>&1 &
+    LOCAL_MIRROR_PID=$!
+    sleep 1
+
+    info "Running local mirror self-test against http://127.0.0.1:${local_mirror_port}/"
+    GITHUB_BASE_URL="http://127.0.0.1:${local_mirror_port}"
+    main "$rehearsal_version"
+    "${INSTALL_DIR}/${BINARY_NAME}" --version
+}
+
 # --- Main / メイン ---
 
 main() {
@@ -602,5 +683,13 @@ main() {
 }
 
 if [ "${CDIDX_INSTALL_SH_LIB_ONLY:-0}" != "1" ]; then
-    main "$@"
+    case "${1:-}" in
+        --self-test-local-mirror)
+            shift
+            run_local_mirror_self_test "${1:-v1.11.0}"
+            ;;
+        *)
+            main "$@"
+            ;;
+    esac
 fi

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -460,6 +460,156 @@ public sealed class InstallScriptTests : IDisposable
     }
 
     [Fact]
+    public void ResolveVersion_UsesConfiguredGitHubApiBaseUrl()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            """
+            curl() {
+                local output_path=""
+                local url=""
+                while [ $# -gt 0 ]; do
+                    case "$1" in
+                        -o)
+                            output_path="$2"
+                            shift 2
+                            ;;
+                        -w)
+                            shift 2
+                            ;;
+                        *)
+                            url="$1"
+                            shift
+                            ;;
+                    esac
+                done
+
+                echo "CURL_URL:$url"
+                printf '{"tag_name":"v1.2.3"}' > "$output_path"
+                printf '200'
+                return 0
+            }
+
+            GITHUB_API_BASE_URL="https://mirror.example/api/"
+            resolve_version ""
+            """);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Fetching latest release version", stdout);
+        Assert.Contains("Version: v1.2.3", stdout);
+        Assert.Contains("CURL_URL:https://mirror.example/api/repos/Widthdom/CodeIndex/releases/latest", stdout);
+        Assert.Equal(string.Empty, stderr);
+    }
+
+    [Fact]
+    public void DownloadAndInstall_UsesConfiguredGitHubReleaseBaseUrl()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var installDir = Path.Combine(_tempRoot, "release_base_url_override_bin");
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            """
+            VERSION="v1.11.0"
+            RID="linux-x64"
+            GITHUB_BASE_URL="https://mirror.example/github/"
+
+            download_release_file() {
+                echo "DOWNLOAD_URL:$1"
+                return 1
+            }
+
+            download_and_install || true
+            """,
+            new Dictionary<string, string?>
+            {
+                ["CDIDX_INSTALL_DIR"] = installDir,
+            },
+            enforceStrictMode: false);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Downloading CodeIndex-linux-x64.tar.gz", stdout);
+        Assert.Contains("DOWNLOAD_URL:https://mirror.example/github/Widthdom/CodeIndex/releases/download/v1.11.0/CodeIndex-linux-x64.tar.gz", stdout);
+        Assert.Equal(string.Empty, stderr);
+    }
+
+    [Fact]
+    public void ResolveVersion_WithoutOverrides_UsesDefaultGitHubApiBaseUrl()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            """
+            curl() {
+                local output_path=""
+                local url=""
+                while [ $# -gt 0 ]; do
+                    case "$1" in
+                        -o)
+                            output_path="$2"
+                            shift 2
+                            ;;
+                        -w)
+                            shift 2
+                            ;;
+                        *)
+                            url="$1"
+                            shift
+                            ;;
+                    esac
+                done
+
+                echo "CURL_URL:$url"
+                printf '{"tag_name":"v1.2.3"}' > "$output_path"
+                printf '200'
+                return 0
+            }
+
+            resolve_version ""
+            """);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Fetching latest release version", stdout);
+        Assert.Contains("Version: v1.2.3", stdout);
+        Assert.Contains("CURL_URL:https://api.github.com/repos/Widthdom/CodeIndex/releases/latest", stdout);
+        Assert.Equal(string.Empty, stderr);
+    }
+
+    [Fact]
+    public void DownloadAndInstall_WithoutOverrides_UsesDefaultGitHubReleaseBaseUrl()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var installDir = Path.Combine(_tempRoot, "release_base_url_default_bin");
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            """
+            VERSION="v1.11.0"
+            RID="linux-x64"
+
+            download_release_file() {
+                echo "DOWNLOAD_URL:$1"
+                return 1
+            }
+
+            download_and_install || true
+            """,
+            new Dictionary<string, string?>
+            {
+                ["CDIDX_INSTALL_DIR"] = installDir,
+            },
+            enforceStrictMode: false);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Downloading CodeIndex-linux-x64.tar.gz", stdout);
+        Assert.Contains("DOWNLOAD_URL:https://github.com/Widthdom/CodeIndex/releases/download/v1.11.0/CodeIndex-linux-x64.tar.gz", stdout);
+        Assert.Equal(string.Empty, stderr);
+    }
+
+    [Fact]
     public void DownloadAndInstall_MissingAsset_DoesNotCreateFilesInEmptyInstallDir()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
### Motivation

- Allow the installer to work in environments that block or proxy `github.com` by letting callers override GitHub host and API base URLs and provide a reproducible local-mirror self-test.
- Document cloud session guidance for environments with restricted egress and show how to run the repo-local installer or a self-test mirror.

### Description

- Added environment overrides `CDIDX_GITHUB_BASE_URL` and `CDIDX_GITHUB_API_BASE_URL` (normalized to remove trailing slashes) and wired them into API and release download URL construction in `install.sh` by using `GITHUB_API_BASE_URL` and `GITHUB_BASE_URL` internally.
- Implemented a `run_local_mirror_self_test` helper in `install.sh` that builds a mock release payload, serves it with `python3 -m http.server`, and invokes the installer against `http://127.0.0.1:<port>` to validate download/checksum/extract flow; added `--self-test-local-mirror` CLI entry point and cleanup of the local mirror process/dir.
- Improved cleanup and error handling to kill the local mirror and remove temp mirror dirs on exit.
- Updated `CLOUD_BOOTSTRAP_PROMPT.md` (English and Japanese) with guidance to pin a repo-local installer, set `CDIDX_GITHUB_BASE_URL`/`CDIDX_GITHUB_API_BASE_URL`, diagnostic curl checks, and how to run the local-mirror self-test (`bash ./install.sh --self-test-local-mirror v1.11.0`).
- Added unit tests in `tests/CodeIndex.Tests/InstallScriptTests.cs` that assert URL construction uses the configured bases and falls back to the defaults.

### Testing

- Ran the test suite with `dotnet test` and the test run completed successfully, including the new tests `ResolveVersion_UsesConfiguredGitHubApiBaseUrl`, `DownloadAndInstall_UsesConfiguredGitHubReleaseBaseUrl`, `ResolveVersion_WithoutOverrides_UsesDefaultGitHubApiBaseUrl`, and `DownloadAndInstall_WithoutOverrides_UsesDefaultGitHubReleaseBaseUrl` which all passed.
- Existing installer-related tests in `tests/CodeIndex.Tests/InstallScriptTests.cs` were also exercised and passed under the same run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a8f44cb08325b0faaf714bb3e177)