### PR TITLE
Add shared CodeIndex guard harness

### DIFF
--- a/.agent_harness/README.md
+++ b/.agent_harness/README.md
@@ -1,0 +1,7 @@
+# Shared Agent Guard Harness
+
+This directory contains the shared command-policy core used by both Claude Code
+and Codex hook adapters in this repository.
+
+Policy logic lives in `command_guard_core.py`.
+Adapter entrypoints live in `.claude/hooks/` and `.codex/hooks/`.

--- a/.agent_harness/__init__.py
+++ b/.agent_harness/__init__.py
@@ -1,0 +1,1 @@
+"""Shared guard harness for CodeIndex workflow policies."""

--- a/.agent_harness/command_guard_core.py
+++ b/.agent_harness/command_guard_core.py
@@ -1,0 +1,323 @@
+"""Shared command guard policy for Claude Code and Codex.
+
+This module keeps the command classification and denial policy in one place
+so the Claude and Codex hook adapters stay thin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+
+MAX_SCRIPT_SCAN_BYTES = 512 * 1024
+LOCAL_CDIDX_REL = Path("src/CodeIndex/bin/Debug/net8.0/cdidx.dll")
+
+_SHELL_CONTROL_TOKENS = {"|", "||", "&", "&&", ";", "|&", "(", ")", "<", ">", "<<", ">>"}
+_INLINE_INTERPRETER_FLAGS = {"-c", "-e", "--eval"}
+
+SEARCH_OR_DISCOVERY_RE = re.compile(
+    r"""(?ix)
+    (^|[^\w./-])
+    (
+      grep|egrep|fgrep|zgrep|rgrep|
+      rg|ripgrep|ag|ack|ack-grep|
+      find|fd|fdfind|locate|mlocate|mdfind
+    )
+    (?=$|[^\w./-])
+    """
+)
+
+GLOBAL_CDIDX_RE = re.compile(
+    r"""(?ix)
+    (^|[^\w./-])
+    (
+      cdidx
+      |~/?\.local/bin/cdidx
+      |\$HOME/\.local/bin/cdidx
+    )
+    (?=$|[^\w./-])
+    """
+)
+
+GIT_GREP_RE = re.compile(r"(?i)(^|[^\w./-])git\s+grep\b")
+LOCAL_CDIDX_DLL_RE = re.compile(r"(?i)cdidx\.dll")
+INLINE_SECRET_RE = re.compile(r"(?i)(api[_-]?key|secret|token|password)\s*[:=]\s*['\"]?[A-Za-z0-9_./+=:-]{20,}")
+COMMAND_SUBSTITUTION_RE = re.compile(r"`|\$\(")
+CONTROL_OP_RE = re.compile(r"(?s)(?:&&|\|\||;|\|&|\||&|`|\$\(|<|>|\n)")
+INLINE_INTERPRETER_RE = re.compile(r"(?i)^\s*(?:python|python3|ruby|perl|node)\b.*(?:\s(?:-c|-e|--eval)\b)")
+
+_FORBIDDEN_COMMAND_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (SEARCH_OR_DISCOVERY_RE, "shell search/file-discovery command is blocked; use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead."),
+    (GLOBAL_CDIDX_RE, "global cdidx is blocked; use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead."),
+    (GIT_GREP_RE, "git grep is blocked; use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead."),
+    (re.compile(r"(?i)\brm\s+-[^\n;|&]*r[^\n;|&]*f\b|\brm\s+-[^\n;|&]*f[^\n;|&]*r\b"), "recursive forced rm is blocked"),
+    (re.compile(r"(?i)\brm\s+-r\b"), "recursive rm is blocked"),
+    (re.compile(r"(?i)\b(?:rmdir|unlink|shred|srm|truncate)\b"), "destructive filesystem command is blocked"),
+    (re.compile(r"(?i)\bdd\s+(?:if|of)="), "dd raw device/file copy is blocked"),
+    (re.compile(r"(?i)\b(?:mkfs|newfs)\b"), "filesystem formatting is blocked"),
+    (re.compile(r"(?i)\bdiskutil\s+(?:erase|partition|apfs\s+delete)\b"), "disk erase/partition operation is blocked"),
+    (re.compile(r"(?i)\bchmod\s+(?:777|-R)\b|\bchown\s+-R\b|\bchgrp\s+-R\b"), "dangerous recursive permission/owner change is blocked"),
+    (re.compile(r"(?i)\b(?:sudo|su|doas)\b"), "privilege escalation is blocked"),
+    (re.compile(r"(?i)\b(?:killall|pkill)\b|\bkill\s+-9\b"), "broad process killing is blocked"),
+    (re.compile(r"(?i)\b(?:curl|wget|http|https|xh|aria2c)\b"), "network download/exfil command is blocked"),
+    (re.compile(r"(?i)\b(?:curl|wget)\b.*\|\s*(?:sh|bash|zsh|python|ruby|perl)\b"), "download-and-execute is blocked"),
+    (re.compile(r"(?i)\b(?:ssh|scp|sftp|rsync|rclone|nc|ncat|netcat|socat|telnet|ftp)\b"), "remote shell/file transfer is blocked"),
+    (re.compile(r"(?i)\b(?:pbcopy|pbpaste)\b"), "clipboard access is blocked"),
+    (re.compile(r"(?i)\b(?:open|osascript|automator)\b|\bshortcuts\s+run\b"), "macOS automation/app launching is blocked"),
+    (re.compile(r"(?i)\b(?:launchctl|security|tccutil|spctl|csrutil|tmutil)\b"), "macOS security/system command is blocked"),
+    (re.compile(r"(?i)\bdefaults\s+write\b|\bplutil\s+-replace\b"), "macOS preference modification is blocked"),
+    (re.compile(r"(?i)\bgit\s+tag\b"), "git tag is blocked unless explicitly performed by the user"),
+    (re.compile(r"(?i)\bgit\s+reset\s+--hard\b"), "git reset --hard is blocked"),
+    (re.compile(r"(?i)\bgit\s+(?:checkout|restore)\s+\.\b"), "checkout/restore of entire worktree is blocked"),
+    (re.compile(r"(?i)\bgit\s+clean\s+-[^\n;|&]*f\b"), "git clean -f is blocked"),
+    (re.compile(r"(?i)\bgit\s+add\s+(?:\.|-A|--all)\b"), "bulk git add is blocked; add explicit safe files only"),
+    (re.compile(r"(?i)\bgit\s+commit\s+--amend\b|\bgit\s+rebase\b|\bgit\s+filter-branch\b|\bgit\s+update-ref\b"), "history rewriting is blocked"),
+    (re.compile(r"(?i)\b(?:npm|yarn|pnpm)\s+publish\b|\bdotnet\s+nuget\s+push\b|\bnuget\s+push\b"), "package publishing is blocked"),
+    (re.compile(r"(?i)\b(?:npm\s+login|npm\s+adduser)\b"), "package registry login is blocked"),
+    (re.compile(r"(?i)\b(?:npx|npm\s+exec|yarn\s+dlx|pnpm\s+dlx)\b"), "ephemeral package execution is blocked"),
+    (re.compile(r"(?i)\b(?:terraform\s+(?:apply|destroy)|kubectl\s+(?:apply|delete)|helm\s+(?:install|upgrade|uninstall))\b"), "infra mutation is blocked"),
+    (re.compile(r"(?i)\bdocker\s+(?:push|login|system\s+prune|volume\s+rm|rm|rmi)\b|\bdocker\s+buildx\s+build\b.*--push\b"), "dangerous docker operation is blocked"),
+    (re.compile(r"(?i)\b(?:aws|gcloud|az)\b"), "cloud CLI is blocked"),
+    (re.compile(r"(?i)\bgh\s+(?:auth|api|secret|release|repo\s+create|repo\s+fork|pr\s+merge)\b"), "GitHub CLI high-risk operation is blocked"),
+    (re.compile(r"(?i)\b(?:cat|less|more|head|tail|sed|awk|python|python3|node|ruby|perl|sqlite3)\b.*(?:\.env\b|\.env\.|\.pem\b|\.key\b|id_rsa|id_ed25519|credentials?|secrets?)"), "reading secret-looking files is blocked"),
+    (INLINE_SECRET_RE, "inline secret-looking value in command is blocked"),
+]
+
+_SCRIPT_FORBIDDEN_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (SEARCH_OR_DISCOVERY_RE, "script contains shell search/file-discovery command"),
+    (GIT_GREP_RE, "script contains git grep"),
+    *_FORBIDDEN_COMMAND_PATTERNS,
+]
+
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "AWS access key"),
+    (re.compile(r"ASIA[0-9A-Z]{16}"), "AWS temporary access key"),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private key"),
+    (re.compile(r"ghp_[A-Za-z0-9_]{30,}"), "GitHub classic token"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{60,}"), "GitHub fine-grained token"),
+    (re.compile(r"sk-[A-Za-z0-9_-]{20,}"), "OpenAI-style API key"),
+    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{20,}"), "Slack token"),
+    (re.compile(r"AIza[0-9A-Za-z_-]{35}"), "Google API key"),
+    (INLINE_SECRET_RE, "generic secret assignment"),
+]
+
+
+@dataclass(frozen=True)
+class GuardDecision:
+    allowed: bool
+    reason: str
+
+
+def _allow(reason: str) -> GuardDecision:
+    return GuardDecision(True, reason)
+
+
+def _deny(reason: str) -> GuardDecision:
+    return GuardDecision(False, reason)
+
+
+def _split_command(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return []
+
+
+def _token_path(token: str, cwd: Path) -> Path | None:
+    if not token or token.startswith("-"):
+        return None
+    if token in {"-c", "-e", "--eval", "-", "source", "."}:
+        return None
+    expanded = Path(os.path.expandvars(os.path.expanduser(token)))
+    if not expanded.is_absolute():
+        expanded = cwd / expanded
+    try:
+        return expanded.resolve()
+    except Exception:
+        return None
+
+
+def _command_mentions_local_cdidx(command: str, project_root: Path) -> bool:
+    tokens = _split_command(command)
+    if len(tokens) < 2:
+        return False
+    if tokens[0] != "dotnet":
+        return False
+    dll = _token_path(tokens[1], project_root)
+    expected = (project_root / LOCAL_CDIDX_REL).resolve()
+    return dll == expected
+
+
+def _command_is_safe_local_cdidx(command: str, cwd: Path, project_root: Path) -> bool:
+    if CONTROL_OP_RE.search(command):
+        return False
+    if COMMAND_SUBSTITUTION_RE.search(command):
+        return False
+    tokens = _split_command(command)
+    if len(tokens) < 2:
+        return False
+    if tokens[0] != "dotnet":
+        return False
+    dll = _token_path(tokens[1], cwd)
+    expected = (project_root / LOCAL_CDIDX_REL).resolve()
+    return dll == expected
+
+
+def _contains_inline_interpreter(command: str) -> bool:
+    return bool(INLINE_INTERPRETER_RE.search(command))
+
+
+def _contains_secret_like_assignment(text: str) -> bool:
+    return bool(INLINE_SECRET_RE.search(text))
+
+
+def evaluate_bash_command(command: str, cwd: Path, project_root: Path) -> GuardDecision:
+    if not isinstance(command, str) or not command.strip():
+        return _deny("Bash command missing from hook input; failing closed")
+
+    if _command_is_safe_local_cdidx(command, cwd, project_root):
+        return _allow("local cdidx command")
+
+    if _command_mentions_local_cdidx(command, project_root):
+        return _deny("local cdidx commands must not use shell control operators or command substitutions")
+
+    if LOCAL_CDIDX_DLL_RE.search(command):
+        return _deny("use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead")
+
+    for pattern, reason in _FORBIDDEN_COMMAND_PATTERNS:
+        if pattern.search(command):
+            return _deny(reason)
+
+    if _contains_inline_interpreter(command):
+        return _deny("inline interpreter execution is blocked; use a reviewed script file instead")
+
+    return _allow("bash-guard allow")
+
+
+def candidate_script_paths(command: str, cwd: Path) -> list[Path]:
+    tokens = _split_command(command)
+    if not tokens:
+        return []
+
+    result: list[Path] = []
+    first = Path(tokens[0]).name
+
+    if first in {"source", "."} and len(tokens) > 1:
+        path = _token_path(tokens[1], cwd)
+        if path is not None:
+            result.append(path)
+        return result
+
+    if first in {"bash", "sh", "zsh", "fish", "python", "python3", "ruby", "perl", "node", "deno", "php"}:
+        if any(token in _INLINE_INTERPRETER_FLAGS for token in tokens[1:]):
+            return result
+        for token in tokens[1:]:
+            if token.startswith("-"):
+                continue
+            path = _token_path(token, cwd)
+            if path is not None:
+                result.append(path)
+            break
+        return result
+
+    path = _token_path(tokens[0], cwd)
+    if path is None:
+        return result
+
+    if tokens[0].startswith(("./", "../", "/", "~")) or path.suffix.lower() in {
+        ".sh", ".bash", ".zsh", ".fish", ".py", ".rb", ".pl", ".js", ".mjs", ".cjs", ".ts", ".php"
+    }:
+        result.append(path)
+
+    return result
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def check_script_file(path: Path, project_root: Path) -> GuardDecision:
+    if not path.exists():
+        return _allow(f"script not found: {path}")
+    if not path.is_file():
+        return _deny(f"candidate script is not a file: {path}")
+
+    project_root = project_root.resolve()
+    try:
+        resolved = path.resolve()
+    except Exception as exc:
+        return _deny(f"could not resolve script path; failing closed: {path}: {exc}")
+
+    if not _is_relative_to(resolved, project_root):
+        return _deny(f"script outside project is blocked: {path}")
+
+    try:
+        data = resolved.read_bytes()[:MAX_SCRIPT_SCAN_BYTES]
+    except Exception as exc:
+        return _deny(f"could not inspect script before execution; failing closed: {path}: {exc}")
+
+    text = data.decode("utf-8", errors="ignore")
+    for pattern, reason in _SCRIPT_FORBIDDEN_PATTERNS:
+        if pattern.search(text):
+            return _deny(f"{reason}: {path}")
+    return _allow(f"script allowed: {path}")
+
+
+def staged_secret_check(cwd: Path) -> GuardDecision:
+    gitleaks = shutil.which("gitleaks")
+    if gitleaks:
+        try:
+            proc = subprocess.run(
+                [gitleaks, "protect", "--staged", "--redact", "--verbose"],
+                cwd=str(cwd),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception as exc:
+            return _deny(f"could not inspect staged diff for secrets with gitleaks; failing closed: {exc}")
+        if proc.returncode != 0:
+            output = (proc.stdout or "").strip()
+            if len(output) > 2000:
+                output = output[:2000] + "\n..."
+            return _deny("gitleaks blocked this commit:\n" + output)
+        return _allow("gitleaks passed")
+
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--cached", "--unified=0", "--no-ext-diff"],
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except Exception as exc:
+        return _deny(f"could not inspect staged diff for secrets; failing closed: {exc}")
+    if proc.returncode != 0:
+        return _deny("could not inspect staged diff for secrets; install gitleaks or fix git diff")
+
+    added_lines = "\n".join(
+        line[1:]
+        for line in (proc.stdout or "").splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+    for pattern, name in _SECRET_PATTERNS:
+        if pattern.search(added_lines):
+            return _deny(
+                f"secret-looking staged content detected before commit: {name}; install gitleaks for better scanning"
+            )
+    return _allow("staged secret scan passed")

--- a/.agent_harness/tests/test_command_guard_core.py
+++ b/.agent_harness/tests/test_command_guard_core.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import sys
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+
+def load_core():
+    root = Path(__file__).resolve().parents[2]
+    path = root / ".agent_harness" / "command_guard_core.py"
+    spec = importlib.util.spec_from_file_location("command_guard_core", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load guard core from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+core = load_core()
+
+
+class CommandGuardCoreTests(TestCase):
+    def test_allows_local_cdidx_relative_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            expected = root / core.LOCAL_CDIDX_REL
+            expected.parent.mkdir(parents=True, exist_ok=True)
+            expected.write_text("", encoding="utf-8")
+
+            decision = core.evaluate_bash_command(
+                "dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search SymbolExtractor",
+                cwd=root,
+                project_root=root,
+            )
+
+            self.assertTrue(decision.allowed)
+
+    def test_allows_local_cdidx_absolute_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            expected = root / core.LOCAL_CDIDX_REL
+            expected.parent.mkdir(parents=True, exist_ok=True)
+            expected.write_text("", encoding="utf-8")
+
+            decision = core.evaluate_bash_command(
+                f"dotnet {expected.resolve()} symbols --lang csharp",
+                cwd=root,
+                project_root=root,
+            )
+
+            self.assertTrue(decision.allowed)
+
+    def test_denies_global_cdidx_and_search_tools(self) -> None:
+        root = Path("/tmp")
+        for command in (
+            "cdidx search SymbolExtractor",
+            "~/.local/bin/cdidx search SymbolExtractor",
+            "$HOME/.local/bin/cdidx search SymbolExtractor",
+            "grep -R SymbolExtractor src",
+            "git grep SymbolExtractor",
+            "find . -name '*.cs'",
+        ):
+            with self.subTest(command=command):
+                decision = core.evaluate_bash_command(command, cwd=root, project_root=root)
+                self.assertFalse(decision.allowed)
+
+    def test_denies_chained_local_cdidx(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            expected = root / core.LOCAL_CDIDX_REL
+            expected.parent.mkdir(parents=True, exist_ok=True)
+            expected.write_text("", encoding="utf-8")
+
+            decision = core.evaluate_bash_command(
+                "dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search Foo | cat",
+                cwd=root,
+                project_root=root,
+            )
+
+            self.assertFalse(decision.allowed)
+
+    def test_denies_inline_interpreter_execution(self) -> None:
+        root = Path("/tmp")
+        decision = core.evaluate_bash_command("python3 -c 'print(1)'", cwd=root, project_root=root)
+        self.assertFalse(decision.allowed)
+
+    def test_candidate_script_paths_detects_direct_and_interpreter_scripts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            script = root / "tools" / "guard.py"
+            script.parent.mkdir(parents=True, exist_ok=True)
+            script.write_text("print('ok')", encoding="utf-8")
+
+            direct = core.candidate_script_paths("./tools/guard.py", cwd=root)
+            interpreter = core.candidate_script_paths("python3 tools/guard.py", cwd=root)
+            sourced = core.candidate_script_paths("source tools/guard.py", cwd=root)
+
+            self.assertEqual([script.resolve()], direct)
+            self.assertEqual([script.resolve()], interpreter)
+            self.assertEqual([script.resolve()], sourced)
+
+    def test_check_script_file_denies_outside_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            outside = Path(tmp).parent / "guard.py"
+            outside.write_text("print('ok')", encoding="utf-8")
+
+            decision = core.check_script_file(outside, project_root=root)
+
+            self.assertFalse(decision.allowed)
+
+    def test_check_script_file_denies_forbidden_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            script = root / "tools" / "guard.sh"
+            script.parent.mkdir(parents=True, exist_ok=True)
+            script.write_text("grep SymbolExtractor src\n", encoding="utf-8")
+
+            decision = core.check_script_file(script, project_root=root)
+
+            self.assertFalse(decision.allowed)
+
+    def test_staged_secret_check_uses_git_diff_fallback(self) -> None:
+        fake_proc = Mock(returncode=0, stdout="+ api_key = 'sk-abcdefghijklmnopqrstuvwx123456'\n", stderr="")
+
+        with patch.object(core.shutil, "which", return_value=None), patch.object(core.subprocess, "run", return_value=fake_proc):
+            decision = core.staged_secret_check(Path("/tmp"))
+
+        self.assertFalse(decision.allowed)

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,24 @@
+# Codex Setup
+
+This repository includes a project-local Codex config and hook policy.
+
+## Enable and trust
+
+Open the repository in Codex and trust the project when prompted so Codex loads
+`.codex/config.toml` and `.codex/hooks.json`.
+
+Keep the config repository-local. Do not add machine-specific home directory
+paths to committed config files.
+
+## Safe usage
+
+For CodeIndex work, dogfood the repo-built binary for code search:
+
+```bash
+dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search SymbolExtractor
+dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll symbols --lang csharp
+dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll inspect src/CodeIndex/Indexer/SymbolExtractor.cs
+```
+
+The guard hooks block grep-like search escape hatches, global `cdidx`, and
+high-risk commands so Codex stays inside the repository policy.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,34 @@
-# Repository-local Codex config
-project_doc_fallback_filenames = ["CLAUDE.md"]
+# CodeIndex Codex project configuration.
+# Project-local Codex config loads only after the project is trusted.
+
+project_doc_fallback_filenames = ["AGENTS.md", "CLAUDE.md"]
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+web_search = "disabled"
+default_permissions = "codeindex_workspace"
+
+[features]
+codex_hooks = true
+
+[sandbox_workspace_write]
+network_access = false
+exclude_slash_tmp = true
+exclude_tmpdir_env_var = true
+
+[permissions.codeindex_workspace.filesystem]
+glob_scan_max_depth = 6
+
+[permissions.codeindex_workspace.filesystem.":project_roots"]
+"." = "write"
+"**/.env" = "none"
+"**/.env.*" = "none"
+"**/*.pem" = "none"
+"**/*.key" = "none"
+"**/id_rsa" = "none"
+"**/id_ed25519" = "none"
+"**/*credentials*" = "none"
+"**/*secret*" = "none"
+"**/*secrets*" = "none"
+
+[permissions.codeindex_workspace.network]
+enabled = false

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/bash_guard.py\"",
+            "timeout": 30,
+            "statusMessage": "Checking Bash command against CodeIndex guard"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/permission_request_guard.py\"",
+            "timeout": 30,
+            "statusMessage": "Checking Bash approval request against CodeIndex guard"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/bash_guard.py
+++ b/.codex/hooks/bash_guard.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""
-Claude Code PreToolUse Bash guard for Widthdom/CodeIndex.
-
-Thin adapter around the shared CodeIndex guard core.
-"""
+"""Codex PreToolUse Bash guard for Widthdom/CodeIndex."""
 
 from __future__ import annotations
 
@@ -31,58 +27,20 @@ def load_core():
 core = load_core()
 
 
-def emit_allow(reason: str) -> None:
-    print(
-        json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "allow",
-                    "permissionDecisionReason": reason,
-                }
-            },
-            ensure_ascii=False,
-        )
-    )
-    sys.exit(0)
-
-
-def emit_deny(reason: str) -> None:
-    print(
-        json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": reason,
-                }
-            },
-            ensure_ascii=False,
-        )
-    )
-    sys.exit(0)
-
-
 def load_payload() -> dict:
     try:
         return json.load(sys.stdin)
-    except Exception as exc:
-        emit_deny(f"failed to parse Claude Code hook input; failing closed: {exc}")
+    except Exception:
+        return {}
 
 
 def get_command(payload: dict) -> str:
     tool_input = payload.get("tool_input") or {}
     command = tool_input.get("command")
-    if not isinstance(command, str):
-        emit_deny("Bash command missing from hook input; failing closed")
-    return command
+    return command if isinstance(command, str) else ""
 
 
 def resolve_project_root(cwd: Path) -> Path:
-    env_root = os.environ.get("CLAUDE_PROJECT_DIR")
-    if env_root:
-        return Path(env_root).resolve()
-
     try:
         proc = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -103,6 +61,22 @@ def resolve_project_root(cwd: Path) -> Path:
     return cwd.resolve()
 
 
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+    sys.exit(2)
+
+
 def main() -> None:
     payload = load_payload()
     command = get_command(payload)
@@ -111,19 +85,19 @@ def main() -> None:
 
     decision = core.evaluate_bash_command(command, cwd=cwd, project_root=project_root)
     if not decision.allowed:
-        emit_deny(decision.reason)
+        deny(decision.reason)
 
     for script in core.candidate_script_paths(command, cwd):
         script_decision = core.check_script_file(script, project_root)
         if not script_decision.allowed:
-            emit_deny(script_decision.reason)
+            deny(script_decision.reason)
 
     if re.search(r"(?i)(^|[\s;&|()`])git\s+commit\b", command):
         commit_decision = core.staged_secret_check(cwd)
         if not commit_decision.allowed:
-            emit_deny(commit_decision.reason)
+            deny(commit_decision.reason)
 
-    emit_allow(decision.reason)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/.codex/hooks/permission_request_guard.py
+++ b/.codex/hooks/permission_request_guard.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python3
-"""
-Claude Code PreToolUse Bash guard for Widthdom/CodeIndex.
-
-Thin adapter around the shared CodeIndex guard core.
-"""
+"""Codex PermissionRequest Bash guard for Widthdom/CodeIndex."""
 
 from __future__ import annotations
 
 import importlib.util
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -31,58 +26,20 @@ def load_core():
 core = load_core()
 
 
-def emit_allow(reason: str) -> None:
-    print(
-        json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "allow",
-                    "permissionDecisionReason": reason,
-                }
-            },
-            ensure_ascii=False,
-        )
-    )
-    sys.exit(0)
-
-
-def emit_deny(reason: str) -> None:
-    print(
-        json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": reason,
-                }
-            },
-            ensure_ascii=False,
-        )
-    )
-    sys.exit(0)
-
-
 def load_payload() -> dict:
     try:
         return json.load(sys.stdin)
-    except Exception as exc:
-        emit_deny(f"failed to parse Claude Code hook input; failing closed: {exc}")
+    except Exception:
+        return {}
 
 
 def get_command(payload: dict) -> str:
     tool_input = payload.get("tool_input") or {}
     command = tool_input.get("command")
-    if not isinstance(command, str):
-        emit_deny("Bash command missing from hook input; failing closed")
-    return command
+    return command if isinstance(command, str) else ""
 
 
 def resolve_project_root(cwd: Path) -> Path:
-    env_root = os.environ.get("CLAUDE_PROJECT_DIR")
-    if env_root:
-        return Path(env_root).resolve()
-
     try:
         proc = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -103,27 +60,34 @@ def resolve_project_root(cwd: Path) -> Path:
     return cwd.resolve()
 
 
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {
+                        "behavior": "deny",
+                        "message": f"Blocked by CodeIndex guard: {reason}",
+                    },
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+    sys.exit(0)
+
+
 def main() -> None:
     payload = load_payload()
     command = get_command(payload)
     cwd = Path(payload.get("cwd") or os.getcwd()).resolve()
     project_root = resolve_project_root(cwd)
-
     decision = core.evaluate_bash_command(command, cwd=cwd, project_root=project_root)
     if not decision.allowed:
-        emit_deny(decision.reason)
+        deny(decision.reason)
 
-    for script in core.candidate_script_paths(command, cwd):
-        script_decision = core.check_script_file(script, project_root)
-        if not script_decision.allowed:
-            emit_deny(script_decision.reason)
-
-    if re.search(r"(?i)(^|[\s;&|()`])git\s+commit\b", command):
-        commit_decision = core.staged_secret_check(cwd)
-        if not commit_decision.allowed:
-            emit_deny(commit_decision.reason)
-
-    emit_allow(decision.reason)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/.codex/rules/codeindex.rules
+++ b/.codex/rules/codeindex.rules
@@ -34,6 +34,13 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["fdfind"],
+    decision = "forbidden",
+    justification = "Use the locally built cdidx.dll instead of fd for repository discovery.",
+    match = ["fdfind SymbolExtractor"],
+)
+
+prefix_rule(
     pattern = ["locate"],
     decision = "forbidden",
     justification = "Use the locally built cdidx.dll instead of locate for repository discovery.",
@@ -41,10 +48,80 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["mlocate"],
+    decision = "forbidden",
+    justification = "Use the locally built cdidx.dll instead of locate for repository discovery.",
+    match = ["mlocate SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["mdfind"],
+    decision = "forbidden",
+    justification = "Use the locally built cdidx.dll instead of locate for repository discovery.",
+    match = ["mdfind SymbolExtractor"],
+)
+
+prefix_rule(
     pattern = ["cdidx"],
     decision = "forbidden",
     justification = "Global cdidx is blocked; use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll.",
     match = ["cdidx search Foo"],
+)
+
+prefix_rule(
+    pattern = ["egrep"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep-like tools for CodeIndex dogfooding.",
+    match = ["egrep SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["fgrep"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep-like tools for CodeIndex dogfooding.",
+    match = ["fgrep SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["zgrep"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep-like tools for CodeIndex dogfooding.",
+    match = ["zgrep SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["rgrep"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep-like tools for CodeIndex dogfooding.",
+    match = ["rgrep SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["ripgrep"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep-like tools for CodeIndex dogfooding.",
+    match = ["ripgrep SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["ag"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep-like tools for CodeIndex dogfooding.",
+    match = ["ag SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["ack"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep-like tools for CodeIndex dogfooding.",
+    match = ["ack SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["ack-grep"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep-like tools for CodeIndex dogfooding.",
+    match = ["ack-grep SymbolExtractor"],
 )
 
 prefix_rule(
@@ -97,6 +174,27 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["scp"],
+    decision = "forbidden",
+    justification = "Remote shell and file transfer commands are blocked.",
+    match = ["scp file example.com:/tmp/"],
+)
+
+prefix_rule(
+    pattern = ["rsync"],
+    decision = "forbidden",
+    justification = "Remote shell and file transfer commands are blocked.",
+    match = ["rsync -av . example.com:/tmp/"],
+)
+
+prefix_rule(
+    pattern = ["rclone"],
+    decision = "forbidden",
+    justification = "Remote shell and file transfer commands are blocked.",
+    match = ["rclone copy . remote:bucket"],
+)
+
+prefix_rule(
     pattern = ["git", "reset", "--hard"],
     decision = "forbidden",
     justification = "History-rewriting Git operations are blocked.",
@@ -146,6 +244,76 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["npm", "exec"],
+    decision = "forbidden",
+    justification = "Ephemeral package execution is blocked.",
+    match = ["npm exec create-vite@latest"],
+)
+
+prefix_rule(
+    pattern = ["yarn", "dlx"],
+    decision = "forbidden",
+    justification = "Ephemeral package execution is blocked.",
+    match = ["yarn dlx create-vite"],
+)
+
+prefix_rule(
+    pattern = ["pnpm", "dlx"],
+    decision = "forbidden",
+    justification = "Ephemeral package execution is blocked.",
+    match = ["pnpm dlx create-vite"],
+)
+
+prefix_rule(
+    pattern = ["npm", "publish"],
+    decision = "forbidden",
+    justification = "Package publishing and registry login are blocked.",
+    match = ["npm publish"],
+)
+
+prefix_rule(
+    pattern = ["yarn", "publish"],
+    decision = "forbidden",
+    justification = "Package publishing and registry login are blocked.",
+    match = ["yarn publish"],
+)
+
+prefix_rule(
+    pattern = ["pnpm", "publish"],
+    decision = "forbidden",
+    justification = "Package publishing and registry login are blocked.",
+    match = ["pnpm publish"],
+)
+
+prefix_rule(
+    pattern = ["dotnet", "nuget", "push"],
+    decision = "forbidden",
+    justification = "Package publishing and registry login are blocked.",
+    match = ["dotnet nuget push pkg.nupkg --source nuget.org"],
+)
+
+prefix_rule(
+    pattern = ["nuget", "push"],
+    decision = "forbidden",
+    justification = "Package publishing and registry login are blocked.",
+    match = ["nuget push pkg.nupkg"],
+)
+
+prefix_rule(
+    pattern = ["npm", "login"],
+    decision = "forbidden",
+    justification = "Package publishing and registry login are blocked.",
+    match = ["npm login"],
+)
+
+prefix_rule(
+    pattern = ["npm", "adduser"],
+    decision = "forbidden",
+    justification = "Package publishing and registry login are blocked.",
+    match = ["npm adduser"],
+)
+
+prefix_rule(
     pattern = ["terraform", "apply"],
     decision = "forbidden",
     justification = "Terraform mutation commands are blocked.",
@@ -171,6 +339,27 @@ prefix_rule(
     decision = "forbidden",
     justification = "Kubernetes mutation commands are blocked.",
     match = ["kubectl delete pod demo"],
+)
+
+prefix_rule(
+    pattern = ["helm", "install"],
+    decision = "forbidden",
+    justification = "Infrastructure mutation commands are blocked.",
+    match = ["helm install demo chart"],
+)
+
+prefix_rule(
+    pattern = ["helm", "upgrade"],
+    decision = "forbidden",
+    justification = "Infrastructure mutation commands are blocked.",
+    match = ["helm upgrade demo chart"],
+)
+
+prefix_rule(
+    pattern = ["helm", "uninstall"],
+    decision = "forbidden",
+    justification = "Infrastructure mutation commands are blocked.",
+    match = ["helm uninstall demo"],
 )
 
 prefix_rule(
@@ -269,4 +458,25 @@ prefix_rule(
     decision = "forbidden",
     justification = "High-risk GitHub CLI operations are blocked.",
     match = ["gh pr merge 123"],
+)
+
+prefix_rule(
+    pattern = ["aws"],
+    decision = "forbidden",
+    justification = "Cloud CLI operations are blocked.",
+    match = ["aws s3 ls"],
+)
+
+prefix_rule(
+    pattern = ["gcloud"],
+    decision = "forbidden",
+    justification = "Cloud CLI operations are blocked.",
+    match = ["gcloud compute instances list"],
+)
+
+prefix_rule(
+    pattern = ["az"],
+    decision = "forbidden",
+    justification = "Cloud CLI operations are blocked.",
+    match = ["az account show"],
 )

--- a/.codex/rules/codeindex.rules
+++ b/.codex/rules/codeindex.rules
@@ -1,0 +1,272 @@
+prefix_rule(
+    pattern = ["rg"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of rg for CodeIndex dogfooding.",
+    match = ["rg SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["grep"],
+    decision = "forbidden",
+    justification = "Use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll instead of grep for CodeIndex dogfooding.",
+    match = ["grep -R SymbolExtractor src"],
+)
+
+prefix_rule(
+    pattern = ["git", "grep"],
+    decision = "forbidden",
+    justification = "Use the locally built cdidx.dll instead of git grep.",
+    match = ["git grep SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["find"],
+    decision = "forbidden",
+    justification = "Use the locally built cdidx.dll instead of find for repository discovery.",
+    match = ["find . -name '*.cs'"],
+)
+
+prefix_rule(
+    pattern = ["fd"],
+    decision = "forbidden",
+    justification = "Use the locally built cdidx.dll instead of fd for repository discovery.",
+    match = ["fd SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["locate"],
+    decision = "forbidden",
+    justification = "Use the locally built cdidx.dll instead of locate for repository discovery.",
+    match = ["locate SymbolExtractor"],
+)
+
+prefix_rule(
+    pattern = ["cdidx"],
+    decision = "forbidden",
+    justification = "Global cdidx is blocked; use dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll.",
+    match = ["cdidx search Foo"],
+)
+
+prefix_rule(
+    pattern = ["rm", "-rf"],
+    decision = "forbidden",
+    justification = "Recursive removal is blocked unless the task explicitly requires it.",
+    match = ["rm -rf /tmp/example"],
+)
+
+prefix_rule(
+    pattern = ["rm", "-fr"],
+    decision = "forbidden",
+    justification = "Recursive removal is blocked unless the task explicitly requires it.",
+    match = ["rm -fr /tmp/example"],
+)
+
+prefix_rule(
+    pattern = ["rm", "-r"],
+    decision = "forbidden",
+    justification = "Recursive removal is blocked unless the task explicitly requires it.",
+    match = ["rm -r /tmp/example"],
+)
+
+prefix_rule(
+    pattern = ["sudo"],
+    decision = "forbidden",
+    justification = "Privilege escalation is blocked.",
+    match = ["sudo cat /etc/hosts"],
+)
+
+prefix_rule(
+    pattern = ["curl"],
+    decision = "forbidden",
+    justification = "Network transfer commands are blocked.",
+    match = ["curl https://example.com"],
+)
+
+prefix_rule(
+    pattern = ["wget"],
+    decision = "forbidden",
+    justification = "Network transfer commands are blocked.",
+    match = ["wget https://example.com"],
+)
+
+prefix_rule(
+    pattern = ["ssh"],
+    decision = "forbidden",
+    justification = "Remote shell and file transfer commands are blocked.",
+    match = ["ssh example.com"],
+)
+
+prefix_rule(
+    pattern = ["git", "reset", "--hard"],
+    decision = "forbidden",
+    justification = "History-rewriting Git operations are blocked.",
+    match = ["git reset --hard"],
+)
+
+prefix_rule(
+    pattern = ["git", "clean", "-f"],
+    decision = "forbidden",
+    justification = "History-rewriting Git operations are blocked.",
+    match = ["git clean -fdx"],
+)
+
+prefix_rule(
+    pattern = ["git", "add", "."],
+    decision = "forbidden",
+    justification = "Bulk Git adds are blocked; add explicit files instead.",
+    match = ["git add ."],
+)
+
+prefix_rule(
+    pattern = ["git", "add", "-A"],
+    decision = "forbidden",
+    justification = "Bulk Git adds are blocked; add explicit files instead.",
+    match = ["git add -A"],
+)
+
+prefix_rule(
+    pattern = ["git", "rebase"],
+    decision = "forbidden",
+    justification = "History rewriting is blocked.",
+    match = ["git rebase main"],
+)
+
+prefix_rule(
+    pattern = ["git", "commit", "--amend"],
+    decision = "forbidden",
+    justification = "Amending commits is blocked; create a new commit instead.",
+    match = ["git commit --amend"],
+)
+
+prefix_rule(
+    pattern = ["npx"],
+    decision = "forbidden",
+    justification = "Ephemeral package execution is blocked.",
+    match = ["npx create-react-app demo"],
+)
+
+prefix_rule(
+    pattern = ["terraform", "apply"],
+    decision = "forbidden",
+    justification = "Terraform mutation commands are blocked.",
+    match = ["terraform apply"],
+)
+
+prefix_rule(
+    pattern = ["terraform", "destroy"],
+    decision = "forbidden",
+    justification = "Terraform mutation commands are blocked.",
+    match = ["terraform destroy"],
+)
+
+prefix_rule(
+    pattern = ["kubectl", "apply"],
+    decision = "forbidden",
+    justification = "Kubernetes mutation commands are blocked.",
+    match = ["kubectl apply -f k8s.yaml"],
+)
+
+prefix_rule(
+    pattern = ["kubectl", "delete"],
+    decision = "forbidden",
+    justification = "Kubernetes mutation commands are blocked.",
+    match = ["kubectl delete pod demo"],
+)
+
+prefix_rule(
+    pattern = ["docker", "push"],
+    decision = "forbidden",
+    justification = "Dangerous Docker operations are blocked.",
+    match = ["docker push example/app:latest"],
+)
+
+prefix_rule(
+    pattern = ["docker", "login"],
+    decision = "forbidden",
+    justification = "Dangerous Docker operations are blocked.",
+    match = ["docker login"],
+)
+
+prefix_rule(
+    pattern = ["docker", "system", "prune"],
+    decision = "forbidden",
+    justification = "Dangerous Docker operations are blocked.",
+    match = ["docker system prune"],
+)
+
+prefix_rule(
+    pattern = ["docker", "volume", "rm"],
+    decision = "forbidden",
+    justification = "Dangerous Docker operations are blocked.",
+    match = ["docker volume rm demo"],
+)
+
+prefix_rule(
+    pattern = ["docker", "rm"],
+    decision = "forbidden",
+    justification = "Dangerous Docker operations are blocked.",
+    match = ["docker rm demo"],
+)
+
+prefix_rule(
+    pattern = ["docker", "rmi"],
+    decision = "forbidden",
+    justification = "Dangerous Docker operations are blocked.",
+    match = ["docker rmi demo"],
+)
+
+prefix_rule(
+    pattern = ["docker", "buildx", "build", "--push"],
+    decision = "forbidden",
+    justification = "Dangerous Docker operations are blocked.",
+    match = ["docker buildx build --push ."],
+)
+
+prefix_rule(
+    pattern = ["gh", "auth"],
+    decision = "forbidden",
+    justification = "High-risk GitHub CLI operations are blocked.",
+    match = ["gh auth login"],
+)
+
+prefix_rule(
+    pattern = ["gh", "api"],
+    decision = "forbidden",
+    justification = "High-risk GitHub CLI operations are blocked.",
+    match = ["gh api repos/Widthdom/CodeIndex"],
+)
+
+prefix_rule(
+    pattern = ["gh", "secret"],
+    decision = "forbidden",
+    justification = "High-risk GitHub CLI operations are blocked.",
+    match = ["gh secret set TOKEN"],
+)
+
+prefix_rule(
+    pattern = ["gh", "release"],
+    decision = "forbidden",
+    justification = "High-risk GitHub CLI operations are blocked.",
+    match = ["gh release create v1.0.0"],
+)
+
+prefix_rule(
+    pattern = ["gh", "repo", "create"],
+    decision = "forbidden",
+    justification = "High-risk GitHub CLI operations are blocked.",
+    match = ["gh repo create demo"],
+)
+
+prefix_rule(
+    pattern = ["gh", "repo", "fork"],
+    decision = "forbidden",
+    justification = "High-risk GitHub CLI operations are blocked.",
+    match = ["gh repo fork Widthdom/CodeIndex"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "merge"],
+    decision = "forbidden",
+    justification = "High-risk GitHub CLI operations are blocked.",
+    match = ["gh pr merge 123"],
+)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,23 @@ For task-specific procedures, read the relevant workflow in `.codex/workflows/`:
 - related/new issue scope control: `.codex/workflows/issue-scope.md`
 
 Do not duplicate workflow rules in this file. Update the shared files instead.
+
+## Code search and safety policy
+
+For CodeIndex work, dogfood the project-built CodeIndex binary.
+
+Do not use grep, rg, ripgrep, ag, ack, find, fd, locate, git grep, Python scripts,
+or a globally installed cdidx for code search or repository discovery.
+
+Use:
+
+`dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll`
+
+Examples:
+
+- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search SymbolExtractor`
+- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll symbols --lang csharp`
+- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll inspect src/CodeIndex/Indexer/SymbolExtractor.cs`
+
+This instruction is a workflow rule. Enforcement is provided separately by the
+Claude and Codex guard hooks.


### PR DESCRIPTION
Summary
- Added a shared Python guard core for Claude and Codex command policy.
- Rewired the Claude Bash guard to use the shared core and added Codex PreToolUse and PermissionRequest adapters.
- Added project-local Codex config, hooks, rules, README docs, and AGENTS policy.
- Added Python tests for allowed and denied command cases plus script and secret-scan coverage.

Validation
- dotnet build CodeIndex.sln -c Release
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json
- python3 -m unittest discover -s .agent_harness/tests -p 'test_*.py'
- python3 -c "import tomllib; from pathlib import Path; tomllib.loads(Path('.codex/config.toml').read_text(encoding='utf-8'))"
- python3 -c "import json; from pathlib import Path; json.loads(Path('.codex/hooks.json').read_text(encoding='utf-8'))"
- python3 -c "import ast; from pathlib import Path; files=['.agent_harness/command_guard_core.py', '.claude/hooks/bash-guard.py', '.codex/hooks/bash_guard.py', '.codex/hooks/permission_request_guard.py']; [ast.parse(Path(f).read_text(encoding='utf-8')) for f in files]"