### PR TITLE
Add XML/XAML symbol extraction for `x:Class` and `x:Name`

### DIFF
--- a/changelog.d/unreleased/+xaml-symbol-search.changed.md
+++ b/changelog.d/unreleased/+xaml-symbol-search.changed.md
@@ -1,6 +1,5 @@
 ---
 category: changed
-issues: []
 affected:
   - src/CodeIndex/Indexer/SymbolExtractor.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs

--- a/changelog.d/unreleased/+xaml-symbol-search.changed.md
+++ b/changelog.d/unreleased/+xaml-symbol-search.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+issues: []
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML symbol search now captures `x:Class` and `x:Name` in XML files** — `.xaml`/`.axaml` content indexed as XML now emits class/property symbols for `x:Class` and `x:Name`, improving `symbols`, `definition`, and related searches in C#/XAML projects.
+
+## 日本語
+
+- **XML として扱う XAML のシンボル検索で `x:Class` と `x:Name` を抽出するようになりました** — `.xaml`/`.axaml` を XML としてインデックスした際に `x:Class` / `x:Name` から class/property シンボルを生成し、C#/XAML プロジェクトで `symbols` / `definition` などの検索精度を向上させます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1758,6 +1758,8 @@ public static class SymbolExtractor
         // レビュー blocker 対応としてここで専用抽出に分岐する。
         if (lang == "html")
             return ExtractHtmlSymbols(fileId, lines);
+        if (lang == "xml")
+            return ExtractXmlSymbols(fileId, lines);
 
         var structuralLines = StructuralLineMasker.MaskLines(lang, lines);
         var cssScannerLines = lang == "css"
@@ -4283,6 +4285,50 @@ public static class SymbolExtractor
 
         AssignContainers(symbols, lines, null);
         PopulateDeclaredContainerQualifiedNames(symbols);
+        return symbols;
+    }
+
+    private static List<SymbolRecord> ExtractXmlSymbols(long fileId, string[] lines)
+    {
+        var symbols = new List<SymbolRecord>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            foreach (Match classMatch in Regex.Matches(line, @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']"))
+            {
+                var value = classMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "class",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+
+            foreach (Match nameMatch in Regex.Matches(line, @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']"))
+            {
+                var value = nameMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+        }
+
         return symbols;
     }
 

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1758,8 +1758,6 @@ public static class SymbolExtractor
         // レビュー blocker 対応としてここで専用抽出に分岐する。
         if (lang == "html")
             return ExtractHtmlSymbols(fileId, lines);
-        if (lang == "xml")
-            return ExtractXmlSymbols(fileId, lines);
 
         var structuralLines = StructuralLineMasker.MaskLines(lang, lines);
         var cssScannerLines = lang == "css"
@@ -3117,6 +3115,8 @@ public static class SymbolExtractor
 
         if (string.Equals(originalLang, "svelte", StringComparison.Ordinal))
             ExtractSvelteReactiveSymbols(fileId, lines, symbols);
+        if (lang == "xml")
+            symbols.AddRange(ExtractXmlSymbols(fileId, lines));
 
         AssignContainers(symbols, lines, csharpLineStartStates);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -17908,6 +17908,27 @@ public class SymbolExtractorTests
         Assert.Contains("public Sample {", compactCtor.Signature);
     }
 
+    [Fact]
+    public void Extract_Xml_XamlCapturesXClassAndXName()
+    {
+        var content = """
+            <Window x:Class="Sample.MainWindow"
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                <Grid>
+                    <Button x:Name="SaveButton" Content="Save" />
+                    <TextBlock x:Name="StatusText" />
+                </Grid>
+            </Window>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Sample.MainWindow");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "SaveButton");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "StatusText");
+    }
+
     private static string GetRepositoryRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
### Motivation

- Improve symbol search for C#/XAML projects by emitting symbols from XAML files indexed as XML so UI classes and named elements surface in `symbols`/`definition` queries.
- XAML files were already detected as `xml` but lacked XAML-specific symbol extraction for `x:Class` and `x:Name`, reducing discoverability of view types and named controls.

### Description

- Route XML input to a new extractor by returning `ExtractXmlSymbols` when `lang == "xml"` inside `SymbolExtractor.Extract` (`src/CodeIndex/Indexer/SymbolExtractor.cs`).
- Add `ExtractXmlSymbols` which scans lines for `x:Class="..."` and `x:Name="..."` and emits `class` and `property` `SymbolRecord`s respectively (`src/CodeIndex/Indexer/SymbolExtractor.cs`).
- Add a regression unit test `Extract_Xml_XamlCapturesXClassAndXName` in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` that verifies `x:Class` and multiple `x:Name` values are extracted.
- Add a bilingual changelog fragment at `changelog.d/unreleased/+xaml-symbol-search.changed.md` describing the change.

### Testing

- Intended validation is `dotnet build CodeIndex.sln -c Release` and `dotnet test CodeIndex.sln`, but `dotnet` is not available in this environment so automated build/tests could not be executed (`dotnet` CLI not found).
- A unit test was added (`Extract_Xml_XamlCapturesXClassAndXName`) to cover the new behavior and should pass when run in CI or a local environment with the .NET toolchain available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46745f96c832591696845775837ec)