### PR TITLE
Improve F# active pattern symbol coverage

### DIFF
--- a/changelog.d/unreleased/+fsharp-active-pattern-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-active-pattern-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# active pattern definitions are now searchable by their case names** — `SymbolExtractor` now emits searchable symbols for `let (|Foo|Bar|)` definitions, so active pattern cases like `Foo`, `Bar`, and partial-pattern forms such as `ParseInt` show up in search results.
+
+## 日本語
+
+- **F# の active pattern 定義を case 名で検索できるようになりました** — `SymbolExtractor` が `let (|Foo|Bar|)` の定義から検索可能な symbol を出すようになり、`Foo` / `Bar` や `ParseInt` のような partial-pattern 形式も検索結果に出るようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -2017,6 +2017,9 @@ private sealed class RubyMaskState
             if (fortranContinuationCandidate != null)
                 matchLine = fortranContinuationCandidate.Value.MatchLine;
 
+            if (lang == "fsharp" && TryAddFSharpActivePatternSymbols(symbols, fileId, line, i + 1))
+                continue;
+
             if (lang == "php")
                 ExtractPhpImportSymbols(symbols, line, i + 1);
 
@@ -22932,6 +22935,45 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
             return name[2..^2];
 
         return name;
+    }
+
+    private static readonly Regex FSharpActivePatternDefinitionRegex = new(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*\(\|(?<cases>.+?)\|\)", RegexOptions.Compiled);
+    private static readonly Regex FSharpActivePatternNameRegex = new(@"^(?:``[^`]+``|[_\p{L}][\w']*)$", RegexOptions.Compiled);
+
+    private static bool TryAddFSharpActivePatternSymbols(List<SymbolRecord> symbols, long fileId, string line, int lineNumber)
+    {
+        var match = FSharpActivePatternDefinitionRegex.Match(line);
+        if (!match.Success)
+            return false;
+
+        var activePatternNames = match.Groups["cases"].Value
+            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var emittedAny = false;
+        foreach (var rawName in activePatternNames)
+        {
+            if (rawName == "_" || !FSharpActivePatternNameRegex.IsMatch(rawName))
+                continue;
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "function",
+                    Name = NormalizeFSharpSymbolName(rawName),
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                },
+                rawLine: line);
+            emittedAny = true;
+        }
+
+        return emittedAny;
     }
 
     private static string NormalizeCSharpSymbolName(string name, Match match, string matchLine)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12676,6 +12676,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsActivePatternDefinitions()
+    {
+        var content = """
+            module MyApp.Patterns
+
+            let (|Even|Odd|) n =
+                if n % 2 = 0 then Even else Odd
+
+            let private (|ParseInt|_|) (value: string) =
+                match System.Int32.TryParse(value) with
+                | true, parsed -> Some parsed
+                | false, _ -> None
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Even");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Odd");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ParseInt");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "_");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsValueBindings()
     {
         // F# value bindings should be indexed by their binding names / F# の値束縛は


### PR DESCRIPTION
## Summary
- Address the active-pattern follow-up candidate from PR #1229 by making `SymbolExtractor` emit searchable symbols for F# active pattern case names.
- Add a regression test that covers complete and partial active patterns, including modifier-prefixed definitions such as `let private (|ParseInt|_|)`.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_FSharp_"`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs changelog.d/unreleased/+fsharp-active-pattern-symbols.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog
- Added `changelog.d/unreleased/+fsharp-active-pattern-symbols.fixed.md`.
- No direct `CHANGELOG.md` edit was made because this is an ordinary implementation PR.

## Follow-up candidates
- F# union-case and record-field symbol coverage still looks like a separate follow-up if search demand shows up.
- Computation expressions may still hide some call-like references in edge cases.