### PR TITLE
Add Kotlin fun interface search coverage

### DIFF
--- a/changelog.d/unreleased/+kotlin-fun-interface-search.fixed.md
+++ b/changelog.d/unreleased/+kotlin-fun-interface-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Kotlin `fun interface` declarations are now indexed for symbol search** — `fun interface` is treated as an interface symbol, so searches for Kotlin SAM types no longer miss these declarations.
+
+## 日本語
+
+- **Kotlin の `fun interface` 宣言がシンボル検索で index されるようになりました** — `fun interface` を interface シンボルとして扱うため、Kotlin の SAM 型を検索したときにこの宣言を取りこぼさなくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1127,7 +1127,8 @@ public static class SymbolExtractor
             // Companion object / コンパニオンオブジェクト
             new("class",    new Regex(@"^\s*companion\s+object(?:\s+(?<name>\w+))?", RegexOptions.Compiled), BodyStyle.Brace),
             // Interface / インターフェース
-            new("interface", new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:sealed|expect|actual)\s+)*interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // Kotlin fun interface / Kotlin の fun interface も interface として扱う。
+            new("interface", new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:sealed|expect|actual)\s+)*(?:fun\s+)?interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum class / enum クラス
             new("enum",     new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:expect|actual)\s+)*enum\s+class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Class/object with expanded modifiers: data, sealed, value, inner, annotation, expect, actual

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12089,10 +12089,11 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_Kotlin_DetectsExpandedFeatures()
     {
-        var content = "sealed interface Shape\nvalue class Email(val value: String)\ninner class Handler\n\ncompanion object {\n    const val MAX = 100\n}\n\nfun String.truncate(max: Int): String = take(max)\nsuspend fun fetchData(): List<Int> = emptyList()\ninline fun <reified T> parse(json: String): T = TODO()";
+        var content = "sealed interface Shape\nfun interface Transformer\nvalue class Email(val value: String)\ninner class Handler\n\ncompanion object {\n    const val MAX = 100\n}\n\nfun String.truncate(max: Int): String = take(max)\nsuspend fun fetchData(): List<Int> = emptyList()\ninline fun <reified T> parse(json: String): T = TODO()";
         var symbols = SymbolExtractor.Extract(1, "kotlin", content);
 
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Shape");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Transformer");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Email");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Handler");
         // Companion object (unnamed) / コンパニオンオブジェクト（無名）


### PR DESCRIPTION
## Summary
- Treat Kotlin `fun interface` declarations as interface symbols so search and symbol lookup find them.
- Added regression coverage to lock the behavior in place.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SymbolExtractorTests`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release`

## Changelog
- Added `changelog.d/unreleased/+kotlin-fun-interface-search.fixed.md`

## Follow-up candidates
- None.