### PR TITLE
Fix same-line C# event/delegate sibling extraction

### DIFF
--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -244,6 +244,12 @@ public static class SymbolExtractor
     private static readonly Regex CSharpSameLinePropertyStatementStartRegex = new(
         $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|unsafe|extern|ref(?:\s+readonly)?)\s+)*(?!(?:class|struct|interface|enum|record|namespace|delegate|event|const|using|return|throw|yield|var|typeof|sizeof|nameof|default|if|for|foreach|while|switch|catch|lock|case|else|when|break|continue|goto|await)\b)(?:(?:ref(?:\s+readonly)?)\s+)?(?:{CSharpTypePattern})\s+(?:{CSharpExplicitInterfaceQualifierPattern}\.)?\w+\s*(?:\{{|=>\s*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CSharpSameLineEventStatementStartRegex = new(
+        $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|unsafe|extern|virtual|override|abstract|sealed|new|partial|file)\s+)*event\s+(?:{CSharpTypePattern})\s+\w+\s*(?:[;=]|\{{)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CSharpSameLineDelegateStatementStartRegex = new(
+        $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|unsafe|file|new)\s+)*delegate\s+(?:{CSharpTypePattern})\s+\w+\s*[\(<]",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CSharpSameLineEventOrDelegateStatementStartRegex = new(
         $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|unsafe|extern|virtual|override|abstract|sealed|new|partial|file)\s+)*(?:event\s+(?:{CSharpTypePattern})\s+\w+\s*(?:[;=]|\{{)|delegate\s+(?:{CSharpTypePattern})\s+\w+\s*[\(<])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1353,6 +1359,14 @@ public static class SymbolExtractor
                             break;
                         }
 
+                        if (lang == "csharp"
+                            && pattern.Kind is "event" or "delegate"
+                            && pattern.BodyStyle == BodyStyle.None
+                            && ShouldDeferCSharpEventOrDelegateSameLineAdvance(patternMatchLine, lineOffset, pattern.Kind))
+                        {
+                            break;
+                        }
+
                         if (lang is "javascript" or "typescript" or "css"
                             || (lang == "csharp"
                                 && pattern.Kind == "enum"
@@ -1579,8 +1593,7 @@ public static class SymbolExtractor
                             sameLineEndUsesRawColumns = false;
                         }
                     }
-                    if (sameLineEndColumn < absoluteStartColumn
-                        && lang == "csharp"
+                    if (lang == "csharp"
                         && kind == "event"
                         && pattern.BodyStyle == BodyStyle.None
                         && HasCSharpEventAccessorStart(patternMatchLine[absoluteStartColumn..]))
@@ -1599,7 +1612,8 @@ public static class SymbolExtractor
                         // これが無いと event signature が後続宣言を飲み込み、後続 sibling が
                         // earlier pattern に届かない。Closes #520.
                         var braceEndColumn = FindSameLineBraceEndColumn(line, csharpSameLineBraceStartColumn, lang, kind);
-                        if (braceEndColumn >= absoluteStartColumn)
+                        if (braceEndColumn >= absoluteStartColumn
+                            && (sameLineEndColumn < absoluteStartColumn || braceEndColumn < sameLineEndColumn))
                         {
                             sameLineEndColumn = braceEndColumn;
                             sameLineEndUsesRawColumns = true;
@@ -10274,6 +10288,23 @@ public static class SymbolExtractor
         return !CSharpTypeBodyDeclarationMarker.IsMatch(remaining)
             && !HasCSharpPropertyAccessorStart(remaining)
             && CSharpSameLinePropertyStatementStartRegex.IsMatch(remaining);
+    }
+
+    private static bool ShouldDeferCSharpEventOrDelegateSameLineAdvance(string matchLine, int startColumn, string kind)
+    {
+        if (startColumn < 0 || startColumn >= matchLine.Length)
+            return false;
+
+        var remaining = matchLine[startColumn..];
+        if (CSharpTypeBodyDeclarationMarker.IsMatch(remaining))
+            return false;
+
+        return kind switch
+        {
+            "event" => CSharpSameLineDelegateStatementStartRegex.IsMatch(remaining),
+            "delegate" => CSharpSameLineEventStatementStartRegex.IsMatch(remaining),
+            _ => false,
+        };
     }
 
     private static bool TryGetCSharpSameLineSemicolonSiblingOffset(string matchLine, int startColumn, out int nextSameLineOffset)

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1347,14 +1347,14 @@ public static class SymbolExtractor
                         if (lang == "csharp"
                             && pattern.Kind == "property"
                             && pattern.BodyStyle == BodyStyle.Brace
-                            && ShouldDeferCSharpBracePropertySameLineAdvance(patternMatchLine, lineOffset))
+                            && ShouldDeferCSharpBracePropertySameLineAdvance(matchLine, lineOffset))
                         {
                             break;
                         }
 
                         if (lang == "csharp"
                             && pattern.Kind == "function"
-                            && ShouldDeferCSharpFunctionSameLineAdvance(patternMatchLine, lineOffset))
+                            && ShouldDeferCSharpFunctionSameLineAdvance(matchLine, lineOffset))
                         {
                             break;
                         }
@@ -1362,7 +1362,7 @@ public static class SymbolExtractor
                         if (lang == "csharp"
                             && pattern.Kind is "event" or "delegate"
                             && pattern.BodyStyle == BodyStyle.None
-                            && ShouldDeferCSharpEventOrDelegateSameLineAdvance(patternMatchLine, lineOffset, pattern.Kind))
+                            && ShouldDeferCSharpEventOrDelegateSameLineAdvance(matchLine, lineOffset, pattern.Kind))
                         {
                             break;
                         }
@@ -10335,7 +10335,8 @@ public static class SymbolExtractor
             return false;
 
         var remaining = matchLine[startColumn..];
-        if (!HasCSharpEventAccessorStart(remaining))
+        if (!CSharpSameLineEventStatementStartRegex.IsMatch(remaining)
+            || !HasCSharpEventAccessorStart(remaining))
             return false;
 
         var bodyEnd = FindCSharpSameLineBraceEndColumn(matchLine, startColumn);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9307,6 +9307,85 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_SameLineAccessorEventBeforePropertyIsCaptured()
+    {
+        // Accessor-bodied events must stop at their own closing `}` even when the next same-line
+        // sibling is a property. Otherwise the semicolon fallback keeps scanning until the later
+        // property terminator, the event signature absorbs `public int P`, and the property never
+        // gets a restart chance. Closes #519.
+        // accessor body を持つ event は、次の same-line sibling が property の場合でも
+        // 自身の閉じ `}` で終端しなければならない。そうしないと semicolon fallback が
+        // 後続 property の終端まで進み、event signature に `public int P` が混入し、
+        // property 側の再開機会も失われる。Closes #519.
+        var content = "public class C { public event System.Action E { add { } remove { } } public int P { get; set; } }";
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Single(symbols.Where(s => s.Kind == "class" && s.Name == "C"));
+
+        var eventSymbol = Assert.Single(symbols.Where(s => s.Kind == "event" && s.Name == "E"));
+        Assert.Equal("class", eventSymbol.ContainerKind);
+        Assert.Equal("C", eventSymbol.ContainerName);
+        Assert.Equal("public event System.Action E { add { } remove { } }", eventSymbol.Signature);
+
+        var property = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "P"));
+        Assert.Equal("class", property.ContainerKind);
+        Assert.Equal("C", property.ContainerName);
+        Assert.Equal("public int P { get; set; }", property.Signature);
+    }
+
+    [Fact]
+    public void Extract_CSharp_SameLineEventBeforeDelegateIsCaptured()
+    {
+        // Delegate rows sit ahead of event rows in the C# pattern list, so a failed delegate
+        // match at `event E;` must not keep scanning forward and claim the later delegate.
+        // Otherwise the earlier event never reaches its own regex family and silently drops.
+        // Closes #522.
+        // C# の pattern 順では delegate 行が event 行より前にあるため、`event E;` で失敗した
+        // delegate row が後続 delegate まで進んではならない。進んでしまうと手前の event が
+        // 自分の regex family に到達できず、無言で欠落する。Closes #522.
+        var content = "public class C { public event System.Action E; public delegate void D(); }";
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Single(symbols.Where(s => s.Kind == "class" && s.Name == "C"));
+
+        var eventSymbol = Assert.Single(symbols.Where(s => s.Kind == "event" && s.Name == "E"));
+        Assert.Equal("class", eventSymbol.ContainerKind);
+        Assert.Equal("C", eventSymbol.ContainerName);
+        Assert.Equal("public event System.Action E;", eventSymbol.Signature);
+
+        var delegateSymbol = Assert.Single(symbols.Where(s => s.Kind == "delegate" && s.Name == "D"));
+        Assert.Equal("class", delegateSymbol.ContainerKind);
+        Assert.Equal("C", delegateSymbol.ContainerName);
+        Assert.Equal("public delegate void D();", delegateSymbol.Signature);
+    }
+
+    [Fact]
+    public void Extract_CSharp_SameLineAccessorEventBeforeDelegateIsCaptured()
+    {
+        // The same cross-family starvation also applies when the earlier declaration is an
+        // accessor-bodied event: the event must clamp at its own accessor block, and the later
+        // delegate must only be reached via the explicit restart path rather than by skipping
+        // past the event statement. Closes #519 / #522.
+        // 同じ cross-family の starvation は、手前が accessor-bodied event の場合にも起こる。
+        // event 自身は accessor block で正しく切れ、後続 delegate には event 文を飛び越える
+        // のではなく明示的な restart 経路で到達しなければならない。Closes #519 / #522.
+        var content = "public class C { public event System.Action E { add { } remove { } } public delegate void D(); }";
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Single(symbols.Where(s => s.Kind == "class" && s.Name == "C"));
+
+        var eventSymbol = Assert.Single(symbols.Where(s => s.Kind == "event" && s.Name == "E"));
+        Assert.Equal("class", eventSymbol.ContainerKind);
+        Assert.Equal("C", eventSymbol.ContainerName);
+        Assert.Equal("public event System.Action E { add { } remove { } }", eventSymbol.Signature);
+
+        var delegateSymbol = Assert.Single(symbols.Where(s => s.Kind == "delegate" && s.Name == "D"));
+        Assert.Equal("class", delegateSymbol.ContainerKind);
+        Assert.Equal("C", delegateSymbol.ContainerName);
+        Assert.Equal("public delegate void D();", delegateSymbol.Signature);
+    }
+
+    [Fact]
     public void Extract_CSharp_SameLineAutoPropertyAfterConstructorsIsCaptured()
     {
         // Same-line C# constructors must not stop later sibling declarations from

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9386,6 +9386,50 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_SameLineDelegateBeforeAccessorEventWithLaterSiblingIsCaptured()
+    {
+        // After a leading delegate restarts the same-line scan at a later accessor-bodied event,
+        // the defer checks for function/property/event/delegate rows must still see the raw event
+        // statement start. If they inspect the property/function merged candidate instead, they
+        // can skip directly to the trailing sibling and silently drop the middle custom event.
+        // Lock the issue #603 repro plus the sibling-family matrix (`property` / `method` /
+        // `delegate` / `event`) in one fixture. Closes #603.
+        // 先頭 delegate から later accessor-bodied event へ same-line restart した後でも、
+        // function/property/event/delegate 各 row の defer 判定は raw の event 文開始位置を
+        // 見続けなければならない。property/function 用の merged candidate を見てしまうと、
+        // 後続 sibling へ直接飛んで中間 custom event が無言で欠落する。#603 の最小再現と、
+        // 後続 sibling family (`property` / `method` / `delegate` / `event`) を 1 fixture で
+        // 固定する。Closes #603.
+        var content = string.Join(
+            "\n",
+            "public class PropertyCase { public delegate void D(); public event System.Action E { add { } remove { } } public int P { get; set; } }",
+            "public class MethodCase { public delegate void D(); public event System.Action E { add { } remove { } } public void M() { } }",
+            "public class DelegateCase { public delegate void D1(); public event System.Action E { add { } remove { } } public delegate void D2(); }",
+            "public class EventCase { public delegate void D1(); public event System.Action E { add { } remove { } } public event System.Action E2; }");
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var propertyEvent = Assert.Single(symbols.Where(s => s.Kind == "event" && s.Name == "E" && s.ContainerName == "PropertyCase"));
+        Assert.Equal("public event System.Action E { add { } remove { } }", propertyEvent.Signature);
+        var property = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "P" && s.ContainerName == "PropertyCase"));
+        Assert.Equal("public int P { get; set; }", property.Signature);
+
+        var methodEvent = Assert.Single(symbols.Where(s => s.Kind == "event" && s.Name == "E" && s.ContainerName == "MethodCase"));
+        Assert.Equal("public event System.Action E { add { } remove { } }", methodEvent.Signature);
+        var method = Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "M" && s.ContainerName == "MethodCase"));
+        Assert.Equal("public void M() { }", method.Signature);
+
+        var delegateEvent = Assert.Single(symbols.Where(s => s.Kind == "event" && s.Name == "E" && s.ContainerName == "DelegateCase"));
+        Assert.Equal("public event System.Action E { add { } remove { } }", delegateEvent.Signature);
+        var delegateTail = Assert.Single(symbols.Where(s => s.Kind == "delegate" && s.Name == "D2" && s.ContainerName == "DelegateCase"));
+        Assert.Equal("public delegate void D2();", delegateTail.Signature);
+
+        var eventEvent = Assert.Single(symbols.Where(s => s.Kind == "event" && s.Name == "E" && s.ContainerName == "EventCase"));
+        Assert.Equal("public event System.Action E { add { } remove { } }", eventEvent.Signature);
+        var trailingEvent = Assert.Single(symbols.Where(s => s.Kind == "event" && s.Name == "E2" && s.ContainerName == "EventCase"));
+        Assert.Equal("public event System.Action E2;", trailingEvent.Signature);
+    }
+
+    [Fact]
     public void Extract_CSharp_SameLineAutoPropertyAfterConstructorsIsCaptured()
     {
         // Same-line C# constructors must not stop later sibling declarations from


### PR DESCRIPTION
Fixes #519
Fixes #522
Fixes #603

## Summary
- keep same-line C# event/delegate scans from starving later sibling declarations
- clamp accessor-bodied same-line events to their accessor block before later semicolon siblings
- add regression coverage for delegate/event/property/method sibling permutations and the review-found follow-up case

## Verification
- dotnet test
- codex adversarial review attempt 3 reported no blocking/actionable findings
- verified CLI indexing with the local `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll` binary on fresh repro projects