### PR TITLE
Fix Haskell instance symbol pollution

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -417,7 +417,7 @@ Type aliases are indexed as `import` symbols in Rust, TypeScript, Swift, Go, F# 
 | Dockerfile | named stages (AS) | base images (FROM), stage dependencies (FROM \<stage\> AS \<new\>, COPY --from=\<stage\>) | -- | -- | -- | -- | -- | -- | -- |
 | Lua | function, local function, `local x = function`, `M.x = function`, `M:x = function` | -- | -- | -- | -- | -- | -- | require | yes |
 | R | name <- function() | -- | -- | -- | -- | -- | -- | library, require | -- |
-| Haskell | type signatures (name ::) | data, newtype, type, instance | -- | class (typeclass) | -- | -- | -- | import | -- |
+| Haskell | type signatures (name ::) | data, newtype, type | -- | class (typeclass) | -- | -- | -- | import | -- |
 | F# | let, let rec, let mutable, let inline, let private/internal/public, quoted identifiers | type, module | -- | -- | -- | -- | -- | open | yes |
 | VB.NET | Sub, Function | Class, Module, Partial Class | Structure, Partial Structure | Interface, Partial Interface | Enum | Property | Event | Namespace, Imports | yes |
 | Zig | fn, pub fn, test | union, error | struct | -- | enum | -- | -- | @import | -- |
@@ -1558,7 +1558,7 @@ Rust / TypeScript / Swift / Go / F# / Scala の type alias は `import` とし�
 | Dockerfile | 名前付きステージ (AS) | ベースイメージ (FROM)、ステージ依存 (FROM \<stage\> AS \<new\>、COPY --from=\<stage\>) | -- | -- | -- | -- | -- | -- | -- |
 | Lua | function, local function, `local x = function`, `M.x = function`, `M:x = function` | -- | -- | -- | -- | -- | -- | require | yes |
 | R | name <- function() | -- | -- | -- | -- | -- | -- | library, require | -- |
-| Haskell | 型シグネチャ (name ::) | data, newtype, type, instance | -- | class (型クラス) | -- | -- | -- | import | -- |
+| Haskell | 型シグネチャ (name ::) | data, newtype, type | -- | class (型クラス) | -- | -- | -- | import | -- |
 | F# | let, let rec, let mutable, let inline, let private/internal/public, quoted identifiers | type, module | -- | -- | -- | -- | -- | open | yes |
 | VB.NET | Sub, Function | Class, Module, Partial Class | Structure, Partial Structure | Interface, Partial Interface | Enum | Property | Event | Namespace, Imports | yes |
 | Zig | fn, pub fn, test | union, error | struct | -- | enum | -- | -- | @import | -- |

--- a/changelog.d/unreleased/311.fixed.md
+++ b/changelog.d/unreleased/311.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 311
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Haskell `instance` declarations no longer emit phantom `class` symbols (#311)** - the Haskell symbol extractor now limits the `class` row to `data`, `newtype`, and `type` declarations, so `instance Greeter Person where` no longer duplicates the real `class Greeter a where` symbol.
+
+## 日本語
+
+- **Haskell の `instance` 宣言が phantom な `class` シンボルを出力しなくなりました (#311)** - Haskell の symbol extractor は `class` row を `data`、`newtype`、`type` 宣言のみに限定するため、`instance Greeter Person where` が本来の `class Greeter a where` シンボルを重複させなくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1162,7 +1162,7 @@ public static class SymbolExtractor
         [
             new("function", new Regex(@"^(?:>\s+|\s*)(?<name>[a-z_]\w*)\s+::", RegexOptions.Compiled), BodyStyle.None),
             new("interface", new Regex(@"^\s*class\s+(?<name>[A-Z]\w*)", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*(?:data|newtype|type|instance)\s+(?<name>[A-Z]\w*)", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?:data|newtype|type)\s+(?<name>[A-Z]\w*)", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*import\s+(?:qualified\s+)?(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["r"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11590,6 +11590,31 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Haskell_DoesNotTreatInstancesAsClasses()
+    {
+        // Haskell instance declarations should not be indexed as phantom type definitions.
+        // Haskell の instance 宣言は phantom な型定義としてはインデックスしない。
+        var content = """
+            class Greeter a where
+                greet :: a -> String
+
+            data Person = Person
+
+            instance Greeter Person where
+                greet _ = "Hello"
+
+            instance Greeter Int where
+                greet _ = "Hi"
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "haskell", content);
+
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Greeter");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "Greeter");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsLetTypeModuleOpen()
     {
         // F#: let, type, module, open / F#: let束縛、型、モジュール、open


### PR DESCRIPTION
## Summary
- Remove Haskell `instance` declarations from the `class` symbol row so they no longer emit phantom `class` entries.
- Add regression coverage for `class`, `data`, and `instance` declarations.
- Update the Haskell row in the developer guide and add a changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Haskell"`
- `dotnet test`

Fixes #311