### PR TITLE
Address VB enum follow-up cases

### DIFF
--- a/changelog.d/unreleased/+vb-enum-followup.fixed.md
+++ b/changelog.d/unreleased/+vb-enum-followup.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **VB enum members now survive leading attributes and multi-line initializers** — the enum member fallback now skips attribute blocks and keeps scanning through continued initializer lines, so members like `Legacy`, `Complex`, and `Ready` remain searchable even when the declaration is split across lines.
+
+## 日本語
+
+- **VB の enum member が先頭属性や複数行 initializer を含んでも索引されるようになりました** — enum member の fallback が attribute block を飛ばし、継続する initializer 行を追跡するため、`Legacy` / `Complex` / `Ready` のような member も改行をまたいだ宣言で検索可能なままになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -5040,6 +5040,10 @@ public static class SymbolExtractor
         {
             var bodyStartLineIndex = enumSymbol.BodyStartLine!.Value - 1;
             var bodyEndLineIndex = enumSymbol.BodyEndLine!.Value - 1;
+            var inAttributeBlock = false;
+            var inInitializer = false;
+            var initializerParenDepth = 0;
+
             for (var lineIndex = bodyStartLineIndex; lineIndex <= bodyEndLineIndex && lineIndex < lines.Length; lineIndex++)
             {
                 var trimmed = lines[lineIndex].Trim();
@@ -5053,16 +5057,44 @@ public static class SymbolExtractor
                 if (trimmed.StartsWith("End Enum", StringComparison.OrdinalIgnoreCase))
                     break;
 
-                var match = VisualBasicEnumMemberRegex.Match(trimmed);
-                if (!match.Success)
+                if (inAttributeBlock)
+                {
+                    var attributeCloseIndex = trimmed.IndexOf('>');
+                    if (attributeCloseIndex < 0)
+                        continue;
+
+                    trimmed = trimmed[(attributeCloseIndex + 1)..].TrimStart();
+                    inAttributeBlock = false;
+                    if (trimmed.Length == 0)
+                        continue;
+                }
+
+                while (trimmed.StartsWith("<", StringComparison.Ordinal))
+                {
+                    var attributeCloseIndex = trimmed.IndexOf('>');
+                    if (attributeCloseIndex < 0)
+                    {
+                        inAttributeBlock = true;
+                        trimmed = string.Empty;
+                        break;
+                    }
+
+                    trimmed = trimmed[(attributeCloseIndex + 1)..].TrimStart();
+                    if (trimmed.Length == 0)
+                        break;
+                }
+
+                if (trimmed.Length == 0)
                     continue;
 
-                var name = match.Groups["name"].Value;
-                if (string.IsNullOrWhiteSpace(name))
+                if (inInitializer)
+                {
+                    UpdateVisualBasicEnumInitializerState(trimmed, ref initializerParenDepth, ref inInitializer);
                     continue;
+                }
 
-                if (name.Length >= 2 && name[0] == '[' && name[^1] == ']')
-                    name = name[1..^1];
+                if (!TryExtractVisualBasicEnumMemberName(trimmed, out var name))
+                    continue;
 
                 symbols.Add(new SymbolRecord
                 {
@@ -5074,8 +5106,78 @@ public static class SymbolExtractor
                     EndLine = lineIndex + 1,
                     Signature = trimmed,
                 });
+
+                UpdateVisualBasicEnumInitializerState(trimmed, ref initializerParenDepth, ref inInitializer);
             }
         }
+    }
+
+    private static bool TryExtractVisualBasicEnumMemberName(string line, out string name)
+    {
+        var match = VisualBasicEnumMemberRegex.Match(line);
+        if (!match.Success)
+        {
+            name = string.Empty;
+            return false;
+        }
+
+        name = match.Groups["name"].Value;
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        if (name.Length >= 2 && name[0] == '[' && name[^1] == ']')
+            name = name[1..^1];
+
+        return true;
+    }
+
+    private static void UpdateVisualBasicEnumInitializerState(string line, ref int parenDepth, ref bool inInitializer)
+    {
+        var code = StripVisualBasicComment(line);
+        foreach (var ch in code)
+        {
+            if (ch == '(')
+                parenDepth++;
+            else if (ch == ')' && parenDepth > 0)
+                parenDepth--;
+        }
+
+        var trimmed = code.TrimEnd();
+        inInitializer = parenDepth > 0
+            || trimmed.EndsWith("_", StringComparison.Ordinal)
+            || trimmed.EndsWith("=", StringComparison.Ordinal)
+            || trimmed.EndsWith("+", StringComparison.Ordinal)
+            || trimmed.EndsWith("-", StringComparison.Ordinal)
+            || trimmed.EndsWith("*", StringComparison.Ordinal)
+            || trimmed.EndsWith("/", StringComparison.Ordinal)
+            || trimmed.EndsWith("&", StringComparison.Ordinal)
+            || trimmed.EndsWith(",", StringComparison.Ordinal)
+            || trimmed.EndsWith(".", StringComparison.Ordinal);
+    }
+
+    private static string StripVisualBasicComment(string line)
+    {
+        var inString = false;
+        for (var i = 0; i < line.Length; i++)
+        {
+            var ch = line[i];
+            if (ch == '"')
+            {
+                if (inString && i + 1 < line.Length && line[i + 1] == '"')
+                {
+                    i++;
+                    continue;
+                }
+
+                inString = !inString;
+                continue;
+            }
+
+            if (!inString && ch == '\'')
+                return line[..i];
+        }
+
+        return line;
     }
 
     private static void RecoverJavaEnumMembersByLine(

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12231,6 +12231,33 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_VB_DetectsEnumMembersWithAttributesAndMultilineInitializers()
+    {
+        // VB.NET enum members can carry attributes and split initializers across lines.
+        // The fallback needs to keep both shapes searchable / VB.NET の enum member は属性と
+        // 複数行 initializer を持てるため、fallback が両方を検索可能に保つこと。
+        var content = """
+            Public Enum Status
+                <Obsolete,
+                 System.ComponentModel.Description("legacy")>
+                Legacy
+
+                Complex = If(
+                    True,
+                    1,
+                    2)
+
+                Ready
+            End Enum
+            """;
+        var symbols = SymbolExtractor.Extract(1, "vb", content);
+
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Legacy");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Complex");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Ready");
+    }
+
+    [Fact]
     public void Extract_CSharp_DetectsPlainFieldDeclarations()
     {
         // Plain fields are now captured as kind `property` so definition/symbols/outline/


### PR DESCRIPTION
## Summary

- Address the follow-up candidates from PR #1166 by teaching the VB enum member fallback to skip leading attribute blocks and keep scanning through multi-line initializer lines.
- Add regression coverage for VB enum members with attributes and more complex multi-line initializers.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_VB_"`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs changelog.d/unreleased/+vb-enum-followup.fixed.md --json`

## Documentation and Changelog

- Added fragment: `changelog.d/unreleased/+vb-enum-followup.fixed.md`
- No direct `CHANGELOG.md` edit was needed because this is an ordinary implementation PR.

## Follow-up candidates addressed

- This PR implements the follow-up candidates called out in PR #1166 for VB enum members with leading attributes and multi-line initializers.