### PR TITLE
Preserve Swift raw string holes inside interpolation holes

### DIFF
--- a/changelog.d/unreleased/1001.fixed.md
+++ b/changelog.d/unreleased/1001.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1001
+affected:
+  - src/CodeIndex/Indexer/StructuralLineMasker.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Swift single-line raw strings inside interpolation holes now preserve real call edges (#1001)** — `StructuralLineMasker` now recursively recognizes nested `#"... "#` literals while scanning a `\#(...)` hole, so matching `\#(...)` bodies stay visible to reference extraction instead of being blanked out with the surrounding raw string.
+
+## 日本語
+
+- **Swift の補間ホール内にある単行 raw 文字列でも本物の call エッジを保持するようになりました (#1001)** — `StructuralLineMasker` が `\#(...)` ホールを走査中に入れ子の `#"... "#` リテラルを再帰的に認識し、対応する `\#(...)` 本文を参照抽出に見えるまま残すようになりました。周囲の raw 文字列と一緒に丸ごと空白化されることはありません。

--- a/src/CodeIndex/Indexer/StructuralLineMasker.cs
+++ b/src/CodeIndex/Indexer/StructuralLineMasker.cs
@@ -2570,6 +2570,19 @@ internal static class StructuralLineMasker
                 var holeDepth = 0;
                 while (q < line.Length)
                 {
+                    // Nested single-line raw string inside the hole. Recurse so the
+                    // nested `\<hashes>(...)` bodies remain visible too.
+                    // ホール内に入れ子の単行 raw 文字列があれば再帰処理し、
+                    // 内側の `\<hashes>(...)` 本文も見えるままにする。
+                    var nestedHashCount = CountRun(line, q, '#');
+                    if (nestedHashCount > 0
+                        && q + nestedHashCount < line.Length
+                        && line[q + nestedHashCount] == '"')
+                    {
+                        q = MaskSwiftSingleLineRawString(line, q, nestedHashCount, masked);
+                        continue;
+                    }
+
                     if (line[q] == '"' || line[q] == '\'')
                     {
                         q = SkipJsSingleLineString(line, q);


### PR DESCRIPTION
## Summary

`StructuralLineMasker` now recursively recognizes nested single-line Swift raw strings while scanning a `\#(...)` interpolation hole, so matching `\#(...)` bodies stay visible to reference extraction instead of being blanked out with the surrounding raw string.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ReferenceExtractorTests`

## Docs / Changelog

- Added bilingual fragment: `changelog.d/unreleased/1001.fixed.md`

## Auto-close

Fixes #1001

## Follow-up candidates

- None identified.