### PR TITLE
Fix Go const and var symbol kinds (#314)

### DIFF
--- a/changelog.d/unreleased/314.fixed.md
+++ b/changelog.d/unreleased/314.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 314
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Go `const` and `var` declarations are now indexed as `property` symbols, and top-level `const` rows are no longer skipped (#314)** — the Go extractor now recognizes package-level `const` declarations at column 0, keeps const-block entries, and maps both `const` and `var` rows to the `property` kind so `symbols` and `definition` return the expected names.
+
+## 日本語
+
+- **Go の `const` / `var` 宣言が `property` シンボルとして index され、トップレベル `const` 行も取りこぼさなくなりました (#314)** — Go extractor は列 0 の package-level `const` 宣言を認識し、`const` ブロック内のエントリも維持したうえで、`const` と `var` の両方を `property` kind に割り当てるため、`symbols` と `definition` が期待どおりの名前を返します。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -972,10 +972,12 @@ public static class SymbolExtractor
             new("interface", new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+interface\b", RegexOptions.Compiled), BodyStyle.Brace),
             // Type alias (type Name = OtherType or type Name OtherType) / 型エイリアス
             new("import",   new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+[=\w]", RegexOptions.Compiled), BodyStyle.None),
+            // Top-level const declarations / トップレベル const 宣言
+            new("property", new Regex(@"^const\s+(?<name>\w+)(?:\s+\w[\w.*\[\]]*)?\s*=", RegexOptions.Compiled), BodyStyle.None),
             // Const declaration inside const block / const ブロック内の定数宣言
-            new("function", new Regex(@"^\s+(?<name>[A-Z]\w*)\s*=\s*", RegexOptions.Compiled), BodyStyle.None),
+            new("property", new Regex(@"^\s+(?<name>[A-Z]\w*)\s*=\s*", RegexOptions.Compiled), BodyStyle.None),
             // Package-level var / パッケージレベル変数
-            new("function", new Regex(@"^var\s+(?<name>\w+)\s", RegexOptions.Compiled), BodyStyle.None),
+            new("property", new Regex(@"^var\s+(?<name>\w+)\s", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["rust"] =
         [

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -171,6 +171,37 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Go_DetectsTopLevelConstsAndVarsAsProperties()
+    {
+        var content = """
+            package demo
+
+            const MaxRetries = 3
+            const Timeout int = 30
+            const (
+                StatusActive = "active"
+            )
+
+            var ErrNotFound = errors.New("not found")
+            var DefaultConfig *Config = &Config{}
+
+            func build() {
+                user := User{Name: "alice"}
+                _ = user
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "MaxRetries");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Timeout");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "StatusActive");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "ErrNotFound");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DefaultConfig");
+        Assert.DoesNotContain(symbols, s => s.Name == "Name");
+    }
+
+    [Fact]
     public void Extract_Cpp_DetectsQualifiedDefinitionsConceptsAndModules()
     {
         var content = """
@@ -10324,9 +10355,9 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "ID");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Callback");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Logger");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "MaxRetries");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "DefaultTimeout");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "GlobalConfig");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "MaxRetries");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DefaultTimeout");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "GlobalConfig");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Index Go top-level const declarations at column 0.
- Map Go const / var symbols to property.
- Add regression coverage for top-level and block-scoped Go declarations.

## Changelog
- `changelog.d/unreleased/314.fixed.md`

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test`

Fixes #314