### PR TITLE
Index TypeScript auto-accessor fields

### DIFF
--- a/changelog.d/unreleased/+ts-accessor-class-fields.fixed.md
+++ b/changelog.d/unreleased/+ts-accessor-class-fields.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **TypeScript auto-accessor class fields are now indexed as properties** — `accessor foo: T;` members inside classes are recognized as `property` symbols, which makes search and outline results include these modern TypeScript declarations.
+
+## 日本語
+
+- **TypeScript の auto-accessor クラスフィールドを property として索引化するようになりました** — クラス内の `accessor foo: T;` メンバーを `property` シンボルとして認識するため、検索や outline に最新の TypeScript 宣言が表示されるようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -9521,6 +9521,46 @@ public static class SymbolExtractor
                     && classScanTarget.ContainerKind is "interface" or "class"
                     && StartsJavaScriptTypeScriptClassMemberAt(sanitizedLine, column))
                 {
+                    if (lang == "typescript"
+                        && classScanTarget.ContainerKind == "class"
+                        && TryParseJavaScriptTypeScriptAccessorFieldHeader(
+                            sanitizedLine,
+                            column,
+                            out var accessorName,
+                            out var accessorVisibility,
+                            out var accessorTypeStartColumn,
+                            out var accessorTypeEndColumn,
+                            out var accessorHeaderEndColumn))
+                    {
+                        var accessorStartLine = i + 1;
+                        if (seenMethodStarts.Add((accessorStartLine, column)))
+                        {
+                            var accessorSignatureEnd = accessorHeaderEndColumn < line.Length
+                                ? accessorHeaderEndColumn + 1
+                                : line.Length;
+                            symbols.Add(new SymbolRecord
+                            {
+                                FileId = fileId,
+                                Kind = "property",
+                                Name = accessorName,
+                                Line = accessorStartLine,
+                                StartLine = accessorStartLine,
+                                EndLine = accessorStartLine,
+                                BodyStartLine = null,
+                                BodyEndLine = null,
+                                Signature = line[column..accessorSignatureEnd].Trim(),
+                                ContainerKind = classScanTarget.ContainerKind,
+                                ContainerName = classScanTarget.ContainerName,
+                                Visibility = accessorVisibility,
+                                ReturnType = NormalizeMetadata(
+                                    line[(accessorTypeStartColumn + 1)..(accessorTypeEndColumn + 1)]),
+                            });
+                        }
+
+                        column = accessorHeaderEndColumn + 1;
+                        continue;
+                    }
+
                     var requireAbstractModifier = classScanTarget.ContainerKind == "class";
                     if (TryParseJavaScriptTypeScriptMemberPropertyHeader(
                         sanitizedLine,
@@ -13213,6 +13253,7 @@ public static class SymbolExtractor
 
         var index = Math.Max(0, startColumn);
         var sawAbstract = false;
+        var sawAccessor = false;
         var sawName = false;
 
         while (index < sanitizedLine.Length)
@@ -13235,7 +13276,7 @@ public static class SymbolExtractor
                 continue;
             }
 
-            if (token is "static" or "readonly" or "override" or "declare")
+            if (token is "static" or "readonly" or "override" or "declare" or "accessor")
             {
                 continue;
             }
@@ -13243,6 +13284,12 @@ public static class SymbolExtractor
             if (token == "abstract")
             {
                 sawAbstract = true;
+                continue;
+            }
+
+            if (token == "accessor")
+            {
+                sawAccessor = true;
                 continue;
             }
 
@@ -13257,7 +13304,7 @@ public static class SymbolExtractor
         if (!sawName)
             return false;
 
-        if (requireAbstractModifier && !sawAbstract)
+        if (requireAbstractModifier && !sawAbstract && !sawAccessor)
             return false;
 
         if (index < sanitizedLine.Length && sanitizedLine[index] == '?')
@@ -13640,6 +13687,87 @@ public static class SymbolExtractor
         }
 
         return false;
+    }
+
+    private static bool TryParseJavaScriptTypeScriptAccessorFieldHeader(
+        string sanitizedLine,
+        int startColumn,
+        out string name,
+        out string? visibility,
+        out int typeStartColumn,
+        out int typeEndColumn,
+        out int headerEndColumn)
+    {
+        name = string.Empty;
+        visibility = null;
+        typeStartColumn = -1;
+        typeEndColumn = -1;
+        headerEndColumn = -1;
+
+        var index = Math.Max(0, startColumn);
+        var sawAccessor = false;
+
+        while (index < sanitizedLine.Length)
+        {
+            while (index < sanitizedLine.Length && char.IsWhiteSpace(sanitizedLine[index]))
+                index++;
+
+            if (index >= sanitizedLine.Length)
+                return false;
+
+            if (!TryReadJavaScriptTypeScriptSourceMethodName(sanitizedLine, ref index, out var token))
+                return false;
+
+            while (index < sanitizedLine.Length && char.IsWhiteSpace(sanitizedLine[index]))
+                index++;
+
+            if (token is "public" or "private" or "protected")
+            {
+                visibility = token;
+                continue;
+            }
+
+            if (token is "static" or "readonly" or "override" or "declare")
+                continue;
+
+            if (token == "accessor")
+            {
+                sawAccessor = true;
+                continue;
+            }
+
+            if (!IsJavaScriptTypeScriptIdentifierStart(token[0]))
+                return false;
+
+            name = token;
+            break;
+        }
+
+        if (!sawAccessor)
+            return false;
+
+        if (index < sanitizedLine.Length && sanitizedLine[index] == '?')
+        {
+            index++;
+            while (index < sanitizedLine.Length && char.IsWhiteSpace(sanitizedLine[index]))
+                index++;
+        }
+
+        if (index >= sanitizedLine.Length || sanitizedLine[index] != ':')
+            return false;
+
+        typeStartColumn = index;
+        if (!TrySkipJavaScriptTypeScriptTypeAnnotationUntilSemicolon(sanitizedLine, ref index, out typeEndColumn))
+            return false;
+
+        while (index < sanitizedLine.Length && char.IsWhiteSpace(sanitizedLine[index]))
+            index++;
+
+        if (index >= sanitizedLine.Length || sanitizedLine[index] != ';')
+            return false;
+
+        headerEndColumn = index;
+        return true;
     }
 
     // Multi-line accumulating wrapper for class-field arrow functions. Mirrors

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -3145,6 +3145,22 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScript_DetectsAccessorClassFields()
+    {
+        var content = """
+            class Settings {
+                accessor theme: string;
+                accessor count: number;
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Settings");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "theme" && s.ContainerKind == "class" && s.ContainerName == "Settings" && s.ReturnType == "string");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "count" && s.ContainerKind == "class" && s.ContainerName == "Settings" && s.ReturnType == "number");
+    }
+
+    [Fact]
     public void Extract_TypeScript_DoesNotMergeAbstractMemberIntoFollowingConcreteMethod()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Added TypeScript class auto-accessor support so `accessor foo: T;` is indexed as a `property` symbol.
- Added a regression test covering `accessor` fields inside a class.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_TypeScript_DetectsAccessorClassFields|FullyQualifiedName~Extract_TypeScript_DetectsDeclarationOnlyMembersInDeclareClassAndInterface"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+ts-accessor-class-fields.fixed.md`

## Follow-up candidates

- Support initializer-bearing auto-accessors such as `accessor foo: T = ...;` if that syntax is needed in real projects.
- Broaden coverage for additional recent TypeScript class-member syntax if it shows up in search gaps.