### PR TITLE
Accept Rust macro query suffixes in symbol search

### DIFF
--- a/changelog.d/unreleased/+rust-macro-query-bang.fixed.md
+++ b/changelog.d/unreleased/+rust-macro-query-bang.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Rust macro queries now accept the trailing `!` used in source code** — symbol search and definition lookup normalize `my_macro!` to the stored macro name `my_macro`, so pasting Rust macro invocations into `cdidx` now finds the expected result.
+
+## 日本語
+
+- **Rust のマクロ検索でソース上の末尾 `!` をそのまま使えるようになりました** — シンボル検索と定義検索で `my_macro!` を保存済みのマクロ名 `my_macro` に正規化するため、Rust のマクロ呼び出しをそのまま貼り付けても期待どおりの結果が返ります。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -2948,18 +2948,41 @@ public partial class DbReader
     // Query-side mirror of the C# declaration canonicalizer. Users commonly type source
     // spellings such as `@class` or `Outer.@class`; the DB stores the canonical names
     // without the verbatim `@`, so query entrypoints normalize to the persisted form first.
+    // Rust macro names are also accepted with a trailing `!` because the extractor stores
+    // them without the punctuation, so `my_macro!` and `my_macro` resolve to the same row.
     // The normalization is applied when `--lang` is omitted or explicitly `csharp` because
     // name-based lookup still needs to treat C# verbatim spellings as canonical symbol names.
     // Other languages, including SQL, must preserve leading `@` characters.
     // C# 宣言側 canonicalizer の query 側ミラー。`@class` / `Outer.@class` のような source
     // spelling を受けても、DB 側の `@` なし canonical 名に合わせてから検索する。
+    // Rust macro 名も extractor 側では末尾 `!` を落として保存するため、`my_macro!` と `my_macro`
+    // を同じ行へ解決できるようにする。
     // `--lang` 未指定または `csharp` 指定では name-based lookup が verbatim spelling を canonical 名へ寄せる。
     // それ以外の言語、特に SQL では先頭 `@` を保持する。
     private static string? NormalizeCSharpVerbatimQuery(string? query, string? lang)
     {
+        if (!string.IsNullOrWhiteSpace(lang) && string.Equals(lang, "rust", StringComparison.OrdinalIgnoreCase))
+        {
+            var rustNormalized = NormalizeRustMacroQuery(query);
+            return string.IsNullOrWhiteSpace(rustNormalized) ? null : rustNormalized;
+        }
+
         if (!string.IsNullOrWhiteSpace(lang) && !string.Equals(lang, "csharp", StringComparison.OrdinalIgnoreCase))
             return query;
         var normalized = query == null ? null : NormalizeDbCSharpQualifiedName(query);
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string? NormalizeRustMacroQuery(string? query)
+    {
+        if (query == null)
+            return null;
+
+        var trimmed = query.TrimEnd();
+        if (!trimmed.EndsWith("!", StringComparison.Ordinal))
+            return trimmed;
+
+        var normalized = trimmed[..^1].TrimEnd();
         return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
     }
 

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -149,6 +149,25 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_RustMacroQueriesIgnoreTrailingBang()
+    {
+        InsertIndexedFile(
+            "src/macros.rs",
+            "rust",
+            """
+            macro_rules! my_macro {
+                () => {};
+            }
+            """);
+
+        var results = _reader.SearchSymbols("my_macro!", lang: "rust", exact: true);
+
+        var symbol = Assert.Single(results);
+        Assert.Equal("my_macro", symbol.Name);
+        Assert.Equal("src/macros.rs", symbol.Path);
+    }
+
+    [Fact]
     public void GetOutline_PreservesNestedSymbolDepths()
     {
         InsertIndexedFile(


### PR DESCRIPTION
## Summary
- Normalize Rust macro queries so trailing `!` resolves to the stored macro symbol name.
- Add a regression test covering `my_macro!` symbol lookup.
- Add a bilingual changelog fragment under `changelog.d/unreleased/`.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.SearchSymbols_RustMacroQueriesIgnoreTrailingBang"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Notes
- This change is not tied to a GitHub issue, so there are no `Fixes #...` lines.