### PR TITLE
Follow up on Python package export searchability

### DIFF
--- a/changelog.d/unreleased/+python-init-all-exports.fixed.md
+++ b/changelog.d/unreleased/+python-init-all-exports.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Python `__all__` exports in package `__init__.py` files are now searchable** — package init modules now surface `__all__` entries as import-style symbols, so `symbols --exact-name` can find public APIs exposed through package re-exports instead of requiring the concrete implementation module path. Added regressions for `__all__` extraction and for `search --exact` staying aligned with symbol lookup on the same package fixture.
+
+## 日本語
+
+- **Python の package `__init__.py` にある `__all__` export を検索できるようになりました** — package の init モジュールで定義された `__all__` の要素を import 形式の symbol として出すため、`symbols --exact-name` でも re-export された public API を concrete な実装モジュール名なしで見つけられます。`__all__` 抽出の回帰と、同じ package fixture に対して `search --exact` が symbol 検索と揃って動くことの回帰を追加しました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -3878,6 +3878,8 @@ private sealed class RubyMaskState
             ExtractGoGroupedDeclarations(fileId, lines, symbols);
         if (lang == "cpp")
             ExtractCppSameLineClassBodyMembers(fileId, lines, symbols);
+        if (lang == "python")
+            ExtractPythonAllExportSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
         NormalizeKotlinSecondaryConstructorNames(symbols);
@@ -4016,8 +4018,10 @@ private sealed class RubyMaskState
     }
 
     private readonly record struct PythonImportSymbolEntry(string Name, int StartColumn);
+    private readonly record struct PythonExportSymbolEntry(string Name, int LineIndex, int StartColumn);
     private static readonly Regex PythonDirectImportRegex = new(@"^import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonAllAssignmentRegex = new(@"^\s*__all__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static List<PythonImportSymbolEntry>? TryExpandPythonImportSymbols(string[] lines, int lineIndex, int absoluteStartColumn)
     {
@@ -4078,6 +4082,132 @@ private sealed class RubyMaskState
             entries,
             seenNames,
             treatAsFromImport: true);
+        return entries.Count > 0 ? entries : null;
+    }
+
+    private static void ExtractPythonAllExportSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var exports = TryExpandPythonAllExportSymbols(lines, i);
+            if (exports == null)
+                continue;
+
+            foreach (var export in exports)
+            {
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    export.LineIndex + 1,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "import",
+                        Name = export.Name,
+                        Line = export.LineIndex + 1,
+                        StartLine = export.LineIndex + 1,
+                        StartColumn = export.StartColumn,
+                        EndLine = export.LineIndex + 1,
+                        Signature = lines[export.LineIndex].Trim(),
+                    },
+                    lines[export.LineIndex]);
+            }
+        }
+    }
+
+    private static List<PythonExportSymbolEntry>? TryExpandPythonAllExportSymbols(string[] lines, int lineIndex)
+    {
+        var line = lines[lineIndex];
+        var match = PythonAllAssignmentRegex.Match(line);
+        if (!match.Success)
+            return null;
+
+        var valuesStartColumn = match.Groups["values"].Index;
+        if (valuesStartColumn < 0 || valuesStartColumn >= line.Length)
+            return null;
+
+        var entries = new List<PythonExportSymbolEntry>();
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+        var currentLineIndex = lineIndex;
+        var currentColumn = valuesStartColumn;
+        var depth = 0;
+        var inString = false;
+        var quoteChar = '\0';
+        var stringStartColumn = -1;
+
+        while (currentLineIndex < lines.Length)
+        {
+            var currentLine = lines[currentLineIndex];
+            if (currentColumn >= currentLine.Length)
+            {
+                if (depth <= 0 && !inString)
+                    break;
+
+                currentLineIndex++;
+                currentColumn = 0;
+                continue;
+            }
+
+            var ch = currentLine[currentColumn];
+            if (inString)
+            {
+                if (ch == '\\' && currentColumn + 1 < currentLine.Length)
+                {
+                    currentColumn += 2;
+                    continue;
+                }
+
+                if (ch == quoteChar)
+                {
+                    var name = currentLine[stringStartColumn..currentColumn].Trim();
+                    if (name.Length > 0 && seenNames.Add(name))
+                    {
+                        entries.Add(new PythonExportSymbolEntry(name, currentLineIndex, stringStartColumn));
+                    }
+
+                    inString = false;
+                    quoteChar = '\0';
+                    stringStartColumn = -1;
+                    currentColumn++;
+                    continue;
+                }
+
+                currentColumn++;
+                continue;
+            }
+
+            if (ch == '#')
+                break;
+
+            if (ch == '\'' || ch == '"')
+            {
+                inString = true;
+                quoteChar = ch;
+                stringStartColumn = currentColumn + 1;
+                currentColumn++;
+                continue;
+            }
+
+            if (ch is '[' or '(' or '{')
+            {
+                depth++;
+                currentColumn++;
+                continue;
+            }
+
+            if (ch is ']' or ')' or '}')
+            {
+                if (depth > 0)
+                    depth--;
+                currentColumn++;
+                if (depth <= 0)
+                    break;
+                continue;
+            }
+
+            currentColumn++;
+        }
+
         return entries.Count > 0 ? entries : null;
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -310,6 +310,44 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSearchAndSymbols_ExactQueriesSeePythonInitAllExports()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_python_init_all_exports");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "package/__init__.py",
+                "python",
+                """
+                __all__ = [
+                    "public_api",
+                ]
+                """);
+
+            var (searchExitCode, searchStdout, searchStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["public_api", "--db", dbPath, "--exact", "--count"],
+                _jsonOptions));
+            var (symbolsExitCode, symbolsStdout, symbolsStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["public_api", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, searchExitCode);
+            Assert.Equal("1", searchStdout.Trim());
+            Assert.Equal(string.Empty, searchStderr);
+
+            Assert.Equal(CommandExitCodes.Success, symbolsExitCode);
+            Assert.Equal("1", symbolsStdout.Trim());
+            Assert.Equal(string.Empty, symbolsStderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunPublishedTrimmedCli_SerializesQueryJsonAndErrorJson()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_trimmed_publish");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -131,6 +131,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesAllExportsFromInitModules()
+    {
+        var content = """
+            __all__ = [
+                "public_api",
+                "secondary_api",
+            ]
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var exports = symbols.Where(symbol => symbol.Kind == "import").ToList();
+
+        Assert.Contains(exports, symbol => symbol.Name == "public_api");
+        Assert.Contains(exports, symbol => symbol.Name == "secondary_api");
+    }
+
+    [Fact]
     public void Extract_Python_HandlesUnclosedMultilineImportBlocksWithoutPhantomSymbols()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Address the follow-up candidates from PR #1252 by indexing Python `__all__` exports from package `__init__.py` files.
- Keep `search --exact` and `symbols --exact-name` aligned on the same package fixture.
- Preserve the earlier dotted-import prefix searchability improvement.

## Verification
- `dotnet test CodeIndex.sln --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Python_ExpandsDottedImportPrefixesForSearchability|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsPythonDottedImportPrefixes"`
- `dotnet test CodeIndex.sln --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Python_IndexesAllExportsFromInitModules|FullyQualifiedName~QueryCommandRunnerTests.RunSearchAndSymbols_ExactQueriesSeePythonInitAllExports"`
- `dotnet test CodeIndex.sln`

## Follow-up candidates
- None from PR #1252; its follow-up items are addressed here.