### PR TITLE
Index Dart constructors and typedef aliases

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -392,7 +392,7 @@ Supported symbol kinds by language (33 languages with symbol extraction):
 | C++ | functions, `#define` macros | class | struct | -- | enum, enum class | -- | -- | #include | yes |
 | PHP | function, const | class | -- | interface, trait | enum | -- | -- | use, require/include | yes |
 | Swift | func | class, actor | struct | protocol | enum | -- | -- | import | yes |
-| Dart | functions | class, mixin, extension | -- | -- | enum | -- | -- | import | yes |
+| Dart | functions, constructors, typedef aliases | class, mixin, extension | -- | -- | enum | -- | -- | import | yes |
 | Scala | def | class, object | -- | trait | enum | -- | -- | import | yes |
 | Elixir | def, defp | defmodule | -- | defprotocol | -- | -- | -- | import, alias, use, require | yes |
 | Crystal | .cr | -- | -- | -- | -- | -- | -- | -- | -- |
@@ -1533,7 +1533,7 @@ LIMIT 20;
 | C++ | 関数, `#define` マクロ | class | struct | -- | enum, enum class | -- | -- | #include | yes |
 | PHP | function, const | class | -- | interface, trait | enum | -- | -- | use, require/include | yes |
 | Swift | func | class, actor | struct | protocol | enum | -- | -- | import | yes |
-| Dart | 関数 | class, mixin, extension | -- | -- | enum | -- | -- | import | yes |
+| Dart | 関数、コンストラクタ、typedef エイリアス | class, mixin, extension | -- | -- | enum | -- | -- | import | yes |
 | Scala | def | class, object | -- | trait | enum | -- | -- | import | yes |
 | Elixir | def, defp | defmodule | -- | defprotocol | -- | -- | -- | import, alias, use, require | yes |
 | Crystal | .cr | -- | -- | -- | -- | -- | -- | -- | -- |

--- a/changelog.d/unreleased/312.fixed.md
+++ b/changelog.d/unreleased/312.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 312
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Dart constructors and `typedef` aliases are now indexed (#312)** — `cdidx` now captures default, named, and factory constructor declarations, along with `const` constructors that use `this` / `super` initializers, plus both modern and legacy `typedef` aliases, so Dart symbol queries no longer drop most of a class's public API surface.
+
+## 日本語
+
+- **Dart のコンストラクタと `typedef` エイリアスを索引するようになりました (#312)** — `cdidx` が default / named / factory コンストラクタ宣言と `this` / `super` を使う `const` コンストラクタ、さらに modern / legacy 両方の `typedef` エイリアスを捕捉するため、Dart の symbol クエリでクラスの公開 API の大半が落ちなくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1187,6 +1187,11 @@ public static class SymbolExtractor
         ["dart"] =
         [
             new("function", new Regex(@"^\s*(?!return\b|await\b|const\b|new\b|throw\b|yield\b|if\b|else\b|for\b|while\b|switch\b|case\b|catch\b|do\b|try\b|finally\b|class\b|enum\b|mixin\b|extension\b|typedef\b|library\b|part\b|import\b|export\b)(?:(?:static|abstract|override|external)\s+)*(?<rt>\w[\w<>,\s\?]*?)\s+(?<name>(?!if\b|else\b|for\b|while\b|switch\b|case\b|class\b|enum\b|mixin\b|extension\b|typedef\b|library\b|part\b|import\b|export\b|abstract\b|void\b|var\b|final\b|late\b|const\b|new\b|return\b|throw\b|yield\b|await\b|extends\b|implements\b|with\b|on\b|is\b|as\b|in\b|of\b|super\b|this\b)\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "rt"),
+            new("function", new Regex(@"^\s*factory\s+(?<name>[A-Z_]\w*(?:\.\w+)?)\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*const\s+(?<name>[A-Z_]\w*(?:\.\w+)?)\s*\((?=[^)]*(?:\bthis\b|\bsuper\b))", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?<name>[A-Z_]\w*(?:\.\w+)?)\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*typedef\s+(?<name>\w+)(?:<[^>]*>)?\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*typedef\s+(?:[\w<>,\[\]\?\.\s]+\s+)+(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:abstract\s+)?(?:class|mixin)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*extension\s+(?<name>\w+)\s+on\s+", RegexOptions.Compiled), BodyStyle.Brace),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14578,6 +14578,53 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dart_DetectsConstructorsAndTypedefAliases()
+    {
+        // Dart: constructors, typedef aliases / Dart: コンストラクタ、typedef エイリアス
+        var content = """
+            abstract class Animal {
+              String name;
+              int age;
+
+              Animal(this.name, this.age);
+              Animal.named({required this.name, this.age = 0});
+              factory Animal.empty() => _EmptyAnimal();
+              factory Animal.fromJson(Map<String, dynamic> json) =>
+                  Animal(json['name'] as String, json['age'] as int);
+              const Animal.constant(this.name, this.age);
+            }
+
+            class Point {
+              const Point(this.x, this.y);
+
+              final int x;
+              final int y;
+            }
+
+            class _EmptyAnimal extends Animal {
+              _EmptyAnimal() : super('', 0);
+            }
+
+            typedef IntCallback = int Function(int value);
+            typedef StringMap = Map<String, String>;
+            typedef int LegacyCallback(int value);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dart", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Animal");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Animal.named");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Animal.empty");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Animal.fromJson");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Animal.constant");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Point");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "_EmptyAnimal");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "IntCallback");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "StringMap");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "LegacyCallback");
+    }
+
+    [Fact]
     public void Extract_Dart_DoesNotTreatKeywordLookalikesAsFunctions()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Indexed Dart default, named, and factory constructors.
- Added support for common `const` constructor forms that use `this` / `super` initializers.
- Indexed both modern `typedef` aliases and legacy function-type aliases.
- Updated the Dart language table in `DEVELOPER_GUIDE.md` and added a changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Updated `DEVELOPER_GUIDE.md` for the Dart language table.
- Added `changelog.d/unreleased/312.fixed.md`.

## Fixes

Fixes #312

## Follow-up candidates

- Bare `const` Dart constructors without `this` / `super` initializers are still not covered by the current heuristic, because widening that regex further would reintroduce false positives on `const` expressions such as `const Widget(key: k)`.