### PR TITLE
Handle Fortran subprogram symbols

### DIFF
--- a/changelog.d/unreleased/+fortran-subprograms.fixed.md
+++ b/changelog.d/unreleased/+fortran-subprograms.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran modules, programs, subroutines, and functions are now indexed** — `module`, `program`, `subroutine`, and `function` declarations are now surfaced as searchable symbols, including common modifier and typed-function forms.
+
+## 日本語
+
+- **Fortran の module / program / subroutine / function を index するようになりました** — `module`、`program`、`subroutine`、`function` 宣言が検索可能なシンボルとして出力され、一般的な修飾子付き・型付き function 形式にも対応しました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1030,6 +1030,17 @@ public static class SymbolExtractor
             // Package-level var / パッケージレベル変数
             new("property", new Regex(@"^var\s+(?<name>\w+)\s", RegexOptions.Compiled), BodyStyle.None),
         ],
+        ["fortran"] =
+        [
+            // Fortran modules / モジュール
+            new("namespace", new Regex(@"^\s*module\s+(?!procedure\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Program units / プログラム本体
+            new("class", new Regex(@"^\s*program\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Subroutines / サブルーチン
+            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Typed or untyped functions / 型付き・型なし関数
+            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*(?:(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)|procedure\s*\([^)]+\))\s+)?function\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+        ],
         ["rust"] =
         [
             // macro_rules! / マクロ定義

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9680,6 +9680,41 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions()
+    {
+        var content = """
+            module math_utils
+              implicit none
+            contains
+              pure real function square(x) result(y)
+                real, intent(in) :: x
+                y = x * x
+              end function square
+
+              recursive subroutine normalize(v)
+              end subroutine normalize
+            end module math_utils
+
+            program demo
+            end program demo
+
+            integer function add(a, b)
+            end function add
+
+            real(kind=8) function typed_value(x)
+            end function typed_value
+            """;
+        var symbols = SymbolExtractor.Extract(1, "fortran", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "math_utils");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "demo");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "square");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "add");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "typed_value");
+    }
+
+    [Fact]
     public void Extract_Go_DetectsGenericTypeDeclarations()
     {
         var content = """


### PR DESCRIPTION
## Summary

This PR improves Fortran symbol search coverage by indexing common top-level declarations.

- `module` declarations are indexed as `namespace` symbols.
- `program` declarations are indexed as `class` symbols.
- `subroutine` and `function` declarations are indexed as `function` symbols.
- Common modifier forms such as `pure`, `recursive`, and typed functions like `real(kind=8) function ...` are also covered.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions|FullyQualifiedName~Extract_Go_DetectsGenericFunctions|FullyQualifiedName~Extract_Go_DetectsFunctions"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+fortran-subprograms.fixed.md`

## Follow-up candidates

- Fortran `submodule` / `end module procedure` syntax is not covered in this change.
- Fortran module/program body-range tracking could be extended to improve container precision for internal procedures.
