### PR TITLE
Expand Fortran interface procedure extraction

### DIFF
--- a/changelog.d/unreleased/+fortran-interface-procedures.fixed.md
+++ b/changelog.d/unreleased/+fortran-interface-procedures.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran interface procedures and `end module procedure` handling are now more complete** — `module procedure`, `procedure(normalized_iface) :: name`, and `procedure, pointer :: name` declarations inside interfaces are indexed as searchable `function` symbols, and `end module procedure` lines are explicitly ignored by the module body-range scan so they do not truncate later module members.
+
+## 日本語
+
+- **Fortran の interface 手続きと `end module procedure` の扱いをより完全にしました** — interface 内の `module procedure`、`procedure(normalized_iface) :: name`、`procedure, pointer :: name` を検索可能な `function` シンボルとして索引し、`end module procedure` 行は module の body-range スキャンで明示的に無視するため、その後ろの module メンバーが途中で切れなくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1047,8 +1047,8 @@ public static class SymbolExtractor
             new("class", new Regex(@"^\s*program\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
-            // Module procedure declarations / モジュール手続き宣言
-            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*module\s+procedure\s+(?:::\s*)?(?<name>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Procedure declarations in interfaces / interface 内の手続き宣言
+            new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*(?:(?:module\s+)?procedure)(?:\s*\([^)]+\))?(?:\s*,\s*[A-Za-z_]\w*)*\s*(?:::\s*)?(?<name>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed or untyped functions / 型付き・型なし関数
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*(?:(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)|procedure\s*\([^)]+\))\s+)?function\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
         ],
@@ -15246,6 +15246,9 @@ private sealed class RubyMaskState
             if (trimmed.Length == 0 || trimmed.StartsWith('!'))
                 continue;
 
+            if (IsFortranModuleProcedureEndLine(trimmed))
+                continue;
+
             if (IsFortranBlockEndLine(trimmed, blockKind))
             {
                 if (bodyStartLine == null)
@@ -15311,6 +15314,19 @@ private sealed class RubyMaskState
             return false;
 
         return afterKind.Length == 0 || afterKind.StartsWith('!') || afterKind.StartsWith('(') || afterKind.StartsWith(':') || char.IsLetterOrDigit(afterKind[0]) || afterKind[0] == '_';
+    }
+
+    private static bool IsFortranModuleProcedureEndLine(string trimmedLine)
+    {
+        if (!StartsWithFortranWord(trimmedLine, "end"))
+            return false;
+
+        var remainder = trimmedLine["end".Length..].TrimStart();
+        if (!StartsWithFortranWord(remainder, "module"))
+            return false;
+
+        var afterModule = remainder["module".Length..].TrimStart();
+        return StartsWithFortranWord(afterModule, "procedure");
     }
 
     private static bool StartsWithFortranWord(string input, string word)

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -2756,17 +2756,18 @@ private sealed class RubyMaskState
                         signature = line[absoluteStartColumn..].Trim();
                     }
 
-                    List<string>? fortranModuleProcedureNames = null;
+                    List<string>? fortranProcedureNames = null;
                     if (lang == "fortran"
                         && pattern.Kind == "function"
-                        && signature.Contains("module procedure", StringComparison.OrdinalIgnoreCase))
+                        && name.Contains(',')
+                        && signature.Contains("procedure", StringComparison.OrdinalIgnoreCase))
                     {
                         var names = name.Split(',');
                         for (var index = 0; index < names.Length; index++)
                             names[index] = names[index].Trim();
 
                         if (names.Any(static candidate => candidate.Length > 0))
-                            fortranModuleProcedureNames = names.Where(static candidate => candidate.Length > 0).ToList();
+                            fortranProcedureNames = names.Where(static candidate => candidate.Length > 0).ToList();
                     }
 
                     var suppressJavaStatementSymbol = false;
@@ -2815,9 +2816,9 @@ private sealed class RubyMaskState
                                     line);
                             }
                         }
-                        else if (fortranModuleProcedureNames != null)
+                        else if (fortranProcedureNames != null)
                         {
-                            foreach (var procedureName in fortranModuleProcedureNames)
+                            foreach (var procedureName in fortranProcedureNames)
                             {
                                 AddSymbolRecord(
                                     symbols,

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9686,11 +9686,16 @@ public class SymbolExtractorTests
             module math_utils
               interface
                 module procedure normalize_iface, normalize_alt
+                procedure(normalize_iface) :: normalize_forward
+                procedure, pointer :: normalize_pointer
               end interface
               implicit none
             contains
               recursive subroutine normalize(v)
               end subroutine normalize
+              end module procedure normalize_iface
+              recursive subroutine normalize2(v)
+              end subroutine normalize2
             end module math_utils
 
             submodule (math_utils) math_utils_impl
@@ -9717,6 +9722,8 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_iface");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_alt");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_forward");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_pointer");
 
         var mathUtilsImpl = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_utils_impl");
         Assert.NotNull(mathUtilsImpl.BodyStartLine);
@@ -9733,6 +9740,10 @@ public class SymbolExtractorTests
         var expand = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "expand");
         Assert.Equal("namespace", expand.ContainerKind);
         Assert.Equal("math_utils_impl", expand.ContainerName);
+
+        var normalize2 = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize2");
+        Assert.Equal("namespace", normalize2.ContainerKind);
+        Assert.Equal("math_utils", normalize2.ContainerName);
 
         Assert.DoesNotContain(symbols, s => s.Kind == "namespace" && s.Name == "subroutine");
 


### PR DESCRIPTION
## Summary

This PR follows up on the `Follow-up candidates` from PR #1212.

- Indexes Fortran interface-body procedure declarations such as `module procedure`, `procedure(normalized_iface) :: name`, and `procedure, pointer :: name` as searchable `function` symbols.
- Makes `end module procedure` explicit in the Fortran module body-range scan so it does not truncate later module members.
- Adds regression coverage for the new interface-body forms and the `end module procedure` case.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions|FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+fortran-interface-procedures.fixed.md`

## Follow-up candidates

- More exotic Fortran interface-body forms may still appear in the wild and could need additional extraction rules.
- If we need finer-grained semantics for `end module procedure` in a future pass, the scanner could be extended beyond the current conservative ignore rule.