### PR TITLE
Improve VB enum search coverage

### DIFF
--- a/changelog.d/unreleased/+vb-enum-search.fixed.md
+++ b/changelog.d/unreleased/+vb-enum-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **VB `Enum` bodies now stay open for later declarations, and enum members are indexed** — `Enum` now participates in VB container range detection so a nested enum no longer cuts off later class or module members, and top-level enum members like `Red` / `Green` now surface as searchable `enum` symbols.
+
+## 日本語
+
+- **VB の `Enum` 本体が後続宣言を途中で切らず、enum メンバーも索引されるようになりました** — VB の container 範囲判定に `Enum` を含めたため、ネストした enum で外側クラスやモジュールの後続メンバーが切り捨てられなくなり、`Red` / `Green` のような enum メンバーも検索可能な `enum` シンボルとして出力されます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1200,7 +1200,7 @@ public static class SymbolExtractor
             new("property", new Regex(@$"^\s*(?:(?:{VbPropertyModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbPropertyModifierPattern})\s+)*Property\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
             new("event",    new Regex(@$"^\s*(?:(?:{VbEventModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbEventModifierPattern})\s+)*Event\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
             new("interface", new Regex(@$"^\s*(?:(?:{VbTypeModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*Interface\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.VisualBasicEnd, "visibility"),
-            new("enum",     new Regex(@$"^\s*(?:(?<visibility>{VbVisibilityPattern})\s+)?Enum\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None, "visibility"),
+            new("enum",     new Regex(@$"^\s*(?:(?<visibility>{VbVisibilityPattern})\s+)?Enum\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.VisualBasicEnd, "visibility"),
             new("struct",   new Regex(@$"^\s*(?:(?:Partial)\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:Partial)\s+)*Structure\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.VisualBasicEnd, "visibility"),
             new("class",    new Regex(@$"^\s*(?:(?:{VbTypeModifierPattern})\s+)*(?:(?<visibility>{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*(?:Class|Module)\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.VisualBasicEnd, "visibility"),
             new("import",   new Regex(@"^\s*Imports\s+(?<name>.+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
@@ -1666,8 +1666,9 @@ public static class SymbolExtractor
     private static readonly Regex ElixirBlockStartRegex = new(@"^\s*(?:defmodule|defprotocol|defimpl|defmacro|defguardp?|defp?)\b", RegexOptions.Compiled);
     private static readonly Regex ElixirBlockTokenRegex = new(@"\b(?:do|fn|end)\b(?!:)", RegexOptions.Compiled);
     private static readonly Regex ElixirDoShorthandRegex = new(@",\s*do:\s*", RegexOptions.Compiled);
-    private static readonly Regex VisualBasicContainerStartRegex = new(@$"^(?:Namespace\b|(?:(?:{VbTypeModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*(?:Class|Module|Structure|Interface)\b|(?:(?:{VbOperatorModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbOperatorModifierPattern})\s+)*Operator\b)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    private static readonly Regex VisualBasicContainerEndRegex = new(@"^End\s+(?:Namespace|Class|Module|Structure|Interface|Operator)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex VisualBasicContainerStartRegex = new(@$"^(?:Namespace\b|(?:(?:{VbTypeModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbTypeModifierPattern})\s+)*(?:Class|Module|Structure|Interface|Enum)\b|(?:(?:{VbOperatorModifierPattern})\s+)*(?:(?:{VbVisibilityPattern})\s+)?(?:(?:{VbOperatorModifierPattern})\s+)*Operator\b)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex VisualBasicContainerEndRegex = new(@"^End\s+(?:Namespace|Class|Module|Structure|Interface|Enum|Operator)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex VisualBasicEnumMemberRegex = new(@"^\s*(?<name>(?:\[[^\]\r\n]+\]|\w+))\s*(?:=\s*[^'\r\n]+)?\s*(?:'|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     // Explicit-interface implementations reuse CSharpTypePattern for the return type so nested
     // generics and function pointers (`delegate*<List<int>, int>`, `delegate*<delegate*<int, void>, int>`)
     // are handled uniformly with the regular method / property / indexer / delegate paths. The
@@ -3163,6 +3164,8 @@ public static class SymbolExtractor
             ExtractJavaCompactConstructors(fileId, lines, symbols);
             ExtractJavaModuleDirectiveSymbols(fileId, lines, structuralLines, symbols);
         }
+        else if (lang == "vb")
+            ExtractVisualBasicEnumMembers(fileId, lines, symbols);
 
         if (string.Equals(originalLang, "svelte", StringComparison.Ordinal))
             ExtractSvelteReactiveSymbols(fileId, lines, symbols);
@@ -5015,6 +5018,60 @@ public static class SymbolExtractor
                 bodyEndLineIndex,
                 bodyEndColumnExclusive,
                 symbols);
+        }
+    }
+
+    private static void ExtractVisualBasicEnumMembers(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        var enumDeclarations = symbols
+            .Where(symbol =>
+                symbol.FileId == fileId
+                && symbol.Kind == "enum"
+                && symbol.BodyStartLine != null
+                && symbol.BodyEndLine != null)
+            .OrderBy(symbol => symbol.StartLine)
+            .ThenByDescending(symbol => symbol.EndLine)
+            .ToList();
+
+        foreach (var enumSymbol in enumDeclarations)
+        {
+            var bodyStartLineIndex = enumSymbol.BodyStartLine!.Value - 1;
+            var bodyEndLineIndex = enumSymbol.BodyEndLine!.Value - 1;
+            for (var lineIndex = bodyStartLineIndex; lineIndex <= bodyEndLineIndex && lineIndex < lines.Length; lineIndex++)
+            {
+                var trimmed = lines[lineIndex].Trim();
+                if (trimmed.Length == 0
+                    || trimmed.StartsWith("'", StringComparison.Ordinal)
+                    || trimmed.StartsWith("Rem ", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (trimmed.StartsWith("End Enum", StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                var match = VisualBasicEnumMemberRegex.Match(trimmed);
+                if (!match.Success)
+                    continue;
+
+                var name = match.Groups["name"].Value;
+                if (string.IsNullOrWhiteSpace(name))
+                    continue;
+
+                if (name.Length >= 2 && name[0] == '[' && name[^1] == ']')
+                    name = name[1..^1];
+
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "enum",
+                    Name = name,
+                    Line = lineIndex + 1,
+                    StartLine = lineIndex + 1,
+                    EndLine = lineIndex + 1,
+                    Signature = trimmed,
+                });
+            }
         }
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12164,6 +12164,35 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_VB_DetectsNestedEnumMembersAndMembersAfterEnum()
+    {
+        // VB.NET enum bodies should stay searchable, and nested enums must not cut off later
+        // declarations in the containing class / VB.NET の enum 本体は検索対象のままであり、
+        // ネストした enum が外側クラスの後続宣言を切り捨てないこと。
+        var content = """
+            Namespace MyApp
+                Public Class Widget
+                    Public Enum Color
+                        Red
+                        Green = 1
+                    End Enum
+
+                    Public Function AfterEnum() As Integer
+                        Return 1
+                    End Function
+                End Class
+            End Namespace
+            """;
+        var symbols = SymbolExtractor.Extract(1, "vb", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Color");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Red");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Green");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "AfterEnum");
+    }
+
+    [Fact]
     public void Extract_CSharp_DetectsPlainFieldDeclarations()
     {
         // Plain fields are now captured as kind `property` so definition/symbols/outline/


### PR DESCRIPTION
## Summary

- Include VB `Enum` in container range detection so nested enums do not truncate later declarations in the containing class or module.
- Index VB enum members as searchable `enum` symbols, including simple bracketed identifiers.
- Add regression coverage for nested enums and later members in `SymbolExtractorTests`.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_VB_"`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs changelog.d/unreleased/+vb-enum-search.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation and Changelog

- Added bilingual fragment: `changelog.d/unreleased/+vb-enum-search.fixed.md`
- No additional README/guide updates were needed because the existing VB support documentation already covers the language at a high level, and this change is a coverage fix within that contract.

## Follow-up candidates

- VB enum members with leading attributes or more complex multi-line initializers may still deserve a dedicated parser-style fallback if we want broader coverage later.