### PR TITLE
Index XAML `x:Class`/`x:Name` in XML files and add tests

### DIFF
--- a/changelog.d/unreleased/+xaml-symbol-search.changed.md
+++ b/changelog.d/unreleased/+xaml-symbol-search.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML symbol search now captures `x:Class` and `x:Name` in XML files** — `.xaml`/`.axaml` content indexed as XML now emits class/property symbols for `x:Class` and `x:Name` when a XAML namespace declaration is present, improving `symbols`, `definition`, and related searches in C#/XAML projects without polluting generic XML results.
+
+## 日本語
+
+- **XML として扱う XAML のシンボル検索で `x:Class` と `x:Name` を抽出するようになりました** — `.xaml`/`.axaml` を XML としてインデックスした際、XAML 名前空間宣言がある場合に `x:Class` / `x:Name` から class/property シンボルを生成し、汎用 XML を汚染せずに C#/XAML プロジェクトで `symbols` / `definition` などの検索精度を向上させます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -99,6 +99,12 @@ public static class SymbolExtractor
     private static readonly Regex GoImportSpecRegex = new(
         @"^(?<name>(?:(?:[._]|[\p{L}_][\p{L}\p{Nd}_]*)\s+)?""(?:\\.|[^""\\])*"")(?:\s*;)?(?:\s*(?://.*|/\*.*\*/))?\s*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlClassRegex = new(
+        @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlNameRegex = new(
+        @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     // Optional TypeScript generic type-argument token that may sit between an HOC call
     // name and its `(`. Consumed only by the TypeScript HOC-binding row — the JavaScript
@@ -3115,6 +3121,8 @@ public static class SymbolExtractor
 
         if (string.Equals(originalLang, "svelte", StringComparison.Ordinal))
             ExtractSvelteReactiveSymbols(fileId, lines, symbols);
+        if (lang == "xml")
+            symbols.AddRange(ExtractXmlSymbols(fileId, lines));
 
         AssignContainers(symbols, lines, csharpLineStartStates);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
@@ -4283,6 +4291,66 @@ public static class SymbolExtractor
 
         AssignContainers(symbols, lines, null);
         PopulateDeclaredContainerQualifiedNames(symbols);
+        return symbols;
+    }
+
+    private static List<SymbolRecord> ExtractXmlSymbols(long fileId, string[] lines)
+    {
+        var hasXamlNamespace = false;
+        foreach (var line in lines)
+        {
+            if (line.IndexOf("xmlns:x=", StringComparison.OrdinalIgnoreCase) < 0)
+                continue;
+            if (line.IndexOf("schemas.microsoft.com/winfx/2006/xaml", StringComparison.OrdinalIgnoreCase) >= 0
+                || line.IndexOf("github.com/avaloniaui", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                hasXamlNamespace = true;
+                break;
+            }
+        }
+
+        if (!hasXamlNamespace)
+            return [];
+
+        var symbols = new List<SymbolRecord>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            foreach (Match classMatch in XamlClassRegex.Matches(line))
+            {
+                var value = classMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "class",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+
+            foreach (Match nameMatch in XamlNameRegex.Matches(line))
+            {
+                var value = nameMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+        }
+
         return symbols;
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -17908,6 +17908,45 @@ public class SymbolExtractorTests
         Assert.Contains("public Sample {", compactCtor.Signature);
     }
 
+    [Fact]
+    public void Extract_Xml_XamlCapturesXClassAndXName()
+    {
+        var content = """
+            <Window x:Class="Sample.MainWindow"
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                <Grid>
+                    <Button x:Name="SaveButton" Content="Save" />
+                    <TextBlock x:Name="StatusText" />
+                </Grid>
+            </Window>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Sample.MainWindow");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "SaveButton");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "StatusText");
+    }
+
+    [Fact]
+    public void Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols()
+    {
+        var content = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <Foo x:Name="ShouldNotBeCaptured" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+        Assert.DoesNotContain(symbols, s => s.Name == "ShouldNotBeCaptured");
+    }
+
     private static string GetRepositoryRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
### Motivation

- Improve symbol search for `.xaml`/`.axaml` content that is indexed as XML by emitting meaningful class/property symbols for XAML-specific attributes when a XAML namespace declaration is present.
- Ensure this enhancement does not pollute generic XML indexing by restricting extraction to files that declare a known XAML namespace.

### Description

- Added `XamlClassRegex` and `XamlNameRegex` to detect `x:Class` and `x:Name` attribute values.  
- Invoke `ExtractXmlSymbols` for `lang == "xml"` inside `SymbolExtractor.Extract` to collect XAML symbols when appropriate.  
- Implemented `ExtractXmlSymbols` which scans lines, checks for known XAML namespace URIs (`schemas.microsoft.com/winfx/2006/xaml` and `github.com/avaloniaui`), and emits `class` symbols for `x:Class` and `property` symbols for `x:Name` with line and signature metadata.  
- Added unit tests `Extract_Xml_XamlCapturesXClassAndXName` and `Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols`, and included a changelog entry at `changelog.d/unreleased/+xaml-symbol-search.changed.md` describing the user-facing change.

### Testing

- Ran unit tests in the test project with `dotnet test tests/CodeIndex.Tests`; the test run completed successfully.  
- Verified new tests `Extract_Xml_XamlCapturesXClassAndXName` and `Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols` pass.  
- Existing `CodeIndex.Tests` suite executed and passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46745f96c832591696845775837ec)