### PR TITLE
Reduce Windows CI Defender scanning

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,8 +63,10 @@ jobs:
       # test suite (temp projects, SQLite DBs, .cdidx directories, synthetic
       # source files) dominates the Windows lane of this matrix; see issue #394.
       # Excluding the workspace plus the effective temp roots before build/test
-      # prevents silent regression if the runner image or TMP/TEMP wiring
-      # changes again in the future.
+      # and the immutable NuGet global package cache keeps Defender from
+      # repeatedly scanning the restore/build inputs that dotnet touches on
+      # Windows. This also prevents silent regression if the runner image or
+      # TMP/TEMP wiring changes again in the future.
       # We rely on -ExclusionPath only: -ExclusionProcess expects full image
       # paths, so bare filenames like 'dotnet.exe' would silently fail to take
       # effect. We include $env:TMP and the live [IO.Path]::GetTempPath() value
@@ -80,8 +82,10 @@ jobs:
       # テストスイートが大量に作る一時ファイル（temp project / SQLite DB /
       # .cdidx / 合成ソース）を Windows Defender が都度スキャンする影響で
       # Windows lane だけ極端に遅くなる（issue #394）。build/test 前に
-      # workspace と実効 temp root 群を build/test 前に除外し、runner image や
-      # TMP/TEMP の配線が今後変わっても silent regression しないようにする。
+      # workspace と実効 temp root 群に加えて変更されない NuGet global package
+      # cache も除外し、Windows で dotnet が繰り返し触る restore/build 入力を
+      # Defender に再スキャンさせない。これで runner image や TMP/TEMP の
+      # 配線が今後変わっても silent regression しないようにする。
       # -ExclusionProcess はフルパスを要求する仕様のため、bare filename では
       # 黙って no-op になる。ここでは -ExclusionPath だけに寄せる。.NET の
       # Path.GetTempPath() は TMP → TEMP → USERPROFILE の順で参照し、pwsh の
@@ -101,7 +105,10 @@ jobs:
             $env:RUNNER_TEMP,
             $env:TEMP,
             $env:TMP,
-            [System.IO.Path]::GetTempPath()
+            [System.IO.Path]::GetTempPath(),
+            $env:NUGET_PACKAGES,
+            (Join-Path $env:USERPROFILE ".nuget\packages"),
+            (Join-Path $env:LOCALAPPDATA "NuGet\packages")
           )
 
           $paths = $candidates |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,10 @@ jobs:
       # test suite (temp projects, SQLite DBs, .cdidx directories, synthetic
       # source files) dominates the Windows lane of this workflow as well.
       # Excluding the workspace plus the effective temp roots before build/test
-      # prevents silent regression if the runner image or TMP/TEMP wiring
-      # changes again in the future.
+      # and the immutable NuGet global package cache keeps Defender from
+      # repeatedly scanning the restore/build inputs that dotnet touches on
+      # Windows. This also prevents silent regression if the runner image or
+      # TMP/TEMP wiring changes again in the future.
       # We rely on -ExclusionPath only: -ExclusionProcess expects full image
       # paths, so bare filenames like 'dotnet.exe' would silently fail to take
       # effect. We include $env:TMP and the live [IO.Path]::GetTempPath() value
@@ -88,8 +90,11 @@ jobs:
       # release workflow の Windows lane でも、テストスイートが大量に作る
       # 一時ファイル（temp project / SQLite DB / .cdidx / 合成ソース）を
       # Windows Defender が都度スキャンする影響は同じく支配的になる。
-      # build/test 前に workspace と実効 temp root 群を除外し、runner image
-      # や TMP/TEMP の配線が今後変わっても silent regression しないようにする。
+      # build/test 前に workspace と実効 temp root 群に加えて変更されない
+      # NuGet global package cache も除外し、Windows で dotnet が繰り返し触る
+      # restore / build 入力を Defender に再スキャンさせない。これで runner
+      # image や TMP/TEMP の配線が今後変わっても silent regression しない
+      # ようにする。
       # -ExclusionProcess はフルパスを要求する仕様のため、bare filename では
       # 黙って no-op になる。ここでは -ExclusionPath だけに寄せる。.NET の
       # Path.GetTempPath() は TMP → TEMP → USERPROFILE の順で参照し、pwsh の
@@ -109,7 +114,10 @@ jobs:
             $env:RUNNER_TEMP,
             $env:TEMP,
             $env:TMP,
-            [System.IO.Path]::GetTempPath()
+            [System.IO.Path]::GetTempPath(),
+            $env:NUGET_PACKAGES,
+            (Join-Path $env:USERPROFILE ".nuget\packages"),
+            (Join-Path $env:LOCALAPPDATA "NuGet\packages")
           )
 
           $paths = $candidates |

--- a/changelog.d/unreleased/+windows-ci-nuget-cache-exclusion.fixed.md
+++ b/changelog.d/unreleased/+windows-ci-nuget-cache-exclusion.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - .github/workflows/dotnet.yml
+  - .github/workflows/release.yml
+---
+
+## English
+
+- **Windows CI now excludes the immutable NuGet global package cache from Defender scanning** — the build-and-test and release workflows now add the restored package cache paths to the Windows Defender exclusion list alongside workspace and temp roots, which reduces repeated scanning of restore/build inputs on Windows runners.
+
+## 日本語
+
+- **Windows CI で変更されない NuGet global package cache も Defender のスキャン対象から外すようになりました** — build-and-test と release の両 workflow で、workspace と temp root に加えて復元済みパッケージ cache のパスも Windows Defender の除外リストへ追加し、Windows runner 上で restore / build 入力が繰り返しスキャンされるのを減らします。


### PR DESCRIPTION
## Summary

Windows CI now excludes the immutable NuGet global package cache in addition to the workspace and temp roots before build and test steps run. This is applied in both the build-and-test workflow and the release workflow so Windows Defender has fewer repeated scans of restore/build inputs on hosted runners.

## Validation

- `git diff --check`
- Reviewed the updated GitHub Actions workflow YAML for both `.github/workflows/dotnet.yml` and `.github/workflows/release.yml`

## Documentation and Changelog

- Added changelog fragment: `changelog.d/unreleased/+windows-ci-nuget-cache-exclusion.fixed.md`
- No direct `CHANGELOG.md` edit was made, per the fragment workflow

## Follow-up

- None identified
