### PR TITLE
Improve F# exception symbol indexing

### DIFF
--- a/changelog.d/unreleased/+fsharp-exception-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-exception-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# `exception` declarations are now indexed as searchable symbols** — `SymbolExtractor` now records top-level F# `exception` definitions, including backtick-escaped names, so exception types appear in `symbols`, `search`, and `impact` results.
+
+## 日本語
+
+- **F# の `exception` 宣言が検索可能な symbol として索引されるようになりました** — `SymbolExtractor` がトップレベルの F# `exception` 定義を記録するため、バッククォートで囲まれた名前も含めて例外型を `symbols` / `search` / `impact` から直接引けます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1181,6 +1181,7 @@ public static class SymbolExtractor
             new("class",    new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
+            new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12044,6 +12044,7 @@ public class SymbolExtractorTests
             type UserId = int
             type User = { Name: string; Age: int }
             type Color = Red | Green | Blue
+            exception ``domain error`` of string
             type Person(name: string) =
                 member _.Name = name
 
@@ -12068,6 +12069,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "User");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Color");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
+        Assert.Contains(symbols, s => s.Kind == "exception" && s.Name == "domain error");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "x");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "counter");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "add");


### PR DESCRIPTION
## Summary
- Index top-level F# `exception` declarations as searchable symbols.
- Cover backtick-escaped exception names in the symbol extractor.
- Add regression coverage for the new F# symbol shape.
- Add a changelog fragment for the user-visible search improvement.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "Extract_FSharp_"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`