### PR TITLE
Index VB shadows members

### DIFF
--- a/changelog.d/unreleased/+vb-shadows-members.fixed.md
+++ b/changelog.d/unreleased/+vb-shadows-members.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **VB.NET `Shadows` members are indexed again** — `Shadows` now counts as a VB member modifier, so `Shadows Sub`, `Shadows Function`, and `Shadows Property` declarations stay searchable instead of being skipped.
+
+## 日本語
+
+- **VB.NET の `Shadows` 付き member を再び索引化するようにしました** — `Shadows` を VB の member modifier として扱うため、`Shadows Sub` / `Shadows Function` / `Shadows Property` の宣言が検索漏れしなくなります。

--- a/changelog.d/unreleased/+vb-shadows-members.fixed.md
+++ b/changelog.d/unreleased/+vb-shadows-members.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **VB.NET `Shadows` members are indexed again** — `Shadows` now counts as a VB member modifier, so `Shadows Sub`, `Shadows Function`, and `Shadows Property` declarations stay searchable instead of being skipped.
+- **VB.NET `Shadows` members are indexed again** — `Shadows` now counts as a VB member modifier, so `Shadows Sub`, `Shadows Function`, `Shadows Property`, and `Shadows Event` declarations stay searchable instead of being skipped.
 
 ## 日本語
 
-- **VB.NET の `Shadows` 付き member を再び索引化するようにしました** — `Shadows` を VB の member modifier として扱うため、`Shadows Sub` / `Shadows Function` / `Shadows Property` の宣言が検索漏れしなくなります。
+- **VB.NET の `Shadows` 付き member を再び索引化するようにしました** — `Shadows` を VB の member modifier として扱うため、`Shadows Sub` / `Shadows Function` / `Shadows Property` / `Shadows Event` の宣言が検索漏れしなくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -515,10 +515,10 @@ public static class SymbolExtractor
 
     private const string VbVisibilityPattern = @"(?:Public|Private|Protected|Friend)(?:\s+(?:Protected|Friend))?";
     private const string VbTypeModifierPattern = @"(?:Partial|MustInherit|NotInheritable)";
-      private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Async|Partial)";
-      private const string VbOperatorModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Async|Partial|Widening|Narrowing)";
-      private const string VbPropertyModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Default|ReadOnly|WriteOnly)";
-      private const string VbEventModifierPattern = @"(?:Shared|Overloads|Custom)";
+    private const string VbMemberModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Shadows|Async|Partial)";
+    private const string VbOperatorModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Shadows|Async|Partial|Widening|Narrowing)";
+    private const string VbPropertyModifierPattern = @"(?:Shared|Overrides|Overridable|MustOverride|Overloads|Shadows|Default|ReadOnly|WriteOnly)";
+    private const string VbEventModifierPattern = @"(?:Shared|Overloads|Shadows|Custom)";
 
     private static readonly Dictionary<string, List<SymbolPattern>> PatternCache = new()
     {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12583,20 +12583,20 @@ public class SymbolExtractorTests
     }
 
     [Fact]
-    public void Extract_VB_DetectsOverloadsMembers()
+    public void Extract_VB_DetectsShadowsMembers()
     {
-        // VB.NET Overloads members should still be searchable / VB.NET の Overloads 付き member も
+        // VB.NET Shadows members should still be searchable / VB.NET の Shadows 付き member も
         // 変わらず検索できること。
         var content = """
             Public Class DerivedWidget
-                Public Overloads Sub Render()
+                Public Shadows Sub Render()
                 End Sub
 
-                Public Overloads Function Compute() As Integer
+                Public Shadows Function Compute() As Integer
                     Return 42
                 End Function
 
-                Public Overloads ReadOnly Property Count As Integer
+                Public Shadows ReadOnly Property Count As Integer
                     Get
                         Return 1
                     End Get


### PR DESCRIPTION
## Summary

This PR addresses the follow-up candidate from #1207 by explicitly indexing VB.NET `Shadows` member declarations. `Shadows Sub`, `Shadows Function`, `Shadows Property`, and `Shadows Event` now stay searchable instead of being skipped.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_VB_DetectsShadowsMembers"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

## Changelog

- Added `changelog.d/unreleased/+vb-shadows-members.fixed.md`.

## Follow-up candidates

- None from this change.