### PR TITLE
Improve T-SQL exact search normalization

### DIFF
--- a/changelog.d/unreleased/+tsql-search-exact-normalization.fixed.md
+++ b/changelog.d/unreleased/+tsql-search-exact-normalization.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **T-SQL exact search now canonicalizes qualified identifiers before matching** — `search --exact-substring` now normalizes `sql` content and queries with the existing SQL name resolver, so bracketed or spaced identifiers such as `[sales] . [usp_Target]` match canonical queries like `sales.usp_Target` without broadening the behavior for other languages.
+
+## 日本語
+
+- **T-SQL の exact search が qualified identifier を正規化してから照合するようになりました** — `search --exact-substring` が既存の SQL name resolver を使って `sql` コンテンツとクエリを正規化するため、`[sales] . [usp_Target]` のような bracket / 空白付き識別子が `sales.usp_Target` のような canonical クエリに一致するようになり、他言語への挙動拡大は起きません。

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -292,20 +292,14 @@ public partial class DbReader
         {
             // Exact substring match using instr() — case-sensitive, no FTS5 tokenization
             // instr() による完全部分一致検索 — 大文字小文字区別、FTS5トークナイズなし
-            sql = @"
+            sql = $@"
                 SELECT f.path, f.lang, c.start_line, c.end_line, c.content,
                        0.0 AS rank
                 FROM chunks c
                 JOIN files f ON c.file_id = f.id
                 WHERE instr(
-                    CASE WHEN f.lang = 'csharp'
-                         THEN sql_normalize_csharp_verbatim_name(c.content)
-                         ELSE c.content
-                    END,
-                    CASE WHEN f.lang = 'csharp'
-                         THEN sql_normalize_csharp_verbatim_name(@exactQuery)
-                         ELSE @exactQuery
-                    END
+                    {GetExactSearchTextSql("c.content", "f.lang")},
+                    {GetExactSearchTextSql("@exactQuery", "f.lang")}
                 ) > 0";
         }
         else
@@ -374,20 +368,14 @@ public partial class DbReader
 
         if (exact)
         {
-            sql = @"
+            sql = $@"
                 SELECT f.path, c.start_line, c.end_line,
                        0.0 AS rank
                 FROM chunks c
                 JOIN files f ON c.file_id = f.id
                 WHERE instr(
-                    CASE WHEN f.lang = 'csharp'
-                         THEN sql_normalize_csharp_verbatim_name(c.content)
-                         ELSE c.content
-                    END,
-                    CASE WHEN f.lang = 'csharp'
-                         THEN sql_normalize_csharp_verbatim_name(@exactQuery)
-                         ELSE @exactQuery
-                    END
+                    {GetExactSearchTextSql("c.content", "f.lang")},
+                    {GetExactSearchTextSql("@exactQuery", "f.lang")}
                 ) > 0";
         }
         else
@@ -472,6 +460,11 @@ public partial class DbReader
             || message.Contains("unterminated string", StringComparison.OrdinalIgnoreCase)
             || message.Contains("no such column", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static string GetExactSearchTextSql(string valueSql, string langSql)
+        => $"CASE WHEN {langSql} = 'csharp' THEN sql_normalize_csharp_verbatim_name({valueSql}) " +
+           $"WHEN {langSql} = 'sql' THEN sql_normalize_name({valueSql}) " +
+           $"ELSE {valueSql} END";
 
     /// <summary>
     /// Remove search results that overlap with a higher-ranked result in the same file.

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -7889,6 +7889,49 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSearch_ExactSubstringTreatsTsqlQualifiedNamesAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_tsql_canonical");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/target.sql",
+                "sql",
+                """
+                CREATE PROCEDURE [sales] . [usp_Target]
+                AS
+                SELECT 1;
+                GO
+                """);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "scripts/ignored.bat",
+                "batch",
+                """
+                [sales] . [usp_Target]
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["sales.usp_Target", "--db", dbPath, "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSearch_ExactSubstringHumanSnippetUsesCaseSensitiveFocusLine()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_human_snippet");


### PR DESCRIPTION
## Summary
- Normalize SQL content and exact queries during `search --exact-substring` so bracketed or spaced qualified identifiers match canonical T-SQL names.
- Add a regression test covering canonical T-SQL exact search behavior and scoping.
- Add a changelog fragment under `changelog.d/unreleased/`.

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunSearch_ExactSubstringTreatsTsqlQualifiedNamesAsCanonical|FullyQualifiedName~RunSearch_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical|FullyQualifiedName~RunSearch_ExactSubstringKeepsNormalizationScopedToCSharp"`