### PR TITLE
Add regression coverage for issue #613

### DIFF
--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -10624,6 +10624,63 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunReferences_ExactJson_CSharpCommentSeparatedAwaitBeforeQueryKeywordNamedLocalFunctionInOrderByDoesNotLeakReferenceContext()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_enum_member_parenthesized_orderby_await_local_function_comment_gap");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "cases.cs"),
+                """
+                using System.Collections.Generic;
+                using System.Linq;
+                using System.Threading.Tasks;
+
+                namespace Demo;
+
+                public enum Status
+                {
+                    Ready
+                }
+
+                public sealed class Holder
+                {
+                    public int Ready { get; set; }
+                }
+
+                public sealed class Uses
+                {
+                    public async Task<IEnumerable<int>> Read(IEnumerable<Holder> items)
+                    {
+                        static async Task<int> select(IEnumerable<Holder> xs) => await Task.FromResult(xs.Count());
+                        return from Status in items
+                               orderby await select /*comment*/ (items), items.Count()
+                               select Status.Ready;
+                    }
+                }
+                """);
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = RunBuiltCli([projectRoot, "--json"]);
+            var (exitCode, stdout, stderr) = RunBuiltCli(["references", "Ready", "--db", dbPath, "--json", "--lang", "csharp", "--exact-name"]);
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+            Assert.Equal(CommandExitCodes.NotFound, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(0, json.GetProperty("count").GetInt32());
+            Assert.Empty(json.GetProperty("references").EnumerateArray());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunReferences_ExactJson_CSharpPostfixNullForgivingBeforeParenthesizedTerminalSelectPreservesLaterEnumReferenceContext()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_enum_member_parenthesized_terminal_select_after_null_forgiving");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2493,6 +2493,44 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpQualifiedEnumMemberAccess_WithCommentSeparatedAwaitBeforeQueryKeywordNamedLocalFunctionInOrderBy_DoesNotLeakReference()
+    {
+        const string content = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+
+            namespace Demo;
+
+            public enum Status
+            {
+                Ready
+            }
+
+            public sealed class Holder
+            {
+                public int Ready { get; set; }
+            }
+
+            public sealed class Uses
+            {
+                public async Task<IEnumerable<int>> Read(IEnumerable<Holder> items)
+                {
+                    static async Task<int> select(IEnumerable<Holder> xs) => await Task.FromResult(xs.Count());
+                    return from Status in items
+                           orderby await select /*comment*/ (items), items.Count()
+                           select Status.Ready;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "Ready" && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_CsharpQualifiedEnumMemberAccess_WithPostfixNullForgivingBeforeParenthesizedTerminalSelect_PreservesOnlyTrailingReference()
     {
         const string content = """


### PR DESCRIPTION
## Summary
- add extractor and CLI regressions for the C# `await select /*comment*/ (items)` trivia-gap shape from issue #613
- confirm the multiline `select
(items)` shape was already covered on current `origin/main`
- validate issue #611 against a control case and close it because the reported repro does not describe a distinct bug

## Test plan
- [x] dotnet test
- [x] dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_CsharpQualifiedEnumMemberAccess_WithCommentSeparatedAwaitBeforeQueryKeywordNamedLocalFunctionInOrderBy_DoesNotLeakReference|FullyQualifiedName~QueryCommandRunnerTests.RunReferences_ExactJson_CSharpCommentSeparatedAwaitBeforeQueryKeywordNamedLocalFunctionInOrderByDoesNotLeakReferenceContext|FullyQualifiedName~ReferenceExtractorTests.Extract_CsharpQualifiedEnumMemberAccess_WithMultilineSelectAfterGreaterThan_DoesNotLeakReference|FullyQualifiedName~QueryCommandRunnerTests.RunReferences_ExactJson_CSharpMultilineSelectAfterGreaterThanDoesNotLeakReferenceContext|FullyQualifiedName~ReferenceExtractorTests.Extract_CsharpQualifiedEnumMemberAccess_WithMultilineThrowBeforeGroup_DoesNotLeakReference|FullyQualifiedName~QueryCommandRunnerTests.RunReferences_ExactJson_CSharpMultilineThrowBeforeGroupDoesNotLeakReferenceContext"