### PR TITLE
Exclude Python conftest helpers from search results

### DIFF
--- a/changelog.d/unreleased/+python-conftest-exclude-tests.fixed.md
+++ b/changelog.d/unreleased/+python-conftest-exclude-tests.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`--exclude-tests` now filters Python `conftest.py` helper files** — search commands treat `conftest.py` as test support, so Python projects can drop fixture-only files from search results along with regular test modules.
+
+## 日本語
+
+- **`--exclude-tests` が Python の `conftest.py` 補助ファイルも除外するようになりました** — 検索コマンドは `conftest.py` を test support とみなすため、Python プロジェクトでは通常のテストモジュールと同様に fixture 専用ファイルを検索結果から外せます。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -94,6 +94,8 @@ public partial class DbReader
             lower(f.path) LIKE '%/test\_%' ESCAPE '\' OR
             lower(f.path) LIKE '%\_tests.%' ESCAPE '\' OR
             lower(f.path) LIKE '%\_test.%' ESCAPE '\' OR
+            lower(f.path) LIKE 'conftest.py' OR
+            lower(f.path) LIKE '%/conftest.py' OR
             lower(f.path) LIKE '%.spec.%' OR
             lower(f.path) LIKE '%.test.%'
         )";

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -7665,6 +7665,41 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSearch_ExcludeTestsSkipsPythonConftestFiles()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_conftest_exclude");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = "python_conftest_fixture_8bb7c4";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/conftest.py",
+                "python",
+                $"fixture_token = \"{queryToken}\"\n");
+
+            var withoutExclude = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--count"],
+                _jsonOptions));
+            var withExclude = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--exclude-tests", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, withoutExclude.Result);
+            Assert.Equal("1", withoutExclude.Stdout.Trim());
+            Assert.Equal(string.Empty, withoutExclude.Stderr);
+
+            Assert.Equal(CommandExitCodes.Success, withExclude.Result);
+            Assert.Equal("0", withExclude.Stdout.Trim());
+            Assert.Equal(string.Empty, withExclude.Stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSearch_ExactSubstringHumanSnippetUsesCaseSensitiveFocusLine()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_human_snippet");


### PR DESCRIPTION
## Summary
- Treat Python `conftest.py` helper files as test files for `--exclude-tests`.
- Add a CLI regression test that proves search returns the file without the flag and excludes it with the flag.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExcludeTestsSkipsPythonConftestFiles`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DbReaderTests.GetFileDependencyHints_MetadataBypassAmbiguityGuard_RespectsExcludeTests`

## Documentation / Changelog
- Added `changelog.d/unreleased/+python-conftest-exclude-tests.fixed.md`.

## Follow-up candidates
- None identified.