### PR TITLE
Support platform flags in Dockerfile search

### DIFF
--- a/changelog.d/unreleased/+dockerfile-platform-flags.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-platform-flags.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Dockerfile stage search now handles `FROM --platform=...` lines** — `cdidx` now recognizes named stages and base images when a Dockerfile `FROM` instruction includes a platform flag, so searches and dependency references stay accurate for modern multi-stage builds.
+
+## 日本語
+
+- **Dockerfile の stage 検索が `FROM --platform=...` 行に対応しました** — Dockerfile の `FROM` 命令に platform フラグが付いていても、`cdidx` が名前付き stage と base image を正しく認識するため、現代的な multi-stage build でも検索結果と依存参照の精度が保たれます。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -40,7 +40,7 @@ public static class ReferenceExtractor
         RegexOptions.Compiled);
 
     private static readonly Regex DockerfileStageReferenceRegex = new(
-        @"^\s*FROM\s+(?<name>\w+)\s+AS\s+\w+\s*$",
+        @"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\w+)\s+AS\s+\w+\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex DockerfileCopyFromReferenceRegex = new(

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1394,8 +1394,8 @@ public static class SymbolExtractor
         ["dockerfile"] =
         [
             new("property", new Regex(@"^\s*ARG\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("function", new Regex(@"^\s*FROM\s+\S+\s+(?:AS|as)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),  // Named stage / 名前付きステージ
-            new("class",    new Regex(@"^\s*FROM\s+(?<name>\S+)", RegexOptions.Compiled), BodyStyle.None),  // Base image / ベースイメージ
+            new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),  // Named stage / 名前付きステージ
+            new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled), BodyStyle.None),  // Base image / ベースイメージ
         ],
         ["protobuf"] =
         [

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -669,6 +669,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileFromStageReferences_IndexPlatformFlaggedStages()
+    {
+        const string content = """
+            FROM golang:1.21 AS builder
+
+            FROM --platform=$BUILDPLATFORM builder AS final
+            COPY --from=builder /src/app /usr/local/bin/app
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Equal(2, references.Count(reference =>
+            reference.SymbolName == "builder"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -17186,6 +17186,22 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
+    {
+        var content = """
+            FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
+            FROM --platform=linux/amd64 alpine:3.20
+            """;
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "builder");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "alpine:3.20");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "--platform=$BUILDPLATFORM");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "golang:1.22");
+        Assert.Equal(2, symbols.Count);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsBuildArgs()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Teach Dockerfile symbol extraction to recognize `FROM --platform=...` lines for both named stages and base images.
- Teach Dockerfile stage reference extraction to resolve platform-flagged `FROM` stage transitions.
- Add targeted tests covering the new Dockerfile forms.
- Add a bilingual changelog fragment at `changelog.d/unreleased/+dockerfile-platform-flags.fixed.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SymbolExtractorTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ReferenceExtractorTests`

## Changelog

- `changelog.d/unreleased/+dockerfile-platform-flags.fixed.md`

## Follow-up candidates

- Broaden Dockerfile keyword handling to cover lowercase instruction forms such as `from` and `as` if that becomes important for real-world input.
- Consider whether additional Dockerfile instructions, such as `ENV`, should also be indexed as searchable symbols.