### PR TITLE
Add tsql alias follow-up coverage

### DIFF
--- a/changelog.d/unreleased/+tsql-impact-deps-alias.internal.md
+++ b/changelog.d/unreleased/+tsql-impact-deps-alias.internal.md
@@ -1,0 +1,15 @@
+---
+category: internal
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Expanded regression coverage for the `--lang tsql` alias on impact and dependency queries** — added tests that exercise the SQL alias through `AnalyzeImpact` and `GetFileDependencies`, so the alias stays covered beyond the original `symbols` and `references` checks.
+
+## 日本語
+
+- **`--lang tsql` 別名の impact と dependency クエリ向け回帰テストを拡充しました** — `AnalyzeImpact` と `GetFileDependencies` で SQL 別名を通すテストを追加し、元の `symbols` / `references` 確認だけに依存しないようにしました。

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -3171,6 +3171,12 @@ public class DbReaderTests : IDisposable
         Assert.Equal("src/sql_bare_call_target.sql", dependency.TargetPath);
         Assert.Equal(1, dependency.ReferenceCount);
 
+        var tsqlDependencies = _reader.GetFileDependencies(limit: 10, lang: "tsql", pathPatterns: ["sql_bare_call_"], excludePathPatterns: null, excludeTests: false);
+        var tsqlDependency = Assert.Single(tsqlDependencies);
+        Assert.Equal("src/sql_bare_call_caller.sql", tsqlDependency.SourcePath);
+        Assert.Equal("src/sql_bare_call_target.sql", tsqlDependency.TargetPath);
+        Assert.Equal(1, tsqlDependency.ReferenceCount);
+
         var hotspot = Assert.Single(
             _reader.GetSymbolHotspots(10, "function", "sql", ["sql_bare_call_"], null, false),
             item => item.Symbol.Name == "dbo.fn_Target");
@@ -3417,6 +3423,11 @@ public class DbReaderTests : IDisposable
         Assert.Equal(1, impact.DefinitionCount);
         Assert.Equal("[dbo].[fn_Target]", Assert.Single(impact.Definitions).Name);
         Assert.Equal("[sales].[fn_Target]", Assert.Single(impact.Callers).CallerName);
+
+        var tsqlImpact = _reader.AnalyzeImpact("dbo.fn_Target", maxDepth: 1, limit: 10, lang: "tsql", pathPatterns: ["sql_quoted_definition"]);
+        Assert.Equal(1, tsqlImpact.DefinitionCount);
+        Assert.Equal("[dbo].[fn_Target]", Assert.Single(tsqlImpact.Definitions).Name);
+        Assert.Equal("[sales].[fn_Target]", Assert.Single(tsqlImpact.Callers).CallerName);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -25862,14 +25862,19 @@ public class QueryCommandRunnerTests
             var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
             TestProjectHelper.InsertIndexedFile(
                 dbPath,
-                "schema.tsql",
+                "schema_target.tsql",
                 "sql",
                 """
                 CREATE PROCEDURE dbo.usp_Target
                 AS
                 SELECT 1;
                 GO
-
+                """);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "schema_caller.tsql",
+                "sql",
+                """
                 CREATE PROCEDURE sales.usp_Caller
                 AS
                 BEGIN


### PR DESCRIPTION
## Summary
- Added regression coverage for the `--lang tsql` alias in the core SQL dependency reader and `AnalyzeImpact` path.
- Kept the original `symbols` and `references` coverage from PR #1160, and extended it to the follow-up candidates.
- Added an internal changelog fragment for the coverage expansion.

## Validation
- `dotnet test CodeIndex.sln --filter FullyQualifiedName~RunSymbolsAndReferences_AcceptTsqlAsSqlLanguageAlias`
- `dotnet test CodeIndex.sln --filter FullyQualifiedName~SqlBareCalls_AlignAggregateReadersWithLeafFallback`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog
- `changelog.d/unreleased/+tsql-impact-deps-alias.internal.md`

## Follow-up candidates addressed
- The `--lang tsql` alias is now covered beyond `symbols` and `references`, including `AnalyzeImpact` and file dependency queries.
