### PR TITLE
[codex] Handle legacy changelog footer tags

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -114,6 +114,8 @@ unreleased comparison target:
 - `[Unreleased]` should compare from the current release version to `HEAD`;
 - the new release tag should compare from the previous version to the new tag;
 - older version links stay intact and are not duplicated.
+- legacy `[version]: .../releases/tag/vX.Y.Z` footer lines are tolerated and
+  preserved when present in older changelog files.
 
 ## Examples
 

--- a/tests/CodeIndex.Tests/ChangelogToolTests.cs
+++ b/tests/CodeIndex.Tests/ChangelogToolTests.cs
@@ -33,6 +33,7 @@ public sealed class ChangelogToolTests
         Assert.Contains("### [Unreleased]\n\n### [1.17.0] - 2026-05-01", changelog.Replace("\r\n", "\n"));
         Assert.Contains("[Unreleased]: https://github.com/Widthdom/CodeIndex/compare/v1.17.0...HEAD", changelog);
         Assert.Contains("[1.17.0]: https://github.com/Widthdom/CodeIndex/compare/v1.16.0...v1.17.0", changelog);
+        Assert.Contains("[1.0.0]: https://github.com/Widthdom/CodeIndex/releases/tag/v1.0.0", changelog);
         Assert.Equal("""
             {
               "version": "1.17.0"
@@ -220,6 +221,7 @@ public sealed class ChangelogToolTests
 
         [Unreleased]: https://github.com/Widthdom/CodeIndex/compare/v1.16.0...HEAD
         [1.16.0]: https://github.com/Widthdom/CodeIndex/compare/v1.15.3...v1.16.0
+        [1.0.0]: https://github.com/Widthdom/CodeIndex/releases/tag/v1.0.0
         """;
 
     private const string SampleFragment = """

--- a/tools/CodeIndex.Changelog/Program.cs
+++ b/tools/CodeIndex.Changelog/Program.cs
@@ -164,6 +164,7 @@ public sealed class ChangelogTool
     private static readonly Regex SlugFragmentNameRegex = new(@"^\+(?<slug>[A-Za-z0-9][A-Za-z0-9-]*)\.(?<category>added|changed|fixed|deprecated|removed|security|docs|internal)\.md$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex ReleaseHeadingRegex = new(@"^### \[[^\]]+\](?: - .+)?$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FooterLinkRegex = new(@"^\[(?<label>[^\]]+)\]: https://github\.com/Widthdom/CodeIndex/compare/v(?<base>\d+\.\d+\.\d+)(?:\.\.\.v(?<target>\d+\.\d+\.\d+)|\.\.\.HEAD)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FooterTagLinkRegex = new(@"^\[(?<label>[^\]]+)\]: https://github\.com/Widthdom/CodeIndex/releases/tag/v(?<version>\d+\.\d+\.\d+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex BulletRegex = new(@"^\s*-\s+\S", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private readonly string _repositoryRoot;
@@ -591,7 +592,7 @@ public sealed class ChangelogTool
 
     private sealed record VersionBlock(string HeadingLine, IReadOnlyList<string> BodyLines);
 
-    private sealed record FooterEntry(string Label, string BaseVersion, string? TargetVersion);
+    private sealed record FooterEntry(string Label, string BaseVersion, string? TargetVersion, bool IsTagLink = false);
 
     private sealed record ParsedChangelog(
         IReadOnlyList<string> PrefixLines,
@@ -744,13 +745,25 @@ public sealed class ChangelogTool
                     continue;
 
                 var match = FooterLinkRegex.Match(line);
-                if (!match.Success)
-                    throw new ChangelogException($"CHANGELOG.md footer contains invalid line: '{line}'.");
+                if (match.Success)
+                {
+                    var label = match.Groups["label"].Value;
+                    var baseVersion = match.Groups["base"].Value;
+                    var targetVersion = match.Groups["target"].Success ? match.Groups["target"].Value : null;
+                    entries.Add(new FooterEntry(label, baseVersion, targetVersion, IsTagLink: false));
+                    continue;
+                }
 
-                var label = match.Groups["label"].Value;
-                var baseVersion = match.Groups["base"].Value;
-                var targetVersion = match.Groups["target"].Success ? match.Groups["target"].Value : null;
-                entries.Add(new FooterEntry(label, baseVersion, targetVersion));
+                var tagMatch = FooterTagLinkRegex.Match(line);
+                if (tagMatch.Success)
+                {
+                    var label = tagMatch.Groups["label"].Value;
+                    var version = tagMatch.Groups["version"].Value;
+                    entries.Add(new FooterEntry(label, version, version, IsTagLink: true));
+                    continue;
+                }
+
+                throw new ChangelogException($"CHANGELOG.md footer contains invalid line: '{line}'.");
             }
 
             return entries;
@@ -759,9 +772,11 @@ public sealed class ChangelogTool
         private static IReadOnlyList<string> RenderFooter(IReadOnlyList<FooterEntry> entries)
         {
             return entries.Select(entry =>
-                entry.TargetVersion is null
-                    ? $"[{entry.Label}]: https://github.com/Widthdom/CodeIndex/compare/v{entry.BaseVersion}...HEAD"
-                    : $"[{entry.Label}]: https://github.com/Widthdom/CodeIndex/compare/v{entry.BaseVersion}...v{entry.TargetVersion}")
+                entry.IsTagLink
+                    ? $"[{entry.Label}]: https://github.com/Widthdom/CodeIndex/releases/tag/v{entry.TargetVersion}"
+                    : entry.TargetVersion is null
+                        ? $"[{entry.Label}]: https://github.com/Widthdom/CodeIndex/compare/v{entry.BaseVersion}...HEAD"
+                        : $"[{entry.Label}]: https://github.com/Widthdom/CodeIndex/compare/v{entry.BaseVersion}...v{entry.TargetVersion}")
                 .ToList();
         }
     }


### PR DESCRIPTION
## Summary
- Teach the changelog tool to parse and preserve legacy `releases/tag` footer links while still rendering compare links for new release entries.
- Add regression coverage for changelog preparation against a footer that already contains `releases/tag/vX.Y.Z`.
- Document the legacy footer compatibility in `changelog.d/README.md`.

## Validation
- `dotnet test CodeIndex.sln -c Release --filter ChangelogToolTests`

## Documentation
- Updated `changelog.d/README.md` to note that legacy `releases/tag` footer lines are tolerated and preserved.

## Notes
- No issue number was associated with this maintenance fix.
