### PR TITLE
Improve F# union and record symbol coverage

### DIFF
--- a/changelog.d/unreleased/+fsharp-union-record-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-union-record-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# union cases and record fields are now searchable as symbols** — `SymbolExtractor` now emits searchable symbol rows for `type Color = Red | Green | Blue` cases and record fields inside `{ Name: string; Age: int }`, so the names inside common F# data declarations are easier to find.
+
+## 日本語
+
+- **F# の union case と record field を symbol として検索できるようになりました** — `SymbolExtractor` が `type Color = Red | Green | Blue` の case 名や `{ Name: string; Age: int }` 内の field 名を検索可能な symbol として出すため、F# の典型的なデータ定義の中身も見つけやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -2365,6 +2365,7 @@ private sealed class RubyMaskState
         var cssQualifiedRuleAncestors = lang == "css"
             ? FindCssQualifiedRuleAncestors(cssScannerLines!)
             : null;
+        var fsharpTypeBodyState = FSharpTypeBodyState.None;
         var symbols = new List<SymbolRecord>();
         var pendingRecordPrimaryComponents = new List<PendingRecordPrimaryComponents>();
         var cssSeenSymbols = lang == "css"
@@ -2406,6 +2407,15 @@ private sealed class RubyMaskState
                 : null;
             if (fortranContinuationCandidate != null)
                 matchLine = fortranContinuationCandidate.Value.MatchLine;
+
+            if (lang == "fsharp")
+                TryAddFSharpTypeMemberSymbols(symbols, fileId, line, i + 1, ref fsharpTypeBodyState);
+
+            if (lang == "fsharp"
+                && TryAddFSharpRecordFieldsFromContext(symbols, fileId, lines, i, line, i + 1))
+            {
+                continue;
+            }
 
             if (lang == "fsharp" && TryAddFSharpActivePatternSymbols(symbols, fileId, line, i + 1))
                 continue;
@@ -23463,8 +23473,250 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
         return name;
     }
 
+    private enum FSharpTypeBodyKind
+    {
+        None,
+        Pending,
+        Record,
+        Union,
+    }
+
+    private readonly record struct FSharpTypeBodyState(FSharpTypeBodyKind Kind, int DeclarationIndent)
+    {
+        public static readonly FSharpTypeBodyState None = new(FSharpTypeBodyKind.None, -1);
+    }
+
+    private static readonly Regex FSharpTypeDeclarationRegex = new(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)*(?<name>(?:``[^`]+``|[_\p{L}][\w']*))(?:\s*<[^>]+>)?\s*=\s*(?<rest>.*)$", RegexOptions.Compiled);
+    private static readonly Regex FSharpRecordFieldRegex = new(@"^(?:\[\<[^>]+\>\]\s*)*(?:mutable\s+)?(?<name>(?:``[^`]+``|[_\p{L}][\w']*))\s*:\s*.+$", RegexOptions.Compiled);
+    private static readonly Regex FSharpUnionCaseRegex = new(@"^\|?\s*(?<name>(?:``[^`]+``|[_\p{L}][\w']*))(?:\s+of\b.*)?$", RegexOptions.Compiled);
     private static readonly Regex FSharpActivePatternDefinitionRegex = new(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*\(\|(?<cases>.+?)\|\)", RegexOptions.Compiled);
     private static readonly Regex FSharpActivePatternNameRegex = new(@"^(?:``[^`]+``|[_\p{L}][\w']*)$", RegexOptions.Compiled);
+
+    private static bool TryAddFSharpTypeMemberSymbols(List<SymbolRecord> symbols, long fileId, string line, int lineNumber, ref FSharpTypeBodyState state)
+    {
+        var trimmed = line.TrimStart();
+        var lineIndent = line.Length - trimmed.Length;
+
+        if (state.Kind == FSharpTypeBodyKind.Record)
+        {
+            if (string.IsNullOrWhiteSpace(trimmed))
+                return false;
+
+            if (lineIndent <= state.DeclarationIndent && !trimmed.StartsWith("}", StringComparison.Ordinal))
+            {
+                state = FSharpTypeBodyState.None;
+                return false;
+            }
+
+            var emitted = TryAddFSharpRecordFields(symbols, fileId, line, lineNumber);
+            if (trimmed.Contains('}'))
+                state = FSharpTypeBodyState.None;
+            return emitted;
+        }
+
+        if (state.Kind == FSharpTypeBodyKind.Union)
+        {
+            if (string.IsNullOrWhiteSpace(trimmed))
+                return false;
+
+            if (lineIndent <= state.DeclarationIndent && !trimmed.StartsWith("|", StringComparison.Ordinal))
+            {
+                state = FSharpTypeBodyState.None;
+                return false;
+            }
+
+            return TryAddFSharpUnionCases(symbols, fileId, line, lineNumber);
+        }
+
+        if (state.Kind == FSharpTypeBodyKind.Pending)
+        {
+            if (string.IsNullOrWhiteSpace(trimmed))
+                return false;
+
+            if (lineIndent <= state.DeclarationIndent)
+            {
+                state = FSharpTypeBodyState.None;
+                return false;
+            }
+
+            if (trimmed.StartsWith("{", StringComparison.Ordinal))
+            {
+                state = new FSharpTypeBodyState(FSharpTypeBodyKind.Record, state.DeclarationIndent);
+                return TryAddFSharpRecordFields(symbols, fileId, trimmed, lineNumber);
+            }
+
+            if (trimmed.StartsWith("|", StringComparison.Ordinal) || FSharpUnionCaseRegex.IsMatch(trimmed))
+            {
+                state = new FSharpTypeBodyState(FSharpTypeBodyKind.Union, state.DeclarationIndent);
+                return TryAddFSharpUnionCases(symbols, fileId, line, lineNumber);
+            }
+
+            state = FSharpTypeBodyState.None;
+            return false;
+        }
+
+        if (!FSharpTypeDeclarationRegex.IsMatch(line))
+            return false;
+
+        var declarationMatch = FSharpTypeDeclarationRegex.Match(line);
+        var rest = declarationMatch.Groups["rest"].Value;
+        if (rest.Length == 0)
+        {
+            state = new FSharpTypeBodyState(FSharpTypeBodyKind.Pending, lineIndent);
+            return false;
+        }
+
+        var restTrimmed = rest.TrimStart();
+        if (restTrimmed.StartsWith("{", StringComparison.Ordinal))
+        {
+            state = new FSharpTypeBodyState(FSharpTypeBodyKind.Record, lineIndent);
+            return TryAddFSharpRecordFields(symbols, fileId, rest, lineNumber);
+        }
+
+        if (TryAddFSharpUnionCasesFromTypeRemainder(symbols, fileId, rest, lineNumber))
+        {
+            state = new FSharpTypeBodyState(FSharpTypeBodyKind.Union, lineIndent);
+            return true;
+        }
+
+        if (restTrimmed.StartsWith("|", StringComparison.Ordinal))
+        {
+            state = new FSharpTypeBodyState(FSharpTypeBodyKind.Union, lineIndent);
+            return TryAddFSharpUnionCases(symbols, fileId, rest, lineNumber);
+        }
+
+        if (restTrimmed.StartsWith("class", StringComparison.Ordinal)
+            || restTrimmed.StartsWith("interface", StringComparison.Ordinal)
+            || restTrimmed.StartsWith("struct", StringComparison.Ordinal)
+            || restTrimmed.StartsWith("enum", StringComparison.Ordinal)
+            || restTrimmed.StartsWith("exception", StringComparison.Ordinal)
+            || restTrimmed.StartsWith("(", StringComparison.Ordinal))
+        {
+            state = FSharpTypeBodyState.None;
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool TryAddFSharpRecordFields(List<SymbolRecord> symbols, long fileId, string line, int lineNumber)
+    {
+        var emittedAny = false;
+        foreach (var segment in line.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var candidate = segment.Trim().TrimStart('{').TrimEnd('}').TrimStart();
+            if (candidate.Length == 0)
+                continue;
+
+            var match = FSharpRecordFieldRegex.Match(candidate);
+            if (!match.Success)
+                continue;
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = NormalizeFSharpSymbolName(match.Groups["name"].Value),
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    EndLine = lineNumber,
+                    Signature = candidate.Trim(),
+                },
+                rawLine: line);
+            emittedAny = true;
+        }
+
+        return emittedAny;
+    }
+
+    private static bool TryAddFSharpRecordFieldsFromContext(List<SymbolRecord> symbols, long fileId, string[] lines, int lineIndex, string line, int lineNumber)
+    {
+        var candidate = line.TrimStart().TrimStart('{').TrimEnd('}').TrimStart();
+        if (candidate.Length == 0 || !FSharpRecordFieldRegex.IsMatch(candidate))
+            return false;
+
+        for (var i = lineIndex - 1; i >= 0; i--)
+        {
+            var previous = lines[i].Trim();
+            if (previous.Length == 0)
+                continue;
+
+            if (FSharpTypeDeclarationRegex.IsMatch(previous))
+            {
+                var declarationMatch = FSharpTypeDeclarationRegex.Match(previous);
+                var rest = declarationMatch.Groups["rest"].Value.TrimStart();
+                if (rest.Length > 0 && !rest.StartsWith("{", StringComparison.Ordinal) && !rest.StartsWith("|", StringComparison.Ordinal))
+                    break;
+
+                return TryAddFSharpRecordFields(symbols, fileId, line, lineNumber);
+            }
+
+            if (previous.StartsWith("type ", StringComparison.Ordinal)
+                || previous.StartsWith("module ", StringComparison.Ordinal)
+                || previous.StartsWith("let ", StringComparison.Ordinal)
+                || previous.StartsWith("open ", StringComparison.Ordinal))
+                break;
+        }
+
+        return false;
+    }
+
+    private static bool TryAddFSharpUnionCases(List<SymbolRecord> symbols, long fileId, string line, int lineNumber)
+    {
+        var emittedAny = false;
+        var segments = line.Contains('|', StringComparison.Ordinal)
+            ? line.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : [line];
+
+        foreach (var segment in segments)
+        {
+            var candidate = segment.Trim().TrimStart('{').TrimEnd('}').TrimStart();
+            if (candidate.Length == 0)
+                continue;
+
+            var match = FSharpUnionCaseRegex.Match(candidate);
+            if (!match.Success)
+                continue;
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = NormalizeFSharpSymbolName(match.Groups["name"].Value),
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    EndLine = lineNumber,
+                    Signature = candidate.Trim(),
+                },
+                rawLine: line);
+            emittedAny = true;
+        }
+
+        return emittedAny;
+    }
+
+    private static bool TryAddFSharpUnionCasesFromTypeRemainder(List<SymbolRecord> symbols, long fileId, string remainder, int lineNumber)
+    {
+        var trimmed = remainder.TrimStart();
+        if (trimmed.Length == 0)
+            return false;
+
+        if (trimmed.Contains('|', StringComparison.Ordinal))
+            return TryAddFSharpUnionCases(symbols, fileId, trimmed, lineNumber);
+
+        if (!FSharpUnionCaseRegex.IsMatch(trimmed))
+            return false;
+
+        return TryAddFSharpUnionCases(symbols, fileId, trimmed, lineNumber);
+    }
 
     private static bool TryAddFSharpActivePatternSymbols(List<SymbolRecord> symbols, long fileId, string line, int lineNumber)
     {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12820,6 +12820,30 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsUnionCasesAndRecordFields()
+    {
+        var content = """
+            module MyApp.Domain
+
+            type Color =
+                | Red
+                | Green
+                | Blue
+
+            type Person =
+                { Name: string
+                  Age: int }
+        """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        Assert.Contains(symbols, s => s.Name == "Red");
+        Assert.Contains(symbols, s => s.Name == "Green");
+        Assert.Contains(symbols, s => s.Name == "Blue");
+        Assert.Contains(symbols, s => s.Name == "Name");
+        Assert.Contains(symbols, s => s.Name == "Age");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsValueBindings()
     {
         // F# value bindings should be indexed by their binding names / F# の値束縛は


### PR DESCRIPTION
Addresses the follow-up candidates listed in PR #1236 by improving F# symbol coverage for union cases and multiline record fields.

Changes:
- Add F# handling for union cases and record fields so their names stay searchable.
- Add regression coverage for F# union-case and record-field symbol extraction.
- Include a changelog fragment for the fix.

Validation:
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_FSharp_"`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs changelog.d/unreleased/+fsharp-union-record-symbols.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`