### PR TITLE
Fix PHP import extraction regressions #162

### DIFF
--- a/changelog.d/unreleased/162.fixed.md
+++ b/changelog.d/unreleased/162.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 162
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP import extraction now keeps aliases, group-use entries, and quoted requires (#162)** — `use function` / `use const` now record the imported symbol instead of the keyword, `use ... as Alias` stores the alias name, group-use statements emit one row per inner import, and `require` / `include` only index quoted literal paths. Dynamic expressions such as `require $var;` are skipped instead of being indexed as junk imports.
+
+## 日本語
+
+- **PHP の import 抽出で alias・group-use・クォート付き require を正しく扱うようになりました (#162)** — `use function` / `use const` はキーワードではなく実際の import 名を記録し、`use ... as Alias` は alias 名を保存し、group-use は内側の import ごとに 1 行ずつ出力し、`require` / `include` はクォート付きのリテラルパスだけを索引します。`require $var;` のような動的式は junk import として記録しません。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -79,6 +79,15 @@ public static class SymbolExtractor
         @"(?:(?:global::)?(?:" + CSharpTypeSegmentPattern + @")(?:\s+(?:" + CSharpTypeSegmentPattern + @"))*" + CSharpTupleSuffixPattern + @")";
     private const string CSharpMethodTypeParameterListPattern =
         @"(?:<(?:(?>[^<>]+)|<(?<CSharpMethodTypeParameterDepth>)|>(?<-CSharpMethodTypeParameterDepth>))*(?(CSharpMethodTypeParameterDepth)(?!))>\s*)?";
+    private static readonly Regex PhpGroupUseRegex = new(
+        @"^\s*use\s+(?:(?<type>function|const)\s+)?(?<prefix>[\w\\]+\\)\{\s*(?<items>[^{}]+?)\s*\}\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+    private static readonly Regex PhpUseRegex = new(
+        @"^\s*use\s+(?:(?<type>function|const)\s+)?(?<name>[\w\\]+)(?:\s+as\s+(?<alias>\w+))?\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+    private static readonly Regex PhpRequireIncludeRegex = new(
+        @"^\s*(?:require|include)(?:_once)?\s*\(?\s*(?:'(?<singleName>[^']+)'|""(?<doubleName>[^""]+)"")\s*\)?\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
     // `delegate` is a non-type keyword only when it is NOT followed by `*` — `delegate*<...>` is a valid return type.
     // `delegate` は `*` を伴わないときだけ非型キーワード扱い。`delegate*<...>` は戻り値型として有効。
     private const string CSharpNonTypeKeywordPattern = @"(?:(?:public|private|protected|internal|static|sealed|partial|readonly|unsafe|extern|virtual|override|abstract|async|new|file|required|ref)\b|delegate\b(?!\s*\*))";
@@ -1090,9 +1099,6 @@ public static class SymbolExtractor
             new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             // Namespace / 名前空間
             new("namespace", new Regex(@"^\s*namespace\s+(?<name>[\w\\]+)", RegexOptions.Compiled), BodyStyle.Brace),
-            // use (import) / use（インポート）
-            new("import",   new Regex(@"^\s*use\s+(?<name>[\w\\]+)", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*(?:require|include)(?:_once)?\s*\(?\s*(?<name>.+?)\s*\)?;", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["swift"] =
         [
@@ -1642,6 +1648,9 @@ public static class SymbolExtractor
             {
                 matchLine = csharpMatchLines![i];
             }
+
+            if (lang == "php")
+                ExtractPhpImportSymbols(symbols, line, i + 1);
 
             // Batch `rem` / `@rem` / `::` comment lines contain the same `&` / `(` / `else` /
             // `do` boundary tokens that the property regex now accepts for inline `set`
@@ -10394,6 +10403,104 @@ public static class SymbolExtractor
         symbols.Add(symbol);
     }
 
+    private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return;
+
+        var groupUseMatch = PhpGroupUseRegex.Match(line);
+        if (groupUseMatch.Success)
+        {
+            var prefix = groupUseMatch.Groups["prefix"].Value;
+            var signature = line.Trim();
+            foreach (var rawItem in groupUseMatch.Groups["items"].Value.Split(','))
+            {
+                var item = rawItem.Trim();
+                if (item.Length == 0)
+                    continue;
+
+                var importedName = item;
+                var alias = string.Empty;
+                var aliasIndex = item.IndexOf(" as ", StringComparison.OrdinalIgnoreCase);
+                if (aliasIndex >= 0)
+                {
+                    importedName = item[..aliasIndex].Trim();
+                    alias = item[(aliasIndex + 4)..].Trim();
+                }
+
+                var symbolName = alias.Length > 0 ? alias : prefix + importedName;
+                if (symbolName.Length == 0)
+                    continue;
+
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    lineNumber,
+                    new SymbolRecord
+                    {
+                        Kind = "import",
+                        Name = symbolName,
+                        Line = lineNumber,
+                        StartLine = lineNumber,
+                        EndLine = lineNumber,
+                        Signature = signature
+                    });
+            }
+
+            return;
+        }
+
+        var useMatch = PhpUseRegex.Match(line);
+        if (useMatch.Success)
+        {
+            var symbolName = useMatch.Groups["alias"].Success
+                ? useMatch.Groups["alias"].Value.Trim()
+                : useMatch.Groups["name"].Value.Trim();
+            if (symbolName.Length > 0)
+            {
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    lineNumber,
+                    new SymbolRecord
+                    {
+                        Kind = "import",
+                        Name = symbolName,
+                        Line = lineNumber,
+                        StartLine = lineNumber,
+                        EndLine = lineNumber,
+                        Signature = line.Trim()
+                    });
+            }
+
+            return;
+        }
+
+        var requireMatch = PhpRequireIncludeRegex.Match(line);
+        if (!requireMatch.Success)
+            return;
+
+        var importedPath = requireMatch.Groups["singleName"].Success
+            ? requireMatch.Groups["singleName"].Value.Trim()
+            : requireMatch.Groups["doubleName"].Value.Trim();
+        if (importedPath.Length == 0)
+            return;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineNumber,
+            new SymbolRecord
+            {
+                Kind = "import",
+                Name = importedPath,
+                Line = lineNumber,
+                StartLine = lineNumber,
+                EndLine = lineNumber,
+                Signature = line.Trim()
+            });
+    }
+
     private static void RemoveTrailingSameNameDeclarationOnlyFunctions(List<SymbolRecord> symbols, SymbolRecord symbol)
     {
         for (var index = symbols.Count - 1; index >= 0; index--)
@@ -15413,20 +15520,19 @@ public static class SymbolExtractor
         return StartsWithCSharpEventAccessorKeyword(text, cursor);
     }
 
-      private static bool ShouldDeferCSharpFunctionSameLineAdvance(string matchLine, int startColumn)
-      {
-          if (startColumn < 0 || startColumn >= matchLine.Length)
-              return false;
+    private static bool ShouldDeferCSharpFunctionSameLineAdvance(string matchLine, int startColumn)
+    {
+        if (startColumn < 0 || startColumn >= matchLine.Length)
+            return false;
 
-          var remaining = matchLine[startColumn..];
-          return !CSharpTypeBodyDeclarationMarker.IsMatch(remaining)
-              && (CSharpSameLinePropertyStatementStartRegex.IsMatch(remaining)
-                  || CSharpSameLineEventOrDelegateStatementStartRegex.IsMatch(remaining));
-      }
+        var remaining = matchLine[startColumn..];
+        return !CSharpTypeBodyDeclarationMarker.IsMatch(remaining)
+            && (CSharpSameLinePropertyStatementStartRegex.IsMatch(remaining)
+                || CSharpSameLineEventOrDelegateStatementStartRegex.IsMatch(remaining));
+    }
 
-      private static bool HasCSharpTokenBeforeIndex(string text, string token, int exclusiveEnd)
-      {
-          return false;
+    private static bool HasCSharpTokenBeforeIndex(string text, string token, int exclusiveEnd)
+    {
         if (string.IsNullOrEmpty(token) || exclusiveEnd <= 0)
             return false;
 

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -15536,10 +15536,17 @@ public static class SymbolExtractor
         if (string.IsNullOrEmpty(token) || exclusiveEnd <= 0)
             return false;
 
+        if (exclusiveEnd > text.Length)
+            exclusiveEnd = text.Length;
+
         var searchStart = 0;
         while (searchStart < exclusiveEnd)
         {
-            var tokenIndex = text.IndexOf(token, searchStart, exclusiveEnd - searchStart, StringComparison.Ordinal);
+            var remaining = exclusiveEnd - searchStart;
+            if (remaining <= 0)
+                return false;
+
+            var tokenIndex = text.IndexOf(token, searchStart, remaining, StringComparison.Ordinal);
             if (tokenIndex < 0)
                 return false;
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10051,6 +10051,41 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsImportAliasesGroupUseAndLiteralRequires()
+    {
+        var content = """
+            <?php
+
+            use Closure;
+            use Illuminate\Auth\Middleware\Authenticate;
+            use Illuminate\Support\Arr as A;
+            use function Laravel\Prompts\text;
+            use const Foo\Bar\BAZ;
+            use X\Y\{A, B as C, D};
+
+            require 'static/path.php';
+            require __DIR__ . '/bootstrap.php';
+            require $variable;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var imports = symbols.Where(s => s.Kind == "import").ToList();
+
+        Assert.Equal(9, imports.Count);
+        Assert.Contains(imports, s => s.Name == "Closure");
+        Assert.Contains(imports, s => s.Name == "Illuminate\\Auth\\Middleware\\Authenticate");
+        Assert.Contains(imports, s => s.Name == "A");
+        Assert.Contains(imports, s => s.Name == "Laravel\\Prompts\\text");
+        Assert.Contains(imports, s => s.Name == "Foo\\Bar\\BAZ");
+        Assert.Contains(imports, s => s.Name == "X\\Y\\A");
+        Assert.Contains(imports, s => s.Name == "C");
+        Assert.Contains(imports, s => s.Name == "X\\Y\\D");
+        Assert.Contains(imports, s => s.Name == "static/path.php");
+        Assert.DoesNotContain(imports, s => s.Name.Contains("__DIR__", StringComparison.Ordinal));
+        Assert.DoesNotContain(imports, s => s.Name.Contains("$variable", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";


### PR DESCRIPTION
## Summary
- Fixed PHP import extraction so `use function` / `use const` record the imported symbol, aliases are preserved, group-use emits one row per imported name, and `require` / `include` only index quoted literals.
- Added regression coverage for alias handling, group-use expansion, and skipping dynamic `require` expressions.

## Validation
- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_PHP_"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs changelog.d/unreleased/162.fixed.md --json`
- `dotnet build CodeIndex.sln` after commit
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json` after commit

## Changelog
- Added `changelog.d/unreleased/162.fixed.md`

Fixes #162

## Follow-up candidates
- None identified.