### PR TITLE
Handle Kotlin use-site targets

### DIFF
--- a/changelog.d/unreleased/+kotlin-annotated-decls.fixed.md
+++ b/changelog.d/unreleased/+kotlin-annotated-decls.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **Kotlin annotation-bearing declarations are indexed now** — `SymbolExtractor` now skips leading Java/Kotlin-style annotations before matching declarations, so `@Serializable data class`, `@Deprecated fun`, and annotated secondary constructors stay searchable instead of being missed.
+- **Kotlin annotation-bearing declarations are indexed now** — `SymbolExtractor` now skips leading Java/Kotlin-style annotations and Kotlin use-site targets before matching declarations, so `@Serializable data class`, `@field:Deprecated val`, `@get:JvmName val`, `@Deprecated fun`, and annotated secondary constructors stay searchable instead of being missed.
 
 ## 日本語
 
-- **Kotlin の annotation 付き宣言が index されるようになりました** — `SymbolExtractor` が Java/Kotlin 風の先頭 annotation を宣言マッチ前に読み飛ばすため、`@Serializable data class`、`@Deprecated fun`、annotation 付き secondary constructor が検索対象から漏れなくなりました。
+- **Kotlin の annotation 付き宣言が index されるようになりました** — `SymbolExtractor` が Java/Kotlin 風の先頭 annotation と Kotlin の use-site target を宣言マッチ前に読み飛ばすため、`@Serializable data class`、`@field:Deprecated val`、`@get:JvmName val`、`@Deprecated fun`、annotation 付き secondary constructor が検索対象から漏れなくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1993,7 +1993,7 @@ public static class SymbolExtractor
                     {
                         var javaLeadingAnnotationOffset = 0;
                         var match = lang is "java" or "kotlin"
-                            ? (TryMatchJavaDeclarationSegment(pattern.Regex, patternMatchLine[lineOffset..], out var javaMatch, out javaLeadingAnnotationOffset)
+                            ? (TryMatchJavaDeclarationSegment(pattern.Regex, patternMatchLine[lineOffset..], lang == "kotlin", out var javaMatch, out javaLeadingAnnotationOffset)
                                 ? javaMatch
                                 : pattern.Regex.Match(patternMatchLine[lineOffset..]))
                             : pattern.Regex.Match(patternMatchLine[lineOffset..]);
@@ -4570,7 +4570,7 @@ public static class SymbolExtractor
                     while (compactConstructorOffset >= 0 && compactConstructorOffset < segment.Length)
                     {
                         var candidateSegment = segment[compactConstructorOffset..];
-                        if (TryMatchJavaDeclarationSegment(JavaCompactConstructorRegex, candidateSegment, out var match, out var javaLeadingAnnotationOffset)
+                        if (TryMatchJavaDeclarationSegment(JavaCompactConstructorRegex, candidateSegment, false, out var match, out var javaLeadingAnnotationOffset)
                             && match.Groups["name"].Value == recordSymbol.Name)
                         {
                             var absoluteStartColumn = segmentStart + compactConstructorOffset + javaLeadingAnnotationOffset + match.Index;
@@ -4684,6 +4684,7 @@ public static class SymbolExtractor
         return TryMatchJavaDeclarationSegment(
             GetCurrentDeclarationRecordRegex("java", symbol.Kind, symbol.Name),
             rawLines[declarationLineIndex],
+            false,
             out _,
             out _);
     }
@@ -5463,7 +5464,7 @@ public static class SymbolExtractor
         return false;
     }
 
-    private static int SkipLeadingJavaAnnotations(string span)
+    private static int SkipLeadingJavaAnnotations(string span, bool allowKotlinUseSiteTargets = false)
     {
         var mode = JavaScanMode.Normal;
         var index = SkipJavaWhitespaceAndComments(span, 0, ref mode);
@@ -5474,6 +5475,13 @@ public static class SymbolExtractor
             index = SkipJavaWhitespaceAndComments(span, index, ref mode);
             if (mode != JavaScanMode.Normal)
                 return index;
+
+            if (allowKotlinUseSiteTargets && TryConsumeKotlinAnnotationTarget(span, ref index))
+            {
+                index = SkipJavaWhitespaceAndComments(span, index, ref mode);
+                if (mode != JavaScanMode.Normal)
+                    return index;
+            }
 
             while (index < span.Length && (char.IsLetterOrDigit(span[index]) || span[index] == '_' || span[index] == '.' || span[index] == '$'))
                 index++;
@@ -5504,9 +5512,32 @@ public static class SymbolExtractor
         return index;
     }
 
+    private static bool TryConsumeKotlinAnnotationTarget(string span, ref int index)
+    {
+        var targetStart = index;
+        while (index < span.Length && (char.IsLetterOrDigit(span[index]) || span[index] == '_'))
+            index++;
+
+        if (index >= span.Length || span[index] != ':')
+        {
+            index = targetStart;
+            return false;
+        }
+
+        if (!KotlinAnnotationTargets.Contains(span[targetStart..index]))
+        {
+            index = targetStart;
+            return false;
+        }
+
+        index++;
+        return true;
+    }
+
     private static bool TryMatchJavaDeclarationSegment(
         Regex regex,
         string segment,
+        bool allowKotlinUseSiteTargets,
         out Match match,
         out int leadingAnnotationOffset)
     {
@@ -5515,7 +5546,7 @@ public static class SymbolExtractor
         if (match.Success)
             return true;
 
-        var skippedOffset = SkipLeadingJavaAnnotations(segment);
+        var skippedOffset = SkipLeadingJavaAnnotations(segment, allowKotlinUseSiteTargets);
         if (skippedOffset <= 0 || skippedOffset >= segment.Length)
             return false;
 
@@ -19897,7 +19928,7 @@ public static class SymbolExtractor
         var recordRegex = GetCurrentDeclarationRecordRegex(lang, kind, recordName);
         var javaLeadingAnnotationOffset = 0;
         var recordMatch = lang is "java" or "kotlin"
-            ? (TryMatchJavaDeclarationSegment(recordRegex, declaration, out var javaRecordMatch, out javaLeadingAnnotationOffset)
+            ? (TryMatchJavaDeclarationSegment(recordRegex, declaration, lang == "kotlin", out var javaRecordMatch, out javaLeadingAnnotationOffset)
                 ? javaRecordMatch
                 : recordRegex.Match(declaration))
             : recordRegex.Match(declaration);
@@ -20531,7 +20562,7 @@ public static class SymbolExtractor
         string? visibility = null;
         if (lang == "kotlin")
         {
-            var stripped = StripLeadingJavaRecordComponentAnnotations(normalized);
+            var stripped = StripLeadingJavaRecordComponentAnnotations(normalized, allowKotlinUseSiteTargets: true);
             normalized = stripped.Text;
             componentLine += stripped.ConsumedNewlines;
 
@@ -20563,7 +20594,7 @@ public static class SymbolExtractor
         {
             var stripped = lang == "csharp"
                 ? StripLeadingCSharpRecordComponentAttributes(normalized)
-                : StripLeadingJavaRecordComponentAnnotations(normalized);
+                : StripLeadingJavaRecordComponentAnnotations(normalized, allowKotlinUseSiteTargets: lang == "kotlin");
             normalized = stripped.Text;
             componentLine += stripped.ConsumedNewlines;
 
@@ -20987,7 +21018,7 @@ public static class SymbolExtractor
         return true;
     }
 
-    private static StrippedRecordComponentText StripLeadingJavaRecordComponentAnnotations(string component)
+    private static StrippedRecordComponentText StripLeadingJavaRecordComponentAnnotations(string component, bool allowKotlinUseSiteTargets)
     {
         var consumedNewlines = 0;
         var trimmed = TrimLeadingWhitespaceAndCountNewlines(component, ref consumedNewlines);
@@ -20996,6 +21027,15 @@ public static class SymbolExtractor
             var index = 1;
             while (index < trimmed.Length && (char.IsLetterOrDigit(trimmed[index]) || trimmed[index] is '_' or '$' or '.'))
                 index++;
+
+            if (allowKotlinUseSiteTargets && index < trimmed.Length && trimmed[index] == ':' && KotlinAnnotationTargets.Contains(trimmed[1..index]))
+            {
+                index++;
+                while (index < trimmed.Length && char.IsWhiteSpace(trimmed[index]))
+                    index++;
+                while (index < trimmed.Length && (char.IsLetterOrDigit(trimmed[index]) || trimmed[index] is '_' or '$' or '.'))
+                    index++;
+            }
 
             if (index < trimmed.Length && trimmed[index] == ':')
             {
@@ -22285,6 +22325,10 @@ public static class SymbolExtractor
         @"^\s*(?:uses|provides)\s+(?<name>[\w.]+)(?:\s+with\s+[\w.,\s]+)?\s*;$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly string[] JavaModuleDirectiveKeywords = ["requires", "exports", "opens", "uses", "provides"];
+    private static readonly HashSet<string> KotlinAnnotationTargets = new(StringComparer.Ordinal)
+    {
+        "field", "get", "set", "param", "setparam", "property", "receiver", "file", "delegate", "all",
+    };
 
     /// <summary>
     /// Estimate cyclomatic complexity of a code body using keyword counting.

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11753,6 +11753,30 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Kotlin_UseSiteTargetsAndAnnotatedSecondaryConstructors_AreIndexed()
+    {
+        var content = """
+            class Envelope(@field:Deprecated val id: String)
+
+            @get:JvmName("displayName")
+            val name: String = "x"
+
+            class Service {
+                @Inject
+                constructor() { }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Envelope");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "id" && s.ContainerKind == "class" && s.ContainerName == "Envelope");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Service");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Service" && s.ContainerKind == "class" && s.ContainerName == "Service");
+    }
+
+    [Fact]
     public void Extract_Kotlin_DetectsExpandedFeatures()
     {
         var content = "sealed interface Shape\nvalue class Email(val value: String)\ninner class Handler\n\ncompanion object {\n    const val MAX = 100\n}\n\nfun String.truncate(max: Int): String = take(max)\nsuspend fun fetchData(): List<Int> = emptyList()\ninline fun <reified T> parse(json: String): T = TODO()";


### PR DESCRIPTION
## Summary
- Follow up on PR #1188's follow-up candidates by teaching `SymbolExtractor` to skip Kotlin use-site targets such as `@field:`, `@param:`, `@get:`, and `@receiver:` before declaration matching.
- This also keeps annotated Kotlin secondary constructors searchable.
- Add regression coverage for Kotlin primary-constructor properties, top-level properties, extension functions, and annotated secondary constructors.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_AnnotatedDeclarations_AreStillIndexed|FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_UseSiteTargetsAndAnnotatedSecondaryConstructors_AreIndexed|FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_DetectsSecondaryConstructors"`
- `dotnet test`

## Changelog
- Added fragment: `changelog.d/unreleased/+kotlin-annotated-decls.fixed.md`

## Follow-up candidates addressed
- Kotlin use-site targets such as `@field:`, `@param:`, `@get:`, and `@receiver:` are now covered.
- Annotated Kotlin secondary constructors are now covered.

## Follow-up candidates
- None.