### PR TITLE
Expand Lisp-family search coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,8 +640,8 @@ The database reflects the working tree at the time of the last index. After swit
 | Verilog | `.v` | -- |
 | SystemVerilog | `.sv`, `.svh` | -- |
 | VHDL | `.vhd`, `.vhdl` | -- |
-| Common Lisp | `.lisp`, `.lsp`, `.cl` | yes (defpackage, defclass, defstruct, defun/defmacro/defgeneric/defmethod) |
-| Racket | `.rkt` | -- |
+| Common Lisp | `.lisp`, `.lsp`, `.cl` | yes (defpackage, in-package, defclass, defstruct, defun/defmacro/defgeneric/defmethod) |
+| Racket | `.rkt` | yes (module, define, struct, require) |
 | Pascal | `.pas`, `.pp`, `.dpr` | -- |
 | Ada | `.ada`, `.adb`, `.ads` | -- |
 | Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` | -- |

--- a/changelog.d/unreleased/+lisp-family-followup.fixed.md
+++ b/changelog.d/unreleased/+lisp-family-followup.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **Racket and Common Lisp follow-up search coverage now surface additional top-level forms** — following up on PR #1175, `cdidx` now extracts Racket `module`, `define`, `struct`, and `require` symbols and also recognizes Common Lisp `in-package` package contexts, so Lisp-family projects no longer fall back to file-only results as often.
+
+## 日本語
+
+- **Racket と Common Lisp の follow-up 検索カバレッジが追加のトップレベル構文を拾うようになりました** — PR #1175 の follow-up として、`cdidx` は Racket の `module`、`define`、`struct`、`require` を抽出し、Common Lisp の `in-package` パッケージ文脈も認識するため、Lisp 系プロジェクトでファイル単位の結果に落ちるケースがさらに減ります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1273,10 +1273,19 @@ public static class SymbolExtractor
         ["commonlisp"] =
         [
             new("namespace", new Regex(@"^\s*\(\s*defpackage\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("import",    new Regex(@"^\s*\(\s*in-package\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("class",     new Regex(@"^\s*\(\s*defclass\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("struct",    new Regex(@"^\s*\(\s*defstruct\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property",  new Regex(@"^\s*\(\s*(?:defparameter|defvar|defconstant)\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function",  new Regex(@"^\s*\(\s*(?:defun|defmacro|defgeneric|defmethod)\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+        ],
+        ["racket"] =
+        [
+            new("namespace", new Regex(@"^\s*\(\s*module(?:\*|\+)?\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("function",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser)?|-values)?\s+\(\s*(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser)?|-values)?\s+(?<name>[^\s()()]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("struct",    new Regex(@"^\s*\(\s*struct\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("import",    new Regex(@"^\s*\(\s*require\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
         ],
         ["dart"] =
         [

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15832,11 +15832,38 @@ public class SymbolExtractorTests
         var symbols = SymbolExtractor.Extract(1, "commonlisp", content);
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == ":my-app");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == ":my-app");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "widget");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "point");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "*default-size*");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "with-widget");
+    }
+
+    [Fact]
+    public void Extract_Racket_DetectsModuleAndDefinitions()
+    {
+        // Racket: module, define, struct, require / Racket: module、define、struct、require
+        var content = """
+            #lang racket
+
+            (module app racket
+              (require racket/list)
+
+              (define answer 42)
+
+              (define (render value)
+                value)
+
+              (struct point (x y)))
+            """;
+        var symbols = SymbolExtractor.Extract(1, "racket", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "app");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "racket/list");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "answer");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "point");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- Followed up on PR #1175 by adding Racket symbol coverage for `module`, `define`, `struct`, and `require`.
- Added a small Common Lisp follow-up so `in-package` also surfaces in search results.
- Added regression coverage for both language paths.
- Updated the README language support table to reflect the new coverage.

## Validation

- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog

- Updated `README.md`.
- Added `changelog.d/unreleased/+lisp-family-followup.fixed.md`.

## Follow-up candidates

- Broaden Racket coverage further if the repo starts relying on additional macro or module forms.
- Consider whether any other Common Lisp package-transition forms should be surfaced beyond `in-package`.
