### PR TITLE
Index bare Dart const constructors

### DIFF
--- a/changelog.d/unreleased/+pr1115-dart-const-constructors.fixed.md
+++ b/changelog.d/unreleased/+pr1115-dart-const-constructors.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Dart bare `const` constructors are now indexed as part of the follow-up to PR #1115** — `cdidx` now recognizes `const` constructor declarations that do not use `this` / `super` initializers when they appear in Dart class bodies, while avoiding phantom symbols from `const` expressions outside member scope.
+
+## 日本語
+
+- **Dart の bare な `const` コンストラクタを PR #1115 の follow-up として索引するようになりました** — `cdidx` は Dart の class 本体内に現れる `this` / `super` 初期化子なしの `const` コンストラクタ宣言を認識し、member scope 外の `const` 式からは phantom symbol を作らないようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -319,6 +319,12 @@ public static class SymbolExtractor
     private static readonly Regex JavaCompactConstructorRegex = new(
         @"^\s*(?:(?<visibility>public|private|protected)\s+)?(?<name>\w+)\s*(?=\{|$)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex DartClassDeclarationRegex = new(
+        @"^\s*(?:(?:abstract|base|final|interface|sealed)\s+)*(?:mixin\s+)?class\s+\w+",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex DartBareConstConstructorRegex = new(
+        @"^\s*const\s+(?<name>[A-Z_]\w*(?:\.\w+)?)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CSharpSameLinePropertyStatementStartRegex = new(
         $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|unsafe|extern|ref(?:\s+readonly)?)\s+)*(?!(?:class|struct|interface|enum|record|namespace|delegate|event|const|using|return|throw|yield|var|typeof|sizeof|nameof|default|if|for|foreach|while|switch|catch|lock|case|else|when|break|continue|goto|await)\b)(?:(?:ref(?:\s+readonly)?)\s+)?(?:{CSharpTypePattern})\s+(?:{CSharpExplicitInterfaceQualifierPattern}\.)?{CSharpIdentifierPattern}\s*(?:\{{|=>\s*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1193,6 +1199,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*(?!return\b|await\b|const\b|new\b|throw\b|yield\b|if\b|else\b|for\b|while\b|switch\b|case\b|catch\b|do\b|try\b|finally\b|class\b|enum\b|mixin\b|extension\b|typedef\b|library\b|part\b|import\b|export\b)(?:(?:static|abstract|override|external)\s+)*(?<rt>\w[\w<>,\s\?]*?)\s+(?<name>(?!if\b|else\b|for\b|while\b|switch\b|case\b|class\b|enum\b|mixin\b|extension\b|typedef\b|library\b|part\b|import\b|export\b|abstract\b|void\b|var\b|final\b|late\b|const\b|new\b|return\b|throw\b|yield\b|await\b|extends\b|implements\b|with\b|on\b|is\b|as\b|in\b|of\b|super\b|this\b)\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "rt"),
             new("function", new Regex(@"^\s*factory\s+(?<name>[A-Z_]\w*(?:\.\w+)?)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*const\s+(?<name>[A-Z_]\w*(?:\.\w+)?)\s*\((?=[^)]*(?:\bthis\b|\bsuper\b))", RegexOptions.Compiled), BodyStyle.None),
+            new("function", DartBareConstConstructorRegex, BodyStyle.None),
             new("function", new Regex(@"^\s*(?<name>[A-Z_]\w*(?:\.\w+)?)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*typedef\s+(?<name>\w+)(?:<[^>]*>)?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*typedef\s+(?:[\w<>,\[\]\?\.\s]+\s+)+(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.None),
@@ -1747,6 +1754,9 @@ public static class SymbolExtractor
         var csharpLineStartStates = lang == "csharp"
             ? BuildCSharpLineStartStates(lines)
             : null;
+        var dartInsideClassBody = lang == "dart"
+            ? BuildDartClassBodyScope(structuralLines)
+            : null;
         var privateScopeColumns = lang is "javascript" or "typescript"
             ? BuildJavaScriptTypeScriptPrivateScopeColumns(lines, lang)
             : null;
@@ -2053,6 +2063,18 @@ public static class SymbolExtractor
                             i,
                             csharpNormalizedStartColumn,
                             line.Length);
+                    }
+
+                    if (lang == "dart"
+                        && ReferenceEquals(pattern.Regex, DartBareConstConstructorRegex)
+                        && !dartInsideClassBody!.IsInsideClassBodyAt(i))
+                    {
+                        // Bare `const` constructors need class-body context; otherwise
+                        // `const Widget(key: k)` expressions become phantom symbols.
+                        // bare な `const` コンストラクタは class 本体内でのみ許可する。
+                        // そうしないと `const Widget(key: k)` の式を phantom symbol にしてしまう。
+                        lineOffset = FindNextSameLineBraceStatementStart(matchLine, absoluteStartColumn + Math.Max(1, match.Length), lang);
+                        continue;
                     }
 
                     // C# candidates that only become visible after string-literal content is
@@ -17748,6 +17770,59 @@ public static class SymbolExtractor
         }
 
         return new CSharpTypeBodyScope(lineStartInsideTypeBody, transitions);
+    }
+
+    private sealed class DartClassBodyScope
+    {
+        private readonly bool[] _lineStartInsideClassBody;
+
+        public DartClassBodyScope(bool[] lineStartInsideClassBody)
+        {
+            _lineStartInsideClassBody = lineStartInsideClassBody;
+        }
+
+        public bool IsInsideClassBodyAt(int lineIndex) => _lineStartInsideClassBody[lineIndex];
+    }
+
+    private static DartClassBodyScope BuildDartClassBodyScope(string[] structuralLines)
+    {
+        var lineStartInsideClassBody = new bool[structuralLines.Length];
+        var scopeStack = new Stack<bool>();
+        scopeStack.Push(false);
+        var declBuffer = new StringBuilder();
+
+        for (int lineIndex = 0; lineIndex < structuralLines.Length; lineIndex++)
+        {
+            lineStartInsideClassBody[lineIndex] = scopeStack.Peek();
+
+            var line = structuralLines[lineIndex];
+            for (int cursor = 0; cursor < line.Length; cursor++)
+            {
+                var ch = line[cursor];
+                if (ch == '{')
+                {
+                    var isClassBody = DartClassDeclarationRegex.IsMatch(declBuffer.ToString());
+                    scopeStack.Push(isClassBody);
+                    declBuffer.Clear();
+                }
+                else if (ch == '}')
+                {
+                    if (scopeStack.Count > 1)
+                        scopeStack.Pop();
+                    declBuffer.Clear();
+                }
+                else if (ch == ';')
+                {
+                    declBuffer.Clear();
+                }
+                else
+                {
+                    declBuffer.Append(ch);
+                }
+            }
+        }
+
+        return new DartClassBodyScope(lineStartInsideClassBody);
     }
 
     private static bool[] FindCSharpSwitchExpressionLines(string[] structuralLines)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14676,6 +14676,15 @@ public class SymbolExtractorTests
               final int y;
             }
 
+            class Token {
+              const Token();
+              const Token.named();
+
+              void demo() {
+                const Widget(key: k);
+              }
+            }
+
             class _EmptyAnimal extends Animal {
               _EmptyAnimal() : super('', 0);
             }
@@ -14693,10 +14702,13 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Animal.fromJson");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Animal.constant");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Point");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Token");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Token.named");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "_EmptyAnimal");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "IntCallback");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "StringMap");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "LegacyCallback");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "Widget");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Added a Dart class-body gate for bare `const` constructors so `cdidx` now indexes declarations like `const Token();` and `const Token.named();`.
- Kept `const` expressions such as `const Widget(key: k)` out of symbol output by only accepting the bare form when it appears in a Dart class body.
- Added regression coverage for the new bare `const` forms and the negative expression case.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Dart_"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/+pr1115-dart-const-constructors.fixed.md`.
- No additional docs update was needed; this is a symbol-extraction heuristic change covered by the changelog fragment.

## Follow-up candidates

- This PR addresses the follow-up candidate noted in PR #1115.