### PR TITLE
Improve PHP trait symbol indexing

### DIFF
--- a/changelog.d/unreleased/+php-trait-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-trait-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP trait declarations now get their own symbol kind** — `trait Foo {}` is indexed as `trait` instead of `interface`, so PHP projects surface trait names more accurately in symbol search and navigation.
+
+## 日本語
+
+- **PHP の trait 宣言が専用のシンボル種別で索引されるようになりました** — `trait Foo {}` は `interface` ではなく `trait` として索引されるため、PHP プロジェクトで trait 名がシンボル検索とナビゲーションにより正確に現れます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1147,7 +1147,7 @@ public static class SymbolExtractor
             // 拡張修飾子対応: abstract, final, readonly (PHP 8.2+)
             new("class",    new Regex(@"^\s*(?:(?:abstract|final|readonly)\s+)*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("interface", new Regex(@"^\s*trait\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("trait", new Regex(@"^\s*trait\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("property", new Regex(@"^\s*case\s+(?<name>\w+)(?:\s*=\s*(?<returnType>[^;]+?))?\s*;", RegexOptions.Compiled), BodyStyle.None, ReturnTypeGroup: "returnType"),
             // Namespace / 名前空間

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11849,12 +11849,33 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_PHP_DetectsFunctionsAndClasses()
     {
-        // PHP: function, class, interface / PHP: 関数、クラス、インターフェース
+        // PHP: function, class, trait / PHP: 関数、クラス、トレイト
         var content = "class AuthService {\n    public function login($user) {\n    }\n}";
         var symbols = SymbolExtractor.Extract(1, "php", content);
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "AuthService");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "login");
+    }
+
+    [Fact]
+    public void Extract_PHP_DetectsTraits()
+    {
+        var content = """
+            <?php
+
+            trait InteractsWithCache {
+                public function remember(): void {}
+            }
+
+            class Example {
+                use InteractsWithCache;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "trait" && s.Name == "InteractsWithCache");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "remember");
     }
 
     [Fact]
@@ -15777,6 +15798,7 @@ public class SymbolExtractorTests
     [InlineData("cpp", "struct Config { };", "struct")]
     [InlineData("cpp", "enum Color { RED };", "enum")]
     [InlineData("php", "interface Foo { }", "interface")]
+    [InlineData("php", "trait Foo { }", "trait")]
     [InlineData("php", "enum Color { }", "enum")]
     [InlineData("scala", "trait Foo", "interface")]
     [InlineData("scala", "enum Color", "enum")]


### PR DESCRIPTION
## Summary
- PHP trait declarations are now indexed as `trait` instead of `interface`.
- Added PHP symbol extraction coverage for trait declarations.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs and changelog
- Added `changelog.d/unreleased/+php-trait-symbols.fixed.md`.
- No additional docs were needed because the change is covered by tests and the changelog fragment.

## Follow-up candidates
- None.