### PR TITLE
Fix #572: respect carried C# block-comment masking in same-line scans

### DIFF
--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1546,9 +1546,10 @@ public static class SymbolExtractor
                     var csharpSameLineBraceStartColumn = csharpSingleLineCollapsedMatch
                         ? csharpSignatureRawStartColumn
                         : absoluteStartColumn;
+                    var csharpSameLineBraceScanLine = lang == "csharp" ? structuralLine : line;
                     var sameLineEndColumn = pattern.BodyStyle == BodyStyle.Brace
                         && bodyEndLine == startLine
-                        ? FindSameLineBraceEndColumn(line, csharpSameLineBraceStartColumn, lang, kind)
+                        ? FindSameLineBraceEndColumn(csharpSameLineBraceScanLine, csharpSameLineBraceStartColumn, lang, kind)
                         : -1;
                     var sameLineEndUsesRawColumns = pattern.BodyStyle == BodyStyle.Brace
                         && bodyEndLine == startLine;
@@ -1583,7 +1584,7 @@ public static class SymbolExtractor
                         // sibling が property など先頭側 pattern へ再到達できるようにする。
                         // これが無いと event signature が後続宣言を飲み込み、後続 sibling が
                         // earlier pattern に届かない。Closes #520.
-                        var braceEndColumn = FindSameLineBraceEndColumn(line, csharpSameLineBraceStartColumn, lang, kind);
+                        var braceEndColumn = FindSameLineBraceEndColumn(csharpSameLineBraceScanLine, csharpSameLineBraceStartColumn, lang, kind);
                         if (braceEndColumn >= absoluteStartColumn)
                         {
                             sameLineEndColumn = braceEndColumn;
@@ -2029,7 +2030,7 @@ public static class SymbolExtractor
                             // 通常の単独宣言行で duplicate 経路を再び開かない。Closes #470 / #473.
                             if (csharpSingleLineCollapsedMatch && sameLineEndUsesRawColumns)
                             {
-                                var rawNextSiblingOffset = FindNextSameLineBraceStatementStart(line, sameLineEndColumn + 1, lang);
+                                var rawNextSiblingOffset = FindNextSameLineBraceStatementStart(structuralLine, sameLineEndColumn + 1, lang);
                                 if (rawNextSiblingOffset > sameLineEndColumn)
                                 {
                                     restartPatternScanOffset = TranslateCSharpRawColumnToCollapsed(
@@ -2113,7 +2114,7 @@ public static class SymbolExtractor
                     var nextSameLineOffset = -1;
                     if (csharpSingleLineCollapsedMatch && sameLineEndUsesRawColumns)
                     {
-                        var rawNextSameLineOffset = FindNextSameLineBraceStatementStart(line, sameLineEndColumn + 1, lang);
+                        var rawNextSameLineOffset = FindNextSameLineBraceStatementStart(structuralLine, sameLineEndColumn + 1, lang);
                         if (rawNextSameLineOffset > sameLineEndColumn)
                         {
                             nextSameLineOffset = TranslateCSharpRawColumnToCollapsed(

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9314,6 +9314,83 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_CarriedBlockCommentLookalike_DoesNotEmitPhantomSymbol()
+    {
+        var content = string.Join(
+            "\n",
+            "namespace Demo;",
+            "",
+            "public partial class Host",
+            "{",
+            "    public partial class Wrapped<T>",
+            "        where T : class",
+            "    {",
+            "        /*",
+            "        public partial class Fake { } */ public partial class Child { } }",
+            "}");
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "Fake");
+        var child = Assert.Single(symbols.Where(s =>
+            s.Kind == "class"
+            && s.Name == "Child"
+            && s.ContainerKind == "class"
+            && s.ContainerName == "Wrapped"));
+        Assert.Equal("public partial class Child { }", child.Signature);
+    }
+
+    [Fact]
+    public void Extract_CSharp_CarriedBlockCommentSameName_DoesNotDuplicateSingleRealSymbol()
+    {
+        var content = string.Join(
+            "\n",
+            "public partial class Host",
+            "{",
+            "    public partial class Wrapped<T>",
+            "        where T : class",
+            "    {",
+            "        /*",
+            "        public partial class Child { } */ public partial class Child { } }",
+            "}");
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var children = symbols
+            .Where(s => s.Kind == "class" && s.Name == "Child")
+            .ToList();
+        var child = Assert.Single(children);
+        Assert.Equal("class", child.ContainerKind);
+        Assert.Equal("Wrapped", child.ContainerName);
+        Assert.Equal("public partial class Child { }", child.Signature);
+    }
+
+    [Fact]
+    public void Extract_CSharp_CarriedBlockCommentSameNamePlusOuterSibling_OnlyKeepsRealSymbols()
+    {
+        var content = string.Join(
+            "\n",
+            "public partial class Host",
+            "{",
+            "    public partial class Wrapped<T>",
+            "        where T : class",
+            "    {",
+            "        /*",
+            "        public partial class Child { } */ public partial class Child { } }",
+            "",
+            "    public partial class Child { }",
+            "}");
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var children = symbols
+            .Where(s => s.Kind == "class" && s.Name == "Child")
+            .OrderBy(s => s.Line)
+            .ToList();
+        Assert.Equal(2, children.Count);
+        Assert.Equal(("class", "Wrapped"), (children[0].ContainerKind, children[0].ContainerName));
+        Assert.Equal(("class", "Host"), (children[1].ContainerKind, children[1].ContainerName));
+        Assert.All(children, child => Assert.Equal("public partial class Child { }", child.Signature));
+    }
+
+    [Fact]
     public void Extract_CSharp_SameLineGenericBraceBodiedMembersStillExposeLaterCompactSiblings()
     {
         // After the #525 raw-column brace clamp, same-line generic brace-bodied


### PR DESCRIPTION
### Motivation
- Symbol extraction for C# incorrectly treated declaration-like text that was still inside a carried `/* ... */` block comment as a same-line sibling, producing phantom symbols.
- The goal is to ensure same-line brace/end-of-statement and sibling-restart calculations consult the structurally-masked line state that preserves carried block-comment mode so comment-contained tokens are not misinterpreted as real declarations.

### Description
- Change same-line brace/sibling scanning to use the carried structural/masked line for C# by introducing `csharpSameLineBraceScanLine` (uses `structuralLine` for `lang == "csharp"`) and pass it into `FindSameLineBraceEndColumn` and `FindNextSameLineBraceStatementStart` where appropriate.
- Update logic that computes `sameLineEndColumn`, `braceEndColumn`, and raw-sibling offsets to consult the structural scan line for C# so block-comment masking is honored when deciding restart positions and brace-end truncation.
- Add three regression tests in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` to cover carried block-comment cases: `Extract_CSharp_CarriedBlockCommentLookalike_DoesNotEmitPhantomSymbol`, `Extract_CSharp_CarriedBlockCommentSameName_DoesNotDuplicateSingleRealSymbol`, and `Extract_CSharp_CarriedBlockCommentSameNamePlusOuterSibling_OnlyKeepsRealSymbols`.
- Files changed: `src/CodeIndex/Indexer/SymbolExtractor.cs` and `tests/CodeIndex.Tests/SymbolExtractorTests.cs`.
- Commit created on branch `fix-issue572` with message: `Fix #572: respect carried C# comment masking in same-line scans`.

### Testing
- Could not run project automated tests because `dotnet` is not available in this environment (`dotnet build` / `dotnet test` reported `dotnet: command not found`).
- Git operations and commit succeeded locally: `git commit` recorded the change and tests were added to the test suite (commit present on branch `fix-issue572`).
- No CI run was available here; CI / `dotnet test` should be executed in CI or a local environment with .NET 8 to validate the new tests and ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73d4a00e48325b1c5b8214a25ffc8)