### PR TITLE
Add R old class constructor coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Perl | `.pl`, `.pm`, `.t`, `.pod` | -- |
 | Solidity | `.sol` | -- |
 | Tcl | `.tcl`, `.tk` | -- |
-| R | `.r`, `.R` | yes (function assignments, methods::setClass/methods::setClassUnion/R6::R6Class/methods::setRefClass with named arguments, R6 public/private/active methods, methods::setGeneric/methods::setMethod with named arguments, library/require) |
+| R | `.r`, `.R` | yes (function assignments, methods::setClass/methods::setClassUnion/methods::setOldClass/R6::R6Class/methods::setRefClass with named arguments, R6 public/private/active methods, methods::setGeneric/methods::setMethod with named arguments, library/require) |
 | Haskell | `.hs`, `.lhs` | yes |
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |

--- a/changelog.d/unreleased/+r-followup-6.fixed.md
+++ b/changelog.d/unreleased/+r-followup-6.fixed.md
@@ -8,8 +8,8 @@ affected:
 
 ## English
 
-- **R search now recognizes named constructor arguments** — following up on PR #1241, `cdidx` now extracts `methods::setClass`, `methods::setRefClass`, `methods::setClassUnion`, `R6::R6Class`, `methods::setGeneric`, and `methods::setMethod` when their identifying names are written as named arguments, in addition to the existing R6 `public` / `private` / `active` method coverage, making more common R object-system declarations searchable by symbol.
+- **R search now recognizes named constructor arguments** — following up on PR #1241, `cdidx` now extracts `methods::setClass`, `methods::setRefClass`, `methods::setClassUnion`, `methods::setOldClass`, `R6::R6Class`, `methods::setGeneric`, and `methods::setMethod` when their identifying names are written as named arguments, in addition to the existing R6 `public` / `private` / `active` method coverage, making more common R object-system declarations searchable by symbol.
 
 ## 日本語
 
-- **R の検索が named constructor 引数に対応しました** — PR #1241 の follow-up として、`cdidx` は `methods::setClass`、`methods::setRefClass`、`methods::setClassUnion`、`R6::R6Class`、`methods::setGeneric`、`methods::setMethod` を名前付き引数で書いた場合でも抽出できるようになり、既存の R6 `public` / `private` / `active` method 抽出とあわせて、R のオブジェクトシステム宣言をより多くシンボル単位で検索できます。
+- **R の検索が named constructor 引数に対応しました** — PR #1241 の follow-up として、`cdidx` は `methods::setClass`、`methods::setRefClass`、`methods::setClassUnion`、`methods::setOldClass`、`R6::R6Class`、`methods::setGeneric`、`methods::setMethod` を名前付き引数で書いた場合でも抽出できるようになり、既存の R6 `public` / `private` / `active` method 抽出とあわせて、R のオブジェクトシステム宣言をより多くシンボル単位で検索できます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1315,7 +1315,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|R6Class)\s*\(\s*(?:(?:Class|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setGeneric\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15788,6 +15788,8 @@ public class SymbolExtractorTests
 
             methods::setRefClass(classname = Widget, fields = list(value = "numeric"))
 
+            methods::setOldClass(classes = "LegacyThing")
+
             R6::R6Class(classname = Thing,
               public = list(print = function() self),
               private = list(secret = function() self),
@@ -15804,6 +15806,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Renderable");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "LegacyThing");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Thing");
         var print = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "print");
         Assert.Equal("public", print.Visibility);


### PR DESCRIPTION
This PR is a follow-up to PR #1243 and addresses its follow-up candidates.

Summary:
- Extend R symbol extraction to recognize `methods::setOldClass` in addition to the existing `methods::setClass`, `methods::setRefClass`, `methods::setClassUnion`, `R6::R6Class`, `methods::setGeneric`, and `methods::setMethod` named-argument handling.
- Keep the existing R6 public/private/active method coverage intact.
- Update the R coverage notes in `README.md`.
- Add a changelog fragment at `changelog.d/unreleased/+r-followup-6.fixed.md`.

Validation:
- `dotnet build`
- `dotnet test CodeIndex.sln --no-build --filter FullyQualifiedName~Extract_R_DetectsS4AndReferenceClassDefinitions --verbosity minimal`
- `dotnet test CodeIndex.sln --no-build --verbosity minimal`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

Follow-up candidates:
- Add support for any additional R object-system constructor aliases if the repo starts using more nonstandard named parameters.
- Expand R6 parsing further if more complex generator layouts or metadata become important for search.