### PR TITLE
Fix Lua assignment-form symbol extraction

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -415,7 +415,7 @@ Supported symbol kinds by language (33 languages with symbol extraction):
 Type aliases are indexed as `import` symbols in Rust, TypeScript, Swift, Go, F# and Scala. In F#, record declarations map to `struct`, discriminated unions map to `enum`, and constructor-style `type` declarations remain `class`.
 Type aliases are indexed as `import` symbols in Rust, TypeScript, Swift, Go, F# and Scala. In F#, record declarations map to `struct`, discriminated unions map to `enum`, and constructor-style `type` declarations remain `class`.
 | Dockerfile | named stages (AS) | base images (FROM), stage dependencies (FROM \<stage\> AS \<new\>, COPY --from=\<stage\>) | -- | -- | -- | -- | -- | -- | -- |
-| Lua | function, local function | -- | -- | -- | -- | -- | -- | require | yes |
+| Lua | function, local function, `local x = function`, `M.x = function`, `M:x = function` | -- | -- | -- | -- | -- | -- | require | yes |
 | R | name <- function() | -- | -- | -- | -- | -- | -- | library, require | -- |
 | Haskell | type signatures (name ::) | data, newtype, type, instance | -- | class (typeclass) | -- | -- | -- | import | -- |
 | F# | let, let rec | type, module | -- | -- | -- | -- | -- | open | yes |
@@ -1556,7 +1556,7 @@ LIMIT 20;
 Rust / TypeScript / Swift / Go / F# / Scala の type alias は `import` としてインデックスされる。F# では record は `struct`、discriminated union は `enum`、constructor 形式の `type` は `class` として扱う。
 Rust / TypeScript / Swift / Go / F# / Scala の type alias は `import` としてインデックスされる。F# では record は `struct`、discriminated union は `enum`、constructor 形式の `type` は `class` として扱う。
 | Dockerfile | 名前付きステージ (AS) | ベースイメージ (FROM)、ステージ依存 (FROM \<stage\> AS \<new\>、COPY --from=\<stage\>) | -- | -- | -- | -- | -- | -- | -- |
-| Lua | function, local function | -- | -- | -- | -- | -- | -- | require | yes |
+| Lua | function, local function, `local x = function`, `M.x = function`, `M:x = function` | -- | -- | -- | -- | -- | -- | require | yes |
 | R | name <- function() | -- | -- | -- | -- | -- | -- | library, require | -- |
 | Haskell | 型シグネチャ (name ::) | data, newtype, type, instance | -- | class (型クラス) | -- | -- | -- | import | -- |
 | F# | let, let rec | type, module | -- | -- | -- | -- | -- | open | yes |

--- a/changelog.d/unreleased/192.fixed.md
+++ b/changelog.d/unreleased/192.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 192
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Lua symbol extraction now recognizes assignment-form function definitions (#192)** — `SymbolExtractor` now captures `local name = function(...)` and table-member assignment forms such as `M.name = function(...)` / `M:name = function(...)` in addition to the existing `function name(...)` and `local function name(...)` patterns. The Lua regression test now covers the new shapes alongside the existing `require` and plain function cases, and the Lua reference row in `DEVELOPER_GUIDE.md` reflects the broader coverage.
+
+## 日本語
+
+- **Lua のシンボル抽出が代入形式の関数定義も認識するようになりました (#192)** — `SymbolExtractor` が既存の `function name(...)` / `local function name(...)` に加えて、`local name = function(...)` や `M.name = function(...)` / `M:name = function(...)` のようなテーブルメンバー代入形式も取得するようになりました。Lua の回帰テストは `require` と通常関数のケースに加えて新しい形もまとめて確認し、`DEVELOPER_GUIDE.md` の Lua 参照行も拡張後の対応範囲を反映しています。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1170,6 +1170,8 @@ public static class SymbolExtractor
         ["lua"] =
         [
             new("function", new Regex(@"^\s*(?:local\s+)?function\s+(?<name>[\w.:]+)\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*local\s+(?<name>[\w]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?<name>[\w]+(?:[.:][\w]+)+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:local\s+\w+\s*=\s*)?require\s*\(?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["elixir"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14381,13 +14381,43 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_Lua_DetectsFunctionsAndRequire()
     {
-        // Lua: function, local function, require / Lua: 関数、ローカル関数、require
-        var content = "local http = require('socket.http')\n\nfunction greet(name)\n  print(name)\nend\n\nlocal function helper(x)\n  return x\nend";
+        // Lua: function, local function, assignment forms, require / Lua: 関数、ローカル関数、代入形式、require
+        var content = """
+            local http = require('socket.http')
+
+            local helper = function(x)
+              return x
+            end
+
+            M.named = function(name)
+              return "hello " .. name
+            end
+
+            function M:method_form(arg)
+              return arg
+            end
+
+            function M.dot_form(arg)
+              return arg
+            end
+
+            local function top_local(x)
+              return x
+            end
+
+            function plain_function(a)
+              return a
+            end
+            """;
         var symbols = SymbolExtractor.Extract(1, "lua", content);
 
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "socket.http");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "greet");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "helper");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "M.named");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "M:method_form");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "M.dot_form");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "top_local");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "plain_function");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Expand Lua symbol extraction to recognize anonymous-function assignments such as `local helper = function(...)` and table-member assignments like `M.named = function(...)`.
- Add a Lua regression test that covers the new assignment forms alongside the existing keyword-style forms and `require`.
- Update the Lua reference row in `DEVELOPER_GUIDE.md`.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SymbolExtractorTests`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs DEVELOPER_GUIDE.md changelog.d/unreleased/192.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog
- Updated `DEVELOPER_GUIDE.md`.
- Added bilingual changelog fragment: `changelog.d/unreleased/192.fixed.md`.

Fixes #192

## Follow-up candidates
- None identified.