### PR TITLE
Add TypeScript type query references

### DIFF
--- a/changelog.d/unreleased/+typescript-type-query.fixed.md
+++ b/changelog.d/unreleased/+typescript-type-query.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **TypeScript `typeof` and `keyof` type queries now surface as `type_reference` edges** — reference extraction now records simple TypeScript type-query targets, so `references`, `impact`, and related search paths can find declarations reached through `typeof Foo` and `keyof Foo` forms.
+
+## 日本語
+
+- **TypeScript の `typeof` / `keyof` 型クエリが `type_reference` エッジとして出るようになりました** — 参照抽出が簡単な TypeScript の型クエリ対象を記録するため、`typeof Foo` や `keyof Foo` 経由で到達する宣言を `references` / `impact` などの検索経路で見つけやすくなりました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -94,6 +94,29 @@ public static class ReferenceExtractor
         "fixed", "await", "yield", "when",
     };
 
+    private static readonly HashSet<string> TypeScriptTypeQueryContextTokens = new(StringComparer.Ordinal)
+    {
+        "type",
+        "interface",
+        "class",
+        "function",
+        "enum",
+        "extends",
+        "implements",
+        "as",
+        "satisfies",
+        "declare",
+        "export",
+        "default",
+        "abstract",
+        "public",
+        "private",
+        "protected",
+        "static",
+        "readonly",
+        "async",
+    };
+
     private static readonly Dictionary<string, HashSet<string>> LanguageSpecificIgnoredCallNames = new(StringComparer.Ordinal)
     {
         // C# contextual keywords and common false positives / C# 文脈キーワードとよくある偽陽性
@@ -1557,6 +1580,17 @@ public static class ReferenceExtractor
                     lineNumber,
                     ResolveContainerForCall,
                     container);
+            }
+            else if (language == "typescript")
+            {
+                EmitTypeScriptTypePositionReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
             }
             else if (language == "css")
             {
@@ -4367,6 +4401,67 @@ public static class ReferenceExtractor
         }
     }
 
+    private static void EmitTypeScriptTypePositionReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var tokens = GetTopLevelTokenSpans(preparedLine);
+        if (tokens.Count == 0)
+            return;
+
+        for (int tokenIndex = 0; tokenIndex < tokens.Count; tokenIndex++)
+        {
+            var token = preparedLine.Substring(tokens[tokenIndex].Start, tokens[tokenIndex].Length);
+            if (token is not "typeof" and not "keyof")
+                continue;
+
+            if (!IsTypeScriptTypeQueryContext(preparedLine, tokens, tokenIndex))
+                continue;
+
+            var expressionStart = tokens[tokenIndex].Start + tokens[tokenIndex].Length;
+            while (expressionStart < preparedLine.Length && char.IsWhiteSpace(preparedLine[expressionStart]))
+                expressionStart++;
+
+            if (expressionStart >= preparedLine.Length)
+                continue;
+
+            if (preparedLine.AsSpan(expressionStart).StartsWith("typeof", StringComparison.Ordinal)
+                && (expressionStart + "typeof".Length == preparedLine.Length
+                    || !IsJavaIdentifierPart(preparedLine[expressionStart + "typeof".Length])))
+            {
+                expressionStart += "typeof".Length;
+                while (expressionStart < preparedLine.Length && char.IsWhiteSpace(preparedLine[expressionStart]))
+                    expressionStart++;
+            }
+
+            if (expressionStart >= preparedLine.Length || !IsJavaIdentifierStart(preparedLine[expressionStart]))
+                continue;
+
+            var expressionEnd = expressionStart + 1;
+            while (expressionEnd < preparedLine.Length
+                   && (IsJavaIdentifierPart(preparedLine[expressionEnd]) || preparedLine[expressionEnd] == '.'))
+            {
+                expressionEnd++;
+            }
+
+            AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                preparedLine.Substring(expressionStart, expressionEnd - expressionStart),
+                expressionStart,
+                context,
+                lineNumber,
+                resolveContainerForColumn(expressionStart),
+                "typescript");
+        }
+    }
+
     private static void EmitJavaModuleDirectiveReferences(
         string preparedLine,
         List<ReferenceRecord> references,
@@ -5778,6 +5873,28 @@ public static class ReferenceExtractor
 
     private static bool IsTypeExpressionIdentifierPart(string language, char c) =>
         language == "csharp" ? IsCSharpIdentifierPart(c) : IsJavaIdentifierPart(c);
+
+    private static bool IsTypeScriptTypeQueryContext(
+        string line,
+        List<(int Start, int Length)> tokens,
+        int keywordIndex)
+    {
+        for (int i = 0; i < keywordIndex; i++)
+        {
+            var token = line.Substring(tokens[i].Start, tokens[i].Length);
+            if (string.Equals(token, "?", StringComparison.Ordinal))
+                return false;
+
+            if (TypeScriptTypeQueryContextTokens.Contains(token))
+                return true;
+        }
+
+        if (keywordIndex == 0)
+            return false;
+
+        var previousToken = line.Substring(tokens[keywordIndex - 1].Start, tokens[keywordIndex - 1].Length);
+        return previousToken.EndsWith(':');
+    }
 
     private readonly record struct CSharpLineColumn(int Line, int Column);
     private readonly record struct CSharpRecursivePatternValueNameRecord(string Name, int Offset, bool IsCasePattern, int ArrowIndex = -1);

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -117,6 +117,31 @@ public static class ReferenceExtractor
         "async",
     };
 
+    private static readonly HashSet<string> TypeScriptTypeQueryDisqualifyingTokens = new(StringComparer.Ordinal)
+    {
+        "if",
+        "else",
+        "for",
+        "foreach",
+        "while",
+        "switch",
+        "case",
+        "do",
+        "try",
+        "catch",
+        "return",
+        "throw",
+        "new",
+        "delete",
+        "void",
+        "await",
+        "yield",
+        "in",
+        "instanceof",
+        "=>",
+        "?",
+    };
+
     private static readonly Dictionary<string, HashSet<string>> LanguageSpecificIgnoredCallNames = new(StringComparer.Ordinal)
     {
         // C# contextual keywords and common false positives / C# 文脈キーワードとよくある偽陽性
@@ -5882,7 +5907,7 @@ public static class ReferenceExtractor
         for (int i = 0; i < keywordIndex; i++)
         {
             var token = line.Substring(tokens[i].Start, tokens[i].Length);
-            if (string.Equals(token, "?", StringComparison.Ordinal))
+            if (TypeScriptTypeQueryDisqualifyingTokens.Contains(token))
                 return false;
 
             if (TypeScriptTypeQueryContextTokens.Contains(token))

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -1609,6 +1609,8 @@ public static class ReferenceExtractor
             else if (language == "typescript")
             {
                 EmitTypeScriptTypePositionReferences(
+                    preparedLines,
+                    i,
                     preparedLine,
                     references,
                     seen,
@@ -4427,6 +4429,8 @@ public static class ReferenceExtractor
     }
 
     private static void EmitTypeScriptTypePositionReferences(
+        IReadOnlyList<string> preparedLines,
+        int lineIndex,
         string preparedLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
@@ -4445,7 +4449,8 @@ public static class ReferenceExtractor
             if (token is not "typeof" and not "keyof")
                 continue;
 
-            if (!IsTypeScriptTypeQueryContext(preparedLine, tokens, tokenIndex))
+            var previousPreparedLine = lineIndex > 0 ? preparedLines[lineIndex - 1] : null;
+            if (!IsTypeScriptTypeQueryContext(preparedLine, tokens, tokenIndex, previousPreparedLine))
                 continue;
 
             var expressionStart = tokens[tokenIndex].Start + tokens[tokenIndex].Length;
@@ -5902,7 +5907,8 @@ public static class ReferenceExtractor
     private static bool IsTypeScriptTypeQueryContext(
         string line,
         List<(int Start, int Length)> tokens,
-        int keywordIndex)
+        int keywordIndex,
+        string? previousPreparedLine)
     {
         for (int i = 0; i < keywordIndex; i++)
         {
@@ -5915,7 +5921,13 @@ public static class ReferenceExtractor
         }
 
         if (keywordIndex == 0)
-            return false;
+        {
+            if (previousPreparedLine == null)
+                return false;
+
+            var previousTrimmed = previousPreparedLine.TrimEnd();
+            return previousTrimmed.EndsWith(':') || previousTrimmed.EndsWith('=');
+        }
 
         var previousToken = line.Substring(tokens[keywordIndex - 1].Start, tokens[keywordIndex - 1].Length);
         return previousToken.EndsWith(':');

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -5925,12 +5925,28 @@ public static class ReferenceExtractor
             if (previousPreparedLine == null)
                 return false;
 
+            if (IsTypeScriptTypeQueryLineContext(previousPreparedLine))
+                return true;
+
             var previousTrimmed = previousPreparedLine.TrimEnd();
-            return previousTrimmed.EndsWith(':') || previousTrimmed.EndsWith('=');
+            return previousTrimmed.EndsWith(':');
         }
 
         var previousToken = line.Substring(tokens[keywordIndex - 1].Start, tokens[keywordIndex - 1].Length);
         return previousToken.EndsWith(':');
+    }
+
+    private static bool IsTypeScriptTypeQueryLineContext(string line)
+    {
+        var tokens = GetTopLevelTokenSpans(line);
+        foreach (var token in tokens)
+        {
+            var text = line.Substring(token.Start, token.Length);
+            if (TypeScriptTypeQueryContextTokens.Contains(text))
+                return true;
+        }
+
+        return false;
     }
 
     private readonly record struct CSharpLineColumn(int Line, int Column);

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18082,4 +18082,17 @@ public class ReferenceExtractorTests
         Assert.Equal(2, references.Count(r => r.SymbolName == "Point" && r.ReferenceKind == "type_reference"));
         Assert.DoesNotContain(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
     }
+
+    [Fact]
+    public void Extract_TypeScriptRuntimeTypeof_OnOneLine_IsNotCapturedAsTypeReference()
+    {
+        const string content = """
+            const runtime = (value: unknown) => typeof value === "string";
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
+    }
 }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18070,6 +18070,8 @@ public class ReferenceExtractorTests
 
             type PointCtor = typeof Point;
             type PointKeys = keyof Point;
+            type PointCtorMultiline =
+                typeof Point;
 
             function runtime(value: unknown) {
                 return typeof value === "string";
@@ -18079,7 +18081,7 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
         var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
 
-        Assert.Equal(2, references.Count(r => r.SymbolName == "Point" && r.ReferenceKind == "type_reference"));
+        Assert.Equal(3, references.Count(r => r.SymbolName == "Point" && r.ReferenceKind == "type_reference"));
         Assert.DoesNotContain(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1673,6 +1673,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptRuntimeTypeofWrappedAssignment_DoesNotBecomeTypeReference()
+    {
+        const string content = """
+            function caller(value: unknown) {
+              const runtime =
+                typeof value === "string";
+              return runtime;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.ReferenceKind == "type_reference"
+            && reference.SymbolName == "value");
+    }
+
+    [Fact]
     public void Extract_JavaScriptContinuedSingleQuotedString_DoesNotPolluteForOfHeaderScan()
     {
         const string content = "function f() {\n" +

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18061,4 +18061,25 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "helper" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "realSwiftCall" && r.ReferenceKind == "call");
     }
+
+    [Fact]
+    public void Extract_TypeScriptTypeQueries_CaptureTypeReferences()
+    {
+        const string content = """
+            class Point {}
+
+            type PointCtor = typeof Point;
+            type PointKeys = keyof Point;
+
+            function runtime(value: unknown) {
+                return typeof value === "string";
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Equal(2, references.Count(r => r.SymbolName == "Point" && r.ReferenceKind == "type_reference"));
+        Assert.DoesNotContain(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
+    }
 }


### PR DESCRIPTION
## Summary
- Add TypeScript reference extraction for simple `typeof` and `keyof` type queries.
- Handle both same-line and wrapped type-query forms while avoiding runtime `typeof` false positives.
- Add regression coverage for single-line runtime `typeof`, `typeof`/`keyof` type queries, and multiline wrapping.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/ReferenceExtractor.cs tests/CodeIndex.Tests/ReferenceExtractorTests.cs changelog.d/unreleased/+typescript-type-query.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog
- Added `changelog.d/unreleased/+typescript-type-query.fixed.md`.

## Follow-up candidates
- Broader TypeScript type-expression coverage such as `typeof import(...)` and other multiline contexts that are not introduced by `:` or `=`.