### PR TITLE
Normalize `--lang py` to `python` for query commands

### DIFF
--- a/changelog.d/unreleased/+python-lang-alias.changed.md
+++ b/changelog.d/unreleased/+python-lang-alias.changed.md
@@ -8,8 +8,8 @@ affected:
 
 ## English
 
-- **`--lang py` now maps to `python`** — query commands that accept `--lang` now canonicalize the common Python shorthand `py`, so Python-focused searches no longer miss indexed `python` files due to alias mismatch.
+- **Python shorthand `--lang` aliases now map to `python`** — query commands that accept `--lang` now canonicalize `py`, `py3`, `pyi`, and `pyw` to `python`, so Python-focused searches no longer miss indexed files due to alias mismatch.
 
 ## 日本語
 
-- **`--lang py` を `python` として扱うようになりました** — `--lang` を受け付けるクエリ系コマンドで、Python の短縮表記 `py` を正規名 `python` に正規化します。これにより、エイリアス不一致で Python ファイル検索が 0 件になる問題を防げます。
+- **Python 系の `--lang` 短縮表記を `python` に正規化するようになりました** — `--lang` を受け付けるクエリ系コマンドで、`py` / `py3` / `pyi` / `pyw` を正規名 `python` に正規化します。これにより、エイリアス不一致で Python ファイル検索が 0 件になる問題を防げます。

--- a/changelog.d/unreleased/+python-lang-alias.changed.md
+++ b/changelog.d/unreleased/+python-lang-alias.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+issues: []
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`--lang py` now maps to `python`** — query commands that accept `--lang` now canonicalize the common Python shorthand `py`, so Python-focused searches no longer miss indexed `python` files due to alias mismatch.
+
+## 日本語
+
+- **`--lang py` を `python` として扱うようになりました** — `--lang` を受け付けるクエリ系コマンドで、Python の短縮表記 `py` を正規名 `python` に正規化します。これにより、エイリアス不一致で Python ファイル検索が 0 件になる問題を防げます。

--- a/changelog.d/unreleased/+python-lang-alias.changed.md
+++ b/changelog.d/unreleased/+python-lang-alias.changed.md
@@ -1,6 +1,5 @@
 ---
 category: changed
-issues: []
 affected:
   - src/CodeIndex/Cli/QueryCommandRunner.cs
   - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -21,6 +21,13 @@ public static class QueryCommandRunner
     internal const int ExactZeroHintProbeLimit = 1;
     internal const int ExactZeroHintSampleLimit = 5;
     private const string HotspotsGroupedByNameKind = "name_kind";
+    private static readonly Dictionary<string, string> LangFilterAliases = new(StringComparer.Ordinal)
+    {
+        ["py"] = "python",
+        ["py3"] = "python",
+        ["pyi"] = "python",
+        ["pyw"] = "python",
+    };
     private static readonly HashSet<string> ValueTakingOptions =
     [
         "--db",
@@ -2988,11 +2995,7 @@ public static class QueryCommandRunner
         if (langValue == null)
             return null;
         var normalized = langValue.ToLowerInvariant();
-        return normalized switch
-        {
-            "py" => "python",
-            _ => normalized,
-        };
+        return LangFilterAliases.TryGetValue(normalized, out var canonical) ? canonical : normalized;
     }
 
     private static bool TryResolveSearchExactMode(QueryCommandOptions options, out bool exact, out string? error)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -2716,9 +2716,13 @@ public static class QueryCommandRunner
                         WarnIfDuplicateSingleValueOption("--lang", langValue!);
                         // Normalize to lowercase so '--lang Python' == '--lang python' — every LangMap key and
                         // every DB 'files.lang' row is lowercase, so the SQL filter and WriteLangHint match.
+                        // Also fold common short aliases (e.g. `py`) to canonical language names so Python-heavy
+                        // workflows can use familiar shorthand without silently returning zero rows.
                         // '--lang Python' と '--lang python' を同一視するため lowercase 正規化する。LangMap の key と
                         // DB の `files.lang` はすべて lowercase なので、SQL filter と WriteLangHint が一致する。
-                        lang = langValue?.ToLowerInvariant();
+                        // さらに `py` のような短縮エイリアスを正規名へ畳み込み、Python 利用時の慣用入力で
+                        // 意図せず 0 件になる事故を避ける。
+                        lang = NormalizeLangFilterValue(langValue);
                     }
                     else
                         AddParseError(langError!);
@@ -2976,6 +2980,18 @@ public static class QueryCommandRunner
             ExactSubstring = exactSubstring,
             ExtraNames = extraNames,
             ParseError = parseErrors == null ? null : string.Join(Environment.NewLine, parseErrors),
+        };
+    }
+
+    internal static string? NormalizeLangFilterValue(string? langValue)
+    {
+        if (langValue == null)
+            return null;
+        var normalized = langValue.ToLowerInvariant();
+        return normalized switch
+        {
+            "py" => "python",
+            _ => normalized,
         };
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -115,6 +115,9 @@ public class QueryCommandRunnerTests
     [Theory]
     [InlineData("Python", "python")]
     [InlineData("py", "python")]
+    [InlineData("PY3", "python")]
+    [InlineData("pyi", "python")]
+    [InlineData("pyw", "python")]
     public void ParseArgs_NormalizesLangAliases(string input, string expected)
     {
         var options = QueryCommandRunner.ParseArgs(["needle", "--lang", input], jsonDefault: false);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -113,6 +113,16 @@ public class QueryCommandRunnerTests
     }
 
     [Theory]
+    [InlineData("Python", "python")]
+    [InlineData("py", "python")]
+    public void ParseArgs_NormalizesLangAliases(string input, string expected)
+    {
+        var options = QueryCommandRunner.ParseArgs(["needle", "--lang", input], jsonDefault: false);
+
+        Assert.Equal(expected, options.Lang);
+    }
+
+    [Theory]
     [InlineData("tokio::spawn", "column qualifier")]
     [InlineData("AND OR", "literal-safe search")]
     [InlineData("foo\"bar", "literal-safe search")]


### PR DESCRIPTION
### Motivation
- Prevent Python-focused searches from returning zero results when users pass the common shorthand `py` or vary case, by canonicalizing `--lang` values to the repository's normalized language names.

### Description
- Add a shared normalizer `NormalizeLangFilterValue` and call it from `QueryCommandRunner.ParseArgs` so values like `py` and `Python` map to `python` at parse time (`src/CodeIndex/Cli/QueryCommandRunner.cs`).
- Add a unit test `ParseArgs_NormalizesLangAliases` to `tests/CodeIndex.Tests/QueryCommandRunnerTests.cs` that verifies `Python -> python` and `py -> python` normalization.
- Add a bilingual changelog fragment under `changelog.d/unreleased/+python-lang-alias.changed.md` describing the change.

### Testing
- Added unit test coverage (`tests/CodeIndex.Tests/QueryCommandRunnerTests.cs`) but could not run the test suite because the `dotnet` CLI is unavailable in this environment (`dotnet: command not found`), so `dotnet build` / `dotnet test` were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4618ae894832584d70958e7a52548)