### PR TITLE
Enhance T-SQL extraction: handle escaped bracket identifiers and numbered procedure suffixes

### DIFF
--- a/changelog.d/unreleased/+tsql-search.changed.md
+++ b/changelog.d/unreleased/+tsql-search.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Improved T-SQL stored-procedure symbol/reference extraction** — SQL `EXEC`/`EXECUTE` now handles escaped bracket identifiers (for example `[proc]]name]`) and numbered procedure suffixes (for example `sp_helptext;1`) more reliably in reference extraction, and SQL symbol parsing now accepts escaped bracket segments in qualified identifiers.
+
+## 日本語
+
+- **T-SQL のストアドプロシージャ向けシンボル/参照抽出を改善** — SQL `EXEC`/`EXECUTE` の参照抽出で、エスケープされた角括弧識別子（例: `[proc]]name]`）と番号付きプロシージャ接尾辞（例: `sp_helptext;1`）をより正確に扱えるようにし、SQL シンボル抽出でも修飾識別子セグメント内の角括弧エスケープを受理するようにしました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -18,7 +18,7 @@ public static class ReferenceExtractor
         int PendingTypeLineNumber,
         string? PendingContext,
         SymbolRecord? PendingContainer);
-    private const string SqlProcCallIdentifierPattern = @"(?:\[[^\[\]\r\n]+\]|`[^`\r\n]+`|""(?:""""|[^""\r\n])+""|##?\w+|[_\p{L}][\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Pc}$]*)";
+    private const string SqlProcCallIdentifierPattern = @"(?:\[(?:[^\]\r\n]|\]\])+\]|`[^`\r\n]+`|""(?:""""|[^""\r\n])+""|##?\w+|[_\p{L}][\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Pc}$]*(?:;\d+)?)";
     private const string SqlProcCallQualifierPattern = @"(?:(?:" + SqlProcCallIdentifierPattern + @")?\s*\.\s*)*";
 
     private static readonly HashSet<string> SupportedLanguages =
@@ -2885,6 +2885,8 @@ public static class ReferenceExtractor
             resolvedName = rawName.Substring(1, rawName.Length - 2);
             if (rawName[0] == '"')
                 resolvedName = resolvedName.Replace("\"\"", "\"", StringComparison.Ordinal);
+            else if (rawName[0] == '[')
+                resolvedName = resolvedName.Replace("]]", "]", StringComparison.Ordinal);
             resolvedIndex = rawIndex + 1;
             wasQuoted = true;
             return;

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -70,7 +70,7 @@ public static class SymbolExtractor
     private const string CSharpIdentifierPattern = @"@?[_\p{L}]\w*";
     private const string CSharpNamespacePattern = CSharpIdentifierPattern + @"(?:\." + CSharpIdentifierPattern + @")*";
     private const string CSharpTypeTokenCharsPattern = @"[\w@?.<>\[\],:*]";
-    private const string SqlQualifiedIdentifierSegmentPattern = @"(?:\[[^\]]+\]|""[^""]+""|[\w$#]+)";
+    private const string SqlQualifiedIdentifierSegmentPattern = @"(?:\[(?:[^\]\r\n]|\]\])+\]|""[^""]+""|[\w$#]+)";
     private const string SqlQualifiedIdentifierPattern =
         @"(?:" + SqlQualifiedIdentifierSegmentPattern + @")(?:\s*\.\s*(?:" + SqlQualifiedIdentifierSegmentPattern + @"))*";
     private const string CSharpTypeSegmentPattern =

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -372,6 +372,36 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SqlExec_WithEscapedBracketIdentifier_IndexesProcedureCall()
+    {
+        const string content = """
+            EXEC [dbo].[proc]]name];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "proc]name"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
+    public void Extract_SqlExec_WithNumberedProcedureSuffix_IndexesProcedureCall()
+    {
+        const string content = """
+            EXEC dbo.sp_helptext;1;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "sp_helptext;1"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_CsharpSameLineDefinitionCalls_KeepRecursiveAndDelegatedReferences()
     {
         // issue #252: same-line definition suppression must drop only the declarator token,

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -136,6 +136,20 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_SqlProcedure_WithEscapedBracketIdentifier_IsDetected()
+    {
+        var content = """
+            CREATE PROCEDURE [dbo].[proc]]name]
+            AS
+            SELECT 1;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "proc]]name");
+    }
+
+    [Fact]
     public void Extract_VueScriptSetup_DetectsTypeScriptSymbols()
     {
         const string content = """


### PR DESCRIPTION
### Motivation

- Improve SQL/T-SQL symbol and reference extraction so `EXEC` / `EXECUTE` / `CALL` forms commonly seen in T-SQL (bracket-escaped identifiers and numbered procedure suffixes) are indexed reliably.
- Prevent missed or incorrectly canonicalized procedure names when identifiers contain escaped `]` tokens or trailing numbering (`;1`), improving `references`/`callers`/`callees` accuracy for SQL codebases.

### Description

- Relaxed the SQL identifier regex in `ReferenceExtractor` (`SqlProcCallIdentifierPattern`) to accept bracket-escaped segments (e.g. `[proc]]name]`) and an optional numbered-suffix form (e.g. `sp_helptext;1`).
- Relaxed the qualified SQL identifier segment pattern in `SymbolExtractor` so symbol extraction accepts escaped bracket segments in qualified names.
- Added normalization in `ReferenceExtractor.NormalizeSqlIdentifier` to unescape `]]` → `]` when converting bracketed identifiers to canonical names used in call rows.
- Added regression tests in `tests/CodeIndex.Tests/ReferenceExtractorTests.cs` and `tests/CodeIndex.Tests/SymbolExtractorTests.cs` and a bilingual changelog fragment at `changelog.d/unreleased/+tsql-search.changed.md` describing the change.

### Testing

- Attempted `dotnet build` / `dotnet test` in this environment but `dotnet` is not available (`/bin/bash: dotnet: command not found`), so no test suite was executed locally here.
- Unit tests covering the new cases were added: `Extract_SqlExec_WithEscapedBracketIdentifier_IndexesProcedureCall`, `Extract_SqlExec_WithNumberedProcedureSuffix_IndexesProcedureCall`, and `Extract_SqlProcedure_WithEscapedBracketIdentifier_IsDetected` (in the referenced test files).
- CI / a .NET-enabled environment should run `dotnet build` and `dotnet test` to validate the changes end-to-end; the changelog fragment is present at `changelog.d/unreleased/+tsql-search.changed.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47856018c8325ac67bd758c50c16b)