### PR TITLE
Document Scala nested interpolator fix for #996

### DIFF
--- a/changelog.d/unreleased/996.fixed.md
+++ b/changelog.d/unreleased/996.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 996
+affected:
+  - src/CodeIndex/Indexer/StructuralLineMasker.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Scala nested interpolator-prefixed triple strings inside holes keep inner calls visible (#996)** — nested `s"""...${innerCall()}..."""`-style literals opened inside a Scala `${...}` hole continue to preserve real call references inside their own interpolation holes while still masking the surrounding body.
+
+## 日本語
+
+- **Scala のホール内にある interpolator 付き triple string で内側の call を保持するようになりました (#996)** — Scala の `${...}` ホール内で開いた `s"""...${innerCall()}..."""` 形式のネスト triple でも、自身の補間ホール内の本物の call 参照を保持しつつ、周囲の本文は引き続きマスクします。


### PR DESCRIPTION
## Summary
- Add the required bilingual unreleased changelog fragment for issue #996.
- The repository already contains the Scala masking behavior that preserves inner call references for nested interpolator-prefixed triple strings, so this PR only documents the regression in the changelog.

## Validation
- dotnet build
- dotnet test --filter "Extract_ScalaStringInterpolatorHoleNestedInterpolatorTriple_PreservesRealCallReferences"
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json

## Notes
- No source changes were needed for the functional fix in this checkout.

Fixes #996