### PR TITLE
Improve Swift search coverage for generic extensions

### DIFF
--- a/changelog.d/unreleased/+swift-extension-generic-targets.changed.md
+++ b/changelog.d/unreleased/+swift-extension-generic-targets.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Swift extension targets now keep generic specializations searchable** — `symbols` and `search` now index declarations like `extension Array<String> where ...` under the concrete extension target instead of dropping them back to the unspecialized base type only.
+
+## 日本語
+
+- **Swift の extension 対象で generic specialization も検索可能にしました** — `symbols` / `search` が `extension Array<String> where ...` のような宣言を、非 specialized な base type のみではなく具体的な extension 対象として索引化するようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1229,8 +1229,12 @@ public static class SymbolExtractor
             new("typealias", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*typealias\s+(?<name>\w+)(?:\s*<[^=]+>)?\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("property", new Regex(@"^\s*(?<visibility>(?:public|private|internal|open|fileprivate|package)(?:\s*\(\s*set\s*\))?)?\s*(?:(?:lazy|weak|unowned|final|static|class|nonisolated)\s+)*(?:let|var)\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Extension declarations are important search anchors in Swift-heavy codebases.
+            // Generic specializations such as `extension Array<String> where ...` should stay searchable
+            // under the concrete target, not just the base type name.
             // extension 宣言は Swift コード検索における重要なアンカー。
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final)\s+)?extension\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // `extension Array<String> where ...` のような generic specialization も、
+            // base type 名だけでなく具体的な対象として検索可能にする。
+            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final)\s+)?extension\s+(?<name>[\w.]+(?:\s*<[^{}\r\n]+>)?)(?=\s*(?:where\b|\{|\s*$))", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // actor (Swift 5.5+) / アクター
             new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final|distributed)\s+)*(?:class|actor)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Type alias / 型エイリアス: backtick-escaped names and generic/where clauses.

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12379,6 +12379,18 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsGenericExtensionTargets()
+    {
+        var content = """
+            extension Array<String> where Element == String {
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Array<String>");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsInitDeinitSubscriptStoredPropertyAndAssociatedType()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Index Swift extension declarations with generic specializations such as `extension Array<String> where ...`
- Add a regression test for generic extension targets
- Add a changelog fragment under `changelog.d/unreleased/`

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter Extract_Swift`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`