### PR TITLE
Fix Go import extraction for #155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
+#### Fixed
+- **Go import extraction now handles grouped `import (...)` blocks, alias forms, and trailing comments (#155)** — `SymbolExtractor` now skips the `import (` opener, extracts each import spec inside grouped blocks, and trims `//` / `/* ... */` suffixes so names no longer leak comments or the literal `(`. Added a regression that covers single-line imports, alias / dot / underscore forms, grouped blocks, and commented lines. Affected: `src/CodeIndex/Indexer/SymbolExtractor.cs`, `tests/CodeIndex.Tests/SymbolExtractorTests.cs`. Fixes #155.
+
 ### [1.17.0] - 2026-04-30
 
 #### Changed
@@ -1043,6 +1046,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
+
+#### Fixed
+- **Go の import 抽出が `import (...)` ブロック、エイリアス形式、末尾コメントを正しく扱うようになりました (#155)** — `SymbolExtractor` は `import (` の opener をシンボル化せず、grouped block 内の各 import spec を抽出し、`//` / `/* ... */` の接尾コメントを切り落とすため、名前にコメントや `(` が漏れなくなります。単一行 import、alias / dot / underscore 形式、grouped block、コメント行をまとめて踏む regression を追加しました。対象: `src/CodeIndex/Indexer/SymbolExtractor.cs`、`tests/CodeIndex.Tests/SymbolExtractorTests.cs`。Fixes #155.
 
 ### [1.17.0] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### [Unreleased]
 
-#### Fixed
-- **Go import extraction now handles grouped `import (...)` blocks, alias forms, and trailing comments (#155)** — `SymbolExtractor` now skips the `import (` opener, extracts each import spec inside grouped blocks, and trims `//` / `/* ... */` suffixes so names no longer leak comments or the literal `(`. Added a regression that covers single-line imports, alias / dot / underscore forms, grouped blocks, and commented lines. Affected: `src/CodeIndex/Indexer/SymbolExtractor.cs`, `tests/CodeIndex.Tests/SymbolExtractorTests.cs`. Fixes #155.
-
 ### [1.17.0] - 2026-04-30
 
 #### Changed
@@ -1046,9 +1043,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## 日本語
 
 ### [Unreleased]
-
-#### Fixed
-- **Go の import 抽出が `import (...)` ブロック、エイリアス形式、末尾コメントを正しく扱うようになりました (#155)** — `SymbolExtractor` は `import (` の opener をシンボル化せず、grouped block 内の各 import spec を抽出し、`//` / `/* ... */` の接尾コメントを切り落とすため、名前にコメントや `(` が漏れなくなります。単一行 import、alias / dot / underscore 形式、grouped block、コメント行をまとめて踏む regression を追加しました。対象: `src/CodeIndex/Indexer/SymbolExtractor.cs`、`tests/CodeIndex.Tests/SymbolExtractorTests.cs`。Fixes #155.
 
 ### [1.17.0] - 2026-04-30
 

--- a/changelog.d/unreleased/155.fixed.md
+++ b/changelog.d/unreleased/155.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 155
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Go import extraction now handles grouped `import (...)` blocks, alias forms, and trailing comments (#155)** — `SymbolExtractor` now skips the `import (` opener, extracts each import spec inside grouped blocks, and trims `//` / `/* ... */` suffixes so names no longer leak comments or the literal `(`. Added a regression that covers single-line imports, alias / dot / underscore forms, grouped blocks, and commented lines.
+
+## 日本語
+
+- **Go の import 抽出が `import (...)` ブロック、エイリアス形式、末尾コメントを正しく扱うようになりました (#155)** — `SymbolExtractor` は `import (` の opener をシンボル化せず、grouped block 内の各 import spec を抽出し、`//` / `/* ... */` の接尾コメントを切り落とすため、名前にコメントや `(` が漏れなくなります。単一行 import、alias / dot / underscore 形式、grouped block、コメント行をまとめて踏む regression を追加しました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -87,6 +87,9 @@ public static class SymbolExtractor
     private const string CppFunctionStartBlacklistPattern = @"^(?!\s*typedef\b)(?!\s*(?:if|else|for|while|switch|return|sizeof|using|namespace)\s*[\(\{;<])";
     private const string CppTemplatePrefixPattern = @"(?:template\s*<[^>]*>\s*)*";
     private static readonly Regex PartialModifierRegex = new(@"\bpartial\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex GoImportSpecRegex = new(
+        @"^(?<name>(?:(?:[._]|[\p{L}_][\p{L}\p{Nd}_]*)\s+)?""(?:\\.|[^""\\])*"")(?:\s*;)?(?:\s*(?://.*|/\*.*\*/))?\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     // Optional TypeScript generic type-argument token that may sit between an HOC call
     // name and its `(`. Consumed only by the TypeScript HOC-binding row — the JavaScript
@@ -964,7 +967,6 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s+(?<name>[A-Z]\w*)\s*=\s*", RegexOptions.Compiled), BodyStyle.None),
             // Package-level var / パッケージレベル変数
             new("function", new Regex(@"^var\s+(?<name>\w+)\s", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*import\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["rust"] =
         [
@@ -1452,6 +1454,114 @@ public static class SymbolExtractor
     /// </summary>
     public static IReadOnlyCollection<string> GetSupportedLanguages() => PatternCache.Keys;
 
+    private static bool TryHandleGoImportLine(
+        long fileId,
+        string line,
+        int lineIndex,
+        List<SymbolRecord> symbols,
+        ref bool inImportBlock)
+    {
+        var trimmed = line.TrimStart();
+
+        if (inImportBlock)
+        {
+            if (trimmed.Length == 0
+                || trimmed.StartsWith("//", StringComparison.Ordinal)
+                || trimmed.StartsWith("/*", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (trimmed.StartsWith(")", StringComparison.Ordinal))
+            {
+                inImportBlock = false;
+                return true;
+            }
+
+            var closingParenIndex = trimmed.IndexOf(')');
+            if (closingParenIndex >= 0)
+            {
+                var blockImportText = trimmed[..closingParenIndex].TrimEnd();
+                if (blockImportText.Length > 0)
+                    TryAddGoImportSymbol(fileId, line, lineIndex, symbols, blockImportText);
+
+                inImportBlock = false;
+                return true;
+            }
+
+            return TryAddGoImportSymbol(fileId, line, lineIndex, symbols, trimmed);
+        }
+
+        if (!trimmed.StartsWith("import", StringComparison.Ordinal)
+            || (trimmed.Length > "import".Length
+                && !char.IsWhiteSpace(trimmed["import".Length])
+                && trimmed["import".Length] != '('))
+            return false;
+
+        var afterImport = trimmed["import".Length..].TrimStart();
+        if (afterImport.StartsWith("(", StringComparison.Ordinal))
+        {
+            var blockRemainder = afterImport[1..].TrimStart();
+            if (blockRemainder.Length > 0)
+            {
+                var closingParenIndex = blockRemainder.IndexOf(')');
+                if (closingParenIndex >= 0)
+                {
+                    var blockImportText = blockRemainder[..closingParenIndex].TrimEnd();
+                    if (blockImportText.Length > 0)
+                        TryAddGoImportSymbol(fileId, line, lineIndex, symbols, blockImportText);
+
+                    inImportBlock = false;
+                    return true;
+                }
+
+                TryAddGoImportSymbol(fileId, line, lineIndex, symbols, blockRemainder);
+            }
+
+            inImportBlock = true;
+            return true;
+        }
+
+        return TryAddGoImportSymbol(fileId, line, lineIndex, symbols, afterImport);
+    }
+
+    private static bool TryAddGoImportSymbol(
+        long fileId,
+        string rawLine,
+        int lineIndex,
+        List<SymbolRecord> symbols,
+        string importText)
+    {
+        var match = GoImportSpecRegex.Match(importText);
+        if (!match.Success)
+            return true;
+
+        var name = match.Groups["name"].Value.Trim();
+        var startColumn = rawLine.IndexOf(name, StringComparison.Ordinal);
+        if (startColumn < 0)
+            startColumn = rawLine.IndexOf(importText, StringComparison.Ordinal);
+        if (startColumn < 0)
+            startColumn = rawLine.Length - rawLine.TrimStart().Length;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineIndex + 1,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "import",
+                Name = name,
+                Line = lineIndex + 1,
+                StartLine = lineIndex + 1,
+                StartColumn = startColumn,
+                EndLine = lineIndex + 1,
+                Signature = name,
+            },
+            rawLine);
+        return true;
+    }
+
     private static readonly HashSet<string> ContainerKinds =
     [
         "class", "struct", "interface", "namespace", "enum"
@@ -1619,6 +1729,7 @@ public static class SymbolExtractor
             ? new HashSet<string>(StringComparer.Ordinal)
             : null;
         var csharpSuppressedContinuationUntil = -1;
+        var goImportBlock = false;
 
         for (int i = 0; i < lines.Length; i++)
         {
@@ -1626,6 +1737,11 @@ public static class SymbolExtractor
                 continue;
 
             var line = lines[i];
+            if (lang == "go"
+                && TryHandleGoImportLine(fileId, line, i, symbols, ref goImportBlock))
+            {
+                continue;
+            }
             var structuralLine = structuralLines[i];
             var cssScannerLine = cssScannerLines?[i];
             var matchLine = structuralLine;

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -95,6 +95,41 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Go_DetectsSingleLineAndGroupedImports()
+    {
+        var content = """
+            package demo
+
+            import "bytes" // ERROR "invalid import path (empty string)"
+            import alias "fmt" // trailing comment
+
+            import (
+                "io"
+                . "strings"
+                _ "net/http/pprof"
+                alias2 "example.com/project"
+                // ignored comment
+            )
+
+            func main() {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var imports = symbols.Where(s => s.Kind == "import").ToList();
+
+        Assert.Equal(6, imports.Count);
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "main");
+        Assert.Contains(imports, s => s.Name == "\"bytes\"");
+        Assert.Contains(imports, s => s.Name == "alias \"fmt\"");
+        Assert.Contains(imports, s => s.Name == "\"io\"");
+        Assert.Contains(imports, s => s.Name == ". \"strings\"");
+        Assert.Contains(imports, s => s.Name == "_ \"net/http/pprof\"");
+        Assert.Contains(imports, s => s.Name == "alias2 \"example.com/project\"");
+        Assert.DoesNotContain(imports, s => s.Name == "(");
+        Assert.DoesNotContain(imports, s => s.Name.Contains("ERROR", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_Cpp_DetectsQualifiedDefinitionsConceptsAndModules()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Handle Go grouped `import (...)` blocks with a dedicated import scanner.
- Capture alias, dot, underscore, and single-line import specs without trailing comments leaking into the symbol name.
- Add regression coverage for single-line and grouped import forms.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter SymbolExtractorTests`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs CHANGELOG.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

Fixes #155