### PR TITLE
Improve Ruby block range masking

### DIFF
--- a/changelog.d/unreleased/+ruby-end-masking.fixed.md
+++ b/changelog.d/unreleased/+ruby-end-masking.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- Ruby `def`/`class` range detection now ignores `end` tokens inside strings and comments, so `definition`, `outline`, and related navigation stay accurate for common Ruby source patterns.
+
+## 日本語
+
+- Ruby の `def` / `class` の範囲判定で、文字列やコメント内の `end` を無視するようにしました。これにより、よくある Ruby ソースのパターンでも `definition` / `outline` などのナビゲーション精度が保たれます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1690,6 +1690,11 @@ public static class SymbolExtractor
 
     private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:class|module|def|if|unless|case|begin|do|while|until|for)\b", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
+    private sealed class RubyMaskState
+    {
+        public bool InSingleQuote { get; set; }
+        public bool InDoubleQuote { get; set; }
+    }
     private static readonly Regex ElixirBlockStartRegex = new(@"^\s*(?:defmodule|defprotocol|defimpl|defmacro|defguardp?|defp?)\b", RegexOptions.Compiled);
     private static readonly Regex ElixirBlockTokenRegex = new(@"\b(?:do|fn|end)\b(?!:)", RegexOptions.Compiled);
     private static readonly Regex ElixirDoShorthandRegex = new(@",\s*do:\s*", RegexOptions.Compiled);
@@ -14703,12 +14708,16 @@ public static class SymbolExtractor
         if (!RubyBlockStartRegex.IsMatch(firstLine))
             return (startIndex + 1, null, null);
 
+        var scanState = new RubyMaskState();
+        var maskedFirstLine = MaskRubyLineForBodyScan(firstLine, scanState);
         int depth = 0;
         int? bodyStartLine = null;
 
         for (int i = startIndex; i < lines.Length; i++)
         {
-            var trimmed = lines[i].Trim();
+            var trimmed = i == startIndex
+                ? maskedFirstLine.Trim()
+                : MaskRubyLineForBodyScan(lines[i], scanState).Trim();
             if (trimmed.Length == 0)
                 continue;
 
@@ -14735,6 +14744,67 @@ public static class SymbolExtractor
         return bodyStartLine == null
             ? (startIndex + 1, null, null)
             : (lines.Length, bodyStartLine, lines.Length);
+    }
+
+    private static string MaskRubyLineForBodyScan(string line, RubyMaskState state)
+    {
+        var masked = line.ToCharArray();
+
+        for (int i = 0; i < line.Length; i++)
+        {
+            if (state.InSingleQuote)
+            {
+                masked[i] = ' ';
+                if (line[i] == '\\' && i + 1 < line.Length)
+                {
+                    masked[++i] = ' ';
+                    continue;
+                }
+
+                if (line[i] == '\'')
+                    state.InSingleQuote = false;
+
+                continue;
+            }
+
+            if (state.InDoubleQuote)
+            {
+                masked[i] = ' ';
+                if (line[i] == '\\' && i + 1 < line.Length)
+                {
+                    masked[++i] = ' ';
+                    continue;
+                }
+
+                if (line[i] == '"')
+                    state.InDoubleQuote = false;
+
+                continue;
+            }
+
+            if (line[i] == '#')
+            {
+                for (int j = i; j < line.Length; j++)
+                    masked[j] = ' ';
+                break;
+            }
+
+            if (line[i] == '\'')
+            {
+                masked[i] = ' ';
+                state.InSingleQuote = true;
+                continue;
+            }
+
+            if (line[i] == '"')
+            {
+                masked[i] = ' ';
+                state.InDoubleQuote = true;
+                continue;
+            }
+        }
+
+        return new string(masked);
     }
 
     private static (int EndLine, int? BodyStartLine, int? BodyEndLine) FindElixirRange(string[] lines, int startIndex)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11854,6 +11854,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_IgnoresEndInsideStringsAndComments()
+    {
+        var content = "class UserService\n  def find_user(id)\n    puts \"the word end should not close this block\"\n    # end should not close this block either\n    id\n  end\nend";
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s =>
+            s.Kind == "class"
+            && s.Name == "UserService"
+            && s.StartLine == 1
+            && s.EndLine == 7
+            && s.BodyStartLine == 2
+            && s.BodyEndLine == 7);
+
+        Assert.Contains(symbols, s =>
+            s.Kind == "function"
+            && s.Name == "find_user"
+            && s.StartLine == 2
+            && s.EndLine == 6
+            && s.BodyStartLine == 3
+            && s.BodyEndLine == 6);
+    }
+
+    [Fact]
     public void Extract_PHP_DetectsFunctionsAndClasses()
     {
         // PHP: function, class, interface / PHP: 関数、クラス、インターフェース


### PR DESCRIPTION
## Summary

- Ruby `def`/`class` range detection now ignores `end` tokens inside strings and comments.
- This keeps `definition`, `outline`, and related navigation accurate for common Ruby source patterns.
- Added a regression test covering `end` inside both a string literal and a comment.

## Validation

- `dotnet build`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added a bilingual changelog fragment at `changelog.d/unreleased/+ruby-end-masking.fixed.md`.
