### PR TITLE
Fix GitHelper merge test branch assumption

### DIFF
--- a/changelog.d/unreleased/1019.fixed.md
+++ b/changelog.d/unreleased/1019.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1019
+affected:
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+---
+
+## English
+
+- **The merge-commit GitHelper regression no longer assumes a `master` branch (#1019)** — `GitHelperTests.GetChangedFilesFromCommit_ReturnsFilesForMergeCommit` now switches back to the repository's current branch before creating the merge commit, so the test stays valid on repositories whose default branch is `main` or any other branch name.
+
+## 日本語
+
+- **merge commit の GitHelper 回帰テストが `master` 前提ではなくなりました (#1019)** — `GitHelperTests.GetChangedFilesFromCommit_ReturnsFilesForMergeCommit` は merge commit を作る前にリポジトリの現在ブランチへ戻るため、default branch が `main` など `master` 以外の環境でもテストが成立します。

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -168,13 +168,14 @@ public class GitHelperTests : IDisposable
         File.WriteAllText(Path.Combine(repoDir, "base.txt"), "base\n");
         RunGit(repoDir, "add", "base.txt");
         RunGit(repoDir, "commit", "-m", "base");
+        var baseBranch = RunGit(repoDir, "branch", "--show-current").Trim();
 
         RunGit(repoDir, "switch", "-c", "feature");
         File.WriteAllText(Path.Combine(repoDir, "feature.txt"), "feature\n");
         RunGit(repoDir, "add", "feature.txt");
         RunGit(repoDir, "commit", "-m", "feature change");
 
-        RunGit(repoDir, "switch", "master");
+        RunGit(repoDir, "switch", baseBranch);
         File.WriteAllText(Path.Combine(repoDir, "main.txt"), "main\n");
         RunGit(repoDir, "add", "main.txt");
         RunGit(repoDir, "commit", "-m", "main change");


### PR DESCRIPTION
## Summary
- Addressed the follow-up candidate from PR #1019 by making `GitHelperTests.GetChangedFilesFromCommit_ReturnsFilesForMergeCommit` branch-agnostic.
- The test now switches back to the repository's current branch before creating the merge commit, so it works when the default branch is `main` or any other branch name.
- Added a bilingual changelog fragment under `changelog.d/unreleased/`.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~GitHelperTests"`

## Follow-up candidate handled
- This PR explicitly addresses the follow-up candidate noted on PR #1019 about the merge-commit GitHelper test assuming `master`.