### PR TITLE
Improve Rust fn modifier extraction coverage

### DIFF
--- a/changelog.d/unreleased/+rust-fn-modifier-coverage.fixed.md
+++ b/changelog.d/unreleased/+rust-fn-modifier-coverage.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Rust function symbol extraction now accepts broader modifier combinations** — `fn` declarations with `default` and `extern` (with or without ABI literals such as `"C-unwind"`) are now recognized, improving Rust symbol search coverage.
+
+## 日本語
+
+- **Rust 関数シンボル抽出で修飾子の組み合わせ対応を拡張しました** — `default` や `extern`（`"C-unwind"` のような ABI 文字列あり/なし）を含む `fn` 宣言を認識できるようになり、Rust のシンボル検索カバレッジが向上しました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -997,8 +997,9 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?macro_rules!\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // const/static items / 定数・静的変数
             new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:const|static)\s+(?<name>\w+)\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            // fn with expanded modifiers: async, const, unsafe, extern / 拡張修飾子: async, const, unsafe, extern
-            new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:(?:async|const|unsafe|extern\s+""C"")\s+)*fn\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // fn with expanded modifiers: async, const, unsafe, default, extern (ABI optional) /
+            // 拡張修飾子: async, const, unsafe, default, extern（ABI は省略可）
+            new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:(?:async|const|unsafe|default|extern(?:\s+""[^""]+"")?)\s+)*fn\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("struct",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:struct|union)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("enum",     new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum variants / `Red`, `Ok(T)`, `Circle { radius: f64 }`, `Point`

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10517,7 +10517,7 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
-        var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";
+        var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";
         var symbols = SymbolExtractor.Extract(1, "rust", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "my_macro");
@@ -10526,6 +10526,9 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "COUNTER");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "default_value");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "raw_ptr");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "no_abi");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ffi_entry");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "trait_default");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Result");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Item");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Callback");


### PR DESCRIPTION
### Motivation

- Improve Rust symbol search coverage so `fn` declarations that use additional modifiers (e.g. `default`, `extern` with optional ABI strings) are recognized by the extractor.
- This addresses gaps where `default async fn`, `extern fn`, or `extern "C-unwind" fn` forms were not being captured by `SymbolExtractor` and thus not discoverable by search.

### Description

- Broadened the Rust `fn` extraction regex in `src/CodeIndex/Indexer/SymbolExtractor.cs` to accept `default` and `extern` modifiers and optional ABI string literals (e.g. `"C-unwind"`).
- Extended the Rust regression sample in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` to include `pub extern fn no_abi()`, `pub unsafe extern "C-unwind" fn ffi_entry()`, and `default async fn trait_default()` and added assertions that these symbols are extracted.
- Added a bilingual changelog fragment `changelog.d/unreleased/+rust-fn-modifier-coverage.fixed.md` describing the change.

### Testing

- Added unit test coverage in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` for the new Rust forms; these tests are expected to run in CI.
- Local `dotnet build` / `dotnet test` were not executed here because the `dotnet` SDK is unavailable in this environment (error: `dotnet: command not found`), so full automated validation must run in the repository CI pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f466ac7eb883259070de83b4ba4505)