### PR TITLE
Fix Ruby symbol extraction for issue #313

### DIFF
--- a/changelog.d/unreleased/313.fixed.md
+++ b/changelog.d/unreleased/313.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 313
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby `attr_accessor` now captures every name in comma-separated lists, and `alias` / `alias_method` declarations are indexed** — `cdidx definition` can now resolve each name in `attr_accessor :a, :b, :c` and similar `attr_reader` / `attr_writer` forms, and Ruby alias declarations now produce function symbols for the introduced name.
+
+## 日本語
+
+- **Ruby の `attr_accessor` はカンマ区切りの全ての名前を捕捉し、`alias` / `alias_method` 宣言も索引化されるようになりました** — `cdidx definition` は `attr_accessor :a, :b, :c` や `attr_reader` / `attr_writer` の各名前を解決できるようになり、Ruby の alias 宣言も導入される名前について function シンボルを生成します。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1055,6 +1055,9 @@ public static class SymbolExtractor
         [
             // attr_accessor/attr_reader/attr_writer as property declarations / プロパティ宣言
             new("property", new Regex(@"^\s*attr_(?:accessor|reader|writer)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
+            // alias_method / alias — capture the introduced method name for navigation
+            new("function", new Regex(@"^\s*alias_method\b\s+:?(?<name>\w+)\s*,\s*:?\w+", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*alias\b\s+:?(?<name>\w+)\s+:?\w+", RegexOptions.Compiled), BodyStyle.None),
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*def\s+(?:self\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),
@@ -2174,6 +2177,10 @@ public static class SymbolExtractor
                         ? match.Groups["name"].Value.Trim()
                         : match.Value.Trim();
                     name = NormalizeExtractedSymbolName(lang, name, match, matchLine);
+                    var rubyAttrNames = lang == "ruby"
+                        && pattern.Kind == "property"
+                        ? TryExpandRubyAttrDeclaratorList(patternMatchLine, absoluteStartColumn, match, name)
+                        : null;
 
                     var rangeLines = lang == "css" && cssScannerLines != null
                         ? cssScannerLines
@@ -2572,6 +2579,43 @@ public static class SymbolExtractor
                                         ReturnType = NormalizeMetadata(entry.ReturnType),
                                     },
                                     line);
+                            }
+                        }
+                        else if (rubyAttrNames != null)
+                        {
+                            var rubyAttrSearchStart = absoluteStartColumn;
+                            foreach (var rubyAttrName in rubyAttrNames)
+                            {
+                                var rubyAttrStartColumn = rubyAttrSearchStart;
+                                if (!string.Equals(rubyAttrName, name, StringComparison.Ordinal))
+                                {
+                                    var foundRubyAttrStart = patternMatchLine.IndexOf(rubyAttrName, rubyAttrSearchStart, StringComparison.Ordinal);
+                                    if (foundRubyAttrStart >= 0)
+                                        rubyAttrStartColumn = foundRubyAttrStart;
+                                }
+
+                                AddSymbolRecord(
+                                    symbols,
+                                    cssSeenSymbols,
+                                    startLine,
+                                    new SymbolRecord
+                                    {
+                                        FileId = fileId,
+                                        Kind = kind,
+                                        Name = rubyAttrName,
+                                        Line = startLine,
+                                        StartLine = startLine,
+                                        StartColumn = rubyAttrStartColumn,
+                                        EndLine = Math.Max(startLine, endLine),
+                                        BodyStartLine = bodyStartLine,
+                                        BodyEndLine = bodyEndLine,
+                                        Signature = signature,
+                                        Visibility = TryGetGroup(match, pattern.VisibilityGroup),
+                                        ReturnType = NormalizeMetadata(rawReturnType),
+                                    },
+                                    line);
+
+                                rubyAttrSearchStart = rubyAttrStartColumn + Math.Max(1, rubyAttrName.Length);
                             }
                         }
                         else
@@ -17303,6 +17347,78 @@ public static class SymbolExtractor
         }
 
         return results.Count > 1 ? results : null;
+    }
+
+    // Ruby attr_accessor / attr_reader / attr_writer declarations can list multiple
+    // names on one line (`attr_accessor :a, :b, :c`). The primary regex only captures
+    // the first entry, so scan the tail for additional `:name` tokens and return the
+    // complete declarator list when there is real fan-out.
+    // Ruby の attr_accessor / attr_reader / attr_writer は 1 行に複数名を並べられる
+    // (`attr_accessor :a, :b, :c`)。primary regex は先頭の 1 件しか捕まえないため、
+    // tail を走査して残りの `:name` トークンを拾い、実際に fan-out があるときだけ
+    // 完全な declarator list を返す。
+    private static List<string>? TryExpandRubyAttrDeclaratorList(
+        string patternMatchLine,
+        int absoluteStartColumn,
+        Match match,
+        string firstName)
+    {
+        if (string.IsNullOrWhiteSpace(firstName))
+            return null;
+
+        var results = new List<string> { firstName };
+        var tailStart = absoluteStartColumn + match.Length;
+        if (tailStart >= patternMatchLine.Length)
+            return null;
+
+        var tail = patternMatchLine[tailStart..];
+        var i = 0;
+        while (i < tail.Length)
+        {
+            while (i < tail.Length && char.IsWhiteSpace(tail[i]))
+                i++;
+            if (i >= tail.Length)
+                break;
+            if (tail[i] != ',')
+                break;
+
+            i++;
+            while (i < tail.Length && char.IsWhiteSpace(tail[i]))
+                i++;
+            if (i >= tail.Length || tail[i] != ':')
+                return null;
+
+            i++;
+            var nameStart = i;
+            while (i < tail.Length && (tail[i] == '_' || char.IsLetterOrDigit(tail[i])))
+                i++;
+
+            var name = tail[nameStart..i];
+            if (name.Length == 0 || !IsRubyIdentifier(name))
+                return null;
+
+            results.Add(name);
+        }
+
+        return results.Count > 1 ? results : null;
+    }
+
+    private static bool IsRubyIdentifier(string value)
+    {
+        if (value.Length == 0)
+            return false;
+
+        if (value[0] != '_' && !char.IsLetter(value[0]))
+            return false;
+
+        for (var i = 1; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (ch != '_' && !char.IsLetterOrDigit(ch))
+                return false;
+        }
+
+        return true;
     }
 
     private static List<string> ScanCSharpTailDeclaratorNames(string tail, bool matchEndedAtEquals)

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1056,8 +1056,8 @@ public static class SymbolExtractor
             // attr_accessor/attr_reader/attr_writer as property declarations / プロパティ宣言
             new("property", new Regex(@"^\s*attr_(?:accessor|reader|writer)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             // alias_method / alias — capture the introduced method name for navigation
-            new("function", new Regex(@"^\s*alias_method\b\s+:?(?<name>\w+)\s*,\s*:?\w+", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(@"^\s*alias\b\s+:?(?<name>\w+)\s+:?\w+", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*alias_method\b\s+:?(?<name>\w+[?!=]?)\s*,\s*:?\w+[?!=]?", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*alias\b\s+:?(?<name>\w+[?!=]?)\s+:?\w+[?!=]?", RegexOptions.Compiled), BodyStyle.None),
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*def\s+(?:self\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10271,6 +10271,42 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsAttrListsAndAliases()
+    {
+        var content = """
+            class Person
+              attr_accessor :name, :age, :email
+              attr_reader :id, :created_at
+              attr_writer :internal_flag, :debug_count
+              attr_accessor :nickname
+
+              def greet(greeting = "Hello")
+                "#{greeting}, #{name}"
+              end
+
+              alias_method :full_name, :name
+              alias greet_alias greet
+              alias :display_name :name
+            end
+            """;
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "name"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "age"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "email"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "id"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "created_at"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "internal_flag"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "debug_count"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "nickname"));
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "greet");
+        Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "full_name"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "greet_alias"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "display_name"));
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10285,7 +10285,9 @@ public class SymbolExtractorTests
               end
 
               alias_method :full_name, :name
+              alias_method :profile!, :name
               alias greet_alias greet
+              alias shout! greet
               alias :display_name :name
             end
             """;
@@ -10302,7 +10304,9 @@ public class SymbolExtractorTests
         Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "nickname"));
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "greet");
         Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "full_name"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "profile!"));
         Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "greet_alias"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "shout!"));
         Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "display_name"));
     }
 


### PR DESCRIPTION
Summary:
- Capture every name in Ruby attr_accessor/attr_reader/attr_writer lists.
- Index Ruby alias_method and alias declarations as function symbols.
- Add regression coverage for multi-name attr lists and alias forms.

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test CodeIndex.sln -c Release`

Fixes #313