### PR TITLE
Expand XAML navigation cues

### DIFF
--- a/changelog.d/unreleased/+xaml-navigation-cues.fixed.md
+++ b/changelog.d/unreleased/+xaml-navigation-cues.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/RepoMapBuilder.cs
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C# XAML navigation now surfaces more app entrypoints and handler targets** — repo-map entrypoint hints now include additional common code-behind filenames such as `Shell.xaml.cs`, `ContentPage.xaml.cs`, `ContentView.xaml.cs`, `Window.xaml.cs`, and `UserControl.xaml.cs`, and XAML event handler attributes like `Clicked` and `SelectionChanged` are indexed as `function` symbols so searches can jump from markup to code-behind more naturally.
+
+## 日本語
+
+- **C# XAML のナビゲーションで entrypoint と handler の両方がより見つかりやすくなりました** — repo map の entrypoint 候補に `Shell.xaml.cs`、`ContentPage.xaml.cs`、`ContentView.xaml.cs`、`Window.xaml.cs`、`UserControl.xaml.cs` などを追加し、`Clicked` や `SelectionChanged` のような XAML event handler 属性も `function` シンボルとして索引化することで、markup から code-behind へより自然に辿れるようになりました。

--- a/src/CodeIndex/Database/RepoMapBuilder.cs
+++ b/src/CodeIndex/Database/RepoMapBuilder.cs
@@ -39,7 +39,7 @@ internal sealed class RepoMapBuilder
     };
     private static readonly Dictionary<string, string[]> EntrypointPathHints = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["csharp"] = ["Program.cs", "Startup.cs", "App.xaml.cs", "MainWindow.xaml.cs", "MainPage.xaml.cs", "AppShell.xaml.cs", "App.cs", "App.razor"],
+        ["csharp"] = ["Program.cs", "Startup.cs", "App.xaml.cs", "MainWindow.xaml.cs", "MainPage.xaml.cs", "AppShell.xaml.cs", "Shell.xaml.cs", "ContentPage.xaml.cs", "ContentView.xaml.cs", "Window.xaml.cs", "UserControl.xaml.cs", "App.cs", "App.razor"],
         ["python"] = ["main.py", "__main__.py", "app.py", "cli.py"],
         ["javascript"] = ["index.js", "main.js", "app.js", "server.js"],
         ["typescript"] = ["index.ts", "main.ts", "app.ts", "server.ts"],

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -141,6 +141,9 @@ public static class SymbolExtractor
     private static readonly Regex XamlKeyRegex = new(
         @"\bx:Key\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlEventHandlerRegex = new(
+        @"\b(?:Clicked|Tapped|Loaded|Unloaded|SelectionChanged|TextChanged|CheckedChanged|Unchecked|SelectedIndexChanged|PointerPressed|PointerReleased|PointerEntered|PointerExited|Drop|DragOver|Completed|Appearing|Disappearing|NavigatedTo|NavigatedFrom|SizeChanged)\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex ObjCCategoryDeclarationRegex = new(
         @"^\s*@(?:interface|implementation)\s+(?<class>\w+)\s*\(\s*(?<category>[^)]+?)\s*\)(?:\s*<[^>]+>)?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -5299,6 +5302,23 @@ private sealed class RubyMaskState
                 {
                     FileId = fileId,
                     Kind = "property",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+
+            foreach (Match handlerMatch in XamlEventHandlerRegex.Matches(line))
+            {
+                var value = handlerMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "function",
                     Name = value,
                     Line = i + 1,
                     StartLine = i + 1,

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -8191,6 +8191,8 @@ public class DbReaderTests : IDisposable
     [InlineData("src/MainWindow.xaml.cs", "MainWindow")]
     [InlineData("src/MainPage.xaml.cs", "MainPage")]
     [InlineData("src/AppShell.xaml.cs", "AppShell")]
+    [InlineData("src/Shell.xaml.cs", "Shell")]
+    [InlineData("src/ContentPage.xaml.cs", "ContentPage")]
     public void GetRepoMap_AddsFileFallbackEntrypointForCommonCSharpXamlCodeBehind(string path, string className)
     {
         InsertIndexedFile(path, "csharp", "public partial class " + className + "\n{\n}\n");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19141,6 +19141,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesCommonEventHandlers()
+    {
+        var content = """
+            <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                <VerticalStackLayout>
+                    <Button Text="Save" Clicked="OnSaveClicked" />
+                    <Entry TextChanged="OnFilterTextChanged" />
+                    <CollectionView SelectionChanged="OnSelectionChanged" />
+                </VerticalStackLayout>
+            </ContentPage>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "OnSaveClicked");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "OnFilterTextChanged");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "OnSelectionChanged");
+    }
+
+    [Fact]
     public void Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Addressed the follow-up candidates from PR #1242.
- Broadened C# XAML entrypoint hints to cover more common code-behind filenames, including `Shell.xaml.cs`, `ContentPage.xaml.cs`, `ContentView.xaml.cs`, `Window.xaml.cs`, and `UserControl.xaml.cs`.
- Indexed common XAML event handler attributes such as `Clicked`, `TextChanged`, and `SelectionChanged` as `function` symbols so searches can jump from markup to code-behind more naturally.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.GetRepoMap_AddsFileFallbackEntrypointForCommonCSharpXamlCodeBehind|FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesCommonEventHandlers"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- No README or workflow docs changed; this is a non-breaking behavior improvement.
- Changelog fragment: `changelog.d/unreleased/+xaml-navigation-cues.fixed.md`

## Follow-up candidates addressed

- Broaden C# XAML entrypoint hints further if more app templates use different code-behind filenames.
- Explore deeper XAML navigation cues by indexing more markup-bound identifiers so search can reach code-behind handlers and related code more directly.