### PR TITLE
Add R S4 symbol coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Perl | `.pl`, `.pm`, `.t`, `.pod` | -- |
 | Solidity | `.sol` | -- |
 | Tcl | `.tcl`, `.tk` | -- |
-| R | `.r`, `.R` | yes |
+| R | `.r`, `.R` | yes (function assignments, setClass/setRefClass, setGeneric/setMethod, library/require) |
 | Haskell | `.hs`, `.lhs` | yes |
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |

--- a/changelog.d/unreleased/+r-followup.fixed.md
+++ b/changelog.d/unreleased/+r-followup.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **R S4 and reference class definitions now surface in symbol search** — `cdidx` now extracts R `setClass` and `setRefClass` declarations as classes, plus `setGeneric` and `setMethod` declarations as functions, so R projects that lean on S4-style object systems get more useful symbol search results instead of falling back to file-level matches.
+
+## 日本語
+
+- **R の S4 / reference class 定義がシンボル検索に出るようになりました** — `cdidx` は R の `setClass` と `setRefClass` を class として、`setGeneric` と `setMethod` を function として抽出するため、S4 系のオブジェクトシステムを使う R プロジェクトでファイル単位の一致に落ちにくくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1289,6 +1289,8 @@ public static class SymbolExtractor
         [
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*(?:setClass|setRefClass)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:setGeneric|setMethod)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:library|require)\s*\(\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15517,6 +15517,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsS4AndReferenceClassDefinitions()
+    {
+        // R: setClass, setRefClass, setGeneric, setMethod / R: setClass、setRefClass、setGeneric、setMethod
+        var content = """
+            setClass("Person", slots = c(name = "character"))
+
+            setRefClass("Widget", fields = list(value = "numeric"))
+
+            setGeneric("normalize", function(x) standardGeneric("normalize"))
+
+            setMethod("show", signature(object = "Person"), function(object) {
+              object
+            })
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "show");
+    }
+
+    [Fact]
     public void Extract_R_DetectsFunctionAssignmentAndLibrary()
     {
         // R: function assignment, library / R: 関数代入、library


### PR DESCRIPTION
This PR is a follow-up to the latest `origin/main` state and expands R search coverage.

It addresses a gap in R symbol extraction by indexing S4 and reference-class declarations: `setClass` and `setRefClass` are extracted as classes, while `setGeneric` and `setMethod` are extracted as functions. That makes R projects using the object system easier to search by symbol instead of falling back to file-only results.

Validation:
- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

Follow-up candidates:
- Handle `setMethod` forms where the method name is not quoted.
- Broaden `setClass` to cover more complex inheritance and class-definition forms.
- Add R6 coverage for `R6Class(...)` so R6-style projects get symbol search support too.