### PR TITLE
Handle generic Go functions

### DIFF
--- a/changelog.d/unreleased/+go-generic-functions.fixed.md
+++ b/changelog.d/unreleased/+go-generic-functions.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Go generic functions are now indexed** — `func Identity[T any](value T) T { ... }` now emits a `function` symbol instead of being skipped, so search and navigation find generic Go functions alongside ordinary ones.
+
+## 日本語
+
+- **Go のジェネリック関数を index するようになりました** — `func Identity[T any](value T) T { ... }` が `function` シンボルとして出力されるようになり、通常の Go 関数と同様に検索やナビゲーションで見つかるようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1018,7 +1018,7 @@ public static class SymbolExtractor
         ],
         ["go"] =
         [
-            new("function", new Regex(@"^func\s+(?:\([^)]+\)\s+)?(?<name>\w+)\s*[\(\[]", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^func\s+(?:\([^)]+\)\s+)?(?<name>\w+)(?:\[[^\]\r\n]+\])?\s*[\(\[]", RegexOptions.Compiled), BodyStyle.Brace),
             new("struct",   new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+struct\b", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+interface\b", RegexOptions.Compiled), BodyStyle.Brace),
             // Type alias (type Name = OtherType or type Name OtherType) / 型エイリアス

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9662,6 +9662,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Go_DetectsGenericFunctions()
+    {
+        var content = """
+            func Identity[T any](value T) T {
+                return value
+            }
+
+            func NewHandler() *Handler {
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Identity");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "NewHandler");
+        Assert.Equal(2, symbols.Count(s => s.Kind == "function"));
+    }
+
+    [Fact]
     public void Extract_Go_DetectsGenericTypeDeclarations()
     {
         var content = """


### PR DESCRIPTION
## Summary

This follow-up improves Go symbol search coverage by indexing generic functions such as `func Identity[T any](value T) T { ... }`.

- Generic Go functions now emit `function` symbols.
- Existing non-generic function and method detection remains unchanged.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Go_DetectsGenericFunctions|FullyQualifiedName~Extract_Go_DetectsFunctions|FullyQualifiedName~Extract_Go_DetectsTypeAliasAndConst"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+go-generic-functions.fixed.md`

## Follow-up candidates

- No additional Go follow-up candidates were intentionally included in this change.