### PR TITLE
Add regression coverage for #339 same-line enum attributes

### DIFF
--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -7041,6 +7041,38 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_Issue339_SameLineAttributedEnumMembersStayIndexed()
+    {
+        // Same-line C# attributes on enum members must not hide the member name.
+        // C# enum member の同行 attribute は member 名を隠してはならない。
+        var content = """
+            namespace EnumAttr;
+
+            public enum Status
+            {
+                [System.Obsolete] Legacy = 0,
+                [System.ComponentModel.DefaultValue(1)] B = 1,
+                [System.Obsolete][System.ComponentModel.Browsable(false)] D = 3,
+
+                [System.Obsolete]
+                E = 4,
+
+                F = 5,
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Status");
+        foreach (var name in new[] { "Legacy", "B", "D", "E", "F" })
+        {
+            var symbol = Assert.Single(symbols.Where(s => s.Name == name));
+            Assert.Equal("enum", symbol.Kind);
+            Assert.Equal("Status", symbol.ContainerName);
+            Assert.Equal("enum", symbol.ContainerKind);
+        }
+    }
+
+    [Fact]
     public void Extract_CSharp_DetectsRegionDirectives()
     {
         var content = "#region Private Methods\nvoid Helper() { }\n#endregion\n\n#region Properties\npublic int X { get; set; }\n#endregion";


### PR DESCRIPTION
## Summary
- add a regression test for the exact issue #339 fixture in `SymbolExtractorTests`
- confirm current `origin/main` already indexes same-line attributed C# enum members correctly
- document that #339 was closed as already fixed on current main once the fixture was pinned

## Why
Issue #339 was still open, but the current extractor no longer reproduces the reported failure. The remaining gap was regression coverage for that exact fixture, so this PR locks in the current behavior and prevents silent reintroduction.

## Validation
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet test --filter "FullyQualifiedName~Extract_CSharp_Issue339_SameLineAttributedEnumMembersStayIndexed"`
- `dotnet test --filter "FullyQualifiedName~SymbolExtractorTests"`
- adversarial codex review on `origin/main..HEAD` with no blocking/actionable findings
