### PR TITLE
Improve PowerShell alias symbol indexing

### DIFF
--- a/changelog.d/unreleased/+powershell-alias-symbols.fixed.md
+++ b/changelog.d/unreleased/+powershell-alias-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PowerShell alias definitions now surface in symbol search** — `Set-Alias` and `New-Alias` declarations are indexed as `alias`, so common shorthand entry points like `gci` and `ls` are easier to discover in PowerShell projects.
+
+## 日本語
+
+- **PowerShell の alias 定義がシンボル検索に現れるようになりました** — `Set-Alias` と `New-Alias` の宣言が `alias` として索引されるため、`gci` や `ls` のような一般的な短縮エントリポイントを PowerShell プロジェクトで見つけやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1498,6 +1498,8 @@ public static class SymbolExtractor
             // コンストラクタは class 本体内に置かれる bare な class-name 宣言なので、
             // PascalCase の条件で cmdlet 風の呼び出しを大半弾きつつ、PS5+ の標準形を拾う。
             new("function", new Regex(@"^\s*(?<name>[A-Z]\w*)\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            // Alias definitions / エイリアス定義
+            new("alias", new Regex(@"^\s*(?:Set-Alias|New-Alias)\s+(?:-Name\s+)?(?<name>[\w-]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             // Attributes and typed properties / 属性付きプロパティと型付きプロパティ
             new("property", new Regex(@"^\s*(?:(?:static|hidden)\s+)*(?:\[[^\]]+\]\s*)+\$(?<name>\w+)\s*(?:=|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             // Class (PowerShell 5+) / クラス (PowerShell 5+)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -16212,6 +16212,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PowerShell_DetectsAliasDefinitions()
+    {
+        const string content = """
+            Set-Alias gci Get-ChildItem
+            New-Alias -Name ls -Value Get-ChildItem
+
+            function Show-Items {
+                gci
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "powershell", content);
+
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "gci");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "ls");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Show-Items");
+    }
+
+    [Fact]
     public void Extract_PowerShell_DetectsClassMembersAndEnumValues()
     {
         var content = """


### PR DESCRIPTION
## Summary
- PowerShell alias declarations are now indexed as `alias`.
- `Set-Alias` and `New-Alias` definitions such as `gci` and `ls` are now discoverable in symbol search.
- Added focused test coverage for alias extraction.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~PowerShell"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs and changelog
- Added `changelog.d/unreleased/+powershell-alias-symbols.fixed.md`.
- No other docs needed because this is a targeted additive search improvement.

## Follow-up candidates
- None.