### PR TITLE
Refine Swift typealias follow-up coverage

### DIFF
--- a/changelog.d/unreleased/+swift-typealias-followup.fixed.md
+++ b/changelog.d/unreleased/+swift-typealias-followup.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Swift `typealias` extraction now handles backtick-escaped names and `where` clauses** — `typealias` declarations no longer fall back to `import` when the alias name is escaped or followed by a constraint clause, and the CLI now has end-to-end coverage for `symbols --lang swift --kind typealias` and `--kind associatedtype`.
+
+## 日本語
+
+- **Swift の `typealias` 抽出がバッククォート付き識別子と `where` 句に対応しました** — `typealias` 宣言は、別名がバッククォートでエスケープされている場合や制約句が付く場合でも `import` にフォールバックせず、CLI には `symbols --lang swift --kind typealias` と `--kind associatedtype` の end-to-end カバレッジも追加しました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1159,8 +1159,8 @@ public static class SymbolExtractor
             new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final)\s+)?extension\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // actor (Swift 5.5+) / アクター
             new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final|distributed)\s+)*(?:class|actor)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            // Type alias / 型エイリアス
-            new("import",   new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*typealias\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            // Type alias / 型エイリアス: backtick-escaped names and generic/where clauses.
+            new("typealias", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*typealias\s+(?<name>`[^`]+`|\w+)(?=\s*(?:<|=|where\b|$))", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*macro\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("interface", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*precedencegroup\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("function", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:prefix|infix|postfix)\s+operator\s+(?<name>\S+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -4396,6 +4396,58 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbols_SwiftKindFiltersSeparateTypealiasAndAssociatedtype()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_swift_kind_filters");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "models.swift"),
+                """
+                public typealias `Callback`<T> = (T) -> Void where T: Sendable
+
+                public protocol Store {
+                    associatedtype Item
+                }
+                """);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json"],
+                _jsonOptions));
+            var (typealiasExitCode, typealiasStdout, typealiasStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json", "--lang", "swift", "--kind", "typealias"],
+                _jsonOptions));
+            var (associatedtypeExitCode, associatedtypeStdout, associatedtypeStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json", "--lang", "swift", "--kind", "associatedtype"],
+                _jsonOptions));
+
+            var typealiasRows = ParseJsonLines(typealiasStdout);
+            var associatedtypeRows = ParseJsonLines(associatedtypeStdout);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+
+            Assert.Equal(CommandExitCodes.Success, typealiasExitCode);
+            Assert.Equal(string.Empty, typealiasStderr);
+            Assert.Single(typealiasRows);
+            Assert.Equal("typealias", typealiasRows[0].RootElement.GetProperty("kind").GetString());
+            Assert.Contains("Callback", typealiasRows[0].RootElement.GetProperty("name").GetString(), StringComparison.Ordinal);
+
+            Assert.Equal(CommandExitCodes.Success, associatedtypeExitCode);
+            Assert.Equal(string.Empty, associatedtypeStderr);
+            Assert.Single(associatedtypeRows);
+            Assert.Equal("associatedtype", associatedtypeRows[0].RootElement.GetProperty("kind").GetString());
+            Assert.Contains("Item", associatedtypeRows[0].RootElement.GetProperty("name").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_And_Definition_NormalizeCSharpVerbatimIdentifiers()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_csharp_verbatim_query_normalization");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10393,6 +10393,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsBacktickEscapedTypealiasAndWhereClause()
+    {
+        var content = """
+            public typealias `Callback`<T> = (T) -> Void where T: Sendable
+            typealias ResultHandler<T> where T: Hashable = (T) -> Void
+
+            public protocol Store {
+                associatedtype Item
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "`Callback`");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "ResultHandler");
+        Assert.Contains(symbols, s => s.Kind == "associatedtype" && s.Name == "Item");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsEnumCasesAndIndirectEnums()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Addressed the follow-up candidates from PR #1157.
- Swift `typealias` extraction now accepts backtick-escaped names and `where`-clause forms without falling back to `import`.
- Added unit coverage for the extractor and end-to-end CLI coverage for `symbols --lang swift --kind typealias` and `--kind associatedtype`.

## Validation
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~Extract_Swift_DetectsBacktickEscapedTypealiasAndWhereClause|FullyQualifiedName~RunSymbols_SwiftKindFiltersSeparateTypealiasAndAssociatedtype"`
- `dotnet build CodeIndex.sln -c Debug`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/QueryCommandRunnerTests.cs changelog.d/unreleased/+swift-typealias-followup.fixed.md --json`

## Documentation / Changelog
- Added `changelog.d/unreleased/+swift-typealias-followup.fixed.md`.
- No additional docs update was needed because the existing Swift symbol-kind guidance already covers the user-facing contract.

## Follow-up candidates
- None.