### PR TITLE
Index named Fortran interfaces

### DIFF
--- a/changelog.d/unreleased/+fortran-named-interface.fixed.md
+++ b/changelog.d/unreleased/+fortran-named-interface.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Named Fortran interfaces are now searchable containers** — `interface math_iface` is indexed as a `namespace` symbol, and procedures declared inside it now attach to that interface instead of falling back to the surrounding module.
+
+## 日本語
+
+- **名前付き Fortran interface を検索可能な container として扱うようになりました** — `interface math_iface` を `namespace` シンボルとして索引し、その中で宣言された procedure が周囲の module ではなく interface にぶら下がるようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1039,6 +1039,8 @@ public static class SymbolExtractor
         ],
         ["fortran"] =
         [
+            // Named interfaces / 名前付き interface
+            new("namespace", new Regex(@"^\s*interface\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Fortran modules / モジュール
             new("namespace", new Regex(@"^\s*module\s+(?!(?:procedure|subroutine|function)\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Fortran submodules / サブモジュール
@@ -15439,6 +15441,12 @@ private sealed class RubyMaskState
                 return false;
 
             kind = "module";
+            return true;
+        }
+
+        if (StartsWithFortranWord(trimmed, "interface"))
+        {
+            kind = "interface";
             return true;
         }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9684,11 +9684,11 @@ public class SymbolExtractorTests
     {
         var content = """
             module math_utils
-              interface
+              interface math_iface
                 module procedure normalize_iface, normalize_alt
                 procedure(normalize_iface) :: normalize_forward
                 procedure, pointer :: normalize_pointer
-              end interface
+              end interface math_iface
               implicit none
             contains
               recursive subroutine normalize(v)
@@ -9720,10 +9720,16 @@ public class SymbolExtractorTests
         Assert.NotNull(mathUtils.BodyStartLine);
         Assert.NotNull(mathUtils.BodyEndLine);
 
+        var mathIface = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_iface");
+        Assert.NotNull(mathIface.BodyStartLine);
+        Assert.NotNull(mathIface.BodyEndLine);
+
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_iface");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_alt");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_forward");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_pointer");
+        Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
+        Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
 
         var mathUtilsImpl = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_utils_impl");
         Assert.NotNull(mathUtilsImpl.BodyStartLine);


### PR DESCRIPTION
## Summary

This PR follows up on the `Follow-up candidates` from PR #1219.

- Indexes named Fortran interfaces like `interface math_iface` as searchable `namespace` symbols.
- Attaches interface-body procedures to the named interface container instead of the surrounding module.
- Keeps the existing `module procedure` and `procedure(...)` coverage working while improving container precision.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions|FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+fortran-named-interface.fixed.md`

## Follow-up candidates

- More exotic unnamed Fortran `abstract interface` forms could still need dedicated handling if they become a search gap.
- Additional continuation-heavy Fortran interface syntax may need more parsing support in a future pass.