### PR TITLE
Fix Terraform symbol extraction

### DIFF
--- a/changelog.d/unreleased/174.fixed.md
+++ b/changelog.d/unreleased/174.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 174
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Terraform symbol extraction now covers core configuration blocks (#174)** - `locals` blocks now keep a stable `locals` name instead of the literal `locals {` text, and `provider`, `terraform`, `import`, `moved`, `removed`, and `check` blocks are indexed as symbols.
+
+## 日本語
+
+- **Terraform のシンボル抽出が主要な設定ブロックを扱うようになりました (#174)** - `locals` ブロックは `locals {` というリテラルではなく安定した `locals` 名で記録され、`provider`、`terraform`、`import`、`moved`、`removed`、`check` ブロックもシンボルとして索引化されます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1308,9 +1308,13 @@ public static class SymbolExtractor
             new("class",    new Regex(@"^\s*resource\s+""[^""]+""\s+""(?<name>[^""]+)""", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*data\s+""[^""]+""\s+""(?<name>[^""]+)""", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*module\s+""(?<name>[^""]+)""", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*provider\s+""(?<name>[^""]+)""", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*(?<name>terraform)\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*(?<name>import|moved|removed)\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*check\s+""(?<name>[^""]+)""", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*variable\s+""(?<name>[^""]+)""", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*output\s+""(?<name>[^""]+)""", RegexOptions.Compiled), BodyStyle.Brace),
-            new("function", new Regex(@"^\s*locals\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?<name>locals)\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
         ],
         ["css"] =
         [

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10067,11 +10067,29 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_Terraform_DetectsResources()
     {
-        var content = "resource \"aws_s3_bucket\" \"my_bucket\" {\n  bucket = \"my-bucket\"\n}\n\nvariable \"region\" {\n  default = \"us-east-1\"\n}\n\noutput \"bucket_arn\" {\n  value = aws_s3_bucket.my_bucket.arn\n}\n\nmodule \"vpc\" {\n  source = \"./modules/vpc\"\n}";
+        var content =
+            "resource \"aws_s3_bucket\" \"my_bucket\" {\n  bucket = \"my-bucket\"\n}\n\n" +
+            "provider \"aws\" {\n  region = \"us-east-1\"\n}\n\n" +
+            "terraform {\n  required_version = \">= 1.0\"\n}\n\n" +
+            "import {\n  id = \"bucket-123\"\n}\n\n" +
+            "moved {\n  from = aws_s3_bucket.old_bucket\n  to = aws_s3_bucket.my_bucket\n}\n\n" +
+            "removed {\n  from = aws_s3_bucket.deprecated_bucket\n}\n\n" +
+            "check \"health\" {\n  assert {\n    condition = true\n  }\n}\n\n" +
+            "locals {\n  region = \"us-east-1\"\n}\n\n" +
+            "variable \"region\" {\n  default = \"us-east-1\"\n}\n\n" +
+            "output \"bucket_arn\" {\n  value = aws_s3_bucket.my_bucket.arn\n}\n\n" +
+            "module \"vpc\" {\n  source = \"./modules/vpc\"\n}";
         var symbols = SymbolExtractor.Extract(1, "terraform", content);
 
         // resource captures logical name (second quoted token), not provider type
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "my_bucket");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "aws");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "terraform");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "import");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "moved");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "removed");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "health");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "locals");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "region");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "bucket_arn");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vpc");


### PR DESCRIPTION
## Summary
- Fixed Terraform symbol extraction so `locals` is indexed as a stable `locals` symbol instead of the literal `locals {` text.
- Added symbol coverage for `provider`, `terraform`, `import`, `moved`, `removed`, and `check` blocks.
- Extended the Terraform symbol extractor test to cover the updated block set.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Terraform_DetectsResources"`
- `dotnet test`

## Docs and changelog
- Added `changelog.d/unreleased/174.fixed.md` as a bilingual fragment.

## Auto-close
- Fixes #174

## Follow-up candidates
- None identified.
