### PR TITLE
Normalize C# verbatim names in exact find matching

### DIFF
--- a/changelog.d/unreleased/+csharp-verbatim-search.fixed.md
+++ b/changelog.d/unreleased/+csharp-verbatim-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **C# exact substring file search now normalizes verbatim qualified names** — `find --exact` now treats C# verbatim prefixes as syntax only, so `Foo.Bar` can match `using @Foo.@Bar;` and other equivalent source spellings.
+
+## 日本語
+
+- **C# の exact substring ファイル検索で verbatim 修飾名を正規化するようになりました** — `find --exact` は C# の verbatim 接頭辞を構文上の差分として扱うため、`Foo.Bar` で `using @Foo.@Bar;` など同値な表記にマッチできるようになりました。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -4811,11 +4811,17 @@ public partial class DbReader
             if (!TryLoadIndexedFileLines(path, out _, out _, out var lineMap) || lineMap.Count == 0)
                 continue;
 
+            var csharpExactSearch = exact && string.Equals(fileLang, "csharp", StringComparison.OrdinalIgnoreCase);
+            var searchQuery = csharpExactSearch ? StripCSharpVerbatimPrefixesForSearch(query) : query;
             for (int lineNumber = 1; lineNumber <= totalLines && results.Count < limit; lineNumber++)
             {
                 if (!lineMap.TryGetValue(lineNumber, out var lineText))
                     continue;
 
+                int[]? rawIndexMap = null;
+                var searchLine = lineText;
+                if (csharpExactSearch)
+                    searchLine = StripCSharpVerbatimPrefixesForSearch(lineText, out rawIndexMap);
                 var snippetStart = Math.Max(1, lineNumber - before);
                 var snippetEnd = Math.Min(totalLines, lineNumber + after);
                 var snippetLineNumbers = Enumerable.Range(snippetStart, snippetEnd - snippetStart + 1)
@@ -4824,26 +4830,34 @@ public partial class DbReader
                 if (snippetLineNumbers.Count == 0)
                     continue;
 
-                for (int searchStart = 0; searchStart < lineText.Length && results.Count < limit;)
+                for (int searchStart = 0; searchStart < searchLine.Length && results.Count < limit;)
                 {
-                    var matchColumn = lineText.IndexOf(query, searchStart, comparison);
+                    var matchColumn = searchLine.IndexOf(searchQuery, searchStart, comparison);
                     if (matchColumn < 0)
                         break;
+
+                    var rawMatchColumn = rawIndexMap == null ? matchColumn : rawIndexMap[matchColumn];
+                    var rawMatchLength = searchQuery.Length;
+                    if (rawIndexMap != null && rawMatchLength > 0)
+                    {
+                        var rawMatchEndIndex = rawIndexMap[matchColumn + rawMatchLength - 1];
+                        rawMatchLength = rawMatchEndIndex - rawMatchColumn + 1;
+                    }
 
                     var snippetLines = snippetLineNumbers.Select(line => lineMap[line]).ToList();
                     var clampedSnippet = LineWidthFormatter.ClampLines(
                         snippetLines,
                         maxLineWidth,
                         focusLineIndex: snippetLineNumbers.IndexOf(lineNumber),
-                        focusColumn: matchColumn + 1,
-                        focusLength: query.Length);
+                        focusColumn: rawMatchColumn + 1,
+                        focusLength: rawMatchLength);
 
                     results.Add(new FileFindResult
                     {
                         Path = path,
                         Lang = fileLang,
                         Line = lineNumber,
-                        Column = matchColumn + 1,
+                        Column = rawMatchColumn + 1,
                         StartLine = snippetLineNumbers[0],
                         EndLine = snippetLineNumbers[^1],
                         Snippet = clampedSnippet.Text,
@@ -4865,7 +4879,7 @@ public partial class DbReader
 
         var comparison = exact ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
         using var fileCmd = _conn.CreateCommand();
-        var sql = "SELECT f.path, f.lines FROM files f WHERE 1=1";
+        var sql = "SELECT f.path, f.lang, f.lines FROM files f WHERE 1=1";
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
@@ -4881,19 +4895,23 @@ public partial class DbReader
         while (fileReader.TrackedRead())
         {
             var path = fileReader.GetString(0);
-            var totalLines = fileReader.GetInt32(1);
+            var fileLang = GetNullableString(fileReader, 1);
+            var totalLines = fileReader.GetInt32(2);
             if (!TryLoadIndexedFileLines(path, out _, out _, out var lineMap) || lineMap.Count == 0)
                 continue;
 
+            var csharpExactSearch = exact && string.Equals(fileLang, "csharp", StringComparison.OrdinalIgnoreCase);
+            var searchQuery = csharpExactSearch ? StripCSharpVerbatimPrefixesForSearch(query) : query;
             var fileMatches = 0;
             for (int lineNumber = 1; lineNumber <= totalLines; lineNumber++)
             {
                 if (!lineMap.TryGetValue(lineNumber, out var lineText))
                     continue;
 
-                for (int searchStart = 0; searchStart < lineText.Length;)
+                var searchLine = csharpExactSearch ? StripCSharpVerbatimPrefixesForSearch(lineText) : lineText;
+                for (int searchStart = 0; searchStart < searchLine.Length;)
                 {
-                    var matchColumn = lineText.IndexOf(query, searchStart, comparison);
+                    var matchColumn = searchLine.IndexOf(searchQuery, searchStart, comparison);
                     if (matchColumn < 0)
                         break;
 
@@ -4911,6 +4929,97 @@ public partial class DbReader
 
         return new QueryCountResult(count, fileCount);
     }
+
+    private static string StripCSharpVerbatimPrefixesForSearch(string text)
+    {
+        if (text.Length == 0 || text.IndexOf('@') < 0)
+            return text;
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        bool atBoundary = true;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (atBoundary && c == '@'
+                && i + 1 < text.Length
+                && IsCSharpIdentifierStartChar(text[i + 1]))
+            {
+                atBoundary = false;
+                continue;
+            }
+
+            sb.Append(c);
+            if (c == '.')
+            {
+                atBoundary = true;
+            }
+            else if (c == ':' && i + 1 < text.Length && text[i + 1] == ':')
+            {
+                sb.Append(':');
+                i++;
+                atBoundary = true;
+            }
+            else
+            {
+                atBoundary = false;
+            }
+        }
+
+        return sb.Length == text.Length ? text : sb.ToString();
+    }
+
+    private static string StripCSharpVerbatimPrefixesForSearch(string text, out int[]? rawIndexMap)
+    {
+        if (text.Length == 0 || text.IndexOf('@') < 0)
+        {
+            rawIndexMap = null;
+            return text;
+        }
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        var map = new List<int>(text.Length);
+        bool atBoundary = true;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (atBoundary && c == '@'
+                && i + 1 < text.Length
+                && IsCSharpIdentifierStartChar(text[i + 1]))
+            {
+                atBoundary = false;
+                continue;
+            }
+
+            sb.Append(c);
+            map.Add(i);
+            if (c == '.')
+            {
+                atBoundary = true;
+            }
+            else if (c == ':' && i + 1 < text.Length && text[i + 1] == ':')
+            {
+                sb.Append(':');
+                map.Add(++i);
+                atBoundary = true;
+            }
+            else
+            {
+                atBoundary = false;
+            }
+        }
+
+        if (sb.Length == text.Length)
+        {
+            rawIndexMap = null;
+            return text;
+        }
+
+        rawIndexMap = map.ToArray();
+        return sb.ToString();
+    }
+
+    private static bool IsCSharpIdentifierStartChar(char c) =>
+        c == '_' || char.IsLetter(c);
 
     /// <summary>
     /// Reconstruct one indexed file into an ordered line map.

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -7814,6 +7814,42 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunFind_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_csharp_verbatim");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/app.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                using @Foo.@Bar;
+                using Foo.Bar;
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["Foo.Bar", "--db", dbPath, "--path", "src/app.cs", "--lang", "csharp", "--json", "--exact", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(2, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSearch_ExactSubstringHumanSnippetUsesCaseSensitiveFocusLine()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_human_snippet");


### PR DESCRIPTION
## Summary

- C# `find --exact` now normalizes verbatim qualified names before matching, so canonical queries like `Foo.Bar` also match source spelled as `@Foo.@Bar`.
- The count path uses the same normalization, so exact counts stay aligned with the returned matches.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunFind_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunFind_CountOnlyJsonCountsEverySameLineOccurrence"`
- `dotnet build CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog

- Added fragment: `changelog.d/unreleased/+csharp-verbatim-search.fixed.md`
- No direct `CHANGELOG.md` edits were made.

## Follow-up candidates

- Apply the same C# verbatim-name normalization to `search --exact-substring` if that command should also treat `@Foo` and `Foo` as equivalent in exact file matching.
- Add a mixed-language regression that proves the C# normalization stays scoped to `lang: csharp`.