### PR TITLE
Fix .kts files being skipped (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+- **`.kts` files now index as Kotlin instead of being silently skipped (#170)** — `FileIndexer` now maps Kotlin Script files to the existing Kotlin language bucket, so `build.gradle.kts`, `settings.gradle.kts`, and standalone `.kts` scripts are no longer dropped at scan time. Added regression coverage for direct language detection and a `build.gradle.kts` fixture that verifies both file indexing and Kotlin symbol extraction. Affected: `src/CodeIndex/Indexer/FileIndexer.cs`, `tests/CodeIndex.Tests/FileIndexerTests.cs`, `README.md`. Fixes #170.
+
 ### [1.17.0] - 2026-04-30
 
 #### Changed
@@ -1041,8 +1043,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ---
 
 ## 日本語
-
+ 
 ### [Unreleased]
+
+- **`.kts` ファイルを Kotlin として index し、黙ってスキップしないようにした (#170)** — `FileIndexer` が Kotlin Script を既存の Kotlin バケットへマップするようになり、`build.gradle.kts`、`settings.gradle.kts`、単独の `.kts` スクリプトが scan 時に落ちなくなりました。直接の言語判定と、`build.gradle.kts` フィクスチャでのファイル index / Kotlin シンボル抽出を確認する regression を追加しました。対象: `src/CodeIndex/Indexer/FileIndexer.cs`、`tests/CodeIndex.Tests/FileIndexerTests.cs`、`README.md`。Fixes #170。
 
 ### [1.17.0] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1041,7 +1041,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ---
 
 ## 日本語
- 
+
 ### [Unreleased]
 
 ### [1.17.0] - 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
-- **`.kts` files now index as Kotlin instead of being silently skipped (#170)** — `FileIndexer` now maps Kotlin Script files to the existing Kotlin language bucket, so `build.gradle.kts`, `settings.gradle.kts`, and standalone `.kts` scripts are no longer dropped at scan time. Added regression coverage for direct language detection and a `build.gradle.kts` fixture that verifies both file indexing and Kotlin symbol extraction. Affected: `src/CodeIndex/Indexer/FileIndexer.cs`, `tests/CodeIndex.Tests/FileIndexerTests.cs`, `README.md`. Fixes #170.
-
 ### [1.17.0] - 2026-04-30
 
 #### Changed
@@ -1045,8 +1043,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
  
 ### [Unreleased]
-
-- **`.kts` ファイルを Kotlin として index し、黙ってスキップしないようにした (#170)** — `FileIndexer` が Kotlin Script を既存の Kotlin バケットへマップするようになり、`build.gradle.kts`、`settings.gradle.kts`、単独の `.kts` スクリプトが scan 時に落ちなくなりました。直接の言語判定と、`build.gradle.kts` フィクスチャでのファイル index / Kotlin シンボル抽出を確認する regression を追加しました。対象: `src/CodeIndex/Indexer/FileIndexer.cs`、`tests/CodeIndex.Tests/FileIndexerTests.cs`、`README.md`。Fixes #170。
 
 ### [1.17.0] - 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Go | `.go` | yes |
 | Rust | `.rs` | yes |
 | Java | `.java` | yes |
-  | Kotlin | `.kt`, `.kts` | yes |
+| Kotlin | `.kt`, `.kts` | yes |
 | Ruby | `.rb`, `.rake`, `.gemspec`, `.podspec`, `Gemfile`, `Rakefile`, `Podfile`, `Guardfile`, `Capfile`, `Vagrantfile` | yes |
 | C | `.c`, `.h` | yes |
 | C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | yes |
@@ -1603,7 +1603,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | Go | `.go` | yes |
 | Rust | `.rs` | yes |
 | Java | `.java` | yes |
-  | Kotlin | `.kt`, `.kts` | yes |
+| Kotlin | `.kt`, `.kts` | yes |
 | Ruby | `.rb`, `.rake`, `.gemspec`, `.podspec`, `Gemfile`, `Rakefile`, `Podfile`, `Guardfile`, `Capfile`, `Vagrantfile` | yes |
 | C | `.c`, `.h` | yes |
 | C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | yes |

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Go | `.go` | yes |
 | Rust | `.rs` | yes |
 | Java | `.java` | yes |
-| Kotlin | `.kt` | yes |
+  | Kotlin | `.kt`, `.kts` | yes |
 | Ruby | `.rb`, `.rake`, `.gemspec`, `.podspec`, `Gemfile`, `Rakefile`, `Podfile`, `Guardfile`, `Capfile`, `Vagrantfile` | yes |
 | C | `.c`, `.h` | yes |
 | C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | yes |
@@ -1603,7 +1603,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | Go | `.go` | yes |
 | Rust | `.rs` | yes |
 | Java | `.java` | yes |
-| Kotlin | `.kt` | yes |
+  | Kotlin | `.kt`, `.kts` | yes |
 | Ruby | `.rb`, `.rake`, `.gemspec`, `.podspec`, `Gemfile`, `Rakefile`, `Podfile`, `Guardfile`, `Capfile`, `Vagrantfile` | yes |
 | C | `.c`, `.h` | yes |
 | C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | yes |

--- a/changelog.d/unreleased/170.fixed.md
+++ b/changelog.d/unreleased/170.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 170
+affected:
+  - src/CodeIndex/Indexer/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - README.md
+---
+
+## English
+
+- **`.kts` files now index as Kotlin instead of being silently skipped (#170)** — `FileIndexer` now maps Kotlin Script files to the existing Kotlin language bucket, so `build.gradle.kts`, `settings.gradle.kts`, and standalone `.kts` scripts are no longer dropped at scan time. Added regression coverage for direct language detection and a `build.gradle.kts` fixture that verifies both file indexing and Kotlin symbol extraction. Fixes #170.
+
+## 日本語
+
+- **`.kts` ファイルを Kotlin として index し、黙ってスキップしないようにした (#170)** — `FileIndexer` が Kotlin Script を既存の Kotlin バケットへマップするようになり、`build.gradle.kts`、`settings.gradle.kts`、単独の `.kts` スクリプトが scan 時に落ちなくなりました。直接の言語判定と、`build.gradle.kts` フィクスチャでのファイル index / Kotlin シンボル抽出を確認する regression を追加しました。Fixes #170。

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -101,6 +101,7 @@ public class FileIndexer
         [".rs"]     = "rust",
         [".java"]   = "java",
         [".kt"]     = "kotlin",
+        [".kts"]    = "kotlin",  // Kotlin Script / Kotlin スクリプト (Gradle Kotlin DSL など)
         [".swift"]  = "swift",
         [".cu"]     = "cuda",
         [".cuh"]    = "cuda",

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -26,6 +26,7 @@ public class FileIndexerTests
     [InlineData("mod.rs", "rust")]
     [InlineData("App.java", "java")]
     [InlineData("Service.cs", "csharp")]
+    [InlineData("Script.kts", "kotlin")]
     [InlineData("style.css", "css")]
     [InlineData("style.scss", "css")]
     [InlineData("page.vue", "vue")]
@@ -436,6 +437,40 @@ public class FileIndexerTests
 
             var expected = files.Keys.OrderBy(name => name, StringComparer.Ordinal).ToList();
             Assert.Equal(expected, scanned);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ScanFiles_IndexesKotlinScriptAndExtractsSymbols()
+    {
+        // Gradle Kotlin DSL files must be indexed as Kotlin, not silently skipped.
+        // Gradle Kotlin DSL ファイルは Kotlin として index され、黙って落ちてはいけない。
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var path = Path.Combine(tempDir, "build.gradle.kts");
+            var content = """
+                plugins {
+                    kotlin("jvm") version "1.9.23"
+                }
+
+                val answer = 42
+                """;
+            File.WriteAllText(path, content);
+
+            var scanned = new FileIndexer(tempDir).ScanFiles().ToList();
+
+            Assert.Single(scanned);
+            Assert.Equal(path, scanned[0]);
+            Assert.Equal("kotlin", FileIndexer.DetectLanguage(path));
+
+            var symbols = SymbolExtractor.Extract(1, "kotlin", content).ToList();
+            Assert.Contains(symbols, symbol => symbol.Kind == "property" && symbol.Name == "answer");
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Map `.kts` files to the existing Kotlin language bucket.
- Add regression coverage for Kotlin Script detection and symbol extraction.
- Move the changelog note to `changelog.d/unreleased/170.fixed.md` to match repository workflow.

Fixes #170