### PR TITLE
Broaden git clean rule example

### DIFF
--- a/.codex/rules/codeindex.rules
+++ b/.codex/rules/codeindex.rules
@@ -202,10 +202,10 @@ prefix_rule(
 )
 
 prefix_rule(
-    pattern = ["git", "clean", "-f"],
+    pattern = ["git", "clean"],
     decision = "forbidden",
     justification = "History-rewriting Git operations are blocked.",
-    match = ["git clean -f"],
+    match = ["git clean -fdx"],
 )
 
 prefix_rule(

--- a/changelog.d/unreleased/1015.fixed.md
+++ b/changelog.d/unreleased/1015.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1015
+affected:
+  - .codex/rules/codeindex.rules
+---
+
+## English
+
+- **The `git clean` rule example now stays representative of `git clean -fdx` (#1015)** — the `prefix_rule` entry was broadened so the example can keep using the destructive `-fdx` form instead of falling back to the narrower `-f` sample.
+
+## 日本語
+
+- **`git clean` ルールの例が `git clean -fdx` を代表したままになりました (#1015)** — `prefix_rule` エントリを広げ、危険な `-fdx` 形式を、狭い `-f` サンプルに逃がさずそのまま例として使えるようにしました。


### PR DESCRIPTION
## Summary

Broadened `.codex/rules/codeindex.rules` so the `git clean` example stays representative of `git clean -fdx` instead of falling back to the narrower `-f` sample.

This addresses the follow-up candidate called out in PR #1015.

## Validation

- `git diff --check`
- `python -m unittest discover -s .agent_harness/tests -p 'test_command_guard_core.py'`

## Docs / Changelog

- Added the required bilingual changelog fragment at `changelog.d/unreleased/1015.fixed.md`.
- No direct `CHANGELOG.md` edit was made, per the fragment workflow for ordinary implementation PRs.

## Follow-up candidates

- None.