### PR TITLE
Fix Rust enum variant indexing (#321)

### DIFF
--- a/changelog.d/unreleased/321.fixed.md
+++ b/changelog.d/unreleased/321.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 321
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Rust enum variants are now indexed as symbols (#321)** - `Ok(T)`, `Err(E)`, struct-like variants such as `Circle { radius: f64 }`, and bare variants like `Point` now appear in `symbols`, `definition`, and related queries.
+
+## 日本語
+
+- **Rust の enum 変種が symbol として index されるようになりました (#321)** - `Ok(T)`、`Err(E)`、`Circle { radius: f64 }` のような struct-like 変種、`Point` のような bare 変種が `symbols`、`definition`、関連クエリに出るようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -991,6 +991,8 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:(?:async|const|unsafe|extern\s+""C"")\s+)*fn\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("struct",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:struct|union)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("enum",     new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // Enum variants / `Red`, `Ok(T)`, `Circle { radius: f64 }`, `Point`
+            new("property", new Regex(@"^\s{4,}(?<name>[A-Z][A-Za-z0-9_]*)\s*(?:\([^()\r\n]*\)|\{[^{}\r\n]*\})?\s*,?\s*$", RegexOptions.Compiled), BodyStyle.None),
             new("interface", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?trait\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // impl Trait for Type / `unsafe impl Trait for Type` should attach to the type being extended.
             // `impl Trait for Type` / `unsafe impl Trait for Type` は、拡張先の型に紐づける。

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10390,6 +10390,40 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Rust_DetectsEnumVariants()
+    {
+        var content = """
+            pub enum Shape {
+                Circle { radius: f64 },
+                Rectangle(f64, f64),
+                Point,
+            }
+
+            pub enum Result<T, E> {
+                Ok(T),
+                Err(E),
+            }
+
+            pub enum Color {
+                Red,
+                Green,
+                Blue,
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Circle");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Rectangle");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Point");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Ok");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Err");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Red");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Green");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Blue");
+        Assert.Equal(8, symbols.Count(s => s.Kind == "property"));
+    }
+
+    [Fact]
     public void Extract_Rust_LifetimeAnnotationsDoNotBreakBraceRanges()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Add a Rust enum-variant symbol row so `Ok(T)`, `Err(E)`, struct-like variants, and bare variants are indexed.
- Add a regression test covering tuple, struct-like, and bare variants.
- Add a bilingual changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Rust_"`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs changelog.d/unreleased/321.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

Fixes #321