### PR TITLE
Expand tsql alias coverage

### DIFF
--- a/changelog.d/unreleased/+tsql-alias-followup.internal.md
+++ b/changelog.d/unreleased/+tsql-alias-followup.internal.md
@@ -1,0 +1,13 @@
+---
+category: internal
+affected:
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Expanded `--lang tsql` regression coverage to callers and callees** — added CLI tests that exercise the SQL alias through `RunCallers` and `RunCallees`, so the follow-up coverage now includes the remaining graph-query entry points.
+
+## 日本語
+
+- **`--lang tsql` の回帰テストを callers / callees まで拡張しました** — SQL 別名を `RunCallers` と `RunCallees` で通す CLI テストを追加し、follow-up 対応のカバレッジを残りのグラフ系エントリポイントにも広げました。

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -26013,6 +26013,29 @@ public class QueryCommandRunnerTests
 
             Assert.Single(referencesTsqlRows);
             Assert.Equal("sales.usp_Caller", referencesTsqlRows[0].GetProperty("container_name").GetString());
+
+            var (callersTsqlExitCode, callersTsqlStdout, callersTsqlStderr) = CaptureConsole(() => QueryCommandRunner.RunCallers(
+                ["dbo.usp_Target", "--db", dbPath, "--json", "--lang", "tsql", "--exact-name"],
+                _jsonOptions));
+            var (calleesTsqlExitCode, calleesTsqlStdout, calleesTsqlStderr) = CaptureConsole(() => QueryCommandRunner.RunCallees(
+                ["sales.usp_Caller", "--db", dbPath, "--json", "--lang", "tsql", "--exact-name"],
+                _jsonOptions));
+
+            var callersTsqlRows = ParseJsonLines(callersTsqlStdout).Select(document => document.RootElement).ToList();
+            var calleesTsqlRows = ParseJsonLines(calleesTsqlStdout).Select(document => document.RootElement).ToList();
+
+            Assert.Equal(CommandExitCodes.Success, callersTsqlExitCode);
+            Assert.Equal(CommandExitCodes.Success, calleesTsqlExitCode);
+            Assert.Equal(string.Empty, callersTsqlStderr);
+            Assert.Equal(string.Empty, calleesTsqlStderr);
+
+            Assert.Single(callersTsqlRows);
+            Assert.Equal("sales.usp_Caller", callersTsqlRows[0].GetProperty("caller_name").GetString());
+            Assert.Equal("usp_Target", callersTsqlRows[0].GetProperty("callee_name").GetString());
+
+            Assert.Single(calleesTsqlRows);
+            Assert.Equal("sales.usp_Caller", calleesTsqlRows[0].GetProperty("caller_name").GetString());
+            Assert.Equal("usp_Target", calleesTsqlRows[0].GetProperty("callee_name").GetString());
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Added regression coverage for `--lang tsql` on `RunCallers` and `RunCallees`.
- Kept the existing `symbols` and `references` coverage in place, along with the follow-up coverage from PR #1167.
- Added an internal changelog fragment for the coverage expansion.

## Validation
- `dotnet test CodeIndex.sln --filter FullyQualifiedName~RunSymbolsAndReferences_AcceptTsqlAsSqlLanguageAlias`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog
- `changelog.d/unreleased/+tsql-alias-followup.internal.md`

## Follow-up candidates from PR #1167 addressed
- `--lang tsql` now stays covered on the remaining graph query entry points (`callers` and `callees`), in addition to `symbols`, `references`, `AnalyzeImpact`, and dependency queries.