### PR TITLE
[codex] Clarify non-issue changelog fragment metadata

### DIFF
--- a/.codex/workflows/changelog-fragment.md
+++ b/.codex/workflows/changelog-fragment.md
@@ -50,6 +50,24 @@ affected:
 - **C# の verbatim 識別子が見つからない場合でも `impact` が元の検索文字列を維持するようになりました (#960)** — `impact` は C# verbatim lookup の miss 時にユーザー入力の綴りを保持するため、human / JSON 出力が誤解を招く canonicalized query を返さなくなりました。
 ```
 
+### Non-issue Fragment Template
+
+```md
+---
+category: docs
+affected:
+  - .codex/workflows/changelog-fragment.md
+---
+
+## English
+
+- **Non-issue changelog fragments omit `issues` front matter** — use `+<slug>.<category>.md` for workflow, docs, or infrastructure changes that are not tied to GitHub issues, and leave out `issues` entirely so validation does not fail on `issues: null` or `issues: []`.
+
+## 日本語
+
+- **issue 非対応の changelog フラグメントでは `issues` の front matter を省略します** — GitHub issue に紐づかない workflow / docs / infrastructure 変更は `+<slug>.<category>.md` を使い、`issues` 自体は書かないことで `issues: null` や `issues: []` の検証失敗を防ぎます。
+```
+
 ### Non-issue Template
 
 ```md
@@ -61,9 +79,9 @@ affected:
 
 ## English
 
- - **Clarified non-issue fragment front matter requirements** — non-issue changelog fragments now omit `issues` entirely, preventing `issues: null` / `issues: []` validation failures in agent-generated fragments.
+- **Clarified non-issue fragment front matter requirements** — non-issue changelog fragments now omit `issues` entirely, preventing `issues: null` / `issues: []` validation failures in agent-generated fragments.
 
 ## 日本語
 
- - **issue 非対応フラグメントの front matter 要件を明確化** — issue 非対応の changelog フラグメントでは `issues` 自体を記載しないようにし、エージェント生成時の `issues: null` / `issues: []` による検証失敗を防止しました。
+- **issue 非対応フラグメントの front matter 要件を明確化** — issue 非対応の changelog フラグメントでは `issues` 自体を記載しないようにし、エージェント生成時の `issues: null` / `issues: []` による検証失敗を防止しました。
 ```

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -61,8 +61,9 @@ When editing changelog content, verify that both English and Japanese entries ar
 - Treat documentation as part of the feature contract, not as optional cleanup.
 - If a change affects user-visible behavior, CLI/MCP output, flags, error messages, install/release behavior, or contributor/agent workflow, update the matching docs in the same change. For CodeIndex this usually means `README.md`, `DEVELOPER_GUIDE.md`, `TESTING_GUIDE.md`, `SELF_IMPROVEMENT.md`, `INTEGRATION_POLICY.md`, `CLAUDE.md`, `AGENT_GUIDE.md`, or the relevant `.codex/workflows/*.md` file.
 - Do not open or merge a PR with a user-visible change unless the required docs and changelog updates are present, or the PR body explicitly explains why no docs/changelog change is needed.
-- Changelog entries are required for user-visible or behavior-changing work. For ordinary implementation PRs, write the changelog entry as a bilingual fragment under `changelog.d/unreleased/`; do not update `CHANGELOG.md` directly as the default path.
-- Ordinary implementation PRs must not edit `CHANGELOG.md`. Reserve direct `CHANGELOG.md` edits for release-preparation PRs that aggregate fragments into a release note. If `CHANGELOG.md` is edited, update both English and Japanese sections in the same commit, and only after confirming the work is a release-preparation change.
+  - Changelog entries are required for user-visible or behavior-changing work. For ordinary implementation PRs, write the changelog entry as a bilingual fragment under `changelog.d/unreleased/`; do not update `CHANGELOG.md` directly as the default path.
+  - Use issue-based fragment names and `issues:` front matter only when the work is actually tied to GitHub issues. For non-issue work, use a `+<slug>.<category>.md` fragment and omit `issues` entirely. Never write `issues: null` or `issues: []`.
+  - Ordinary implementation PRs must not edit `CHANGELOG.md`. Reserve direct `CHANGELOG.md` edits for release-preparation PRs that aggregate fragments into a release note. If `CHANGELOG.md` is edited, update both English and Japanese sections in the same commit, and only after confirming the work is a release-preparation change.
 
 ## Repository Rules
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -40,6 +40,8 @@ Examples:
 Use issue numbers when the PR is tied to GitHub issues. Use `+<slug>` for
 workflow, infrastructure, documentation, or other changes without a stable
 issue number.
+If the fragment is not tied to an issue, omit `issues` from the front matter
+entirely; do not write `issues: null` or `issues: []`.
 
 ## Categories
 
@@ -88,6 +90,24 @@ affected:
 ## 日本語
 
 - **C# の verbatim 識別子が見つからない場合でも `impact` が元の検索文字列を維持するようになりました (#960)** — `impact` は C# verbatim lookup の miss 時にユーザー入力の綴りを保持するため、human / JSON 出力が誤解を招く canonicalized query を返さなくなりました。
+```
+
+For a non-issue fragment, the same template should simply omit `issues`:
+
+```md
+---
+category: docs
+affected:
+  - changelog.d/README.md
+---
+
+## English
+
+- **Non-issue fragments omit `issues` front matter** — use a `+<slug>.<category>.md` file name and leave out `issues` entirely when the work is not tied to GitHub issues.
+
+## 日本語
+
+- **issue 非対応フラグメントでは `issues` の front matter を省略します** — GitHub issue に紐づかない作業では `+<slug>.<category>.md` を使い、`issues` は完全に省略します。
 ```
 
 ## Release preparation


### PR DESCRIPTION
## Summary
- Clarify that non-issue changelog fragments must omit `issues` entirely
- Add explicit guidance that `issues: null` and `issues: []` are invalid for non-issue work
- Add a non-issue example to the shared changelog fragment docs

## Why
Agents were still writing empty `issues` metadata on fragments that are not tied to GitHub issues, which then failed validation in the changelog pipeline.

## Validation
- `git diff --check`

## Notes
- This change only updates documentation and workflow guidance.