### PR TITLE
Index Go module and workspace manifests

### DIFF
--- a/changelog.d/unreleased/+go-module-workspace.fixed.md
+++ b/changelog.d/unreleased/+go-module-workspace.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Go module and workspace manifests now index as Go files** — `go.mod` and `go.work` are recognized as `go`, so module and workspace manifests participate in Go search results instead of being left out as unknown filenames.
+
+## 日本語
+
+- **Go の module / workspace マニフェストが Go ファイルとしてインデックスされるようになりました** — `go.mod` と `go.work` を `go` として認識するため、モジュールおよびワークスペースのマニフェストも Go の検索結果に含まれ、未知のファイル名として取りこぼされなくなります。

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -270,6 +270,8 @@ public class FileIndexer
         ["BUILD.bazel"]   = "python",
         ["WORKSPACE"]     = "python",       // Bazel workspace / Bazel ワークスペース
         ["WORKSPACE.bazel"]= "python",
+        ["go.mod"]        = "go",           // Go module manifest / Go モジュールマニフェスト
+        ["go.work"]       = "go",           // Go workspace manifest / Go ワークスペースマニフェスト
         [".editorconfig"] = "editorconfig",
         [".gitignore"]    = "gitignore",
         [".dockerignore"] = "dockerignore",

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -85,6 +85,8 @@ public class FileIndexerTests
     [InlineData("BUILD.bazel", "python")]
     [InlineData("WORKSPACE", "python")]
     [InlineData("WORKSPACE.bazel", "python")]
+    [InlineData("go.mod", "go")]
+    [InlineData("go.work", "go")]
     // Issue #189: additional extensions / 追加拡張子
     [InlineData("types.pyi", "python")]
     [InlineData("windowed.pyw", "python")]


### PR DESCRIPTION
Summary:
- recognize `go.mod` and `go.work` as `go` so Go module and workspace manifests are included in Go search/indexing

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~FileIndexerTests.DetectLanguage_KnownExtensions_ReturnsCorrectLang`

Changelog:
- `changelog.d/unreleased/+go-module-workspace.fixed.md`

Follow-up candidates:
- None identified.
