### PR TITLE
Handle escaped T-SQL bracket identifiers and numbered procedure suffixes; add tests

### DIFF
--- a/changelog.d/unreleased/+tsql-search.changed.md
+++ b/changelog.d/unreleased/+tsql-search.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Improved T-SQL stored-procedure symbol/reference extraction** — SQL `EXEC`/`EXECUTE` now handles escaped bracket identifiers (for example `[proc]]name]`) and numbered procedure suffixes (for example `sp_helptext;1`) more reliably in reference extraction, and SQL symbol parsing now accepts escaped bracket segments in qualified identifiers.
+
+## 日本語
+
+- **T-SQL のストアドプロシージャ向けシンボル/参照抽出を改善** — SQL `EXEC`/`EXECUTE` の参照抽出で、エスケープされた角括弧識別子（例: `[proc]]name]`）と番号付きプロシージャ接尾辞（例: `sp_helptext;1`）をより正確に扱えるようにし、SQL シンボル抽出でも修飾識別子セグメント内の角括弧エスケープを受理するようにしました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -18,7 +18,7 @@ public static class ReferenceExtractor
         int PendingTypeLineNumber,
         string? PendingContext,
         SymbolRecord? PendingContainer);
-    private const string SqlProcCallIdentifierPattern = @"(?:\[[^\[\]\r\n]+\]|`[^`\r\n]+`|""(?:""""|[^""\r\n])+""|##?\w+|[_\p{L}][\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Pc}$]*)";
+    private const string SqlProcCallIdentifierPattern = @"(?:\[(?:[^\]\r\n]|\]\])+\]|`[^`\r\n]+`|""(?:""""|[^""\r\n])+""|##?\w+|[_\p{L}][\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Pc}$]*(?:;\d+)?)";
     private const string SqlProcCallQualifierPattern = @"(?:(?:" + SqlProcCallIdentifierPattern + @")?\s*\.\s*)*";
 
     private static readonly HashSet<string> SupportedLanguages =
@@ -2885,6 +2885,8 @@ public static class ReferenceExtractor
             resolvedName = rawName.Substring(1, rawName.Length - 2);
             if (rawName[0] == '"')
                 resolvedName = resolvedName.Replace("\"\"", "\"", StringComparison.Ordinal);
+            else if (rawName[0] == '[')
+                resolvedName = resolvedName.Replace("]]", "]", StringComparison.Ordinal);
             resolvedIndex = rawIndex + 1;
             wasQuoted = true;
             return;

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -70,7 +70,7 @@ public static class SymbolExtractor
     private const string CSharpIdentifierPattern = @"@?[_\p{L}]\w*";
     private const string CSharpNamespacePattern = CSharpIdentifierPattern + @"(?:\." + CSharpIdentifierPattern + @")*";
     private const string CSharpTypeTokenCharsPattern = @"[\w@?.<>\[\],:*]";
-    private const string SqlQualifiedIdentifierSegmentPattern = @"(?:\[[^\]]+\]|""[^""]+""|[\w$#]+)";
+    private const string SqlQualifiedIdentifierSegmentPattern = @"(?:\[(?:[^\]\r\n]|\]\])+\]|""[^""]+""|[\w$#]+)";
     private const string SqlQualifiedIdentifierPattern =
         @"(?:" + SqlQualifiedIdentifierSegmentPattern + @")(?:\s*\.\s*(?:" + SqlQualifiedIdentifierSegmentPattern + @"))*";
     private const string CSharpTypeSegmentPattern =

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -372,6 +372,38 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SqlExec_WithEscapedBracketIdentifier_IndexesProcedureCall()
+    {
+        const string content = """
+            EXEC [dbo].[proc]]name];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "proc]name"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
+    public void Extract_SqlExec_WithNumberedProcedureSuffix_IndexesProcedureCall()
+    {
+        const string content = """
+            EXEC dbo.sp_helptext;1;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        // SQL Server's `;number` procedure suffix is parsed as a call to the base
+        // procedure name in the current normalizer path.
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "sp_helptext"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_CsharpSameLineDefinitionCalls_KeepRecursiveAndDelegatedReferences()
     {
         // issue #252: same-line definition suppression must drop only the declarator token,

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -136,6 +136,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_SqlProcedure_WithEscapedBracketIdentifier_IsDetected()
+    {
+        var content = """
+            CREATE PROCEDURE [dbo].[proc]]name]
+            AS
+            SELECT 1;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+
+        Assert.Contains(symbols, s =>
+            s.Kind == "function"
+            && s.Name.Contains("proc", StringComparison.OrdinalIgnoreCase)
+            && s.Name.Contains("name", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Extract_VueScriptSetup_DetectsTypeScriptSymbols()
     {
         const string content = """


### PR DESCRIPTION
### Motivation

- Fix T-SQL symbol and reference extraction so bracket-escaped identifiers like `[proc]]name]` and SQL Server numbered procedure suffixes like `sp_helptext;1` are parsed and normalized correctly.

### Description

- Relaxed `SqlProcCallIdentifierPattern` to accept bracket segments with `]]` escapes and optional `;number` suffixes when parsing `EXEC`/`EXECUTE` calls.
- Relaxed `SqlQualifiedIdentifierSegmentPattern` to accept bracket segments that contain `]]` escapes in qualified identifiers.
- Updated `NormalizeSqlIdentifier` to unescape `]]` to `]` when normalizing bracket-quoted identifiers.
- Added unit tests `Extract_SqlExec_WithEscapedBracketIdentifier_IndexesProcedureCall`, `Extract_SqlExec_WithNumberedProcedureSuffix_IndexesProcedureCall`, and `Extract_SqlProcedure_WithEscapedBracketIdentifier_IsDetected` to verify parsing and indexing behavior.
- Added an unreleased changelog entry documenting the change in both English and Japanese.

### Testing

- Ran the code tests in `tests/CodeIndex.Tests` (via `dotnet test`), and the updated test cases passed successfully.
- Existing test suite was exercised and no regressions were observed in the updated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47856018c8325ac67bd758c50c16b)