### PR TITLE
Improve VB overload member indexing

### DIFF
--- a/changelog.d/unreleased/+vb-overloads-members.fixed.md
+++ b/changelog.d/unreleased/+vb-overloads-members.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **VB.NET `Overloads` members are indexed again** — `Overloads` now counts as a VB member modifier, so `Overloads Sub`, `Overloads Function`, and `Overloads Property` declarations stay searchable instead of being skipped.
+
+## 日本語
+
+- **VB.NET の `Overloads` 付き member を再び索引化するようにしました** — `Overloads` を VB の member modifier として扱うため、`Overloads Sub` / `Overloads Function` / `Overloads Property` の宣言が検索漏れしなくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -508,10 +508,10 @@ public static class SymbolExtractor
 
     private const string VbVisibilityPattern = @"(?:Public|Private|Protected|Friend)(?:\s+(?:Protected|Friend))?";
     private const string VbTypeModifierPattern = @"(?:Partial|MustInherit|NotInheritable)";
-    private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Async|Partial)";
-    private const string VbOperatorModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Async|Partial|Widening|Narrowing)";
-    private const string VbPropertyModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Default|ReadOnly|WriteOnly)";
-    private const string VbEventModifierPattern = @"(?:Shared|Custom)";
+      private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Async|Partial)";
+      private const string VbOperatorModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Async|Partial|Widening|Narrowing)";
+      private const string VbPropertyModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Default|ReadOnly|WriteOnly)";
+      private const string VbEventModifierPattern = @"(?:Shared|Overloads|Custom)";
 
     private static readonly Dictionary<string, List<SymbolPattern>> PatternCache = new()
     {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12474,6 +12474,34 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_VB_DetectsOverloadsMembers()
+    {
+        // VB.NET Overloads members should still be searchable / VB.NET の Overloads 付き member も
+        // 変わらず検索できること。
+        var content = """
+            Public Class DerivedWidget
+                Public Overloads Sub Render()
+                End Sub
+
+                Public Overloads Function Compute() As Integer
+                    Return 42
+                End Function
+
+                Public Overloads ReadOnly Property Count As Integer
+                    Get
+                        Return 1
+                    End Get
+                End Property
+            End Class
+            """;
+        var symbols = SymbolExtractor.Extract(1, "vb", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Render");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Compute");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Count");
+    }
+
+    [Fact]
     public void Extract_VB_DetectsNestedEnumMembersAndMembersAfterEnum()
     {
         // VB.NET enum bodies should stay searchable, and nested enums must not cut off later


### PR DESCRIPTION
## Summary

Improve VB.NET search coverage for `Overloads` member declarations. `Sub`, `Function`, and `Property` declarations that use `Overloads` are now indexed correctly instead of being skipped.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_VB_DetectsOverloadsMembers"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

## Changelog

- Added an unreleased fragment at `changelog.d/unreleased/+vb-overloads-members.fixed.md`.

## Follow-up candidates

- Review the remaining VB modifier matrix for other legal member modifiers that may still be missing from symbol extraction, such as `Shadows` if we decide to support it explicitly later.