### PR TITLE
Add Common Lisp symbol extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Verilog | `.v` | -- |
 | SystemVerilog | `.sv`, `.svh` | -- |
 | VHDL | `.vhd`, `.vhdl` | -- |
-| Common Lisp | `.lisp`, `.lsp`, `.cl` | -- |
+| Common Lisp | `.lisp`, `.lsp`, `.cl` | yes (defpackage, defclass, defstruct, defun/defmacro/defgeneric/defmethod) |
 | Racket | `.rkt` | -- |
 | Pascal | `.pas`, `.pp`, `.dpr` | -- |
 | Ada | `.ada`, `.adb`, `.ads` | -- |

--- a/changelog.d/unreleased/+commonlisp-search.fixed.md
+++ b/changelog.d/unreleased/+commonlisp-search.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **Common Lisp files now surface top-level definitions in search** — `cdidx` now extracts `defpackage`, `defclass`, `defstruct`, `defparameter`/`defvar`/`defconstant`, `defun`, `defmacro`, `defgeneric`, and `defmethod` symbols from `.lisp`, `.lsp`, and `.cl` files so Lisp projects produce useful symbol search results instead of falling back to file-only matches.
+
+## 日本語
+
+- **Common Lisp ファイルでトップレベル定義が検索に出るようになりました** — `cdidx` は `.lisp` / `.lsp` / `.cl` ファイルから `defpackage`、`defclass`、`defstruct`、`defparameter` / `defvar` / `defconstant`、`defun`、`defmacro`、`defgeneric`、`defmethod` を抽出するため、Lisp プロジェクトでシンボル検索が効くようになり、ファイル単位の一致だけに落ちなくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1255,6 +1255,14 @@ public static class SymbolExtractor
             new("interface", new Regex(@"^\s*defprotocol\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.ElixirEnd),
             new("import",   new Regex(@"^\s*(?:import|alias|use|require)\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],
+        ["commonlisp"] =
+        [
+            new("namespace", new Regex(@"^\s*\(\s*defpackage\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("class",     new Regex(@"^\s*\(\s*defclass\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("struct",    new Regex(@"^\s*\(\s*defstruct\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property",  new Regex(@"^\s*\(\s*(?:defparameter|defvar|defconstant)\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("function",  new Regex(@"^\s*\(\s*(?:defun|defmacro|defgeneric|defmethod)\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+        ],
         ["dart"] =
         [
             new("function", new Regex(@"^\s*(?!return\b|await\b|const\b|new\b|throw\b|yield\b|if\b|else\b|for\b|while\b|switch\b|case\b|catch\b|do\b|try\b|finally\b|class\b|enum\b|mixin\b|extension\b|typedef\b|library\b|part\b|import\b|export\b)(?:(?:static|abstract|override|external)\s+)*(?<rt>\w[\w<>,\s\?]*?)\s+(?<name>(?!if\b|else\b|for\b|while\b|switch\b|case\b|class\b|enum\b|mixin\b|extension\b|typedef\b|library\b|part\b|import\b|export\b|abstract\b|void\b|var\b|final\b|late\b|const\b|new\b|return\b|throw\b|yield\b|await\b|extends\b|implements\b|with\b|on\b|is\b|as\b|in\b|of\b|super\b|this\b)\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "rt"),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15750,6 +15750,42 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "greet");
     }
 
+    [Fact]
+    public void Extract_CommonLisp_DetectsTopLevelDefinitions()
+    {
+        // Common Lisp: package, classes, structs, variables, functions / Common Lisp: パッケージ、クラス、構造体、変数、関数
+        var content = """
+            (defpackage :my-app
+              (:use :cl))
+
+            (in-package :my-app)
+
+            (defclass widget ()
+              ())
+
+            (defstruct point
+              x
+              y)
+
+            (defparameter *default-size* 42)
+
+            (defun render (widget)
+              widget)
+
+            (defmacro with-widget ((widget) &body body)
+              `(let ((,widget ,widget))
+                 ,@body))
+            """;
+        var symbols = SymbolExtractor.Extract(1, "commonlisp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == ":my-app");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "widget");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "point");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "*default-size*");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "with-widget");
+    }
+
     [Theory]
     [InlineData("csharp", "public interface IFoo { }", "interface")]
     [InlineData("csharp", "public enum Color { }", "enum")]


### PR DESCRIPTION
## Summary

- Added Common Lisp symbol extraction for `defpackage`, `defclass`, `defstruct`, `defparameter`/`defvar`/`defconstant`, `defun`, `defmacro`, `defgeneric`, and `defmethod`.
- Added regression coverage for Common Lisp top-level definitions.
- Updated the README language support table to reflect the new Common Lisp symbol coverage.

## Validation

- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog

- Updated `README.md`.
- Added `changelog.d/unreleased/+commonlisp-search.fixed.md`.

## Follow-up candidates

- Add comparable symbol extraction for `racket` and other Lisp-family syntaxes that still fall back to file-only indexing.
- Consider capturing additional Common Lisp forms such as `in-package` or `setf` method names if they become important search targets.