### PR TITLE
Improve Swift symbol extraction: extensions and backtick-escaped function names

### DIFF
--- a/changelog.d/unreleased/+swift-search.changed.md
+++ b/changelog.d/unreleased/+swift-search.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Swift symbol search now indexes extension declarations and escaped function names** — `symbols`/`search` can now find Swift `extension` targets and backtick-escaped function identifiers (for example, ``func `repeat`()``).
+
+## 日本語
+
+- **Swift シンボル検索で extension 宣言とエスケープ関数名を索引化** — `symbols` / `search` が Swift の `extension` 対象とバッククォート付き関数名（例: ``func `repeat`()``）を検出できるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1124,11 +1124,18 @@ public static class SymbolExtractor
         ],
         ["swift"] =
         [
-            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:static|class|nonisolated|mutating|nonmutating)\s+)*(?:override\s+)?func\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // Swift function names may be ordinary identifiers or escaped identifiers
+            // wrapped in backticks (e.g. `func `repeat`() {}`).
+            // Swift の関数名は通常識別子に加えて、バッククォートでエスケープした識別子
+            // （例: `func `repeat`() {}`）も取りうる。
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:static|class|nonisolated|mutating|nonmutating)\s+)*(?:override\s+)?func\s+(?<name>`[^`]+`|\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("struct",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final)\s+)*struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("enum",      new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:indirect\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("property",  new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:indirect\s+)?case\s+(?<name>\w+)(?:\s*\([^)]*\))?(?:\s*=\s*(?<returnType>.+?))?\s*$", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),
             new("interface", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*protocol\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // Extension declarations are important search anchors in Swift-heavy codebases.
+            // extension 宣言は Swift コード検索における重要なアンカー。
+            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final)\s+)?extension\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // actor (Swift 5.5+) / アクター
             new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final|distributed)\s+)*(?:class|actor)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Type alias / 型エイリアス

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11730,6 +11730,20 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsExtensionsAndEscapedFunctionNames()
+    {
+        var content = """
+            public extension URLSession {
+                func `repeat`() {}
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "URLSession");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "`repeat`");
+    }
+
+    [Fact]
     public void Extract_C_DetectsFunctionsAndStructs()
     {
         // C: functions, struct / C: 関数、構造体


### PR DESCRIPTION
### Motivation
- Improve Swift search accuracy by indexing `extension` declarations and supporting backtick-escaped function identifiers (e.g. ``func `repeat`()``) which were previously missed by symbol extraction.

### Description
- Update `src/CodeIndex/Indexer/SymbolExtractor.cs` to accept backtick-escaped Swift function names in the `func` row and to recognize `extension` declarations as searchable symbols.
- Add a regression test `Extract_Swift_DetectsExtensionsAndEscapedFunctionNames` in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` to validate both behaviors.
- Add a bilingual changelog fragment at `changelog.d/unreleased/+swift-search.changed.md` describing the user-visible change.

### Testing
- Attempted local validation: `dotnet build CodeIndex.sln -c Debug` could not be run because `dotnet` is not available in this environment, so build and test were not executed locally.
- A unit test covering extensions and backtick-escaped function names was added and committed, and CI is expected to run `dotnet test` to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4684b775883259a1ef72f2479e785)