### PR TITLE
Add VB operator symbol search support

### DIFF
--- a/changelog.d/unreleased/+vb-search-improvements.fixed.md
+++ b/changelog.d/unreleased/+vb-search-improvements.fixed.md
@@ -5,12 +5,13 @@ affected:
   - src/CodeIndex/Indexer/SymbolExtractor.cs
   - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
 ---
 
 ## English
 
-- **VB search now ignores `Rem` comments and extracts delegate symbols** — reference extraction strips VB `Rem` comment lines before scanning for calls, and `Delegate Sub/Function` declarations are now emitted as `delegate` symbols so they show up in `symbols`, `definition`, and graph-oriented queries.
+- **VB search now ignores `Rem` comments and extracts delegate/operator symbols** — reference extraction strips VB `Rem` comment lines before scanning for calls, `Delegate Sub/Function` declarations are emitted as `delegate` symbols, and `Operator` declarations now show up as searchable `operator` symbols in `symbols`, `definition`, and graph-oriented queries.
 
 ## 日本語
 
-- **VB 検索で `Rem` コメントを無視し、Delegate 宣言を抽出するようになりました** — call/reference 抽出の前に VB の `Rem` コメント行を取り除き、`Delegate Sub/Function` 宣言を `delegate` シンボルとして出力するため、`symbols`、`definition`、graph 系クエリで見つけられるようになりました。
+- **VB 検索で `Rem` コメントを無視し、Delegate / Operator 宣言を抽出するようになりました** — call/reference 抽出の前に VB の `Rem` コメント行を取り除き、`Delegate Sub/Function` を `delegate` シンボルとして、`Operator` 宣言を `operator` シンボルとして出力するため、`symbols`、`definition`、graph 系クエリで見つけられるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -488,12 +488,12 @@ public static class SymbolExtractor
         @"^\s*\$:\s*(?<name>\w+)\s*=",
         RegexOptions.Compiled);
 
-      private const string VbVisibilityPattern = @"(?:Public|Private|Protected|Friend)(?:\s+(?:Protected|Friend))?";
-      private const string VbTypeModifierPattern = @"(?:Partial|MustInherit|NotInheritable)";
-      private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Async|Partial)";
-      private const string VbOperatorModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Async|Partial|Widening|Narrowing)";
-      private const string VbPropertyModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Default|ReadOnly|WriteOnly)";
-      private const string VbEventModifierPattern = @"(?:Shared|Custom)";
+    private const string VbVisibilityPattern = @"(?:Public|Private|Protected|Friend)(?:\s+(?:Protected|Friend))?";
+    private const string VbTypeModifierPattern = @"(?:Partial|MustInherit|NotInheritable)";
+    private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Async|Partial)";
+    private const string VbOperatorModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Async|Partial|Widening|Narrowing)";
+    private const string VbPropertyModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Default|ReadOnly|WriteOnly)";
+    private const string VbEventModifierPattern = @"(?:Shared|Custom)";
 
     private static readonly Dictionary<string, List<SymbolPattern>> PatternCache = new()
     {
@@ -1665,8 +1665,8 @@ public static class SymbolExtractor
     private static readonly Regex ElixirBlockStartRegex = new(@"^\s*(?:defmodule|defprotocol|defimpl|defmacro|defguardp?|defp?)\b", RegexOptions.Compiled);
     private static readonly Regex ElixirBlockTokenRegex = new(@"\b(?:do|fn|end)\b(?!:)", RegexOptions.Compiled);
     private static readonly Regex ElixirDoShorthandRegex = new(@",\s*do:\s*", RegexOptions.Compiled);
-      private static readonly Regex VisualBasicContainerStartRegex = new(@$"^(?:Namespace\b|(?:(?:{VbTypeModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*(?:Class|Module|Structure|Interface)\b|(?:(?:{VbOperatorModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbOperatorModifierPattern})\s+)*Operator\b)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-      private static readonly Regex VisualBasicContainerEndRegex = new(@"^End\s+(?:Namespace|Class|Module|Structure|Interface|Operator)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex VisualBasicContainerStartRegex = new(@$"^(?:Namespace\b|(?:(?:{VbTypeModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*(?:Class|Module|Structure|Interface)\b|(?:(?:{VbOperatorModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbOperatorModifierPattern})\s+)*Operator\b)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex VisualBasicContainerEndRegex = new(@"^End\s+(?:Namespace|Class|Module|Structure|Interface|Operator)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     // Explicit-interface implementations reuse CSharpTypePattern for the return type so nested
     // generics and function pointers (`delegate*<List<int>, int>`, `delegate*<delegate*<int, void>, int>`)
     // are handled uniformly with the regular method / property / indexer / delegate paths. The

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -488,11 +488,12 @@ public static class SymbolExtractor
         @"^\s*\$:\s*(?<name>\w+)\s*=",
         RegexOptions.Compiled);
 
-    private const string VbVisibilityPattern = @"(?:Public|Private|Protected|Friend)(?:\s+(?:Protected|Friend))?";
-    private const string VbTypeModifierPattern = @"(?:Partial|MustInherit|NotInheritable)";
-    private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Async|Partial)";
-    private const string VbPropertyModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Default|ReadOnly|WriteOnly)";
-    private const string VbEventModifierPattern = @"(?:Shared|Custom)";
+      private const string VbVisibilityPattern = @"(?:Public|Private|Protected|Friend)(?:\s+(?:Protected|Friend))?";
+      private const string VbTypeModifierPattern = @"(?:Partial|MustInherit|NotInheritable)";
+      private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Async|Partial)";
+      private const string VbOperatorModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Async|Partial|Widening|Narrowing)";
+      private const string VbPropertyModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Default|ReadOnly|WriteOnly)";
+      private const string VbEventModifierPattern = @"(?:Shared|Custom)";
 
     private static readonly Dictionary<string, List<SymbolPattern>> PatternCache = new()
     {
@@ -1194,6 +1195,7 @@ public static class SymbolExtractor
             new("namespace", new Regex(@"^\s*Namespace\s+(?<name>(?:Global\.)?[\w.]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.VisualBasicEnd),
             new("delegate", new Regex(@$"^\s*(?:(?:{VbMemberModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?Delegate\s+(?:Sub|Function)\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
             new("function", new Regex(@$"^\s*(?:(?:{VbMemberModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbMemberModifierPattern})\s+)*(?:Sub|Function)\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
+            new("operator", new Regex(@$"^\s*(?:(?:{VbOperatorModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbOperatorModifierPattern})\s+)*(?<name>Operator\s+[^\s(]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.VisualBasicEnd, "visibility"),
             new("property", new Regex(@$"^\s*(?:(?:{VbPropertyModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbPropertyModifierPattern})\s+)*Property\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
             new("event",    new Regex(@$"^\s*(?:(?:{VbEventModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbEventModifierPattern})\s+)*Event\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
             new("interface", new Regex(@$"^\s*(?:(?:{VbTypeModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*Interface\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.VisualBasicEnd, "visibility"),
@@ -1663,8 +1665,8 @@ public static class SymbolExtractor
     private static readonly Regex ElixirBlockStartRegex = new(@"^\s*(?:defmodule|defprotocol|defimpl|defmacro|defguardp?|defp?)\b", RegexOptions.Compiled);
     private static readonly Regex ElixirBlockTokenRegex = new(@"\b(?:do|fn|end)\b(?!:)", RegexOptions.Compiled);
     private static readonly Regex ElixirDoShorthandRegex = new(@",\s*do:\s*", RegexOptions.Compiled);
-    private static readonly Regex VisualBasicContainerStartRegex = new(@$"^(?:Namespace\b|(?:(?:{VbTypeModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*(?:Class|Module|Structure|Interface)\b)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    private static readonly Regex VisualBasicContainerEndRegex = new(@"^End\s+(?:Namespace|Class|Module|Structure|Interface)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+      private static readonly Regex VisualBasicContainerStartRegex = new(@$"^(?:Namespace\b|(?:(?:{VbTypeModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*(?:Class|Module|Structure|Interface)\b|(?:(?:{VbOperatorModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbOperatorModifierPattern})\s+)*Operator\b)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+      private static readonly Regex VisualBasicContainerEndRegex = new(@"^End\s+(?:Namespace|Class|Module|Structure|Interface|Operator)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     // Explicit-interface implementations reuse CSharpTypePattern for the return type so nested
     // generics and function pointers (`delegate*<List<int>, int>`, `delegate*<delegate*<int, void>, int>`)
     // are handled uniformly with the regular method / property / indexer / delegate paths. The

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -4670,6 +4670,63 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbols_VBOperatorDeclarationsUseDistinctExactNames()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_vb_operator_names");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/Money.vb",
+                "vb",
+                """
+                Namespace MyApp
+                    Public Class Money
+                        Public Shared Operator +(left As Money, right As Money) As Money
+                            Return New Money()
+                        End Operator
+
+                        Public Shared Widening Operator CType(value As Money) As Decimal
+                            Return 0D
+                        End Operator
+                    End Class
+                End Namespace
+                """);
+
+            var (addExitCode, addStdout, addStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json", "--lang", "vb", "--kind", "operator", "--name", "Operator +", "--exact-name"],
+                _jsonOptions));
+
+            using var addDocument = ParseJsonOutput(addStdout);
+            var addSymbol = addDocument.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, addExitCode);
+            Assert.Equal(string.Empty, addStderr);
+            Assert.Equal("Operator +", addSymbol.GetProperty("name").GetString());
+            Assert.Equal("operator", addSymbol.GetProperty("kind").GetString());
+            Assert.Equal("Money", addSymbol.GetProperty("container_name").GetString());
+
+            var (conversionExitCode, conversionStdout, conversionStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json", "--lang", "vb", "--kind", "operator", "--name", "Operator CType", "--exact-name"],
+                _jsonOptions));
+
+            using var conversionDocument = ParseJsonOutput(conversionStdout);
+            var conversionSymbol = conversionDocument.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, conversionExitCode);
+            Assert.Equal(string.Empty, conversionStderr);
+            Assert.Equal("Operator CType", conversionSymbol.GetProperty("name").GetString());
+            Assert.Equal("operator", conversionSymbol.GetProperty("kind").GetString());
+            Assert.Equal("Money", conversionSymbol.GetProperty("container_name").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_CSharpPlainFieldEdgeCasesExposeAllDeclarators()
     {
         // End-to-end coverage for the three plain-field shapes the codex adversarial

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14840,6 +14840,42 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_VB_DetectsOperatorDeclarations()
+    {
+        var content = """
+            Namespace MyApp
+
+            Public Class Money
+                Public Shared Operator +(left As Money, right As Money) As Money
+                    Return New Money()
+                End Operator
+
+                Public Shared Widening Operator CType(value As Money) As Decimal
+                    Return 0D
+                End Operator
+            End Class
+            End Namespace
+            """;
+        var symbols = SymbolExtractor.Extract(1, "vb", content);
+
+        var add = Assert.Single(symbols, s => s.Kind == "operator" && s.Name == "Operator +");
+        Assert.Equal(4, add.StartLine);
+        Assert.Equal(5, add.BodyStartLine);
+        Assert.Equal(6, add.BodyEndLine);
+        Assert.Equal(6, add.EndLine);
+        Assert.Equal("class", add.ContainerKind);
+        Assert.Equal("Money", add.ContainerName);
+
+        var conversion = Assert.Single(symbols, s => s.Kind == "operator" && s.Name == "Operator CType");
+        Assert.Equal(8, conversion.StartLine);
+        Assert.Equal(9, conversion.BodyStartLine);
+        Assert.Equal(10, conversion.BodyEndLine);
+        Assert.Equal(10, conversion.EndLine);
+        Assert.Equal("class", conversion.ContainerKind);
+        Assert.Equal("Money", conversion.ContainerName);
+    }
+
+    [Fact]
     public void Extract_VB_DetectsNamespaceAndImplicitVisibilityDeclarations()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Add VB `Operator` symbol extraction and body-range handling so operator overloads are searchable as `operator` symbols.
- Add CLI coverage to prove exact-name symbol search can resolve VB operators end to end.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_VB_DetectsOperatorDeclarations"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunSymbols_VBOperatorDeclarationsUseDistinctExactNames"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_VB_"`

## Docs / Changelog
- Added the bilingual fragment at `changelog.d/unreleased/+vb-search-improvements.fixed.md`.
- No direct `CHANGELOG.md` edit was needed because this is an ordinary implementation change.

## Follow-up candidates
- None.