### PR TITLE
Add T-SQL assembly and XML schema collection coverage

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -406,7 +406,7 @@ Supported symbol kinds by language (33 languages with symbol extraction):
 | Solidity | .sol | -- | -- | -- | -- | -- | -- | -- | -- |
 | Tcl | .tcl, .tk | -- | -- | -- | -- | -- | -- | -- | -- |
 | Shell | function declarations | -- | -- | -- | -- | -- | -- | -- | -- |
-| SQL | PROCEDURE/PROC, FUNCTION, TRIGGER, AGGREGATE, PARTITION FUNCTION | TABLE, VIEW, INDEX, TYPE, TYPE BODY, PACKAGE, PACKAGE BODY, SEQUENCE, DOMAIN, SYNONYM, DATABASE, DATABASE LINK, LOGIN, USER, ROLE, CERTIFICATE, DIRECTORY, CONTEXT, PROFILE, PARTITION SCHEME, FULLTEXT CATALOG | -- | -- | enum (`CREATE TYPE ... AS ENUM`) | -- | -- | EXTENSION | yes |
+| SQL | PROCEDURE/PROC, FUNCTION, TRIGGER, AGGREGATE, PARTITION FUNCTION | TABLE, VIEW, INDEX, TYPE, TYPE BODY, PACKAGE, PACKAGE BODY, SEQUENCE, DOMAIN, SYNONYM, DATABASE, DATABASE LINK, LOGIN, USER, ROLE, CERTIFICATE, DIRECTORY, CONTEXT, PROFILE, ASSEMBLY, XML SCHEMA COLLECTION, PARTITION SCHEME, FULLTEXT CATALOG | -- | -- | enum (`CREATE TYPE ... AS ENUM`) | -- | -- | EXTENSION | yes |
 | Terraform | variable, output, locals | resource, data, module | -- | -- | -- | `var.*`, `local.*`, `module.*`, `data.*`, same-file resource-like `TYPE.NAME` references such as `aws_instance.web` and `depends_on = [aws_s3_bucket.foo]` | -- | -- | -- |
 | Protobuf | rpc | message, service | -- | -- | enum | -- | -- | import | -- |
 | GraphQL | query, mutation, subscription | type, union, scalar, input | -- | interface | enum | -- | -- | -- | -- |

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ The database reflects the working tree at the time of the last index. After swit
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 Query-time `--lang tsql` is accepted as an alias for the SQL bucket.
-T-SQL `CREATE AGGREGATE` / `ALTER AGGREGATE` declarations are also searchable.
+T-SQL `CREATE AGGREGATE` / `ALTER AGGREGATE` and `CREATE/ALTER ASSEMBLY` / `XML SCHEMA COLLECTION` declarations are also searchable.
 | Markdown | `.md` | -- |
 | YAML | `.yaml`, `.yml` | -- |
 | JSON | `.json` | -- |
@@ -1638,7 +1638,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 クエリ時の `--lang tsql` は SQL バケットの別名として受け付けられます。
-T-SQL の `CREATE AGGREGATE` / `ALTER AGGREGATE` も検索対象です。
+T-SQL の `CREATE AGGREGATE` / `ALTER AGGREGATE` と `CREATE/ALTER ASSEMBLY` / `XML SCHEMA COLLECTION` も検索対象です。
 | Markdown | `.md` | -- |
 | YAML | `.yaml`, `.yml` | -- |
 | JSON | `.json` | -- |

--- a/changelog.d/unreleased/+tsql-followup-assembly.fixed.md
+++ b/changelog.d/unreleased/+tsql-followup-assembly.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+  - README.md
+---
+
+## English
+
+- **T-SQL assembly and XML schema collection declarations now surface as searchable symbols** — the SQL extractor now indexes `CREATE/ALTER ASSEMBLY` and `CREATE/ALTER XML SCHEMA COLLECTION` rows, so SQL Server deployment scripts for those object types are no longer skipped by `symbols` and `definition`.
+
+## 日本語
+
+- **T-SQL の assembly と XML schema collection 宣言が検索可能な symbol として表面化するようになりました** — SQL extractor が `CREATE/ALTER ASSEMBLY` と `CREATE/ALTER XML SCHEMA COLLECTION` を index するため、これらのオブジェクト種別の SQL Server 配備スクリプトが `symbols` / `definition` で取りこぼされなくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1438,7 +1438,7 @@ public static class SymbolExtractor
             // Include T-SQL SECURITY POLICY so row-level-security policy definitions are discoverable.
             // T-SQL のサーバ/データベースレベルのプリンシパル・オブジェクトと、Oracle 固有の DIRECTORY / CONTEXT / PROFILE。
             // T-SQL の SECURITY POLICY も含め、行レベルセキュリティポリシー定義を検索可能にする。
-            new("class",    new Regex($@"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:DATABASE|LOGIN|USER|ROLE|CERTIFICATE|DIRECTORY|CONTEXT|PROFILE|SECURITY\s+POLICY)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("class",    new Regex($@"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:DATABASE|LOGIN|USER|ROLE|CERTIFICATE|DIRECTORY|CONTEXT|PROFILE|ASSEMBLY|XML\s+SCHEMA\s+COLLECTION|SECURITY\s+POLICY)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             // T-SQL partitioning and full-text catalogs
             // T-SQL のパーティション関連と全文検索カタログ
             new("function", new Regex($@"^\s*CREATE\s+PARTITION\s+FUNCTION\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
@@ -1473,7 +1473,7 @@ public static class SymbolExtractor
             // `ALTER PACKAGE <name> COMPILE BODY` / `ALTER TYPE <name> COMPILE BODY` の形で、下の
             // generic ALTER 行で拾う。`ALTER PACKAGE BODY <name>` のような構文は Oracle に存在しない。
             new("class",    new Regex($@"^\s*ALTER\s+DATABASE\s+LINK\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("class",    new Regex($@"^\s*ALTER\s+(?:TABLE|(?:MATERIALIZED\s+)?VIEW|SEQUENCE|SYNONYM|LOGIN|USER|ROLE|DATABASE|CERTIFICATE|INDEX|PACKAGE|TYPE|DOMAIN|DIRECTORY|PROFILE|PARTITION\s+SCHEME|FULLTEXT\s+CATALOG|SECURITY\s+POLICY)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("class",    new Regex($@"^\s*ALTER\s+(?:TABLE|(?:MATERIALIZED\s+)?VIEW|SEQUENCE|SYNONYM|LOGIN|USER|ROLE|DATABASE|CERTIFICATE|INDEX|PACKAGE|TYPE|DOMAIN|DIRECTORY|PROFILE|ASSEMBLY|XML\s+SCHEMA\s+COLLECTION|PARTITION\s+SCHEME|FULLTEXT\s+CATALOG|SECURITY\s+POLICY)\b\s+(?<name>{SqlQualifiedIdentifierPattern})", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
         ],
         ["terraform"] =
         [

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9803,6 +9803,8 @@ public class SymbolExtractorTests
             "CREATE TYPE sales.Money FROM DECIMAL(18, 4) NOT NULL;\n" +
             "CREATE SEQUENCE sales.OrderSeq START WITH 1 INCREMENT BY 1;\n" +
             "CREATE AGGREGATE dbo.SumInt (@value INT) RETURNS INT EXTERNAL NAME dbo.SumInt;\n" +
+            "CREATE ASSEMBLY dbo.MyAssembly FROM 0x010203;\n" +
+            "CREATE XML SCHEMA COLLECTION dbo.XmlCollection AS N'<schema />';\n" +
             "CREATE RULE sales.discount_rule AS @price > 0;\n" +
             "CREATE DEFAULT dbo.zero_default AS 0;\n" +
             "CREATE SYNONYM dbo.Customers FOR external.Customers;\n" +
@@ -9823,6 +9825,8 @@ public class SymbolExtractorTests
             "ALTER FUNCTION dbo.fn_Total() RETURNS INT AS BEGIN RETURN 1 END;\n" +
             "ALTER PARTITION FUNCTION pf_OrdersByYear() SPLIT RANGE ('2025-01-01');\n" +
             "ALTER AGGREGATE dbo.SumInt (@value INT) RETURNS INT EXTERNAL NAME dbo.SumIntV2;\n" +
+            "ALTER ASSEMBLY dbo.MyAssembly FROM 0x040506;\n" +
+            "ALTER XML SCHEMA COLLECTION dbo.XmlCollection ADD N'<schema />';\n" +
             "ALTER SCHEMA sales TRANSFER dbo.Customers;\n" +
             "ALTER EXTENSION hstore UPDATE TO '1.5';\n" +
             "ALTER CERTIFICATE svc_cert WITH PRIVATE KEY (DECRYPTION BY PASSWORD = 'x');\n" +
@@ -9834,6 +9838,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.Money");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.OrderSeq");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dbo.SumInt");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.MyAssembly");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.XmlCollection");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "sales.discount_rule");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.zero_default");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.Customers");
@@ -9862,6 +9868,10 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "pf_OrdersByYear" && s.Signature != null && s.Signature.StartsWith("ALTER PARTITION FUNCTION", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dbo.SumInt" && s.Signature != null && s.Signature.StartsWith("CREATE AGGREGATE", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "dbo.SumInt" && s.Signature != null && s.Signature.StartsWith("ALTER AGGREGATE", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.MyAssembly" && s.Signature != null && s.Signature.StartsWith("CREATE ASSEMBLY", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.MyAssembly" && s.Signature != null && s.Signature.StartsWith("ALTER ASSEMBLY", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.XmlCollection" && s.Signature != null && s.Signature.StartsWith("CREATE XML SCHEMA COLLECTION", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "dbo.XmlCollection" && s.Signature != null && s.Signature.StartsWith("ALTER XML SCHEMA COLLECTION", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "sales" && s.Signature != null && s.Signature.StartsWith("ALTER SCHEMA", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "hstore");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "svc_cert" && s.Signature != null && s.Signature.StartsWith("ALTER CERTIFICATE", StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Summary

- Added SQL Server `CREATE/ALTER ASSEMBLY` handling to the SQL symbol extractor.
- Added SQL Server `CREATE/ALTER XML SCHEMA COLLECTION` handling to the SQL symbol extractor.
- Added regression coverage for both shapes in the SQL extractor test suite.
- Updated the SQL support tables in `README.md` and `DEVELOPER_GUIDE.md`.
- Added a bilingual changelog fragment under `changelog.d/unreleased/`.

This PR follows up on PR #1211 and explicitly addresses its remaining follow-up candidates.

## Follow-up candidates addressed

- `CREATE/ALTER ASSEMBLY` is now indexed as a searchable symbol, so SQL Server assembly deployment scripts are no longer skipped by `symbols` / `definition`.
- `CREATE/ALTER XML SCHEMA COLLECTION` is now indexed as a searchable symbol, so XML schema deployment scripts are no longer skipped by `symbols` / `definition`.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_SQL_DetectsTSqlDdlKinds|FullyQualifiedName~SymbolExtractorTests.Extract_SQL_DetectsCreateStatements"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog

- `changelog.d/unreleased/+tsql-followup-assembly.fixed.md`
- `README.md`
- `DEVELOPER_GUIDE.md`