### PR TITLE
Normalize XAML x:Key markup extensions

### DIFF
--- a/changelog.d/unreleased/+xaml-key-markup-extension.changed.md
+++ b/changelog.d/unreleased/+xaml-key-markup-extension.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML `x:Key` markup extensions are now normalized before indexing** — resource keys such as `x:Key="{x:Static local:Keys.AccentBrush}"` are indexed using the inner reference instead of the raw brace-wrapped markup extension, which makes `ResourceDictionary` keys easier to search.
+
+## 日本語
+
+- **XAML の `x:Key` markup extension を正規化してからインデックスするようになりました** — `x:Key="{x:Static local:Keys.AccentBrush}"` のようなリソースキーは、波括弧付きの markup extension そのものではなく内側の参照名でインデックスされるため、`ResourceDictionary` のキーをより検索しやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -4530,7 +4530,7 @@ private sealed class RubyMaskState
 
             foreach (Match keyMatch in XamlKeyRegex.Matches(line))
             {
-                var value = keyMatch.Groups["value"].Value.Trim();
+                var value = NormalizeXamlKeyValue(keyMatch.Groups["value"].Value);
                 if (value.Length == 0)
                     continue;
                 symbols.Add(new SymbolRecord
@@ -4547,6 +4547,23 @@ private sealed class RubyMaskState
         }
 
         return symbols;
+    }
+
+    private static string NormalizeXamlKeyValue(string value)
+    {
+        value = value.Trim();
+        if (value.Length < 2 || value[0] != '{' || value[^1] != '}')
+            return value;
+
+        value = value[1..^1].Trim();
+        if (value.Length == 0)
+            return value;
+
+        var separatorIndex = value.IndexOfAny([' ', '\t', '\r', '\n']);
+        if (separatorIndex >= 0)
+            value = value[(separatorIndex + 1)..].Trim();
+
+        return value;
     }
 
     private static bool IsHtmlTagNameStart(char c) => (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18726,7 +18726,7 @@ public class SymbolExtractorTests
         var content = """
             <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-                <SolidColorBrush x:Key="AccentBrush" Color="Tomato" />
+                <SolidColorBrush x:Key="{x:Static local:Keys.AccentBrush}" Color="Tomato" />
                 <Style x:Key="PrimaryButtonStyle" TargetType="Button">
                     <Setter Property="Background" Value="{StaticResource AccentBrush}" />
                 </Style>
@@ -18735,7 +18735,7 @@ public class SymbolExtractorTests
 
         var symbols = SymbolExtractor.Extract(1, "xml", content);
 
-        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "AccentBrush");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "local:Keys.AccentBrush");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "PrimaryButtonStyle");
     }
 


### PR DESCRIPTION
## Summary
- Addresses the follow-up candidate from PR #1202.
- Normalize XAML `x:Key` markup extension values before indexing so keys like `x:Key="{x:Static local:Keys.AccentBrush}"` are stored using the inner reference.
- Keep existing plain `x:Key` behavior and add regression coverage for both forms.
- Add a bilingual changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Xml_XamlCapturesXKey"`
- `dotnet build`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Review
- Adversarial review completed with no blocking issues.

## Follow-up candidates
- `x:Key` values that use named arguments or nested markup extensions, such as `x:Key="{x:Static Member={x:Type local:Keys}.AccentBrush}"`, are still normalized with a heuristic approach.