### PR TITLE
Expand HTML resource-link imports

### DIFF
--- a/changelog.d/unreleased/+html-resource-links.fixed.md
+++ b/changelog.d/unreleased/+html-resource-links.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **HTML now treats common resource-bearing tags as searchable imports** — `SymbolExtractor` now emits `import` symbols for `img[src]`, `iframe[src]`, media `src`/`poster` values, `object[data]`, and SVG `use[href]` / `image[href]` in addition to the existing `script[src]` and `link[href]` coverage, so `definition` / `references` can jump to more real asset targets in HTML-heavy projects.
+
+## 日本語
+
+- **HTML でよく使う resource-bearing タグも検索可能な import として扱うようになりました** — `SymbolExtractor` は従来の `script[src]` / `link[href]` に加えて、`img[src]`、`iframe[src]`、media 系の `src` / `poster`、`object[data]`、SVG の `use[href]` / `image[href]` からも `import` シンボルを出すようになり、HTML が多いプロジェクトでも `definition` / `references` から実資産の参照先へ飛びやすくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -4601,6 +4601,12 @@ private sealed class RubyMaskState
         "missing-glyph",
     };
 
+    private static bool IsHtmlSrcResourceTag(string tagNameLower) =>
+        tagNameLower is "audio" or "embed" or "iframe" or "img" or "input" or "script" or "source" or "track" or "video";
+
+    private static bool IsHtmlHrefResourceTag(string tagNameLower) =>
+        tagNameLower is "image" or "link" or "use";
+
     private static string MaskHtmlRawTextRegions(string text)
     {
         // Walk `text` character by character, masking the body of raw-text /
@@ -5192,9 +5198,13 @@ private sealed class RubyMaskState
                     continue;
 
                 string? emitKind = null;
-                if (attrNameLower == "src" && tagNameLower == "script")
+                if (attrNameLower == "src" && IsHtmlSrcResourceTag(tagNameLower))
                     emitKind = "import";
-                else if (attrNameLower == "href" && tagNameLower == "link")
+                else if ((attrNameLower == "href" || attrNameLower == "xlink:href") && IsHtmlHrefResourceTag(tagNameLower))
+                    emitKind = "import";
+                else if (attrNameLower == "data" && tagNameLower == "object")
+                    emitKind = "import";
+                else if (attrNameLower == "poster" && tagNameLower == "video")
                     emitKind = "import";
                 else if (attrNameLower == "id" && !attrName.Contains(':') && !attrName.Contains('-') && !attrName.Contains('.'))
                     emitKind = "property";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -17295,6 +17295,36 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Html_CapturesCommonResourceTagsAsImports()
+    {
+        // HTML pages often embed navigable assets outside `<script>` / `<link>` too:
+        // images, iframes, media, and embedded documents are all useful search targets.
+        // Keep those resource-bearing attributes queryable so `definition` / `references`
+        // can jump to the referenced path instead of only seeing the raw text chunk.
+        // HTML ページは `<script>` / `<link>` 以外にも探索対象の資産を埋め込む。
+        // 画像・iframe・メディア・埋め込み文書も検索できるようにして、
+        // `definition` / `references` が raw text chunk ではなく参照先へ飛べるようにする。
+        var content = """
+            <img src="/images/logo.png" alt="logo">
+            <iframe src="/docs/frame.html"></iframe>
+            <video poster="/media/thumb.jpg">
+              <source src="/media/movie.mp4" type="video/mp4">
+            </video>
+            <object data="/files/manual.pdf"></object>
+            <svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="/icons.svg#check"></use></svg>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "html", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/images/logo.png");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/docs/frame.html");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/media/thumb.jpg");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/media/movie.mp4");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/files/manual.pdf");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/icons.svg#check");
+    }
+
+    [Fact]
     public void Extract_Html_CapturesCustomWebComponentTagsAsClasses()
     {
         // Custom element tag names always contain a hyphen per the HTML spec.


### PR DESCRIPTION
## Summary
- Expand HTML import symbol extraction to cover common resource-bearing tags beyond `script[src]` and `link[href]`
- Add regressions for `img`, `iframe`, media, `object`, and SVG resource links
- Add a changelog fragment under `changelog.d/unreleased/`

## Verification
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Html_"`