### PR TITLE
Improve Rust use reexport indexing

### DIFF
--- a/changelog.d/unreleased/+rust-use-reexports.fixed.md
+++ b/changelog.d/unreleased/+rust-use-reexports.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Rust `use` re-exports and imported leaf names are now indexed** — symbol extraction now records `pub use` / `pub(crate) use` statements and the imported leaf or alias names inside `use` trees, so searches can find re-exported Rust symbols directly.
+
+## 日本語
+
+- **Rust の `use` re-export と import 先の leaf 名もインデックスされるようになりました** — `pub use` / `pub(crate) use` と `use` tree の中の leaf 名や alias 名もシンボル抽出で記録するため、re-export された Rust シンボルを直接検索できるようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -129,6 +129,9 @@ public static class SymbolExtractor
     private static readonly Regex GoValueBlockSpecRegex = new(
         @"^(?<names>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex RustUseStatementRegex = new(
+        @"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?use\s+(?<body>.+);\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex XamlClassRegex = new(
         @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1086,7 +1089,7 @@ public static class SymbolExtractor
             new("namespace", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?mod\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // type alias / 型エイリアス
             new("import",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?type\s+(?<name>\w+)(?:\s*<[^=]+>)?", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("import",   new Regex(@"^\s*use\s+(?<name>.+);", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?use\s+(?<name>.+);", RegexOptions.Compiled), BodyStyle.None, "visibility"),
         ],
         ["java"] =
         [
@@ -1970,6 +1973,200 @@ public static class SymbolExtractor
                 continue;
             }
         }
+    }
+
+    private static void ExtractRustUseSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var match = RustUseStatementRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var body = match.Groups["body"].Value.Trim();
+            if (body.Length == 0)
+                continue;
+
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            CollectRustUseSymbolNames(body, names);
+
+            foreach (var name in names)
+            {
+                if (HasRustSymbol(symbols, fileId, i + 1, "import", name))
+                    continue;
+
+                var startColumn = line.IndexOf(name, StringComparison.Ordinal);
+                if (startColumn < 0)
+                    startColumn = line.Length - line.TrimStart().Length;
+
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    i + 1,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "import",
+                        Name = name,
+                        Line = i + 1,
+                        StartLine = i + 1,
+                        StartColumn = startColumn,
+                        EndLine = i + 1,
+                        Signature = line.Trim(),
+                    },
+                    line);
+            }
+        }
+    }
+
+    private static void CollectRustUseSymbolNames(string body, ISet<string> names)
+    {
+        var text = body.Trim();
+        if (text.Length == 0)
+            return;
+
+        var openBraceIndex = FindTopLevelChar(text, '{');
+        if (openBraceIndex >= 0)
+        {
+            var closeBraceIndex = FindMatchingRustBrace(text, openBraceIndex);
+            if (closeBraceIndex > openBraceIndex)
+            {
+                var inner = text[(openBraceIndex + 1)..closeBraceIndex];
+                foreach (var item in SplitRustUseItems(inner))
+                    CollectRustUseSymbolNames(item, names);
+                return;
+            }
+        }
+
+        var aliasIndex = FindTopLevelKeyword(text, " as ");
+        if (aliasIndex >= 0)
+        {
+            var alias = text[(aliasIndex + 4)..].Trim();
+            if (alias.Length > 0)
+                names.Add(alias);
+        }
+
+        var leaf = text;
+        if (aliasIndex >= 0)
+            leaf = text[..aliasIndex].Trim();
+
+        if (leaf.Length == 0)
+            return;
+
+        var leafIndex = leaf.LastIndexOf("::", StringComparison.Ordinal);
+        if (leafIndex >= 0)
+            leaf = leaf[(leafIndex + 2)..].Trim();
+
+        if (leaf.Length > 0 && leaf is not "self" and not "super" and not "crate")
+            names.Add(leaf);
+    }
+
+    private static IEnumerable<string> SplitRustUseItems(string text)
+    {
+        var start = 0;
+        var braceDepth = 0;
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            switch (text[i])
+            {
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    if (braceDepth > 0)
+                        braceDepth--;
+                    break;
+                case ',':
+                    if (braceDepth == 0)
+                    {
+                        var item = text[start..i].Trim();
+                        if (item.Length > 0)
+                            yield return item;
+                        start = i + 1;
+                    }
+                    break;
+            }
+        }
+
+        var tail = text[start..].Trim();
+        if (tail.Length > 0)
+            yield return tail;
+    }
+
+    private static int FindTopLevelChar(string text, char target)
+    {
+        var braceDepth = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            switch (text[i])
+            {
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    if (braceDepth > 0)
+                        braceDepth--;
+                    break;
+                default:
+                    if (braceDepth == 0 && text[i] == target)
+                        return i;
+                    break;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindMatchingRustBrace(string text, int openIndex)
+    {
+        var braceDepth = 0;
+        for (var i = openIndex; i < text.Length; i++)
+        {
+            if (text[i] == '{')
+                braceDepth++;
+            else if (text[i] == '}')
+            {
+                braceDepth--;
+                if (braceDepth == 0)
+                    return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindTopLevelKeyword(string text, string keyword)
+    {
+        var braceDepth = 0;
+        for (var i = 0; i <= text.Length - keyword.Length; i++)
+        {
+            switch (text[i])
+            {
+                case '{':
+                    braceDepth++;
+                    continue;
+                case '}':
+                    if (braceDepth > 0)
+                        braceDepth--;
+                    continue;
+            }
+
+            if (braceDepth == 0 && text.AsSpan(i, keyword.Length).SequenceEqual(keyword))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static bool HasRustSymbol(List<SymbolRecord> symbols, long fileId, int lineNumber, string kind, string name)
+    {
+        return symbols.Any(symbol =>
+            symbol.FileId == fileId
+            && symbol.Line == lineNumber
+            && symbol.Kind == kind
+            && symbol.Name == name);
     }
 
     private static readonly HashSet<string> ContainerKinds =
@@ -3619,6 +3816,8 @@ private sealed class RubyMaskState
 
         if (string.Equals(originalLang, "svelte", StringComparison.Ordinal))
             ExtractSvelteReactiveSymbols(fileId, lines, symbols);
+        if (lang == "rust")
+            ExtractRustUseSymbols(fileId, lines, symbols);
         if (lang == "go")
             ExtractGoGroupedDeclarations(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -2058,7 +2058,7 @@ public static class SymbolExtractor
         if (leafIndex >= 0)
             leaf = leaf[(leafIndex + 2)..].Trim();
 
-        if (leaf.Length > 0 && leaf is not "self" and not "super" and not "crate")
+        if (leaf.Length > 0 && leaf is not "self" and not "super" and not "crate" and not "*")
             names.Add(leaf);
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10933,6 +10933,7 @@ public class SymbolExtractorTests
             pub use std::fmt::Display;
             pub(crate) use std::io::Result as IoResult;
             use std::collections::HashMap;
+            pub use std::collections::*;
             """;
         var symbols = SymbolExtractor.Extract(1, "rust", content);
 
@@ -10942,6 +10943,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Display");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "IoResult");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "HashMap");
+        Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "*");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10927,6 +10927,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Rust_DetectsPubUseStatements()
+    {
+        var content = """
+            pub use std::fmt::Display;
+            pub(crate) use std::io::Result as IoResult;
+            use std::collections::HashMap;
+            """;
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "std::fmt::Display");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "std::io::Result as IoResult");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "std::collections::HashMap");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Display");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "IoResult");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "HashMap");
+    }
+
+    [Fact]
     public void Extract_Rust_MapsImplBlocksToImplementingType()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Index Rust `pub use` and `pub(crate) use` re-exports.
- Record imported leaf names and aliases from Rust `use` trees so direct symbol searches like `Display`, `IoResult`, and `HashMap` work.
- Add regression coverage for re-exported and imported Rust symbols.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Rust"`
- Full test suite: `3363` passed, `3` skipped, `0` failed.
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog
- Added fragment: `changelog.d/unreleased/+rust-use-reexports.fixed.md`