### PR TITLE
Index Python project manifest files

### DIFF
--- a/changelog.d/unreleased/+python-project-manifests.fixed.md
+++ b/changelog.d/unreleased/+python-project-manifests.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Python project manifests now participate in Python search** — `pyproject.toml` and `requirements.txt` are recognized as `python`, so common project metadata files show up in Python search results and language listings instead of being skipped as generic text.
+
+## 日本語
+
+- **Python のプロジェクトマニフェストが Python 検索に参加するようになりました** — `pyproject.toml` と `requirements.txt` を `python` として認識するため、よく使われるプロジェクトメタデータファイルが汎用テキストとして取りこぼされず、Python の検索結果や言語一覧に含まれるようになります。

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -270,6 +270,8 @@ public class FileIndexer
         ["BUILD.bazel"]   = "python",
         ["WORKSPACE"]     = "python",       // Bazel workspace / Bazel ワークスペース
         ["WORKSPACE.bazel"]= "python",
+        ["pyproject.toml"] = "python",      // Python project manifest / Python プロジェクトマニフェスト
+        ["requirements.txt"] = "python",    // Python dependencies manifest / Python 依存関係マニフェスト
         ["go.mod"]        = "go",           // Go module manifest / Go モジュールマニフェスト
         ["go.work"]       = "go",           // Go workspace manifest / Go ワークスペースマニフェスト
         [".editorconfig"] = "editorconfig",
@@ -892,11 +894,10 @@ public class FileIndexer
 
     internal static LanguageDetectionResult TryDetectLanguage(string filePath)
     {
-        var ext = Path.GetExtension(filePath);
-        if (LangMap.TryGetValue(ext, out var lang))
-            return new LanguageDetectionResult(FileProbeStatus.Supported, lang);
-
-        // Fall back to exact file name matching / ファイル名の完全一致で言語を検出
+        // Exact filename matching beats extension lookup so manifest-style filenames like
+        // `pyproject.toml` can map to a project language instead of the generic file type.
+        // `pyproject.toml` のようなマニフェスト系ファイル名が、汎用拡張子ではなく
+        // プロジェクト言語に紐づくよう、完全一致ファイル名を拡張子より先に判定する。
         var fileName = Path.GetFileName(filePath);
         if (FileNameMap.TryGetValue(fileName, out var nameLang))
             return new LanguageDetectionResult(FileProbeStatus.Supported, nameLang);
@@ -913,6 +914,10 @@ public class FileIndexer
                 return new LanguageDetectionResult(FileProbeStatus.Supported, prefixLang);
             }
         }
+
+        var ext = Path.GetExtension(filePath);
+        if (LangMap.TryGetValue(ext, out var lang))
+            return new LanguageDetectionResult(FileProbeStatus.Supported, lang);
 
         if (!string.IsNullOrEmpty(ext))
             return new LanguageDetectionResult(FileProbeStatus.Unsupported, null);

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -85,6 +85,8 @@ public class FileIndexerTests
     [InlineData("BUILD.bazel", "python")]
     [InlineData("WORKSPACE", "python")]
     [InlineData("WORKSPACE.bazel", "python")]
+    [InlineData("pyproject.toml", "python")]
+    [InlineData("requirements.txt", "python")]
     [InlineData("go.mod", "go")]
     [InlineData("go.work", "go")]
     // Issue #189: additional extensions / 追加拡張子
@@ -360,6 +362,30 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void ScanFiles_IndexesPythonProjectManifests()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(Path.Combine(tempDir, "pyproject.toml"), "[project]\nname = 'sample'\n");
+            File.WriteAllText(Path.Combine(tempDir, "requirements.txt"), "pytest\n");
+            File.WriteAllText(Path.Combine(tempDir, "unknown.txt"), "ignored\n");
+
+            var files = new FileIndexer(tempDir).ScanFiles()
+                .Select(path => Path.GetRelativePath(tempDir, path).Replace('\\', '/'))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.Equal(["pyproject.toml", "requirements.txt"], files);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void GetLanguageExtensions_ExposesPrefixAndFileNameVariants()
     {
         // `cdidx languages` (and the MCP listing) should advertise everything TryDetectLanguage
@@ -379,6 +405,8 @@ public class FileIndexerTests
         Assert.Equal("ruby", map["Gemfile"]);
         Assert.Equal("ruby", map["Rakefile"]);
         Assert.Equal("python", map["BUILD.bazel"]);
+        Assert.Equal("python", map["pyproject.toml"]);
+        Assert.Equal("python", map["requirements.txt"]);
 
         // Prefix variants (Dockerfile.dev, Makefile.am, ...) surface as `<Prefix><suffix>` pseudo-entries.
         // プレフィックス変種は `<Prefix><suffix>` 形の擬似エントリとして露出する。


### PR DESCRIPTION
Summary:
- recognize `pyproject.toml` and `requirements.txt` as `python` so common Python project manifests participate in search and language listing output
- adjust filename detection to prefer exact-name matches before extension lookup, which lets manifest-style filenames map to their project language instead of the generic extension bucket

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests.DetectLanguage_KnownExtensions_ReturnsCorrectLang|FullyQualifiedName~FileIndexerTests.ScanFiles_IndexesPythonProjectManifests|FullyQualifiedName~FileIndexerTests.GetLanguageExtensions_ExposesPrefixAndFileNameVariants"`

Changelog:
- `changelog.d/unreleased/+python-project-manifests.fixed.md`

Follow-up candidates:
- Consider whether other Python project metadata files like `setup.cfg` or `tox.ini` should also be indexed as `python` if we want broader project-manifest coverage.
