### PR TITLE
Index annotated Kotlin declarations

### DIFF
--- a/changelog.d/unreleased/+kotlin-annotated-decls.fixed.md
+++ b/changelog.d/unreleased/+kotlin-annotated-decls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Kotlin annotation-bearing declarations are indexed now** — `SymbolExtractor` now skips leading Java/Kotlin-style annotations before matching declarations, so `@Serializable data class`, `@Deprecated fun`, and annotated secondary constructors stay searchable instead of being missed.
+
+## 日本語
+
+- **Kotlin の annotation 付き宣言が index されるようになりました** — `SymbolExtractor` が Java/Kotlin 風の先頭 annotation を宣言マッチ前に読み飛ばすため、`@Serializable data class`、`@Deprecated fun`、annotation 付き secondary constructor が検索対象から漏れなくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1964,7 +1964,7 @@ public static class SymbolExtractor
                     while (lineOffset >= 0 && lineOffset < patternMatchLine.Length)
                     {
                         var javaLeadingAnnotationOffset = 0;
-                        var match = lang == "java"
+                        var match = lang is "java" or "kotlin"
                             ? (TryMatchJavaDeclarationSegment(pattern.Regex, patternMatchLine[lineOffset..], out var javaMatch, out javaLeadingAnnotationOffset)
                                 ? javaMatch
                                 : pattern.Regex.Match(patternMatchLine[lineOffset..]))
@@ -19803,7 +19803,7 @@ public static class SymbolExtractor
 
         var recordRegex = GetCurrentDeclarationRecordRegex(lang, kind, recordName);
         var javaLeadingAnnotationOffset = 0;
-        var recordMatch = lang == "java"
+        var recordMatch = lang is "java" or "kotlin"
             ? (TryMatchJavaDeclarationSegment(recordRegex, declaration, out var javaRecordMatch, out javaLeadingAnnotationOffset)
                 ? javaRecordMatch
                 : recordRegex.Match(declaration))

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11714,6 +11714,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Kotlin_AnnotatedDeclarations_AreStillIndexed()
+    {
+        var content = """
+            @Serializable
+            class Envelope { }
+
+            @Deprecated("use markedV2")
+            fun marked(): Int = 1
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Envelope");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "marked");
+    }
+
+    [Fact]
     public void Extract_Kotlin_DetectsExpandedFeatures()
     {
         var content = "sealed interface Shape\nvalue class Email(val value: String)\ninner class Handler\n\ncompanion object {\n    const val MAX = 100\n}\n\nfun String.truncate(max: Int): String = take(max)\nsuspend fun fetchData(): List<Int> = emptyList()\ninline fun <reified T> parse(json: String): T = TODO()";


### PR DESCRIPTION
## Summary
- Teach `SymbolExtractor` to skip leading Java/Kotlin-style annotations when matching Kotlin declarations.
- This keeps annotated Kotlin classes and functions searchable instead of dropping them at index time.
- Add a regression test for annotated Kotlin declarations.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_AnnotatedDeclarations_AreStillIndexed|FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_DetectsSecondaryConstructors"`
- `dotnet test`

## Changelog
- Added fragment: `changelog.d/unreleased/+kotlin-annotated-decls.fixed.md`

## Follow-up candidates
- Kotlin use-site targets such as `@field:` / `@get:` before declarations are not explicitly covered yet.
- A dedicated regression for annotated Kotlin secondary constructors would be useful if those forms become a recurring source of misses.