### PR TITLE
Add JS/TS object literal parity tests

### DIFF
--- a/changelog.d/unreleased/+js-ts-object-literal-parity.fixed.md
+++ b/changelog.d/unreleased/+js-ts-object-literal-parity.fixed.md
@@ -1,0 +1,13 @@
+---
+category: fixed
+affected:
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **JavaScript and TypeScript object-literal coverage stays in sync** — added matching regression tests for multi-line object literal bindings and exported object literal alias properties so the shared JS/TS scanner behavior stays aligned.
+
+## 日本語
+
+- **JavaScript と TypeScript の object literal カバレッジを揃えました** — 複数行の object literal binding と export された object literal の alias property について、対応する回帰テストを追加し、共有される JS/TS scanner の挙動がずれないようにしました。

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -2504,6 +2504,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaScript_DetectsMultiLineObjectLiteralBinding()
+    {
+        // The `{` may sit on a line after the `=` binding; collector must thread
+        // the lex state across lines to find the open brace.
+        // `{` が `=` バインディングと別行にあっても、collector は lex 状態を
+        // 跨いで open brace を検出できること。
+        var content = """
+            const obj =
+            {
+                foo() { return 1; },
+                *bar() { yield 1; },
+            };
+            """;
+        var symbols = SymbolExtractor.Extract(1, "javascript", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "foo" && s.ContainerKind == "object" && s.ContainerName == "obj");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "bar" && s.ContainerKind == "object" && s.ContainerName == "obj");
+    }
+
+    [Fact]
     public void Extract_JavaScript_DoesNotTreatQuotedOrComputedExportedObjectLiteralKeysAsValueSideShorthandProperties()
     {
         var content = """
@@ -17364,6 +17384,27 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "foo" && s.ContainerKind == "object" && s.ContainerName == "obj");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "bar" && s.ContainerKind == "object" && s.ContainerName == "obj");
+    }
+
+    [Fact]
+    public void Extract_TypeScript_DetectsExportedObjectLiteralAliasProperties()
+    {
+        var content = """
+            const foo = 1;
+            function inner() { return 3; }
+            function named() { return 4; }
+            const answer = 42;
+            module.exports = { foo, alias: inner, named, method() {} };
+            export default { answer };
+            """;
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "foo" && s.ContainerKind == "object" && s.ContainerName == "module.exports");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "alias" && s.ContainerKind == "object" && s.ContainerName == "module.exports");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "named" && s.ContainerKind == "object" && s.ContainerName == "module.exports");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "method" && s.ContainerKind == "object" && s.ContainerName == "module.exports");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "answer" && s.ContainerKind == "object" && s.ContainerName == "default");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "inner" && s.ContainerKind == "object" && s.ContainerName == "module.exports");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Add parity coverage for the shared JavaScript/TypeScript object-literal scanner in both directions:

- add a JavaScript test for multi-line object literal bindings
- add a TypeScript test for exported object literal alias properties

These keep the JS/TS object-literal behavior aligned and make the shared scanner contract explicit.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_JavaScript_DetectsMultiLineObjectLiteralBinding|FullyQualifiedName~SymbolExtractorTests.Extract_TypeScript_DetectsExportedObjectLiteralAliasProperties"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog

- Added `[+js-ts-object-literal-parity.fixed.md](/Users/widthdom/Projects/mine/cdidx/CodeIndex/changelog.d/unreleased/+js-ts-object-literal-parity.fixed.md)`

This change only adds test coverage for existing shared behavior and does not change runtime output or user-visible commands.

## Follow-up

- None