### PR TITLE
Enhance Swift symbol extraction coverage for search anchors

### DIFF
--- a/changelog.d/unreleased/+swift-search-anchors.changed.md
+++ b/changelog.d/unreleased/+swift-search-anchors.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+issues: null
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Improved Swift symbol extraction for initializer-style anchors** — Swift `init`, `deinit`, and `subscript` declarations are now indexed as function symbols, making Swift code searches more complete for object lifecycle and indexed-access entry points.
+
+## 日本語
+
+- **Swift の初期化系アンカー抽出を強化** — Swift の `init`・`deinit`・`subscript` 宣言を function シンボルとして index 化するようになり、オブジェクトライフサイクルや添字アクセスの検索網羅性が向上しました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1130,17 +1130,25 @@ public static class SymbolExtractor
             // Swift の関数名は通常識別子に加えて、バッククォートでエスケープした識別子
             // （例: `func `repeat`() {}`）も取りうる。
             new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:static|class|nonisolated|mutating|nonmutating)\s+)*(?:override\s+)?func\s+(?<name>`[^`]+`|\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // Swift initializer/deinitializer/subscript are high-value query anchors.
+            // Swift の initializer/deinitializer/subscript は検索アンカーとして重要。
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:required|convenience|override|nonisolated)\s+)*(?<name>init)\s*(?:<[^>]+>\s*)?\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:nonisolated\s+)?(?<name>deinit)\b", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:static|class|nonisolated)\s+)*(?<name>subscript)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("struct",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final)\s+)*struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("enum",      new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:indirect\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("property",  new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:indirect\s+)?case\s+(?<name>\w+)(?:\s*\([^)]*\))?(?:\s*=\s*(?<returnType>.+?))?\s*$", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),
             new("interface", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*protocol\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Extension declarations are important search anchors in Swift-heavy codebases.
             // extension 宣言は Swift コード検索における重要なアンカー。
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final)\s+)?extension\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final)\s+)?extension\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // actor (Swift 5.5+) / アクター
             new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final|distributed)\s+)*(?:class|actor)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Type alias / 型エイリアス
             new("import",   new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*typealias\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("import",   new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*associatedtype\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:prefix|postfix|infix)\s+operator\s+(?<name>\S+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*precedencegroup\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("import",   new Regex(@"^\s*import\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["objc"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10419,6 +10419,72 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsInitDeinitAndSubscript()
+    {
+        var content = """
+            public final class CacheBox {
+                public required init(capacity: Int) { }
+                deinit { }
+                subscript(key: String) -> Int { 1 }
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "init");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "deinit");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "subscript");
+    }
+
+    [Fact]
+    public void Extract_Swift_DetectsAssociatedType()
+    {
+        var content = """
+            public protocol Repository {
+                associatedtype Item
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Item");
+    }
+
+    [Fact]
+    public void Extract_Swift_DetectsCustomOperatorDeclarations()
+    {
+        var content = """
+            infix operator <=> : ComparisonPrecedence
+            prefix operator +++
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "<=>");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "+++");
+    }
+
+    [Fact]
+    public void Extract_Swift_DetectsPrecedenceGroup()
+    {
+        var content = """
+            precedencegroup ExponentPrecedence {
+                associativity: right
+                higherThan: MultiplicationPrecedence
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ExponentPrecedence");
+    }
+
+    [Fact]
+    public void Extract_Swift_DetectsDottedExtensionTarget()
+    {
+        var content = """
+            extension Foundation.URL {
+                func normalized() -> URL { self }
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Foundation.URL");
+    }
+
+    [Fact]
     public void Extract_ObjC_DetectsInterfacesPropertiesMethodsAndImports()
     {
         var content = """


### PR DESCRIPTION
### Motivation
- Swift codebases rely on non-standard anchors (initializers, subscripts, operators, precedence groups, dotted extension targets) that were under-indexed and reduced search coverage.

### Description
- Added Swift symbol regexes to index `init`, `deinit`, and `subscript` as `function` symbols and to capture `associatedtype`, custom `operator` declarations, and `precedencegroup` declarations in `SymbolExtractor` (`src/CodeIndex/Indexer/SymbolExtractor.cs`).
- Improved the `extension` pattern to accept dotted targets (e.g. `Foundation.URL`).
- Added unit tests covering each enhancement in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` and added a bilingual unreleased changelog fragment at `changelog.d/unreleased/+swift-search-anchors.changed.md`.
- Implemented as 5 logical commits covering the five enhancement areas and prepared a PR draft titled as above.

### Testing
- Could not run automated tests locally because the environment lacks the .NET SDK (`dotnet` not found), so `dotnet test CodeIndex.sln -c Release` was not executed and local validation was skipped.
- Added unit tests for all new Swift extraction cases; these should be executed by CI (`dotnet test`) and are expected to pass once run in a .NET-enabled environment.
- Changelog fragment created and included for pipeline validation (`changelog.d/unreleased/+swift-search-anchors.changed.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46d4137c4832580aeb4a1244a0941)