### PR TITLE
Index Objective-C enum macros

### DIFF
--- a/changelog.d/unreleased/+objc-ns-enum.fixed.md
+++ b/changelog.d/unreleased/+objc-ns-enum.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Objective-C now indexes Apple enum macro typedefs** — `SymbolExtractor` now records `NS_ENUM`, `NS_OPTIONS`, `NS_EXTENSIBLE_ENUM`, and `NS_ERROR_ENUM` declarations as `enum` symbols, so common Objective-C type definitions show up in `symbols`, `definition`, and other search-driven views instead of being skipped.
+
+## 日本語
+
+- **Objective-C で Apple の enum マクロ typedef を索引するようになりました** — `SymbolExtractor` が `NS_ENUM`、`NS_OPTIONS`、`NS_EXTENSIBLE_ENUM`、`NS_ERROR_ENUM` を `enum` シンボルとして記録するため、Objective-C のよくある型定義が `symbols`、`definition`、その他の検索ベースの表示から落ちずに見えるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1187,6 +1187,10 @@ public static class SymbolExtractor
             new("class",    new Regex(@"^\s*@interface\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*@implementation\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*@protocol\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.Brace),
+            // Apple enum macros / Apple の enum マクロ
+            new("enum",     new Regex(@"^\s*typedef\s+(?:NS_(?:CLOSED_)?ENUM|NS_EXTENSIBLE_ENUM)\s*\([^,]+,\s*(?<name>\w+)\s*\)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("enum",     new Regex(@"^\s*typedef\s+NS_OPTIONS\s*\([^,]+,\s*(?<name>\w+)\s*\)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("enum",     new Regex(@"^\s*typedef\s+NS_ERROR_ENUM\s*\([^,]+,\s*(?<name>\w+)\s*\)", RegexOptions.Compiled), BodyStyle.Brace),
             new("property", new Regex(@"^\s*@property\b(?:\s*\([^)]*\))?.*?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*[+-]\s*\([^)]*\)\s*(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("import",   new Regex(@"^\s*#(?:import|include)\s+[<""](?<name>[^"">]+)[>""]", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10555,12 +10555,34 @@ public class SymbolExtractorTests
                 NSLog(@"Woof!");
             }
             @end
+
+            typedef NS_ENUM(NSInteger, FruitType) {
+                FruitTypeApple,
+                FruitTypeOrange,
+            };
+
+            typedef NS_EXTENSIBLE_ENUM(NSInteger, FruitMood) {
+                FruitMoodRipe,
+            };
+
+            typedef NS_OPTIONS(NSUInteger, FruitOptions) {
+                FruitOptionJuicy = 1 << 0,
+                FruitOptionCitrus = 1 << 1,
+            };
+
+            typedef NS_ERROR_ENUM(NSInteger, FruitError) {
+                FruitErrorUnknown,
+            };
             """;
         var symbols = SymbolExtractor.Extract(1, "objc", content);
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Dog");
         Assert.Equal(2, symbols.Count(s => s.Kind == "class" && s.Name == "Dog"));
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Animal");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitType");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitMood");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitOptions");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitError");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "age");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "bark");


### PR DESCRIPTION
## Summary

- Add Objective-C symbol extraction for Apple enum macro typedefs (`NS_ENUM`, `NS_OPTIONS`, `NS_EXTENSIBLE_ENUM`, `NS_ERROR_ENUM`).
- Cover the new behavior with a regression test in `SymbolExtractorTests`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SymbolExtractorTests`
- `dotnet test`

## Documentation / Changelog

- Added `changelog.d/unreleased/+objc-ns-enum.fixed.md`.
- No direct `CHANGELOG.md` edit was needed because this is an ordinary implementation PR.

## Follow-up candidates

- None in this PR.
