### PR TITLE
Fix Gradle DSL reference extraction for issue #280

### DIFF
--- a/changelog.d/unreleased/280.fixed.md
+++ b/changelog.d/unreleased/280.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 280
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Gradle block DSL and command-style calls now produce reference rows (#280)** — `ReferenceExtractor` now captures idiomatic Gradle/Groovy forms such as `plugins { ... }`, `dependencies { ... }`, `task buildJar(type: Jar) { ... }`, `apply plugin: 'java'`, `implementation '...'`, and `println 'x'` instead of dropping them behind the shared paren-only matcher and global keyword filter.
+
+## 日本語
+
+- **Gradle の block DSL と command-style 呼び出しが reference row に出るようになりました (#280)** — `ReferenceExtractor` が `plugins { ... }`、`dependencies { ... }`、`task buildJar(type: Jar) { ... }`、`apply plugin: 'java'`、`implementation '...'`、`println 'x'` のような慣用的な Gradle/Groovy 形式を拾うようになり、共通の `(` 必須 matcher と global keyword filter で落ちなくなりました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -358,6 +358,20 @@ public static class ReferenceExtractor
     {
         "match", "catch", "else", "finally",
     };
+    // Gradle/Groovy block and command-style DSL calls such as `plugins { ... }`,
+    // `task buildJar(type: Jar) { ... }`, `apply plugin: 'java'`, and `println 'x'`
+    // do not use the shared `foo(...)` shape. Keep the matcher narrow to known DSL
+    // call forms so ordinary assignment lines stay out of the graph.
+    // Gradle/Groovy の block / command 型 DSL 呼び出し (`plugins { ... }`、
+    // `task buildJar(type: Jar) { ... }`、`apply plugin: 'java'`、`println 'x'`) は
+    // 共通の `foo(...)` 形では拾えない。代わりに、既知の DSL 呼び出し形に絞った
+    // 専用 matcher で取り込む。
+    private static readonly Regex GradleBlockCallRegex = new(
+        @"(?<![\w$@])(?<name>[A-Za-z_]\w*)\b(?:\s+[^\r\n{]+?)?\s*\{",
+        RegexOptions.Compiled);
+    private static readonly Regex GradleCommandCallRegex = new(
+        @"(?<![\w$@])(?<name>[A-Za-z_]\w*)\s+(?=(?:['""]|[_\p{L}]|\d|\.|:))",
+        RegexOptions.Compiled);
     // PowerShell cmdlet / function calls are statement-start or pipeline-stage forms such as
     // `Get-ChildItem -Path .`, `Write-Host "x"`, and `$items | ForEach-Object { ... }`.
     // The shared CallRegex only sees parenthesized calls and would split hyphenated cmdlets
@@ -2204,6 +2218,29 @@ public static class ReferenceExtractor
                         if (ScalaIgnoredBlockCallNames.Contains(name))
                             continue;
                         AddCallLikeReference(name, callIndex);
+                    }
+                }
+                else if (language == "gradle")
+                {
+                    void AddGradleDslReference(string name, int callIndex)
+                    {
+                        var normalizedName = NormalizeAtPrefixedIdentifier(name);
+                        var callContainer = ResolveContainerForCall(callIndex);
+                        AddReference(references, seen, fileId, normalizedName, callIndex, "call", context, lineNumber, callContainer);
+                    }
+
+                    foreach (Match match in GradleBlockCallRegex.Matches(preparedLine))
+                    {
+                        var name = match.Groups["name"].Value;
+                        var callIndex = match.Groups["name"].Index;
+                        AddGradleDslReference(name, callIndex);
+                    }
+
+                    foreach (Match match in GradleCommandCallRegex.Matches(preparedLine))
+                    {
+                        var name = match.Groups["name"].Value;
+                        var callIndex = match.Groups["name"].Index;
+                        AddGradleDslReference(name, callIndex);
                     }
                 }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14584,6 +14584,97 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GradleDslBlockAndCommandForms_AreCapturedAsCalls()
+    {
+        // issue #280: Gradle/Groovy block DSL (`plugins {}` / `dependencies {}` / `repositories {}`)
+        // and command-style calls (`implementation '...'` / `println 'x'` / `apply plugin: 'java'`)
+        // must surface as reference rows instead of disappearing behind the shared `foo(...)` regex.
+        // issue #280: Gradle/Groovy の block DSL (`plugins {}` / `dependencies {}` / `repositories {}`)
+        // と command-style 呼び出し (`implementation '...'` / `println 'x'` / `apply plugin: 'java'`)
+        // は、共通の `foo(...)` regex に落ちず reference row として残る必要がある。
+        const string content = """
+            plugins {
+                id 'java'
+                id 'application'
+            }
+
+            dependencies {
+                implementation 'com.google.guava:guava:32.0.0-jre'
+                testImplementation 'junit:junit:4.13'
+                api project(':shared')
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            application {
+                mainClass = 'com.example.Main'
+            }
+
+            task buildJar(type: Jar) {
+                from sourceSets.main.output
+                manifest {
+                    attributes 'Main-Class': 'com.example.Main'
+                }
+            }
+
+            subprojects {
+                apply plugin: 'java'
+            }
+
+            doLast {
+                println 'hello'
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "gradle", content);
+        var references = ReferenceExtractor.Extract(1, "gradle", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "plugins"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "dependencies"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "repositories"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "application"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "task"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "implementation"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "testImplementation"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "api"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "apply"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "from"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "attributes"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "println"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "doLast"
+            && reference.ReferenceKind == "call");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "mainClass");
+    }
+
+    [Fact]
     public void Extract_JavaMethodBodyCall_StaysCall()
     {
         // Regression guard: ordinary Java method call remains `call`, not `annotation`.


### PR DESCRIPTION
Fixes #280

## Summary
- Capture Gradle/Groovy block DSL and command-style call forms in `references`.
- Keep Gradle DSL keywords alive via a Gradle-specific ignore exception.
- Add regression coverage and a bilingual changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_Gradle"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`