### PR TITLE
Fix Rust macro reference extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,3 +29,4 @@ The `.codex/workflows/` directory is a shared workflow library for all coding ag
 ## Reference Extraction
 
 - Dockerfile multi-stage builds now emit `call`-kind reference edges for `FROM <stage> AS <new>` and `COPY --from=<stage>` when the source name matches a named stage in the same file, so `callers` and `impact` can follow stage dependencies instead of treating intermediate stages as unused.
+- Rust macro invocations (`name!(...)` / `name![...]` / `name!{...}`) now emit `call`-kind reference edges, while the `macro_rules!` declaration keyword remains suppressed so macro definitions do not double-count as calls.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -37,7 +37,7 @@ src/CodeIndex/
     FileIndexer.cs            — Directory scan, shared path filtering for full/update runs, built-in skip lists plus `.gitignore` / `.cdidxignore`, extension/file-name/shebang language detection, FileRecord building
     ChunkSplitter.cs          — 80-line chunks with 10-line overlap
     SymbolExtractor.cs        — Hybrid symbol extraction: compiled regexes for most languages, plus a lightweight JS/TS lexer/state machine for class-body methods and semicolon-terminated interface/abstract properties, Java method guards for generic type-parameter prefixes and statement keywords, C/C++ out-of-class member definitions / operators / concepts / inline namespaces / modules, CSS grouping/nesting selectors and selector lists / named at-rules, per-file hash-based duplicate bookkeeping for same-line restart suppression, scope filtering, and range resolution
-    ReferenceExtractor.cs     — Regex-based call/reference extraction, including JSX component open tags in `.jsx` / `.tsx` files, method-reference / method-group handoffs, type-position `type_reference` edges plus a depth-aware fallback for nested-generic call sites (31 languages with graph queries)
+    ReferenceExtractor.cs     — Regex-based call/reference extraction, including JSX component open tags in `.jsx` / `.tsx` files, method-reference / method-group handoffs, Rust macro invocations (`name!(...)` / `name![...]` / `name!{...}`), type-position `type_reference` edges plus a depth-aware fallback for nested-generic call sites (31 languages with graph queries)
   Mcp/
     McpServer.cs              — MCP server (stdin/stdout JSON-RPC 2.0 for AI coding tools; includes batch_query)
   Models/

--- a/changelog.d/unreleased/258.fixed.md
+++ b/changelog.d/unreleased/258.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 258
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - CLAUDE.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Rust macro invocations now appear in `references`, `callers`, `callees`, and `impact` (#258)** — `ReferenceExtractor` now recognizes Rust macro call syntax with `!` plus `()`, `[]`, or `{}`, including path-qualified forms like `std::println!`, and it suppresses the `macro_rules!` declaration keyword so macro definitions do not double-count as calls.
+
+## 日本語
+
+- **Rust の macro 呼び出しが `references` / `callers` / `callees` / `impact` に出るようになりました (#258)** — `ReferenceExtractor` が `!` に続く `()` / `[]` / `{}` の Rust macro 呼び出しを認識し、`std::println!` のような path-qualified 形式も拾うようになりました。同時に `macro_rules!` の宣言キーワードは抑止しているため、macro 定義が call として二重計上されることはありません。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -82,6 +82,15 @@ public static class ReferenceExtractor
         {
             "instanceof", "super", "this", "assert", "throws", "extends", "implements", "synchronized",
         },
+        // Rust macro declaration keywords / Rust マクロ宣言キーワード
+        // `macro_rules!` declarations will be seen by the Rust macro-call regex below, but they are
+        // declaration sites rather than call sites, so suppress the keyword itself.
+        // `macro_rules!` 宣言は下の Rust macro-call regex でも見えてしまうが、これは呼び出しではなく
+        // 宣言なのでキーワード自体を抑止する。
+        ["rust"] = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "macro_rules",
+        },
         // JavaScript / TypeScript contextual keywords / JavaScript / TypeScript 文脈キーワード
         ["javascript"] = new HashSet<string>(StringComparer.Ordinal)
         {
@@ -256,6 +265,14 @@ public static class ReferenceExtractor
     // 平坦な `<[^>\n]+>` では末尾 `>>` を釣り合わせられないため、depth-aware な fallback scanner
     // で補完する。issue #263 参照。
     private static readonly Regex CallRegex = new($@"(?<![\w$])(?<name>{CSharpIdentifierPattern})(?:\?\.)?(?:<[^>\n]+>)?\s*\(", RegexOptions.Compiled);
+    // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
+    // Capture the full path-qualified macro name so `std::println!`, `log::info!`, and
+    // `my_macro!` all surface as references. The `macro_rules` declaration keyword is filtered
+    // by the Rust ignore list above.
+    // Rust の macro 呼び出しは共通の末尾 `(` ではなく `!` の後に `()` / `[]` / `{}` を取る。
+    // `std::println!` / `log::info!` / `my_macro!` のような path-qualified 名も含めて拾い、
+    // `macro_rules` 宣言キーワードは上の Rust ignore list で除外する。
+    private static readonly Regex RustMacroCallRegex = new($@"(?<![\w$])(?<name>{FunctionalIdentifierPattern}(?:::{FunctionalIdentifierPattern})*)(?:<[^>\n]+>)?!\s*[\(\[\{{]", RegexOptions.Compiled);
     // Ruby command-syntax calls such as `puts "hi"`, `greet bob`, and `before_action :auth`
     // omit the trailing `(` that the shared CallRegex requires.
     // Ruby の command syntax 呼び出し (`puts "hi"` / `greet bob` / `before_action :auth`)
@@ -2144,6 +2161,16 @@ public static class ReferenceExtractor
                 // `call` / `instantiate` を発行する。issue #263 参照。
                 foreach (var candidate in EnumerateNestedGenericCallCandidates(preparedLine, matchedCallIndices))
                     AddCallLikeReference(candidate.Name, candidate.NameIndex);
+            }
+
+            if (language == "rust")
+            {
+                foreach (Match match in RustMacroCallRegex.Matches(preparedLine))
+                {
+                    var name = match.Groups["name"].Value;
+                    var callIndex = match.Groups["name"].Index;
+                    AddCallLikeReference(name, callIndex);
+                }
             }
 
             if (language == "csharp")

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -111,6 +111,57 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
+    {
+        // issue #258: Rust macro invocations need to surface as call-like references so
+        // callers / callees / impact can follow both std macros and user-defined macros.
+        // issue #258: Rust の macro 呼び出しは call 相当の reference として出し、
+        // std macro と user 定義 macro の両方を callers / callees / impact から辿れるようにする。
+        const string content = """
+            macro_rules! my_macro {
+                ($x:expr) => { $x + 1 };
+            }
+
+            fn helper(x: i32) -> i32 { x }
+
+            fn main() {
+                std::println!("hello");
+                let v = vec![1, 2, 3];
+                let msg = format!("x={}", 42);
+                let y = my_macro!(42);
+                let z = helper(1);
+                dbg!(y + z);
+                let _ = msg;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        var callReferences = references.Where(reference => reference.ReferenceKind == "call").ToList();
+        Assert.Equal(6, callReferences.Count);
+        Assert.Contains(callReferences, reference =>
+            reference.SymbolName == "std::println"
+            && reference.ContainerName == "main");
+        Assert.Contains(callReferences, reference =>
+            reference.SymbolName == "vec"
+            && reference.ContainerName == "main");
+        Assert.Contains(callReferences, reference =>
+            reference.SymbolName == "format"
+            && reference.ContainerName == "main");
+        Assert.Contains(callReferences, reference =>
+            reference.SymbolName == "my_macro"
+            && reference.ContainerName == "main");
+        Assert.Contains(callReferences, reference =>
+            reference.SymbolName == "dbg"
+            && reference.ContainerName == "main");
+        Assert.Contains(callReferences, reference =>
+            reference.SymbolName == "helper"
+            && reference.ContainerName == "main");
+        Assert.DoesNotContain(callReferences, reference => reference.SymbolName == "macro_rules");
+    }
+
+    [Fact]
     public void Extract_Css_CustomPropertiesAnimationsAndSelectors_AreReferenced()
     {
         const string content = """


### PR DESCRIPTION
Adds a Rust-specific macro-call reference pattern so references, callers, callees, and impact can see name!(...), name![...], and name!{...} forms again. Fixes #258