### PR TITLE
Expand VB.NET startup file hints

### DIFF
--- a/changelog.d/unreleased/+vb-followup-startup.fixed.md
+++ b/changelog.d/unreleased/+vb-followup-startup.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/RepoMapBuilder.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **VB.NET repo maps now recognize more common startup file names** — `map` / `repo map` now treats `Form1.vb` and `App.xaml.vb` as entrypoint file fallbacks too, extending the earlier VB startup-file follow-up so WinForms and WPF projects surface more naturally.
+
+## 日本語
+
+- **VB.NET の repo map がより一般的な起動ファイル名を認識するようになりました** — `map` / `repo map` は `Form1.vb` と `App.xaml.vb` も entrypoint の file fallback として扱うため、前回の VB startup-file follow-up を拡張し、WinForms / WPF プロジェクトをより自然に見つけやすくなります。

--- a/src/CodeIndex/Database/RepoMapBuilder.cs
+++ b/src/CodeIndex/Database/RepoMapBuilder.cs
@@ -53,7 +53,7 @@ internal sealed class RepoMapBuilder
         ["dart"] = ["main.dart", "app.dart"],
         ["scala"] = ["Main.scala", "App.scala", "Application.scala"],
         ["fsharp"] = ["Program.fs", "App.fs"],
-        ["vb"] = ["Program.vb", "Main.vb", "Module.vb", "Module1.vb", "App.vb"],
+        ["vb"] = ["Program.vb", "Main.vb", "Module.vb", "Module1.vb", "Form1.vb", "App.xaml.vb", "App.vb"],
         ["c"] = ["main.c"],
         ["cpp"] = ["main.cpp", "main.cc", "main.cxx"],
         ["haskell"] = ["Main.hs", "Main.lhs"],

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -8190,6 +8190,8 @@ public class DbReaderTests : IDisposable
     [Theory]
     [InlineData("src/Main.vb")]
     [InlineData("src/Module.vb")]
+    [InlineData("src/Form1.vb")]
+    [InlineData("src/App.xaml.vb")]
     public void GetRepoMap_AddsFileFallbackEntrypointForCommonVbStartupFiles(string path)
     {
         InsertIndexedFile(path, "vb",


### PR DESCRIPTION
## Summary
- Addresses the follow-up candidates from PR #1230 by adding VB.NET startup-file hints for `Form1.vb` and `App.xaml.vb`.
- Keeps the existing VB repo map coverage aligned with common WinForms and WPF startup layouts.

## Validation
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release --filter GetRepoMap_AddsFileFallbackEntrypointForCommonVbStartupFiles`

## Documentation / Changelog
- Added fragment: `changelog.d/unreleased/+vb-followup-startup.fixed.md`

## Follow-up candidates
- None from the previous PR's VB startup-file suggestions; this PR addresses them directly.