### PR TITLE
Fix Rust constructor reference filtering

### DIFF
--- a/changelog.d/unreleased/273.fixed.md
+++ b/changelog.d/unreleased/273.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 273
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust constructor calls now survive the shared call-name ignore list (#273)** — `Type::new(...)` and `Default::default()` are now preserved for Rust while the shared `new` / `default` suppression still applies to other languages. Added regression coverage for Rust constructors and the Go `new(T)` builtin.
+
+## 日本語
+
+- **Rust の constructor 呼び出しが共有の call-name 無視リストで落ちなくなりました (#273)** — Rust では `Type::new(...)` と `Default::default()` を保持しつつ、共有の `new` / `default` 抑止は他言語に対しては継続します。Rust の constructor と Go の `new(T)` builtin に対する回帰テストも追加しました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -173,6 +173,15 @@ public static class ReferenceExtractor
             "all", "clean", "install", "build", "run", "help",
         },
     };
+    private static readonly Dictionary<string, HashSet<string>> LanguageSpecificCallNameKeeps = new(StringComparer.Ordinal)
+    {
+        // Rust uses `new` / `default` as ordinary method names (`Type::new`, `Default::default`).
+        // Rust では `new` / `default` は通常のメソッド名 (`Type::new`, `Default::default`)。
+        ["rust"] = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "new", "default",
+        },
+    };
 
     // JavaScript / TypeScript tokens that legally sit immediately before a template literal
     // without being a tag identifier: unary / binary operators (`void \`...\``,
@@ -13348,6 +13357,12 @@ public static class ReferenceExtractor
 
     private static bool IsIgnoredCallName(string language, string name)
     {
+        if (LanguageSpecificCallNameKeeps.TryGetValue(language, out var languageSpecificKeepNames)
+            && languageSpecificKeepNames.Contains(name))
+        {
+            return false;
+        }
+
         if (language == "php")
         {
             if (SharedIgnoredCallNamesCaseInsensitive.Contains(name))

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7729,6 +7729,89 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustConstructors_PreserveNewAndDefaultCalls()
+    {
+        // Regression for issue #273: Rust's `Type::new()` and `Default::default()`
+        // are ordinary method calls, not keywords. The shared `new` / `default`
+        // ignore list must not suppress them.
+        // issue #273 回帰: Rust の `Type::new()` と `Default::default()` は通常の
+        // メソッド呼び出しであり、キーワードではない。共有の `new` / `default`
+        // ignore list で落としてはいけない。
+        const string content = """
+            struct Point {
+                x: i32,
+                y: i32,
+            }
+
+            impl Point {
+                fn new(x: i32, y: i32) -> Self {
+                    Self { x, y }
+                }
+            }
+
+            fn make_point() -> Point {
+                Point::new(1, 2)
+            }
+
+            fn make_vec() -> Vec<i32> {
+                Vec::new()
+            }
+
+            fn make_string() -> String {
+                String::new()
+            }
+
+            fn make_default() -> Point {
+                Default::default()
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Equal(3, references.Count(reference =>
+            reference.SymbolName == "new"
+            && reference.ReferenceKind == "call"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "new"
+            && reference.ContainerName == "make_point");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "new"
+            && reference.ContainerName == "make_vec");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "new"
+            && reference.ContainerName == "make_string");
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "default"
+            && reference.ReferenceKind == "call"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "default"
+            && reference.ContainerName == "make_default");
+    }
+
+    [Fact]
+    public void Extract_GoBuiltinNew_RemainsIgnored()
+    {
+        // Regression for issue #273: Rust gets an exception for `new`, but Go's
+        // builtin `new(T)` should still remain ignored so we do not regress the
+        // existing false-positive suppression.
+        // issue #273 回帰: Rust には `new` の例外を与えるが、Go の builtin
+        // `new(T)` は引き続き無視されるべきで、既存の偽陽性抑止を壊してはならない。
+        const string content = """
+            package main
+
+            func makeValue() *int {
+                return new(int)
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "new");
+    }
+
+    [Fact]
     public void Extract_JsTemplateHoleBlockCommentBody_DoesNotLeakPhantomReferences()
     {
         // Regression for issue #291 follow-up: identifiers inside a `/* ... */`


### PR DESCRIPTION
## Summary
- Add a Rust keep-list so `Type::new(...)` and `Default::default()` are preserved as call references.
- Keep Go's `new(T)` builtin ignored.
- Add regression coverage for Rust constructors and the Go builtin case.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet test`

## Changelog
- `changelog.d/unreleased/273.fixed.md`

Fixes #273