### PR TITLE
[codex] Fix #309: route Vue and Svelte SFC scripts through TS extraction

### DIFF
--- a/changelog.d/unreleased/309.fixed.md
+++ b/changelog.d/unreleased/309.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 309
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Vue and Svelte SFC script blocks now index as TypeScript/JavaScript** — `.vue` and `.svelte` files now route their `<script>` content through the existing TS/JS symbol and reference extractors, so `symbols`, `definition`, `outline`, `callers`, `callees`, and `map` no longer come back empty for component scripts.
+
+## 日本語
+
+- **Vue / Svelte の SFC script ブロックが TypeScript / JavaScript として index されるようになりました** — `.vue` と `.svelte` の `<script>` 内容を既存の TS/JS symbol / reference extractor に通すため、コンポーネント script に対する `symbols`、`definition`、`outline`、`callers`、`callees`、`map` が空結果にならなくなります。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -827,10 +827,14 @@ public static class ReferenceExtractor
         "field", "get", "set", "param", "setparam", "property", "receiver", "file", "delegate", "all",
     };
 
-    public static IReadOnlyCollection<string> GetSupportedLanguages() => SupportedLanguages;
+    public static IReadOnlyCollection<string> GetSupportedLanguages()
+        => SupportedLanguages.Concat(new[] { "vue", "svelte" }).ToArray();
+
+    private static string? NormalizeLanguage(string? lang)
+        => lang is "vue" or "svelte" ? "typescript" : lang;
 
     public static bool SupportsLanguage(string? lang) =>
-        lang != null && SupportedLanguages.Contains(lang);
+        NormalizeLanguage(lang) is string normalized && SupportedLanguages.Contains(normalized);
 
     public static bool? SupportsSymbolGraph(string? lang, string? kind, string? containerKind)
     {
@@ -901,6 +905,7 @@ public static class ReferenceExtractor
         if (!SupportsLanguage(lang))
             return [];
 
+        lang = NormalizeLanguage(lang);
         var language = lang!;
         var isJsxFile = IsJsxFilePath(path);
 

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -464,6 +464,10 @@ public static class SymbolExtractor
         $@"^\s*(?<name>{JavaScriptTypeScriptIdentifierPattern})\s*(?:(?=,)|(?=}})|$)",
         RegexOptions.Compiled);
 
+    private static readonly Regex SvelteReactivePropertyRegex = new(
+        @"^\s*\$:\s*(?<name>\w+)\s*=",
+        RegexOptions.Compiled);
+
     private const string VbVisibilityPattern = @"(?:Public|Private|Protected|Friend)(?:\s+(?:Protected|Friend))?";
     private const string VbTypeModifierPattern = @"(?:Partial|MustInherit|NotInheritable)";
     private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Async|Partial)";
@@ -1473,7 +1477,11 @@ public static class SymbolExtractor
     /// Return the set of languages that have symbol-extraction patterns.
     /// シンボル抽出パターンを持つ言語のセットを返す。
     /// </summary>
-    public static IReadOnlyCollection<string> GetSupportedLanguages() => PatternCache.Keys;
+    public static IReadOnlyCollection<string> GetSupportedLanguages()
+        => PatternCache.Keys.Concat(new[] { "vue", "svelte" }).ToArray();
+
+    private static string? NormalizeLanguage(string? lang)
+        => lang is "vue" or "svelte" ? "typescript" : lang;
 
     private static bool TryHandleGoImportLine(
         long fileId,
@@ -1675,6 +1683,8 @@ public static class SymbolExtractor
     /// <returns>List of extracted symbols / 抽出されたシンボルのリスト</returns>
     public static List<SymbolRecord> Extract(long fileId, string? lang, string content)
     {
+        var originalLang = lang;
+        lang = NormalizeLanguage(lang);
         if (lang == null || !PatternCache.TryGetValue(lang, out var patterns))
             return [];
 
@@ -3019,11 +3029,39 @@ public static class SymbolExtractor
             ExtractJavaModuleDirectiveSymbols(fileId, lines, structuralLines, symbols);
         }
 
+        if (string.Equals(originalLang, "svelte", StringComparison.Ordinal))
+            ExtractSvelteReactiveSymbols(fileId, lines, symbols);
+
         AssignContainers(symbols, lines, csharpLineStartStates);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
         NormalizeKotlinSecondaryConstructorNames(symbols);
         PopulateDeclaredContainerQualifiedNames(symbols);
         return symbols;
+    }
+
+    private static void ExtractSvelteReactiveSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var match = SvelteReactivePropertyRegex.Match(lines[i]);
+            if (!match.Success)
+                continue;
+
+            var name = match.Groups["name"].Value;
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            symbols.Add(new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "property",
+                Name = name,
+                Line = i + 1,
+                StartLine = i + 1,
+                EndLine = i + 1,
+                Signature = lines[i].Trim(),
+            });
+        }
     }
 
     private static void ExtractJavaModuleDirectiveSymbols(long fileId, string[] rawLines, string[] structuralLines, List<SymbolRecord> symbols)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -162,6 +162,57 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_VueScriptSetup_DetectsJavaScriptTypeScriptCalls()
+    {
+        const string content = """
+            <script setup lang="ts">
+            import { computed, ref } from "vue";
+
+            const count = ref(0);
+            const doubled = computed(() => count.value * 2);
+
+            function increment() {
+                count.value++;
+            }
+            </script>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "vue", content);
+        var references = ReferenceExtractor.Extract(1, "vue", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "ref"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "computed"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(ReferenceExtractor.GetSupportedLanguages(), lang => lang == "vue");
+    }
+
+    [Fact]
+    public void Extract_SvelteScript_DetectsJavaScriptTypeScriptCalls()
+    {
+        const string content = """
+            <script lang="ts">
+                function increment() {}
+
+                function trigger() {
+                    increment();
+                }
+            </script>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "svelte", content);
+        var references = ReferenceExtractor.Extract(1, "svelte", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "increment"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "trigger");
+        Assert.Contains(ReferenceExtractor.GetSupportedLanguages(), lang => lang == "svelte");
+    }
+
+    [Fact]
     public void Extract_Css_CustomPropertiesAnimationsAndSelectors_AreReferenced()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -136,6 +136,56 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_VueScriptSetup_DetectsTypeScriptSymbols()
+    {
+        const string content = """
+            <script setup lang="ts">
+            import { computed, ref } from "vue";
+
+            const count = ref(0);
+            const doubled = computed(() => count.value * 2);
+
+            function increment() {
+                count.value++;
+            }
+            </script>
+
+            <template>
+                <button @click="increment">{{ count }} / {{ doubled }}</button>
+            </template>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "vue", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "increment");
+        Assert.Contains(symbols, symbol => symbol.Kind == "import" && symbol.Name.Contains("computed", StringComparison.Ordinal));
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "vue");
+    }
+
+    [Fact]
+    public void Extract_SvelteScript_DetectsTypeScriptSymbolsAndReactiveProperty()
+    {
+        const string content = """
+            <script lang="ts">
+                let count = 0;
+                $: doubled = count * 2;
+
+                function increment() {
+                    count++;
+                }
+            </script>
+
+            <button on:click={increment}>{count} / {doubled}</button>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "svelte", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "increment");
+        Assert.Contains(symbols, symbol => symbol.Kind == "property" && symbol.Name == "doubled");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "svelte");
+    }
+
+    [Fact]
     public void Extract_Go_DetectsSingleLineAndGroupedImports()
     {
         var content = """


### PR DESCRIPTION
## Summary
Route `.vue` and `.svelte` SFC `<script>` blocks through the existing TypeScript/JavaScript symbol and reference extractors.

## Impact
Vue and Svelte component scripts now surface symbols and call references for `symbols`, `definition`, `outline`, `callers`, `callees`, and `map` instead of indexing as FTS-only files.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet test`

Fixes #309