### PR TITLE
Index `x:Class` and `x:Name` from XAML/XML files into symbols

### DIFF
--- a/changelog.d/unreleased/+xaml-symbol-search.changed.md
+++ b/changelog.d/unreleased/+xaml-symbol-search.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML symbol search now captures `x:Class` and `x:Name` in XML files** — `.xaml`/`.axaml` content indexed as XML now emits class/property symbols for `x:Class` and `x:Name`, improving `symbols`, `definition`, and related searches in C#/XAML projects.
+
+## 日本語
+
+- **XML として扱う XAML のシンボル検索で `x:Class` と `x:Name` を抽出するようになりました** — `.xaml`/`.axaml` を XML としてインデックスした際に `x:Class` / `x:Name` から class/property シンボルを生成し、C#/XAML プロジェクトで `symbols` / `definition` などの検索精度を向上させます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -99,6 +99,12 @@ public static class SymbolExtractor
     private static readonly Regex GoImportSpecRegex = new(
         @"^(?<name>(?:(?:[._]|[\p{L}_][\p{L}\p{Nd}_]*)\s+)?""(?:\\.|[^""\\])*"")(?:\s*;)?(?:\s*(?://.*|/\*.*\*/))?\s*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlClassRegex = new(
+        @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlNameRegex = new(
+        @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     // Optional TypeScript generic type-argument token that may sit between an HOC call
     // name and its `(`. Consumed only by the TypeScript HOC-binding row — the JavaScript
@@ -3115,6 +3121,8 @@ public static class SymbolExtractor
 
         if (string.Equals(originalLang, "svelte", StringComparison.Ordinal))
             ExtractSvelteReactiveSymbols(fileId, lines, symbols);
+        if (lang == "xml")
+            symbols.AddRange(ExtractXmlSymbols(fileId, lines));
 
         AssignContainers(symbols, lines, csharpLineStartStates);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
@@ -4283,6 +4291,50 @@ public static class SymbolExtractor
 
         AssignContainers(symbols, lines, null);
         PopulateDeclaredContainerQualifiedNames(symbols);
+        return symbols;
+    }
+
+    private static List<SymbolRecord> ExtractXmlSymbols(long fileId, string[] lines)
+    {
+        var symbols = new List<SymbolRecord>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            foreach (Match classMatch in XamlClassRegex.Matches(line))
+            {
+                var value = classMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "class",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+
+            foreach (Match nameMatch in XamlNameRegex.Matches(line))
+            {
+                var value = nameMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+        }
+
         return symbols;
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -17908,6 +17908,27 @@ public class SymbolExtractorTests
         Assert.Contains("public Sample {", compactCtor.Signature);
     }
 
+    [Fact]
+    public void Extract_Xml_XamlCapturesXClassAndXName()
+    {
+        var content = """
+            <Window x:Class="Sample.MainWindow"
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                <Grid>
+                    <Button x:Name="SaveButton" Content="Save" />
+                    <TextBlock x:Name="StatusText" />
+                </Grid>
+            </Window>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Sample.MainWindow");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "SaveButton");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "StatusText");
+    }
+
     private static string GetRepositoryRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
### Motivation

- Improve symbol discovery for C#/XAML projects by extracting class and named element symbols from `.xaml`/`.axaml` files that are indexed as XML.

### Description

- Add `XamlClassRegex` and `XamlNameRegex` regular expressions to detect `x:Class` and `x:Name` attributes. 
- Add `ExtractXmlSymbols` which scans XML lines and emits `SymbolRecord` entries with `Kind` set to `class` for `x:Class` and `property` for `x:Name`, including file/line/signature metadata. 
- Invoke `ExtractXmlSymbols` when `lang == "xml"` so XAML content indexed as XML contributes symbols. 
- Add unit test `Extract_Xml_XamlCapturesXClassAndXName` and a changelog entry describing the change.

### Testing

- Ran the test suite with `dotnet test` and the tests in `tests/CodeIndex.Tests` completed successfully, including the new `Extract_Xml_XamlCapturesXClassAndXName` test.
- No automated test failures were observed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46745f96c832591696845775837ec)