### PR TITLE
[codex] tsql search alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Batch | `.bat`, `.cmd` | yes |
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
+Query-time `--lang tsql` is accepted as an alias for the SQL bucket.
 | Markdown | `.md` | -- |
 | YAML | `.yaml`, `.yml` | -- |
 | JSON | `.json` | -- |
@@ -1632,6 +1633,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | Batch | `.bat`, `.cmd` | yes |
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
+クエリ時の `--lang tsql` は SQL バケットの別名として受け付けられます。
 | Markdown | `.md` | -- |
 | YAML | `.yaml`, `.yml` | -- |
 | JSON | `.json` | -- |

--- a/changelog.d/unreleased/+tsql-lang-alias.fixed.md
+++ b/changelog.d/unreleased/+tsql-lang-alias.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - README.md
+---
+
+## English
+
+- **`--lang tsql` now resolves to the SQL index bucket** — query-time language filters treat `tsql` as an alias for `sql`, so T-SQL projects get the same search, definition, caller, and reference results as the SQL bucket.
+
+## 日本語
+
+- **`--lang tsql` が SQL インデックスバケットに解決されるようになりました** — クエリ時の言語フィルタで `tsql` を `sql` の別名として扱うため、T-SQL プロジェクトでも SQL バケットと同じ検索・定義・caller・reference 結果を得られます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -27,6 +27,7 @@ public static class QueryCommandRunner
         ["py3"] = "python",
         ["pyi"] = "python",
         ["pyw"] = "python",
+        ["tsql"] = "sql",
     };
     private static readonly HashSet<string> ValueTakingOptions =
     [

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -570,7 +570,7 @@ public partial class DbReader
         IReadOnlyList<string>? excludePathPatterns,
         bool excludeTests)
     {
-        if (lang != null && !string.Equals(lang, "sql", StringComparison.OrdinalIgnoreCase))
+        if (lang != null && !IsSqlLanguage(lang))
             return false;
 
         using var cmd = _conn.CreateCommand();
@@ -708,7 +708,7 @@ public partial class DbReader
 
         cmd.CommandText = sql;
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            cmd.Parameters.AddWithValue("@lang", NormalizeQueryLanguage(lang));
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
 
         return cmd.ExecuteScalar() != null;
@@ -772,7 +772,10 @@ public partial class DbReader
     }
 
     internal static bool IsSqlLanguage(string? lang)
-        => string.Equals(lang, "sql", StringComparison.OrdinalIgnoreCase);
+        => string.Equals(NormalizeQueryLanguage(lang), "sql", StringComparison.OrdinalIgnoreCase);
+
+    internal static string? NormalizeQueryLanguage(string? lang)
+        => string.Equals(lang, "tsql", StringComparison.OrdinalIgnoreCase) ? "sql" : lang;
 
     internal static bool ContainsSqlLanguage(IEnumerable<string?> langs)
         => langs.Any(IsSqlLanguage);
@@ -846,6 +849,7 @@ public partial class DbReader
     /// </summary>
     public List<FileResult> ListFiles(string? query = null, int limit = 20, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, DateTime? since = null)
     {
+        lang = NormalizeQueryLanguage(lang);
         using var cmd = _conn.CreateCommand();
 
         var sql = $@"
@@ -899,6 +903,7 @@ public partial class DbReader
 
     public QueryCountResult CountListFiles(string? query = null, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, DateTime? since = null)
     {
+        lang = NormalizeQueryLanguage(lang);
         using var cmd = _conn.CreateCommand();
 
         var sql = @"
@@ -936,6 +941,7 @@ public partial class DbReader
     public List<ReferenceResult> SearchReferences(string? query = null, int limit = 20, string? lang = null, string? referenceKind = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool exact = false, int maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth)
     {
         maxLineWidth = LineWidthFormatter.ClampMaxLineWidth(maxLineWidth);
+        lang = NormalizeQueryLanguage(lang);
         query = NormalizeCSharpVerbatimQuery(query, lang) ?? query ?? string.Empty;
         if (!_hasReferencesTable)
             return new List<ReferenceResult>();
@@ -1152,7 +1158,7 @@ public partial class DbReader
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            cmd.Parameters.AddWithValue("@lang", NormalizeQueryLanguage(lang));
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
         if (includeOrdering)
         {
@@ -3103,7 +3109,7 @@ public partial class DbReader
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            cmd.Parameters.AddWithValue("@lang", NormalizeQueryLanguage(lang));
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
         cmd.Parameters.AddWithValue("@limit", limit);
 
@@ -3113,6 +3119,7 @@ public partial class DbReader
 
     public QueryCountResult CountSearchReferencesTotal(string? query = null, string? lang = null, string? referenceKind = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool exact = false)
     {
+        lang = NormalizeQueryLanguage(lang);
         query = NormalizeCSharpVerbatimQuery(query, lang) ?? query ?? string.Empty;
         if (ShouldApplyCSharpUsingStaticConstantPatternReferenceFilter(lang, referenceKind, exact))
             return CountSearchReferencesTotalWithUsingStaticFilter(query, lang, referenceKind, pathPatterns, excludePathPatterns, excludeTests, exact);
@@ -3223,7 +3230,7 @@ public partial class DbReader
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            cmd.Parameters.AddWithValue("@lang", NormalizeQueryLanguage(lang));
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
 
         return ExecuteCountSummary(cmd);
@@ -3237,6 +3244,7 @@ public partial class DbReader
     {
         if (string.IsNullOrWhiteSpace(query) || IsBareVerbatimQueryToken(query))
             return new List<CallerResult>();
+        lang = NormalizeQueryLanguage(lang);
         query = NormalizeCSharpVerbatimQuery(query, lang) ?? query ?? string.Empty;
         if (!_hasReferencesTable) return new List<CallerResult>();
         using var cmd = _conn.CreateCommand();
@@ -3345,7 +3353,7 @@ public partial class DbReader
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            cmd.Parameters.AddWithValue("@lang", NormalizeQueryLanguage(lang));
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
         cmd.Parameters.AddWithValue("@limit", limit);
 
@@ -3376,6 +3384,7 @@ public partial class DbReader
     {
         if (string.IsNullOrWhiteSpace(query) || IsBareVerbatimQueryToken(query))
             return 0;
+        lang = NormalizeQueryLanguage(lang);
         query = NormalizeCSharpVerbatimQuery(query, lang) ?? query ?? string.Empty;
         if (!_hasReferencesTable) return 0;
         using var cmd = _conn.CreateCommand();
@@ -3451,7 +3460,7 @@ public partial class DbReader
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            cmd.Parameters.AddWithValue("@lang", NormalizeQueryLanguage(lang));
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
         cmd.Parameters.AddWithValue("@limit", limit);
 
@@ -3537,7 +3546,7 @@ public partial class DbReader
         if (referenceKind != null)
             cmd.Parameters.AddWithValue("@referenceKind", referenceKind);
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            cmd.Parameters.AddWithValue("@lang", NormalizeQueryLanguage(lang));
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
 
         return ExecuteCountSummary(cmd);
@@ -3551,6 +3560,7 @@ public partial class DbReader
     {
         if (string.IsNullOrWhiteSpace(query) || IsBareVerbatimQueryToken(query))
             return new List<CalleeResult>();
+        lang = NormalizeQueryLanguage(lang);
         query = NormalizeCSharpVerbatimQuery(query, lang) ?? query ?? string.Empty;
         if (!_hasReferencesTable) return new List<CalleeResult>();
         using var cmd = _conn.CreateCommand();
@@ -3684,6 +3694,7 @@ public partial class DbReader
     {
         if (string.IsNullOrWhiteSpace(query) || IsBareVerbatimQueryToken(query))
             return 0;
+        lang = NormalizeQueryLanguage(lang);
         query = NormalizeCSharpVerbatimQuery(query, lang) ?? query ?? string.Empty;
         if (!_hasReferencesTable) return 0;
         using var cmd = _conn.CreateCommand();
@@ -3769,6 +3780,7 @@ public partial class DbReader
 
     public QueryCountResult CountCalleesTotal(string query, string? lang = null, string? referenceKind = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool exact = false)
     {
+        lang = NormalizeQueryLanguage(lang);
         if (!_hasReferencesTable)
             return new QueryCountResult(0, 0);
 
@@ -4102,6 +4114,7 @@ public partial class DbReader
     /// </summary>
     public ImpactAnalysisResult AnalyzeImpact(string symbolName, int maxDepth = 5, int limit = 50, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false)
     {
+        lang = NormalizeQueryLanguage(lang);
         var resolvedName = ResolveSymbolName(symbolName, lang);
         var definitions = ResolveImpactDefinitions(resolvedName, lang, pathPatterns, excludePathPatterns, excludeTests);
         var definitionPaths = definitions
@@ -5398,6 +5411,7 @@ public partial class DbReader
     /// </summary>
     public List<FileDependencyResult> GetFileDependencies(int limit = 50, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool reverse = false)
     {
+        lang = NormalizeQueryLanguage(lang);
         if (!_hasReferencesTable) return new List<FileDependencyResult>();
         using var cmd = _conn.CreateCommand();
         var referenceLineJoin = ReferenceLineJoinSql("r");

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -207,6 +207,7 @@ public partial class DbReader
 
     public QueryCountResult CountSearchSymbolsTotal(IReadOnlyList<string>? queries, string? kind = null, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, DateTime? since = null, bool exact = false)
     {
+        lang = DbReader.NormalizeQueryLanguage(lang);
         using var cmd = _conn.CreateCommand();
 
         var sql = @"
@@ -286,6 +287,7 @@ public partial class DbReader
     /// </summary>
     public List<SymbolResult> SearchSymbols(IReadOnlyList<string>? queries, int limit = 20, string? kind = null, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, DateTime? since = null, bool exact = false)
     {
+        lang = DbReader.NormalizeQueryLanguage(lang);
         // Multi-name queries: run one search per name to guarantee per-name candidate coverage
         // (a common/earlier-sorting name cannot starve others out of the candidate pool), then
         // round-robin interleave the per-name results under a single global `limit` cap so the
@@ -455,6 +457,7 @@ public partial class DbReader
     /// </summary>
     public List<DefinitionResult> GetDefinitions(string query, int limit = 20, string? kind = null, string? lang = null, bool includeBody = false, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, DateTime? since = null, bool exact = false)
     {
+        lang = DbReader.NormalizeQueryLanguage(lang);
         var symbols = SearchSymbols(query, limit, kind, lang, pathPatterns, excludePathPatterns, excludeTests, since, exact);
         var results = new List<DefinitionResult>();
 
@@ -650,6 +653,7 @@ public partial class DbReader
             };
         }
 
+        lang = DbReader.NormalizeQueryLanguage(lang);
         var normalizedQuery = NormalizeCSharpVerbatimQuery(query, lang) ?? query;
         // Propagate `exact` to every bundled sub-query so the one-round-trip AI workflow
         // (`inspect` / MCP `analyze_symbol`) keeps the same precision contract as the leaf

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -25854,6 +25854,59 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbolsAndReferences_AcceptTsqlAsSqlLanguageAlias()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_tsql_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "schema.tsql",
+                "sql",
+                """
+                CREATE PROCEDURE dbo.usp_Target
+                AS
+                SELECT 1;
+                GO
+
+                CREATE PROCEDURE sales.usp_Caller
+                AS
+                BEGIN
+                    EXEC dbo.usp_Target;
+                END
+                GO
+                """);
+            MarkGraphAndFoldReady(dbPath);
+
+            var (symbolsTsqlExitCode, symbolsTsqlStdout, symbolsTsqlStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json", "--lang", "tsql", "--exact-name", "dbo.usp_Target"],
+                _jsonOptions));
+            var (referencesTsqlExitCode, referencesTsqlStdout, referencesTsqlStderr) = CaptureConsole(() => QueryCommandRunner.RunReferences(
+                ["--db", dbPath, "--json", "--lang", "tsql", "--exact-name", "dbo.usp_Target"],
+                _jsonOptions));
+
+            var symbolsTsqlRows = ParseJsonLines(symbolsTsqlStdout).Select(document => document.RootElement).ToList();
+            var referencesTsqlRows = ParseJsonLines(referencesTsqlStdout).Select(document => document.RootElement).ToList();
+
+            Assert.Equal(CommandExitCodes.Success, symbolsTsqlExitCode);
+            Assert.Equal(CommandExitCodes.Success, referencesTsqlExitCode);
+            Assert.Equal(string.Empty, symbolsTsqlStderr);
+            Assert.Equal(string.Empty, referencesTsqlStderr);
+
+            Assert.Single(symbolsTsqlRows);
+            Assert.Equal("dbo.usp_Target", symbolsTsqlRows[0].GetProperty("name").GetString());
+
+            Assert.Single(referencesTsqlRows);
+            Assert.Equal("sales.usp_Caller", referencesTsqlRows[0].GetProperty("container_name").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_AcceptsKindFunctionCaseInsensitively()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_kind_case");


### PR DESCRIPTION
## What changed
- Accept `--lang tsql` as an alias for the SQL bucket in query-time search, symbols, references, callers, callees, impact, deps, hotspots, and related language-aware paths.
- Normalize `tsql` to `sql` in the CLI parser and DB readers so SQL-backed queries behave consistently across entry points.
- Add regression coverage for `symbols` and `references` against a T-SQL file.
- Document the alias in the README and add a changelog fragment.

## Why
- T-SQL projects were already indexed as `sql`, but the query surface did not consistently accept `tsql` as the user-facing language name.

## Validation
- `dotnet test CodeIndex.sln --filter FullyQualifiedName~RunSymbolsAndReferences_AcceptTsqlAsSqlLanguageAlias`
- `dotnet build CodeIndex.sln`