### PR TITLE
Refine Fortran block detection

### DIFF
--- a/changelog.d/unreleased/+fortran-body-range.fixed.md
+++ b/changelog.d/unreleased/+fortran-body-range.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran modules, submodules, and programs now keep body ranges** — `module`, `submodule`, and `program` declarations now track their matching `end` lines so internal procedures stay contained under the right parent symbol.
+
+## 日本語
+
+- **Fortran の module / submodule / program で body range を保持するようになりました** — `module`、`submodule`、`program` 宣言が対応する `end` 行まで範囲を追跡するため、内部手続きが正しい親シンボルの下に収まるようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -181,6 +181,7 @@ public static class SymbolExtractor
         Brace,
         Indent,
         RubyEnd,
+        FortranEnd,
         ElixirEnd,
         VisualBasicEnd,
         SqlProcBody,
@@ -1033,9 +1034,11 @@ public static class SymbolExtractor
         ["fortran"] =
         [
             // Fortran modules / モジュール
-            new("namespace", new Regex(@"^\s*module\s+(?!procedure\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("namespace", new Regex(@"^\s*module\s+(?!(?:procedure|subroutine|function)\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
+            // Fortran submodules / サブモジュール
+            new("namespace", new Regex(@"^\s*submodule\s*\(\s*[^)]*\)\s*(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Program units / プログラム本体
-            new("class", new Regex(@"^\s*program\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("class", new Regex(@"^\s*program\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed or untyped functions / 型付き・型なし関数
@@ -11777,15 +11780,16 @@ private sealed class RubyMaskState
         {
             BodyStyle.Brace when lang is "javascript" or "typescript" => FindJavaScriptBraceRange(lines, startIndex, lang, startColumn),
             BodyStyle.Brace when lang == "csharp" => FindCSharpBraceRange(lines, startIndex, startColumn),
-            BodyStyle.Brace when lang == "java" => FindJavaBraceRange(lines, startIndex, startColumn),
-            BodyStyle.Brace => FindBraceRange(lines, startIndex, startColumn, lang),
-            BodyStyle.Indent => FindIndentRange(lines, startIndex),
-            BodyStyle.RubyEnd => FindRubyRange(lines, startIndex),
-            BodyStyle.ElixirEnd => FindElixirRange(lines, startIndex),
-            BodyStyle.VisualBasicEnd => FindVisualBasicRange(lines, startIndex),
-            BodyStyle.SqlProcBody => FindSqlProcBodyRange(lines, startIndex),
-            _ => (startIndex + 1, null, null),
-        };
+              BodyStyle.Brace when lang == "java" => FindJavaBraceRange(lines, startIndex, startColumn),
+              BodyStyle.Brace => FindBraceRange(lines, startIndex, startColumn, lang),
+              BodyStyle.Indent => FindIndentRange(lines, startIndex),
+              BodyStyle.RubyEnd => FindRubyRange(lines, startIndex),
+              BodyStyle.FortranEnd => FindFortranRange(lines, startIndex),
+              BodyStyle.ElixirEnd => FindElixirRange(lines, startIndex),
+              BodyStyle.VisualBasicEnd => FindVisualBasicRange(lines, startIndex),
+              BodyStyle.SqlProcBody => FindSqlProcBodyRange(lines, startIndex),
+              _ => (startIndex + 1, null, null),
+          };
     }
 
     private static bool TryFindKotlinScalaExpressionBodyEndLine(string line, int startColumn)
@@ -15127,6 +15131,95 @@ private sealed class RubyMaskState
         return bodyStartLine == null
             ? (startIndex + 1, null, null)
             : (endLine, bodyStartLine, endLine);
+    }
+
+    private static (int EndLine, int? BodyStartLine, int? BodyEndLine) FindFortranRange(string[] lines, int startIndex)
+    {
+        if (!TryGetFortranBlockStartKind(lines[startIndex], out var blockKind))
+            return (startIndex + 1, null, null);
+
+        int? bodyStartLine = null;
+        var endLine = startIndex + 1;
+
+        for (int i = startIndex + 1; i < lines.Length; i++)
+        {
+            var trimmed = lines[i].Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith('!'))
+                continue;
+
+            if (IsFortranBlockEndLine(trimmed, blockKind))
+            {
+                if (bodyStartLine == null)
+                    return (i + 1, null, null);
+
+                return (i + 1, bodyStartLine, i + 1);
+            }
+
+            if (bodyStartLine == null)
+                bodyStartLine = i + 1;
+
+            endLine = i + 1;
+        }
+
+        return bodyStartLine == null
+            ? (startIndex + 1, null, null)
+            : (endLine, bodyStartLine, endLine);
+    }
+
+    private static bool TryGetFortranBlockStartKind(string line, out string kind)
+    {
+        kind = string.Empty;
+        var trimmed = line.TrimStart();
+        if (trimmed.Length == 0)
+            return false;
+
+        if (StartsWithFortranWord(trimmed, "module"))
+        {
+            var remainder = trimmed["module".Length..].TrimStart();
+            if (StartsWithFortranWord(remainder, "procedure") || StartsWithFortranWord(remainder, "subroutine") || StartsWithFortranWord(remainder, "function"))
+                return false;
+
+            kind = "module";
+            return true;
+        }
+
+        if (StartsWithFortranWord(trimmed, "submodule"))
+        {
+            kind = "submodule";
+            return true;
+        }
+
+        if (StartsWithFortranWord(trimmed, "program"))
+        {
+            kind = "program";
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsFortranBlockEndLine(string trimmedLine, string blockKind)
+    {
+        if (!StartsWithFortranWord(trimmedLine, "end"))
+            return false;
+
+        var remainder = trimmedLine["end".Length..].TrimStart();
+        if (!StartsWithFortranWord(remainder, blockKind))
+            return false;
+
+        var afterKind = remainder[blockKind.Length..].TrimStart();
+        if (blockKind == "module" && StartsWithFortranWord(afterKind, "procedure"))
+            return false;
+
+        return afterKind.Length == 0 || afterKind.StartsWith('!') || afterKind.StartsWith('(') || afterKind.StartsWith(':') || char.IsLetterOrDigit(afterKind[0]) || afterKind[0] == '_';
+    }
+
+    private static bool StartsWithFortranWord(string input, string word)
+    {
+        if (!input.StartsWith(word, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return input.Length == word.Length || !char.IsLetterOrDigit(input[word.Length]) && input[word.Length] != '_';
     }
 
     private static (int EndLine, int? BodyStartLine, int? BodyEndLine) FindRubyRange(string[] lines, int startIndex)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9686,16 +9686,18 @@ public class SymbolExtractorTests
             module math_utils
               implicit none
             contains
-              pure real function square(x) result(y)
-                real, intent(in) :: x
-                y = x * x
-              end function square
-
               recursive subroutine normalize(v)
               end subroutine normalize
             end module math_utils
 
+            submodule (math_utils) math_utils_impl
+            contains
+              module subroutine expand(v)
+              end subroutine expand
+            end submodule math_utils_impl
+
             program demo
+              print *, "hello"
             end program demo
 
             integer function add(a, b)
@@ -9706,10 +9708,28 @@ public class SymbolExtractorTests
             """;
         var symbols = SymbolExtractor.Extract(1, "fortran", content);
 
-        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "math_utils");
-        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "demo");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "square");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize");
+        var mathUtils = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_utils");
+        Assert.NotNull(mathUtils.BodyStartLine);
+        Assert.NotNull(mathUtils.BodyEndLine);
+
+        var mathUtilsImpl = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_utils_impl");
+        Assert.NotNull(mathUtilsImpl.BodyStartLine);
+        Assert.NotNull(mathUtilsImpl.BodyEndLine);
+
+        var demo = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "demo");
+        Assert.NotNull(demo.BodyStartLine);
+        Assert.NotNull(demo.BodyEndLine);
+
+        var normalize = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize");
+        Assert.Equal("namespace", normalize.ContainerKind);
+        Assert.Equal("math_utils", normalize.ContainerName);
+
+        var expand = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "expand");
+        Assert.Equal("namespace", expand.ContainerKind);
+        Assert.Equal("math_utils_impl", expand.ContainerName);
+
+        Assert.DoesNotContain(symbols, s => s.Kind == "namespace" && s.Name == "subroutine");
+
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "add");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "typed_value");
     }


### PR DESCRIPTION
## Summary

This PR follows up on the `Follow-up candidates` from PR #1199.

- Treats Fortran `submodule` as a real container with tracked body range.
- Avoids misclassifying `module subroutine` / `module function` as module declarations.
- Improves container resolution for internal procedures nested under Fortran module-like blocks.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions|FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+fortran-body-range.fixed.md`

## Follow-up candidates

- Fortran `end module procedure` still uses the current conservative handling and could be modeled more precisely if broader syntax coverage is needed.
- Additional Fortran procedure forms beyond `module subroutine` / `module function` may still need explicit coverage as they appear in the wild.