### PR TITLE
Index batch goto/call targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ The database reflects the working tree at the time of the last index. After swit
 | MSBuild | `.csproj`, `.fsproj`, `.vbproj`, `.props`, `.targets` | -- |
 | Shell | `.sh`, `.bash`, `.zsh`, `.fish` | command-style function calls |
 | PowerShell | `.ps1`, `.psm1`, `.psd1` | function/filter (scope prefixes), configuration, workflow, class constructors/methods/properties, enum values, Import-Module, using module/namespace/assembly |
-| Batch | `.bat`, `.cmd` | yes |
+| Batch | `.bat`, `.cmd` | labels + `goto`/`call` targets |
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 Query-time `--lang tsql` is accepted as an alias for the SQL bucket.
@@ -1634,7 +1634,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | MSBuild | `.csproj`, `.fsproj`, `.vbproj`, `.props`, `.targets` | -- |
 | Shell | `.sh`, `.bash`, `.zsh`, `.fish` | 関数のコマンド構文呼び出し |
 | PowerShell | `.ps1`, `.psm1`, `.psd1` | 関数/フィルタ（scope プレフィックス付き）、configuration、workflow、class、enum、Import-Module、using module/namespace/assembly |
-| Batch | `.bat`, `.cmd` | yes |
+| Batch | `.bat`, `.cmd` | ラベル + `goto`/`call` ターゲット |
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 クエリ時の `--lang tsql` は SQL バケットの別名として受け付けられます。

--- a/changelog.d/unreleased/+bat-call-targets.changed.md
+++ b/changelog.d/unreleased/+bat-call-targets.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Batch `goto :label` / `call :label` targets are now indexed as call references** — `batch` files now emit `call`-kind references for jump targets, so `references`, `callers`, `callees`, and `impact` can trace `goto :Build` / `call :Build` edges instead of treating batch labels as isolated symbols.
+
+## 日本語
+
+- **Batch の `goto :label` / `call :label` ターゲットを call 参照として索引するようになりました** — `batch` ファイルでもジャンプ先に `call` 種別の参照が出るため、`references` / `callers` / `callees` / `impact` で `goto :Build` / `call :Build` の関係を辿れるようになり、ラベルが孤立したシンボルのままになりません。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -25,7 +25,7 @@ public static class ReferenceExtractor
     [
         "python", "javascript", "typescript", "csharp", "go", "rust",
         "java", "kotlin", "ruby", "c", "cpp", "php", "swift",
-        "dart", "scala", "elixir", "lua", "vb", "fsharp", "sql", "cobol",
+        "dart", "scala", "elixir", "lua", "vb", "fsharp", "sql", "cobol", "batch",
         "r", "powershell", "shell", "haskell",
         "gradle", "terraform", "protobuf", "dockerfile", "makefile",
         "zig", "css"
@@ -52,6 +52,12 @@ public static class ReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolPerformRegex = new(
         @"^\s*PERFORM\s+(?!(?:VARYING|UNTIL|WITH|TIMES|TEST|THRU|THROUGH)\b)(?<name>[A-Z0-9][A-Z0-9-]*)(?:\s+(?:THRU|THROUGH)\s+(?<end>[A-Z0-9][A-Z0-9-]*))?",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    // Batch `goto :label` / `call :label` targets are line-oriented and do not use parentheses.
+    // batch の `goto :label` / `call :label` は行指向で、括弧を使わない。
+    private static readonly Regex BatchLabelTargetRegex = new(
+        @"^\s*@?\s*(?:goto|call)\s+:(?<name>[\w.\-]+)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     // Terraform dotted references are paren-less and therefore invisible to the shared CallRegex.
@@ -2309,6 +2315,20 @@ public static class ReferenceExtractor
 
                     if (RubyCommandTargetSingleTokenNames.Contains(name))
                         break;
+                }
+            }
+
+            if (language is "batch" && !IsBatchCommentLine(originalLine))
+            {
+                foreach (Match match in BatchLabelTargetRegex.Matches(preparedLine))
+                {
+                    var name = match.Groups["name"].Value;
+                    if (string.Equals(name, "eof", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var callIndex = match.Groups["name"].Index;
+                    var callContainer = ResolveContainerForCall(callIndex);
+                    AddReference(references, seen, fileId, name, callIndex, "call", context, lineNumber, callContainer);
                 }
             }
 
@@ -14974,5 +14994,50 @@ public static class ReferenceExtractor
             backslashCount++;
 
         return (backslashCount & 1) == 1;
+    }
+
+    /// <summary>
+    /// Return true when a batch (.bat / .cmd) line is a comment, i.e. `::` / `:::` / `rem` /
+    /// `@rem` (with optional leading whitespace and case-insensitive `rem`).
+    /// batch (.bat / .cmd) のコメント行 (`::` / `:::` / `rem` / `@rem`、先頭空白可、`rem` は大小文字不問) のときに
+    /// true を返す。
+    /// </summary>
+    private static bool IsBatchCommentLine(string line)
+    {
+        var i = 0;
+        while (i < line.Length && (line[i] == ' ' || line[i] == '\t'))
+            i++;
+
+        if (i >= line.Length)
+            return false;
+
+        if (line[i] == ':' && i + 1 < line.Length && line[i + 1] == ':')
+            return true;
+
+        if (line[i] == '@')
+        {
+            var j = i + 1;
+            while (j < line.Length && (line[j] == ' ' || line[j] == '\t'))
+                j++;
+            return IsBatchRemKeyword(line, j);
+        }
+
+        return IsBatchRemKeyword(line, i);
+    }
+
+    private static bool IsBatchRemKeyword(string line, int start)
+    {
+        if (start + 3 > line.Length)
+            return false;
+        if ((line[start] | 0x20) != 'r')
+            return false;
+        if ((line[start + 1] | 0x20) != 'e')
+            return false;
+        if ((line[start + 2] | 0x20) != 'm')
+            return false;
+        if (start + 3 == line.Length)
+            return true;
+        var next = line[start + 3];
+        return next == ' ' || next == '\t' || next == '\r' || next == '\n';
     }
 }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6707,6 +6707,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Batch_IndexesGotoAndCallTargets()
+    {
+        const string content = """
+            @echo off
+            goto :Build
+            rem goto :Ignored
+            :Build
+            call :Build
+            :: call :Commented
+            goto :EOF
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "batch", content);
+        var references = ReferenceExtractor.Extract(1, "batch", content, symbols);
+
+        Assert.Equal(2, references.Count(r => r.SymbolName == "Build" && r.ReferenceKind == "call"));
+        Assert.DoesNotContain(references, r => r.SymbolName == "EOF" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Ignored" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Commented" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_SQL_TruncateTargetsHandleOnlyAndMultipleTargets()
     {
         // issues #684 / #711: `TRUNCATE TABLE` should skip `ONLY` and keep all comma-separated


### PR DESCRIPTION
## Summary

- Added batch reference extraction for `goto :label` and `call :label` targets.
- Batch comment lines are ignored so `rem` / `::` lines do not create false references.
- Added a regression test that covers `goto :Build`, `call :Build`, `goto :EOF`, and commented lines.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter ReferenceExtractorTests`
- Refreshed the local CodeIndex DB for the changed files with `cdidx index . --files ...`

## Docs and changelog

- Updated the batch language row in `README.md` to reflect the new `goto` / `call` target coverage.
- Added `changelog.d/unreleased/+bat-call-targets.changed.md`.

## Follow-up candidates

- Broader batch control-flow parsing, especially inline forms like `if errorlevel 1 goto :label` and other chained jump patterns.
