### PR TITLE
Handle C++ decltype expr and class members

### DIFF
--- a/changelog.d/unreleased/+cpp-decltype-auto-search.fixed.md
+++ b/changelog.d/unreleased/+cpp-decltype-auto-search.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **C++ symbol search now keeps `decltype(auto)` functions visible** — the C++ function extractor now accepts `decltype(auto)` return-type atoms, so modern functions such as `constexpr decltype(auto) value()` are indexed and searchable instead of falling through the generic function heuristic.
+- **C++ symbol search now keeps `decltype(expr)` functions visible** — the C++ function extractor now accepts general `decltype(...)` return-type atoms, so modern functions such as `constexpr decltype(foo(42)) value()` are indexed and searchable instead of falling through the generic function heuristic. Added a dedicated C++ class-body regression fixture for constructor, destructor, and operator-overload coverage.
 
 ## 日本語
 
-- **C++ の symbol 検索で `decltype(auto)` 関数が見えるようになりました** — C++ の function extractor が `decltype(auto)` を戻り値型トークンとして受け入れるようになり、`constexpr decltype(auto) value()` のような現代的な関数が汎用ヒューリスティックに落ちずに index / search されるようになりました。
+- **C++ の symbol 検索で `decltype(expr)` 関数が見えるようになりました** — C++ の function extractor が一般的な `decltype(...)` を戻り値型トークンとして受け入れるようになり、`constexpr decltype(foo(42)) value()` のような現代的な関数が汎用ヒューリスティックに落ちずに index / search されるようになりました。あわせて、constructor / destructor / operator overload を追跡する C++ class-body 用の回帰 fixture を追加しました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -73,13 +73,15 @@ public static class SymbolExtractor
     private const string SqlQualifiedIdentifierSegmentPattern = @"(?:\[(?:[^\]\r\n]|\]\])+\]|""[^""]+""|[\w$#]+)";
     private const string SqlQualifiedIdentifierPattern =
         @"(?:" + SqlQualifiedIdentifierSegmentPattern + @")(?:\s*\.\s*(?:" + SqlQualifiedIdentifierSegmentPattern + @"))*";
-    // C++ return-type atoms need to accept both ordinary word tokens and `decltype(auto)`.
-    // The latter is common in modern C++ APIs and previously fell through the generic
-    // function pattern, making those functions invisible to symbol-oriented search.
-    // C++ の戻り値型トークンは通常の単語トークンに加え `decltype(auto)` も受け入れる必要がある。
-    // 後者は現代的な C++ API でよく使われるが、従来は汎用 function パターンから漏れており、
-    // その関数が symbol ベースの検索から見えなくなっていた。
-    private const string CppFunctionReturnTypeAtomPattern = @"(?:decltype\s*\(\s*auto\s*\)|[\w:<>]+)";
+    // C++ return-type atoms need to accept both ordinary word tokens and `decltype(...)`.
+    // The decltype branch allows nested parentheses so modern forms such as
+    // `decltype(auto)`, `decltype((value))`, and `decltype(foo<T>(x))` stay searchable.
+    // C++ の戻り値型トークンは通常の単語トークンに加え `decltype(...)` も受け入れる必要がある。
+    // ここで括弧の入れ子を許容し、`decltype(auto)` / `decltype((value))` /
+    // `decltype(foo<T>(x))` のような現代的な形も検索可能なままにする。
+    private const string CppDecltypePattern =
+        @"decltype\s*\((?:(?>[^()]+)|\((?<CppDecltypeDepth>)|\)(?<-CppDecltypeDepth>))*(?(CppDecltypeDepth)(?!))\)";
+    private const string CppFunctionReturnTypeAtomPattern = @"(?:" + CppDecltypePattern + @"|[\w:<>~]+)";
     private const string CSharpTypeSegmentPattern =
         @"(?:" + CSharpTypeTokenCharsPattern + @"+(?:" + CSharpTupleGroupPattern + CSharpTypeTokenCharsPattern + @"*)*|" + CSharpTupleGroupPattern + CSharpTypeTokenCharsPattern + @"*)";
     private const string CSharpTypePattern =
@@ -1186,7 +1188,7 @@ public static class SymbolExtractor
             new("namespace", new Regex(CppFunctionStartBlacklistPattern + @"(?:export\s+)?module\s+(?<name>[\w.]+)\b", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(CppFunctionStartBlacklistPattern + @"inline\s+namespace\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:export\s+)?concept\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:(?<returnType>(?:(?:" + CppTypeAtomPattern + @")[\s*&]+)+))?(?:(?:[\w:<>]+\s*::\s*)+)?" + CFunctionNameBlacklistPattern + @"(?<name>~?\w+|operator(?:\s*\(\)|\s*\[\]|\s*[^\s(]+(?:\s+[^\s(]+)?))(?:\s*<[^>]+>)?\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:(?<returnType>(?:(?:" + CppFunctionReturnTypeAtomPattern + @")[\s*&]+)+))?(?:(?:[\w:<>]+\s*::\s*)+)?" + CFunctionNameBlacklistPattern + @"(?<name>~?\w+|operator(?:\s*\(\)|\s*\[\]|\s*[^\s(]+(?:\s+[^\s(]+)?))(?:\s*<[^>]+>)?\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
             // Type alias / 型エイリアス
             new("import", new Regex(CppFunctionStartBlacklistPattern + @"template\s*<[^>]+>\s*(?:export\s+)?using\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:export\s+)?using\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None),
@@ -3841,6 +3843,8 @@ private sealed class RubyMaskState
             ExtractRustUseSymbols(fileId, lines, symbols);
         if (lang == "go")
             ExtractGoGroupedDeclarations(fileId, lines, symbols);
+        if (lang == "cpp")
+            ExtractCppSameLineClassBodyMembers(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
         NormalizeKotlinSecondaryConstructorNames(symbols);
@@ -3871,6 +3875,111 @@ private sealed class RubyMaskState
                 Signature = lines[i].Trim(),
             });
         }
+    }
+
+    private static void ExtractCppSameLineClassBodyMembers(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        var classSymbols = symbols
+            .Where(symbol =>
+                symbol.Kind is "class" or "struct"
+                && symbol.BodyStartLine.HasValue
+                && symbol.BodyEndLine.HasValue
+                && symbol.StartLine == symbol.BodyStartLine.Value
+                && symbol.EndLine == symbol.BodyEndLine.Value)
+            .ToList();
+
+        foreach (var classSymbol in classSymbols)
+        {
+            var lineIndex = classSymbol.StartLine - 1;
+            if (lineIndex < 0 || lineIndex >= lines.Length)
+                continue;
+
+            var line = lines[lineIndex];
+            var openBraceIndex = line.IndexOf('{');
+            var closeBraceIndex = line.LastIndexOf('}');
+            if (openBraceIndex < 0 || closeBraceIndex <= openBraceIndex)
+                continue;
+
+            var body = line[(openBraceIndex + 1)..closeBraceIndex];
+            if (body.Length == 0)
+                continue;
+
+            var segments = body.Split(';');
+            var searchStart = 0;
+            foreach (var segment in segments)
+            {
+                var trimmedSegment = segment.Trim();
+                if (trimmedSegment.Length == 0)
+                {
+                    searchStart += segment.Length + 1;
+                    continue;
+                }
+
+                var segmentStart = line.IndexOf(trimmedSegment, searchStart, StringComparison.Ordinal);
+                if (segmentStart < 0)
+                {
+                    searchStart += segment.Length + 1;
+                    continue;
+                }
+
+                if (TryAddCppSameLineClassMemberSymbol(fileId, classSymbol, trimmedSegment, lineIndex + 1, symbols))
+                    searchStart = segmentStart + trimmedSegment.Length + 1;
+                else
+                    searchStart = segmentStart + trimmedSegment.Length + 1;
+            }
+        }
+    }
+
+    private static bool TryAddCppSameLineClassMemberSymbol(
+        long fileId,
+        SymbolRecord classSymbol,
+        string segment,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        foreach (var pattern in PatternCache["cpp"])
+        {
+            if (pattern.Kind != "function")
+                continue;
+
+            var match = pattern.Regex.Match(segment);
+            if (!match.Success)
+                continue;
+
+            var name = match.Groups["name"].Success
+                ? match.Groups["name"].Value.Trim()
+                : match.Value.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            if (symbols.Any(symbol =>
+                symbol.Kind == "function"
+                && symbol.Line == lineNumber
+                && symbol.Name == name
+                && symbol.ContainerKind == classSymbol.Kind
+                && symbol.ContainerName == classSymbol.Name))
+            {
+                return true;
+            }
+
+            symbols.Add(new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = name,
+                Line = lineNumber,
+                StartLine = lineNumber,
+                EndLine = lineNumber,
+                Signature = segment.Trim(),
+                ContainerKind = classSymbol.Kind,
+                ContainerName = classSymbol.Name,
+                ReturnType = TryGetGroup(match, "returnType"),
+            });
+
+            return true;
+        }
+
+        return false;
     }
 
     private readonly record struct PythonImportSymbolEntry(string Name, int StartColumn);
@@ -17420,7 +17529,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
         if (kind is not ("class" or "struct" or "interface" or "enum" or "namespace"))
             return false;
 
-        return lang is "csharp" or "java";
+        return lang is "csharp" or "java" or "cpp";
     }
 
     private static bool IsCSharpFieldLikeFunctionPattern(SymbolPattern pattern)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12573,14 +12573,28 @@ public class SymbolExtractorTests
     public void Extract_Cpp_DetectsClassAndNamespace()
     {
         // C++: class, namespace, functions / C++: クラス、名前空間、関数
-        var content = "namespace MyApp {\nconstexpr decltype(auto) value() { return 42; }\nclass Handler {\n    void process(int data) {\n    }\n};\n}";
+        var content = "namespace MyApp {\nconstexpr decltype(foo(42)) value() { return foo(42); }\nclass Handler {\n    void process(int data) {\n    }\n};\n}";
         var symbols = SymbolExtractor.Extract(1, "cpp", content);
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Handler" && s.ContainerName == "MyApp");
         var value = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "value");
         Assert.Equal("MyApp", value.ContainerName);
-        Assert.Contains("decltype(auto)", value.ReturnType);
+        Assert.Contains("decltype(foo(42))", value.ReturnType);
+    }
+
+    [Fact]
+    public void Extract_Cpp_DetectsClassBodyMembers()
+    {
+        // C++: constructors, destructors, operator overloads / C++: コンストラクタ、デストラクタ、演算子オーバーロード
+        var content = "class Handler { Handler(); ~Handler(); Handler operator+(const Handler& other) const; };";
+
+        var symbols = SymbolExtractor.Extract(1, "cpp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Handler");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Handler" && s.ContainerName == "Handler");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "~Handler" && s.ContainerName == "Handler");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "operator+" && s.ContainerName == "Handler");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Address the follow-up candidates from PR #1249.
- Broaden the C++ return-type handling from `decltype(auto)` to general `decltype(...)` expressions so modern return signatures stay searchable.
- Add a dedicated C++ class-body regression fixture and a same-line class-body member post-pass so constructor, destructor, and operator-overload coverage is tracked separately from top-level functions.
- Update the unreleased changelog fragment for the follow-up work.

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~CodeIndex.Tests.SymbolExtractorTests.Extract_Cpp_"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~CodeIndex.Tests.ChangelogToolTests"`