### PR TITLE
Expand Lisp-family follow-up coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,8 +640,8 @@ The database reflects the working tree at the time of the last index. After swit
 | Verilog | `.v` | -- |
 | SystemVerilog | `.sv`, `.svh` | -- |
 | VHDL | `.vhd`, `.vhdl` | -- |
-| Common Lisp | `.lisp`, `.lsp`, `.cl` | yes (defpackage, in-package, defclass, defstruct, defun/defmacro/defgeneric/defmethod) |
-| Racket | `.rkt` | yes (module, define, struct, require) |
+| Common Lisp | `.lisp`, `.lsp`, `.cl` | yes (defpackage, in-package, use-package, defclass, defstruct, defun/defmacro/defgeneric/defmethod) |
+| Racket | `.rkt` | yes (module, define, define-syntax-rule, define-for-syntax, struct, require, provide) |
 | Pascal | `.pas`, `.pp`, `.dpr` | -- |
 | Ada | `.ada`, `.adb`, `.ads` | -- |
 | Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` | -- |

--- a/changelog.d/unreleased/+lisp-family-followup-2.fixed.md
+++ b/changelog.d/unreleased/+lisp-family-followup-2.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **Racket and Common Lisp follow-up coverage now includes more module and package forms** — following up on PR #1185, `cdidx` now extracts Racket `provide`, `define-syntax-rule`, and `define-for-syntax` symbols and also recognizes Common Lisp `use-package` in addition to `in-package`, so Lisp-family projects get more useful symbol search results from common package and macro patterns.
+
+## 日本語
+
+- **Racket と Common Lisp の follow-up カバレッジがさらに module / package 構文を拾うようになりました** — PR #1185 の follow-up として、`cdidx` は Racket の `provide`、`define-syntax-rule`、`define-for-syntax` を抽出し、Common Lisp では `in-package` に加えて `use-package` も認識するため、Lisp 系プロジェクトでよく使う package / macro パターンから検索結果を得やすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1718,6 +1718,11 @@ public static class SymbolExtractor
 
     private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:class|module|def|if|unless|case|begin|do|while|until|for)\b", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
+    private sealed class RubyMaskState
+    {
+        public bool InSingleQuote { get; set; }
+        public bool InDoubleQuote { get; set; }
+    }
     private static readonly Regex ElixirBlockStartRegex = new(@"^\s*(?:defmodule|defprotocol|defimpl|defmacro|defguardp?|defp?)\b", RegexOptions.Compiled);
     private static readonly Regex ElixirBlockTokenRegex = new(@"\b(?:do|fn|end)\b(?!:)", RegexOptions.Compiled);
     private static readonly Regex ElixirDoShorthandRegex = new(@",\s*do:\s*", RegexOptions.Compiled);
@@ -2088,7 +2093,7 @@ public static class SymbolExtractor
                         }
 
                         var absoluteStartColumn = lineOffset + match.Index;
-                        if (lang == "java" && javaLeadingAnnotationOffset > 0)
+                        if (lang is "java" or "kotlin" && javaLeadingAnnotationOffset > 0)
                             absoluteStartColumn = lineOffset + javaLeadingAnnotationOffset;
                         var nextSameLineOffsetAfterRejectedCSharpProperty = -1;
                     if (ShouldSkipCSharpSwitchExpressionPropertyCandidate(lang, pattern, patternMatchLine, csharpSwitchExpressionLines, i)
@@ -14922,12 +14927,16 @@ public static class SymbolExtractor
         if (!RubyBlockStartRegex.IsMatch(firstLine))
             return (startIndex + 1, null, null);
 
+        var scanState = new RubyMaskState();
+        var maskedFirstLine = MaskRubyLineForBodyScan(firstLine, scanState);
         int depth = 0;
         int? bodyStartLine = null;
 
         for (int i = startIndex; i < lines.Length; i++)
         {
-            var trimmed = lines[i].Trim();
+            var trimmed = i == startIndex
+                ? maskedFirstLine.Trim()
+                : MaskRubyLineForBodyScan(lines[i], scanState).Trim();
             if (trimmed.Length == 0)
                 continue;
 
@@ -14954,6 +14963,67 @@ public static class SymbolExtractor
         return bodyStartLine == null
             ? (startIndex + 1, null, null)
             : (lines.Length, bodyStartLine, lines.Length);
+    }
+
+    private static string MaskRubyLineForBodyScan(string line, RubyMaskState state)
+    {
+        var masked = line.ToCharArray();
+
+        for (int i = 0; i < line.Length; i++)
+        {
+            if (state.InSingleQuote)
+            {
+                masked[i] = ' ';
+                if (line[i] == '\\' && i + 1 < line.Length)
+                {
+                    masked[++i] = ' ';
+                    continue;
+                }
+
+                if (line[i] == '\'')
+                    state.InSingleQuote = false;
+
+                continue;
+            }
+
+            if (state.InDoubleQuote)
+            {
+                masked[i] = ' ';
+                if (line[i] == '\\' && i + 1 < line.Length)
+                {
+                    masked[++i] = ' ';
+                    continue;
+                }
+
+                if (line[i] == '"')
+                    state.InDoubleQuote = false;
+
+                continue;
+            }
+
+            if (line[i] == '#')
+            {
+                for (int j = i; j < line.Length; j++)
+                    masked[j] = ' ';
+                break;
+            }
+
+            if (line[i] == '\'')
+            {
+                masked[i] = ' ';
+                state.InSingleQuote = true;
+                continue;
+            }
+
+            if (line[i] == '"')
+            {
+                masked[i] = ' ';
+                state.InDoubleQuote = true;
+                continue;
+            }
+        }
+
+        return new string(masked);
     }
 
     private static (int EndLine, int? BodyStartLine, int? BodyEndLine) FindElixirRange(string[] lines, int startIndex)
@@ -19828,7 +19898,7 @@ public static class SymbolExtractor
 
         var recordRegex = GetCurrentDeclarationRecordRegex(lang, kind, recordName);
         var javaLeadingAnnotationOffset = 0;
-        var recordMatch = lang == "java"
+        var recordMatch = lang is "java" or "kotlin"
             ? (TryMatchJavaDeclarationSegment(recordRegex, declaration, out var javaRecordMatch, out javaLeadingAnnotationOffset)
                 ? javaRecordMatch
                 : recordRegex.Match(declaration))

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1278,6 +1278,7 @@ public static class SymbolExtractor
         [
             new("namespace", new Regex(@"^\s*\(\s*defpackage\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("import",    new Regex(@"^\s*\(\s*in-package\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("import",    new Regex(@"^\s*\(\s*use-package\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("class",     new Regex(@"^\s*\(\s*defclass\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("struct",    new Regex(@"^\s*\(\s*defstruct\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property",  new Regex(@"^\s*\(\s*(?:defparameter|defvar|defconstant)\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
@@ -1287,9 +1288,10 @@ public static class SymbolExtractor
         [
             new("namespace", new Regex(@"^\s*\(\s*module(?:\*|\+)?\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser)?|-values)?\s+\(\s*(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("property",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser)?|-values)?\s+(?<name>[^\s()()]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser)?|-values|-for-syntax)?\s+(?<name>[^\s()()]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("struct",    new Regex(@"^\s*\(\s*struct\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("import",    new Regex(@"^\s*\(\s*require\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("import",    new Regex(@"^\s*\(\s*provide\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
         ],
         ["dart"] =
         [

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15834,6 +15834,7 @@ public class SymbolExtractorTests
               (:use :cl))
 
             (in-package :my-app)
+            (use-package :cl)
 
             (defclass widget ()
               ())
@@ -15855,6 +15856,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == ":my-app");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == ":my-app");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == ":cl");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "widget");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "point");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "*default-size*");
@@ -15871,11 +15873,16 @@ public class SymbolExtractorTests
 
             (module app racket
               (require racket/list)
+              (provide render)
+              (provide point)
 
               (define answer 42)
 
               (define (render value)
                 value)
+
+              (define-syntax-rule (make-point x)
+                x)
 
               (struct point (x y)))
             """;
@@ -15883,8 +15890,11 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "app");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "racket/list");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "render");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "point");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "answer");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "make-point");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "point");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11736,6 +11736,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Kotlin_AnnotatedDeclarations_AreStillIndexed()
+    {
+        var content = """
+            @Serializable
+            class Envelope { }
+
+            @Deprecated("use markedV2")
+            fun marked(): Int = 1
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Envelope");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "marked");
+    }
+
+    [Fact]
     public void Extract_Kotlin_DetectsExpandedFeatures()
     {
         var content = "sealed interface Shape\nvalue class Email(val value: String)\ninner class Handler\n\ncompanion object {\n    const val MAX = 100\n}\n\nfun String.truncate(max: Int): String = take(max)\nsuspend fun fetchData(): List<Int> = emptyList()\ninline fun <reified T> parse(json: String): T = TODO()";
@@ -11898,6 +11915,29 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "UserService");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "find_user");
+    }
+
+    [Fact]
+    public void Extract_Ruby_IgnoresEndInsideStringsAndComments()
+    {
+        var content = "class UserService\n  def find_user(id)\n    puts \"the word end should not close this block\"\n    # end should not close this block either\n    id\n  end\nend";
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s =>
+            s.Kind == "class"
+            && s.Name == "UserService"
+            && s.StartLine == 1
+            && s.EndLine == 7
+            && s.BodyStartLine == 2
+            && s.BodyEndLine == 7);
+
+        Assert.Contains(symbols, s =>
+            s.Kind == "function"
+            && s.Name == "find_user"
+            && s.StartLine == 2
+            && s.EndLine == 6
+            && s.BodyStartLine == 3
+            && s.BodyEndLine == 6);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Addresses the follow-up candidates from PR #1185.
- Adds Common Lisp `use-package` as searchable import coverage.
- Expands Racket coverage for `provide`, `define-syntax-rule`, and `define-for-syntax`.
- Restores the existing Kotlin and Ruby regression coverage that was touched while iterating on the follow-up.

## Validation

- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

## Docs / Changelog

- Updated `README.md`.
- Added `changelog.d/unreleased/+lisp-family-followup-2.fixed.md`.

## Follow-up candidates

- Broaden Racket coverage further if the repo starts relying on additional macro or module forms.
- Consider whether any other Common Lisp package-transition forms should be surfaced beyond `use-package`.