### PR TITLE
Expand R follow-up search coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Perl | `.pl`, `.pm`, `.t`, `.pod` | -- |
 | Solidity | `.sol` | -- |
 | Tcl | `.tcl`, `.tk` | -- |
-| R | `.r`, `.R` | yes (function assignments, setClass/setClassUnion/R6Class/setRefClass, R6 public/private/active methods, setGeneric/setMethod, library/require) |
+| R | `.r`, `.R` | yes (function assignments, methods::setClass/methods::setClassUnion/R6::R6Class/methods::setRefClass, R6 public/private/active methods, methods::setGeneric/methods::setMethod, library/require) |
 | Haskell | `.hs`, `.lhs` | yes |
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |

--- a/changelog.d/unreleased/+r-followup-5.fixed.md
+++ b/changelog.d/unreleased/+r-followup-5.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **R class and R6 constructors now recognize common namespace-qualified forms** — following up on PR #1234, `cdidx` now extracts `methods::setClass`, `methods::setRefClass`, `methods::setClassUnion`, `methods::setGeneric`, `methods::setMethod`, and `R6::R6Class` in addition to the existing unqualified forms, and it also records R6 public/private/active bindings with visibility metadata so more R object-system code is searchable by symbol instead of by file.
+
+## 日本語
+
+- **R の class / R6 コンストラクタがよくある namespace 修飾形式に対応しました** — PR #1234 の follow-up として、`cdidx` は `methods::setClass`、`methods::setRefClass`、`methods::setClassUnion`、`methods::setGeneric`、`methods::setMethod`、`R6::R6Class` を既存の unqualified 形式に加えて抽出し、R6 の public / private / active binding に visibility メタデータも残すため、R のオブジェクトシステムを使うコードをシンボル単位で検索しやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1312,9 +1312,10 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("class",    new Regex(@"^\s*(?:setClass|setRefClass|setClassUnion|R6Class)\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(@"^\s*setGeneric\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(@"^\s*setMethod\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|R6Class)\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setGeneric\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*(?:library|require)\s*\(\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15679,26 +15679,20 @@ public class SymbolExtractorTests
     {
         // R: setClass, setClassUnion, setRefClass, R6Class, setGeneric, setMethod / R: setClass、setClassUnion、setRefClass、R6Class、setGeneric、setMethod
         var content = """
-            setClass(Person, slots = c(name = "character"))
+            methods::setClass(Person, slots = c(name = "character"))
 
-            setClassUnion(Renderable, c(Person, Widget))
+            methods::setClassUnion(Renderable, c(Person, Widget))
 
-            setRefClass(Widget, fields = list(value = "numeric"))
+            methods::setRefClass(Widget, fields = list(value = "numeric"))
 
-            R6Class(Thing,
-              public = list(
-                print = function() self
-              ),
-              private = list(
-                secret = function() self
-              ),
-              active = list(
-                state = function(value) self
-              ))
+            R6::R6Class(Thing,
+              public = list(print = function() self),
+              private = list(secret = function() self),
+              active = list(state = function(value) self))
 
-            setGeneric("normalize", function(x) standardGeneric("normalize"))
+            methods::setGeneric("normalize", function(x) standardGeneric("normalize"))
 
-            setMethod(show, signature(object = "Person"), function(object) {
+            methods::setMethod(show, signature(object = "Person"), function(object) {
               object
             })
             """;
@@ -15708,9 +15702,12 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Renderable");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Thing");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "print");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "secret");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "state");
+        var print = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "print");
+        Assert.Equal("public", print.Visibility);
+        var secret = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "secret");
+        Assert.Equal("private", secret.Visibility);
+        var state = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "state");
+        Assert.Equal("active", state.Visibility);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "show");
     }


### PR DESCRIPTION
This PR is a follow-up to PR #1234 and addresses its follow-up candidates.

Summary:
- Extend R symbol extraction to support namespace-qualified constructors and methods such as `methods::setClass`, `methods::setClassUnion`, `methods::setRefClass`, `methods::setGeneric`, `methods::setMethod`, and `R6::R6Class`.
- Capture R6 `public` / `private` / `active` one-line method bindings with visibility metadata.
- Update the R language coverage notes in `README.md`.
- Add a changelog fragment at `changelog.d/unreleased/+r-followup-5.fixed.md`.

Validation:
- `dotnet build`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`