### PR TITLE
Broaden R class name coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Perl | `.pl`, `.pm`, `.t`, `.pod` | -- |
 | Solidity | `.sol` | -- |
 | Tcl | `.tcl`, `.tk` | -- |
-| R | `.r`, `.R` | yes (function assignments, setClass/setClassUnion/R6Class/setRefClass, R6 public methods, setGeneric/setMethod, library/require) |
+| R | `.r`, `.R` | yes (function assignments, setClass/setClassUnion/R6Class/setRefClass, R6 public/private/active methods, setGeneric/setMethod, library/require) |
 | Haskell | `.hs`, `.lhs` | yes |
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |

--- a/changelog.d/unreleased/+r-followup-4.fixed.md
+++ b/changelog.d/unreleased/+r-followup-4.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **R class definitions now handle bare names and more R6 bindings** — following up on PR #1226, `cdidx` now recognizes unquoted `setClass`, `setRefClass`, `setClassUnion`, and `R6Class` names, and it continues surfacing R6 public, private, and active `name = function(...)` bindings as function symbols, so more R object-system code is searchable by symbol instead of by file.
+
+## 日本語
+
+- **R の class 定義が裸の名前とより多くの R6 binding に対応しました** — PR #1226 の follow-up として、`cdidx` はクォートなしの `setClass`、`setRefClass`、`setClassUnion`、`R6Class` を認識し、R6 の public / private / active な `name = function(...)` binding も function シンボルとして出すため、R のオブジェクトシステムを使うコードをシンボル単位で検索しやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1306,7 +1306,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("class",    new Regex(@"^\s*(?:setClass|setRefClass|setClassUnion|R6Class)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?:setClass|setRefClass|setClassUnion|R6Class)\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*setGeneric\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*setMethod\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:library|require)\s*\(\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15593,15 +15593,21 @@ public class SymbolExtractorTests
     {
         // R: setClass, setClassUnion, setRefClass, R6Class, setGeneric, setMethod / R: setClass、setClassUnion、setRefClass、R6Class、setGeneric、setMethod
         var content = """
-            setClass("Person", slots = c(name = "character"))
+            setClass(Person, slots = c(name = "character"))
 
-            setClassUnion("Renderable", c("Person", "Widget"))
+            setClassUnion(Renderable, c(Person, Widget))
 
-            setRefClass("Widget", fields = list(value = "numeric"))
+            setRefClass(Widget, fields = list(value = "numeric"))
 
-            R6Class("Thing",
+            R6Class(Thing,
               public = list(
                 print = function() self
+              ),
+              private = list(
+                secret = function() self
+              ),
+              active = list(
+                state = function(value) self
               ))
 
             setGeneric("normalize", function(x) standardGeneric("normalize"))
@@ -15617,6 +15623,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Thing");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "print");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "secret");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "state");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "show");
     }


### PR DESCRIPTION
This PR is a follow-up to PR #1226 and addresses the follow-up candidates called out there.

Summary:
- Extends R class extraction to accept bare symbol names for `setClass`, `setRefClass`, `setClassUnion`, and `R6Class` in addition to quoted names.
- Keeps the existing R6 function-binding coverage in place, including public, private, and active `name = function(...)` members.

Validation:
- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

Docs/changelog:
- Updated `README.md` to describe the expanded R class coverage.
- Added changelog fragment `changelog.d/unreleased/+r-followup-4.fixed.md`.

Follow-up candidates:
- Add more specialized `setClass` parsing if future R code uses additional constructor forms beyond the current first-argument capture.
- Expand `R6Class(...)` handling if private or active bindings need dedicated metadata beyond name extraction.