### PR TITLE
Improve C# XAML code-behind entrypoint discovery

### DIFF
--- a/changelog.d/unreleased/+csharp-xaml-entrypoints.fixed.md
+++ b/changelog.d/unreleased/+csharp-xaml-entrypoints.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/RepoMapBuilder.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **C# XAML code-behind files now surface as repo-map entrypoints** — `MainWindow.xaml.cs`, `MainPage.xaml.cs`, and `AppShell.xaml.cs` are treated as likely C# entry files so repo-map navigation and search-oriented exploration can land on common XAML app startup surfaces more reliably.
+
+## 日本語
+
+- **C# の XAML code-behind ファイルが repo map の entrypoint として出やすくなりました** — `MainWindow.xaml.cs`、`MainPage.xaml.cs`、`AppShell.xaml.cs` を C# の代表的なエントリーファイルとして扱うことで、repo map ベースの探索や検索から一般的な XAML アプリの起点へより確実に辿り着けるようになりました。

--- a/src/CodeIndex/Database/RepoMapBuilder.cs
+++ b/src/CodeIndex/Database/RepoMapBuilder.cs
@@ -39,7 +39,7 @@ internal sealed class RepoMapBuilder
     };
     private static readonly Dictionary<string, string[]> EntrypointPathHints = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["csharp"] = ["Program.cs", "Startup.cs", "App.xaml.cs", "App.cs", "App.razor"],
+        ["csharp"] = ["Program.cs", "Startup.cs", "App.xaml.cs", "MainWindow.xaml.cs", "MainPage.xaml.cs", "AppShell.xaml.cs", "App.cs", "App.razor"],
         ["python"] = ["main.py", "__main__.py", "app.py", "cli.py"],
         ["javascript"] = ["index.js", "main.js", "app.js", "server.js"],
         ["typescript"] = ["index.ts", "main.ts", "app.ts", "server.ts"],

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -8188,6 +8188,19 @@ public class DbReaderTests : IDisposable
     }
 
     [Theory]
+    [InlineData("src/MainWindow.xaml.cs", "MainWindow")]
+    [InlineData("src/MainPage.xaml.cs", "MainPage")]
+    [InlineData("src/AppShell.xaml.cs", "AppShell")]
+    public void GetRepoMap_AddsFileFallbackEntrypointForCommonCSharpXamlCodeBehind(string path, string className)
+    {
+        InsertIndexedFile(path, "csharp", "public partial class " + className + "\n{\n}\n");
+
+        var map = _reader.GetRepoMap(limit: 5, pathPatterns: new[] { path });
+
+        Assert.Contains(map.Entrypoints, item => item.Kind == "class" && item.Name == className && item.Path == path);
+    }
+
+    [Theory]
     [InlineData("src/Main.vb")]
     [InlineData("src/Module.vb")]
     [InlineData("src/Form1.vb")]


### PR DESCRIPTION
## Summary

- Expanded C# repo-map entrypoint hints so common XAML code-behind files like `MainWindow.xaml.cs`, `MainPage.xaml.cs`, and `AppShell.xaml.cs` are surfaced more reliably.
- Added regression coverage for those XAML code-behind entrypoints.
- Added a bilingual changelog fragment under `changelog.d/unreleased/`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.GetRepoMap_"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- No README or workflow docs changed; this is a non-breaking behavior improvement.
- Changelog fragment: `changelog.d/unreleased/+csharp-xaml-entrypoints.fixed.md`

## Follow-up candidates

- Broaden C# XAML entrypoint hints further if we see more app templates using other code-behind filenames.
- Explore extracting additional XAML navigation cues, such as more markup-bound identifiers, if search/navigation needs another step up.