### PR TITLE
Index PHP enum cases as symbols

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -390,7 +390,7 @@ Supported symbol kinds by language (33 languages with symbol extraction):
 | Ruby | def, Rails DSL, block-call `name { ... }` / `name do ... end` | class, module | -- | -- | -- | attr_accessor/reader/writer | -- | require | yes |
 | C | functions, `#define` macros | -- | struct | -- | enum | -- | -- | #include | yes |
 | C++ | functions, `#define` macros | class | struct | -- | enum, enum class | -- | -- | #include | yes |
-| PHP | function, const | class | -- | interface, trait | enum | -- | -- | use, require/include | yes |
+| PHP | function, const, enum cases | class | -- | interface, trait | enum | -- | -- | use, require/include | yes |
 | Swift | func | class, actor | struct | protocol | enum | -- | -- | import | yes |
 | Dart | functions | class, mixin, extension | -- | -- | enum | -- | -- | import | yes |
 | Scala | def | class, object | -- | trait | enum | -- | -- | import | yes |
@@ -1531,7 +1531,7 @@ LIMIT 20;
 | Ruby | def, Rails DSL, ブロック呼び出し `name { ... }` / `name do ... end` | class, module | -- | -- | -- | attr_accessor/reader/writer | -- | require | yes |
 | C | 関数, `#define` マクロ | -- | struct | -- | enum | -- | -- | #include | yes |
 | C++ | 関数, `#define` マクロ | class | struct | -- | enum, enum class | -- | -- | #include | yes |
-| PHP | function, const | class | -- | interface, trait | enum | -- | -- | use, require/include | yes |
+| PHP | function, const, enum cases | class | -- | interface, trait | enum | -- | -- | use, require/include | yes |
 | Swift | func | class, actor | struct | protocol | enum | -- | -- | import | yes |
 | Dart | 関数 | class, mixin, extension | -- | -- | enum | -- | -- | import | yes |
 | Scala | def | class, object | -- | trait | enum | -- | -- | import | yes |

--- a/changelog.d/unreleased/318.fixed.md
+++ b/changelog.d/unreleased/318.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 318
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **PHP enum cases are now indexed as symbols (#318)** — `case Pending;` and backed cases such as `case USD = 'USD';` are now captured inside PHP enums, with backed values preserved in `return_type` so `symbols`, `definition`, and `outline` can surface the full enum value set.
+
+## 日本語
+
+- **PHP の enum case がシンボルとして index されるようになりました (#318)** — `case Pending;` や `case USD = 'USD';` のような backed case も PHP enum 内で取得され、backed value は `return_type` に保持されるため、`symbols`・`definition`・`outline` で enum の値一覧を表示できるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1099,6 +1099,7 @@ public static class SymbolExtractor
             new("interface", new Regex(@"^\s*interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*trait\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("property", new Regex(@"^\s*case\s+(?<name>\w+)(?:\s*=\s*(?<returnType>[^;]+?))?\s*;", RegexOptions.Compiled), BodyStyle.None, ReturnTypeGroup: "returnType"),
             // Namespace / 名前空間
             new("namespace", new Regex(@"^\s*namespace\s+(?<name>[\w\\]+)", RegexOptions.Compiled), BodyStyle.Brace),
         ],

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10154,7 +10154,46 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_PHP_DetectsExpandedFeatures()
     {
-        var content = "<?php\nnamespace App\\Models;\n\nuse Illuminate\\Database\\Eloquent\\Model;\n\nreadonly class Config {\n    public const VERSION = '1.0';\n    public function getName(): string { return ''; }\n}\n\nenum Status: string {\n    case Active = 'active';\n}";
+        var content = """
+            <?php
+            namespace App\Models;
+
+            use Illuminate\Database\Eloquent\Model;
+
+            readonly class Config {
+                public const VERSION = '1.0';
+                public function getName(): string { return ''; }
+            }
+
+            enum Status: string {
+                case Active = 'active';
+                case Pending = 'pending';
+            }
+
+            enum OrderStatus {
+                case Draft;
+                case Published;
+            }
+
+            enum Priority: int {
+                case Low = 1;
+
+                public function label(): string {
+                    return match ($this) {
+                        Priority::Low => 'low',
+                    };
+                }
+            }
+
+            function inspectState(int $state): void {
+                switch ($state) {
+                    case 1:
+                        break;
+                    case 'x':
+                        break;
+                }
+            }
+            """;
         var symbols = SymbolExtractor.Extract(1, "php", content);
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name.Contains("App"));
@@ -10163,6 +10202,14 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "VERSION");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "getName");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Status");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "OrderStatus");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Priority");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Active" && s.ContainerName == "Status" && s.ReturnType == "'active'");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Pending" && s.ContainerName == "Status" && s.ReturnType == "'pending'");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Draft" && s.ContainerName == "OrderStatus" && s.ReturnType == null);
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Published" && s.ContainerName == "OrderStatus" && s.ReturnType == null);
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Low" && s.ContainerName == "Priority" && s.ReturnType == "1");
+        Assert.Equal(5, symbols.Count(s => s.Kind == "property"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Added a PHP symbol pattern for `case` declarations so enum cases are indexed as `property` symbols.
- Preserved backed enum values in `return_type`.
- Expanded PHP symbol extractor coverage with enum-case assertions and a switch-label regression check.
- Updated the PHP language support row in `DEVELOPER_GUIDE.md`.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog
- Added bilingual fragment: `changelog.d/unreleased/318.fixed.md`
- Updated PHP support table in `DEVELOPER_GUIDE.md`

## Auto-close
Fixes #318

## Follow-up candidates
- None identified in this change.