### PR TITLE
Expand Fortran interface continuation handling

### DIFF
--- a/changelog.d/unreleased/+fortran-interface-continuation.fixed.md
+++ b/changelog.d/unreleased/+fortran-interface-continuation.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran interface continuations and abstract interface prototypes are now searchable** — continuation-heavy `module procedure`, `procedure(...) :: name`, and `subroutine ...` declarations inside `interface` / `abstract interface` blocks are merged across `&` continuations before symbol matching, so they surface as `function` symbols instead of being skipped line by line.
+
+## 日本語
+
+- **Fortran の interface 継続行と abstract interface の prototype も検索対象になりました** — `interface` / `abstract interface` ブロック内の `module procedure`、`procedure(...) :: name`、`subroutine ...` 宣言を `&` 継続行ごとにまとめてからシンボル照合するため、1 行ずつでは取りこぼしていたものが `function` シンボルとして現れます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -303,6 +303,10 @@ public static class SymbolExtractor
         int? SignatureLastLineExclusiveEndColumn = null,
         int? ExpressionBodyEndLineIndex = null);
 
+    private readonly record struct FortranContinuationMatchCandidate(
+        string MatchLine,
+        int LastConsumedLineIndex);
+
     private enum CSharpAccessorProbeStatus
     {
         Pending,
@@ -2002,6 +2006,12 @@ private sealed class RubyMaskState
                 matchLine = csharpMatchLines![i];
             }
 
+            var fortranContinuationCandidate = lang == "fortran"
+                ? TryBuildFortranContinuationMatchLine(lines, i)
+                : null;
+            if (fortranContinuationCandidate != null)
+                matchLine = fortranContinuationCandidate.Value.MatchLine;
+
             if (lang == "php")
                 ExtractPhpImportSymbols(symbols, line, i + 1);
 
@@ -2058,6 +2068,8 @@ private sealed class RubyMaskState
                         ? BuildCSharpPropertyMatchLine(lines, csharpMatchLines!, i)
                         : new CSharpPropertyMatchCandidate(matchLine, i, i);
                     var patternMatchLine = csharpPropertyCandidate.MatchLine;
+                    if (fortranContinuationCandidate != null)
+                        patternMatchLine = fortranContinuationCandidate.Value.MatchLine;
                     var lineOffset = patternStartOffset;
                     string? csharpWrappedModifierPrefix = null;
                     while (lineOffset >= 0 && lineOffset < patternMatchLine.Length)
@@ -2424,6 +2436,8 @@ private sealed class RubyMaskState
                         && TryFindKotlinScalaExpressionBodyEndLine(line, absoluteStartColumn)
                             ? (i + 1, null, null)
                             : ResolveRange(rangeLines, i, pattern.BodyStyle, lang, absoluteStartColumn);
+                    if (fortranContinuationCandidate != null)
+                        endLine = Math.Max(endLine, fortranContinuationCandidate.Value.LastConsumedLineIndex + 1);
                     var startLine = i + 1;
                     if (lang == "csharp"
                         && pattern.Kind == "property"
@@ -2766,7 +2780,9 @@ private sealed class RubyMaskState
                     }
                     else
                     {
-                        signature = line[absoluteStartColumn..].Trim();
+                        signature = lang == "fortran"
+                            ? patternMatchLine[absoluteStartColumn..].Trim()
+                            : line[absoluteStartColumn..].Trim();
                     }
 
                     List<string>? fortranProcedureNames = null;
@@ -15426,6 +15442,82 @@ private sealed class RubyMaskState
         return bodyStartLine == null
             ? (startIndex + 1, null, null)
             : (endLine, bodyStartLine, endLine);
+    }
+
+    private static FortranContinuationMatchCandidate? TryBuildFortranContinuationMatchLine(string[] lines, int startIndex)
+    {
+        var firstLine = lines[startIndex];
+        var firstTrimmed = firstLine.TrimStart();
+        if (!StartsWithFortranContinuationCandidate(firstTrimmed))
+            return null;
+
+        var firstCode = StripFortranComment(firstLine).TrimEnd();
+        if (!firstCode.Contains('&'))
+            return null;
+
+        var builder = new StringBuilder(firstCode.Length + 32);
+        var lastConsumedLineIndex = startIndex;
+        var currentLine = firstCode;
+
+        while (true)
+        {
+            var continuationIndex = currentLine.LastIndexOf('&');
+            if (continuationIndex < 0)
+            {
+                if (currentLine.Length > 0)
+                {
+                    if (builder.Length > 0)
+                        builder.Append(' ');
+                    builder.Append(currentLine.Trim());
+                }
+
+                break;
+            }
+
+            if (builder.Length > 0)
+                builder.Append(' ');
+            builder.Append(currentLine[..continuationIndex].TrimEnd());
+
+            if (lastConsumedLineIndex + 1 >= lines.Length)
+                break;
+
+            var nextLine = StripFortranComment(lines[lastConsumedLineIndex + 1]).TrimStart();
+            if (nextLine.StartsWith('&'))
+                nextLine = nextLine[1..].TrimStart();
+
+            lastConsumedLineIndex++;
+            currentLine = nextLine.TrimEnd();
+            if (currentLine.Length == 0)
+                break;
+        }
+
+        var normalized = builder.ToString().Trim();
+        return normalized.Length == 0 || lastConsumedLineIndex == startIndex
+            ? null
+            : new FortranContinuationMatchCandidate(normalized, lastConsumedLineIndex);
+    }
+
+    private static bool StartsWithFortranContinuationCandidate(string trimmedLine)
+    {
+        if (StartsWithFortranWord(trimmedLine, "interface"))
+            return true;
+
+        if (StartsWithFortranWord(trimmedLine, "abstract"))
+        {
+            var afterAbstract = trimmedLine["abstract".Length..].TrimStart();
+            return StartsWithFortranWord(afterAbstract, "interface");
+        }
+
+        return StartsWithFortranWord(trimmedLine, "module")
+            || StartsWithFortranWord(trimmedLine, "subroutine")
+            || StartsWithFortranWord(trimmedLine, "function")
+            || StartsWithFortranWord(trimmedLine, "procedure");
+    }
+
+    private static string StripFortranComment(string line)
+    {
+        var commentIndex = line.IndexOf('!');
+        return commentIndex >= 0 ? line[..commentIndex] : line;
     }
 
     private static bool TryGetFortranBlockStartKind(string line, out string kind)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9685,10 +9685,19 @@ public class SymbolExtractorTests
         var content = """
             module math_utils
               interface math_iface
-                module procedure normalize_iface, normalize_alt
-                procedure(normalize_iface) :: normalize_forward
-                procedure, pointer :: normalize_pointer
+                module procedure &
+                  normalize_iface, &
+                  normalize_alt
+                procedure(normalize_iface) :: &
+                  normalize_forward
+                procedure, pointer :: &
+                  normalize_pointer
               end interface math_iface
+              abstract interface
+                subroutine abstract_callback( &
+                    value)
+                end subroutine abstract_callback
+              end interface
               implicit none
             contains
               recursive subroutine normalize(v)
@@ -9728,6 +9737,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_alt");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_forward");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_pointer");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "abstract_callback");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
 


### PR DESCRIPTION
## Summary

This PR follows up on the `Follow-up candidates` from PR #1223.

- Merges continuation-heavy Fortran `interface` / `abstract interface` declarations across `&` lines before symbol matching.
- Keeps `module procedure`, `procedure(...) :: name`, and prototype-style `subroutine ...` declarations searchable even when the interface body is wrapped across multiple physical lines.
- Adds regression coverage for continuation-heavy interface syntax and abstract interface prototypes.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions|FullyQualifiedName~SymbolExtractorTests"`

## Changelog

- Added fragment: `changelog.d/unreleased/+fortran-interface-continuation.fixed.md`

## Follow-up candidates

- More exotic `abstract interface` shapes may still need dedicated handling if they become a search gap.
- There may be additional Fortran continuation forms outside interface blocks that could merit the same continuation-merging treatment in a future pass.