### PR TITLE
Expand Kotlin use-site target coverage

### DIFF
--- a/changelog.d/unreleased/+kotlin-annotated-decls.fixed.md
+++ b/changelog.d/unreleased/+kotlin-annotated-decls.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **Kotlin annotation-bearing declarations are indexed now** — `SymbolExtractor` now skips leading Java/Kotlin-style annotations and Kotlin use-site targets before matching declarations, so `@Serializable data class`, `@field:Deprecated val`, `@get:JvmName val`, `@Deprecated fun`, and annotated secondary constructors stay searchable instead of being missed.
+- **Kotlin annotation-bearing declarations are indexed now** — `SymbolExtractor` now skips leading Java/Kotlin-style annotations and Kotlin use-site targets before matching declarations, so `@Serializable data class`, `@field:Deprecated val`, `@param:Deprecated val`, `@get:JvmName val`, `@receiver:JvmName fun`, `@Deprecated fun`, and annotated secondary constructors stay searchable instead of being missed.
 
 ## 日本語
 
-- **Kotlin の annotation 付き宣言が index されるようになりました** — `SymbolExtractor` が Java/Kotlin 風の先頭 annotation と Kotlin の use-site target を宣言マッチ前に読み飛ばすため、`@Serializable data class`、`@field:Deprecated val`、`@get:JvmName val`、`@Deprecated fun`、annotation 付き secondary constructor が検索対象から漏れなくなりました。
+- **Kotlin の annotation 付き宣言が index されるようになりました** — `SymbolExtractor` が Java/Kotlin 風の先頭 annotation と Kotlin の use-site target を宣言マッチ前に読み飛ばすため、`@Serializable data class`、`@field:Deprecated val`、`@param:Deprecated val`、`@get:JvmName val`、`@receiver:JvmName fun`、`@Deprecated fun`、annotation 付き secondary constructor が検索対象から漏れなくなりました。

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11756,10 +11756,13 @@ public class SymbolExtractorTests
     public void Extract_Kotlin_UseSiteTargetsAndAnnotatedSecondaryConstructors_AreIndexed()
     {
         var content = """
-            class Envelope(@field:Deprecated val id: String)
+            class Envelope(@field:Deprecated val id: String, @param:Deprecated val count: Int)
 
             @get:JvmName("displayName")
             val name: String = "x"
+
+            @receiver:JvmName("decorate")
+            fun String.marked(): String = this
 
             class Service {
                 @Inject
@@ -11771,7 +11774,9 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Envelope");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "id" && s.ContainerKind == "class" && s.ContainerName == "Envelope");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "count" && s.ContainerKind == "class" && s.ContainerName == "Envelope");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "marked");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Service");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Service" && s.ContainerKind == "class" && s.ContainerName == "Service");
     }


### PR DESCRIPTION
## Summary
- Follow up on PR #1197's follow-up candidates by explicitly covering Kotlin `@param:` and `@receiver:` use-site targets.
- Keep annotated Kotlin secondary constructors searchable.
- Extend the Kotlin regression fixture so `@field:`, `@param:`, `@get:`, and `@receiver:` are all exercised directly.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_AnnotatedDeclarations_AreStillIndexed|FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_UseSiteTargetsAndAnnotatedSecondaryConstructors_AreIndexed|FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_DetectsSecondaryConstructors"`
- `dotnet test`

## Changelog
- Added fragment: `changelog.d/unreleased/+kotlin-annotated-decls.fixed.md`

## Follow-up candidates addressed
- Kotlin use-site targets such as `@field:`, `@param:`, `@get:`, and `@receiver:` are now covered.
- Annotated Kotlin secondary constructors are now covered.

## Follow-up candidates
- None.