### PR TITLE
Recognize T-SQL SECURITY POLICY in SQL symbol extraction

### DIFF
--- a/changelog.d/unreleased/+tsql-security-policy.fixed.md
+++ b/changelog.d/unreleased/+tsql-security-policy.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Improved T-SQL DDL symbol coverage** — SQL symbol extraction now recognizes `CREATE SECURITY POLICY` and `ALTER SECURITY POLICY` declarations, so row-level security policy objects become searchable.
+
+## 日本語
+
+- **T-SQL DDL シンボル抽出を強化** — SQL シンボル抽出で `CREATE SECURITY POLICY` / `ALTER SECURITY POLICY` 宣言を認識するようにし、行レベルセキュリティポリシーのオブジェクトも検索可能にしました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1304,8 +1304,10 @@ public static class SymbolExtractor
             // `LINK` を name として飲み込まないようにする。SHARED と PUBLIC はこの順で 2 語並ぶことがある。
             new("class",    new Regex($@"^\s*CREATE\s+(?:SHARED\s+)?(?:PUBLIC\s+)?DATABASE\s+LINK\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             // T-SQL server-level / database-level principals and objects, plus Oracle-only DIRECTORY / CONTEXT / PROFILE.
+            // Include T-SQL SECURITY POLICY so row-level-security policy definitions are discoverable.
             // T-SQL のサーバ/データベースレベルのプリンシパル・オブジェクトと、Oracle 固有の DIRECTORY / CONTEXT / PROFILE。
-            new("class",    new Regex($@"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:DATABASE|LOGIN|USER|ROLE|CERTIFICATE|DIRECTORY|CONTEXT|PROFILE)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            // T-SQL の SECURITY POLICY も含め、行レベルセキュリティポリシー定義を検索可能にする。
+            new("class",    new Regex($@"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:DATABASE|LOGIN|USER|ROLE|CERTIFICATE|DIRECTORY|CONTEXT|PROFILE|SECURITY\s+POLICY)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             // T-SQL partitioning and full-text catalogs
             // T-SQL のパーティション関連と全文検索カタログ
             new("function", new Regex($@"^\s*CREATE\s+PARTITION\s+FUNCTION\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
@@ -1339,7 +1341,7 @@ public static class SymbolExtractor
             // `ALTER PACKAGE <name> COMPILE BODY` / `ALTER TYPE <name> COMPILE BODY` の形で、下の
             // generic ALTER 行で拾う。`ALTER PACKAGE BODY <name>` のような構文は Oracle に存在しない。
             new("class",    new Regex($@"^\s*ALTER\s+DATABASE\s+LINK\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("class",    new Regex($@"^\s*ALTER\s+(?:TABLE|(?:MATERIALIZED\s+)?VIEW|SEQUENCE|SYNONYM|LOGIN|USER|ROLE|DATABASE|CERTIFICATE|INDEX|PACKAGE|TYPE|DOMAIN|DIRECTORY|PROFILE|PARTITION\s+SCHEME|FULLTEXT\s+CATALOG)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("class",    new Regex($@"^\s*ALTER\s+(?:TABLE|(?:MATERIALIZED\s+)?VIEW|SEQUENCE|SYNONYM|LOGIN|USER|ROLE|DATABASE|CERTIFICATE|INDEX|PACKAGE|TYPE|DOMAIN|DIRECTORY|PROFILE|PARTITION\s+SCHEME|FULLTEXT\s+CATALOG|SECURITY\s+POLICY)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
         ],
         ["terraform"] =
         [

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9613,6 +9613,7 @@ public class SymbolExtractorTests
             "CREATE ROLE sales_writer AUTHORIZATION dbo;\n" +
             "CREATE DATABASE sales_db;\n" +
             "CREATE CERTIFICATE svc_cert WITH SUBJECT = 'svc';\n" +
+            "CREATE SECURITY POLICY SalesFilter ADD FILTER PREDICATE Security.fn_salesPredicate(SalesRep) ON dbo.Orders WITH (STATE = ON);\n" +
             "CREATE PARTITION FUNCTION pf_OrdersByYear (datetime2) AS RANGE RIGHT FOR VALUES ('2024-01-01');\n" +
             "CREATE PARTITION SCHEME ps_OrdersByYear AS PARTITION pf_OrdersByYear TO ([primary]);\n" +
             "CREATE FULLTEXT CATALOG ftc_sales WITH ACCENT_SENSITIVITY=OFF;\n" +
@@ -9626,6 +9627,7 @@ public class SymbolExtractorTests
             "ALTER SCHEMA sales TRANSFER dbo.Customers;\n" +
             "ALTER EXTENSION hstore UPDATE TO '1.5';\n" +
             "ALTER CERTIFICATE svc_cert WITH PRIVATE KEY (DECRYPTION BY PASSWORD = 'x');\n" +
+            "ALTER SECURITY POLICY SalesFilter WITH (STATE = OFF);\n" +
             "ALTER DOMAIN us_postal_code DROP NOT NULL;\n";
         var symbols = SymbolExtractor.Extract(1, "sql", content);
 
@@ -9638,6 +9640,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales_writer");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales_db");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "svc_cert");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "SalesFilter");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "pf_OrdersByYear");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ps_OrdersByYear");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ftc_sales");
@@ -9658,6 +9661,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "sales" && s.Signature != null && s.Signature.StartsWith("ALTER SCHEMA", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "hstore");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "svc_cert" && s.Signature != null && s.Signature.StartsWith("ALTER CERTIFICATE", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "SalesFilter" && s.Signature != null && s.Signature.StartsWith("ALTER SECURITY POLICY", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "us_postal_code");
 
         // SQL `CREATE SCHEMA sales;` and `ALTER SCHEMA sales TRANSFER ...;` are body-less


### PR DESCRIPTION
### Motivation

- Improve SQL/T-SQL symbol discovery so row-level security policies become searchable as first-class objects.
- Keep SQL extraction coverage consistent with other T-SQL DDL kinds so `symbols`/`definition`/`inspect` queries surface security policy objects.

### Description

- Extend the SQL `CREATE` regex to accept `SECURITY POLICY` as a class-like object so `CREATE SECURITY POLICY <name>` is captured (file: `src/CodeIndex/Indexer/SymbolExtractor.cs`).
- Extend the corresponding `ALTER` regex so `ALTER SECURITY POLICY <name>` is captured with the same `class` kind and signature semantics.
- Add regression coverage to `Extract_SQL_DetectsTSqlDdlKinds` in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` asserting both `CREATE` and `ALTER` detection for a `SalesFilter` example.
- Add an unreleased bilingual changelog fragment at `changelog.d/unreleased/+tsql-security-policy.fixed.md` describing the improvement.

### Testing

- Added unit assertions in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` to validate `CREATE SECURITY POLICY` and `ALTER SECURITY POLICY` are detected (tests included in the change).
- Attempted to run CI-style validation via `dotnet build CodeIndex.sln -c Debug` in this environment, but the command failed because `dotnet` is not available here, so automated build/tests could not be executed.
- No failing automated tests were observed locally because test execution could not be performed in this environment; CI should run the test suite after the PR is created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46055a8a8832587a2b009dcbf6a2f)