### PR TITLE
Index Swift private-set properties

### DIFF
--- a/changelog.d/unreleased/+swift-private-set-properties.fixed.md
+++ b/changelog.d/unreleased/+swift-private-set-properties.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Swift `private(set)` and `fileprivate(set)` properties are now searchable** - Swift property extraction now accepts setter-restricted stored properties, so common access-controlled state like `private(set) var value` stays visible to `symbols` and related search workflows.
+
+## 日本語
+
+- **Swift の `private(set)` / `fileprivate(set)` 付きプロパティを検索できるようにしました** - Swift の property extraction で setter 制限付きの stored property を受け付けるようにしたため、`private(set) var value` のようなアクセス制御された状態も `symbols` などから見えるようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1209,7 +1209,7 @@ public static class SymbolExtractor
             new("interface", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*protocol\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("associatedtype", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*associatedtype\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("typealias", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*typealias\s+(?<name>\w+)(?:\s*<[^=]+>)?\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("property", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:lazy|weak|unowned|final|static|class|nonisolated)\s+)*(?:let|var)\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("property", new Regex(@"^\s*(?<visibility>(?:public|private|internal|open|fileprivate|package)(?:\s*\(\s*set\s*\))?)?\s*(?:(?:lazy|weak|unowned|final|static|class|nonisolated)\s+)*(?:let|var)\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Extension declarations are important search anchors in Swift-heavy codebases.
             // extension 宣言は Swift コード検索における重要なアンカー。
             new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final)\s+)?extension\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10587,6 +10587,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsPrivateSetProperties()
+    {
+        var content = """
+            public struct Counter {
+                private(set) var value = 0
+                fileprivate(set) var label = "shared"
+                public(set) var capacity = 10
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Counter");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "value");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "label");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "capacity");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsEnumCasesAndIndirectEnums()
     {
         var content = """


### PR DESCRIPTION
This PR adds a Swift search enhancement on top of the latest `origin/main`.

Changes:
- index Swift `private(set)` / `fileprivate(set)` stored properties as searchable `property` symbols
- add a regression test covering setter-restricted Swift properties
- add a changelog fragment under `changelog.d/unreleased/`

Validation:
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release --no-build --filter "FullyQualifiedName~Swift|FullyQualifiedName~SymbolExtractorTests"`

Adversarial review:
- completed against `origin/main..HEAD`

Follow-up candidates:
- none identified in this PR