### PR TITLE
Extend HTML resource-link coverage follow-up

### DIFF
--- a/changelog.d/unreleased/+html-resource-links-followup.fixed.md
+++ b/changelog.d/unreleased/+html-resource-links-followup.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **HTML resource-link coverage now includes `srcset` and navigable anchor/image-map links** — `SymbolExtractor` now emits `import` symbols for `img[srcset]` and `source[srcset]` by extracting each URL candidate, and it also treats `a[href]` and `area[href]` as searchable imports. This extends the earlier HTML resource-link follow-up so `definition` / `references` can reach more asset and navigation targets from HTML-heavy codebases.
+
+## 日本語
+
+- **HTML の resource-link 対応を `srcset` と遷移可能な anchor / image-map link まで広げました** — `SymbolExtractor` は `img[srcset]` と `source[srcset]` から各 URL candidate を `import` として出力し、`a[href]` と `area[href]` も検索可能な import として扱います。前回の HTML resource-link follow-up を拡張し、HTML が多いコードベースでも `definition` / `references` からより多くの資産・遷移先へ辿れるようにしました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -4616,7 +4616,53 @@ private sealed class RubyMaskState
         tagNameLower is "audio" or "embed" or "iframe" or "img" or "input" or "script" or "source" or "track" or "video";
 
     private static bool IsHtmlHrefResourceTag(string tagNameLower) =>
-        tagNameLower is "image" or "link" or "use";
+        tagNameLower is "a" or "area" or "image" or "link" or "use";
+
+    private static bool IsHtmlSrcsetResourceTag(string tagNameLower) =>
+        tagNameLower is "img" or "source";
+
+    private static IEnumerable<string> EnumerateHtmlSrcsetUrls(string value)
+    {
+        var index = 0;
+        while (index < value.Length)
+        {
+            while (index < value.Length && (char.IsWhiteSpace(value[index]) || value[index] == ','))
+                index++;
+
+            if (index >= value.Length)
+                yield break;
+
+            var start = index;
+            var isDataUrl = value.AsSpan(index).StartsWith("data:", StringComparison.OrdinalIgnoreCase);
+            if (isDataUrl)
+            {
+                index += "data:".Length;
+                while (index < value.Length)
+                {
+                    if (char.IsWhiteSpace(value[index]))
+                        break;
+                    if (value[index] == ',' && (index + 1 >= value.Length || char.IsWhiteSpace(value[index + 1])))
+                        break;
+                    index++;
+                }
+            }
+            else
+            {
+                while (index < value.Length && !char.IsWhiteSpace(value[index]) && value[index] != ',')
+                    index++;
+            }
+
+            var url = value[start..index].Trim();
+            if (url.Length > 0)
+                yield return url;
+
+            while (index < value.Length && value[index] != ',')
+                index++;
+
+            if (index < value.Length && value[index] == ',')
+                index++;
+        }
+    }
 
     private static string MaskHtmlRawTextRegions(string text)
     {
@@ -5209,22 +5255,39 @@ private sealed class RubyMaskState
                     continue;
 
                 string? emitKind = null;
+                List<string>? emittedNames = null;
                 if (attrNameLower == "src" && IsHtmlSrcResourceTag(tagNameLower))
+                {
                     emitKind = "import";
+                    emittedNames = [attrValue.Trim()];
+                }
+                else if (attrNameLower == "srcset" && IsHtmlSrcsetResourceTag(tagNameLower))
+                {
+                    emitKind = "import";
+                    emittedNames = EnumerateHtmlSrcsetUrls(attrValue).ToList();
+                }
                 else if ((attrNameLower == "href" || attrNameLower == "xlink:href") && IsHtmlHrefResourceTag(tagNameLower))
+                {
                     emitKind = "import";
+                    emittedNames = [attrValue.Trim()];
+                }
                 else if (attrNameLower == "data" && tagNameLower == "object")
+                {
                     emitKind = "import";
+                    emittedNames = [attrValue.Trim()];
+                }
                 else if (attrNameLower == "poster" && tagNameLower == "video")
+                {
                     emitKind = "import";
+                    emittedNames = [attrValue.Trim()];
+                }
                 else if (attrNameLower == "id" && !attrName.Contains(':') && !attrName.Contains('-') && !attrName.Contains('.'))
+                {
                     emitKind = "property";
+                    emittedNames = [attrValue.Trim()];
+                }
 
-                if (emitKind == null)
-                    continue;
-
-                var name = attrValue.Trim();
-                if (name.Length == 0)
+                if (emitKind == null || emittedNames == null || emittedNames.Count == 0)
                     continue;
 
                 // Anchor the symbol at the attribute value so cross-line tags like
@@ -5235,16 +5298,19 @@ private sealed class RubyMaskState
                 var anchor = attrValueStart >= 0 ? attrValueStart : pos;
                 var startLine = FindHtmlLineNumber(lineStarts, anchor);
                 var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
-                symbols.Add(new SymbolRecord
+                foreach (var emittedName in emittedNames)
                 {
-                    FileId = fileId,
-                    Kind = emitKind,
-                    Name = name,
-                    Line = startLine,
-                    StartLine = startLine,
-                    EndLine = startLine,
-                    Signature = lines[signatureIndex].Trim(),
-                });
+                    symbols.Add(new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = emitKind,
+                        Name = emittedName,
+                        Line = startLine,
+                        StartLine = startLine,
+                        EndLine = startLine,
+                        Signature = lines[signatureIndex].Trim(),
+                    });
+                }
             }
 
             pos = cursor < maskedText.Length ? cursor + 1 : cursor;

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -17331,22 +17331,32 @@ public class SymbolExtractorTests
         // `definition` / `references` が raw text chunk ではなく参照先へ飛べるようにする。
         var content = """
             <img src="/images/logo.png" alt="logo">
+            <img srcset="/images/logo-1x.png 1x, /images/logo-2x.png 2x" src="/images/logo.png" alt="logo">
             <iframe src="/docs/frame.html"></iframe>
             <video poster="/media/thumb.jpg">
               <source src="/media/movie.mp4" type="video/mp4">
+              <source srcset="/media/movie-480.jpg 480w, /media/movie-960.jpg 960w">
             </video>
             <object data="/files/manual.pdf"></object>
             <svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="/icons.svg#check"></use></svg>
+            <a href="/docs/readme.html">Read more</a>
+            <area href="/docs/map.html">
             """;
 
         var symbols = SymbolExtractor.Extract(1, "html", content);
 
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/images/logo.png");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/images/logo-1x.png");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/images/logo-2x.png");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/docs/frame.html");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/media/thumb.jpg");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/media/movie.mp4");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/media/movie-480.jpg");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/media/movie-960.jpg");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/files/manual.pdf");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/icons.svg#check");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/docs/readme.html");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "/docs/map.html");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Follow up on PR #1247’s HTML resource-link candidates
- Add `img[srcset]` and `source[srcset]` URL extraction
- Treat `a[href]` and `area[href]` as searchable imports
- Keep the earlier `script` / `link` / `img` / `iframe` / media / `object` / SVG coverage intact

## Verification
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Html_"`