### PR TITLE
Fix changelog fragment issue metadata

### DIFF
--- a/changelog.d/unreleased/+kotlin-primary-constructor-properties.fixed.md
+++ b/changelog.d/unreleased/+kotlin-primary-constructor-properties.fixed.md
@@ -1,6 +1,7 @@
 ---
 category: fixed
-issues: []
+issues:
+  - 1127
 affected:
   - src/CodeIndex/Indexer/SymbolExtractor.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs


### PR DESCRIPTION
## Summary
- Fix the Kotlin property changelog fragment so the validator accepts it.
- Replace the empty `issues: []` front matter with the merged PR number.

## Validation
- `dotnet run --project tools/CodeIndex.Changelog -- check`

## Changelog
- This PR only fixes an unreleased fragment file already consumed by the previous merge.
