### PR TITLE
Improve F# match-arm search coverage

### DIFF
--- a/changelog.d/unreleased/+fsharp-match-arm-application.fixed.md
+++ b/changelog.d/unreleased/+fsharp-match-arm-application.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# match arms now contribute search hits for calls after `->`** — `ReferenceExtractor` now treats `match ... -> printfn ...` style branches as F# space-application contexts, so common calls inside pattern matches stay searchable instead of being missed.
+
+## 日本語
+
+- **F# の match arm で `->` の後ろに続く呼び出しも検索対象になるようになりました** — `ReferenceExtractor` が `match ... -> printfn ...` のような F# の branch を空白区切り application として扱うため、pattern match 内のよく使う呼び出しを取りこぼしにくくなりました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -394,12 +394,14 @@ public static class ReferenceExtractor
     // F# also allows ordinary space-separated application such as `printfn "x"` or
     // `List.map increment numbers`. Capture the callable leaf when the expression starts a
     // statement or follows a small set of expression separators so common non-paren calls stay
-    // visible without trying to parse the full language.
+    // visible without trying to parse the full language. Match arms (`| Some x -> printfn ...`)
+    // are included because they are a very common F# search target.
     // F# では `printfn "x"` や `List.map increment numbers` のような空白区切り application も普通に使う。
     // 全体構文の解析はせず、文頭または少数の式区切りの後ろにある callable leaf を拾うことで、
-    // 慣用的な non-paren 呼び出しも可視化する。
+    // 慣用的な non-paren 呼び出しも可視化する。`| Some x -> printfn ...` のような match arm も
+    // F# の検索対象として重要なので含める。
     private static readonly Regex FSharpSpaceApplicationCallRegex = new(
-        $@"(?:\b(?:then|do|else|in)\s+|[=(,\[\{{;]\s*|^\s*)
+        $@"(?:\b(?:then|do|else|in)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{FSharpIdentifierPattern})\s*\.\s*)*
             (?<name>{FSharpIdentifierPattern})\b
             (?=\s+(?:{FSharpIdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7720,6 +7720,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsMatchArmApplicationCalls()
+    {
+        const string content = """
+            let describe value =
+                match value with
+                | Some user -> printfn "User: %A" user
+                | None -> failwith "Missing value"
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "printfn" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "failwith" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "match");
+    }
+
+    [Fact]
     public void Extract_R_DetectsCallSites()
     {
         const string content = """


### PR DESCRIPTION
## Summary
- Teach F# space-application extraction to recognize `match ... -> ...` branches, so common calls inside pattern matches stay searchable.
- Add a regression test that covers `printfn` and `failwith` inside F# match arms.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_FSharp_"`
- `dotnet test CodeIndex.sln`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog
- Added `changelog.d/unreleased/+fsharp-match-arm-application.fixed.md`.
- No direct `CHANGELOG.md` edit was made because this is an ordinary implementation PR.

## Follow-up candidates
- F# active patterns and computation expressions may still hide some call-like references.
- F# union-case and record-field symbol coverage may be worth a separate improvement if search demand shows up.