### PR TITLE
Index Fortran module procedure declarations

### DIFF
--- a/changelog.d/unreleased/+fortran-module-procedure.fixed.md
+++ b/changelog.d/unreleased/+fortran-module-procedure.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran `module procedure` declarations are now searchable** — `module procedure` lines are indexed as `function` symbols, so interface-bound procedure names show up in `symbols`, `definition`, and related lookups instead of being silently skipped.
+
+## 日本語
+
+- **Fortran の `module procedure` 宣言が検索対象になりました** — `module procedure` 行を `function` シンボルとして索引するため、interface に紐づく手続き名が `symbols`、`definition`、関連検索に現れ、無言で取りこぼされなくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1048,7 +1048,7 @@ public static class SymbolExtractor
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Module procedure declarations / モジュール手続き宣言
-            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*module\s+procedure\s+(?:::\s*)?(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*module\s+procedure\s+(?:::\s*)?(?<name>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed or untyped functions / 型付き・型なし関数
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*(?:(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)|procedure\s*\([^)]+\))\s+)?function\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
         ],
@@ -2748,6 +2748,19 @@ private sealed class RubyMaskState
                         signature = line[absoluteStartColumn..].Trim();
                     }
 
+                    List<string>? fortranModuleProcedureNames = null;
+                    if (lang == "fortran"
+                        && pattern.Kind == "function"
+                        && signature.Contains("module procedure", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var names = name.Split(',');
+                        for (var index = 0; index < names.Length; index++)
+                            names[index] = names[index].Trim();
+
+                        if (names.Any(static candidate => candidate.Length > 0))
+                            fortranModuleProcedureNames = names.Where(static candidate => candidate.Length > 0).ToList();
+                    }
+
                     var suppressJavaStatementSymbol = false;
                     if (lang == "java" && pattern.Kind == "function")
                     {
@@ -2790,6 +2803,34 @@ private sealed class RubyMaskState
                                         Signature = signature,
                                         Visibility = TryGetGroup(match, pattern.VisibilityGroup),
                                         ReturnType = NormalizeMetadata(entry.ReturnType),
+                                    },
+                                    line);
+                            }
+                        }
+                        else if (fortranModuleProcedureNames != null)
+                        {
+                            foreach (var procedureName in fortranModuleProcedureNames)
+                            {
+                                AddSymbolRecord(
+                                    symbols,
+                                    cssSeenSymbols,
+                                    startLine,
+                                    new SymbolRecord
+                                    {
+                                        FileId = fileId,
+                                        Kind = kind,
+                                        Name = procedureName,
+                                        Line = startLine,
+                                        StartLine = startLine,
+                                        StartColumn = csharpSingleLineCollapsedMatch
+                                            ? csharpSignatureRawStartColumn
+                                            : absoluteStartColumn,
+                                        EndLine = Math.Max(startLine, endLine),
+                                        BodyStartLine = bodyStartLine,
+                                        BodyEndLine = bodyEndLine,
+                                        Signature = signature,
+                                        Visibility = TryGetGroup(match, pattern.VisibilityGroup),
+                                        ReturnType = NormalizeMetadata(rawReturnType),
                                     },
                                     line);
                             }

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1047,6 +1047,8 @@ public static class SymbolExtractor
             new("class", new Regex(@"^\s*program\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Module procedure declarations / モジュール手続き宣言
+            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*module\s+procedure\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed or untyped functions / 型付き・型なし関数
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*(?:(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)|procedure\s*\([^)]+\))\s+)?function\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
         ],

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1048,7 +1048,7 @@ public static class SymbolExtractor
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Module procedure declarations / モジュール手続き宣言
-            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*module\s+procedure\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*module\s+procedure\s+(?:::?\s*)?(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed or untyped functions / 型付き・型なし関数
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*(?:(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)|procedure\s*\([^)]+\))\s+)?function\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
         ],

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1048,7 +1048,7 @@ public static class SymbolExtractor
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Module procedure declarations / モジュール手続き宣言
-            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*module\s+procedure\s+(?:::?\s*)?(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*module\s+procedure\s+(?:::\s*)?(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed or untyped functions / 型付き・型なし関数
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*(?:(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)|procedure\s*\([^)]+\))\s+)?function\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
         ],

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9684,6 +9684,9 @@ public class SymbolExtractorTests
     {
         var content = """
             module math_utils
+              interface
+                module procedure normalize_iface
+              end interface
               implicit none
             contains
               recursive subroutine normalize(v)
@@ -9711,6 +9714,8 @@ public class SymbolExtractorTests
         var mathUtils = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_utils");
         Assert.NotNull(mathUtils.BodyStartLine);
         Assert.NotNull(mathUtils.BodyEndLine);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_iface");
 
         var mathUtilsImpl = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_utils_impl");
         Assert.NotNull(mathUtilsImpl.BodyStartLine);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9685,7 +9685,7 @@ public class SymbolExtractorTests
         var content = """
             module math_utils
               interface
-                module procedure normalize_iface
+                module procedure normalize_iface, normalize_alt
               end interface
               implicit none
             contains
@@ -9716,6 +9716,7 @@ public class SymbolExtractorTests
         Assert.NotNull(mathUtils.BodyEndLine);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_iface");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_alt");
 
         var mathUtilsImpl = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_utils_impl");
         Assert.NotNull(mathUtilsImpl.BodyStartLine);


### PR DESCRIPTION
## Summary

This PR follows up on the `Follow-up candidates` from PR #1206.

- Indexes `module procedure` declarations as searchable `function` symbols.
- Keeps these interface-bound procedure names visible to `symbols` and `definition` lookups instead of skipping them.
- Adds a regression test to cover the new Fortran form alongside the existing module/submodule coverage.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions|FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+fortran-module-procedure.fixed.md`

## Follow-up candidates

- More Fortran interface-body forms may still need explicit coverage if they appear in the wild.
- `end module procedure` is still handled conservatively in the body-range scanner if future syntax support needs finer-grained modeling.