### PR TITLE
Clarify changelog fragment policy

### DIFF
--- a/.codex/workflows/changelog-fragment.md
+++ b/.codex/workflows/changelog-fragment.md
@@ -10,6 +10,7 @@ workflow behavior.
 
 Do not edit `CHANGELOG.md` in ordinary implementation PRs.
 Add one or more bilingual fragments under `changelog.d/unreleased/` instead.
+Treat any request to "update the changelog" as a fragment request unless the task is explicitly a release-preparation PR that aggregates existing fragments into `CHANGELOG.md`.
 
 ## Steps
 

--- a/.codex/workflows/precommit.md
+++ b/.codex/workflows/precommit.md
@@ -11,7 +11,7 @@ Run this before each commit.
 5. If public behavior, CLI/MCP output, install/release behavior, or workflow behavior changed, confirm matching docs and changelog updates are present in the same change unless you can clearly justify why they are unnecessary.
 6. If documentation changed, confirm it matches implementation and covers the user-facing contract accurately.
 7. If a changelog update is required, confirm it is a valid bilingual fragment under `changelog.d/unreleased/` unless the task is explicitly a release-preparation change.
-8. Fail the precommit check if ordinary implementation work edited `CHANGELOG.md` without a release-preparation reason.
+8. Fail the precommit check if ordinary implementation work edited `CHANGELOG.md` without a release-preparation reason. Direct `CHANGELOG.md` edits are not the normal response to a changelog request.
 9. If docs or changelog were intentionally omitted for a user-visible change, stop and fix that before committing.
 10. Confirm issue auto-close references will be placed in the PR body as `Fixes #...`.
 11. Confirm the commit message is English and includes relevant issue numbers.

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -61,8 +61,8 @@ When editing changelog content, verify that both English and Japanese entries ar
 - Treat documentation as part of the feature contract, not as optional cleanup.
 - If a change affects user-visible behavior, CLI/MCP output, flags, error messages, install/release behavior, or contributor/agent workflow, update the matching docs in the same change. For CodeIndex this usually means `README.md`, `DEVELOPER_GUIDE.md`, `TESTING_GUIDE.md`, `SELF_IMPROVEMENT.md`, `INTEGRATION_POLICY.md`, `CLAUDE.md`, `AGENT_GUIDE.md`, or the relevant `.codex/workflows/*.md` file.
 - Do not open or merge a PR with a user-visible change unless the required docs and changelog updates are present, or the PR body explicitly explains why no docs/changelog change is needed.
-- Changelog entries are required for user-visible or behavior-changing work. For ordinary implementation PRs, the changelog entry is normally a bilingual fragment under `changelog.d/unreleased/`, not a direct edit to `CHANGELOG.md`.
-- Ordinary implementation PRs must not edit `CHANGELOG.md`; reserve direct `CHANGELOG.md` edits for release-preparation PRs that aggregate fragments. If `CHANGELOG.md` is edited, update both English and Japanese sections in the same commit.
+- Changelog entries are required for user-visible or behavior-changing work. For ordinary implementation PRs, write the changelog entry as a bilingual fragment under `changelog.d/unreleased/`; do not update `CHANGELOG.md` directly as the default path.
+- Ordinary implementation PRs must not edit `CHANGELOG.md`. Reserve direct `CHANGELOG.md` edits for release-preparation PRs that aggregate fragments into a release note. If `CHANGELOG.md` is edited, update both English and Japanese sections in the same commit, and only after confirming the work is a release-preparation change.
 
 ## Repository Rules
 


### PR DESCRIPTION
Update the shared agent and workflow docs to make it explicit that ordinary implementation work must use bilingual fragments under changelog.d/unreleased/ instead of editing CHANGELOG.md directly.\n\nThis is a docs-only change.