### PR TITLE
[codex] Add COBOL search coverage

### DIFF
--- a/changelog.d/unreleased/+cobol-search-coverage.fixed.md
+++ b/changelog.d/unreleased/+cobol-search-coverage.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **COBOL source files are now indexed and shown in `cdidx languages`** — `FileIndexer` now recognizes common COBOL extensions (`.cbl`, `.cob`, `.cobol`, `.cpy`), so COBOL projects are no longer skipped during indexing and their contents become searchable through the normal full-text path.
+
+## 日本語
+
+- **COBOL ソースファイルが index 対象になり、`cdidx languages` にも表示されるようになりました** — `FileIndexer` が一般的な COBOL 拡張子（`.cbl`、`.cob`、`.cobol`、`.cpy`）を認識するため、COBOL プロジェクトが indexing で落とされず、通常の全文検索経路で検索できるようになります。

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -191,6 +191,10 @@ public class FileIndexer
         [".f08"]    = "fortran",
         [".for"]    = "fortran",
         [".ftn"]    = "fortran",
+        [".cbl"]    = "cobol",
+        [".cob"]    = "cobol",
+        [".cobol"]  = "cobol",
+        [".cpy"]    = "cobol",   // COBOL copybook / COBOL コピー句
         [".raku"]   = "raku",
         [".rakumod"]= "raku",
         [".rakutest"]= "raku",

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -151,6 +151,10 @@ public class FileIndexerTests
     [InlineData("demo.f08", "fortran")]
     [InlineData("demo.for", "fortran")]
     [InlineData("demo.ftn", "fortran")]
+    [InlineData("demo.cbl", "cobol")]
+    [InlineData("demo.cob", "cobol")]
+    [InlineData("demo.cobol", "cobol")]
+    [InlineData("demo.cpy", "cobol")]
     [InlineData("demo.raku", "raku")]
     [InlineData("demo.rakumod", "raku")]
     [InlineData("demo.rakutest", "raku")]
@@ -364,6 +368,10 @@ public class FileIndexerTests
         Assert.Equal("fortran", map[".f90"]);
         Assert.Equal("raku", map[".raku"]);
         Assert.Equal("perl", map[".t"]);
+        Assert.Equal("cobol", map[".cbl"]);
+        Assert.Equal("cobol", map[".cob"]);
+        Assert.Equal("cobol", map[".cobol"]);
+        Assert.Equal("cobol", map[".cpy"]);
         // Mainstream extension-only languages should now be recognized for search/indexing.
         // 主要な拡張子ベース言語も search/indexing 用に認識されるべき。
         Assert.Equal("ocaml", map[".ml"]);
@@ -391,6 +399,36 @@ public class FileIndexerTests
         // Objective-C は独立バケットにし、`.m` / `.mm` をスキップせずに index する。
         Assert.Equal("objc", map[".m"]);
         Assert.Equal("objc", map[".mm"]);
+    }
+
+    [Fact]
+    public void ScanFiles_IndexesCobolExtensions()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var files = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["hello.cbl"] = "       IDENTIFICATION DIVISION.\n       PROGRAM-ID. HELLO.\n",
+                ["copy.cpy"] = "       01  COPY-NAME PIC X(10).\n",
+                ["legacy.cob"] = "       PROCEDURE DIVISION.\n",
+                ["modern.cobol"] = "       STOP RUN.\n",
+            };
+            foreach (var (name, content) in files)
+                File.WriteAllText(Path.Combine(tempDir, name), content);
+
+            var scanned = new FileIndexer(tempDir).ScanFiles()
+                .Select(path => Path.GetRelativePath(tempDir, path).Replace('\\', '/'))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.Equal(files.Keys.OrderBy(n => n, StringComparer.Ordinal).ToList(), scanned);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Added common COBOL extensions (`.cbl`, `.cob`, `.cobol`, `.cpy`) to the file-language map so COBOL projects are indexed instead of skipped.
- Extended `FileIndexerTests` to cover COBOL extension detection, language listing, and scan-time inclusion.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests"`
- `dotnet build CodeIndex.sln -c Release`

## Docs / Changelog

- Added an unreleased fragment at `changelog.d/unreleased/+cobol-search-coverage.fixed.md`.

## Follow-up candidates

- COBOL symbol/reference extraction is still not implemented, so `search` coverage is now better but graph-style queries remain unavailable for COBOL files.