### PR TITLE
Tighten agent docs and changelog rules

### DIFF
--- a/.codex/workflows/issue-fix.md
+++ b/.codex/workflows/issue-fix.md
@@ -31,7 +31,7 @@ Use this workflow for GitHub issue implementation tasks.
 10. Produce a plan of at most 10 lines. Include only likely changed files or areas, validation commands, and risks.
 11. Implement the smallest correct fix.
 12. Add or update tests for changed behavior.
-13. Update documentation and changelog only when appropriate. If the changelog is edited, verify both English and Japanese entries according to repository convention.
+13. Update documentation and changelog whenever the issue changes user-visible behavior, CLI/MCP output, flags, error messages, install/release behavior, or workflow behavior. Skip them only for strictly internal changes, and record the rationale explicitly if you do.
 14. Run relevant validation commands.
 15. Follow `.codex/workflows/precommit.md` before committing.
 16. Commit with an English commit message that includes relevant issue numbers.

--- a/.codex/workflows/pr-finalize.md
+++ b/.codex/workflows/pr-finalize.md
@@ -10,6 +10,7 @@ Use this after implementation, commit, and review are complete.
 4. The PR body must include:
    - summary;
    - validation;
+   - documentation/changelog updates, or a clear rationale if none were required;
    - `Fixes #...` lines for issues that should auto-close;
    - follow-up candidates, if any.
 

--- a/.codex/workflows/precommit.md
+++ b/.codex/workflows/precommit.md
@@ -8,12 +8,13 @@ Run this before each commit.
 2. Confirm no unrelated refactors were added.
 3. Confirm code search followed the local `cdidx` rule from `AGENT_GUIDE.md`.
 4. Run the relevant build and test commands for the files changed.
-5. If public behavior changed, confirm tests were added or updated.
-6. If documentation changed, confirm it matches implementation.
+5. If public behavior, CLI/MCP output, install/release behavior, or workflow behavior changed, confirm matching docs and changelog updates are present in the same change unless you can clearly justify why they are unnecessary.
+6. If documentation changed, confirm it matches implementation and covers the user-facing contract accurately.
 7. If changelog content changed, confirm both English and Japanese entries are present where required by repository convention.
-8. Confirm issue auto-close references will be placed in the PR body as `Fixes #...`.
-9. Confirm the commit message is English and includes relevant issue numbers.
-10. Check `git diff --stat` and `git diff` for accidental changes.
+8. If docs or changelog were intentionally omitted for a user-visible change, stop and fix that before committing.
+9. Confirm issue auto-close references will be placed in the PR body as `Fixes #...`.
+10. Confirm the commit message is English and includes relevant issue numbers.
+11. Check `git diff --stat` and `git diff` for accidental changes.
 
 ## Validation Commands
 

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -56,12 +56,19 @@ Avoid unrelated refactors.
 Preserve public behavior unless the issue explicitly requires a change.
 When editing changelog content, verify that both English and Japanese entries are updated where the repository convention requires both.
 
+## Documentation Rules
+
+- Treat documentation as part of the feature contract, not as optional cleanup.
+- If a change affects user-visible behavior, CLI/MCP output, flags, error messages, install/release behavior, or contributor/agent workflow, update the matching docs in the same change. For CodeIndex this usually means `README.md`, `DEVELOPER_GUIDE.md`, `TESTING_GUIDE.md`, `SELF_IMPROVEMENT.md`, `INTEGRATION_POLICY.md`, `CLAUDE.md`, `AGENT_GUIDE.md`, or the relevant `.codex/workflows/*.md` file.
+- Do not open or merge a PR with a user-visible change unless the required docs and changelog updates are present, or the PR body explicitly explains why no docs/changelog change is needed.
+- Changelog entries are required for user-visible or behavior-changing work. If `CHANGELOG.md` is edited, update both English and Japanese sections in the same commit.
+
 ## Repository Rules
 
 - Follow `DEVELOPER_GUIDE.md` for architecture and dependency policy. Production/runtime dependencies stay limited to `Microsoft.Data.Sqlite`.
 - Follow `TESTING_GUIDE.md` for test conventions, helpers, and parallelism rules.
 - Follow `SELF_IMPROVEMENT.md` when the task is about improving `cdidx` itself.
-- If a change is user-facing, keep the matching tests, docs, and changelog entry in the same commit when practical.
+- If a change is user-facing, keep the matching tests, docs, and changelog entry in the same commit.
 - Preserve cross-platform behavior when touching filesystem behavior, process execution, console output, or SQLite lifetime.
 - Ask before implementing breaking, destructive, or user-workflow-changing changes.
 


### PR DESCRIPTION
## Summary
- Added explicit documentation and changelog requirements for user-visible changes.
- Strengthened precommit, issue-fix, and PR finalization workflows so missing docs/changelog updates are treated as a blocking gap.

## Validation
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files AGENT_GUIDE.md .codex/workflows/precommit.md .codex/workflows/issue-fix.md .codex/workflows/pr-finalize.md --json`
- Reviewed the diff with `git diff --stat` and `git diff`.

## Documentation / Changelog
- Updated `AGENT_GUIDE.md` and the shared workflow files.
- No `CHANGELOG.md` entry was needed because this change only tightens internal agent process rules.

## Follow-up
- None.