### PR TITLE
Preserve SCSS alias scoping in count totals

### DIFF
--- a/changelog.d/unreleased/+pr1105-scss-count-alias.fixed.md
+++ b/changelog.d/unreleased/+pr1105-scss-count-alias.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1105
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SCSS `$` queries now stay scoped in `callers --count` / `callees --count` (#1105 follow-up)** — `CountCallersTotal` and `CountCalleesTotal` now preserve the leading `$` long enough to apply the CSS/SCSS alias branch, so `$primary` and `$rounded` continue to resolve only against CSS rows instead of broadening to unrelated names. Added a regression that mixes CSS and non-CSS rows with the same canonical names and verifies the count totals stay at the CSS-only values.
+
+## 日本語
+
+- **SCSS の `$` クエリが `callers --count` / `callees --count` でもスコープを保つようになりました (#1105 follow-up)** — `CountCallersTotal` と `CountCalleesTotal` が先頭の `$` を alias 判定まで保持するようになり、`$primary` と `$rounded` は CSS/SCSS 行だけに解決されて、無関係な名前へ広がらなくなりました。CSS 行と非 CSS 行に同じ canonical 名を混ぜた回帰テストを追加し、count total が CSS 限定の値のままであることを確認しています。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -3464,9 +3464,6 @@ public partial class DbReader
         if (!_hasReferencesTable)
             return new QueryCountResult(0, 0);
 
-        if (query.Length > 0 && query[0] == '$')
-            query = query[1..];
-
         using var cmd = _conn.CreateCommand();
         var referenceLineJoin = ReferenceLineJoinSql("r");
         var contextSql = ReferenceContextSql("r");
@@ -3774,9 +3771,6 @@ public partial class DbReader
     {
         if (!_hasReferencesTable)
             return new QueryCountResult(0, 0);
-
-        if (query.Length > 0 && query[0] == '$')
-            query = query[1..];
 
         using var cmd = _conn.CreateCommand();
         var groupedSql = @"

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -7054,6 +7054,79 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void GraphQueries_CountTotalsPreserveScssAliasScope()
+    {
+        var cssFileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "styles/theme.scss",
+            Lang = "css",
+            Size = 128,
+            Lines = 8,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertReferences([
+            new ReferenceRecord
+            {
+                FileId = cssFileId,
+                SymbolName = "primary",
+                ReferenceKind = "call",
+                Line = 4,
+                Column = 10,
+                Context = "color: $primary;",
+                ContainerKind = "rule",
+                ContainerName = ".button",
+            },
+            new ReferenceRecord
+            {
+                FileId = cssFileId,
+                SymbolName = "radius",
+                ReferenceKind = "call",
+                Line = 6,
+                Column = 12,
+                Context = "@include rounded(4px);",
+                ContainerKind = "function",
+                ContainerName = "rounded",
+            },
+        ]);
+
+        var jsFileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "scripts/theme.js",
+            Lang = "javascript",
+            Size = 128,
+            Lines = 8,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertReferences([
+            new ReferenceRecord
+            {
+                FileId = jsFileId,
+                SymbolName = "primary",
+                ReferenceKind = "call",
+                Line = 4,
+                Column = 10,
+                Context = "color: $primary;",
+                ContainerKind = "rule",
+                ContainerName = ".button",
+            },
+            new ReferenceRecord
+            {
+                FileId = jsFileId,
+                SymbolName = "radius",
+                ReferenceKind = "call",
+                Line = 6,
+                Column = 12,
+                Context = "@include rounded(4px);",
+                ContainerKind = "function",
+                ContainerName = "rounded",
+            },
+        ]);
+
+        Assert.Equal(new QueryCountResult(1, 1), _reader.CountCallersTotal("$primary", exact: true));
+        Assert.Equal(new QueryCountResult(1, 1), _reader.CountCalleesTotal("$rounded", exact: true));
+    }
+
+    [Fact]
     public void GetCallers_ExposesDistinctReferenceKindsForMixedGroups()
     {
         // Regression for #501: when a single container reaches the same callee via


### PR DESCRIPTION
## Summary
- Keep the SCSS `$` alias branch intact in `CountCallersTotal` and `CountCalleesTotal` so `callers --count` / `callees --count` stay scoped to CSS rows.
- Add a regression that mixes CSS and non-CSS rows with the same canonical names and verifies the count totals remain CSS-only.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~GraphQueries_CountTotalsPreserveScssAliasScope"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~GraphQueries_DefaultGraphQueriesKeepSubscribeRowsVisible|FullyQualifiedName~GraphQueries_CountTotalsPreserveScssAliasScope"`

## Changelog
- Added `changelog.d/unreleased/+pr1105-scss-count-alias.fixed.md`.

## Follow-up candidates
- This PR addresses the remaining Follow-up candidates from PR #1105 by preserving SCSS alias scoping in the count-total graph paths.