### PR TITLE
Fix Swift enum cases and indirect enums

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -369,7 +369,7 @@ The step size is `80 - 10 = 70` lines. A file with N lines produces `ceil((N - 8
 
 ## Symbol extraction
 
-Most languages still use **compiled regex patterns**, matched one line at a time for functions, classes, and sometimes imports. JavaScript and TypeScript add a lightweight lexer/state machine on top of the regex pass for cases that line-oriented regex cannot handle reliably, such as class-body bare methods, computed and modifier-prefixed methods, scope-aware synthetic class expressions, and JS/TS-specific range resolution. Swift and Kotlin still use the regex path, but a small dedicated trailing-lambda pass keeps idiomatic `name { ... }` call sites visible to the graph. Scala has a separate block-call pass for `name { ... }` / `name { x => ... }` forms so idiomatic calls such as `foreach {}`, `Try {}`, and `synchronized {}` stay visible too. HTML uses a dedicated character-level state machine instead of the regex pattern loop — it walks tag openers, quoted/unquoted attribute values (including multi-line values), and masks `<script>`/`<style>`/`<textarea>`/`<title>` bodies plus `<!-- ... -->` comments so attribute-lookalike strings inside those regions do not leak phantom symbols. Named capture groups still extract identifiers for the regex-driven paths. Recent JS/TS additions also cover barrel re-export surfaces across commented, multiline, namespace, minified, TypeScript type-only-star, and `with {}` / `assert {}` import-attribute forms, while preserving the corresponding source-module `import` rows, alongside direct CommonJS named export assignments and their same-line / multiline parenthesized wrappers, multiline / constrained / async TypeScript generic-arrow RHS forms, prefix-safe function/class discrimination, and exported object-literal alias/shorthand properties.
+Most languages still use **compiled regex patterns**, matched one line at a time for functions, classes, and sometimes imports. JavaScript and TypeScript add a lightweight lexer/state machine on top of the regex pass for cases that line-oriented regex cannot handle reliably, such as class-body bare methods, computed and modifier-prefixed methods, scope-aware synthetic class expressions, and JS/TS-specific range resolution. Swift still uses the regex path for `func`, `class`, `struct`, `protocol`, `enum`, `indirect enum`, and enum cases, while a small dedicated trailing-lambda pass keeps idiomatic `name { ... }` call sites visible to the graph. Kotlin also stays on the regex path. Scala has a separate block-call pass for `name { ... }` / `name { x => ... }` forms so idiomatic calls such as `foreach {}`, `Try {}`, and `synchronized {}` stay visible too. HTML uses a dedicated character-level state machine instead of the regex pattern loop — it walks tag openers, quoted/unquoted attribute values (including multi-line values), and masks `<script>`/`<style>`/`<textarea>`/`<title>` bodies plus `<!-- ... -->` comments so attribute-lookalike strings inside those regions do not leak phantom symbols. Named capture groups still extract identifiers for the regex-driven paths. Recent JS/TS additions also cover barrel re-export surfaces across commented, multiline, namespace, minified, TypeScript type-only-star, and `with {}` / `assert {}` import-attribute forms, while preserving the corresponding source-module `import` rows, alongside direct CommonJS named export assignments and their same-line / multiline parenthesized wrappers, multiline / constrained / async TypeScript generic-arrow RHS forms, prefix-safe function/class discrimination, and exported object-literal alias/shorthand properties.
 
 Supported symbol kinds by language (33 languages with symbol extraction):
 
@@ -391,7 +391,7 @@ Supported symbol kinds by language (33 languages with symbol extraction):
 | C | functions, `#define` macros | -- | struct | -- | enum | -- | -- | #include | yes |
 | C++ | functions, `#define` macros | class | struct | -- | enum, enum class | -- | -- | #include | yes |
 | PHP | function, const, enum cases | class | -- | interface, trait | enum | -- | -- | use, require/include | yes |
-| Swift | func | class, actor | struct | protocol | enum | -- | -- | import | yes |
+| Swift | func | class, actor | struct | protocol | enum, property | -- | -- | import | yes |
 | Dart | functions, constructors, typedef aliases | class, mixin, extension | -- | -- | enum | -- | -- | import | yes |
 | Scala | def | class, object | -- | trait | enum | -- | -- | import | yes |
 | Elixir | def, defp | defmodule | -- | defprotocol | -- | -- | -- | import, alias, use, require | yes |
@@ -1510,7 +1510,7 @@ LIMIT 20;
 
 ## シンボル抽出
 
-大半の言語では、今も **コンパイル済み正規表現パターン**を1行ずつ適用して関数、クラス、場合によってはインポートを抽出します。一方で JavaScript / TypeScript には、行単位の正規表現だけでは安定して扱えない class body の bare method、computed / modifier 付き method、scope-aware な synthetic class expression、JS/TS 専用の range 解決を補うため、軽量な lexer / state machine を追加しています。Swift / Kotlin は引き続き正規表現経路ですが、小さな trailing-lambda 専用パスで `name { ... }` 形の慣用的な呼び出しを graph から落とさないようにしています。Scala には `name { ... }` / `name { x => ... }` 形式を拾う専用の block-call パスがあり、`foreach {}` や `Try {}`、`synchronized {}` のような慣用的な呼び出しも graph から消えないようにしています。HTML は汎用の正規表現ループを使わず、専用の文字単位 state machine でタグ構造を走査し、引用符付き/なし属性値（複数行の引用符付き値を含む）と `<script>` / `<style>` / `<textarea>` / `<title>` の raw-text 本体、`<!-- ... -->` コメントをマスクして、属性名に似た本体内文字列から phantom シンボルが漏れないようにしています。正規表現ベースの経路では引き続き名前付きキャプチャグループで識別子を取得します。
+大半の言語では、今も **コンパイル済み正規表現パターン**を1行ずつ適用して関数、クラス、場合によってはインポートを抽出します。一方で JavaScript / TypeScript には、行単位の正規表現だけでは安定して扱えない class body の bare method、computed / modifier 付き method、scope-aware な synthetic class expression、JS/TS 専用の range 解決を補うため、軽量な lexer / state machine を追加しています。Swift は引き続き正規表現経路ですが、`func` / `class` / `struct` / `protocol` / `enum` / `indirect enum` と enum case を拾うようにしており、小さな trailing-lambda 専用パスで `name { ... }` 形の慣用的な呼び出しを graph から落とさないようにしています。Kotlin も正規表現経路のままです。Scala には `name { ... }` / `name { x => ... }` 形式を拾う専用の block-call パスがあり、`foreach {}` や `Try {}`、`synchronized {}` のような慣用的な呼び出しも graph から消えないようにしています。HTML は汎用の正規表現ループを使わず、専用の文字単位 state machine でタグ構造を走査し、引用符付き/なし属性値（複数行の引用符付き値を含む）と `<script>` / `<style>` / `<textarea>` / `<title>` の raw-text 本体、`<!-- ... -->` コメントをマスクして、属性名に似た本体内文字列から phantom シンボルが漏れないようにしています。正規表現ベースの経路では引き続き名前付きキャプチャグループで識別子を取得します。
 
 言語別対応シンボル種別（シンボル抽出対応33言語）:
 
@@ -1532,7 +1532,7 @@ LIMIT 20;
 | C | 関数, `#define` マクロ | -- | struct | -- | enum | -- | -- | #include | yes |
 | C++ | 関数, `#define` マクロ | class | struct | -- | enum, enum class | -- | -- | #include | yes |
 | PHP | function, const, enum cases | class | -- | interface, trait | enum | -- | -- | use, require/include | yes |
-| Swift | func | class, actor | struct | protocol | enum | -- | -- | import | yes |
+| Swift | func | class, actor | struct | protocol | enum, property | -- | -- | import | yes |
 | Dart | 関数、コンストラクタ、typedef エイリアス | class, mixin, extension | -- | -- | enum | -- | -- | import | yes |
 | Scala | def | class, object | -- | trait | enum | -- | -- | import | yes |
 | Elixir | def, defp | defmodule | -- | defprotocol | -- | -- | -- | import, alias, use, require | yes |

--- a/changelog.d/unreleased/319.fixed.md
+++ b/changelog.d/unreleased/319.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 319
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Swift enum cases and `indirect enum` declarations are now indexed (#319)** — `SymbolExtractor` now accepts `indirect enum` declarations and captures enum cases such as `case timeout`, `case server(code: Int, message: String)`, `case inactive = "off"`, and `indirect case node(...)` as `property` symbols, while keeping switch-arm `case ...:` lines out of the index. Added regressions for raw-value cases, associated-value cases, `indirect case`, `indirect enum`, and switch-case false positives. Affected: `src/CodeIndex/Indexer/SymbolExtractor.cs`, `tests/CodeIndex.Tests/SymbolExtractorTests.cs`, `DEVELOPER_GUIDE.md`. Fixes #319.
+
+## 日本語
+
+- **Swift の enum case と `indirect enum` 宣言も index されるようになりました (#319)** — `indirect enum` 宣言を受け付けるようにし、`case timeout`、`case server(code: Int, message: String)`、`case inactive = "off"`、`indirect case node(...)` のような enum case を `property` symbol として捕捉するようにしました。一方で switch の `case ...:` 行は index に含めません。raw-value case、associated-value case、`indirect case`、`indirect enum`、switch-case の false positive を防ぐ regression を追加しました。対象: `src/CodeIndex/Indexer/SymbolExtractor.cs`、`tests/CodeIndex.Tests/SymbolExtractorTests.cs`、`DEVELOPER_GUIDE.md`。Fixes #319.

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1119,7 +1119,8 @@ public static class SymbolExtractor
         [
             new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:static|class|nonisolated|mutating|nonmutating)\s+)*(?:override\s+)?func\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("struct",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final)\s+)*struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("enum",      new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("enum",      new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:indirect\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("property",  new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:indirect\s+)?case\s+(?<name>\w+)(?:\s*\([^)]*\))?(?:\s*=\s*(?<returnType>.+?))?\s*$", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),
             new("interface", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*protocol\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // actor (Swift 5.5+) / アクター
             new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final|distributed)\s+)*(?:class|actor)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10343,6 +10343,58 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsEnumCasesAndIndirectEnums()
+    {
+        var content = """
+            public enum NetworkError: Error {
+                case timeout
+                case server(code: Int, message: String)
+                case client(Int)
+                case unknown
+            }
+
+            indirect enum Tree<T> {
+                case leaf(T)
+                indirect case node(Tree<T>, Tree<T>)
+            }
+
+            enum Status: String, Codable {
+                case active
+                case inactive = "off"
+                case pending
+            }
+
+            func handle(_ error: NetworkError) {
+                switch error {
+                case .overheated:
+                    break
+                case let .recoverable(code, message):
+                    break
+                }
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "NetworkError");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Tree");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Status");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "timeout");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "server");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "client");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "unknown");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "leaf");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "node");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "active");
+
+        var inactive = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "inactive"));
+        Assert.Equal("\"off\"", inactive.ReturnType);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "pending");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "overheated");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "recoverable");
+    }
+
+    [Fact]
     public void Extract_ObjC_DetectsInterfacesPropertiesMethodsAndImports()
     {
         var content = """


### PR DESCRIPTION
Fixes #319

## Summary
- Accept `indirect enum` declarations in the Swift extractor.
- Capture Swift enum cases as `property` symbols, including associated values and raw values.
- Add regressions for switch-arm false positives and update the Swift guidance/docs.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Swift"`
- `dotnet test`