### PR TITLE
Expand Fortran continuation handling follow-up

### DIFF
--- a/changelog.d/unreleased/+fortran-continuation-followup.fixed.md
+++ b/changelog.d/unreleased/+fortran-continuation-followup.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran continuation-heavy declarations now stay searchable outside interface blocks** — the continuation merger now also recognizes leading modifiers and type-specifier prefixes, so multi-line declarations such as `integer(kind=4) &` / `function ...` and `pure &` / `recursive &` / `subroutine ...` still surface as `function` symbols instead of being skipped.
+
+## 日本語
+
+- **Fortran の継続行が多い宣言も interface ブロック外で検索対象として残るようになりました** — 継続行の結合処理が先頭の修飾子や型指定子プレフィックスも認識するため、`integer(kind=4) &` / `function ...` や `pure &` / `recursive &` / `subroutine ...` のような複数行宣言も `function` シンボルとして現れ、取りこぼしません。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -15943,10 +15943,27 @@ private sealed class RubyMaskState
             return StartsWithFortranWord(afterAbstract, "interface");
         }
 
+        return StartsWithFortranContinuationPrefix(trimmedLine);
+    }
+
+    private static bool StartsWithFortranContinuationPrefix(string trimmedLine)
+    {
         return StartsWithFortranWord(trimmedLine, "module")
             || StartsWithFortranWord(trimmedLine, "subroutine")
             || StartsWithFortranWord(trimmedLine, "function")
-            || StartsWithFortranWord(trimmedLine, "procedure");
+            || StartsWithFortranWord(trimmedLine, "procedure")
+            || StartsWithFortranWord(trimmedLine, "pure")
+            || StartsWithFortranWord(trimmedLine, "elemental")
+            || StartsWithFortranWord(trimmedLine, "recursive")
+            || StartsWithFortranWord(trimmedLine, "impure")
+            || StartsWithFortranWord(trimmedLine, "integer")
+            || StartsWithFortranWord(trimmedLine, "real")
+            || StartsWithFortranWord(trimmedLine, "logical")
+            || StartsWithFortranWord(trimmedLine, "complex")
+            || StartsWithFortranWord(trimmedLine, "character")
+            || StartsWithFortranWord(trimmedLine, "double")
+            || StartsWithFortranWord(trimmedLine, "type")
+            || StartsWithFortranWord(trimmedLine, "class");
     }
 
     private static string StripFortranComment(string line)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9713,16 +9713,26 @@ public class SymbolExtractorTests
                   normalize_alt
                 procedure(normalize_iface) :: &
                   normalize_forward
-                procedure, pointer :: &
+              procedure, pointer :: &
                   normalize_pointer
               end interface math_iface
-              abstract interface
+              abstract &
+              interface
                 subroutine abstract_callback( &
                     value)
                 end subroutine abstract_callback
               end interface
               implicit none
             contains
+              integer(kind=4) &
+              function split_value(value)
+              end function split_value
+
+              pure &
+              recursive &
+              subroutine split_subroutine(value)
+              end subroutine split_subroutine
+
               recursive subroutine normalize(v)
               end subroutine normalize
               end module procedure normalize_iface
@@ -9761,6 +9771,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_forward");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_pointer");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "abstract_callback");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "split_value");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "split_subroutine");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
 


### PR DESCRIPTION
## Summary

This PR addresses the Follow-up candidates listed in PR #1225.

- Continues merging Fortran declarations when leading modifiers or type-specifier prefixes are split across `&`-continued lines.
- Covers split `abstract interface` headers as well as continuation-heavy declarations outside interface blocks.
- Adds regression coverage for the split abstract interface header and the new non-interface continuation shapes.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Docs / Changelog

- Added fragment: `changelog.d/unreleased/+fortran-continuation-followup.fixed.md`

## Follow-up candidates

- No additional follow-up candidates were identified for this pass beyond the items already addressed from PR #1225.