### PR TITLE
Support generic F# type aliases

### DIFF
--- a/changelog.d/unreleased/+fsharp-generic-typealias.fixed.md
+++ b/changelog.d/unreleased/+fsharp-generic-typealias.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# generic type abbreviations and backtick-escaped alias names stay searchable as `typealias`** — `type Result<'T> = Choice<'T, string>` and similar abbreviations now remain visible to `symbols`, `definition`, and `outline`, including aliases that use a `when` constraint or backtick-escaped names.
+
+## 日本語
+
+- **F# の generic type abbreviation とバッククォート付き別名名が `typealias` として検索可能になりました** — `type Result<'T> = Choice<'T, string>` のような省略形が `symbols`、`definition`、`outline` から消えず、`when` 制約やバッククォートでエスケープされた別名も見えるままになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1238,14 +1238,22 @@ public static class SymbolExtractor
         [
             new("function", new Regex(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
+            // mistaken for union cases just because the right-hand side starts with a capitalized
+            // type name.
+            // `type Result<'T> = Choice<'T, string>` のような generic abbreviation は、
+            // 右辺が大文字始まりの型名でも union case と誤認しない。
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*<[^=]+?>\s*(?:when\b[^=]+)?\s*=\s*(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
             new("enum", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("typealias", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
+            // Simple aliases without generic parameters stay searchable as `typealias`.
+            // generic 引数なしの単純な alias も `typealias` として検索可能にする。
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>\w+)\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12488,12 +12488,18 @@ public class SymbolExtractorTests
             type UserId = int
             type OrderId = string
             type Names = string list
+            type Result<'T> = Choice<'T, string>
+            type Pair<'T, 'U> = 'T * 'U
             """;
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
 
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "OrderId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Names");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Result");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Pair");
+        Assert.DoesNotContain(symbols, s => s.Kind == "enum" && s.Name == "Result");
+        Assert.DoesNotContain(symbols, s => s.Kind == "enum" && s.Name == "Pair");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

This PR addresses the follow-up candidate from PR #1201 by making F# generic type abbreviations searchable as `typealias`.

- `type Result<'T> = Choice<'T, string>` now indexes as `typealias`
- Generic aliases with multiple parameters are covered as well
- The F# enum rule no longer steals generic aliases just because the right-hand side starts with a capitalized type name

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~Extract_FSharp_`
- `dotnet test`

## Changelog

- Added `changelog.d/unreleased/+fsharp-generic-typealias.fixed.md`

## Follow-up candidates

- None
