### PR TITLE
Index C typedef aliases

### DIFF
--- a/changelog.d/unreleased/+c-typedef-aliases.fixed.md
+++ b/changelog.d/unreleased/+c-typedef-aliases.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C typedef aliases for tagged structs and enums are now indexed** — `SymbolExtractor` now records aliases such as `typedef struct Node Node_t;` and `typedef enum Mode Mode_t;`, so common C type names are searchable in `symbols` and definition-oriented views instead of being skipped.
+
+## 日本語
+
+- **C の tagged struct / enum の typedef alias を索引するようになりました** — `SymbolExtractor` が `typedef struct Node Node_t;` や `typedef enum Mode Mode_t;` のような alias を記録するため、よく使われる C の型名が `symbols` や definition 系の表示から落ちずに検索できるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1129,7 +1129,9 @@ public static class SymbolExtractor
             // #define macros / #define マクロ
             new("function", new Regex(@"^\s*#\s*define\s+(?<name>[A-Za-z_]\w*)\(", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*#\s*define\s+(?<name>[A-Za-z_]\w*)(?=\s|$)", RegexOptions.Compiled), BodyStyle.None),
+            new("struct",   new Regex(@"^\s*typedef\s+struct\s+(?:\w+\s*)?(?:\*+\s*)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*(?:typedef\s+)?struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("enum",     new Regex(@"^\s*typedef\s+enum\s+(?:\w+\s+)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*(?:typedef\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("import",   new Regex(@"^\s*#include\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
         ],

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12104,6 +12104,32 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_C_DetectsTypedefStructAndEnumAliases()
+    {
+        var content = """
+            typedef struct Node Node_t;
+            typedef struct Payload* PayloadRef;
+            typedef enum Mode Mode_t;
+
+            struct Node {
+                int value;
+            };
+
+            enum Mode {
+                ModeIdle,
+                ModeActive,
+            };
+            """;
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Node_t");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "PayloadRef");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Mode_t");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Node");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Mode");
+    }
+
+    [Fact]
     public void Extract_C_DoesNotCapturePrimitiveTypesForFunctionPointerTypedefs()
     {
         // C: function-pointer typedefs and ordinary functions / C: 関数ポインタ typedef と通常関数


### PR DESCRIPTION
## Summary

- Index C typedef aliases for tagged `struct` and `enum` declarations such as `typedef struct Node Node_t;` and `typedef enum Mode Mode_t;`.
- Keep the existing C type-name coverage for the original tag while exposing the alias for search-driven views.
- Add regression coverage for struct aliases, pointer-style struct aliases, and enum aliases.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~Extract_C_`
- `dotnet test`

## Documentation / Changelog

- Added `changelog.d/unreleased/+c-typedef-aliases.fixed.md`.
- No direct `CHANGELOG.md` edit was needed because this is an ordinary implementation PR.

## Review

- Adversarial review completed on `origin/main..HEAD`; no blocking or actionable issues were found.

## Follow-up candidates

- None in this PR.
