### PR TITLE
Show Windows batch aliases in CLI help

### DIFF
--- a/changelog.d/unreleased/+bat-lang-help-completion.changed.md
+++ b/changelog.d/unreleased/+bat-lang-help-completion.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+---
+
+## English
+
+- **Windows batch aliases now appear in CLI help and completions** — `--lang` help now mentions `bat` and `cmd` as aliases for `batch`, and shell completion lists them alongside the canonical language name so users can discover the shorthand directly from the CLI.
+
+## 日本語
+
+- **Windows バッチの alias が CLI help と補完候補に表示されるようになりました** — `--lang` の help に `batch` の別名として `bat` と `cmd` を明記し、シェル補完でも canonical な言語名と並んで候補に出すことで、CLI から短縮表記を見つけやすくしました。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -381,7 +381,7 @@ public static class ConsoleUi
         Console.WriteLine("  --db <path>                Database file path (default: .cdidx/codeindex.db in current directory)");
         Console.WriteLine("  --json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)");
         Console.WriteLine("  --limit <n>, --top <n>     Max results to return (default: 20)");
-        Console.WriteLine("  --lang <lang>              Filter by language");
+        Console.WriteLine("  --lang <lang>              Filter by language (aliases: bat, cmd)");
         Console.WriteLine("  --path <glob>              Restrict matches to glob-style path patterns (* and ?)");
         Console.WriteLine("  --query <query>            Pass a query literal, useful when the query starts with '-'");
         Console.WriteLine("  --exclude-path <glob>      Exclude glob-style path patterns (* and ?) (repeatable)");
@@ -571,7 +571,11 @@ public static class ConsoleUi
     /// 補完値用にFileIndexerからソート済みのユニークな言語名を取得する。
     /// </summary>
     private static string GetCompletionLangs() =>
-        string.Join(" ", FileIndexer.GetLanguageExtensions().Values.Distinct().OrderBy(l => l));
+        string.Join(" ", FileIndexer.GetLanguageExtensions().Values
+            .Append("bat")
+            .Append("cmd")
+            .Distinct()
+            .OrderBy(l => l));
 
     private static void PrintBashCompletions()
     {

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -58,6 +58,7 @@ public class ConsoleUiTests
         Assert.Contains("cdidx unused [--db <path>] [--json] [--limit <n>] [--kind <kind>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count]", output);
         Assert.Contains("cdidx hotspots [--db <path>] [--json] [--limit <n>] [--kind <kind>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count] [--group-by-name]", output);
         Assert.Contains("--json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)", output);
+        Assert.Contains("--lang <lang>              Filter by language (aliases: bat, cmd)", output);
         Assert.Contains("--group-by-name            hotspots: collapse rows sharing (name, kind) across files into one line", output);
         Assert.Contains("cdidx search \"Run();\" --exact-substring        Case-sensitive exact substring search", output);
         Assert.Contains("cdidx search --query --path --path README.md   Search for a literal option token", output);
@@ -328,6 +329,21 @@ public class ConsoleUiTests
                 Console.SetOut(originalOut);
             }
         }
+    }
+
+    [Fact]
+    public void GetCompletionLangs_IncludesWindowsBatchAliases()
+    {
+        var method = typeof(ConsoleUi).GetMethod("GetCompletionLangs", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        Assert.NotNull(method);
+        var value = method!.Invoke(null, []);
+
+        var langs = value?.ToString() ?? string.Empty;
+        var tokens = langs.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Contains("bat", tokens);
+        Assert.Contains("batch", tokens);
+        Assert.Contains("cmd", tokens);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- Surface the Windows batch aliases `bat` and `cmd` in the `--lang` help text.
- Include the same aliases in generated bash/zsh completion candidates.
- This explicitly addresses the follow-up candidate from PR #1184.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests.PrintUsage_WithoutBanner_HidesAsciiArtAndEasterEggFlags|FullyQualifiedName~ConsoleUiTests.PrintCompletions_KnownShell_ReturnsTrue|FullyQualifiedName~ConsoleUiTests.GetCompletionLangs_IncludesWindowsBatchAliases"`

## Documentation / Changelog
- Added `changelog.d/unreleased/+bat-lang-help-completion.changed.md`.

## Follow-up candidates
- None identified.