### PR TITLE
[codex] Remove stray changelog footer block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2077,6 +2077,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [1.0.2]: https://github.com/Widthdom/CodeIndex/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Widthdom/CodeIndex/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Widthdom/CodeIndex/releases/tag/v1.0.0
-## Unreleased
-
-- Fix Java text blocks so call-shaped lines inside `"""..."""` bodies no longer emit phantom `call` references.


### PR DESCRIPTION
## Summary
- Remove the stray trailing `## Unreleased` block from `CHANGELOG.md` so the file ends at the footer, not after it.

## Validation
- Not run; this is a markdown-only cleanup.

## Documentation
- Updated `CHANGELOG.md` directly as requested for the separate changelog cleanup branch.

## Notes
- This PR is intentionally separate from the changelog-tool compatibility fix.
