### PR TITLE
Index C++ decltype(auto) functions

### DIFF
--- a/changelog.d/unreleased/+cpp-decltype-auto-search.fixed.md
+++ b/changelog.d/unreleased/+cpp-decltype-auto-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C++ symbol search now keeps `decltype(auto)` functions visible** — the C++ function extractor now accepts `decltype(auto)` return-type atoms, so modern functions such as `constexpr decltype(auto) value()` are indexed and searchable instead of falling through the generic function heuristic.
+
+## 日本語
+
+- **C++ の symbol 検索で `decltype(auto)` 関数が見えるようになりました** — C++ の function extractor が `decltype(auto)` を戻り値型トークンとして受け入れるようになり、`constexpr decltype(auto) value()` のような現代的な関数が汎用ヒューリスティックに落ちずに index / search されるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -73,6 +73,13 @@ public static class SymbolExtractor
     private const string SqlQualifiedIdentifierSegmentPattern = @"(?:\[(?:[^\]\r\n]|\]\])+\]|""[^""]+""|[\w$#]+)";
     private const string SqlQualifiedIdentifierPattern =
         @"(?:" + SqlQualifiedIdentifierSegmentPattern + @")(?:\s*\.\s*(?:" + SqlQualifiedIdentifierSegmentPattern + @"))*";
+    // C++ return-type atoms need to accept both ordinary word tokens and `decltype(auto)`.
+    // The latter is common in modern C++ APIs and previously fell through the generic
+    // function pattern, making those functions invisible to symbol-oriented search.
+    // C++ の戻り値型トークンは通常の単語トークンに加え `decltype(auto)` も受け入れる必要がある。
+    // 後者は現代的な C++ API でよく使われるが、従来は汎用 function パターンから漏れており、
+    // その関数が symbol ベースの検索から見えなくなっていた。
+    private const string CppFunctionReturnTypeAtomPattern = @"(?:decltype\s*\(\s*auto\s*\)|[\w:<>]+)";
     private const string CSharpTypeSegmentPattern =
         @"(?:" + CSharpTypeTokenCharsPattern + @"+(?:" + CSharpTupleGroupPattern + CSharpTypeTokenCharsPattern + @"*)*|" + CSharpTupleGroupPattern + CSharpTypeTokenCharsPattern + @"*)";
     private const string CSharpTypePattern =
@@ -119,6 +126,7 @@ public static class SymbolExtractor
     private const string CFunctionNameBlacklistPattern = @"(?!(?:int|void|char|short|long|float|double|signed|unsigned|bool|_Bool|size_t|ssize_t|intptr_t|uintptr_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t)\b)";
     private const string CppFunctionStartBlacklistPattern = @"^(?!\s*typedef\b)(?!\s*(?:if|else|for|while|switch|return|sizeof|using|namespace)\s*[\(\{;<])";
     private const string CppTemplatePrefixPattern = @"(?:template\s*<[^>]*>\s*)*";
+    private const string CppTypeAtomPattern = @"(?:decltype\s*\(\s*auto\s*\)|[\w:<>~]+)";
     private static readonly Regex PartialModifierRegex = new(@"\bpartial\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex GoImportSpecRegex = new(
         @"^(?<name>(?:(?:[._]|[\p{L}_][\p{L}\p{Nd}_]*)\s+)?""(?:\\.|[^""\\])*"")(?:\s*;)?(?:\s*(?://.*|/\*.*\*/))?\s*$",
@@ -1177,7 +1185,7 @@ public static class SymbolExtractor
             new("namespace", new Regex(CppFunctionStartBlacklistPattern + @"(?:export\s+)?module\s+(?<name>[\w.]+)\b", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(CppFunctionStartBlacklistPattern + @"inline\s+namespace\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:export\s+)?concept\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:(?<returnType>(?:[\w:<>~]+[\s*&]+)+))?(?:(?:[\w:<>]+\s*::\s*)+)?" + CFunctionNameBlacklistPattern + @"(?<name>~?\w+|operator(?:\s*\(\)|\s*\[\]|\s*[^\s(]+(?:\s+[^\s(]+)?))(?:\s*<[^>]+>)?\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:(?<returnType>(?:(?:" + CppTypeAtomPattern + @")[\s*&]+)+))?(?:(?:[\w:<>]+\s*::\s*)+)?" + CFunctionNameBlacklistPattern + @"(?<name>~?\w+|operator(?:\s*\(\)|\s*\[\]|\s*[^\s(]+(?:\s+[^\s(]+)?))(?:\s*<[^>]+>)?\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
             // Type alias / 型エイリアス
             new("import", new Regex(CppFunctionStartBlacklistPattern + @"template\s*<[^>]+>\s*(?:export\s+)?using\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:export\s+)?using\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12559,11 +12559,14 @@ public class SymbolExtractorTests
     public void Extract_Cpp_DetectsClassAndNamespace()
     {
         // C++: class, namespace, functions / C++: クラス、名前空間、関数
-        var content = "namespace MyApp {\nclass Handler {\n    void process(int data) {\n    }\n};\n}";
+        var content = "namespace MyApp {\nconstexpr decltype(auto) value() { return 42; }\nclass Handler {\n    void process(int data) {\n    }\n};\n}";
         var symbols = SymbolExtractor.Extract(1, "cpp", content);
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Handler" && s.ContainerName == "MyApp");
+        var value = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "value");
+        Assert.Equal("MyApp", value.ContainerName);
+        Assert.Contains("decltype(auto)", value.ReturnType);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Extend the C++ function extractor to accept `decltype(auto)` return-type atoms so modern functions remain searchable.
- Add a regression covering a top-level `constexpr decltype(auto) value()` declaration.
- Add an unreleased changelog fragment under `changelog.d/unreleased/`.

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "Extract_Cpp_DetectsClassAndNamespace"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~CodeIndex.Tests.SymbolExtractorTests.Extract_Cpp_"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~CodeIndex.Tests.ChangelogToolTests"`

## Follow-up candidates
- Broaden C++ return-type parsing further to cover general `decltype(expr)` forms, not just `decltype(auto)`.
- Add a dedicated C++ class-body member regression fixture so constructor/destructor/operator coverage is tracked separately from top-level function coverage.