### PR TITLE
Make shell aliases searchable

### DIFF
--- a/changelog.d/unreleased/+shell-alias-search.fixed.md
+++ b/changelog.d/unreleased/+shell-alias-search.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Shell aliases are now searchable as first-class symbols** — `shell` indexing now records `alias` definitions and includes them in shell callable-name matching, so `search`, `references`, and related queries can find both alias definitions and alias call sites in Linux shell scripts.
+
+## 日本語
+
+- **Shell alias を第一級のシンボルとして検索できるようになりました** — `shell` のインデックスで `alias` 定義を記録し、shell の callable-name 判定にも含めるようにしたため、Linux shell スクリプト内の alias 定義と alias 呼び出しの両方を `search` / `references` などで見つけられます。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -6325,7 +6325,7 @@ public static class ReferenceExtractor
         var names = new HashSet<string>(StringComparer.Ordinal);
         foreach (var symbol in symbols)
         {
-            if (symbol.Kind != "function" || string.IsNullOrWhiteSpace(symbol.Name))
+            if (symbol.Kind is not ("function" or "alias") || string.IsNullOrWhiteSpace(symbol.Name))
                 continue;
 
             names.Add(symbol.Name);

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1413,6 +1413,8 @@ public static class SymbolExtractor
             // Bash/Zsh function declarations / Bash/Zsh 関数宣言
             new("function", new Regex(@"^\s*(?:function\s+)?(?<name>\w+)\s*\(\s*\)\s*\{?", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*function\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            // Alias definitions / エイリアス定義
+            new("alias", new Regex(@"^\s*alias(?:\s+-[^\s=]+)*\s+(?<name>[A-Za-z_]\w*)\s*=", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["sql"] =
         [

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -196,6 +196,33 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Shell_DetectsAliasCalls()
+    {
+        const string content = """
+            alias ll='ls -la'
+            alias -g G='| grep'
+
+            run() {
+              ll /tmp
+              G pattern
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+        var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
+
+        Assert.Equal(2, references.Count(reference => reference.ReferenceKind == "call"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "ll"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "G"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_CobolPerform_CapturesParagraphLevelCallReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9915,11 +9915,24 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_Shell_DetectsFunctions()
     {
-        var content = "function setup() {\n  echo 'setup'\n}\n\ncleanup() {\n  echo 'cleanup'\n}";
+        var content = """
+            function setup() {
+              echo 'setup'
+            }
+
+            cleanup() {
+              echo 'cleanup'
+            }
+
+            alias ll='ls -la'
+            alias -g G='| grep'
+            """;
         var symbols = SymbolExtractor.Extract(1, "shell", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "setup");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "cleanup");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "ll");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "G");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `shell` alias definitions to symbol extraction so alias names can be indexed and searched.
- Include shell aliases in callable-name lookup so alias call sites are recognized as `call` references.
- Add tests covering alias definition extraction and alias call detection.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter 'FullyQualifiedName~Extract_Shell_DetectsFunctions|FullyQualifiedName~Extract_Shell_DetectsAliasCalls'`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release`

## Changelog
- `changelog.d/unreleased/+shell-alias-search.fixed.md`

## Follow-up candidates
- Broader shell alias syntax coverage, such as multi-alias lines or more exotic alias names, if we decide those are worth indexing later.