### PR TITLE
Improve Java symbol extraction coverage for search

### DIFF
--- a/changelog.d/unreleased/+java-search-coverage.changed.md
+++ b/changelog.d/unreleased/+java-search-coverage.changed.md
@@ -1,6 +1,5 @@
 ---
 category: changed
-issues: []
 affected:
   - src/CodeIndex/Indexer/SymbolExtractor.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs

--- a/changelog.d/unreleased/+java-search-coverage.changed.md
+++ b/changelog.d/unreleased/+java-search-coverage.changed.md
@@ -1,0 +1,17 @@
+---
+category: changed
+issues: []
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- Improved Java symbol search coverage in `symbols`/`definition` by adding package extraction, constructor extraction, broader qualified/generic return-type matching, and annotation-friendly matching for methods and constants.
+- Expanded parity checks so Java-focused extraction improvements are validated with regression tests, which also helps Kotlin/C# cross-language consistency efforts.
+
+## 日本語
+
+- `symbols` / `definition` の Java シンボル検索カバレッジを強化し、`package` 抽出、コンストラクタ抽出、修飾名/ジェネリック戻り値型の対応拡張、メソッド・定数のアノテーション併用形を取得できるようにしました。
+- Java 抽出強化に対する回帰テストを追加し、Kotlin/C# への横展開時に整合性を保ちやすくしました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1039,7 +1039,7 @@ public static class SymbolExtractor
             new("class",    new Regex(@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|final|abstract|sealed|non-sealed|strictfp)\s+)*class\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
             // Static final field (Java equivalent of C# const) — order-flexible and annotation-friendly.
             // static final フィールド — 語順柔軟かつアノテーション併用にも対応。
-            new("function", new Regex($@"^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?<visibility>public|private|protected)?\s*(?:(?:static|final|transient|volatile)\s+)*(?:(?<=\s)static\s+)?(?:(?<=\s)final\s+)?(?<returnType>{JavaReturnTypePattern})\s+(?<name>[A-Z_]\w*)\s*=", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, "visibility", "returnType"),
+            new("function", new Regex($@"^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?<visibility>public|private|protected)?\s*(?=(?:(?:static|final|transient|volatile)\s+)*static\b)(?=(?:(?:static|final|transient|volatile)\s+)*final\b)(?:(?:static|final|transient|volatile)\s+)*(?<returnType>{JavaReturnTypePattern})\s+(?<name>[A-Z_]\w*)\s*=", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, "visibility", "returnType"),
             // Constructor (including compact same-line forms) / コンストラクタ
             new("function", new Regex($@"^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?<visibility>public|private|protected)?\s*(?:(?:static|final|synchronized|strictfp)\s+)*(?<name>{JavaIdentifierPattern})\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
             // Method with return type — expanded modifiers (default, native, synchronized, final)

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -79,6 +79,12 @@ public static class SymbolExtractor
         @"(?:(?:global::)?(?:" + CSharpTypeSegmentPattern + @")(?:\s+(?:" + CSharpTypeSegmentPattern + @"))*" + CSharpTupleSuffixPattern + @")";
     private const string CSharpMethodTypeParameterListPattern =
         @"(?:<(?:(?>[^<>]+)|<(?<CSharpMethodTypeParameterDepth>)|>(?<-CSharpMethodTypeParameterDepth>))*(?(CSharpMethodTypeParameterDepth)(?!))>\s*)?";
+    private const string JavaIdentifierPattern = @"[\p{L}_$][\p{L}\p{Nd}_$]*";
+    private const string JavaQualifiedIdentifierPattern = JavaIdentifierPattern + @"(?:\s*\.\s*" + JavaIdentifierPattern + @")*";
+    private const string JavaMethodTypeParameterPattern =
+        @"(?:<(?:(?>[^<>]+)|<(?<JavaMethodTypeParameterDepth>)|>(?<-JavaMethodTypeParameterDepth>))*(?(JavaMethodTypeParameterDepth)(?!))>\s+)?";
+    private const string JavaReturnTypePattern =
+        @"(?:" + JavaQualifiedIdentifierPattern + @"(?:\s*<[^;=(){}]+>)?(?:\s*\[\s*\])*)";
     private static readonly Regex PhpGroupUseRegex = new(
         @"^\s*use\s+(?:(?<type>function|const)\s+)?(?<prefix>[\w\\]+\\)\{\s*(?<items>[^{}]+?)\s*\}\s*;",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
@@ -1016,6 +1022,8 @@ public static class SymbolExtractor
         ],
         ["java"] =
         [
+            // Package declaration / package 宣言
+            new("namespace", new Regex(@"^\s*package\s+(?<name>[\w.]+)\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
             // Module declaration (Java 9+ module-info.java) / モジュール宣言（Java 9+ の module-info.java）
             new("namespace", new Regex(@"^\s*(?:open\s+)?module\s+(?<name>[\w.]+)\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
             // Annotation type (@interface) / アノテーション型
@@ -1029,12 +1037,14 @@ public static class SymbolExtractor
             // Class — with extended modifiers (final, sealed, static, abstract, strictfp)
             // クラス — 拡張修飾子対応（final, sealed, static, abstract, strictfp）
             new("class",    new Regex(@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|final|abstract|sealed|non-sealed|strictfp)\s+)*class\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
-            // Static final field (Java equivalent of C# const) — order-flexible (static final or final static), generic types with spaces
-            // static final フィールド — 語順柔軟（static final / final static）、スペース含むジェネリック型対応
-            new("function", new Regex(@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|final)\s+){2}(?<returnType>[\w?.<>\[\],\s]+?)\s+(?<name>[A-Z_]\w*)\s*=", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, "visibility", "returnType"),
+            // Static final field (Java equivalent of C# const) — order-flexible and annotation-friendly.
+            // static final フィールド — 語順柔軟かつアノテーション併用にも対応。
+            new("function", new Regex($@"^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?<visibility>public|private|protected)?\s*(?:(?:static|final|transient|volatile)\s+)*(?:(?<=\s)static\s+)?(?:(?<=\s)final\s+)?(?<returnType>{JavaReturnTypePattern})\s+(?<name>[A-Z_]\w*)\s*=", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, "visibility", "returnType"),
+            // Constructor (including compact same-line forms) / コンストラクタ
+            new("function", new Regex($@"^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?<visibility>public|private|protected)?\s*(?:(?:static|final|synchronized|strictfp)\s+)*(?<name>{JavaIdentifierPattern})\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
             // Method with return type — expanded modifiers (default, native, synchronized, final)
             // 戻り値型付きメソッド — 拡張修飾子対応（default, native, synchronized, final）
-            new("function", new Regex(@"^\s*(?!(?:return|throw|new|if|for|while|switch|do|case|else|try|catch|finally|synchronized|break|continue|yield|assert)\b)(?<visibility>public|private|protected)?\s*(?:(?:static|abstract|synchronized|final|default|native|strictfp)\s+)*(?!(?:record)\b)(?:<[^>]*>+\s+)?(?<returnType>\w+(?:<[^>]+>)?(?:\[\])?)\s+(?<name>\w+)\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility", "returnType"),
+            new("function", new Regex($@"^\s*(?!(?:return|throw|new|if|for|while|switch|do|case|else|try|catch|finally|synchronized|break|continue|yield|assert)\b)(?:@\w+(?:\([^)]*\))?\s+)*(?<visibility>public|private|protected)?\s*(?:(?:static|abstract|synchronized|final|default|native|strictfp)\s+)*(?!(?:record)\b){JavaMethodTypeParameterPattern}(?<returnType>{JavaReturnTypePattern})\s+(?<name>{JavaIdentifierPattern})\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility", "returnType"),
             // Enum members are extracted by ExtractJavaEnumMembers using a body-scoped scanner,
             // which handles any indent style (tab, 2-space, 4-space) and skips member-like lines
             // outside the enum body (e.g. `\tRED();` method calls inside a class body).

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10704,6 +10704,31 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Java_DetectsPackageConstructorsQualifiedReturnTypesAndAnnotatedMembers()
+    {
+        var content = """
+            package com.example.service;
+
+            public class UserService {
+                @Deprecated
+                public UserService() {}
+
+                public java.util.List<String[]> loadAll() { return java.util.List.of(); }
+
+                @Deprecated
+                public static final java.util.Map<String, Integer> MAX_RETRIES = java.util.Map.of();
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "com.example.service");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "UserService");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "loadAll" && s.ReturnType == "java.util.List<String[]>");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "MAX_RETRIES" && s.ReturnType == "java.util.Map<String, Integer>");
+    }
+
+    [Fact]
     public void Extract_Java_DetectsRecordAndSealedClass()
     {
         // Java 16+ record, Java 17+ sealed class / Java 16 の record、Java 17 の sealed class


### PR DESCRIPTION
### Motivation
- Increase Java search/definition coverage by capturing additional Java symbols that were previously missed by line-oriented regexes.  
- Target non-breaking, high-value improvements (package, constructors, qualified/generic return types, annotated members) that improve results for Java users and AI workflows.  
- Prepare a clear path for later parity/rollout to Kotlin and C# without changing existing behavior.

### Description
- Add Java-specific token patterns: `JavaIdentifierPattern`, `JavaQualifiedIdentifierPattern`, `JavaMethodTypeParameterPattern`, and `JavaReturnTypePattern` to better recognize qualified and generic return types in `SymbolExtractor`.  
- Add `package` extraction as a `namespace` row and a constructor row so top-level package and constructor symbols are emitted for Java sources.  
- Broaden method and static-final constant rows to accept annotations and qualified/generic return types, and add annotation-friendly handling for `static final` constants.  
- Add a regression test `Extract_Java_DetectsPackageConstructorsQualifiedReturnTypesAndAnnotatedMembers` in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` and add a bilingual changelog fragment at `changelog.d/unreleased/+java-search-coverage.changed.md`.

### Testing
- Attempted `dotnet build` / `dotnet test` but automated builds/tests could not be run in this environment because `dotnet` is not installed (error: `dotnet: command not found`).  
- Static validations performed: updated `src/CodeIndex/Indexer/SymbolExtractor.cs`, added tests under `tests/CodeIndex.Tests/SymbolExtractorTests.cs`, and added changelog fragment under `changelog.d/unreleased/` (no test execution performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f468e15214832582edc71575b1af6c)