### PR TITLE
[codex] Expand multiline Python import parsing

### DIFF
--- a/changelog.d/unreleased/+python-multiline-imports.fixed.md
+++ b/changelog.d/unreleased/+python-multiline-imports.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python search now expands multiline parenthesized imports** — `from package import (...)` blocks now surface every imported name and alias across continuation lines, so search results match the identifiers used in the body of the import list instead of stopping at the opening line.
+
+## 日本語
+
+- **Python 検索が multiline の parenthesized import を展開するようになりました** — `from package import (...)` 形式でも、継続行にある imported name / alias をすべて拾うため、検索結果が import リスト本体の識別子に一致し、先頭行だけで止まらなくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -3533,7 +3533,6 @@ private sealed class RubyMaskState
             return false;
 
         var currentLineIndex = startLineIndex;
-        var sawContinuationLine = false;
         var fragment = importSpecs[1..];
 
         while (currentLineIndex < lines.Length)
@@ -3545,8 +3544,9 @@ private sealed class RubyMaskState
             if (fragmentStartColumn >= currentLine.Length)
             {
                 currentLineIndex++;
-                sawContinuationLine = true;
                 fragment = string.Empty;
+                if (currentLineIndex >= lines.Length)
+                    return true;
                 continue;
             }
 
@@ -3576,7 +3576,7 @@ private sealed class RubyMaskState
                             treatAsFromImport: true);
                     }
 
-                    return sawContinuationLine;
+                    return true;
                 }
 
                 AddPythonImportSpecEntries(
@@ -3589,13 +3589,12 @@ private sealed class RubyMaskState
             }
 
             if (currentLineIndex + 1 >= lines.Length)
-                return false;
+                return true;
 
             currentLineIndex++;
-            sawContinuationLine = true;
         }
 
-        return false;
+        return true;
     }
 
     private static void AddPythonImportSpecEntries(

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -3533,6 +3533,7 @@ private sealed class RubyMaskState
             return false;
 
         var currentLineIndex = startLineIndex;
+        var importLineIndent = FindFirstNonWhitespaceColumn(lines[startLineIndex]);
         var fragment = importSpecs[1..];
 
         while (currentLineIndex < lines.Length)
@@ -3549,6 +3550,9 @@ private sealed class RubyMaskState
                     return true;
                 continue;
             }
+
+            if (currentLineIndex != startLineIndex && fragmentStartColumn <= importLineIndent)
+                return true;
 
             fragment = currentLineIndex == startLineIndex
                 ? fragment

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -2817,7 +2817,7 @@ private sealed class RubyMaskState
                     if (!suppressJavaStatementSymbol)
                     {
                         var pythonImportEntries = lang == "python" && pattern.Kind == "import"
-                            ? TryExpandPythonImportSymbols(line, absoluteStartColumn)
+                            ? TryExpandPythonImportSymbols(lines, i, absoluteStartColumn)
                             : null;
                         var declaratorEntries = lang == "csharp"
                             && pattern.Kind == "property"
@@ -3459,8 +3459,9 @@ private sealed class RubyMaskState
     private static readonly Regex PythonDirectImportRegex = new(@"^import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static List<PythonImportSymbolEntry>? TryExpandPythonImportSymbols(string line, int absoluteStartColumn)
+    private static List<PythonImportSymbolEntry>? TryExpandPythonImportSymbols(string[] lines, int lineIndex, int absoluteStartColumn)
     {
+        var line = lines[lineIndex];
         if (absoluteStartColumn < 0 || absoluteStartColumn >= line.Length)
             return null;
 
@@ -3499,14 +3500,102 @@ private sealed class RubyMaskState
         var modulePart = fromImportMatch.Groups["module"].Value;
         var fromImportSpecs = fromImportMatch.Groups["imports"].Value;
         AddPythonImportModuleEntry(line, absoluteStartColumn, modulePart, entries, seenNames);
+        if (TryExpandPythonMultilineParenthesizedImportBlock(
+                lines,
+                lineIndex,
+                absoluteStartColumn + fromImportMatch.Groups["imports"].Index,
+                fromImportSpecs,
+                entries,
+                seenNames))
+        {
+            return entries.Count > 0 ? entries : null;
+        }
+
         AddPythonImportSpecEntries(
             line,
-            absoluteStartColumn,
+            absoluteStartColumn + fromImportMatch.Groups["imports"].Index,
             fromImportSpecs,
             entries,
             seenNames,
             treatAsFromImport: true);
         return entries.Count > 0 ? entries : null;
+    }
+
+    private static bool TryExpandPythonMultilineParenthesizedImportBlock(
+        string[] lines,
+        int startLineIndex,
+        int importsStartColumn,
+        string importSpecs,
+        List<PythonImportSymbolEntry> entries,
+        HashSet<string> seenNames)
+    {
+        if (!importSpecs.StartsWith('(') || importSpecs.EndsWith(')'))
+            return false;
+
+        var currentLineIndex = startLineIndex;
+        var sawContinuationLine = false;
+        var fragment = importSpecs[1..];
+
+        while (currentLineIndex < lines.Length)
+        {
+            var currentLine = lines[currentLineIndex];
+            var fragmentStartColumn = currentLineIndex == startLineIndex
+                ? Math.Min(importsStartColumn + 1, currentLine.Length)
+                : FindFirstNonWhitespaceColumn(currentLine);
+            if (fragmentStartColumn >= currentLine.Length)
+            {
+                currentLineIndex++;
+                sawContinuationLine = true;
+                fragment = string.Empty;
+                continue;
+            }
+
+            fragment = currentLineIndex == startLineIndex
+                ? fragment
+                : currentLine[fragmentStartColumn..];
+
+            var commentIndex = fragment.IndexOf('#');
+            if (commentIndex >= 0)
+                fragment = fragment[..commentIndex];
+
+            fragment = fragment.TrimEnd();
+            if (fragment.Length > 0)
+            {
+                var closingParenIndex = fragment.IndexOf(')');
+                if (closingParenIndex >= 0)
+                {
+                    fragment = fragment[..closingParenIndex].TrimEnd();
+                    if (fragment.Length > 0)
+                    {
+                        AddPythonImportSpecEntries(
+                            currentLine,
+                            fragmentStartColumn,
+                            fragment,
+                            entries,
+                            seenNames,
+                            treatAsFromImport: true);
+                    }
+
+                    return sawContinuationLine;
+                }
+
+                AddPythonImportSpecEntries(
+                    currentLine,
+                    fragmentStartColumn,
+                    fragment,
+                    entries,
+                    seenNames,
+                    treatAsFromImport: true);
+            }
+
+            if (currentLineIndex + 1 >= lines.Length)
+                return false;
+
+            currentLineIndex++;
+            sawContinuationLine = true;
+        }
+
+        return false;
     }
 
     private static void AddPythonImportSpecEntries(
@@ -3596,6 +3685,15 @@ private sealed class RubyMaskState
         }
 
         entries.Add(new PythonImportSymbolEntry(symbolName, startColumn));
+    }
+
+    private static int FindFirstNonWhitespaceColumn(string text)
+    {
+        var column = 0;
+        while (column < text.Length && char.IsWhiteSpace(text[column]))
+            column++;
+
+        return column;
     }
 
     private static void ExtractJavaModuleDirectiveSymbols(long fileId, string[] rawLines, string[] structuralLines, List<SymbolRecord> symbols)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -113,6 +113,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_HandlesUnclosedMultilineImportBlocksWithoutPhantomSymbols()
+    {
+        var content = """
+            from itertools import (
+                chain,
+                zip_longest as zipl,
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var imports = symbols.Where(symbol => symbol.Kind == "import").ToList();
+
+        Assert.Contains(imports, symbol => symbol.Name == "itertools");
+        Assert.Contains(imports, symbol => symbol.Name == "chain");
+        Assert.Contains(imports, symbol => symbol.Name == "zip_longest");
+        Assert.Contains(imports, symbol => symbol.Name == "zipl");
+        Assert.DoesNotContain(imports, symbol => symbol.Name == "(");
+    }
+
+    [Fact]
     public void Extract_Protobuf_DetectsEnumPackageOneofExtendAndService()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -87,6 +87,10 @@ public class SymbolExtractorTests
         var content = """
             import numpy as np
             from  collections   import  defaultdict, OrderedDict as OD
+            from itertools import (
+                chain,
+                zip_longest as zipl,
+            )
             from .helpers import build as build_helper
             """;
 
@@ -99,6 +103,10 @@ public class SymbolExtractorTests
         Assert.Contains(imports, symbol => symbol.Name == "defaultdict");
         Assert.Contains(imports, symbol => symbol.Name == "OrderedDict");
         Assert.Contains(imports, symbol => symbol.Name == "OD");
+        Assert.Contains(imports, symbol => symbol.Name == "itertools");
+        Assert.Contains(imports, symbol => symbol.Name == "chain");
+        Assert.Contains(imports, symbol => symbol.Name == "zip_longest");
+        Assert.Contains(imports, symbol => symbol.Name == "zipl");
         Assert.Contains(imports, symbol => symbol.Name == "helpers");
         Assert.Contains(imports, symbol => symbol.Name == "build");
         Assert.Contains(imports, symbol => symbol.Name == "build_helper");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -132,6 +132,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_StopsAtUnclosedMultilineImportBlocksBeforeUnrelatedCode()
+    {
+        var content = """
+            from itertools import (
+                chain,
+                zip_longest as zipl,
+
+            value = 1
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var imports = symbols.Where(symbol => symbol.Kind == "import").ToList();
+
+        Assert.Contains(imports, symbol => symbol.Name == "itertools");
+        Assert.Contains(imports, symbol => symbol.Name == "chain");
+        Assert.Contains(imports, symbol => symbol.Name == "zip_longest");
+        Assert.Contains(imports, symbol => symbol.Name == "zipl");
+        Assert.DoesNotContain(imports, symbol => symbol.Name == "value = 1");
+    }
+
+    [Fact]
     public void Extract_Protobuf_DetectsEnumPackageOneofExtendAndService()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Addresses the follow-up candidate from PR #1231 by expanding Python import extraction for multiline parenthesized `from ... import (...)` blocks.
- Preserves aliases and imported names across wrapped import lists, and avoids emitting phantom symbols when the block reaches EOF without a closing parenthesis.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`

## Changelog
- Added `changelog.d/unreleased/+python-multiline-imports.fixed.md`

## Follow-up Candidates
- None identified for this change.