### PR TITLE
Handle TypeScript auto-accessor initializers

### DIFF
--- a/changelog.d/unreleased/+ts-auto-accessor-initializer.fixed.md
+++ b/changelog.d/unreleased/+ts-auto-accessor-initializer.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **TypeScript auto-accessor fields with initializers are now indexed as properties** — `accessor foo: T = ...;` and `accessor foo = ...;` now emit `property` symbols and keep scanning through the initializer so later class members are still indexed correctly.
+
+## 日本語
+
+- **initializer 付きの TypeScript auto-accessor を property として index するようになりました** — `accessor foo: T = ...;` と `accessor foo = ...;` が `property` シンボルとして出力され、initializer をまたいでスキャンを継続するため後続のクラスメンバも正しく index されます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -9547,7 +9547,8 @@ public static class SymbolExtractor
                             out var accessorVisibility,
                             out var accessorTypeStartColumn,
                             out var accessorTypeEndColumn,
-                            out var accessorHeaderEndColumn))
+                            out var accessorHeaderEndColumn,
+                            out var accessorHasInitializer))
                     {
                         var accessorStartLine = i + 1;
                         if (seenMethodStarts.Add((accessorStartLine, column)))
@@ -9570,8 +9571,18 @@ public static class SymbolExtractor
                                 ContainerName = classScanTarget.ContainerName,
                                 Visibility = accessorVisibility,
                                 ReturnType = NormalizeMetadata(
-                                    line[(accessorTypeStartColumn + 1)..(accessorTypeEndColumn + 1)]),
+                                    accessorTypeStartColumn >= 0 && accessorTypeEndColumn >= accessorTypeStartColumn
+                                        ? line[(accessorTypeStartColumn + 1)..(accessorTypeEndColumn + 1)]
+                                        : null),
                             });
+                        }
+
+                        if (accessorHasInitializer)
+                        {
+                            inFieldInitializer = true;
+                            initializerParenDepth = 0;
+                            initializerBracketDepth = 0;
+                            initializerBraceDepth = 0;
                         }
 
                         column = accessorHeaderEndColumn + 1;
@@ -13874,13 +13885,15 @@ public static class SymbolExtractor
         out string? visibility,
         out int typeStartColumn,
         out int typeEndColumn,
-        out int headerEndColumn)
+        out int headerEndColumn,
+        out bool hasInitializer)
     {
         name = string.Empty;
         visibility = null;
         typeStartColumn = -1;
         typeEndColumn = -1;
         headerEndColumn = -1;
+        hasInitializer = false;
 
         var index = Math.Max(0, startColumn);
         var sawAccessor = false;
@@ -13931,21 +13944,123 @@ public static class SymbolExtractor
                 index++;
         }
 
-        if (index >= sanitizedLine.Length || sanitizedLine[index] != ':')
-            return false;
-
-        typeStartColumn = index;
-        if (!TrySkipJavaScriptTypeScriptTypeAnnotationUntilSemicolon(sanitizedLine, ref index, out typeEndColumn))
-            return false;
-
         while (index < sanitizedLine.Length && char.IsWhiteSpace(sanitizedLine[index]))
             index++;
 
-        if (index >= sanitizedLine.Length || sanitizedLine[index] != ';')
+        if (index >= sanitizedLine.Length)
+            return false;
+
+        if (sanitizedLine[index] == ':')
+        {
+            typeStartColumn = index;
+            if (!TrySkipJavaScriptTypeScriptTypeAnnotationUntilAccessorTerminator(sanitizedLine, ref index, out typeEndColumn, out hasInitializer))
+                return false;
+
+            while (index < sanitizedLine.Length && char.IsWhiteSpace(sanitizedLine[index]))
+                index++;
+        }
+        else if (sanitizedLine[index] == '=')
+        {
+            hasInitializer = true;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (index >= sanitizedLine.Length)
+            return false;
+
+        if (sanitizedLine[index] == '=')
+        {
+            hasInitializer = true;
+            headerEndColumn = index;
+            return true;
+        }
+
+        if (sanitizedLine[index] != ';')
             return false;
 
         headerEndColumn = index;
         return true;
+    }
+
+    // Walks a TypeScript accessor field type annotation from `:` to either a terminating `;` or
+    // a field initializer `=`. This mirrors the member-property helper but keeps the auto-accessor
+    // initializer boundary visible so the outer scanner can switch into field-initializer mode.
+    // TypeScript の accessor field 型注釈を `:` から終端 `;` または initializer `=` まで歩く。
+    // member-property 用 helper を踏襲しつつ、auto-accessor の initializer 境界を外側に見せることで、
+    // 呼び出し側が field-initializer モードへ切り替えられるようにする。
+    private static bool TrySkipJavaScriptTypeScriptTypeAnnotationUntilAccessorTerminator(
+        string sanitizedLine,
+        ref int index,
+        out int typeEndColumn,
+        out bool hasInitializer)
+    {
+        typeEndColumn = -1;
+        hasInitializer = false;
+
+        if (index >= sanitizedLine.Length || sanitizedLine[index] != ':')
+            return false;
+
+        var lastNonWs = index;
+        index++;
+
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        var braceDepth = 0;
+        var angleDepth = 0;
+
+        while (index < sanitizedLine.Length)
+        {
+            var ch = sanitizedLine[index];
+
+            if (ch == '=' && index + 1 < sanitizedLine.Length && sanitizedLine[index + 1] == '>')
+            {
+                if (parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && angleDepth == 0)
+                    lastNonWs = index + 1;
+                index += 2;
+                continue;
+            }
+
+            if (parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && angleDepth == 0)
+            {
+                if (ch == ';')
+                {
+                    typeEndColumn = lastNonWs;
+                    return true;
+                }
+
+                if (ch == '=')
+                {
+                    if (index + 1 < sanitizedLine.Length && sanitizedLine[index + 1] == '=')
+                    {
+                        index += 2;
+                        continue;
+                    }
+
+                    typeEndColumn = lastNonWs;
+                    hasInitializer = true;
+                    return true;
+                }
+
+                if (!char.IsWhiteSpace(ch))
+                    lastNonWs = index;
+            }
+
+            if (ch == '(') parenDepth++;
+            else if (ch == ')' && parenDepth > 0) parenDepth--;
+            else if (ch == '[') bracketDepth++;
+            else if (ch == ']' && bracketDepth > 0) bracketDepth--;
+            else if (ch == '{') braceDepth++;
+            else if (ch == '}' && braceDepth > 0) braceDepth--;
+            else if (ch == '<') angleDepth++;
+            else if (ch == '>' && angleDepth > 0) angleDepth--;
+
+            index++;
+        }
+
+        return false;
     }
 
     // Multi-line accumulating wrapper for class-field arrow functions. Mirrors

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -17505,6 +17505,36 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScript_DetectsAutoAccessorWithInitializer()
+    {
+        var content = """
+            class Foo {
+                accessor theme: string = "dark";
+                accessor count = 1;
+                handleClick = () => { return this.count; };
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+
+        var theme = symbols.FirstOrDefault(s => s.Kind == "property" && s.Name == "theme");
+        Assert.NotNull(theme);
+        Assert.Equal("class", theme.ContainerKind);
+        Assert.Equal("Foo", theme.ContainerName);
+        Assert.Equal("string", theme.ReturnType);
+
+        var count = symbols.FirstOrDefault(s => s.Kind == "property" && s.Name == "count");
+        Assert.NotNull(count);
+        Assert.Equal("class", count.ContainerKind);
+        Assert.Equal("Foo", count.ContainerName);
+        Assert.Null(count.ReturnType);
+
+        var handleClick = symbols.FirstOrDefault(s => s.Kind == "function" && s.Name == "handleClick");
+        Assert.NotNull(handleClick);
+        Assert.Equal("class", handleClick.ContainerKind);
+        Assert.Equal("Foo", handleClick.ContainerName);
+    }
+
+    [Fact]
     public void Extract_JavaScript_DetectsClassFieldArrowWithExpressionBody()
     {
         var content = """


### PR DESCRIPTION
## Summary

This is a follow-up to PR #1179 and addresses its remaining Follow-up candidates by extending TypeScript class-member indexing to cover auto-accessor initializers.

- `accessor foo: T = ...;` and `accessor foo = ...;` are now indexed as `property` symbols.
- The scanner now keeps consuming the initializer so later class members are still indexed correctly.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_TypeScript_DetectsAutoAccessorWithInitializer|FullyQualifiedName~Extract_TypeScript_DetectsClassFieldArrowFunctionWithTypes"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+ts-auto-accessor-initializer.fixed.md`

## Follow-up candidates addressed

- The remaining follow-up candidate from PR #1179 was the initializer-bearing TypeScript auto-accessor shape.
- This PR closes that gap; no additional follow-up candidates are intentionally included here.