### PR TITLE
Fix Java text block reference leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1965,3 +1965,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [1.0.2]: https://github.com/Widthdom/CodeIndex/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Widthdom/CodeIndex/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Widthdom/CodeIndex/releases/tag/v1.0.0
+## Unreleased
+
+- Fix Java text blocks so call-shaped lines inside `"""..."""` bodies no longer emit phantom `call` references.

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -767,7 +767,10 @@ public static class ReferenceExtractor
         if (content.Contains('\r'))
             content = content.Replace("\r\n", "\n").Replace("\r", "\n");
         content = FileIndexer.StripLineLeadingBom(content);
-        var lines = content.Split('\n');
+        var maskedContent = string.Equals(language, "java", StringComparison.OrdinalIgnoreCase)
+            ? MaskJavaTextBlocks(content)
+            : content;
+        var lines = maskedContent.Split('\n');
         var structuralLines = StructuralLineMasker.MaskLines(language, lines, out var jsTaggedTemplateHits);
         var csharpLinesInsideMultilineStringContent = language == "csharp"
             ? BuildCSharpMultilineStringContentLines(lines)
@@ -13271,4 +13274,68 @@ public static class ReferenceExtractor
 
     private static bool IsPythonStringPrefixChar(char c) =>
         c is 'r' or 'R' or 'u' or 'U' or 'b' or 'B' or 'f' or 'F';
+
+    private static string MaskJavaTextBlocks(string content)
+    {
+        var chars = content.ToCharArray();
+
+        for (var i = 0; i + 2 < chars.Length; i++)
+        {
+            if (!IsJavaTextBlockOpening(chars, i))
+                continue;
+
+            // Mask the body but keep line breaks so all existing line/column logic stays valid.
+            i += 3;
+            while (i < chars.Length)
+            {
+                if (i + 2 < chars.Length
+                    && chars[i] == '"'
+                    && chars[i + 1] == '"'
+                    && chars[i + 2] == '"'
+                    && !IsEscapedByBackslashes(chars, i))
+                {
+                    i += 2;
+                    break;
+                }
+
+                if (chars[i] != '\r' && chars[i] != '\n')
+                    chars[i] = ' ';
+                i++;
+            }
+        }
+
+        return new string(chars);
+    }
+
+    private static bool IsJavaTextBlockOpening(IReadOnlyList<char> chars, int index)
+    {
+        if (index + 2 >= chars.Count)
+            return false;
+
+        if (chars[index] != '"' || chars[index + 1] != '"' || chars[index + 2] != '"')
+            return false;
+
+        if (IsEscapedByBackslashes(chars, index))
+            return false;
+
+        for (var i = index + 3; i < chars.Count; i++)
+        {
+            var c = chars[i];
+            if (c == '\r' || c == '\n')
+                return true;
+            if (!char.IsWhiteSpace(c))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsEscapedByBackslashes(IReadOnlyList<char> chars, int index)
+    {
+        var backslashCount = 0;
+        for (var i = index - 1; i >= 0 && chars[i] == '\\'; i--)
+            backslashCount++;
+
+        return (backslashCount & 1) == 1;
+    }
 }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -408,6 +408,62 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaTextBlock_DoesNotEmitPhantomCallReferences()
+    {
+        const string content = """"
+            public class Main {
+                void doReal() {
+                    legitimateCall();
+                    another(1, 2);
+                }
+
+                String templateA = """
+                    SELECT * FROM users WHERE name = badCall(x);
+                    UPDATE phantomMethod(arg) SET y = z;
+                    otherFake(1, 2, 3);
+                    """;
+
+                String templateB = """
+                    someIdentifier();
+
+                    """;
+
+                String templateC = """
+                    literal only
+                    """ + suffix();
+
+                void legitimateCall() {}
+                void another(int a, int b) {}
+                String suffix() { return ""; }
+            }
+            """";
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "badCall"
+            && reference.ReferenceKind == "call");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "otherFake"
+            && reference.ReferenceKind == "call");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "someIdentifier"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "legitimateCall"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "doReal");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "another"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "doReal");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "suffix"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_CsharpInterpolatedRawString_KeepsInterpolationCallReferences()
     {
         const string content = """"


### PR DESCRIPTION
Fix Java 15+ text blocks so call-shaped lines inside `"""..."""` bodies are masked before reference extraction.

Tests: `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter ReferenceExtractorTests`

Fixes #301