### PR TITLE
Expand Python import search

### DIFF
--- a/changelog.d/unreleased/+python-import-bindings.fixed.md
+++ b/changelog.d/unreleased/+python-import-bindings.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python import search now includes local bindings and imported names** — `import numpy as np` now surfaces both `numpy` and `np`, and `from ... import ...` statements surface the imported names and aliases that Python code actually binds, so search results match the identifiers developers use in code.
+
+## 日本語
+
+- **Python の import 検索で local binding と imported name も拾うようになりました** — `import numpy as np` では `numpy` と `np` の両方を、`from ... import ...` では Python コードが実際に束縛する imported name / alias を拾うため、検索結果がコード中で使う識別子と一致しやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -527,7 +527,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*(?:async\s+)?def\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*\(", RegexOptions.Compiled), BodyStyle.Indent),
             new("class",    new Regex(@"^\s*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Indent),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*(?:from\s+(?<name>[\w.]+)\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?:from\s+(?<name>(?:\.+[\w.]*|[\w.]+))\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cobol"] =
         [
@@ -2795,13 +2795,42 @@ private sealed class RubyMaskState
 
                     if (!suppressJavaStatementSymbol)
                     {
+                        var pythonImportEntries = lang == "python" && pattern.Kind == "import"
+                            ? TryExpandPythonImportSymbols(line, absoluteStartColumn)
+                            : null;
                         var declaratorEntries = lang == "csharp"
                             && pattern.Kind == "property"
                             && pattern.BodyStyle == BodyStyle.None
                             ? TryExpandCSharpFieldDeclaratorList(patternMatchLine, absoluteStartColumn, match, pattern.ReturnTypeGroup, name)
                             : null;
 
-                        if (declaratorEntries != null)
+                        if (pythonImportEntries != null)
+                        {
+                            foreach (var entry in pythonImportEntries)
+                            {
+                                AddSymbolRecord(
+                                    symbols,
+                                    cssSeenSymbols,
+                                    startLine,
+                                    new SymbolRecord
+                                    {
+                                        FileId = fileId,
+                                        Kind = kind,
+                                        Name = entry.Name,
+                                        Line = startLine,
+                                        StartLine = startLine,
+                                        StartColumn = entry.StartColumn,
+                                        EndLine = Math.Max(startLine, endLine),
+                                        BodyStartLine = bodyStartLine,
+                                        BodyEndLine = bodyEndLine,
+                                        Signature = signature,
+                                        Visibility = TryGetGroup(match, pattern.VisibilityGroup),
+                                        ReturnType = NormalizeMetadata(rawReturnType),
+                                    },
+                                    line);
+                            }
+                        }
+                        else if (declaratorEntries != null)
                         {
                             foreach (var entry in declaratorEntries)
                             {
@@ -3403,6 +3432,149 @@ private sealed class RubyMaskState
                 Signature = lines[i].Trim(),
             });
         }
+    }
+
+    private readonly record struct PythonImportSymbolEntry(string Name, int StartColumn);
+    private static readonly Regex PythonDirectImportRegex = new(@"^import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static List<PythonImportSymbolEntry>? TryExpandPythonImportSymbols(string line, int absoluteStartColumn)
+    {
+        if (absoluteStartColumn < 0 || absoluteStartColumn >= line.Length)
+            return null;
+
+        var statement = line[absoluteStartColumn..].Trim();
+        if (statement.Length == 0)
+            return null;
+
+        var commentIndex = statement.IndexOf('#');
+        if (commentIndex >= 0)
+            statement = statement[..commentIndex].TrimEnd();
+
+        if (statement.Length == 0)
+            return null;
+
+        var entries = new List<PythonImportSymbolEntry>();
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+
+        var directImportMatch = PythonDirectImportRegex.Match(statement);
+        if (directImportMatch.Success)
+        {
+            var directImportSpecs = directImportMatch.Groups["imports"].Value;
+            AddPythonImportSpecEntries(
+                line,
+                absoluteStartColumn,
+                directImportSpecs,
+                entries,
+                seenNames,
+                treatAsFromImport: false);
+            return entries.Count > 0 ? entries : null;
+        }
+
+        var fromImportMatch = PythonFromImportRegex.Match(statement);
+        if (!fromImportMatch.Success)
+            return null;
+
+        var modulePart = fromImportMatch.Groups["module"].Value;
+        var fromImportSpecs = fromImportMatch.Groups["imports"].Value;
+        AddPythonImportModuleEntry(line, absoluteStartColumn, modulePart, entries, seenNames);
+        AddPythonImportSpecEntries(
+            line,
+            absoluteStartColumn,
+            fromImportSpecs,
+            entries,
+            seenNames,
+            treatAsFromImport: true);
+        return entries.Count > 0 ? entries : null;
+    }
+
+    private static void AddPythonImportSpecEntries(
+        string line,
+        int absoluteStartColumn,
+        string importedNames,
+        List<PythonImportSymbolEntry> entries,
+        HashSet<string> seenNames,
+        bool treatAsFromImport)
+    {
+        importedNames = importedNames.Trim();
+        if (importedNames.Length == 0)
+            return;
+
+        if (importedNames.StartsWith('(') && importedNames.EndsWith(')'))
+            importedNames = importedNames[1..^1].Trim();
+
+        var searchStartColumn = absoluteStartColumn;
+        foreach (var rawSpec in importedNames.Split(','))
+        {
+            var spec = rawSpec.Trim();
+            if (spec.Length == 0 || spec == "*")
+                continue;
+
+            var aliasIndex = spec.IndexOf(" as ", StringComparison.Ordinal);
+            var importedName = aliasIndex >= 0
+                ? spec[..aliasIndex].Trim()
+                : spec;
+            var localName = aliasIndex >= 0
+                ? spec[(aliasIndex + " as ".Length)..].Trim()
+                : importedName.Split('.')[0].Trim();
+
+            if (importedName.Length > 0)
+            {
+                AddPythonImportEntry(line, absoluteStartColumn, importedName, entries, seenNames, ref searchStartColumn);
+            }
+
+            if (localName.Length > 0
+                && (!string.Equals(localName, importedName, StringComparison.Ordinal) || treatAsFromImport))
+            {
+                AddPythonImportEntry(line, absoluteStartColumn, localName, entries, seenNames, ref searchStartColumn);
+            }
+        }
+    }
+
+    private static void AddPythonImportModuleEntry(
+        string line,
+        int absoluteStartColumn,
+        string modulePart,
+        List<PythonImportSymbolEntry> entries,
+        HashSet<string> seenNames)
+    {
+        modulePart = modulePart.Trim();
+        if (modulePart.Length == 0)
+            return;
+
+        var normalizedModule = modulePart.TrimStart('.');
+        if (normalizedModule.Length == 0)
+            return;
+
+        var searchStartColumn = absoluteStartColumn;
+        AddPythonImportEntry(line, absoluteStartColumn, normalizedModule, entries, seenNames, ref searchStartColumn);
+    }
+
+    private static void AddPythonImportEntry(
+        string line,
+        int absoluteStartColumn,
+        string symbolName,
+        List<PythonImportSymbolEntry> entries,
+        HashSet<string> seenNames,
+        ref int searchStartColumn)
+    {
+        symbolName = symbolName.Trim();
+        if (symbolName.Length == 0 || !seenNames.Add(symbolName))
+            return;
+
+        var startColumn = line.IndexOf(symbolName, searchStartColumn, StringComparison.Ordinal);
+        if (startColumn < 0)
+        {
+            startColumn = line.IndexOf(symbolName, absoluteStartColumn, StringComparison.Ordinal);
+            if (startColumn < 0)
+                startColumn = absoluteStartColumn;
+        }
+        else
+        {
+            searchStartColumn = startColumn + Math.Max(1, symbolName.Length);
+        }
+
+        entries.Add(new PythonImportSymbolEntry(symbolName, startColumn));
     }
 
     private static void ExtractJavaModuleDirectiveSymbols(long fileId, string[] rawLines, string[] structuralLines, List<SymbolRecord> symbols)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -82,6 +82,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_ExpandsImportAliasesAndImportedNames()
+    {
+        var content = """
+            import numpy as np
+            from  collections   import  defaultdict, OrderedDict as OD
+            from .helpers import build as build_helper
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var imports = symbols.Where(symbol => symbol.Kind == "import").ToList();
+
+        Assert.Contains(imports, symbol => symbol.Name == "numpy");
+        Assert.Contains(imports, symbol => symbol.Name == "np");
+        Assert.Contains(imports, symbol => symbol.Name == "collections");
+        Assert.Contains(imports, symbol => symbol.Name == "defaultdict");
+        Assert.Contains(imports, symbol => symbol.Name == "OrderedDict");
+        Assert.Contains(imports, symbol => symbol.Name == "OD");
+        Assert.Contains(imports, symbol => symbol.Name == "helpers");
+        Assert.Contains(imports, symbol => symbol.Name == "build");
+        Assert.Contains(imports, symbol => symbol.Name == "build_helper");
+    }
+
+    [Fact]
     public void Extract_Protobuf_DetectsEnumPackageOneofExtendAndService()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Python import symbols now include local bindings and imported names. `import numpy as np` now yields both `numpy` and `np`, and `from ... import ...` statements surface the names and aliases that Python code actually binds.
- Added coverage for direct imports, aliases, relative imports, and irregular whitespace in import statements.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`

## Docs / Changelog
- Added `changelog.d/unreleased/+python-import-bindings.fixed.md`.
- No `CHANGELOG.md` edits; this is an ordinary implementation PR.

## Follow-up candidates
- Multiline parenthesized Python import lists are still line-based and are not expanded yet.