### PR TITLE
Enhance Swift symbol extraction coverage

### DIFF
--- a/changelog.d/unreleased/+swift-symbol-coverage.fixed.md
+++ b/changelog.d/unreleased/+swift-symbol-coverage.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Expanded Swift symbol extraction coverage** — Swift indexing now captures `init`/`deinit`/`subscript` members, `associatedtype` declarations, stored `let`/`var` properties, `macro` declarations, operator/precedence definitions, package visibility, and dotted extension targets such as `Foundation.URLSession`.
+
+## 日本語
+
+- **Swift シンボル抽出の対応範囲を拡張** — Swift のインデックス作成で `init` / `deinit` / `subscript` メンバー、`associatedtype` 宣言、保存プロパティの `let` / `var`、`macro` 宣言、演算子/precedence 定義、`package` 可視性、`Foundation.URLSession` のようなドット区切り extension 対象を抽出できるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1137,18 +1137,26 @@ public static class SymbolExtractor
             // wrapped in backticks (e.g. `func `repeat`() {}`).
             // Swift の関数名は通常識別子に加えて、バッククォートでエスケープした識別子
             // （例: `func `repeat`() {}`）も取りうる。
-            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:static|class|nonisolated|mutating|nonmutating)\s+)*(?:override\s+)?func\s+(?<name>`[^`]+`|\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("struct",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final)\s+)*struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("enum",      new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:indirect\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("property",  new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:indirect\s+)?case\s+(?<name>\w+)(?:\s*\([^)]*\))?(?:\s*=\s*(?<returnType>.+?))?\s*$", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),
-            new("interface", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*protocol\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:static|class|nonisolated|mutating|nonmutating)\s+)*(?:override\s+)?func\s+(?<name>`[^`]+`|\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:required|convenience|nonisolated|mutating|nonmutating|override)\s+)*(?<name>init)(?:\?)?\s*\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:nonisolated)\s+)*(?<name>deinit)\s*(?:\{|$)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:static|class|nonisolated|mutating|nonmutating|override)\s+)*(?<name>subscript)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("struct",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final)\s+)*struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("enum",      new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:indirect\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("property",  new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:indirect\s+)?case\s+(?<name>\w+)(?:\s*\([^)]*\))?(?:\s*=\s*(?<returnType>.+?))?\s*$", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),
+            new("interface", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*protocol\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("import",   new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*associatedtype\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("property", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:lazy|weak|unowned|final|static|class|nonisolated)\s+)*(?:let|var)\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Extension declarations are important search anchors in Swift-heavy codebases.
             // extension 宣言は Swift コード検索における重要なアンカー。
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final)\s+)?extension\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final)\s+)?extension\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // actor (Swift 5.5+) / アクター
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*(?:(?:final|distributed)\s+)*(?:class|actor)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final|distributed)\s+)*(?:class|actor)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Type alias / 型エイリアス
-            new("import",   new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate)?\s*typealias\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("import",   new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*typealias\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*macro\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("interface", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*precedencegroup\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:prefix|infix|postfix)\s+operator\s+(?<name>\S+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*import\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["objc"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11771,6 +11771,82 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsInitDeinitSubscriptStoredPropertyAndAssociatedType()
+    {
+        var content = """
+            public extension Foundation.URLSession {
+                public convenience init?(configuration: URLSessionConfiguration) {
+                }
+
+                deinit {
+                }
+
+                subscript(index: Int) -> String {
+                    "value"
+                }
+            }
+
+            public protocol CacheStore {
+                associatedtype Key
+            }
+
+            public struct UserCache {
+                public let capacity: Int
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Foundation.URLSession");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "init");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "deinit");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "subscript");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Key");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "capacity");
+    }
+
+    [Fact]
+    public void Extract_Swift_SupportsPackageVisibility()
+    {
+        var content = """
+            package struct SessionCache {
+                package func save() { }
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "SessionCache");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "save");
+    }
+
+    [Fact]
+    public void Extract_Swift_DetectsMacroDeclarations()
+    {
+        var content = """
+            public macro stringify<T>(_ value: T) = #externalMacro(module: "MyMacros", type: "StringifyMacro")
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "stringify");
+    }
+
+    [Fact]
+    public void Extract_Swift_DetectsOperatorsAndPrecedenceGroup()
+    {
+        var content = """
+            public precedencegroup ForwardApplicationPrecedence {
+                associativity: left
+            }
+
+            infix operator |> : ForwardApplicationPrecedence
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ForwardApplicationPrecedence");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "|>");
+    }
+
+    [Fact]
     public void Extract_C_DetectsFunctionsAndStructs()
     {
         // C: functions, struct / C: 関数、構造体


### PR DESCRIPTION
### Motivation

- Improve Swift search/indexing accuracy by expanding symbol extraction to cover commonly used Swift declarations that were previously missed.
- Make `cdidx` more useful for Swift-heavy codebases by recognizing initializer/deinitializer/subscript forms, stored properties, associated types, macros, operators, and dotted extension targets.

### Description

- Extend Swift regex patterns in `src/CodeIndex/Indexer/SymbolExtractor.cs` to capture `init`/`deinit`/`subscript` members, stored `let`/`var` properties, `associatedtype`, `typealias`, dotted `extension` targets (e.g. `Foundation.URLSession`), and support `package` visibility.
- Add patterns to index Swift `macro` declarations, `precedencegroup` definitions, and `prefix|infix|postfix operator` declarations so these declarations appear as searchable symbols.
- Add new/extended unit tests in `tests/CodeIndex.Tests/SymbolExtractorTests.cs` covering init/deinit/subscript, stored properties, associatedtype, package visibility, macros, operators, and precedencegroup extraction.
- Add a bilingual changelog fragment at `changelog.d/unreleased/+swift-symbol-coverage.fixed.md` describing the Swift extraction improvements.

### Testing

- No automated build or unit tests were executed in this environment because `dotnet` is not available here; running `dotnet build CodeIndex.sln -c Release` and `dotnet test CodeIndex.sln -c Release` in CI or a local environment with the .NET SDK is required to validate the changes.
- The change includes new unit tests under `tests/CodeIndex.Tests/SymbolExtractorTests.cs` which the CI should run and report pass/fail for the added Swift cases when the repository pipeline executes the standard `dotnet` validation commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4740cd42c832596947be5e06184ab)