### PR TITLE
docs: require `issues: null` for non-issue changelog fragments and add example template

### DIFF
--- a/.codex/workflows/changelog-fragment.md
+++ b/.codex/workflows/changelog-fragment.md
@@ -18,9 +18,13 @@ Treat any request to "update the changelog" as a fragment request unless the tas
 2. If no changelog entry is required, explain why in the PR body.
 3. If required, create a fragment named `<issue>.<category>.md`,
    `<issue>-<issue>.<category>.md`, or `+<slug>.<category>.md`.
+   - If the work is **not** issue-based, use `+<slug>.<category>.md`.
 4. Use one of the allowed categories: `added`, `changed`, `fixed`,
    `deprecated`, `removed`, `security`, `docs`, `internal`.
 5. Include required front matter.
+   - For issue-based work, `issues` must list one or more issue numbers.
+   - For non-issue work, set `issues: null`.
+   - Do **not** write `issues: []` (empty arrays fail validation/pipeline checks).
 6. Include both `## English` and `## 日本語` sections.
 7. Do not include release headings or compare-link footer definitions.
 8. Validate fragments before committing.
@@ -44,4 +48,23 @@ affected:
 ## 日本語
 
 - **C# の verbatim 識別子が見つからない場合でも `impact` が元の検索文字列を維持するようになりました (#960)** — `impact` は C# verbatim lookup の miss 時にユーザー入力の綴りを保持するため、human / JSON 出力が誤解を招く canonicalized query を返さなくなりました。
+```
+
+### Non-issue Template
+
+```md
+---
+category: docs
+issues: null
+affected:
+  - .codex/workflows/changelog-fragment.md
+---
+
+## English
+
+- **Clarified non-issue fragment front matter requirements** — non-issue changelog fragments now explicitly require `issues: null`, preventing `issues: []` validation failures in agent-generated fragments.
+
+## 日本語
+
+- **issue 非対応フラグメントの front matter 要件を明確化** — issue 非対応の changelog フラグメントでは `issues: null` を明示的に必須とし、エージェント生成時の `issues: []` による検証失敗を防止しました。
 ```


### PR DESCRIPTION
### Motivation

- Agents repeatedly generated changelog fragments with `issues: []`, which fails pipeline validation and blocks PRs. 
- The workflow needs an explicit, copy-safe guideline so agents and contributors produce valid non-issue fragments.

### Description

- Updated `.codex/workflows/changelog-fragment.md` to instruct non-issue fragments use the `+<slug>.<category>.md` naming convention. 
- Added a rule that non-issue fragments must set `issues: null` and explicitly forbid `issues: []`. 
- Added a bilingual `Non-issue Template` example that demonstrates `issues: null` and shows both English and Japanese entries. 
- Small editorial clarifications around front-matter requirements for issue-based vs non-issue fragments.

### Testing

- Attempted to run the local index search with `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search "issues: []"`, but the command failed because `dotnet` is not available in the environment. No other automated tests were run locally; CI will validate the workflow and templates on merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46a96a7b48325a3cb8056e8442596)