### PR TITLE
Fix Dart keyword lookalike symbols

### DIFF
--- a/changelog.d/unreleased/163.fixed.md
+++ b/changelog.d/unreleased/163.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 163
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Dart function extraction now skips `else if`, `case const Class()`, and keyword-shaped lookalikes (#163)** — tightened the Dart `function` heuristic so control-flow and declaration keywords no longer become phantom `function if` / `function Class` rows, while valid declarations such as `void build(...)`, `String bar()`, and `abstract class Widget` still extract correctly.
+
+## 日本語
+
+- **Dart の関数抽出で `else if` や `case const Class()`、キーワード形の偽陽性を拾わなくなりました (#163)** — Dart の `function` 判定を絞り込み、制御構文や宣言キーワードが `function if` / `function Class` のような幻の行にならないようにしました。`void build(...)`、`String bar()`、`abstract class Widget` のような正しい宣言は引き続き抽出されます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1173,7 +1173,7 @@ public static class SymbolExtractor
         ],
         ["dart"] =
         [
-            new("function", new Regex(@"^\s*(?!return\b|await\b|const\b|new\b|throw\b|yield\b|if\b|for\b|while\b|switch\b|catch\b)(?:(?:static|abstract|override|external)\s+)*(?<rt>\w[\w<>,\s\?]*?)\s+(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "rt"),
+            new("function", new Regex(@"^\s*(?!return\b|await\b|const\b|new\b|throw\b|yield\b|if\b|else\b|for\b|while\b|switch\b|case\b|catch\b|do\b|try\b|finally\b|class\b|enum\b|mixin\b|extension\b|typedef\b|library\b|part\b|import\b|export\b)(?:(?:static|abstract|override|external)\s+)*(?<rt>\w[\w<>,\s\?]*?)\s+(?<name>(?!if\b|else\b|for\b|while\b|switch\b|case\b|class\b|enum\b|mixin\b|extension\b|typedef\b|library\b|part\b|import\b|export\b|abstract\b|void\b|var\b|final\b|late\b|const\b|new\b|return\b|throw\b|yield\b|await\b|extends\b|implements\b|with\b|on\b|is\b|as\b|in\b|of\b|super\b|this\b)\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "rt"),
             new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:abstract\s+)?(?:class|mixin)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*extension\s+(?<name>\w+)\s+on\s+", RegexOptions.Compiled), BodyStyle.Brace),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14333,6 +14333,40 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dart_DoesNotTreatKeywordLookalikesAsFunctions()
+    {
+        var content = """
+            abstract class Widget {}
+
+            String bar() => 'bar';
+
+            void sample(bool first, bool secondReady) {
+              if (first) {
+              }
+              else if (secondReady) {
+              }
+            }
+
+            void handle(Object value) {
+              switch (value) {
+                case const Class():
+                  break;
+              }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dart", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "bar");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "sample");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "handle");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "if");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "Class");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "class");
+    }
+
+    [Fact]
     public void Extract_Dart_DetectsImportAndEnum()
     {
         // Dart: import, enum / Dart: インポート、列挙型


### PR DESCRIPTION
Fixes #163

## Summary
- Tighten Dart function extraction so `else if`, `case const Class()`, and keyword-shaped lookalikes no longer produce phantom `function` symbols.
- Keep valid Dart declarations like `void build(...)`, `String bar()`, and `abstract class Widget` indexed.
- Add a regression test covering the false-positive shapes.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Dart"`
- `dotnet test CodeIndex.sln -c Release`