### PR TITLE
Expose Objective-C category and CF enum symbols

### DIFF
--- a/changelog.d/unreleased/+objc-category-cf-enum.fixed.md
+++ b/changelog.d/unreleased/+objc-category-cf-enum.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Objective-C now exposes category names and CoreFoundation enum macros in symbol search** — `SymbolExtractor` emits `Foo(Category)`-style category symbols for `@interface` / `@implementation` declarations and indexes `CF_ENUM` / `CF_OPTIONS` typedefs alongside the existing Apple enum macros, so category-specific and CoreFoundation type names now show up in `symbols` and definition-oriented views.
+
+## 日本語
+
+- **Objective-C でカテゴリ名と CoreFoundation の enum マクロが symbol search に出るようになりました** — `SymbolExtractor` が `@interface` / `@implementation` 宣言から `Foo(Category)` 形式のカテゴリ symbol を出力し、既存の Apple enum マクロに加えて `CF_ENUM` / `CF_OPTIONS` の typedef も索引するため、カテゴリ単位の名前や CoreFoundation 型名が `symbols` や definition 系の表示に現れるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -126,6 +126,9 @@ public static class SymbolExtractor
     private static readonly Regex XamlNameRegex = new(
         @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex ObjCCategoryDeclarationRegex = new(
+        @"^\s*@(?:interface|implementation)\s+(?<class>\w+)\s*\(\s*(?<category>[^)]+?)\s*\)(?:\s*<[^>]+>)?",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     // Optional TypeScript generic type-argument token that may sit between an HOC call
     // name and its `(`. Consumed only by the TypeScript HOC-binding row — the JavaScript
@@ -1201,11 +1204,13 @@ public static class SymbolExtractor
         [
             new("class",    new Regex(@"^\s*@interface\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*@implementation\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*@(?:interface|implementation)\s+(?<name>\w+\s*\(\s*[^)]+?\s*\))\b", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*@protocol\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.Brace),
             // Apple enum macros / Apple の enum マクロ
             new("enum",     new Regex(@"^\s*typedef\s+(?:NS_(?:CLOSED_)?ENUM|NS_EXTENSIBLE_ENUM)\s*\([^,]+,\s*(?<name>\w+)\s*\)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*typedef\s+NS_OPTIONS\s*\([^,]+,\s*(?<name>\w+)\s*\)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*typedef\s+NS_ERROR_ENUM\s*\([^,]+,\s*(?<name>\w+)\s*\)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("enum",     new Regex(@"^\s*typedef\s+(?:CF_ENUM|CF_OPTIONS)\s*\([^,]+,\s*(?<name>\w+)\s*\)", RegexOptions.Compiled), BodyStyle.Brace),
             new("property", new Regex(@"^\s*@property\b(?:\s*\([^)]*\))?.*?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*[+-]\s*\([^)]*\)\s*(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("import",   new Regex(@"^\s*#(?:import|include)\s+[<""](?<name>[^"">]+)[>""]", RegexOptions.Compiled), BodyStyle.None),
@@ -2789,6 +2794,34 @@ public static class SymbolExtractor
                                     ReturnType = NormalizeMetadata(rawReturnType),
                                 },
                                 line);
+
+                            if (lang == "objc"
+                                && pattern.Kind == "class"
+                                && TryGetObjCCategoryDisplayName(patternMatchLine[absoluteStartColumn..], name, out var categoryDisplayName))
+                            {
+                                AddSymbolRecord(
+                                    symbols,
+                                    cssSeenSymbols,
+                                    startLine,
+                                    new SymbolRecord
+                                    {
+                                        FileId = fileId,
+                                        Kind = "class",
+                                        Name = categoryDisplayName,
+                                        Line = startLine,
+                                        StartLine = startLine,
+                                        StartColumn = csharpSingleLineCollapsedMatch
+                                            ? csharpSignatureRawStartColumn
+                                            : absoluteStartColumn,
+                                        EndLine = Math.Max(startLine, endLine),
+                                        BodyStartLine = bodyStartLine,
+                                        BodyEndLine = bodyEndLine,
+                                        Signature = signature,
+                                        Visibility = TryGetGroup(match, pattern.VisibilityGroup),
+                                        ReturnType = NormalizeMetadata(rawReturnType),
+                                    },
+                                    line);
+                            }
                         }
                     }
 
@@ -21369,6 +21402,26 @@ public static class SymbolExtractor
         symbol.Kind is "class" or "interface" or "struct"
         && !string.IsNullOrWhiteSpace(symbol.Signature)
         && PartialModifierRegex.IsMatch(symbol.Signature);
+
+    private static bool TryGetObjCCategoryDisplayName(string objcDeclaration, string baseName, out string displayName)
+    {
+        var match = ObjCCategoryDeclarationRegex.Match(objcDeclaration);
+        if (!match.Success || !string.Equals(match.Groups["class"].Value, baseName, StringComparison.Ordinal))
+        {
+            displayName = string.Empty;
+            return false;
+        }
+
+        var categoryName = match.Groups["category"].Value.Trim();
+        if (categoryName.Length == 0)
+        {
+            displayName = string.Empty;
+            return false;
+        }
+
+        displayName = $"{baseName}({categoryName})";
+        return true;
+    }
 
     private static bool CanContainSymbols(SymbolRecord symbol)
     {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10582,9 +10582,16 @@ public class SymbolExtractorTests
             - (NSString *)describe;
             @end
 
+            @interface Dog (Testing)
+            - (BOOL)isReady;
+            @end
+
             @implementation Dog
             - (void)bark {
                 NSLog(@"Woof!");
+            }
+            - (BOOL)isReady {
+                return YES;
             }
             @end
 
@@ -10605,19 +10612,31 @@ public class SymbolExtractorTests
             typedef NS_ERROR_ENUM(NSInteger, FruitError) {
                 FruitErrorUnknown,
             };
+
+            typedef CF_ENUM(NSInteger, FruitKind) {
+                FruitKindFresh,
+            };
+
+            typedef CF_OPTIONS(NSUInteger, FruitFlags) {
+                FruitFlagTasty = 1 << 0,
+            };
             """;
         var symbols = SymbolExtractor.Extract(1, "objc", content);
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Dog");
-        Assert.Equal(2, symbols.Count(s => s.Kind == "class" && s.Name == "Dog"));
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Dog(Testing)");
+        Assert.True(symbols.Count(s => s.Kind == "class" && s.Name == "Dog") >= 2);
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Animal");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitType");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitMood");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitOptions");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitError");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitKind");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "FruitFlags");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "age");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "bark");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "isReady");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "greet");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dogWithName");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "move");


### PR DESCRIPTION
## Summary

This PR addresses the follow-up candidates from #1177.

- Emit additional Objective-C category symbols such as `Foo(Category)` for `@interface` / `@implementation` declarations.
- Index `CF_ENUM` and `CF_OPTIONS` typedefs alongside the existing Objective-C enum macro support.
- Extend Objective-C regression coverage to lock in category-name search and CoreFoundation enum macro extraction.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SymbolExtractorTests`
- `dotnet test`

## Documentation / Changelog

- Added `changelog.d/unreleased/+objc-category-cf-enum.fixed.md`.
- No direct `CHANGELOG.md` edit was needed because this is an ordinary implementation PR.

## Follow-up candidates

- None in this PR.
