### PR TITLE
Keep indexing/update progress visible during long-running interactive runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Changed
+- **Interactive indexing/output no longer goes visually silent after `Indexing...`** — `IndexCommandRunner` now keeps a live `Indexing...` spinner active on interactive terminals during full-scan indexing work instead of stopping it before the first file and leaving the user with a fixed line until the next 50-file progress redraw or warning. Scoped update runs now also keep a live `Updating...` spinner under the same interactive-only contract, pausing only long enough to print `[WARN]`, `[OK]`, `[SKIP]`, `[DEL]`, `[ERR]`, or progress-bar output cleanly and then resuming immediately. Redirected stdout behavior is intentionally unchanged in shape: stdout still gets a single `Indexing...` banner plus line-based progress, while warnings stay on stderr, so logs/pipes do not collect spinner-frame noise. README examples now document both the interactive and redirected-output behavior, and `SELF_IMPROVEMENT.md` now explicitly treats visible liveness for long-running human-facing CLI flows as a regression bar. Added regression coverage ensuring redirected full-scan output prints `Indexing...` exactly once and redirected verbose update output does not duplicate the `Updating ... file(s)...` banner. Affected: `src/CodeIndex/Cli/IndexCommandRunner.cs`, `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`, `README.md`, `SELF_IMPROVEMENT.md`.
+
 ### [1.12.0] - 2026-04-19
 
 #### Changed
@@ -745,6 +748,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### 変更
+- **対話ターミナルで `Indexing...` の後に視覚的に無音化しないよう改善** — `IndexCommandRunner` は、フルスキャン index の最初のファイル処理前に `Indexing...` スピナーを止めて次の 50 ファイル進捗更新または警告まで固定行のまま放置するのではなく、対話ターミナルでは重い処理中も `Indexing...` スピナーを維持するようになった。`--files` / `--commits` の scoped update も同じ interactive-only 契約で `Updating...` スピナーを維持し、`[WARN]` / `[OK]` / `[SKIP]` / `[DEL]` / `[ERR]` / プログレスバーを表示する直前だけ一時停止し、表示後すぐ再開する。stdout をリダイレクトした場合の形は意図的に維持しており、stdout には従来どおり `Indexing...` を 1 回だけ出し、その後は行ベースの進捗だけを出し、警告は引き続き stderr に分離するため、ログや pipe にスピナーフレームが混ざらない。README には interactive / redirected の両挙動を追記し、`SELF_IMPROVEMENT.md` にも「長時間の人間向け CLI では visible liveness を保つ」ことを回帰基準として明文化した。加えて、redirected full-scan 出力で `Indexing...` が 1 回だけ出ること、redirected verbose update で `Updating ... file(s)...` バナーが重複しないことを固定する回帰テストを追加。対象: `src/CodeIndex/Cli/IndexCommandRunner.cs`、`tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`、`README.md`、`SELF_IMPROVEMENT.md`。
 
 ### [1.12.0] - 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ Default output:
 ⠹ Scanning...
   Found 42 files
 
-Indexing...
+⠋ Indexing...
+⠙ Indexing...
   ████████████████████░░░░░░░░░░░░  67.0%  [28/42]
 
 Done.
@@ -215,6 +216,8 @@ Done.
   Elapsed : 00:00:02
 ```
 
+During long-running indexing on an interactive terminal, `Indexing...` stays live as a spinner instead of dropping to a fixed line until the next 50-file progress update. Warnings still print immediately, but the spinner resumes right after each warning so the run does not look frozen. When stdout is redirected (for example `cdidx . > out.txt`), cdidx prints a single `Indexing...` line to stdout, keeps warnings on stderr, and emits only line-based progress updates to stdout.
+
 Machine-readable output also reports the post-run readiness bits directly:
 
 ```bash
@@ -228,6 +231,7 @@ cdidx ./myproject --json
 With `--verbose`, each file also shows a status tag so you can see exactly what happened:
 
 ```
+  [WARN] src/generated/min.js: line exceeded max display width
   [OK  ] src/app.cs (12 chunks, 5 symbols)
   [SKIP] src/utils.cs
   [DEL ] src/old.cs
@@ -235,6 +239,8 @@ With `--verbose`, each file also shows a status tag so you can see exactly what 
 ```
 
 > `[OK  ]` = indexed successfully, `[SKIP]` = unchanged / skipped, `[DEL ]` = deleted from DB (file removed from disk), `[ERR ]` = failed (verbose mode includes stack trace)
+
+Warnings are written to stderr. On an interactive terminal, the indexing spinner pauses long enough to print each warning cleanly, then resumes immediately.
 
 This is useful for debugging indexing issues or verifying which files were actually processed.
 
@@ -1088,7 +1094,8 @@ cdidx ./myproject --verbose     # ファイルごとの詳細表示
 ⠹ Scanning...
   Found 42 files
 
-Indexing...
+⠋ Indexing...
+⠙ Indexing...
   ████████████████████░░░░░░░░░░░░  67.0%  [28/42]
 
 Done.
@@ -1103,6 +1110,8 @@ Done.
   Elapsed : 00:00:02
 ```
 
+対話ターミナルで長時間インデックスするときも、`Indexing...` は次の 50 ファイル更新まで固定文字列に落ちず、スピナーとして動き続けます。警告はその場で表示されますが、各警告の直後にスピナーが再開するため、処理が止まったようには見えません。stdout をリダイレクトしている場合（例: `cdidx . > out.txt`）は、stdout には `Indexing...` を 1 回だけ出し、警告は stderr に分離したまま、stdout には行単位の進捗だけを出します。
+
 機械向けの `--json` 出力でも、実行後の readiness bit がそのまま返ります:
 
 ```bash
@@ -1116,6 +1125,7 @@ cdidx ./myproject --json
 `--verbose` を付けると、各ファイルにステータスタグも表示され、何が起きたか一目でわかります:
 
 ```
+  [WARN] src/generated/min.js: 表示幅を超える長い行を検出
   [OK  ] src/app.cs (12 chunks, 5 symbols)
   [SKIP] src/utils.cs
   [DEL ] src/old.cs
@@ -1123,6 +1133,8 @@ cdidx ./myproject --json
 ```
 
 > `[OK  ]` = インデックス成功、`[SKIP]` = 未変更・スキップ、`[DEL ]` = DBから削除（ディスク上のファイルが消えた）、`[ERR ]` = 失敗（verboseではスタックトレースも表示）
+
+警告は stderr に出ます。対話ターミナルでは、警告をきれいに表示するために一瞬だけスピナーを止め、表示後すぐに再開します。
 
 インデックスの問題をデバッグしたり、どのファイルが実際に処理されたかを確認するのに便利です。
 

--- a/SELF_IMPROVEMENT.md
+++ b/SELF_IMPROVEMENT.md
@@ -47,6 +47,7 @@ The loop is not just "suggest ideas". It is:
 - When searching and navigating code to investigate bugs, plan fixes, or verify changes, always use the **locally built binary** — not the globally installed version. This ensures query results reflect the latest extraction rules and DB schema from this branch.
 - If the **locally built binary** crashes, aborts unexpectedly, or exposes a new defect during this loop, do not silently work around it or fall back to an older/global binary. Notify the user with the concrete failure, explain that the self-improvement loop is now blocked or tainted by that defect, and propose fixing it as a separate task or as the next approved priority.
 - Treat the loop itself as ongoing regression coverage and light monkey testing. Do not limit yourself to only the safest or most standard workflows; actively exercise recent features, edge features, and less-traveled commands/options so the loop can indirectly surface crashes, bad assumptions, stale help text, and integration defects.
+- For long-running human-facing CLI workflows, preserve visible liveness. Interactive terminals should continue to show progress or spinner activity during expensive work, and warnings/progress redraws must not leave the user staring at a stale `Indexing...` line or a silent screen that looks frozen.
 - If a change may be breaking, migration-heavy, destructive, or likely to impose manual work on users, **stop and ask for approval before implementing**.
 - Respect language differences. Do not pretend every query type is meaningful for every language.
 - Respect platform differences. Do not assume Windows, macOS, and Linux behave the same for paths, file locking, process invocation, or cleanup.
@@ -386,6 +387,7 @@ Read `SELF_IMPROVEMENT.md`, inspect the current repo with cdidx itself, identify
 - バグ調査、修正計画、変更検証のためにコード検索・ナビゲーションを行うときも、常に **ローカルビルド版** を使う。グローバルインストール版は使わない。これにより、このブランチの最新の抽出ルールと DB スキーマを反映した検索結果が得られる。
 - このループ中に **ローカルビルド版** がクラッシュしたり、異常終了したり、新しい不具合を露呈した場合は、黙って回避したり古い版・グローバル版へ逃げたりしないこと。具体的な失敗内容をユーザーに通知し、その不具合によって自己改善ループがブロックされている、または結果の信頼性が損なわれていることを説明したうえで、別タスクまたは次の承認済み優先事項として修正提案を出すこと。
 - このループ自体を、継続的なリグレッション確認と軽いモンキーテストとして扱うこと。最も安全で標準的なワークフローだけに偏らず、新しい機能、利用頻度の低い機能、枝葉末節のオプションも積極的に触り、間接的にクラッシュ、古いヘルプ文、想定漏れ、統合不具合をあぶり出すこと。
+- 人間向け CLI の長時間処理では、生存表示を維持すること。重い処理中も対話ターミナルには進捗かスピナーが見え続けるべきであり、警告表示や再描画のせいで古い `Indexing...` 行だけが残ったり、固まったように見える無音画面になったりしてはならない。
 - 変更が破壊的、移行負荷が高い、危険、またはユーザーに手間を強いる可能性があるなら、**実装前に必ず承認を取る**。
 - 言語差分を無視しない。すべての言語で同じ検索が意味を持つと仮定しない。
 - 次の改善が明確で非破壊なら、議論だけで止まらず実装を優先する。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -588,6 +588,8 @@ public static class IndexCommandRunner
 
         if (!options.Json)
             Console.WriteLine($"Updating {targetPaths.Count} file(s)...");
+        CancellationTokenSource? updateCts = null;
+        var interactiveUpdateSpinner = !options.Json && !Console.IsOutputRedirected;
         int updated = 0, removed = 0, skipped = 0, warnings = 0, errors = 0;
         var errorList = new List<object>();
         var warningList = new List<object>();
@@ -653,8 +655,37 @@ public static class IndexCommandRunner
                 }
 
                 if (!options.Json)
+                {
+                    PauseUpdateSpinnerForConsoleWrite();
                     ConsoleUi.PrintWarning($"{scanError.Path}: {scanError.Message}");
+                    ResumeUpdateSpinnerAfterConsoleWrite();
+                }
             }
+        }
+
+        void StartUpdateSpinnerIfNeeded()
+        {
+            if (!interactiveUpdateSpinner || updateCts != null)
+                return;
+
+            updateCts = ConsoleUi.StartSpinner("Updating...", spinnerFrames);
+        }
+
+        void PauseUpdateSpinnerForConsoleWrite()
+        {
+            if (updateCts == null)
+                return;
+
+            ConsoleUi.StopSpinner(updateCts);
+            updateCts = null;
+        }
+
+        void ResumeUpdateSpinnerAfterConsoleWrite()
+        {
+            if (!interactiveUpdateSpinner)
+                return;
+
+            StartUpdateSpinnerIfNeeded();
         }
 
         if (writer.CountUnsupportedReferences(supportedGraphLanguages) > 0)
@@ -667,8 +698,11 @@ public static class IndexCommandRunner
                 purgeTxn.Commit();
         }
 
+        StartUpdateSpinnerIfNeeded();
+
         foreach (var relPath in targetPaths)
         {
+            StartUpdateSpinnerIfNeeded();
             var absPath = Path.Combine(projectRoot, relPath.Replace('/', Path.DirectorySeparatorChar));
             try
             {
@@ -678,7 +712,11 @@ public static class IndexCommandRunner
                     {
                         skipped++;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [SKIP] {relPath} (not in DB)");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                         continue;
                     }
 
@@ -691,13 +729,21 @@ public static class IndexCommandRunner
                         removed++;
                         ftsMutated = true;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [DEL ] {relPath}");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                     }
                     else
                     {
                         skipped++;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [SKIP] {relPath} (not in DB)");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                     }
                     continue;
                 }
@@ -710,7 +756,11 @@ public static class IndexCommandRunner
                     {
                         skipped++;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [SKIP] {relPath} ({DescribePathFilter(pathFilter.FilterKind)})");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                         continue;
                     }
 
@@ -718,7 +768,11 @@ public static class IndexCommandRunner
                     {
                         skipped++;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [SKIP] {relPath} ({DescribePathFilter(pathFilter.FilterKind)})");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                         continue;
                     }
 
@@ -731,13 +785,21 @@ public static class IndexCommandRunner
                         removed++;
                         ftsMutated = true;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [DEL ] {relPath} ({DescribePathFilter(pathFilter.FilterKind)})");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                     }
                     else
                     {
                         skipped++;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [SKIP] {relPath} ({DescribePathFilter(pathFilter.FilterKind)})");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                     }
                     continue;
                 }
@@ -752,10 +814,12 @@ public static class IndexCommandRunner
                     errorList.Add(new { file = relPath, message = "Could not probe file for indexability/language." });
                     if (!options.Json)
                     {
+                        PauseUpdateSpinnerForConsoleWrite();
                         if (options.Verbose)
                             Console.Error.WriteLine($"  [ERR ] {relPath}: Could not probe file for indexability/language.");
                         else
                             Console.Error.WriteLine($"  [ERR ] {relPath}: Could not probe file for indexability/language.");
+                        ResumeUpdateSpinnerAfterConsoleWrite();
                     }
                     continue;
                 }
@@ -766,7 +830,11 @@ public static class IndexCommandRunner
                     {
                         skipped++;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [SKIP] {relPath} (unsupported type)");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                         continue;
                     }
 
@@ -779,13 +847,21 @@ public static class IndexCommandRunner
                         removed++;
                         ftsMutated = true;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [DEL ] {relPath} (no longer indexable)");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                     }
                     else
                     {
                         skipped++;
                         if (options.Verbose && !options.Json)
+                        {
+                            PauseUpdateSpinnerForConsoleWrite();
                             Console.WriteLine($"  [SKIP] {relPath} (unsupported type)");
+                            ResumeUpdateSpinnerAfterConsoleWrite();
+                        }
                     }
                     continue;
                 }
@@ -793,7 +869,11 @@ public static class IndexCommandRunner
                 var (record, content, rawBytes, warning) = indexer.BuildRecordWithRawBytes(absPath);
 
                 if (warning != null && !options.Json)
+                {
+                    PauseUpdateSpinnerForConsoleWrite();
                     ConsoleUi.PrintWarning(warning);
+                    ResumeUpdateSpinnerAfterConsoleWrite();
+                }
 
                 var existingId = writer.GetUnchangedFileId(
                     record.Path,
@@ -804,7 +884,11 @@ public static class IndexCommandRunner
                 {
                     skipped++;
                     if (options.Verbose && !options.Json)
+                    {
+                        PauseUpdateSpinnerForConsoleWrite();
                         Console.WriteLine($"  [SKIP] {relPath} (unchanged)");
+                        ResumeUpdateSpinnerAfterConsoleWrite();
+                    }
                     continue;
                 }
 
@@ -827,7 +911,11 @@ public static class IndexCommandRunner
                 updated++;
                 ftsMutated = true;
                 if (options.Verbose && !options.Json)
+                {
+                    PauseUpdateSpinnerForConsoleWrite();
                     Console.WriteLine($"  [OK  ] {relPath} ({chunks.Count} chunks, {symbols.Count} symbols, {references.Count} refs)");
+                    ResumeUpdateSpinnerAfterConsoleWrite();
+                }
             }
             catch (Exception ex)
             {
@@ -837,13 +925,17 @@ public static class IndexCommandRunner
                 errorList.Add(new { file = relPath, message = ex.Message });
                 if (!options.Json)
                 {
+                    PauseUpdateSpinnerForConsoleWrite();
                     if (options.Verbose)
                         Console.Error.WriteLine($"  [ERR ] {relPath}: {ex.Message}\n{ex.StackTrace}");
                     else
                         Console.Error.WriteLine($"  [ERR ] {relPath}: {ex.Message}");
+                    ResumeUpdateSpinnerAfterConsoleWrite();
                 }
             }
         }
+
+        PauseUpdateSpinnerForConsoleWrite();
 
         if (purgedRefs > 0 && !options.Json)
             Console.WriteLine($"  Purged {purgedRefs:N0} stale references (unsupported language)");
@@ -1311,25 +1403,69 @@ public static class IndexCommandRunner
             Console.WriteLine($"  Purged {purgedRefs:N0} stale references (unsupported language)");
 
         CancellationTokenSource? indexCts = null;
-        if (!options.Json)
-            indexCts = ConsoleUi.StartSpinner("Indexing...", spinnerFrames);
         int processed = 0, skipped = 0, warnings = warningList.Count, errors = errorList.Count;
-        bool indexSpinnerStopped = false;
+
+        var interactiveIndexSpinner = !options.Json && !Console.IsOutputRedirected;
+        var redirectedIndexingMessagePrinted = false;
+
+        void StartIndexSpinnerIfNeeded()
+        {
+            if (!interactiveIndexSpinner || indexCts != null)
+                return;
+
+            indexCts = ConsoleUi.StartSpinner("Indexing...", spinnerFrames);
+        }
+
+        void PauseIndexSpinnerForConsoleWrite()
+        {
+            if (indexCts == null)
+                return;
+
+            ConsoleUi.StopSpinner(indexCts);
+            indexCts = null;
+        }
+
+        void ResumeIndexSpinnerAfterConsoleWrite()
+        {
+            if (!interactiveIndexSpinner || processed >= files.Count)
+                return;
+
+            StartIndexSpinnerIfNeeded();
+        }
+
+        void EnsureIndexingActivityVisible()
+        {
+            if (options.Json)
+                return;
+
+            if (interactiveIndexSpinner)
+            {
+                StartIndexSpinnerIfNeeded();
+                return;
+            }
+
+            if (redirectedIndexingMessagePrinted)
+                return;
+
+            Console.WriteLine("Indexing...");
+            redirectedIndexingMessagePrinted = true;
+        }
+
+        EnsureIndexingActivityVisible();
 
         foreach (var filePath in files)
         {
-            if (!indexSpinnerStopped)
-            {
-                ConsoleUi.StopSpinner(indexCts);
-                indexSpinnerStopped = true;
-                if (!options.Json) Console.WriteLine("Indexing...");
-            }
+            EnsureIndexingActivityVisible();
             try
             {
                 var (record, content, rawBytes, warning) = indexer.BuildRecordWithRawBytes(filePath);
 
                 if (warning != null && !options.Json)
+                {
+                    PauseIndexSpinnerForConsoleWrite();
                     ConsoleUi.PrintWarning(warning);
+                    ResumeIndexSpinnerAfterConsoleWrite();
+                }
 
                 var existingId = writer.GetUnchangedFileId(
                     record.Path,
@@ -1342,10 +1478,17 @@ public static class IndexCommandRunner
                     processed++;
                     if (options.Verbose && !options.Json)
                     {
+                        PauseIndexSpinnerForConsoleWrite();
                         ConsoleUi.ClearProgressLine();
                         Console.WriteLine($"  [SKIP] {record.Path}");
+                        ResumeIndexSpinnerAfterConsoleWrite();
                     }
-                    if (!options.Json) ConsoleUi.PrintProgress(processed, files.Count);
+                    if (!options.Json)
+                    {
+                        PauseIndexSpinnerForConsoleWrite();
+                        ConsoleUi.PrintProgress(processed, files.Count);
+                        ResumeIndexSpinnerAfterConsoleWrite();
+                    }
                     continue;
                 }
 
@@ -1366,8 +1509,10 @@ public static class IndexCommandRunner
 
                 if (options.Verbose && !options.Json)
                 {
+                    PauseIndexSpinnerForConsoleWrite();
                     ConsoleUi.ClearProgressLine();
                     Console.WriteLine($"  [OK  ] {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols, {references.Count} refs)");
+                    ResumeIndexSpinnerAfterConsoleWrite();
                 }
             }
             catch (Exception ex)
@@ -1376,23 +1521,26 @@ public static class IndexCommandRunner
                 errorList.Add(new { file = filePath, message = ex.Message });
                 if (!options.Json)
                 {
+                    PauseIndexSpinnerForConsoleWrite();
                     ConsoleUi.ClearProgressLine();
                     if (options.Verbose)
                         Console.Error.WriteLine($"  [ERR ] {filePath}: {ex.Message}\n{ex.StackTrace}");
                     else
                         Console.Error.WriteLine($"  [ERR ] {filePath}: {ex.Message}");
+                    ResumeIndexSpinnerAfterConsoleWrite();
                 }
             }
 
             processed++;
-            if (!options.Json) ConsoleUi.PrintProgress(processed, files.Count);
+            if (!options.Json)
+            {
+                PauseIndexSpinnerForConsoleWrite();
+                ConsoleUi.PrintProgress(processed, files.Count);
+                ResumeIndexSpinnerAfterConsoleWrite();
+            }
         }
 
-        if (!indexSpinnerStopped)
-        {
-            ConsoleUi.StopSpinner(indexCts);
-            if (!options.Json) Console.WriteLine("Indexing...");
-        }
+        PauseIndexSpinnerForConsoleWrite();
 
         writer.OptimizeFts();
         // Only stamp readiness on a fully successful run (errors == 0). A partial / error

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -1185,6 +1185,27 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_FullScan_RedirectedOutput_PrintsIndexingBannerOnce()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
+            File.WriteAllText(Path.Combine(projectRoot, "util.py"), "def helper():\n    return 1\n");
+
+            var (exitCode, stdout, stderr) = RunAndCaptureStreams([projectRoot]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, CountOccurrences(stdout, "Indexing..."));
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_UpdateMode_WithIndexingErrors_PrintsRecoveryWarning()
     {
         var projectRoot = CreateTempProject();
@@ -1202,6 +1223,32 @@ public class IndexCommandRunnerTests
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Contains("Some files failed to update", stderr);
             Assert.Contains("rerun `cdidx index", stderr);
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_UpdateMode_VerboseRedirectedOutput_DoesNotRepeatUpdatingBanner()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } public void Extra() { } }\n");
+            File.SetLastWriteTimeUtc(Path.Combine(projectRoot, "app.cs"), DateTime.UtcNow.AddSeconds(2));
+
+            var (exitCode, stdout, stderr) = RunAndCaptureStreams([projectRoot, "--files", "app.cs", "--verbose"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, CountOccurrences(stdout, "Updating 1 file(s)..."));
         }
         finally
         {
@@ -4460,6 +4507,22 @@ public class IndexCommandRunnerTests
         var projectRoot = Path.Combine(Path.GetTempPath(), $"cdidx_index_runner_{Guid.NewGuid():N}");
         Directory.CreateDirectory(projectRoot);
         return projectRoot;
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            throw new ArgumentException("value must be non-empty", nameof(value));
+
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
     }
 
     [UnsupportedOSPlatform("windows")]


### PR DESCRIPTION
## Summary

This keeps `cdidx index` / scoped update runs from looking frozen after `Indexing...` or `Updating...` begins.

Previously, full-scan indexing stopped the spinner before the first file was processed, so users could be left staring at a fixed `Indexing...` line until either:
- the next 50-file progress redraw, or
- a warning happened to be printed

Scoped update runs had the same problem during long per-file work.

## What changed

- Keep the `Indexing...` spinner alive during interactive full-scan indexing work
- Keep the `Updating...` spinner alive during interactive scoped update work
- Pause the spinner only long enough to print:
  - `[WARN]`
  - `[OK]`
  - `[SKIP]`
  - `[DEL]`
  - `[ERR]`
  - progress-bar redraws
- Resume the spinner immediately after those writes
- Preserve redirected stdout behavior:
  - stdout still gets a single `Indexing...` banner
  - warnings still go to stderr
  - no spinner-frame noise is added to logs/pipes

## Docs

- Updated `README.md` examples and behavior notes for:
  - interactive terminal output
  - redirected stdout
  - warning behavior during indexing
- Updated `SELF_IMPROVEMENT.md` to treat visible liveness for long-running human-facing CLI flows as a regression bar
- Added `CHANGELOG.md` entries under `[Unreleased]`

## Tests

Added regression coverage for:
- redirected full-scan output printing `Indexing...` exactly once
- redirected verbose update output not duplicating the `Updating ... file(s)...` banner

Also verified:
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~IndexCommandRunnerTests`

## Notes

A full test run still has one pre-existing unrelated failure in `GitHelperTests` due to a `git switch master` assumption.
