### PR TITLE
Add T-SQL aggregate symbol coverage

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -406,7 +406,7 @@ Supported symbol kinds by language (33 languages with symbol extraction):
 | Solidity | .sol | -- | -- | -- | -- | -- | -- | -- | -- |
 | Tcl | .tcl, .tk | -- | -- | -- | -- | -- | -- | -- | -- |
 | Shell | function declarations | -- | -- | -- | -- | -- | -- | -- | -- |
-| SQL | PROCEDURE/PROC, FUNCTION, TRIGGER, PARTITION FUNCTION | TABLE, VIEW, INDEX, TYPE, TYPE BODY, PACKAGE, PACKAGE BODY, SEQUENCE, DOMAIN, SYNONYM, DATABASE, DATABASE LINK, LOGIN, USER, ROLE, CERTIFICATE, DIRECTORY, CONTEXT, PROFILE, PARTITION SCHEME, FULLTEXT CATALOG | -- | -- | enum (`CREATE TYPE ... AS ENUM`) | -- | -- | EXTENSION | yes |
+| SQL | PROCEDURE/PROC, FUNCTION, TRIGGER, AGGREGATE, PARTITION FUNCTION | TABLE, VIEW, INDEX, TYPE, TYPE BODY, PACKAGE, PACKAGE BODY, SEQUENCE, DOMAIN, SYNONYM, DATABASE, DATABASE LINK, LOGIN, USER, ROLE, CERTIFICATE, DIRECTORY, CONTEXT, PROFILE, PARTITION SCHEME, FULLTEXT CATALOG | -- | -- | enum (`CREATE TYPE ... AS ENUM`) | -- | -- | EXTENSION | yes |
 | Terraform | variable, output, locals | resource, data, module | -- | -- | -- | `var.*`, `local.*`, `module.*`, `data.*`, same-file resource-like `TYPE.NAME` references such as `aws_instance.web` and `depends_on = [aws_s3_bucket.foo]` | -- | -- | -- |
 | Protobuf | rpc | message, service | -- | -- | enum | -- | -- | import | -- |
 | GraphQL | query, mutation, subscription | type, union, scalar, input | -- | interface | enum | -- | -- | -- | -- |

--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ The database reflects the working tree at the time of the last index. After swit
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 Query-time `--lang tsql` is accepted as an alias for the SQL bucket.
+T-SQL `CREATE AGGREGATE` / `ALTER AGGREGATE` declarations are also searchable.
 | Markdown | `.md` | -- |
 | YAML | `.yaml`, `.yml` | -- |
 | JSON | `.json` | -- |
@@ -1637,6 +1638,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 クエリ時の `--lang tsql` は SQL バケットの別名として受け付けられます。
+T-SQL の `CREATE AGGREGATE` / `ALTER AGGREGATE` も検索対象です。
 | Markdown | `.md` | -- |
 | YAML | `.yaml`, `.yml` | -- |
 | JSON | `.json` | -- |

--- a/changelog.d/unreleased/+tsql-aggregate.fixed.md
+++ b/changelog.d/unreleased/+tsql-aggregate.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+  - README.md
+---
+
+## English
+
+- **T-SQL `CREATE AGGREGATE` / `ALTER AGGREGATE` declarations now surface as searchable functions** — the SQL extractor now indexes SQL Server aggregate definitions alongside the existing procedure/function/trigger rows, so `symbols`, `definition`, and related search flows can find them instead of silently skipping the declaration.
+
+## 日本語
+
+- **T-SQL の `CREATE AGGREGATE` / `ALTER AGGREGATE` 宣言が検索可能な function として表面化するようになりました** — SQL extractor が SQL Server の aggregate 定義を既存の procedure/function/trigger 行と同様に index するため、`symbols` / `definition` / 関連検索で宣言を取りこぼさなくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1398,6 +1398,11 @@ public static class SymbolExtractor
             // BodyStyle.SqlProcBody により BEGIN...END / dollar-quoted の本体範囲を求め、ReferenceExtractor の
             // ResolveContainerForCall が本体内の呼び出しを外側のプロシージャに帰属させられるようにする（issue #429）。
             new("function", new Regex($@"^\s*CREATE\s+(?:OR\s+(?:REPLACE|ALTER)\s+)?(?:PROCEDURE|PROC|FUNCTION|TRIGGER)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.SqlProcBody),
+            // SQL Server aggregate definitions are callable search anchors too, but they do not have
+            // a statement body to scan, so they stay on the BodyStyle.None path.
+            // SQL Server の aggregate 定義も検索アンカーとして有用だが、走査すべき statement body は
+            // 持たないため BodyStyle.None のまま扱う。
+            new("function", new Regex($@"^\s*CREATE\s+AGGREGATE\b\s+(?<name>{SqlQualifiedIdentifierPattern})\s*\(", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("enum",     new Regex($@"^\s*CREATE\s+TYPE\s+(?<name>{SqlQualifiedIdentifierPattern})\s+AS\s+ENUM\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             // Oracle: CREATE [OR REPLACE] TYPE BODY <name> and CREATE [OR REPLACE] PACKAGE [BODY] <name>.
             // These must precede the bare CREATE TYPE / CREATE PACKAGE rows so the `BODY` keyword is
@@ -1450,6 +1455,7 @@ public static class SymbolExtractor
             // BodyStyle.SqlProcBody を使う。ALTER PARTITION FUNCTION は本体を持たない
             // （パーティション境界の変更のみ）ため、下の別パターンで BodyStyle.None のままにする。
             new("function", new Regex($@"^\s*ALTER\s+(?:PROCEDURE|PROC|FUNCTION|TRIGGER)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.SqlProcBody),
+            new("function", new Regex($@"^\s*ALTER\s+AGGREGATE\b\s+(?<name>{SqlQualifiedIdentifierPattern})\s*\(", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex($@"^\s*ALTER\s+PARTITION\s+FUNCTION\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("namespace", new Regex($@"^\s*ALTER\s+SCHEMA\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("import",   new Regex($@"^\s*ALTER\s+EXTENSION\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9782,6 +9782,7 @@ public class SymbolExtractorTests
             "CREATE SCHEMA sales AUTHORIZATION dbo;\n" +
             "CREATE TYPE sales.Money FROM DECIMAL(18, 4) NOT NULL;\n" +
             "CREATE SEQUENCE sales.OrderSeq START WITH 1 INCREMENT BY 1;\n" +
+            "CREATE AGGREGATE dbo.SumInt (@value INT) RETURNS INT EXTERNAL NAME dbo.SumInt;\n" +
             "CREATE RULE sales.discount_rule AS @price > 0;\n" +
             "CREATE DEFAULT dbo.zero_default AS 0;\n" +
             "CREATE SYNONYM dbo.Customers FOR external.Customers;\n" +
@@ -9801,6 +9802,7 @@ public class SymbolExtractorTests
             "ALTER PROCEDURE dbo.sp_DailyReport AS SELECT 2;\n" +
             "ALTER FUNCTION dbo.fn_Total() RETURNS INT AS BEGIN RETURN 1 END;\n" +
             "ALTER PARTITION FUNCTION pf_OrdersByYear() SPLIT RANGE ('2025-01-01');\n" +
+            "ALTER AGGREGATE dbo.SumInt (@value INT) RETURNS INT EXTERNAL NAME dbo.SumIntV2;\n" +
             "ALTER SCHEMA sales TRANSFER dbo.Customers;\n" +
             "ALTER EXTENSION hstore UPDATE TO '1.5';\n" +
             "ALTER CERTIFICATE svc_cert WITH PRIVATE KEY (DECRYPTION BY PASSWORD = 'x');\n" +
@@ -9811,6 +9813,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "sales");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.Money");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.OrderSeq");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dbo.SumInt");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.discount_rule");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.zero_default");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.Customers");
@@ -9837,6 +9840,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dbo.sp_DailyReport" && s.Signature != null && s.Signature.StartsWith("ALTER PROCEDURE", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dbo.fn_Total");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "pf_OrdersByYear" && s.Signature != null && s.Signature.StartsWith("ALTER PARTITION FUNCTION", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dbo.SumInt" && s.Signature != null && s.Signature.StartsWith("CREATE AGGREGATE", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dbo.SumInt" && s.Signature != null && s.Signature.StartsWith("ALTER AGGREGATE", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "sales" && s.Signature != null && s.Signature.StartsWith("ALTER SCHEMA", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "hstore");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "svc_cert" && s.Signature != null && s.Signature.StartsWith("ALTER CERTIFICATE", StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Summary

- Added SQL Server `CREATE AGGREGATE` / `ALTER AGGREGATE` handling to the SQL symbol extractor.
- Added regression coverage for T-SQL aggregate symbols in the SQL extractor test suite.
- Updated the SQL support tables in `README.md` and `DEVELOPER_GUIDE.md`.
- Added a bilingual changelog fragment under `changelog.d/unreleased/`.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_SQL_DetectsTSqlDdlKinds|FullyQualifiedName~SymbolExtractorTests.Extract_SQL_DetectsCreateStatements"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog

- `changelog.d/unreleased/+tsql-aggregate.fixed.md`
- `README.md`
- `DEVELOPER_GUIDE.md`

## Follow-up candidates

- `CREATE/ALTER ASSEMBLY` is still not indexed as a symbol, so SQL Server assembly deployment scripts can still be skipped by `symbols` / `definition`.
- `CREATE/ALTER XML SCHEMA COLLECTION` is still not indexed as a symbol, so XML schema deployment scripts can still be skipped by `symbols` / `definition`. 