### PR TITLE
Refine C++ namespace import normalization

### DIFF
--- a/changelog.d/unreleased/+cpp-namespace-import-followups.fixed.md
+++ b/changelog.d/unreleased/+cpp-namespace-import-followups.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C++ `using namespace` imports now ignore trailing comments** — namespace import targets are normalized before storage, so `using namespace std; // comment` and similar forms still index as `std` instead of capturing the comment suffix. The older regex fallback for C++ namespace import rows was removed in favor of the helper-based path.
+
+## 日本語
+
+- **C++ の `using namespace` import が末尾コメントを無視するようになりました** — namespace import の target を保存前に正規化するため、`using namespace std; // comment` のような形もコメント部分を含めず `std` として索引されます。あわせて、C++ namespace import 行に対する古い regex fallback は helper ベースの経路へ整理しました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1169,10 +1169,6 @@ public static class SymbolExtractor
             new("namespace", new Regex(CppFunctionStartBlacklistPattern + @"inline\s+namespace\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:export\s+)?concept\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:(?<returnType>(?:[\w:<>~]+[\s*&]+)+))?(?:(?:[\w:<>]+\s*::\s*)+)?" + CFunctionNameBlacklistPattern + @"(?<name>~?\w+|operator(?:\s*\(\)|\s*\[\]|\s*[^\s(]+(?:\s+[^\s(]+)?))(?:\s*<[^>]+>)?\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
-            // Namespace aliases / 名前空間エイリアス
-            new("import", new Regex(CppFunctionStartBlacklistPattern + @"namespace\s+(?<name>\w+)\s*=\s*(?:::)?[\w:]+", RegexOptions.Compiled), BodyStyle.None),
-            // Namespace directives / 名前空間導入
-            new("import", new Regex(CppFunctionStartBlacklistPattern + @"using\s+namespace\s+(?<name>(?:::)?[\w:]+)", RegexOptions.Compiled), BodyStyle.None),
             // Type alias / 型エイリアス
             new("import", new Regex(CppFunctionStartBlacklistPattern + @"template\s*<[^>]+>\s*(?:export\s+)?using\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:export\s+)?using\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None),
@@ -11715,9 +11711,7 @@ private sealed class RubyMaskState
 
         if (trimmed.StartsWith("using namespace ", StringComparison.Ordinal))
         {
-            var target = trimmed["using namespace ".Length..].Trim();
-            if (target.EndsWith(';'))
-                target = target[..^1].TrimEnd();
+            var target = NormalizeCppUsingNamespaceTarget(trimmed["using namespace ".Length..]);
 
             if (target.Length > 0)
             {
@@ -11811,6 +11805,22 @@ private sealed class RubyMaskState
             return null;
 
         return text[start..end].ToString();
+    }
+
+    private static string NormalizeCppUsingNamespaceTarget(string text)
+    {
+        var target = text.Trim();
+        var commentIndex = target.IndexOf("//", StringComparison.Ordinal);
+        if (commentIndex < 0)
+            commentIndex = target.IndexOf("/*", StringComparison.Ordinal);
+
+        if (commentIndex >= 0)
+            target = target[..commentIndex].TrimEnd();
+
+        if (target.EndsWith(';'))
+            target = target[..^1].TrimEnd();
+
+        return target;
     }
 
     private static void RemoveTrailingSameNameDeclarationOnlyFunctions(List<SymbolRecord> symbols, SymbolRecord symbol)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -376,7 +376,7 @@ public class SymbolExtractorTests
             template <typename T> using Ptr = std::unique_ptr<T>;
 
             namespace demo {
-                using namespace std;
+                using namespace std; // comment to ignore
             }
             """;
 
@@ -394,7 +394,7 @@ public class SymbolExtractorTests
         var content = """
             namespace demo {
                 using DemoValue = long;
-                using namespace std;
+                using namespace std; /* comment to ignore */
             }
             """;
 


### PR DESCRIPTION
## Summary
- Addressed the follow-up candidates from PR #1228.
- Normalized C++ `using namespace ...` targets before storage so trailing comments are ignored.
- Removed the now-redundant C++ namespace-import regex fallback and kept the helper-based path.
- Preserved the existing C++ module / alias coverage and added regression tests.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Docs and changelog
- Added `changelog.d/unreleased/+cpp-namespace-import-followups.fixed.md`.
- No README update was needed because the existing C++ import documentation still describes the same user-facing search behavior.

## Follow-up candidates
- None beyond the items from PR #1228 that were already addressed here.