### PR TITLE
Follow up: C# exact search verbatim normalization

### DIFF
--- a/changelog.d/unreleased/+csharp-verbatim-search.fixed.md
+++ b/changelog.d/unreleased/+csharp-verbatim-search.fixed.md
@@ -1,14 +1,17 @@
 ---
 category: fixed
 affected:
-  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/SearchSnippetFormatter.cs
   - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
 ---
 
 ## English
 
-- **C# exact substring file search now normalizes verbatim qualified names** — `find --exact` now treats C# verbatim prefixes as syntax only, so `Foo.Bar` can match `using @Foo.@Bar;` and other equivalent source spellings.
+- **C# exact substring search now normalizes verbatim qualified names** — `search --exact-substring` now treats C# verbatim prefixes as syntax only, so `Foo.Bar` can match `using @Foo.@Bar;` and other equivalent source spellings while leaving non-C# files unchanged.
 
 ## 日本語
 
-- **C# の exact substring ファイル検索で verbatim 修飾名を正規化するようになりました** — `find --exact` は C# の verbatim 接頭辞を構文上の差分として扱うため、`Foo.Bar` で `using @Foo.@Bar;` など同値な表記にマッチできるようになりました。
+- **C# の exact substring 検索で verbatim 修飾名を正規化するようになりました** — `search --exact-substring` は C# の verbatim 接頭辞を構文上の差分として扱うため、`Foo.Bar` で `using @Foo.@Bar;` など同値な表記にマッチでき、C# 以外のファイルはそのまま維持されます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -136,14 +136,14 @@ public static class QueryCommandRunner
             if (options.Json)
             {
                 foreach (var r in results)
-                    Console.WriteLine(JsonSerializer.Serialize(SearchSnippetFormatter.ToCompactResult(r, options.Query, options.SnippetLines, exact, options.MaxLineWidth), jsonOptions));
+                    Console.WriteLine(JsonSerializer.Serialize(SearchSnippetFormatter.ToCompactResult(r, options.Query, options.SnippetLines, exact, options.MaxLineWidth, r.Lang), jsonOptions));
             }
             else
             {
                 foreach (var r in results)
                 {
                     Console.WriteLine($"{r.Path}:{r.StartLine}-{r.EndLine}");
-                    var snippetLines = SearchSnippetFormatter.Format(r.Content, options.Query, options.SnippetLines, exact, options.MaxLineWidth);
+                    var snippetLines = SearchSnippetFormatter.Format(r.Content, options.Query, options.SnippetLines, exact, options.MaxLineWidth, r.Lang);
                     foreach (var line in snippetLines)
                         Console.WriteLine($"  {line}");
                     Console.WriteLine();

--- a/src/CodeIndex/Cli/SearchSnippetFormatter.cs
+++ b/src/CodeIndex/Cli/SearchSnippetFormatter.cs
@@ -11,9 +11,9 @@ public static class SearchSnippetFormatter
     public const int DefaultSnippetLines = 8;
     public const int MaxSnippetLines = 20;
 
-    public static IReadOnlyList<string> Format(string content, string query, int maxLines = DefaultSnippetLines, bool caseSensitive = false, int maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth)
+    public static IReadOnlyList<string> Format(string content, string query, int maxLines = DefaultSnippetLines, bool caseSensitive = false, int maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth, string? lang = null)
     {
-        var excerpt = BuildExcerpt(content, query, absoluteStartLine: 1, maxLines, caseSensitive, maxLineWidth);
+        var excerpt = BuildExcerpt(content, query, absoluteStartLine: 1, maxLines, caseSensitive, maxLineWidth, lang);
         if (excerpt.Lines.Count == 0)
             return [];
 
@@ -29,9 +29,9 @@ public static class SearchSnippetFormatter
         return snippet;
     }
 
-    public static CompactSearchResult ToCompactResult(SearchResult result, string query, int maxLines = DefaultSnippetLines, bool caseSensitive = false, int maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth)
+    public static CompactSearchResult ToCompactResult(SearchResult result, string query, int maxLines = DefaultSnippetLines, bool caseSensitive = false, int maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth, string? lang = null)
     {
-        var excerpt = BuildExcerpt(result.Content, query, result.StartLine, maxLines, caseSensitive, maxLineWidth);
+        var excerpt = BuildExcerpt(result.Content, query, result.StartLine, maxLines, caseSensitive, maxLineWidth, lang ?? result.Lang);
         return new CompactSearchResult
         {
             Path = result.Path,
@@ -50,7 +50,7 @@ public static class SearchSnippetFormatter
         };
     }
 
-    public static SearchSnippetExcerpt BuildExcerpt(string content, string query, int absoluteStartLine, int maxLines = DefaultSnippetLines, bool caseSensitive = false, int maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth)
+    public static SearchSnippetExcerpt BuildExcerpt(string content, string query, int absoluteStartLine, int maxLines = DefaultSnippetLines, bool caseSensitive = false, int maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth, string? lang = null)
     {
         maxLines = ClampSnippetLines(maxLines);
         maxLineWidth = LineWidthFormatter.ClampMaxLineWidth(maxLineWidth);
@@ -66,15 +66,31 @@ public static class SearchSnippetFormatter
         }
 
         var normalizedQuery = query.Trim();
+        var normalizeCSharpVerbatimNames = caseSensitive && string.Equals(lang, "csharp", StringComparison.OrdinalIgnoreCase);
+        if (normalizeCSharpVerbatimNames)
+            normalizedQuery = CSharpVerbatimNameNormalizer.Normalize(normalizedQuery);
+
         var tokens = query
             .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
             .Select(NormalizeToken)
             .Where(t => t.Length > 0)
             .Where(t => t is not "AND" and not "OR" and not "NOT" and not "NEAR")
+            .Select(token => normalizeCSharpVerbatimNames ? CSharpVerbatimNameNormalizer.Normalize(token) : token)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        var matchIndexes = FindMatchingLineIndexes(lines, normalizedQuery, tokens, caseSensitive);
+        string[]? normalizedLines = null;
+        int[][]? rawIndexMaps = null;
+        if (normalizeCSharpVerbatimNames)
+        {
+            normalizedLines = new string[lines.Length];
+            rawIndexMaps = new int[lines.Length][];
+            for (int i = 0; i < lines.Length; i++)
+                normalizedLines[i] = CSharpVerbatimNameNormalizer.Normalize(lines[i], out rawIndexMaps[i]);
+        }
+
+        var matchLinesSource = normalizedLines ?? lines;
+        var matchIndexes = FindMatchingLineIndexes(matchLinesSource, normalizedQuery, tokens, caseSensitive);
         var focusStart = matchIndexes.Count > 0 ? matchIndexes[0] : 0;
         var focusEnd = focusStart;
         foreach (var matchIndex in matchIndexes.Skip(1))
@@ -118,7 +134,15 @@ public static class SearchSnippetFormatter
         for (int i = start; i <= end; i++)
         {
             var originalLine = lines[i];
-            var clamped = ClampSnippetLine(originalLine, maxLineWidth, matchSet.Contains(i) ? normalizedQuery : null, tokens, caseSensitive);
+            ClampedTextResult clamped;
+            if (normalizeCSharpVerbatimNames && matchSet.Contains(i) && normalizedLines != null && rawIndexMaps != null)
+            {
+                clamped = ClampNormalizedSnippetLine(originalLine, normalizedLines[i], rawIndexMaps[i], maxLineWidth, normalizedQuery, tokens, caseSensitive);
+            }
+            else
+            {
+                clamped = ClampSnippetLine(originalLine, maxLineWidth, matchSet.Contains(i) ? normalizedQuery : null, tokens, caseSensitive);
+            }
             clampedLines.Add(clamped.Text);
             if (clamped.Truncated)
                 truncatedLineCount++;
@@ -134,7 +158,7 @@ public static class SearchSnippetFormatter
                 Text = clamped.Text,
                 OriginalLineLength = originalLine.Length,
                 Truncated = clamped.Truncated,
-                Terms = GetMatchedTerms(originalLine, normalizedQuery, tokens, caseSensitive),
+                Terms = GetMatchedTerms(normalizeCSharpVerbatimNames && normalizedLines != null ? normalizedLines[i] : originalLine, normalizedQuery, tokens, caseSensitive),
             });
         }
 
@@ -168,6 +192,19 @@ public static class SearchSnippetFormatter
             return LineWidthFormatter.ClampLine(line, maxLineWidth);
 
         return LineWidthFormatter.ClampLine(line, maxLineWidth, matchColumn, matchLength);
+    }
+
+    private static ClampedTextResult ClampNormalizedSnippetLine(string originalLine, string normalizedLine, int[] rawIndexMap, int maxLineWidth, string normalizedQuery, string[] tokens, bool caseSensitive)
+    {
+        var (matchColumn, matchLength) = FindFirstMatchColumn(normalizedLine, normalizedQuery, tokens, caseSensitive);
+        if (matchColumn <= 0)
+            return LineWidthFormatter.ClampLine(originalLine, maxLineWidth);
+
+        var normalizedStart = matchColumn - 1;
+        var normalizedEnd = Math.Min(rawIndexMap.Length - 1, normalizedStart + Math.Max(1, matchLength) - 1);
+        var rawFocusColumn = rawIndexMap[normalizedStart] + 1;
+        var rawFocusLength = rawIndexMap[normalizedEnd] - rawIndexMap[normalizedStart] + 1;
+        return LineWidthFormatter.ClampLine(originalLine, maxLineWidth, rawFocusColumn, rawFocusLength);
     }
 
     private static (int Column, int Length) FindFirstMatchColumn(string line, string normalizedQuery, string[] tokens, bool caseSensitive)
@@ -269,6 +306,7 @@ public static class SearchSnippetFormatter
             .Trim('"', '\'', '(', ')')
             .TrimEnd('*');
     }
+
 }
 
 public sealed class CompactSearchResult

--- a/src/CodeIndex/Database/CSharpVerbatimNameNormalizer.cs
+++ b/src/CodeIndex/Database/CSharpVerbatimNameNormalizer.cs
@@ -1,0 +1,107 @@
+namespace CodeIndex.Database;
+
+/// <summary>
+/// Normalizes C# verbatim identifiers by stripping `@` only at identifier boundaries.
+/// C# の verbatim 識別子を正規化し、識別子境界の `@` だけを除去する。
+/// </summary>
+internal static class CSharpVerbatimNameNormalizer
+{
+    internal static string Normalize(string text)
+    {
+        if (text.Length == 0 || text.IndexOf('@') < 0)
+            return text;
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        bool atBoundary = true;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (atBoundary && c == '@'
+                && i + 1 < text.Length
+                && IsCSharpIdentifierStartChar(text[i + 1]))
+            {
+                atBoundary = false;
+                continue;
+            }
+
+            sb.Append(c);
+            if (c == '.')
+            {
+                atBoundary = true;
+            }
+            else if (c == ':' && i + 1 < text.Length && text[i + 1] == ':')
+            {
+                sb.Append(':');
+                i++;
+                atBoundary = true;
+            }
+            else
+            {
+                atBoundary = false;
+            }
+        }
+
+        return sb.Length == text.Length ? text : sb.ToString();
+    }
+
+    internal static string Normalize(string text, out int[] rawIndexMap)
+    {
+        if (text.Length == 0)
+        {
+            rawIndexMap = [];
+            return text;
+        }
+
+        if (text.IndexOf('@') < 0)
+        {
+            rawIndexMap = BuildIdentityMap(text.Length);
+            return text;
+        }
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        var map = new List<int>(text.Length);
+        bool atBoundary = true;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (atBoundary && c == '@'
+                && i + 1 < text.Length
+                && IsCSharpIdentifierStartChar(text[i + 1]))
+            {
+                atBoundary = false;
+                continue;
+            }
+
+            sb.Append(c);
+            map.Add(i);
+            if (c == '.')
+            {
+                atBoundary = true;
+            }
+            else if (c == ':' && i + 1 < text.Length && text[i + 1] == ':')
+            {
+                sb.Append(':');
+                map.Add(++i);
+                atBoundary = true;
+            }
+            else
+            {
+                atBoundary = false;
+            }
+        }
+
+        rawIndexMap = sb.Length == text.Length ? BuildIdentityMap(text.Length) : map.ToArray();
+        return sb.Length == text.Length ? text : sb.ToString();
+    }
+
+    private static int[] BuildIdentityMap(int length)
+    {
+        var map = new int[length];
+        for (int i = 0; i < length; i++)
+            map[i] = i;
+        return map;
+    }
+
+    private static bool IsCSharpIdentifierStartChar(char c) =>
+        c == '_' || char.IsLetter(c);
+}

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -349,6 +349,9 @@ public class DbContext : IDisposable
                 return normalizedName.Length == 0 ? null : NameFold.Fold(normalizedName) ?? normalizedName;
             });
         connection.CreateFunction(
+            "sql_normalize_csharp_verbatim_name",
+            (string? text) => string.IsNullOrWhiteSpace(text) ? null : CSharpVerbatimNameNormalizer.Normalize(text));
+        connection.CreateFunction(
             "sql_segment_count",
             (string? name) => string.IsNullOrWhiteSpace(name) ? (int?)null : SqlNameResolver.GetSegmentCount(name));
         connection.CreateFunction(

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -297,7 +297,16 @@ public partial class DbReader
                        0.0 AS rank
                 FROM chunks c
                 JOIN files f ON c.file_id = f.id
-                WHERE instr(c.content, @exactQuery) > 0";
+                WHERE instr(
+                    CASE WHEN f.lang = 'csharp'
+                         THEN sql_normalize_csharp_verbatim_name(c.content)
+                         ELSE c.content
+                    END,
+                    CASE WHEN f.lang = 'csharp'
+                         THEN sql_normalize_csharp_verbatim_name(@exactQuery)
+                         ELSE @exactQuery
+                    END
+                ) > 0";
         }
         else
         {
@@ -370,7 +379,16 @@ public partial class DbReader
                        0.0 AS rank
                 FROM chunks c
                 JOIN files f ON c.file_id = f.id
-                WHERE instr(c.content, @exactQuery) > 0";
+                WHERE instr(
+                    CASE WHEN f.lang = 'csharp'
+                         THEN sql_normalize_csharp_verbatim_name(c.content)
+                         ELSE c.content
+                    END,
+                    CASE WHEN f.lang = 'csharp'
+                         THEN sql_normalize_csharp_verbatim_name(@exactQuery)
+                         ELSE @exactQuery
+                    END
+                ) > 0";
         }
         else
         {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -7814,9 +7814,9 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
-    public void RunFind_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical()
+    public void RunSearch_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical()
     {
-        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_csharp_verbatim");
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_csharp_verbatim");
         try
         {
             var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
@@ -7828,11 +7828,10 @@ public class QueryCommandRunnerTests
                 namespace Demo;
 
                 using @Foo.@Bar;
-                using Foo.Bar;
                 """);
 
-            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
-                ["Foo.Bar", "--db", dbPath, "--path", "src/app.cs", "--lang", "csharp", "--json", "--exact", "--count"],
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Foo.Bar", "--db", dbPath, "--path", "src/app.cs", "--json", "--exact-substring", "--count"],
                 _jsonOptions));
 
             using var document = ParseJsonOutput(stdout);
@@ -7840,7 +7839,47 @@ public class QueryCommandRunnerTests
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
-            Assert.Equal(2, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_ExactSubstringKeepsNormalizationScopedToCSharp()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_csharp_scope");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/app.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                using @Foo.@Bar;
+                """);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "scripts/run.bat",
+                "batch",
+                "@Foo.@Bar\r\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Foo.Bar", "--db", dbPath, "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
             Assert.Equal(1, json.GetProperty("files").GetInt32());
         }
         finally


### PR DESCRIPTION
Implements the Follow-up candidates from PR #1221.

- `search --exact-substring` now normalizes C# verbatim qualified names before matching, while leaving non-C# files unchanged.
- Added a mixed-language regression to prove the normalization stays scoped to `lang: csharp`.
- Updated the changelog fragment for this follow-up work.

Validation:
- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringKeepsNormalizationScopedToCSharp|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringHumanSnippetUsesCaseSensitiveFocusLine"`