### PR TITLE
Update README language count

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cdidx deps --path src/           # File-level dependency graph
 cdidx mcp                        # Start MCP server for AI tools
 ```
 
-63 languages supported. 24 MCP tools. Incremental updates. Zero config.
+78 languages supported. 24 MCP tools. Incremental updates. Zero config.
 
 - **Docs**: [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for architecture, AI response details, and release workflow
 - **AI dev contract**: [SELF_IMPROVEMENT.md](SELF_IMPROVEMENT.md)
@@ -1041,7 +1041,7 @@ cdidx deps --path src/           # ファイル間依存グラフ
 cdidx mcp                        # AIツール向けMCPサーバー起動
 ```
 
-46言語対応。24 MCPツール。インクリメンタル更新。設定不要。
+78言語対応。24 MCPツール。インクリメンタル更新。設定不要。
 
 - **ドキュメント**: [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) アーキテクチャ、AI応答の詳細、リリース手順
 - **AI開発規約**: [SELF_IMPROVEMENT.md](SELF_IMPROVEMENT.md)

--- a/changelog.d/unreleased/+readme-language-count.fixed.md
+++ b/changelog.d/unreleased/+readme-language-count.fixed.md
@@ -1,0 +1,13 @@
+---
+category: fixed
+affected:
+  - README.md
+---
+
+## English
+
+- Updated the README's language-support summary to match the current `cdidx languages` output.
+
+## 日本語
+
+- README の言語サポート概要を、現在の `cdidx languages` の出力に合わせて更新しました。


### PR DESCRIPTION
Summary:
- Updated the README's language-support summary in English and Japanese to match the current `cdidx languages` output.
- Added a bilingual changelog fragment for the documentation update.

Validation:
- dotnet build CodeIndex.sln
- dotnet test CodeIndex.sln -c Release
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files README.md changelog.d/unreleased/+readme-language-count.fixed.md --json

Review:
- No blocking/actionable issues found.