### PR TITLE
Improve VB search coverage

### DIFF
--- a/changelog.d/unreleased/+vb-search-improvements.fixed.md
+++ b/changelog.d/unreleased/+vb-search-improvements.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **VB search now ignores `Rem` comments and extracts delegate symbols** — reference extraction strips VB `Rem` comment lines before scanning for calls, and `Delegate Sub/Function` declarations are now emitted as `delegate` symbols so they show up in `symbols`, `definition`, and graph-oriented queries.
+
+## 日本語
+
+- **VB 検索で `Rem` コメントを無視し、Delegate 宣言を抽出するようになりました** — call/reference 抽出の前に VB の `Rem` コメント行を取り除き、`Delegate Sub/Function` 宣言を `delegate` シンボルとして出力するため、`symbols`、`definition`、graph 系クエリで見つけられるようになりました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -13392,9 +13392,13 @@ public static class ReferenceExtractor
                 result = result[..dashCommentIndex];
         }
 
-        // VB.NET uses ' for line comments / VB.NET は ' を行コメントに使う
+        // VB.NET uses Rem and ' for line comments / VB.NET は Rem と ' を行コメントに使う
         if (lang is "vb")
         {
+            var remCommentMatch = VisualBasicRemCommentRegex.Match(result);
+            if (remCommentMatch.Success)
+                result = result[..remCommentMatch.Index];
+
             var vbCommentIndex = result.IndexOf('\'');
             if (vbCommentIndex >= 0)
                 result = result[..vbCommentIndex];
@@ -13402,6 +13406,10 @@ public static class ReferenceExtractor
 
         return result;
     }
+
+    private static readonly Regex VisualBasicRemCommentRegex = new(
+        @"(?:^|:)\s*Rem\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     private static string MaskPythonSingleLineFStrings(string line)
     {

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1191,6 +1191,7 @@ public static class SymbolExtractor
         ["vb"] =
         [
             new("namespace", new Regex(@"^\s*Namespace\s+(?<name>(?:Global\.)?[\w.]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.VisualBasicEnd),
+            new("delegate", new Regex(@$"^\s*(?:(?:{VbMemberModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?Delegate\s+(?:Sub|Function)\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
             new("function", new Regex(@$"^\s*(?:(?:{VbMemberModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbMemberModifierPattern})\s+)*(?:Sub|Function)\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
             new("property", new Regex(@$"^\s*(?:(?:{VbPropertyModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbPropertyModifierPattern})\s+)*Property\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
             new("event",    new Regex(@$"^\s*(?:(?:{VbEventModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbEventModifierPattern})\s+)*Event\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14238,6 +14238,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_VB_RemCommentedCall_DoesNotEmitReference()
+    {
+        // VB.NET `Rem` comments should be stripped before call extraction so commented-out
+        // helpers do not leak as phantom references / VB.NET の `Rem` コメントは call 抽出前に
+        // 除去し、コメント内の helper が幽霊 reference として出ないことを固定する。
+        var content = """
+            Public Module Program
+                Public Sub Helper()
+                End Sub
+
+                Public Sub Run()
+                    Rem Helper()
+                    Helper()
+                End Sub
+            End Module
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "vb", content);
+        var references = ReferenceExtractor.Extract(1, "vb", content, symbols);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "Helper" && r.ReferenceKind == "call" && r.Line == 6);
+        Assert.Contains(references, r => r.SymbolName == "Helper" && r.ReferenceKind == "call" && r.Line == 7);
+    }
+
+    [Fact]
     public void Extract_SqlCallBacktickIdentifierContainingHash_IsCaptured()
     {
         // A `#` inside a backtick-quoted identifier is part of the identifier, not a comment marker.

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14796,6 +14796,22 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_VB_DetectsDelegateDeclarations()
+    {
+        // VB.NET Delegate declarations should be searchable as delegate symbols / VB.NET の
+        // Delegate 宣言は delegate シンボルとして検索できる必要がある。
+        var content = """
+            Public Delegate Sub ProgressHandler(value As Integer)
+            Friend Delegate Function Formatter(input As String) As String
+            """;
+        var symbols = SymbolExtractor.Extract(1, "vb", content);
+
+        Assert.Contains(symbols, s => s.Kind == "delegate" && s.Name == "ProgressHandler");
+        var formatter = Assert.Single(symbols, s => s.Kind == "delegate" && s.Name == "Formatter");
+        Assert.Equal("Friend", formatter.Visibility);
+    }
+
+    [Fact]
     public void Extract_VB_DetectsNamespaceAndImplicitVisibilityDeclarations()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Strip VB `Rem` comments before reference extraction so comment text no longer leaks into call/reference search.
- Add VB `Delegate Sub/Function` symbol extraction so delegates are searchable and show up in graph-oriented queries.
- Cover both changes with focused regression tests.

## Validation
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests|FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test CodeIndex.sln -c Release`

## Docs / Changelog
- Added bilingual changelog fragment at `changelog.d/unreleased/+vb-search-improvements.fixed.md`.
- No additional docs were needed beyond the changelog because the user-facing behavior change is captured by the existing language/query contracts and tests.

## Follow-up
- None.
