### PR TITLE
Normalize C include targets

### DIFF
--- a/changelog.d/unreleased/+c-include-targets.fixed.md
+++ b/changelog.d/unreleased/+c-include-targets.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C and C++ `#include` targets are now indexed without delimiter noise** — include symbols now store `stdio.h`, `"project/foo.h"`, or bare macro targets instead of the raw directive text, which makes header searches more precise in C-family projects.
+
+## 日本語
+
+- **C / C++ の `#include` 対象を区切り記号なしでインデックスするようになりました** — include シンボルは生のディレクティブ文字列ではなく `stdio.h`、`"project/foo.h"`、あるいは裸のマクロ対象を保存するため、C 系プロジェクトでヘッダー検索をより正確にできます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1104,7 +1104,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*#\s*define\s+(?<name>[A-Za-z_]\w*)(?=\s|$)", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*(?:typedef\s+)?struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*(?:typedef\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("import",   new Regex(@"^\s*#include\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*#include\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cpp"] =
         [
@@ -1120,7 +1120,7 @@ public static class SymbolExtractor
             new("struct",   new Regex(@"^\s*struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("namespace", new Regex(@"^\s*namespace\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*(?:typedef\s+)?enum\s+(?:class\s+)?(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("import",   new Regex(@"^\s*#include\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*#include\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["php"] =
         [

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11923,6 +11923,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_C_NormalizesIncludeTargets()
+    {
+        // C: include targets should be searchable by header name / C: include 先はヘッダー名で検索できるべき
+        var content = """
+            #include <stdio.h>
+            #include "project/foo.h"
+            #include HEADER_NAME
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stdio.h");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "project/foo.h");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "HEADER_NAME");
+    }
+
+    [Fact]
     public void Extract_Cpp_DetectsClassAndNamespace()
     {
         // C++: class, namespace, functions / C++: クラス、名前空間、関数


### PR DESCRIPTION
## Summary
- Normalize C/C++ `#include` symbols to the header target instead of the raw directive text.
- Add coverage for angle-bracket, quoted, and bare include targets in the C extractor tests.
- Record the change in a bilingual changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_C_"`
- `dotnet test`

## Notes
- No issue references were provided for auto-close.