### PR TITLE
Index F# type abbreviations

### DIFF
--- a/changelog.d/unreleased/+fsharp-typealias.fixed.md
+++ b/changelog.d/unreleased/+fsharp-typealias.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# type abbreviations are now indexed for search** — `SymbolExtractor` now records `type UserId = int`-style aliases as `typealias` symbols, so common F# type names show up in `symbols` and definition-oriented views instead of being skipped.
+
+## 日本語
+
+- **F# の type abbreviation を検索用に索引するようになりました** — `SymbolExtractor` が `type UserId = int` 形式の alias を `typealias` シンボルとして記録するため、よく使われる F# の型名が `symbols` や definition 系の表示から落ちずに見えるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1220,6 +1220,9 @@ public static class SymbolExtractor
         ["fsharp"] =
         [
             new("function", new Regex(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
+            new("struct", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("enum", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12355,7 +12355,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp.Domain");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System");
-        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "UserId");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "User");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Color");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
@@ -12372,11 +12372,31 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsTypeAbbreviations()
+    {
+        var content = """
+            module MyApp.Types
+
+            type UserId = int
+            type OrderId = string
+            type Names = string list
+            """;
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "OrderId");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Names");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsNamespacesModulesAndMembers()
     {
         // F#: namespace rec, module private, member forms / F#: namespace rec、module private、member形
         var content = """
             namespace rec MyApp.Domain
+
+            type UserId = int
+            type OrderId = string
 
             type Person(name: string) =
                 member this.Name = name
@@ -12395,6 +12415,8 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp.Domain");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "OrderId");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Name");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Age");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Create");


### PR DESCRIPTION
## Summary

- Index F# type abbreviations such as `type UserId = int` and `type Names = string list` as `typealias` symbols.
- Preserve the existing F# record, union, class, namespace, and member coverage while making common alias names searchable in `symbols` and definition-oriented views.
- Add regression coverage for F# aliases in the existing F# suite.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~Extract_FSharp_`
- `dotnet test`

## Documentation / Changelog

- Added `changelog.d/unreleased/+fsharp-typealias.fixed.md`.
- No direct `CHANGELOG.md` edit was needed because this is an ordinary implementation PR.

## Review

- Adversarial review completed on `origin/main..HEAD`; no blocking or actionable issues were found.

## Follow-up candidates

- Generic F# type abbreviations such as `type Result<'T> = ...` deserve a dedicated follow-up if we want explicit coverage for that shape.
