### PR TITLE
Teach hotspot-family markers about MSBuild

### DIFF
--- a/changelog.d/unreleased/+msbuild-hotspot-family.fixed.md
+++ b/changelog.d/unreleased/+msbuild-hotspot-family.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **MSBuild project files now participate in hotspot-family marker detection** — the hotspot-family marker path treats `.csproj`, `.fsproj`, `.vbproj`, `.props`, and `.targets` as a first-class `msbuild` family so project-scope fingerprinting and scope keys follow MSBuild project structure instead of falling back to generic heuristics.
+
+## 日本語
+
+- **MSBuild のプロジェクトファイルが hotspot-family の marker 判定に参加するようになりました** — hotspot-family の marker 判定で `.csproj`、`.fsproj`、`.vbproj`、`.props`、`.targets` を第一級の `msbuild` ファミリーとして扱うため、project-scope の fingerprint と scope key が一般的なヒューリスティックではなく MSBuild の構成に沿って決まるようになります。

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -983,14 +983,17 @@ public class FileIndexer
         var projectMarkerPatterns = GetProjectMarkerPatterns(lang);
         if (projectMarkerPatterns != null)
         {
+            var primaryProjectMarkerPatterns = GetPrimaryProjectMarkerPatterns(lang) ?? projectMarkerPatterns;
             var currentDir = Path.GetDirectoryName(Path.GetFullPath(absolutePath));
             while (!string.IsNullOrEmpty(currentDir))
             {
-                var markerCount = CountProjectMarkerFiles(currentDir, projectMarkerPatterns);
+                var markerCount = CountProjectMarkerFiles(currentDir, primaryProjectMarkerPatterns);
                 if (markerCount == 1)
                     return NormalizeScopeKey(Path.GetRelativePath(_projectRoot, currentDir));
                 if (markerCount > 1)
                     return DeriveAmbiguousProjectScopeKey(Path.GetFullPath(absolutePath), currentDir);
+                if (CountProjectMarkerFiles(currentDir, projectMarkerPatterns) > 0)
+                    return NormalizeScopeKey(Path.GetRelativePath(_projectRoot, currentDir));
 
                 if (PathsEqual(currentDir, _projectRoot))
                     break;
@@ -1117,6 +1120,15 @@ public class FileIndexer
         "vb" => ["*.vbproj"],
         "fsharp" => ["*.fsproj"],
         "msbuild" => ["*.csproj", "*.fsproj", "*.vbproj", "*.props", "*.targets"],
+        _ => null,
+    };
+
+    private static IReadOnlyList<string>? GetPrimaryProjectMarkerPatterns(string? lang) => lang switch
+    {
+        "csharp" => ["*.csproj"],
+        "vb" => ["*.vbproj"],
+        "fsharp" => ["*.fsproj"],
+        "msbuild" => ["*.csproj", "*.fsproj", "*.vbproj"],
         _ => null,
     };
 

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -63,7 +63,7 @@ public class FileIndexer
             PathFilterKind.ExcludedByDefaultFile;
     }
 
-    private static readonly string[] HotspotFamilyMarkerLanguages = ["csharp", "vb", "fsharp"];
+    private static readonly string[] HotspotFamilyMarkerLanguages = ["csharp", "vb", "fsharp", "msbuild"];
     private static readonly string[] IgnoreFileNames = [".gitignore", ".cdidxignore"];
     // Extension-to-language mapping / 拡張子→言語名マッピング
     private static readonly Dictionary<string, string> LangMap = new(StringComparer.OrdinalIgnoreCase)
@@ -980,13 +980,13 @@ public class FileIndexer
 
     public string GetFamilyScopeKey(string absolutePath, string? lang)
     {
-        var projectMarkerPattern = GetProjectMarkerPattern(lang);
-        if (projectMarkerPattern != null)
+        var projectMarkerPatterns = GetProjectMarkerPatterns(lang);
+        if (projectMarkerPatterns != null)
         {
             var currentDir = Path.GetDirectoryName(Path.GetFullPath(absolutePath));
             while (!string.IsNullOrEmpty(currentDir))
             {
-                var markerCount = Directory.EnumerateFiles(currentDir, projectMarkerPattern, SearchOption.TopDirectoryOnly).Take(2).Count();
+                var markerCount = CountProjectMarkerFiles(currentDir, projectMarkerPatterns);
                 if (markerCount == 1)
                     return NormalizeScopeKey(Path.GetRelativePath(_projectRoot, currentDir));
                 if (markerCount > 1)
@@ -1006,16 +1006,16 @@ public class FileIndexer
     public static IReadOnlyList<string> GetHotspotFamilyMarkerLanguages() => HotspotFamilyMarkerLanguages;
 
     public static bool SupportsHotspotFamilyMarkerLanguage(string? lang) =>
-        GetProjectMarkerPattern(lang) != null;
+        GetProjectMarkerPatterns(lang) != null;
 
     public string? GetProjectMarkerFingerprint(string? lang)
     {
-        var projectMarkerPattern = GetProjectMarkerPattern(lang);
-        if (projectMarkerPattern == null)
+        var projectMarkerPatterns = GetProjectMarkerPatterns(lang);
+        if (projectMarkerPatterns == null)
             return null;
 
         var projectMarkers = new List<string>();
-        CollectProjectMarkerFiles(_projectRoot, projectMarkerPattern, projectMarkers);
+        CollectProjectMarkerFiles(_projectRoot, projectMarkerPatterns, projectMarkers);
         projectMarkers.Sort(StringComparer.Ordinal);
 
         var payload = string.Join('\n', projectMarkers);
@@ -1065,19 +1065,38 @@ public class FileIndexer
         return $"{left}/{right}";
     }
 
-    private void CollectProjectMarkerFiles(string dir, string pattern, List<string> projectMarkers)
+    private static int CountProjectMarkerFiles(string dir, IReadOnlyList<string> patterns)
+    {
+        var count = 0;
+        foreach (var pattern in patterns)
+        {
+            foreach (var _ in Directory.EnumerateFiles(dir, pattern, SearchOption.TopDirectoryOnly))
+            {
+                count++;
+                if (count > 1)
+                    return count;
+            }
+        }
+
+        return count;
+    }
+
+    private void CollectProjectMarkerFiles(string dir, IReadOnlyList<string> patterns, List<string> projectMarkers)
     {
         try
         {
-            foreach (var file in Directory.EnumerateFiles(dir, pattern, SearchOption.TopDirectoryOnly))
-                projectMarkers.Add(NormalizeScopeKey(Path.GetRelativePath(_projectRoot, file)));
+            foreach (var pattern in patterns)
+            {
+                foreach (var file in Directory.EnumerateFiles(dir, pattern, SearchOption.TopDirectoryOnly))
+                    projectMarkers.Add(NormalizeScopeKey(Path.GetRelativePath(_projectRoot, file)));
+            }
 
             foreach (var subDir in Directory.EnumerateDirectories(dir))
             {
                 if (SkipDirs.Contains(Path.GetFileName(subDir)))
                     continue;
 
-                CollectProjectMarkerFiles(subDir, pattern, projectMarkers);
+                CollectProjectMarkerFiles(subDir, patterns, projectMarkers);
             }
         }
         catch (UnauthorizedAccessException)
@@ -1092,11 +1111,12 @@ public class FileIndexer
         }
     }
 
-    private static string? GetProjectMarkerPattern(string? lang) => lang switch
+    private static IReadOnlyList<string>? GetProjectMarkerPatterns(string? lang) => lang switch
     {
-        "csharp" => "*.csproj",
-        "vb" => "*.vbproj",
-        "fsharp" => "*.fsproj",
+        "csharp" => ["*.csproj"],
+        "vb" => ["*.vbproj"],
+        "fsharp" => ["*.fsproj"],
+        "msbuild" => ["*.csproj", "*.fsproj", "*.vbproj", "*.props", "*.targets"],
         _ => null,
     };
 

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -194,6 +194,29 @@ public class FileIndexerTests
         }
     }
 
+    [Fact]
+    public void GetFamilyScopeKey_MsbuildProjectFileIgnoresDirectoryBuildMarkersForScope()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            var srcDir = Path.Combine(tempDir, "src");
+            Directory.CreateDirectory(srcDir);
+            File.WriteAllText(Path.Combine(srcDir, "App.csproj"), "<Project />");
+            File.WriteAllText(Path.Combine(srcDir, "Directory.Build.props"), "<Project />");
+            File.WriteAllText(Path.Combine(srcDir, "Directory.Build.targets"), "<Project />");
+
+            var indexer = new FileIndexer(tempDir);
+
+            Assert.Equal("src", indexer.GetFamilyScopeKey(Path.Combine(srcDir, "App.csproj"), "msbuild"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
     [Theory]
     // Bare trailing-dot forms should not match prefix rules — suffix must be non-empty.
     // 末尾ドットだけの形はプレフィックス規則に一致しない（サフィックス必須）。

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -169,6 +169,32 @@ public class FileIndexerTests
     }
 
     [Theory]
+    [InlineData("App.csproj")]
+    [InlineData("Directory.Build.props")]
+    [InlineData("Directory.Build.targets")]
+    [InlineData("Library.fsproj")]
+    [InlineData("Project.vbproj")]
+    public void GetProjectMarkerFingerprint_RecognizesMsbuildProjectMarkers(string markerFileName)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_msbuild_marker_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, markerFileName), "<Project />");
+
+            var indexer = new FileIndexer(tempDir);
+
+            Assert.True(FileIndexer.SupportsHotspotFamilyMarkerLanguage("msbuild"));
+            Assert.False(string.IsNullOrWhiteSpace(indexer.GetProjectMarkerFingerprint("msbuild")));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Theory]
     // Bare trailing-dot forms should not match prefix rules — suffix must be non-empty.
     // 末尾ドットだけの形はプレフィックス規則に一致しない（サフィックス必須）。
     [InlineData("Dockerfile.")]


### PR DESCRIPTION
This PR addresses the follow-up candidate from PR #1198 by teaching the hotspot-family marker path about `msbuild`.

What changed:
- add `msbuild` to the hotspot-family marker language list
- treat `.csproj`, `.fsproj`, `.vbproj`, `.props`, and `.targets` as MSBuild markers for family fingerprinting
- keep MSBuild project files from becoming ambiguous just because `Directory.Build.props` / `Directory.Build.targets` live beside a single project file
- add regression coverage for MSBuild marker fingerprints and family scope key behavior

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~FileIndexerTests.GetProjectMarkerFingerprint_RecognizesMsbuildProjectMarkers`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~FileIndexerTests.GetFamilyScopeKey_MsbuildProjectFileIgnoresDirectoryBuildMarkersForScope`

Changelog fragment:
- added under `changelog.d/unreleased/`
