### PR TITLE
Surface R6 public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Perl | `.pl`, `.pm`, `.t`, `.pod` | -- |
 | Solidity | `.sol` | -- |
 | Tcl | `.tcl`, `.tk` | -- |
-| R | `.r`, `.R` | yes (function assignments, setClass/setClassUnion/R6Class/setRefClass, setGeneric/setMethod, library/require) |
+| R | `.r`, `.R` | yes (function assignments, setClass/setClassUnion/R6Class/setRefClass, R6 public methods, setGeneric/setMethod, library/require) |
 | Haskell | `.hs`, `.lhs` | yes |
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |

--- a/changelog.d/unreleased/+r-followup-3.fixed.md
+++ b/changelog.d/unreleased/+r-followup-3.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **R6 public methods now surface in symbol search** — following up on PR #1222, `cdidx` now extracts R6-style `name = function(...)` public method definitions in addition to the existing `setClass`, `setRefClass`, `setClassUnion`, `R6Class`, `setGeneric`, and `setMethod` coverage, so R6 projects expose their method names instead of falling back to file-only search results.
+
+## 日本語
+
+- **R6 の public メソッドがシンボル検索に出るようになりました** — PR #1222 の follow-up として、`cdidx` は R6 でよく使う `name = function(...)` 形式の public メソッド定義を抽出し、既存の `setClass`、`setRefClass`、`setClassUnion`、`R6Class`、`setGeneric`、`setMethod` とあわせて、R6 プロジェクトでメソッド名から検索しやすくします。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1301,6 +1301,7 @@ public static class SymbolExtractor
         [
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:setClass|setRefClass|setClassUnion|R6Class)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*setGeneric\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*setMethod\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15589,7 +15589,10 @@ public class SymbolExtractorTests
 
             setRefClass("Widget", fields = list(value = "numeric"))
 
-            R6Class("Thing", public = list(print = function() self))
+            R6Class("Thing",
+              public = list(
+                print = function() self
+              ))
 
             setGeneric("normalize", function(x) standardGeneric("normalize"))
 
@@ -15603,6 +15606,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Renderable");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Thing");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "print");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "show");
     }


### PR DESCRIPTION
This PR is a follow-up to PR #1222 and addresses the follow-up candidates called out there.

Summary:
- Extends R search coverage so R6 public methods defined as `name = function(...)` are indexed as functions.
- Keeps the existing R coverage for `setClass`, `setRefClass`, `setClassUnion`, `R6Class`, `setGeneric`, and `setMethod`.

Validation:
- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

Docs/changelog:
- Updated `README.md` to describe the expanded R6 coverage.
- Added changelog fragment `changelog.d/unreleased/+r-followup-3.fixed.md`.

Follow-up candidates:
- Add support for additional `setClass` forms if the repository needs more class-definition variants.
- Expand `R6Class(...)` handling further for private or active bindings if those become important search targets.