### PR TITLE
Parse nested Swift extension targets

### DIFF
--- a/changelog.d/unreleased/+swift-extension-parser.fixed.md
+++ b/changelog.d/unreleased/+swift-extension-parser.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Swift extension target parsing now handles nested generics and conformances** — `symbols` and `search` now keep `extension Foo<Bar<Baz>>: Protocol where ...` indexed under the concrete extension target instead of relying on a brittle line regex.
+
+## 日本語
+
+- **Swift の extension target 解析がネストした generic と conformance を扱えるようになりました** — `symbols` / `search` が `extension Foo<Bar<Baz>>: Protocol where ...` のような宣言を、壊れやすい行単位 regex ではなく具体的な extension target として索引化します。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1240,12 +1240,12 @@ public static class SymbolExtractor
             new("typealias", new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*typealias\s+(?<name>\w+)(?:\s*<[^=]+>)?\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("property", new Regex(@"^\s*(?<visibility>(?:public|private|internal|open|fileprivate|package)(?:\s*\(\s*set\s*\))?)?\s*(?:(?:lazy|weak|unowned|final|static|class|nonisolated)\s+)*(?:let|var)\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Extension declarations are important search anchors in Swift-heavy codebases.
-            // Generic specializations such as `extension Array<String> where ...` should stay searchable
-            // under the concrete target, not just the base type name.
+            // A dedicated parser keeps nested generic targets searchable even when the
+            // extension also carries protocol conformances or `where` clauses.
             // extension 宣言は Swift コード検索における重要なアンカー。
-            // `extension Array<String> where ...` のような generic specialization も、
-            // base type 名だけでなく具体的な対象として検索可能にする。
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final)\s+)?extension\s+(?<name>[\w.]+(?:\s*<[^{}\r\n]+>)?)(?=\s*(?:where\b|\{|\s*$))", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // 専用パーサにより、protocol conformance や `where` 句が付く場合でも
+            // ネストした generic target を検索対象として維持する。
+            new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final)\s+)?extension\s+(?<name>[^\r\n{]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // actor (Swift 5.5+) / アクター
             new("class",    new Regex(@"^\s*(?<visibility>public|private|internal|open|fileprivate|package)?\s*(?:(?:final|distributed)\s+)*(?:class|actor)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Type alias / 型エイリアス: backtick-escaped names and generic/where clauses.
@@ -23576,6 +23576,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
             "cobol" => NormalizeCobolSymbolName(name),
             "fsharp" => NormalizeFSharpSymbolName(name),
             "kotlin" => NormalizeKotlinSymbolName(name, matchLine),
+            "swift" => NormalizeSwiftSymbolName(name),
             "sql" => NormalizeSqlSymbolName(name),
             _ => name,
         };
@@ -23912,6 +23913,119 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
             || string.Equals(trimmedName, "companion object", StringComparison.Ordinal)
             ? "Companion"
             : name;
+    }
+
+    private static string NormalizeSwiftSymbolName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return name;
+
+        var trimmed = name.Trim();
+        if (trimmed.IndexOf('<') < 0
+            && trimmed.IndexOf(':') < 0
+            && trimmed.IndexOf("where", StringComparison.Ordinal) < 0
+            && trimmed.IndexOf('/') < 0)
+        {
+            return trimmed;
+        }
+
+        var builder = new StringBuilder(trimmed.Length);
+        var angleDepth = 0;
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        var inBackticks = false;
+
+        for (var index = 0; index < trimmed.Length; index++)
+        {
+            var ch = trimmed[index];
+
+            if (inBackticks)
+            {
+                builder.Append(ch);
+                if (ch == '`')
+                    inBackticks = false;
+                continue;
+            }
+
+            if (ch == '`')
+            {
+                builder.Append(ch);
+                inBackticks = true;
+                continue;
+            }
+
+            if (angleDepth == 0 && parenDepth == 0 && bracketDepth == 0)
+            {
+                if (ch == ':' || ch == '{')
+                    break;
+
+                if (ch == '/' && index + 1 < trimmed.Length)
+                {
+                    var next = trimmed[index + 1];
+                    if (next == '/' || next == '*')
+                        break;
+                }
+
+                if (char.IsWhiteSpace(ch))
+                {
+                    var nextIndex = index + 1;
+                    while (nextIndex < trimmed.Length && char.IsWhiteSpace(trimmed[nextIndex]))
+                        nextIndex++;
+
+                    if (nextIndex >= trimmed.Length)
+                        break;
+
+                    if (trimmed[nextIndex] == ':'
+                        || trimmed[nextIndex] == '{'
+                        || (trimmed[nextIndex] == '/' && nextIndex + 1 < trimmed.Length && trimmed[nextIndex + 1] is '/' or '*')
+                        || StartsWithWord(trimmed, nextIndex, "where"))
+                    {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if (StartsWithWord(trimmed, index, "where"))
+                    break;
+            }
+
+            switch (ch)
+            {
+                case '<':
+                    angleDepth++;
+                    builder.Append(ch);
+                    break;
+                case '>':
+                    if (angleDepth > 0)
+                        angleDepth--;
+                    builder.Append(ch);
+                    break;
+                case '(':
+                    parenDepth++;
+                    builder.Append(ch);
+                    break;
+                case ')':
+                    if (parenDepth > 0)
+                        parenDepth--;
+                    builder.Append(ch);
+                    break;
+                case '[':
+                    bracketDepth++;
+                    builder.Append(ch);
+                    break;
+                case ']':
+                    if (bracketDepth > 0)
+                        bracketDepth--;
+                    builder.Append(ch);
+                    break;
+                default:
+                    builder.Append(ch);
+                    break;
+            }
+        }
+
+        return builder.ToString().Trim();
     }
 
     private static string NormalizeCobolSymbolName(string name)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12444,6 +12444,18 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsNestedGenericExtensionTargetsWithConformance()
+    {
+        var content = """
+            extension Foundation.Dictionary<String, Array<Int>>: Sendable where Value == Int {
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Foundation.Dictionary<String, Array<Int>>");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsInitDeinitSubscriptStoredPropertyAndAssociatedType()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Replace the Swift extension target extraction regex with a small parser that preserves nested generic targets
- Keep Swift extension symbols searchable when the declaration includes protocol conformances or `where` clauses
- Add regression coverage for nested generic extension targets
- Add a changelog fragment under `changelog.d/unreleased/`

## Follow-up from #1251
- This PR implements the follow-up candidate noted in PR #1251: Swift extension target extraction was still regex-based, so nested generic targets and conformances could be mishandled.

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter Extract_Swift`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`