### PR TITLE
Normalize Windows batch language aliases

### DIFF
--- a/changelog.d/unreleased/+bat-lang-alias.changed.md
+++ b/changelog.d/unreleased/+bat-lang-alias.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Windows batch `--lang` aliases now map to `batch`** — query commands that accept `--lang` now canonicalize `bat` and `cmd` to `batch`, so Windows batch searches keep working with the shorthand names users commonly type.
+
+## 日本語
+
+- **Windows バッチ向けの `--lang` 別名が `batch` に正規化されるようになりました** — `--lang` を受け付けるクエリ系コマンドで `bat` と `cmd` を `batch` に正規化するため、Windows バッチ検索でもユーザーがよく入力する短縮名のまま検索できます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -23,6 +23,8 @@ public static class QueryCommandRunner
     private const string HotspotsGroupedByNameKind = "name_kind";
     private static readonly Dictionary<string, string> LangFilterAliases = new(StringComparer.Ordinal)
     {
+        ["bat"] = "batch",
+        ["cmd"] = "batch",
         ["py"] = "python",
         ["py3"] = "python",
         ["pyi"] = "python",

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -113,6 +113,8 @@ public class QueryCommandRunnerTests
     }
 
     [Theory]
+    [InlineData("bat", "batch")]
+    [InlineData("cmd", "batch")]
     [InlineData("Python", "python")]
     [InlineData("py", "python")]
     [InlineData("PY3", "python")]
@@ -123,6 +125,36 @@ public class QueryCommandRunnerTests
         var options = QueryCommandRunner.ParseArgs(["needle", "--lang", input], jsonDefault: false);
 
         Assert.Equal(expected, options.Lang);
+    }
+
+    [Theory]
+    [InlineData("bat")]
+    [InlineData("cmd")]
+    public void RunSearch_NormalizesBatchLangAliases(string input)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_batch_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = "batch_lang_alias_7a24d1";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "scripts/run.bat",
+                "batch",
+                $"echo {queryToken}\r\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--lang", input, "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- Canonicalize `bat` and `cmd` to `batch` for query commands that accept `--lang`.
- Add regression coverage for parsing and search results with the Windows batch aliases.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.ParseArgs_NormalizesLangAliases|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_NormalizesBatchLangAliases"`

## Documentation / Changelog
- Added `changelog.d/unreleased/+bat-lang-alias.changed.md`.

## Follow-up candidates
- Consider surfacing the `bat` / `cmd` aliases in any user-facing CLI help or generated completion text if the repository starts documenting language aliases explicitly.