### PR TITLE
[codex] Add T-SQL legacy DDL symbols

### DIFF
--- a/changelog.d/unreleased/+tsql-legacy-ddl.fixed.md
+++ b/changelog.d/unreleased/+tsql-legacy-ddl.fixed.md
@@ -1,6 +1,5 @@
 ---
 category: fixed
-issues: []
 affected:
   - src/CodeIndex/Indexer/SymbolExtractor.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs

--- a/changelog.d/unreleased/+tsql-legacy-ddl.fixed.md
+++ b/changelog.d/unreleased/+tsql-legacy-ddl.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues: []
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **T-SQL `RULE` and `DEFAULT` definitions now show up in symbol search** — `CREATE RULE` and `CREATE DEFAULT` rows are now indexed as SQL symbols, so older SQL Server codebases can find those legacy object names instead of skipping them entirely.
+
+## 日本語
+
+- **T-SQL の `RULE` と `DEFAULT` 定義がシンボル検索に出るようになりました** — `CREATE RULE` と `CREATE DEFAULT` の行を SQL シンボルとして索引付けするため、古い SQL Server コードベースでもこれらの legacy オブジェクト名を取りこぼさず検索できます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1324,6 +1324,11 @@ public static class SymbolExtractor
             new("class",    new Regex($@"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:EDITIONABLE\s+|NONEDITIONABLE\s+)?PACKAGE\s+BODY\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("class",    new Regex($@"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:EDITIONABLE\s+|NONEDITIONABLE\s+)?PACKAGE\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("class",    new Regex($@"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?TYPE\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            // SQL Server legacy scalar-object definitions still appear in older T-SQL codebases.
+            // The `AS <expression>` tail is part of the definition, not a body to track.
+            // SQL Server の legacy な scalar-object 定義は古い T-SQL コードベースに残っている。
+            // 末尾の `AS <expression>` は定義の一部であり、追跡すべき body ではない。
+            new("class",    new Regex($@"^\s*CREATE\s+(?:RULE|DEFAULT)\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("namespace", new Regex($@"^\s*CREATE\s+SCHEMA\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:(?<name>(?!AUTHORIZATION\b){SqlQualifiedIdentifierPattern})|AUTHORIZATION\s+(?<name>{SqlQualifiedIdentifierPattern}))", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("class",    new Regex($@"^\s*CREATE\s+(?:SEQUENCE|DOMAIN)\s+(?:IF\s+NOT\s+EXISTS\s+)?(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("import",   new Regex($@"^\s*CREATE\s+EXTENSION\s+(?:IF\s+NOT\s+EXISTS\s+)?(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9624,6 +9624,8 @@ public class SymbolExtractorTests
             "CREATE SCHEMA sales AUTHORIZATION dbo;\n" +
             "CREATE TYPE sales.Money FROM DECIMAL(18, 4) NOT NULL;\n" +
             "CREATE SEQUENCE sales.OrderSeq START WITH 1 INCREMENT BY 1;\n" +
+            "CREATE RULE sales.discount_rule AS @price > 0;\n" +
+            "CREATE DEFAULT dbo.zero_default AS 0;\n" +
             "CREATE SYNONYM dbo.Customers FOR external.Customers;\n" +
             "CREATE LOGIN [app_service] WITH PASSWORD = 'x';\n" +
             "CREATE USER app_service FOR LOGIN app_service;\n" +
@@ -9651,6 +9653,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "sales");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.Money");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.OrderSeq");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.discount_rule");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.zero_default");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.Customers");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "[app_service]");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "app_service");


### PR DESCRIPTION
## What changed
- Added SQL symbol extraction for legacy T-SQL `CREATE RULE` and `CREATE DEFAULT` definitions.
- Added a regression test that exercises these legacy definitions alongside the existing SQL/T-SQL coverage.
- Added a bilingual changelog fragment under `changelog.d/unreleased/`.

## Why
Older SQL Server codebases still contain `RULE` and `DEFAULT` objects, but they were not surfaced by symbol search, so those definitions were effectively invisible in `cdidx` results.

## Impact
Users can now find legacy T-SQL rule/default definitions through symbol search and downstream definition-oriented workflows.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_SQL_DetectsTSqlDdlKinds"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~SymbolExtractorTests.Extract_SQL_"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs changelog.d/unreleased/+tsql-legacy-ddl.fixed.md