### PR TITLE
Fix issue #363: add exact regression coverage for C# phantom string symbols

### DIFF
--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -3734,6 +3734,88 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbols_CSharpIssue363Fixture_DoesNotReturnPhantomSymbols()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_csharp_issue363");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "R.cs"),
+                """""
+                namespace CsRawStringPhantom;
+
+                public class Svc
+                {
+                    public int RealMethod() => 0;
+
+                    public string DocsExample() => """
+                        public void FakeMethod() { }
+                        public int FakeProp { get; set; }
+                        public class FakeClass { }
+                        public interface IFakeIface { }
+                        public delegate int FakeDel();
+                        public event System.EventHandler FakeEvent;
+                        public Foo() { }
+                        """;
+
+                    public string VerbatimExample() => @"
+                        public void VerbatimFake() { }
+                    ";
+
+                    public string InterpExample() => $"""
+                        public void InterpFake() { }
+                        """;
+
+                    public int AnotherReal() => 1;
+                }
+                """"");
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json"],
+                _jsonOptions));
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json", "--lang", "csharp"],
+                _jsonOptions));
+
+            var rows = ParseJsonLines(stdout);
+            var symbols = rows
+                .Select(row => row.RootElement.GetProperty("name").GetString())
+                .OfType<string>()
+                .ToHashSet(StringComparer.Ordinal);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(7, rows.Count);
+
+            Assert.Contains("CsRawStringPhantom", symbols);
+            Assert.Contains("Svc", symbols);
+            Assert.Contains("RealMethod", symbols);
+            Assert.Contains("DocsExample", symbols);
+            Assert.Contains("VerbatimExample", symbols);
+            Assert.Contains("InterpExample", symbols);
+            Assert.Contains("AnotherReal", symbols);
+
+            Assert.DoesNotContain("FakeMethod", symbols);
+            Assert.DoesNotContain("FakeProp", symbols);
+            Assert.DoesNotContain("FakeClass", symbols);
+            Assert.DoesNotContain("IFakeIface", symbols);
+            Assert.DoesNotContain("FakeDel", symbols);
+            Assert.DoesNotContain("FakeEvent", symbols);
+            Assert.DoesNotContain("Foo", symbols);
+            Assert.DoesNotContain("VerbatimFake", symbols);
+            Assert.DoesNotContain("InterpFake", symbols);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_CssExactNameSeparatesLiteralSelectors()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_css_exact_name");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -2987,6 +2987,68 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_Issue363RawInterpolatedAndVerbatimStrings_DoNotLeakPhantomSymbols()
+    {
+        // Regression for issue #363 exact repro: code-shaped members inside C# raw,
+        // interpolated raw, and multi-line verbatim strings must not be indexed as
+        // real symbols. The current main branch already handles this correctly; this
+        // test locks the user-reported fixture in place so future refactors cannot
+        // silently reopen it.
+        // issue #363 の exact repro 回帰: C# の raw string / 補間付き raw string /
+        // 複数行 verbatim string 内のコード風メンバーを本物の symbol として
+        // index してはならない。現行 main では直っているため、このテストで
+        // ユーザー報告フィクスチャを固定し、将来の refactor での再発を防ぐ。
+        var content = """""
+            namespace CsRawStringPhantom;
+
+            public class Svc
+            {
+                public int RealMethod() => 0;
+
+                public string DocsExample() => """
+                    public void FakeMethod() { }
+                    public int FakeProp { get; set; }
+                    public class FakeClass { }
+                    public interface IFakeIface { }
+                    public delegate int FakeDel();
+                    public event System.EventHandler FakeEvent;
+                    public Foo() { }
+                    """;
+
+                public string VerbatimExample() => @"
+                    public void VerbatimFake() { }
+                ";
+
+                public string InterpExample() => $"""
+                    public void InterpFake() { }
+                    """;
+
+                public int AnotherReal() => 1;
+            }
+            """"";
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "namespace" && symbol.Name == "CsRawStringPhantom");
+        Assert.Contains(symbols, symbol => symbol.Kind == "class" && symbol.Name == "Svc");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "RealMethod");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "DocsExample");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "VerbatimExample");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "InterpExample");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "AnotherReal");
+        Assert.Equal(7, symbols.Count);
+
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "FakeMethod");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "FakeProp");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "FakeClass");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "IFakeIface");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "FakeDel");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "FakeEvent");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "Foo");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "VerbatimFake");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "InterpFake");
+    }
+
+    [Fact]
     public void Extract_CSharp_CommentedTripleQuotesDoNotHideFollowingMembers()
     {
         var content = "public class FixtureHost\n{\n    // \"\"\" this is only a comment marker\n    public void Run() { }\n}";


### PR DESCRIPTION
## Summary

Fixes #363.

This PR adds exact regression coverage for the user-reported C# phantom-symbol fixture involving raw strings, interpolated raw strings, and multi-line verbatim strings.

## What changed

- Added a `SymbolExtractorTests` exact repro for issue #363.
- Added a `QueryCommandRunnerTests` end-to-end `RunSymbols` regression for the same fixture.
- Verified that the current local binary already returns the expected 7 symbols for the issue fixture and locked that behavior in tests.

## Why

The underlying masking behavior is already present on current `main`, but issue #363's exact dogfood fixture was not pinned directly in the test suite. This PR prevents silent regression of that specific report.

## Validation

- `dotnet test`
- Local repro with `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index ...` and `symbols --db ... --json`
- Adversarial Codex review on `origin/main...HEAD` with no blocking/actionable findings