### PR TITLE
Fix #361: add regression coverage for split-line C# return types

### DIFF
--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -5713,6 +5713,10 @@ public class SymbolExtractorTests
                 public Dictionary<string, int>
                     Cache { get; } = new();
 
+                public T Create<T>(string name)
+                    where T : class, new()
+                    => default!;
+
                 public int
                     this[string key] { get => 0; set { } }
 
@@ -5733,13 +5737,36 @@ public class SymbolExtractorTests
         Assert.Equal(12, cache.StartLine);
         Assert.Equal(13, cache.EndLine);
 
+        var create = Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "Create"));
+        Assert.Equal("public", create.Visibility);
+        Assert.Equal("T", create.ReturnType);
+        Assert.Equal(15, create.StartLine);
+        Assert.Equal(17, create.EndLine);
+
         var indexer = Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "Item"));
         Assert.Equal("public", indexer.Visibility);
         Assert.Equal("int", indexer.ReturnType);
-        Assert.Equal(15, indexer.StartLine);
-        Assert.Equal(16, indexer.EndLine);
+        Assert.Equal(19, indexer.StartLine);
+        Assert.Equal(20, indexer.EndLine);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Simple" && s.ReturnType == "int");
+        Assert.Equal(
+            new[]
+            {
+                ("class", "Svc"),
+                ("function", "Create"),
+                ("function", "GetMapping"),
+                ("function", "Item"),
+                ("function", "Simple"),
+                ("namespace", "CsMultilineSig"),
+                ("property", "Cache"),
+            },
+            symbols
+                .Where(s => s.Kind != "import")
+                .Select(s => (s.Kind, s.Name))
+                .OrderBy(x => x.Kind, StringComparer.Ordinal)
+                .ThenBy(x => x.Name, StringComparer.Ordinal)
+                .ToArray());
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -5691,6 +5691,58 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_SplitReturnTypeLine_StillCapturesMethodPropertyAndIndexer()
+    {
+        // issue #361: when a long C# return type wraps onto the previous line, the
+        // method/property/indexer must still be emitted instead of being silently
+        // dropped by a per-line-only regex pass.
+        // issue #361: C# の長い戻り値型が前行へ折り返されても、method/property/indexer は
+        // per-line 前提の regex で silent drop されず、引き続き抽出される必要がある。
+        var content = """
+            using System.Collections.Generic;
+
+            namespace CsMultilineSig;
+
+            public class Svc
+            {
+                public Dictionary<string, List<int>>
+                    GetMapping(
+                        string key,
+                        int defaultValue) => new();
+
+                public Dictionary<string, int>
+                    Cache { get; } = new();
+
+                public int
+                    this[string key] { get => 0; set { } }
+
+                public int Simple() => 0;
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var getMapping = Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "GetMapping"));
+        Assert.Equal("public", getMapping.Visibility);
+        Assert.Equal("Dictionary<string,List<int>>", getMapping.ReturnType);
+        Assert.Equal(7, getMapping.StartLine);
+        Assert.Equal(10, getMapping.EndLine);
+
+        var cache = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "Cache"));
+        Assert.Equal("public", cache.Visibility);
+        Assert.Equal("Dictionary<string,int>", cache.ReturnType);
+        Assert.Equal(12, cache.StartLine);
+        Assert.Equal(13, cache.EndLine);
+
+        var indexer = Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "Item"));
+        Assert.Equal("public", indexer.Visibility);
+        Assert.Equal("int", indexer.ReturnType);
+        Assert.Equal(15, indexer.StartLine);
+        Assert.Equal(16, indexer.EndLine);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Simple" && s.ReturnType == "int");
+    }
+
+    [Fact]
     public void Extract_CSharp_AllmanBlockBodiedProperty_WithIntermediateBlockComment_IsExtracted()
     {
         // issue #233 fourth review follow-up: when an Allman-style block-bodied property


### PR DESCRIPTION
## Summary
- add explicit SymbolExtractor regression coverage for C# members whose return type is on the previous line
- assert the full non-import symbol set from the issue #361 repro, including the `Create<T>` control case
- verify the expected line ranges, visibility, and return types for the split-line method/property/indexer shapes

## Verification
- `dotnet test`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter Extract_CSharp_SplitReturnTypeLine_StillCapturesMethodPropertyAndIndexer`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~CodeIndex.Tests.SymbolExtractorTests`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index <tmpdir> --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll symbols --db <tmpdir>/.cdidx/codeindex.db --json --lang csharp`

## Notes
- adversarial codex review reported no blocking/actionable findings after the follow-up test tightening
- filed follow-up issue #496 for an unrelated C# phantom-function false positive found during review

Fixes #361