### PR TITLE
Fix protobuf symbol extraction for #172

### DIFF
--- a/changelog.d/unreleased/172.fixed.md
+++ b/changelog.d/unreleased/172.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 172
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Protobuf now indexes `enum` as `enum`, and captures `package`, `oneof`, and `extend` declarations (#172)** — `SymbolExtractor` now re-kinds protobuf `enum` declarations correctly, records `package` lines as `namespace` symbols, and surfaces `oneof` / `extend` blocks so protobuf schemas show up in `symbols`, `definition`, and `outline` with the right structural shape. Added a focused regression fixture that covers all four cases and preserves `service` / `rpc` extraction.
+
+## 日本語
+
+- **Protobuf で `enum` を正しい `enum` として索引し、`package` / `oneof` / `extend` 宣言も取得するようになりました (#172)** — `SymbolExtractor` が protobuf の `enum` 宣言を正しい kind に振り分け、`package` 行を `namespace` シンボルとして記録し、`oneof` / `extend` ブロックも表面化するようにしたため、protobuf スキーマが `symbols` / `definition` / `outline` に正しい構造で出るようになります。4 ケースをまとめて確認する regression fixture を追加し、`service` / `rpc` 抽出は維持しています。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1206,7 +1206,10 @@ public static class SymbolExtractor
         ["protobuf"] =
         [
             new("class",    new Regex(@"^\s*message\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("class",    new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("namespace", new Regex(@"^\s*package\s+(?<name>[\w.]+)\s*;", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*oneof\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*extend\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*service\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*rpc\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*import\s+""(?<name>[^""]+)"";", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -82,6 +82,47 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Protobuf_DetectsEnumPackageOneofExtendAndService()
+    {
+        var content = """
+            syntax = "proto3";
+
+            package google.api;
+
+            message IssueDetails {
+              enum Severity {
+                SEVERITY_UNSPECIFIED = 0;
+                DEPRECATION = 1;
+              }
+
+              oneof kind {
+                string name = 1;
+                int32 code = 2;
+              }
+            }
+
+            extend google.protobuf.FieldOptions {
+              string custom = 50001;
+            }
+
+            service Greeter {
+              rpc SayHello (HelloRequest) returns (HelloReply);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "protobuf", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "google.api");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "IssueDetails");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Severity" && s.ContainerName == "IssueDetails");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "kind" && s.ContainerName == "IssueDetails");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "google.protobuf.FieldOptions");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Greeter");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "SayHello");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "Severity" && s.ContainerName == "IssueDetails");
+    }
+
+    [Fact]
     public void Extract_JavaScript_DetectsFunctionsAndClasses()
     {
         // Should detect exported and non-exported functions and classes
@@ -15331,7 +15372,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "google/protobuf/timestamp.proto");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "User");
-        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Status");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Status");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "UserService");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "GetUser");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ListUsers");


### PR DESCRIPTION
## Summary
- Re-kind protobuf `enum` declarations as `enum`.
- Capture protobuf `package`, `oneof`, and `extend` declarations.
- Add regression coverage for the protobuf symbol shapes and keep `service` / `rpc` extraction intact.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Changelog
- Updated the changelog via `changelog.d/unreleased/172.fixed.md` instead of editing `CHANGELOG.md` directly.

Fixes #172