### PR TITLE
Fix Go generic type extraction (#262)

### DIFF
--- a/changelog.d/unreleased/262.fixed.md
+++ b/changelog.d/unreleased/262.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 262
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Go generic type declarations now appear in `symbols` again (#262)** — `SymbolExtractor` now accepts optional Go type-parameter blocks between the type name and `struct` / `interface` / type-alias bodies, so `type Stack[T any] struct { ... }` and similar declarations no longer disappear from the index. Added a regression covering generic structs, interfaces, and defined types. Affected: `src/CodeIndex/Indexer/SymbolExtractor.cs`, `tests/CodeIndex.Tests/SymbolExtractorTests.cs`. Fixes #262.
+
+## 日本語
+
+- **Go のジェネリック型宣言が再び `symbols` に現れるようになりました (#262)** — `SymbolExtractor` は型名と `struct` / `interface` / type alias 本体の間にある Go の型パラメータブロックを許可するようになり、`type Stack[T any] struct { ... }` のような宣言が index から消えなくなりました。ジェネリックな struct / interface / 定義型を含む回帰テストも追加しました。影響範囲: `src/CodeIndex/Indexer/SymbolExtractor.cs`, `tests/CodeIndex.Tests/SymbolExtractorTests.cs`. Fixes #262.

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -968,10 +968,10 @@ public static class SymbolExtractor
         ["go"] =
         [
             new("function", new Regex(@"^func\s+(?:\([^)]+\)\s+)?(?<name>\w+)\s*[\(\[]", RegexOptions.Compiled), BodyStyle.Brace),
-            new("struct",   new Regex(@"^type\s+(?<name>\w+)\s+struct\b", RegexOptions.Compiled), BodyStyle.Brace),
-            new("interface", new Regex(@"^type\s+(?<name>\w+)\s+interface\b", RegexOptions.Compiled), BodyStyle.Brace),
+            new("struct",   new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+struct\b", RegexOptions.Compiled), BodyStyle.Brace),
+            new("interface", new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+interface\b", RegexOptions.Compiled), BodyStyle.Brace),
             // Type alias (type Name = OtherType or type Name OtherType) / 型エイリアス
-            new("import",   new Regex(@"^type\s+(?<name>\w+)\s+[=\w]", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+[=\w]", RegexOptions.Compiled), BodyStyle.None),
             // Const declaration inside const block / const ブロック内の定数宣言
             new("function", new Regex(@"^\s+(?<name>[A-Z]\w*)\s*=\s*", RegexOptions.Compiled), BodyStyle.None),
             // Package-level var / パッケージレベル変数

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9439,6 +9439,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Go_DetectsGenericTypeDeclarations()
+    {
+        var content = """
+            type Stack[T any] struct {
+                items []T
+            }
+
+            type Container[T comparable, U any] interface {
+                Get() U
+            }
+
+            type Alias[T any] string
+            """;
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Stack");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Container");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Alias");
+    }
+
+    [Fact]
     public void Extract_Shell_DetectsFunctions()
     {
         var content = "function setup() {\n  echo 'setup'\n}\n\ncleanup() {\n  echo 'cleanup'\n}";


### PR DESCRIPTION
## Summary
- Allow Go `type` declarations with generic parameter blocks to match `struct`, `interface`, and defined-type forms.
- Add regression coverage for generic struct, interface, and defined type declarations.
- Add a bilingual changelog fragment for the user-visible fix.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Go_"`
- `dotnet test`

Fixes #262