### PR TITLE
Index XAML resource keys for search

### DIFF
--- a/changelog.d/unreleased/+xaml-key-symbols.changed.md
+++ b/changelog.d/unreleased/+xaml-key-symbols.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML `x:Key` values are now indexed for search** — `.xaml` and `.axaml` files already treated as XAML now emit `property` symbols for resource keys such as `x:Key="AccentBrush"`, making ResourceDictionary names searchable alongside `x:Class` and `x:Name`.
+
+## 日本語
+
+- **XAML の `x:Key` 値も検索対象としてインデックスするようになりました** — XAML として扱われる `.xaml` / `.axaml` ファイルで、`x:Key="AccentBrush"` のようなリソースキーを `property` シンボルとして出力するようにし、`x:Class` / `x:Name` と並んで ResourceDictionary 名も検索できるようにしました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -126,6 +126,9 @@ public static class SymbolExtractor
     private static readonly Regex XamlNameRegex = new(
         @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlKeyRegex = new(
+        @"\bx:Key\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex ObjCCategoryDeclarationRegex = new(
         @"^\s*@(?:interface|implementation)\s+(?<class>\w+)\s*\(\s*(?<category>[^)]+?)\s*\)(?:\s*<[^>]+>)?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -4482,6 +4485,23 @@ public static class SymbolExtractor
             foreach (Match nameMatch in XamlNameRegex.Matches(line))
             {
                 var value = nameMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+
+            foreach (Match keyMatch in XamlKeyRegex.Matches(line))
+            {
+                var value = keyMatch.Groups["value"].Value.Trim();
                 if (value.Length == 0)
                     continue;
                 symbols.Add(new SymbolRecord

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18603,6 +18603,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesXKey()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                <SolidColorBrush x:Key="AccentBrush" Color="Tomato" />
+                <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+                    <Setter Property="Background" Value="{StaticResource AccentBrush}" />
+                </Style>
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "AccentBrush");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "PrimaryButtonStyle");
+    }
+
+    [Fact]
     public void Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Index XAML `x:Key` values as `property` symbols when a XAML namespace is present.
- Add regression coverage for ResourceDictionary keys alongside existing `x:Class` / `x:Name` behavior.
- Add a bilingual changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Xml_XamlCapturesXKey"`
- `dotnet build`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Review
- Adversarial review completed with no blocking issues.