### PR TITLE
Apply SCSS alias normalization to count commands

### DIFF
--- a/changelog.d/unreleased/1046.fixed.md
+++ b/changelog.d/unreleased/1046.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1046
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **SCSS `$` queries now work in `references --count`, `callers`, and `callees` (#1046)** — the same alias normalization added for SCSS `references` now also applies to the count and call-graph query paths, so `$primary` and `$rounded` resolve to the canonical CSS rows instead of returning false negatives. Added regression coverage for `references --count`, `callers`, and `callees` with SCSS fixtures.
+
+## 日本語
+
+- **SCSS の `$` クエリが `references --count`、`callers`、`callees` でも動くようになりました (#1046)** — SCSS `references` に追加した alias 正規化が count と call-graph のクエリ経路にも適用されるようになり、`$primary` や `$rounded` が canonical な CSS 行に解決されて取りこぼしにくくなりました。SCSS fixture を使った `references --count`、`callers`、`callees` の回帰テストも追加しています。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -3137,6 +3137,10 @@ public partial class DbReader
         var totalAliasScope = totalSuffixAlias != null
             ? " AND f.lang = 'csharp' AND r.reference_kind = 'attribute'"
             : string.Empty;
+        var totalCssScssVariableAlias = ComputeCssScssVariableAlias(query);
+        var totalCssScssVariableAliasScope = totalCssScssVariableAlias != null
+            ? " AND f.lang = 'css'"
+            : string.Empty;
         const string sqlLeafTotalScope = " AND f.lang = 'sql'";
         if (query != null)
         {
@@ -3161,19 +3165,25 @@ public partial class DbReader
             else if (exact && _foldReady)
                 innerSql += totalSuffixAlias != null
                     ? $" AND (r.symbol_name_folded = @query OR (r.symbol_name_folded = @queryAttributeAlias{totalAliasScope}){(allowSqlLeafFallback ? $" OR (r.symbol_name_folded = @aliasQueryLeafFolded{sqlLeafTotalScope})" : string.Empty)})"
-                    : allowSqlLeafFallback
+                    : totalCssScssVariableAlias != null
+                        ? $" AND (r.symbol_name_folded = @query OR (r.symbol_name_folded = @queryCssScssVariableAlias{totalCssScssVariableAliasScope}){(allowSqlLeafFallback ? $" OR (r.symbol_name_folded = @aliasQueryLeafFolded{sqlLeafTotalScope})" : string.Empty)})"
+                        : allowSqlLeafFallback
                         ? $" AND (r.symbol_name_folded = @query OR (r.symbol_name_folded = @aliasQueryLeafFolded{sqlLeafTotalScope}))"
                         : " AND r.symbol_name_folded = @query";
             else if (exact)
                 innerSql += totalSuffixAlias != null
                     ? $" AND (r.symbol_name = @query COLLATE NOCASE OR (r.symbol_name = @queryAttributeAlias COLLATE NOCASE{totalAliasScope}){(allowSqlLeafFallback ? $" OR (r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE{sqlLeafTotalScope})" : string.Empty)})"
-                    : allowSqlLeafFallback
+                    : totalCssScssVariableAlias != null
+                        ? $" AND (r.symbol_name = @query COLLATE NOCASE OR (r.symbol_name = @queryCssScssVariableAlias COLLATE NOCASE{totalCssScssVariableAliasScope}){(allowSqlLeafFallback ? $" OR (r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE{sqlLeafTotalScope})" : string.Empty)})"
+                        : allowSqlLeafFallback
                         ? $" AND (r.symbol_name = @query COLLATE NOCASE OR (r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE{sqlLeafTotalScope}))"
                         : " AND r.symbol_name = @query COLLATE NOCASE";
             else
                 innerSql += totalSuffixAlias != null
                     ? $" AND (r.symbol_name LIKE @query ESCAPE '\\' OR (r.symbol_name = @queryAttributeAlias COLLATE NOCASE{totalAliasScope}) OR (r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE{sqlLeafTotalScope}))"
-                    : $" AND (r.symbol_name LIKE @query ESCAPE '\\' OR (r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE{sqlLeafTotalScope}))";
+                    : totalCssScssVariableAlias != null
+                        ? $" AND (r.symbol_name LIKE @query ESCAPE '\\' OR (r.symbol_name = @queryCssScssVariableAlias COLLATE NOCASE{totalCssScssVariableAliasScope}) OR (r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE{sqlLeafTotalScope}))"
+                        : $" AND (r.symbol_name LIKE @query ESCAPE '\\' OR (r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE{sqlLeafTotalScope}))";
         }
         if (referenceKind != null)
             innerSql += " AND r.reference_kind = @referenceKind";
@@ -3201,6 +3211,13 @@ public partial class DbReader
                     ? NameFold.Fold(totalSuffixAlias) ?? totalSuffixAlias
                     : totalSuffixAlias;
                 cmd.Parameters.AddWithValue("@queryAttributeAlias", aliasParam);
+            }
+            if (totalCssScssVariableAlias != null)
+            {
+                var aliasParam = exact && _foldReady
+                    ? NameFold.Fold(totalCssScssVariableAlias) ?? totalCssScssVariableAlias
+                    : totalCssScssVariableAlias;
+                cmd.Parameters.AddWithValue("@queryCssScssVariableAlias", aliasParam);
             }
         }
         if (referenceKind != null)
@@ -3255,6 +3272,10 @@ public partial class DbReader
             sql += NonInvocationReferenceKindsExclusion;
         var allowSqlLeafFallback = AllowSqlLeafFallbackForQuery(query);
         var useSqlQualifiedContextMatch = SqlNameResolver.HasQualifier(query);
+        var cssScssVariableAlias = ComputeCssScssVariableAlias(query);
+        var cssScssVariableAliasScope = cssScssVariableAlias != null
+            ? " AND f.lang = 'css'"
+            : string.Empty;
         if (useSqlQualifiedContextMatch && exact && _foldReady)
             sql += $" AND (((f.lang = 'sql') AND sql_context_has_name_folded_at({contextSql}, @aliasQuery, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name_folded = @query))";
         else if (useSqlQualifiedContextMatch && exact)
@@ -3265,14 +3286,20 @@ public partial class DbReader
             sql += $" AND (((f.lang = 'sql') AND sql_context_like_name_at({contextSql}, @aliasQuery, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name LIKE @query ESCAPE '\\'))";
         else if (exact && _foldReady)
             sql += allowSqlLeafFallback
-                ? " AND (r.symbol_name_folded = @query OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.symbol_name_folded = @query OR (r.symbol_name_folded = @queryCssScssVariableAlias{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
+                    : " AND (r.symbol_name_folded = @query OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
                 : " AND r.symbol_name_folded = @query";
         else if (exact)
             sql += allowSqlLeafFallback
-                ? " AND (r.symbol_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.symbol_name = @query COLLATE NOCASE OR (r.symbol_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                    : " AND (r.symbol_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
                 : " AND r.symbol_name = @query COLLATE NOCASE";
         else
-            sql += " AND (r.symbol_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))";
+            sql += cssScssVariableAlias != null
+                ? $" AND (r.symbol_name LIKE @query ESCAPE '\\' OR (r.symbol_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                : " AND (r.symbol_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))";
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
@@ -3305,6 +3332,13 @@ public partial class DbReader
         cmd.Parameters.AddWithValue("@query", callersQueryParam);
         cmd.Parameters.AddWithValue("@aliasQuery", query);
         cmd.Parameters.AddWithValue("@aliasQueryLeafFolded", NameFold.Fold(SqlNameResolver.GetLeafName(query)) ?? SqlNameResolver.GetLeafName(query));
+        if (cssScssVariableAlias != null)
+        {
+            var aliasParam = exact && _foldReady
+                ? NameFold.Fold(cssScssVariableAlias) ?? cssScssVariableAlias
+                : cssScssVariableAlias;
+            cmd.Parameters.AddWithValue("@queryCssScssVariableAlias", aliasParam);
+        }
         cmd.Parameters.AddWithValue("@preferExactCase", exact ? 1 : 0);
         cmd.Parameters.AddWithValue("@rawQuery", exact ? query : string.Empty);
         cmd.Parameters.AddWithValue("@rankingQuery", query.Trim());
@@ -3363,6 +3397,10 @@ public partial class DbReader
             groupedSql += $" AND r.reference_kind IN {CallGraphReferenceKindsSql}";
         var allowSqlLeafFallback = AllowSqlLeafFallbackForQuery(query);
         var useSqlQualifiedContextMatch = SqlNameResolver.HasQualifier(query);
+        var cssScssVariableAlias = ComputeCssScssVariableAlias(query);
+        var cssScssVariableAliasScope = cssScssVariableAlias != null
+            ? " AND f.lang = 'css'"
+            : string.Empty;
         if (useSqlQualifiedContextMatch && exact && _foldReady)
             groupedSql += $" AND (((f.lang = 'sql') AND sql_context_has_name_folded_at({contextSql}, @aliasQuery, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name_folded = @query))";
         else if (useSqlQualifiedContextMatch && exact)
@@ -3373,14 +3411,20 @@ public partial class DbReader
             groupedSql += $" AND (((f.lang = 'sql') AND sql_context_like_name_at({contextSql}, @aliasQuery, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name LIKE @query ESCAPE '\\'))";
         else if (exact && _foldReady)
             groupedSql += allowSqlLeafFallback
-                ? " AND (r.symbol_name_folded = @query OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.symbol_name_folded = @query OR (r.symbol_name_folded = @queryCssScssVariableAlias{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
+                    : " AND (r.symbol_name_folded = @query OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
                 : " AND r.symbol_name_folded = @query";
         else if (exact)
             groupedSql += allowSqlLeafFallback
-                ? " AND (r.symbol_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.symbol_name = @query COLLATE NOCASE OR (r.symbol_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                    : " AND (r.symbol_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
                 : " AND r.symbol_name = @query COLLATE NOCASE";
         else
-            groupedSql += " AND (r.symbol_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))";
+            groupedSql += cssScssVariableAlias != null
+                ? $" AND (r.symbol_name LIKE @query ESCAPE '\\' OR (r.symbol_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                : " AND (r.symbol_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))";
         if (lang != null)
             groupedSql += " AND f.lang = @lang";
         AppendPathFilters(ref groupedSql, pathPatterns, excludePathPatterns, excludeTests);
@@ -3397,6 +3441,13 @@ public partial class DbReader
         cmd.Parameters.AddWithValue("@query", value);
         cmd.Parameters.AddWithValue("@aliasQuery", query);
         cmd.Parameters.AddWithValue("@aliasQueryLeafFolded", NameFold.Fold(SqlNameResolver.GetLeafName(query)) ?? SqlNameResolver.GetLeafName(query));
+        if (cssScssVariableAlias != null)
+        {
+            var aliasParam = exact && _foldReady
+                ? NameFold.Fold(cssScssVariableAlias) ?? cssScssVariableAlias
+                : cssScssVariableAlias;
+            cmd.Parameters.AddWithValue("@queryCssScssVariableAlias", aliasParam);
+        }
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
@@ -3413,9 +3464,16 @@ public partial class DbReader
         if (!_hasReferencesTable)
             return new QueryCountResult(0, 0);
 
+        if (query.Length > 0 && query[0] == '$')
+            query = query[1..];
+
         using var cmd = _conn.CreateCommand();
         var referenceLineJoin = ReferenceLineJoinSql("r");
         var contextSql = ReferenceContextSql("r");
+        var cssScssVariableAlias = ComputeCssScssVariableAlias(query);
+        var cssScssVariableAliasScope = cssScssVariableAlias != null
+            ? " AND f.lang = 'css'"
+            : string.Empty;
         var groupedSql = @"
             SELECT path, lang
             FROM (
@@ -3442,14 +3500,20 @@ public partial class DbReader
             groupedSql += $" AND (((f.lang = 'sql') AND sql_context_like_name_at({contextSql}, @aliasQuery, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name LIKE @query ESCAPE '\\'))";
         else if (exact && _foldReady)
             groupedSql += allowSqlLeafFallback
-                ? " AND (r.symbol_name_folded = @query OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.symbol_name_folded = @query OR (r.symbol_name_folded = @queryCssScssVariableAlias{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
+                    : " AND (r.symbol_name_folded = @query OR (f.lang = 'sql' AND r.symbol_name_folded = @aliasQueryLeafFolded))"
                 : " AND r.symbol_name_folded = @query";
         else if (exact)
             groupedSql += allowSqlLeafFallback
-                ? " AND (r.symbol_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.symbol_name = @query COLLATE NOCASE OR (r.symbol_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                    : " AND (r.symbol_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
                 : " AND r.symbol_name = @query COLLATE NOCASE";
         else
-            groupedSql += " AND (r.symbol_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))";
+            groupedSql += cssScssVariableAlias != null
+                ? $" AND (r.symbol_name LIKE @query ESCAPE '\\' OR (r.symbol_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))"
+                : " AND (r.symbol_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@aliasQuery) COLLATE NOCASE))";
         if (lang != null)
             groupedSql += " AND f.lang = @lang";
         AppendPathFilters(ref groupedSql, pathPatterns, excludePathPatterns, excludeTests);
@@ -3466,6 +3530,13 @@ public partial class DbReader
         cmd.Parameters.AddWithValue("@query", value);
         cmd.Parameters.AddWithValue("@aliasQuery", query);
         cmd.Parameters.AddWithValue("@aliasQueryLeafFolded", NameFold.Fold(SqlNameResolver.GetLeafName(query)) ?? SqlNameResolver.GetLeafName(query));
+        if (cssScssVariableAlias != null)
+        {
+            var aliasParam = exact && _foldReady
+                ? NameFold.Fold(cssScssVariableAlias) ?? cssScssVariableAlias
+                : cssScssVariableAlias;
+            cmd.Parameters.AddWithValue("@queryCssScssVariableAlias", aliasParam);
+        }
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
@@ -3514,20 +3585,30 @@ public partial class DbReader
             sql += NonInvocationReferenceKindsExclusion;
         var allowSqlLeafFallback = AllowSqlLeafFallbackForQuery(query);
         var useSqlQualifiedContainerMatch = SqlNameResolver.HasQualifier(query);
+        var cssScssVariableAlias = ComputeCssScssVariableAlias(query);
+        var cssScssVariableAliasScope = cssScssVariableAlias != null
+            ? " AND f.lang = 'css'"
+            : string.Empty;
         if (exact && useSqlQualifiedContainerMatch && _foldReady)
             sql += " AND (((f.lang = 'sql') AND sql_segment_count(r.container_name) = @aliasQuerySegmentCount AND sql_normalize_name_folded(r.container_name) = @aliasQueryNormalizedFolded) OR ((f.lang != 'sql') AND r.container_name_folded = @query))";
         else if (exact && useSqlQualifiedContainerMatch)
             sql += " AND (((f.lang = 'sql') AND sql_segment_count(r.container_name) = @aliasQuerySegmentCount AND sql_normalize_name(r.container_name) = @aliasQueryNormalized COLLATE NOCASE) OR ((f.lang != 'sql') AND r.container_name = @query COLLATE NOCASE))";
         else if (exact && _foldReady)
             sql += allowSqlLeafFallback
-                ? " AND (r.container_name_folded = @query OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.container_name_folded = @query OR (r.container_name_folded = @queryCssScssVariableAlias{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
+                    : " AND (r.container_name_folded = @query OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
                 : " AND r.container_name_folded = @query";
         else if (exact)
             sql += allowSqlLeafFallback
-                ? " AND (r.container_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.container_name = @query COLLATE NOCASE OR (r.container_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                    : " AND (r.container_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
                 : " AND r.container_name = @query COLLATE NOCASE";
         else
-            sql += " AND (r.container_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))";
+            sql += cssScssVariableAlias != null
+                ? $" AND (r.container_name LIKE @query ESCAPE '\\' OR (r.container_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                : " AND (r.container_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))";
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
@@ -3562,6 +3643,13 @@ public partial class DbReader
         cmd.Parameters.AddWithValue("@aliasQueryNormalized", SqlNameResolver.NormalizeQualifiedName(query));
         cmd.Parameters.AddWithValue("@aliasQueryNormalizedFolded", NameFold.Fold(SqlNameResolver.NormalizeQualifiedName(query)) ?? SqlNameResolver.NormalizeQualifiedName(query));
         cmd.Parameters.AddWithValue("@aliasQuerySegmentCount", SqlNameResolver.GetSegmentCount(query));
+        if (cssScssVariableAlias != null)
+        {
+            var aliasParam = exact && _foldReady
+                ? NameFold.Fold(cssScssVariableAlias) ?? cssScssVariableAlias
+                : cssScssVariableAlias;
+            cmd.Parameters.AddWithValue("@queryCssScssVariableAlias", aliasParam);
+        }
         cmd.Parameters.AddWithValue("@preferExactCase", exact ? 1 : 0);
         cmd.Parameters.AddWithValue("@rawQuery", exact ? query : string.Empty);
         cmd.Parameters.AddWithValue("@rankingQuery", query.Trim());
@@ -3621,20 +3709,30 @@ public partial class DbReader
             groupedSql += $" AND r.reference_kind IN {CallGraphReferenceKindsSql}";
         var allowSqlLeafFallback = AllowSqlLeafFallbackForQuery(query);
         var useSqlQualifiedContainerMatch = SqlNameResolver.HasQualifier(query);
+        var cssScssVariableAlias = ComputeCssScssVariableAlias(query);
+        var cssScssVariableAliasScope = cssScssVariableAlias != null
+            ? " AND f.lang = 'css'"
+            : string.Empty;
         if (exact && useSqlQualifiedContainerMatch && _foldReady)
             groupedSql += " AND (((f.lang = 'sql') AND sql_segment_count(r.container_name) = @aliasQuerySegmentCount AND sql_normalize_name_folded(r.container_name) = @aliasQueryNormalizedFolded) OR ((f.lang != 'sql') AND r.container_name_folded = @query))";
         else if (exact && useSqlQualifiedContainerMatch)
             groupedSql += " AND (((f.lang = 'sql') AND sql_segment_count(r.container_name) = @aliasQuerySegmentCount AND sql_normalize_name(r.container_name) = @aliasQueryNormalized COLLATE NOCASE) OR ((f.lang != 'sql') AND r.container_name = @query COLLATE NOCASE))";
         else if (exact && _foldReady)
             groupedSql += allowSqlLeafFallback
-                ? " AND (r.container_name_folded = @query OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.container_name_folded = @query OR (r.container_name_folded = @queryCssScssVariableAlias{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
+                    : " AND (r.container_name_folded = @query OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
                 : " AND r.container_name_folded = @query";
         else if (exact)
             groupedSql += allowSqlLeafFallback
-                ? " AND (r.container_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.container_name = @query COLLATE NOCASE OR (r.container_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                    : " AND (r.container_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
                 : " AND r.container_name = @query COLLATE NOCASE";
         else
-            groupedSql += " AND (r.container_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))";
+            groupedSql += cssScssVariableAlias != null
+                ? $" AND (r.container_name LIKE @query ESCAPE '\\' OR (r.container_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                : " AND (r.container_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))";
         if (lang != null)
             groupedSql += " AND f.lang = @lang";
         AppendPathFilters(ref groupedSql, pathPatterns, excludePathPatterns, excludeTests);
@@ -3654,6 +3752,13 @@ public partial class DbReader
         cmd.Parameters.AddWithValue("@aliasQueryNormalized", SqlNameResolver.NormalizeQualifiedName(query));
         cmd.Parameters.AddWithValue("@aliasQueryNormalizedFolded", NameFold.Fold(SqlNameResolver.NormalizeQualifiedName(query)) ?? SqlNameResolver.NormalizeQualifiedName(query));
         cmd.Parameters.AddWithValue("@aliasQuerySegmentCount", SqlNameResolver.GetSegmentCount(query));
+        if (cssScssVariableAlias != null)
+        {
+            var aliasParam = exact && _foldReady
+                ? NameFold.Fold(cssScssVariableAlias) ?? cssScssVariableAlias
+                : cssScssVariableAlias;
+            cmd.Parameters.AddWithValue("@queryCssScssVariableAlias", aliasParam);
+        }
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
@@ -3669,6 +3774,9 @@ public partial class DbReader
     {
         if (!_hasReferencesTable)
             return new QueryCountResult(0, 0);
+
+        if (query.Length > 0 && query[0] == '$')
+            query = query[1..];
 
         using var cmd = _conn.CreateCommand();
         var groupedSql = @"
@@ -3690,20 +3798,30 @@ public partial class DbReader
             groupedSql += $" AND r.reference_kind IN {CallGraphReferenceKindsSql}";
         var allowSqlLeafFallback = AllowSqlLeafFallbackForQuery(query);
         var useSqlQualifiedContainerMatch = SqlNameResolver.HasQualifier(query);
+        var cssScssVariableAlias = ComputeCssScssVariableAlias(query);
+        var cssScssVariableAliasScope = cssScssVariableAlias != null
+            ? " AND f.lang = 'css'"
+            : string.Empty;
         if (exact && useSqlQualifiedContainerMatch && _foldReady)
             groupedSql += " AND (((f.lang = 'sql') AND sql_segment_count(r.container_name) = @aliasQuerySegmentCount AND sql_normalize_name_folded(r.container_name) = @aliasQueryNormalizedFolded) OR ((f.lang != 'sql') AND r.container_name_folded = @query))";
         else if (exact && useSqlQualifiedContainerMatch)
             groupedSql += " AND (((f.lang = 'sql') AND sql_segment_count(r.container_name) = @aliasQuerySegmentCount AND sql_normalize_name(r.container_name) = @aliasQueryNormalized COLLATE NOCASE) OR ((f.lang != 'sql') AND r.container_name = @query COLLATE NOCASE))";
         else if (exact && _foldReady)
             groupedSql += allowSqlLeafFallback
-                ? " AND (r.container_name_folded = @query OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.container_name_folded = @query OR (r.container_name_folded = @queryCssScssVariableAlias{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
+                    : " AND (r.container_name_folded = @query OR (f.lang = 'sql' AND sql_leaf_name_folded(r.container_name) = @aliasQueryLeafFolded))"
                 : " AND r.container_name_folded = @query";
         else if (exact)
             groupedSql += allowSqlLeafFallback
-                ? " AND (r.container_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                ? cssScssVariableAlias != null
+                    ? $" AND (r.container_name = @query COLLATE NOCASE OR (r.container_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                    : " AND (r.container_name = @query COLLATE NOCASE OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
                 : " AND r.container_name = @query COLLATE NOCASE";
         else
-            groupedSql += " AND (r.container_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))";
+            groupedSql += cssScssVariableAlias != null
+                ? $" AND (r.container_name LIKE @query ESCAPE '\\' OR (r.container_name = @queryCssScssVariableAlias COLLATE NOCASE{cssScssVariableAliasScope}) OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))"
+                : " AND (r.container_name LIKE @query ESCAPE '\\' OR (f.lang = 'sql' AND sql_leaf_name(r.container_name) = @aliasQuery COLLATE NOCASE))";
         if (lang != null)
             groupedSql += " AND f.lang = @lang";
         AppendPathFilters(ref groupedSql, pathPatterns, excludePathPatterns, excludeTests);
@@ -3723,6 +3841,13 @@ public partial class DbReader
         cmd.Parameters.AddWithValue("@aliasQueryNormalized", SqlNameResolver.NormalizeQualifiedName(query));
         cmd.Parameters.AddWithValue("@aliasQueryNormalizedFolded", NameFold.Fold(SqlNameResolver.NormalizeQualifiedName(query)) ?? SqlNameResolver.NormalizeQualifiedName(query));
         cmd.Parameters.AddWithValue("@aliasQuerySegmentCount", SqlNameResolver.GetSegmentCount(query));
+        if (cssScssVariableAlias != null)
+        {
+            var aliasParam = exact && _foldReady
+                ? NameFold.Fold(cssScssVariableAlias) ?? cssScssVariableAlias
+                : cssScssVariableAlias;
+            cmd.Parameters.AddWithValue("@queryCssScssVariableAlias", aliasParam);
+        }
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -13290,6 +13290,92 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunGraphCounts_ExactJson_CssScssVariableAliasAppliesToCallersAndCallees()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_css_scss_variable_alias_counts");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "styles"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "styles", "theme.scss"),
+                """
+                $primary: #3366cc;
+                $spacing-base: 8px;
+
+                @mixin rounded($radius) {
+                  border-radius: $radius;
+                }
+
+                %button-base {
+                  padding: 4px;
+                }
+
+                .button {
+                  color: $primary;
+                  padding: $spacing-base * 2;
+                  @include rounded(4px);
+                }
+
+                .card {
+                  @extend %button-base;
+                  border: 1px solid $primary;
+                }
+                """);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = RunBuiltCli([projectRoot, "--json"]);
+            var (referencesCountExitCode, referencesCountStdout, referencesCountStderr) = RunBuiltCli(["references", "$primary", "--db", dbPath, "--json", "--lang", "css", "--exact-name", "--count"]);
+            var (callersExitCode, callersStdout, callersStderr) = RunBuiltCli(["callers", "$primary", "--db", dbPath, "--json", "--lang", "css", "--exact-name"]);
+            var (callersCountExitCode, callersCountStdout, callersCountStderr) = RunBuiltCli(["callers", "$primary", "--db", dbPath, "--json", "--lang", "css", "--exact-name", "--count"]);
+            var (calleesExitCode, calleesStdout, calleesStderr) = RunBuiltCli(["callees", "$rounded", "--db", dbPath, "--json", "--lang", "css", "--exact-name"]);
+            var (calleesCountExitCode, calleesCountStdout, calleesCountStderr) = RunBuiltCli(["callees", "$rounded", "--db", dbPath, "--json", "--lang", "css", "--exact-name", "--count"]);
+
+            using var referencesCountDocument = ParseJsonOutput(referencesCountStdout);
+            using var callersCountDocument = ParseJsonOutput(callersCountStdout);
+            using var calleesCountDocument = ParseJsonOutput(calleesCountStdout);
+
+            var callersRows = ParseJsonLines(callersStdout);
+            var calleesRows = ParseJsonLines(calleesStdout);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+
+            Assert.Equal(CommandExitCodes.Success, referencesCountExitCode);
+            Assert.Equal(string.Empty, referencesCountStderr);
+            Assert.Equal(2, referencesCountDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, referencesCountDocument.RootElement.GetProperty("files").GetInt32());
+
+            Assert.Equal(CommandExitCodes.Success, callersExitCode);
+            Assert.Equal(string.Empty, callersStderr);
+            Assert.Equal(2, callersRows.Count);
+            Assert.All(callersRows, row => Assert.Contains(row.RootElement.GetProperty("caller_name").GetString(), [".button", ".card"]));
+            Assert.All(callersRows, row => Assert.Equal("primary", row.RootElement.GetProperty("callee_name").GetString()));
+            Assert.All(callersRows, row => Assert.Equal("call", row.RootElement.GetProperty("reference_kind").GetString()));
+
+            Assert.Equal(CommandExitCodes.Success, callersCountExitCode);
+            Assert.Equal(string.Empty, callersCountStderr);
+            Assert.Equal(2, callersCountDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, callersCountDocument.RootElement.GetProperty("files").GetInt32());
+
+            Assert.Equal(CommandExitCodes.Success, calleesExitCode);
+            Assert.Equal(string.Empty, calleesStderr);
+            var calleesRow = Assert.Single(calleesRows);
+            Assert.Equal("rounded", calleesRow.RootElement.GetProperty("caller_name").GetString());
+            Assert.Equal("radius", calleesRow.RootElement.GetProperty("callee_name").GetString());
+            Assert.Equal("call", calleesRow.RootElement.GetProperty("reference_kind").GetString());
+
+            Assert.Equal(CommandExitCodes.Success, calleesCountExitCode);
+            Assert.Equal(string.Empty, calleesCountStderr);
+            Assert.Equal(1, calleesCountDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, calleesCountDocument.RootElement.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunReferences_ExactJson_SqlModifierPrefixedObjectsResolveRealNames()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_sql_modifier_prefixed_objects");


### PR DESCRIPTION
## Summary
- Extend the SCSS `$` alias normalization from PR #1046 to `references --count`, `callers`, and `callees`.
- Keep the existing non-count behavior intact while covering both count-only and graph-query paths with regressions.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~RunReferences_ExactJson_CssScssVariableAndExtendReferences_AreVisible|FullyQualifiedName~RunGraphCounts_ExactJson_CssScssVariableAliasAppliesToCallersAndCallees"`

## Docs / Changelog
- Added `changelog.d/unreleased/1046.fixed.md`.
- No direct `CHANGELOG.md` edit; this is an ordinary implementation follow-up.

## Follow-up candidates
- Addressed the SCSS `$` alias follow-up candidates from PR #1046 for `references --count`, `callers`, and `callees`.