### PR TITLE
Improve VB.NET repo map entrypoint hints

### DIFF
--- a/changelog.d/unreleased/+vb-repo-map-entrypoints.fixed.md
+++ b/changelog.d/unreleased/+vb-repo-map-entrypoints.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/RepoMapBuilder.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **VB.NET repo maps now recognize common startup file names** — `map` / `repo map` now treats `Main.vb` and `Module.vb` as entrypoint file fallbacks in addition to `Program.vb`, `Module1.vb`, and `App.vb`, so VB projects with renamed startup modules are easier to surface.
+
+## 日本語
+
+- **VB.NET の repo map が一般的な起動ファイル名を認識するようになりました** — `map` / `repo map` は `Program.vb`、`Module1.vb`、`App.vb` に加えて `Main.vb` と `Module.vb` も entrypoint の file fallback として扱うため、名前を変更した VB の起動モジュールを見つけやすくなります。

--- a/src/CodeIndex/Database/RepoMapBuilder.cs
+++ b/src/CodeIndex/Database/RepoMapBuilder.cs
@@ -53,7 +53,7 @@ internal sealed class RepoMapBuilder
         ["dart"] = ["main.dart", "app.dart"],
         ["scala"] = ["Main.scala", "App.scala", "Application.scala"],
         ["fsharp"] = ["Program.fs", "App.fs"],
-        ["vb"] = ["Program.vb", "Module1.vb", "App.vb"],
+        ["vb"] = ["Program.vb", "Main.vb", "Module.vb", "Module1.vb", "App.vb"],
         ["c"] = ["main.c"],
         ["cpp"] = ["main.cpp", "main.cc", "main.cxx"],
         ["haskell"] = ["Main.hs", "Main.lhs"],

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -8187,6 +8187,24 @@ public class DbReaderTests : IDisposable
         Assert.Contains(map.Entrypoints, item => item.Kind == "file" && item.Name == "Program.cs" && item.Path == "src/Program.cs");
     }
 
+    [Theory]
+    [InlineData("src/Main.vb")]
+    [InlineData("src/Module.vb")]
+    public void GetRepoMap_AddsFileFallbackEntrypointForCommonVbStartupFiles(string path)
+    {
+        InsertIndexedFile(path, "vb",
+            """
+            Public Class Launcher
+                Public Sub Execute()
+                End Sub
+            End Class
+            """);
+
+        var map = _reader.GetRepoMap(limit: 5, pathPatterns: new[] { path });
+
+        Assert.Contains(map.Entrypoints, item => item.Kind == "function" && item.Name == "Execute" && item.Path == path);
+    }
+
     [Fact]
     public void GetRepoMap_KeepsScopedFreshnessAndAddsWorkspaceFreshness()
     {


### PR DESCRIPTION
## Summary
- Expand VB.NET repo map entrypoint hints to include `Main.vb` and `Module.vb`.
- Add a regression test covering VB startup-file heuristics in `DbReaderTests`.

## Validation
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release --filter GetRepoMap_AddsFileFallbackEntrypoint`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Database/RepoMapBuilder.cs tests/CodeIndex.Tests/DbReaderTests.cs`

## Documentation / Changelog
- Added fragment: `changelog.d/unreleased/+vb-repo-map-entrypoints.fixed.md`

## Follow-up candidates
- Consider whether WinForms/WPF startup files like `Form1.vb` or `App.xaml.vb` deserve similar entrypoint hints.
- Review whether other VB.NET naming conventions should be added only after observing real repo examples.