### PR TITLE
Expand R search coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Perl | `.pl`, `.pm`, `.t`, `.pod` | -- |
 | Solidity | `.sol` | -- |
 | Tcl | `.tcl`, `.tk` | -- |
-| R | `.r`, `.R` | yes (function assignments, setClass/setRefClass, setGeneric/setMethod, library/require) |
+| R | `.r`, `.R` | yes (function assignments, setClass/setClassUnion/R6Class/setRefClass, setGeneric/setMethod, library/require) |
 | Haskell | `.hs`, `.lhs` | yes |
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |

--- a/changelog.d/unreleased/+r-followup-2.fixed.md
+++ b/changelog.d/unreleased/+r-followup-2.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **R search coverage now includes more S4, union, and R6 forms** — following up on PR #1215, `cdidx` now extracts unquoted `setMethod` declarations, recognizes additional class-definition forms such as `setClassUnion` and `R6Class`, and keeps the existing `setClass`, `setRefClass`, `setGeneric`, and function-assignment coverage so R projects using richer object systems surface more useful symbol search results.
+
+## 日本語
+
+- **R の検索カバレッジが S4 / union / R6 まで広がりました** — PR #1215 の follow-up として、`cdidx` はクォートなしの `setMethod` 宣言を抽出し、`setClassUnion` や `R6Class` のような追加の class 定義形式も認識するため、より豊かなオブジェクトシステムを使う R プロジェクトで検索結果が見つかりやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1299,8 +1299,9 @@ public static class SymbolExtractor
         [
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("class",    new Regex(@"^\s*(?:setClass|setRefClass)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(@"^\s*(?:setGeneric|setMethod)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?:setClass|setRefClass|setClassUnion|R6Class)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*setGeneric\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*setMethod\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:library|require)\s*\(\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15536,22 +15536,28 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_R_DetectsS4AndReferenceClassDefinitions()
     {
-        // R: setClass, setRefClass, setGeneric, setMethod / R: setClass、setRefClass、setGeneric、setMethod
+        // R: setClass, setClassUnion, setRefClass, R6Class, setGeneric, setMethod / R: setClass、setClassUnion、setRefClass、R6Class、setGeneric、setMethod
         var content = """
             setClass("Person", slots = c(name = "character"))
 
+            setClassUnion("Renderable", c("Person", "Widget"))
+
             setRefClass("Widget", fields = list(value = "numeric"))
+
+            R6Class("Thing", public = list(print = function() self))
 
             setGeneric("normalize", function(x) standardGeneric("normalize"))
 
-            setMethod("show", signature(object = "Person"), function(object) {
+            setMethod(show, signature(object = "Person"), function(object) {
               object
             })
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Renderable");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Thing");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "show");
     }


### PR DESCRIPTION
This PR is a follow-up to PR #1215 and addresses the follow-up candidates called out there.

Summary:
- Extends R symbol extraction to cover additional object-system forms.
- `setClass`, `setRefClass`, `setClassUnion`, and `R6Class` are extracted as classes.
- `setGeneric` is extracted as a function, and `setMethod` now supports quoted and unquoted method names.

Validation:
- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

Docs/changelog:
- Updated `README.md` to describe the expanded R coverage.
- Added changelog fragment `changelog.d/unreleased/+r-followup-2.fixed.md`.

Follow-up candidates:
- Handle additional `setClass` class-definition variants beyond the current first-argument form.
- Expand `R6Class(...)` handling if the repository needs more R6-specific symbol details.