### PR TITLE
Improve R symbol indexing for backtick-escaped function names

### DIFF
--- a/changelog.d/unreleased/+r-backtick-function-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-backtick-function-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R backtick-escaped function names are now indexed** — function definitions such as `` `plot-model` <- function(...) `` are recognized as `function` symbols, so searches can find valid R identifiers that use punctuation and other non-syntactic characters.
+
+## 日本語
+
+- **R のバッククォート付き関数名を検索対象としてインデックスするようになりました** — `` `plot-model` <- function(...) `` のような定義を `function` シンボルとして認識するため、句読点などの非構文文字を含む有効な R 識別子も検索で見つけられるようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1262,6 +1262,7 @@ public static class SymbolExtractor
         ],
         ["r"] =
         [
+            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("import",   new Regex(@"^\s*(?:library|require)\s*\(\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15271,6 +15271,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsBacktickEscapedFunctionNames()
+    {
+        // Backtick-escaped names are valid R identifiers / バッククォート付きの名前は R の有効な識別子
+        const string content = """
+            `plot-model` <- function(data) {
+              data
+            }
+
+            my_plot <- function(x) {
+              x
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "plot-model");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "my_plot");
+    }
+
+    [Fact]
     public void Extract_R_DetectsFunctionAssignmentAndLibrary()
     {
         // R: function assignment, library / R: 関数代入、library


### PR DESCRIPTION
## Summary
- Index R backtick-escaped function definitions such as `` `plot-model` <- function(...) `` as `function` symbols.
- Add regression coverage for backtick-escaped and ordinary R function names.
- Add a bilingual changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_R_DetectsBacktickEscapedFunctionNames"`
- `dotnet build`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Review
- Adversarial review completed with no blocking issues.