### PR TITLE
Fix GraphQL symbol extraction for #171

### DIFF
--- a/changelog.d/unreleased/171.fixed.md
+++ b/changelog.d/unreleased/171.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 171
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **GraphQL fragments, directives, and broader `extend` declarations are now indexed (#171)** — `SymbolExtractor` now captures `fragment X on Y` declarations as `function` symbols, directive definitions like `directive @auth ...` as `function` symbols, and broader `extend` declarations for `type` / `interface` / `input` / `enum` / `union` / `scalar` instead of silently dropping them. Added regressions for the new GraphQL forms while keeping the existing `type` / `query` / `enum` coverage. Affected: `src/CodeIndex/Indexer/SymbolExtractor.cs`, `tests/CodeIndex.Tests/SymbolExtractorTests.cs`. Fixes #171.
+
+## 日本語
+
+- **GraphQL の fragment / directive / より広い `extend` 宣言も index されるようになりました (#171)** — `fragment X on Y` を `function` symbol として、`directive @auth ...` の定義を `function` symbol として、さらに `type` / `interface` / `input` / `enum` / `union` / `scalar` のより広い `extend` 宣言も silent drop せずに捕捉するようにしました。既存の `type` / `query` / `enum` の coverage を保ちつつ、新しい GraphQL 形状の regression を追加しました。対象: `src/CodeIndex/Indexer/SymbolExtractor.cs`、`tests/CodeIndex.Tests/SymbolExtractorTests.cs`。Fixes #171.

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1185,7 +1185,10 @@ public static class SymbolExtractor
             new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:type|union|scalar|input)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?:query|mutation|subscription)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("class",    new Regex(@"^\s*(?:extend\s+type)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*fragment\s+(?<name>\w+)\s+on\s+\w+", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*directive\s+@(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*extend\s+(?:type|interface|input|enum)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*extend\s+(?:union|scalar)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*schema\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
         ],
         ["gradle"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14396,6 +14396,80 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_GraphQL_DetectsFragmentsDirectivesAndExtends()
+    {
+        var content = """
+            type User {
+              id: ID!
+            }
+
+            input CreateUserInput {
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            enum Role {
+              ADMIN
+              USER
+            }
+
+            fragment ProcessingTimeoutError on ProcessingTimeoutError {
+              __typename
+              message
+            }
+
+            directive @auth(role: String!) on FIELD_DEFINITION
+
+            extend type ExtendedUser {
+              profile: Profile
+            }
+
+            extend interface ExtendedNode {
+              archived: Boolean
+            }
+
+            extend input ExtendedCreateUserInput {
+              email: String
+            }
+
+            extend enum ExtendedRole {
+              GUEST
+            }
+
+            extend union SearchResult = User | Organization
+
+            extend scalar DateTime
+
+            query GetUser($id: ID!) {
+              user(id: $id) { name }
+            }
+
+            mutation CreateUser($input: CreateUserInput!) {
+              createUser(input: $input) { id }
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "graphql", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "User");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "CreateUserInput");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Node");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Role");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ProcessingTimeoutError");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "auth");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ExtendedUser");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ExtendedNode");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ExtendedCreateUserInput");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ExtendedRole");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "SearchResult");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DateTime");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "GetUser");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "CreateUser");
+    }
+
+    [Fact]
     public void Extract_Gradle_DetectsSymbols()
     {
         // Both legacy apply plugin: and modern plugins { id '...' } forms


### PR DESCRIPTION
## Summary
- Capture GraphQL fragments, directive definitions, and broader extend declarations in SymbolExtractor.
- Add regression coverage for GraphQL fragments, directives, and extend forms.
- Record the user-visible change in a bilingual changelog fragment under changelog.d/unreleased/.

Fixes #171