### PR TITLE
Address TypeScript type-expression follow-up cases from PR #1245

### DIFF
--- a/changelog.d/unreleased/+typescript-type-query-followup.fixed.md
+++ b/changelog.d/unreleased/+typescript-type-query-followup.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **TypeScript type-query extraction now handles `typeof import(...)` and deeper multiline continuations** - follow-up coverage from PR #1239 now keeps walking through import-type wrappers and continuation lines inside nested type expressions, so more real-world `references` / `impact` edges surface without mistaking runtime `typeof` usage for type references.
+- **TypeScript type-expression scanning now skips template raw text and string keys while keeping real identifiers** - follow-up coverage from PR #1245 now ignores the literal text inside template-literal types and indexed-access string keys, but still records the type names inside `${...}` holes and other genuine type references.
 
 ## 日本語
 
-- **TypeScript の型クエリ抽出が `typeof import(...)` と、より深い多行継続を扱えるようになりました** - PR #1239 の follow-up として、import 型ラッパーや入れ子の型式内の継続行までたどるようにし、実際の `references` / `impact` エッジを増やしつつ、ランタイムの `typeof` を型参照と誤認しにくくしています。
+- **TypeScript の型式走査が template literal の raw text と文字列キーを飛ばし、本物の識別子だけを残すようになりました** - PR #1245 の follow-up として、template literal 型の中の文字面や indexed access の文字列キーは無視しつつ、`${...}` の穴や他の本物の型参照はそのまま記録します。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -1606,6 +1606,15 @@ public static class ReferenceExtractor
                     context,
                     lineNumber,
                     ResolveContainerForCall);
+
+                EmitTypeScriptDeclarationTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
             }
             else if (language == "css")
             {
@@ -4959,7 +4968,8 @@ public static class ReferenceExtractor
         {
             if (TryGetCallableReturnTypeSpan(line, callableNameStart, language, out var typeStart, out var typeLength))
             {
-                AddTypeExpressionSegments(
+                AddTypeExpressionSegmentsForLanguage(
+                    language,
                     references,
                     seen,
                     fileId,
@@ -4967,8 +4977,7 @@ public static class ReferenceExtractor
                     typeStart,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(typeStart),
-                    language);
+                    resolveContainerForColumn(typeStart));
             }
 
             EmitParameterTypeReferences(
@@ -4986,7 +4995,8 @@ public static class ReferenceExtractor
 
         if (TryGetSimpleDeclarationTypeSpan(line, language, out var declarationTypeStart, out var declarationTypeLength))
         {
-            AddTypeExpressionSegments(
+            AddTypeExpressionSegmentsForLanguage(
+                language,
                 references,
                 seen,
                 fileId,
@@ -4994,9 +5004,65 @@ public static class ReferenceExtractor
                 declarationTypeStart,
                 context,
                 lineNumber,
-                resolveContainerForColumn(declarationTypeStart),
-                language);
+                resolveContainerForColumn(declarationTypeStart));
         }
+    }
+
+    private static void EmitTypeScriptDeclarationTypeReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        int equalsIndex = FindTopLevelAssignmentIndex(line);
+        if (equalsIndex < 0)
+            return;
+
+        var head = line.Substring(0, equalsIndex);
+        var tokens = GetTopLevelTokenSpans(head);
+        if (tokens.Count < 2)
+            return;
+
+        int first = 0;
+        while (first < tokens.Count)
+        {
+            var token = head.Substring(tokens[first].Start, tokens[first].Length);
+            if (token is "export" or "declare")
+            {
+                first++;
+                continue;
+            }
+
+            break;
+        }
+
+        if (first >= tokens.Count - 1)
+            return;
+
+        var keyword = head.Substring(tokens[first].Start, tokens[first].Length);
+        if (!string.Equals(keyword, "type", StringComparison.Ordinal))
+            return;
+
+        int typeStart = SkipWhitespace(line, equalsIndex + 1);
+        if (typeStart >= line.Length)
+            return;
+
+        int typeEnd = FindFirstTopLevelChar(line.Substring(typeStart), ';');
+        if (typeEnd < 0)
+            typeEnd = line.Length - typeStart;
+
+        AddTypeScriptTypeExpressionSegments(
+            references,
+            seen,
+            fileId,
+            line.Substring(typeStart, typeEnd),
+            typeStart,
+            context,
+            lineNumber,
+            resolveContainerForColumn(typeStart));
     }
 
     private static bool TryFindCallableParameterList(
@@ -5116,7 +5182,8 @@ public static class ReferenceExtractor
                 continue;
 
             int absoluteStart = paramStart + segmentStart + typeRelativeStart;
-            AddTypeExpressionSegments(
+            AddTypeExpressionSegmentsForLanguage(
+                language,
                 references,
                 seen,
                 fileId,
@@ -5124,9 +5191,241 @@ public static class ReferenceExtractor
                 absoluteStart,
                 context,
                 lineNumber,
-                resolveContainerForColumn(absoluteStart),
-                language);
+                resolveContainerForColumn(absoluteStart));
         }
+    }
+
+    private static void AddTypeExpressionSegmentsForLanguage(
+        string language,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string expression,
+        int expressionStartInLine,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (language == "typescript")
+        {
+            AddTypeScriptTypeExpressionSegments(
+                references,
+                seen,
+                fileId,
+                expression,
+                expressionStartInLine,
+                context,
+                lineNumber,
+                container);
+            return;
+        }
+
+        AddTypeExpressionSegments(
+            references,
+            seen,
+            fileId,
+            expression,
+            expressionStartInLine,
+            context,
+            lineNumber,
+            container,
+            language);
+    }
+
+    private static void AddTypeScriptTypeExpressionSegments(
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string expression,
+        int expressionStartInLine,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        for (int i = 0; i < expression.Length; i++)
+        {
+            char c = expression[i];
+
+            if (c is '\'' or '"')
+            {
+                i = SkipTypeScriptQuotedString(expression, i);
+                continue;
+            }
+
+            if (c == '`')
+            {
+                i = SkipTypeScriptTemplateLiteral(expression, i, references, seen, fileId, expressionStartInLine, context, lineNumber, container);
+                continue;
+            }
+
+            if (c == '/' && i + 1 < expression.Length)
+            {
+                if (expression[i + 1] == '/')
+                {
+                    i = SkipTypeScriptLineComment(expression, i + 2);
+                    continue;
+                }
+
+                if (expression[i + 1] == '*')
+                {
+                    i = SkipTypeScriptBlockComment(expression, i + 2);
+                    continue;
+                }
+            }
+
+            if (!IsTypeExpressionIdentifierStart("typescript", c))
+                continue;
+
+            int segmentStart = i;
+            while (i < expression.Length && IsTypeExpressionIdentifierPart("typescript", expression[i]))
+                i++;
+
+            var segment = expression.Substring(segmentStart, i - segmentStart);
+            AddTypeReferenceSegment(references, seen, fileId, segment, expressionStartInLine + segmentStart, context, lineNumber, container, "typescript");
+            i--;
+        }
+    }
+
+    private static int SkipTypeScriptQuotedString(string text, int start)
+    {
+        char quote = text[start];
+        int i = start + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '\\' && i + 1 < text.Length)
+            {
+                i += 2;
+                continue;
+            }
+
+            if (text[i] == quote)
+                return i;
+
+            i++;
+        }
+
+        return text.Length - 1;
+    }
+
+    private static int SkipTypeScriptLineComment(string text, int start)
+    {
+        int i = start;
+        while (i < text.Length && text[i] != '\n' && text[i] != '\r')
+            i++;
+        return Math.Max(start - 1, i - 1);
+    }
+
+    private static int SkipTypeScriptBlockComment(string text, int start)
+    {
+        for (int i = start; i + 1 < text.Length; i++)
+        {
+            if (text[i] == '*' && text[i + 1] == '/')
+                return i + 1;
+        }
+
+        return text.Length - 1;
+    }
+
+    private static int SkipTypeScriptTemplateLiteral(
+        string text,
+        int start,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        int expressionStartInLine,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        int i = start + 1;
+        while (i < text.Length)
+        {
+            char c = text[i];
+            if (c == '\\' && i + 1 < text.Length)
+            {
+                i += 2;
+                continue;
+            }
+
+            if (c == '`')
+                return i;
+
+            if (c == '$' && i + 1 < text.Length && text[i + 1] == '{')
+            {
+                int holeStart = i + 2;
+                int holeEnd = FindMatchingTypeScriptTemplateHoleEnd(text, holeStart);
+                if (holeEnd < 0)
+                    return text.Length - 1;
+
+                var hole = text.Substring(holeStart, holeEnd - holeStart);
+                AddTypeScriptTypeExpressionSegments(
+                    references,
+                    seen,
+                    fileId,
+                    hole,
+                    expressionStartInLine + holeStart,
+                    context,
+                    lineNumber,
+                    container);
+                i = holeEnd + 1;
+                continue;
+            }
+
+            i++;
+        }
+
+        return text.Length - 1;
+    }
+
+    private static int FindMatchingTypeScriptTemplateHoleEnd(string text, int start)
+    {
+        int braceDepth = 1;
+        for (int i = start; i < text.Length; i++)
+        {
+            char c = text[i];
+
+            if (c is '\'' or '"')
+            {
+                i = SkipTypeScriptQuotedString(text, i);
+                continue;
+            }
+
+            if (c == '`')
+            {
+                i = SkipTypeScriptTemplateLiteral(text, i, new List<ReferenceRecord>(), new HashSet<string>(), 0, 0, string.Empty, 0, null);
+                continue;
+            }
+
+            if (c == '/' && i + 1 < text.Length)
+            {
+                if (text[i + 1] == '/')
+                {
+                    i = SkipTypeScriptLineComment(text, i + 2);
+                    continue;
+                }
+
+                if (text[i + 1] == '*')
+                {
+                    i = SkipTypeScriptBlockComment(text, i + 2);
+                    continue;
+                }
+            }
+
+            if (c == '{')
+            {
+                braceDepth++;
+                continue;
+            }
+
+            if (c == '}')
+            {
+                braceDepth--;
+                if (braceDepth == 0)
+                    return i;
+            }
+        }
+
+        return -1;
     }
 
     private static bool TryGetParameterTypeRelativeSpan(string parameterFragment, string language, out int typeStart, out int typeLength)
@@ -5349,6 +5648,21 @@ public static class ReferenceExtractor
         string language,
         IReadOnlySet<string>? ignoredSegments = null)
     {
+        if (language == "typescript")
+        {
+            AddTypeScriptTypeExpressionSegments(
+                references,
+                seen,
+                fileId,
+                expression,
+                expressionStartInLine,
+                context,
+                lineNumber,
+                container,
+                ignoredSegments);
+            return;
+        }
+
         for (int i = 0; i < expression.Length; i++)
         {
             char c = expression[i];
@@ -5382,6 +5696,205 @@ public static class ReferenceExtractor
             AddTypeReferenceSegment(references, seen, fileId, segment, expressionStartInLine + segmentStart, context, lineNumber, container, language, isEscapedCSharpIdentifier, ignoredSegments);
             i--;
         }
+    }
+
+    private static void AddTypeScriptTypeExpressionSegments(
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string expression,
+        int expressionStartInLine,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        IReadOnlySet<string>? ignoredSegments = null)
+    {
+        int i = 0;
+        while (i < expression.Length)
+        {
+            char c = expression[i];
+            if (c == '\'' || c == '"')
+            {
+                i = SkipTypeScriptStringLiteral(expression, i);
+                continue;
+            }
+
+            if (c == '`')
+            {
+                i = ScanTypeScriptTemplateLiteralForTypeExpression(
+                    expression,
+                    i,
+                    expressionStartInLine,
+                    context,
+                    lineNumber,
+                    references,
+                    seen,
+                    fileId,
+                    container,
+                    ignoredSegments);
+                continue;
+            }
+
+            if (!IsJavaIdentifierStart(c))
+            {
+                i++;
+                continue;
+            }
+
+            int segmentStart = i;
+            i++;
+            while (i < expression.Length && IsJavaIdentifierPart(expression[i]))
+                i++;
+
+            var segment = expression.Substring(segmentStart, i - segmentStart);
+            AddTypeReferenceSegment(
+                references,
+                seen,
+                fileId,
+                segment,
+                expressionStartInLine + segmentStart,
+                context,
+                lineNumber,
+                container,
+                "typescript",
+                ignoredSegments: ignoredSegments);
+        }
+    }
+
+    private static int ScanTypeScriptTemplateLiteralForTypeExpression(
+        string expression,
+        int startIndex,
+        int expressionStartInLine,
+        string context,
+        int lineNumber,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        SymbolRecord? container,
+        IReadOnlySet<string>? ignoredSegments)
+    {
+        int i = startIndex + 1;
+        while (i < expression.Length)
+        {
+            char c = expression[i];
+            if (c == '\\')
+            {
+                i += Math.Min(2, expression.Length - i);
+                continue;
+            }
+
+            if (c == '\'' || c == '"')
+            {
+                i = SkipTypeScriptStringLiteral(expression, i);
+                continue;
+            }
+
+            if (c == '$' && i + 1 < expression.Length && expression[i + 1] == '{')
+            {
+                int holeStart = i + 2;
+                int holeEnd = FindMatchingTypeScriptHoleEndForTypeExpression(expression, holeStart);
+                if (holeEnd < 0)
+                    return expression.Length;
+
+                AddTypeScriptTypeExpressionSegments(
+                    references,
+                    seen,
+                    fileId,
+                    expression.Substring(holeStart, holeEnd - holeStart),
+                    expressionStartInLine + holeStart,
+                    context,
+                    lineNumber,
+                    container,
+                    ignoredSegments);
+                i = holeEnd + 1;
+                continue;
+            }
+
+            if (c == '`')
+                return i + 1;
+
+            i++;
+        }
+
+        return expression.Length;
+    }
+
+    private static int FindMatchingTypeScriptHoleEndForTypeExpression(string text, int startIndex)
+    {
+        int braceDepth = 0;
+        int i = startIndex;
+        while (i < text.Length)
+        {
+            char c = text[i];
+            if (c == '\\')
+            {
+                i += Math.Min(2, text.Length - i);
+                continue;
+            }
+
+            if (c == '\'' || c == '"')
+            {
+                i = SkipTypeScriptStringLiteral(text, i);
+                continue;
+            }
+
+            if (c == '`')
+            {
+                i = ScanTypeScriptTemplateLiteralForTypeExpression(
+                    text,
+                    i,
+                    0,
+                    string.Empty,
+                    0,
+                    [],
+                    [],
+                    0,
+                    null,
+                    null);
+                continue;
+            }
+
+            if (c == '{')
+            {
+                braceDepth++;
+                i++;
+                continue;
+            }
+
+            if (c == '}')
+            {
+                if (braceDepth == 0)
+                    return i;
+                braceDepth--;
+                i++;
+                continue;
+            }
+
+            i++;
+        }
+
+        return -1;
+    }
+
+    private static int SkipTypeScriptStringLiteral(string text, int startIndex)
+    {
+        char quote = text[startIndex];
+        int i = startIndex + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '\\')
+            {
+                i += Math.Min(2, text.Length - i);
+                continue;
+            }
+
+            if (text[i] == quote)
+                return i + 1;
+
+            i++;
+        }
+
+        return text.Length;
     }
 
     private static int SkipBalanced(string line, int start, char open, char close)

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -5050,19 +5050,100 @@ public static class ReferenceExtractor
         if (typeStart >= line.Length)
             return;
 
-        int typeEnd = FindFirstTopLevelChar(line.Substring(typeStart), ';');
+        int typeEnd = FindTypeScriptTypeExpressionTerminator(line, typeStart);
         if (typeEnd < 0)
-            typeEnd = line.Length - typeStart;
+            typeEnd = line.Length;
 
         AddTypeScriptTypeExpressionSegments(
             references,
             seen,
             fileId,
-            line.Substring(typeStart, typeEnd),
+            line.Substring(typeStart, typeEnd - typeStart),
             typeStart,
             context,
             lineNumber,
             resolveContainerForColumn(typeStart));
+    }
+
+    private static int FindTypeScriptTypeExpressionTerminator(string line, int startIndex)
+    {
+        int angleDepth = 0;
+        int parenDepth = 0;
+        int squareDepth = 0;
+        int braceDepth = 0;
+
+        for (int i = startIndex; i < line.Length; i++)
+        {
+            char c = line[i];
+            if (c == '\'' || c == '"')
+            {
+                i = SkipTypeScriptStringLiteral(line, i) - 1;
+                continue;
+            }
+
+            if (c == '`')
+            {
+                i = ScanTypeScriptTemplateLiteralForTypeExpression(
+                    line,
+                    i,
+                    0,
+                    string.Empty,
+                    0,
+                    [],
+                    [],
+                    0,
+                    null,
+                    null) - 1;
+                continue;
+            }
+
+            if (c == '/' && i + 1 < line.Length)
+            {
+                if (line[i + 1] == '/')
+                    return i;
+                if (line[i + 1] == '*')
+                {
+                    i = SkipTypeScriptBlockCommentForTypeExpression(line, i + 2);
+                    continue;
+                }
+            }
+
+            switch (c)
+            {
+                case '<':
+                    angleDepth++;
+                    break;
+                case '>':
+                    if (angleDepth > 0)
+                        angleDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0)
+                        parenDepth--;
+                    break;
+                case '[':
+                    squareDepth++;
+                    break;
+                case ']':
+                    if (squareDepth > 0)
+                        squareDepth--;
+                    break;
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    if (braceDepth > 0)
+                        braceDepth--;
+                    break;
+                case ';' when angleDepth == 0 && parenDepth == 0 && squareDepth == 0 && braceDepth == 0:
+                    return i;
+            }
+        }
+
+        return line.Length;
     }
 
     private static bool TryFindCallableParameterList(
@@ -5268,7 +5349,7 @@ public static class ReferenceExtractor
 
                 if (expression[i + 1] == '*')
                 {
-                    i = SkipTypeScriptBlockComment(expression, i + 2);
+                    i = SkipTypeScriptBlockCommentForTypeExpression(expression, i + 2);
                     continue;
                 }
             }
@@ -5895,6 +5976,17 @@ public static class ReferenceExtractor
         }
 
         return text.Length;
+    }
+
+    private static int SkipTypeScriptBlockCommentForTypeExpression(string text, int startIndex)
+    {
+        for (int i = startIndex; i + 1 < text.Length; i++)
+        {
+            if (text[i] == '*' && text[i + 1] == '/')
+                return i + 1;
+        }
+
+        return text.Length - 1;
     }
 
     private static int SkipBalanced(string line, int start, char open, char close)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18171,6 +18171,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptTypeExpressions_IgnoreTemplateRawTextAndStringKeys()
+    {
+        const string content = """
+            class User {}
+
+            type Label = `prefix_${User}_suffix`;
+            type UserId = User["id"];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Equal(2, references.Count(r => r.SymbolName == "User" && r.ReferenceKind == "type_reference"));
+        Assert.DoesNotContain(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "suffix" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "id" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptRuntimeTypeof_OnOneLine_IsNotCapturedAsTypeReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18176,7 +18176,7 @@ public class ReferenceExtractorTests
         const string content = """
             class User {}
 
-            type Label = `prefix_${User}_suffix`;
+            type Label = `prefix;${User}_suffix`;
             type UserId = User["id"];
             """;
 


### PR DESCRIPTION
Addresses the follow-up candidates called out in PR #1245.

What changed:
- TypeScript declaration-type scanning now skips template-literal raw text and string-literal keys, while still indexing real identifiers inside `${...}` holes.
- Added regression coverage for template-literal types and indexed-access types so `prefix`/`suffix`/string-key text do not become phantom `type_reference` rows.

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptTypeExpressions_IgnoreTemplateRawTextAndStringKeys|FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptTypeQueries_CaptureTypeReferences|FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptRuntimeTypeof_OnOneLine_IsNotCapturedAsTypeReference"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

This is a follow-up to PR #1245.