### PR TITLE
Add Dockerfile ARG symbol indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ The database reflects the working tree at the time of the last index. After swit
 | GraphQL | `.graphql`, `.gql` | yes |
 | Gradle | `.gradle` | yes |
 | Makefile | `Makefile`, `GNUmakefile`, `Makefile.<suffix>`, `GNUmakefile.<suffix>`, `.mk` | yes |
-| Dockerfile | `Dockerfile`, `Containerfile`, `Dockerfile.<suffix>`, `Containerfile.<suffix>` | yes |
+| Dockerfile | `Dockerfile`, `Containerfile`, `Dockerfile.<suffix>`, `Containerfile.<suffix>` | yes; `ARG` build args are searchable as `property` symbols |
 | Assembly | `.s`, `.S`, `.asm`, `.nasm` | -- |
 | CUDA | `.cu`, `.cuh` | -- |
 | GLSL | `.glsl`, `.vert`, `.frag` | -- |
@@ -1627,7 +1627,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | GraphQL | `.graphql`, `.gql` | yes |
 | Gradle | `.gradle` | yes |
 | Makefile | `Makefile`, `GNUmakefile`, `Makefile.<suffix>`, `GNUmakefile.<suffix>`, `.mk` | yes |
-| Dockerfile | `Dockerfile`, `Containerfile`, `Dockerfile.<suffix>`, `Containerfile.<suffix>` | yes |
+| Dockerfile | `Dockerfile`, `Containerfile`, `Dockerfile.<suffix>`, `Containerfile.<suffix>` | yes; `ARG` ビルド引数も `property` シンボルとして検索可 |
 | Zig | `.zig` | yes |
 | XAML | `.xaml`, `.axaml` | -- |
 | MSBuild | `.csproj`, `.fsproj`, `.vbproj`, `.props`, `.targets` | -- |

--- a/changelog.d/unreleased/+dockerfile-build-args.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-build-args.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **Dockerfile `ARG` build arguments are now searchable as `property` symbols** - Dockerfile symbol extraction now indexes `ARG` declarations such as `NODE_VERSION` and `APP_HOME`, making build-time knobs visible to `symbols`, `search`, and related symbol-aware workflows.
+
+## 日本語
+
+- **Dockerfile の `ARG` ビルド引数を `property` シンボルとして検索できるようにしました** - Dockerfile の symbol extraction で `NODE_VERSION` や `APP_HOME` のような `ARG` 宣言をインデックスするため、ビルド時の設定値を `symbols` / `search` などのシンボル対応ワークフローから名前でたどれます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1359,6 +1359,7 @@ public static class SymbolExtractor
         ],
         ["dockerfile"] =
         [
+            new("property", new Regex(@"^\s*ARG\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+\S+\s+(?:AS|as)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?<name>\S+)", RegexOptions.Compiled), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -16825,6 +16825,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsBuildArgs()
+    {
+        var content = """
+            ARG NODE_VERSION=20
+            FROM node:${NODE_VERSION} AS builder
+
+            ARG APP_HOME
+            WORKDIR /app
+            """;
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "NODE_VERSION");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "APP_HOME");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "builder");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name.Contains("node:${NODE_VERSION}", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_Protobuf_DetectsSymbols()
     {
         var content = """


### PR DESCRIPTION
This PR adds a Dockerfile search enhancement on top of the latest `origin/main`.

Changes:
- index Dockerfile `ARG` build arguments as `property` symbols
- add a regression test covering `ARG NODE_VERSION=20` and `ARG APP_HOME`
- document the new searchable Dockerfile `ARG` symbols in README
- add a changelog fragment under `changelog.d/unreleased/`

Adversarial review:
- completed against `origin/main..HEAD`

Follow-up candidates:
- none identified in this PR