### PR TITLE
Improve CSS property symbol indexing

### DIFF
--- a/changelog.d/unreleased/+css-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+css-property-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **CSS custom property registrations are now indexed** — `@property --accent-color` is surfaced as a `property`, so registered custom properties are easier to find alongside inline `--tokens` in CSS projects.
+
+## 日本語
+
+- **CSS のカスタムプロパティ登録が索引されるようになりました** — `@property --accent-color` が `property` として現れるため、登録済みのカスタムプロパティを CSS プロジェクトで inline の `--token` とあわせて見つけやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1454,6 +1454,8 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*@keyframes\s+(?<name>[\w-]+)", RegexOptions.Compiled), BodyStyle.Brace),
             // @font-face / フォントフェイス
             new("function", new Regex(@"^\s*@font-face\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.Brace),
+            // @property / カスタムプロパティ登録
+            new("property", new Regex(@"^\s*@property\s+(?<name>--[\w-]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.Brace),
             // @page / ページ規則
             new("namespace", new Regex(@"^\s*@page(?:\s+(?<name>:[\w-]+))?", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.Brace),
             // @namespace / 名前空間

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15950,6 +15950,12 @@ public class SymbolExtractorTests
               to { opacity: 1; }
             }
 
+            @property --accent-color {
+              syntax: "<color>";
+              inherits: true;
+              initial-value: #09f;
+            }
+
             .container {
               max-width: 1200px;
             }
@@ -15966,6 +15972,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "shade-color");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "flex-center");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "fade-in");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "--accent-color");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == ".container");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "#header");
     }


### PR DESCRIPTION
## Summary
- CSS `@property` registrations are now indexed as `property` symbols.
- Added test coverage for registered custom properties alongside existing CSS symbol detection.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_CSS_"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs and changelog
- Added `changelog.d/unreleased/+css-property-symbols.fixed.md`.
- No additional docs were needed because this is a targeted additive search improvement.

## Follow-up candidates
- None.