### PR TITLE
Expand Racket follow-up symbol coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ The database reflects the working tree at the time of the last index. After swit
 | SystemVerilog | `.sv`, `.svh` | -- |
 | VHDL | `.vhd`, `.vhdl` | -- |
 | Common Lisp | `.lisp`, `.lsp`, `.cl` | yes (defpackage, in-package, use-package, defclass, defstruct, defun/defmacro/defgeneric/defmethod) |
-| Racket | `.rkt` | yes (module, define, define-syntax-rule, define-for-syntax, struct, require, provide) |
+| Racket | `.rkt` | yes (module, define, define-syntax-rule, define-syntaxes, define-for-syntax, struct, require, provide) |
 | Pascal | `.pas`, `.pp`, `.dpr` | -- |
 | Ada | `.ada`, `.adb`, `.ads` | -- |
 | Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` | -- |

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Verilog | `.v` | -- |
 | SystemVerilog | `.sv`, `.svh` | -- |
 | VHDL | `.vhd`, `.vhdl` | -- |
-| Common Lisp | `.lisp`, `.lsp`, `.cl` | yes (defpackage, in-package, use-package, defclass, defstruct, defun/defmacro/defgeneric/defmethod) |
+| Common Lisp | `.lisp`, `.lsp`, `.cl` | yes (defpackage, in-package, use-package, import/shadowing-import, defclass, defstruct, defun/defmacro/defgeneric/defmethod) |
 | Racket | `.rkt` | yes (module, define, define-syntax-rule, define-syntaxes, define-for-syntax, struct, require, provide) |
 | Pascal | `.pas`, `.pp`, `.dpr` | -- |
 | Ada | `.ada`, `.adb`, `.ads` | -- |

--- a/changelog.d/unreleased/+lisp-family-followup-3.fixed.md
+++ b/changelog.d/unreleased/+lisp-family-followup-3.fixed.md
@@ -8,8 +8,8 @@ affected:
 
 ## English
 
-- **Racket follow-up coverage now includes `define-syntaxes`** — following up on PR #1196, `cdidx` now extracts Racket `define-syntaxes` forms in addition to the existing `module`, `define`, `define-syntax-rule`, `define-for-syntax`, `struct`, `require`, and `provide` coverage, so macro-heavy Racket projects get more useful symbol search results from common syntax-definition patterns.
+- **Racket follow-up coverage now includes `define-syntaxes`, and Common Lisp package transitions now include `import` / `shadowing-import`** — following up on PR #1196, `cdidx` now extracts Racket `define-syntaxes` forms in addition to the existing `module`, `define`, `define-syntax-rule`, `define-for-syntax`, `struct`, `require`, and `provide` coverage, and it also recognizes Common Lisp `import` and `shadowing-import` package-transition forms alongside `in-package` and `use-package`, so macro-heavy Racket projects and package-oriented Common Lisp projects get more useful symbol search results from common namespace patterns.
 
 ## 日本語
 
-- **Racket の follow-up カバレッジが `define-syntaxes` まで拾うようになりました** — PR #1196 の follow-up として、`cdidx` は既存の `module`、`define`、`define-syntax-rule`、`define-for-syntax`、`struct`、`require`、`provide` に加えて Racket の `define-syntaxes` も抽出するため、マクロ中心の Racket プロジェクトでよく使う構文定義パターンから検索結果を得やすくなります。
+- **Racket の follow-up カバレッジが `define-syntaxes` まで拾うようになり、Common Lisp のパッケージ遷移も広がりました** — PR #1196 の follow-up として、`cdidx` は既存の `module`、`define`、`define-syntax-rule`、`define-for-syntax`、`struct`、`require`、`provide` に加えて Racket の `define-syntaxes` も抽出し、さらに Common Lisp では `in-package` や `use-package` に加えて `import` / `shadowing-import` も認識するため、マクロ中心の Racket プロジェクトとパッケージ志向の Common Lisp プロジェクトの両方で検索結果を得やすくなります。

--- a/changelog.d/unreleased/+lisp-family-followup-3.fixed.md
+++ b/changelog.d/unreleased/+lisp-family-followup-3.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **Racket follow-up coverage now includes `define-syntaxes`** — following up on PR #1196, `cdidx` now extracts Racket `define-syntaxes` forms in addition to the existing `module`, `define`, `define-syntax-rule`, `define-for-syntax`, `struct`, `require`, and `provide` coverage, so macro-heavy Racket projects get more useful symbol search results from common syntax-definition patterns.
+
+## 日本語
+
+- **Racket の follow-up カバレッジが `define-syntaxes` まで拾うようになりました** — PR #1196 の follow-up として、`cdidx` は既存の `module`、`define`、`define-syntax-rule`、`define-for-syntax`、`struct`、`require`、`provide` に加えて Racket の `define-syntaxes` も抽出するため、マクロ中心の Racket プロジェクトでよく使う構文定義パターンから検索結果を得やすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1295,8 +1295,8 @@ public static class SymbolExtractor
         ["racket"] =
         [
             new("namespace", new Regex(@"^\s*\(\s*module(?:\*|\+)?\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("function",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser)?|-values)?\s+\(\s*(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("property",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser)?|-values|-for-syntax)?\s+(?<name>[^\s()()]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("function",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser|es)?|-values)?\s+\(\s*(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property",  new Regex(@"^\s*\(\s*define(?:-syntax(?:-rule|-parser|es)?|-values|-for-syntax)?\s+(?<name>[^\s()()]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("struct",    new Regex(@"^\s*\(\s*struct\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("import",    new Regex(@"^\s*\(\s*require\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("import",    new Regex(@"^\s*\(\s*provide\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1287,6 +1287,7 @@ public static class SymbolExtractor
             new("namespace", new Regex(@"^\s*\(\s*defpackage\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("import",    new Regex(@"^\s*\(\s*in-package\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("import",    new Regex(@"^\s*\(\s*use-package\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("import",    new Regex(@"^\s*\(\s*(?:shadowing-)?import\s+['""]?(?<name>[^\s()'""]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("class",     new Regex(@"^\s*\(\s*defclass\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("struct",    new Regex(@"^\s*\(\s*defstruct\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property",  new Regex(@"^\s*\(\s*(?:defparameter|defvar|defconstant)\s+(?<name>[^\s()]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -16035,7 +16035,7 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_Racket_DetectsModuleAndDefinitions()
     {
-        // Racket: module, define, struct, require / Racket: module、define、struct、require
+        // Racket: module, define, define-syntaxes, struct, require / Racket: module、define、define-syntaxes、struct、require
         var content = """
             #lang racket
 
@@ -16052,6 +16052,10 @@ public class SymbolExtractorTests
               (define-syntax-rule (make-point x)
                 x)
 
+              (define-syntaxes (make-point-2)
+                (lambda (stx)
+                  stx))
+
               (struct point (x y)))
             """;
         var symbols = SymbolExtractor.Extract(1, "racket", content);
@@ -16063,6 +16067,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "answer");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "make-point");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "make-point-2");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "point");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15996,13 +15996,15 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_CommonLisp_DetectsTopLevelDefinitions()
     {
-        // Common Lisp: package, classes, structs, variables, functions / Common Lisp: パッケージ、クラス、構造体、変数、関数
+        // Common Lisp: package, package transitions, classes, structs, variables, functions / Common Lisp: パッケージ、パッケージ遷移、クラス、構造体、変数、関数
         var content = """
             (defpackage :my-app
               (:use :cl))
 
             (in-package :my-app)
             (use-package :cl)
+            (import 'widget)
+            (shadowing-import 'render)
 
             (defclass widget ()
               ())
@@ -16025,6 +16027,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == ":my-app");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == ":my-app");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == ":cl");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "widget");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "render");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "widget");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "point");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "*default-size*");


### PR DESCRIPTION
This PR is a follow-up to PR #1196 and addresses the Follow-up candidates called out there.

It expands Racket search coverage to include `define-syntaxes` and extends Common Lisp package-transition coverage to include `import` and `shadowing-import`, which improves symbol search results for macro-heavy Racket projects and package-oriented Common Lisp projects while keeping the existing follow-up behavior intact.

Validation:
- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`