### PR TITLE
Address shell alias follow-ups

### DIFF
--- a/changelog.d/unreleased/+shell-alias-followups.fixed.md
+++ b/changelog.d/unreleased/+shell-alias-followups.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Shell alias follow-up coverage now includes hyphenated names and zsh global aliases** — shell alias definitions now accept hyphenated names, command-style lookup recognizes those aliases, and zsh `alias -g` uses are indexed even when they appear outside command-head positions.
+
+## 日本語
+
+- **Shell alias のフォローアップ対応として、ハイフン入り名と zsh の global alias を扱えるようになりました** — shell の alias 定義でハイフン入りの名前を許可し、コマンド構文の lookup でもその alias を認識するようにしました。さらに zsh の `alias -g` は command-head 以外の位置でもインデックスされます。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -486,7 +486,7 @@ public static class ReferenceExtractor
     // は末尾 `(` を持たないため、共通 CallRegex では拾えない。bare command head に限定し、
     // さらに現在ファイルで定義された function 名だけを参照として出す。
     private static readonly Regex ShellCommandCallRegex = new(
-        @"(?:^\s*(?!(?:if|then|do|else|elif|while|until|time|fi)\b)|[|;&{]\s*|&&\s*|\|\|\s*|!\s+|\b(?:if|then|do|else|elif|while|until|time)\s+)(?<name>[A-Za-z_]\w*)(?=\s|$|[;|&}])",
+        @"(?:^\s*(?!(?:if|then|do|else|elif|while|until|time|fi)\b)|[|;&{]\s*|&&\s*|\|\|\s*|!\s+|\b(?:if|then|do|else|elif|while|until|time)\s+)(?<name>[A-Za-z_][A-Za-z0-9_-]*)(?=\s|$|[;|&}])",
         RegexOptions.Compiled);
     // SQL stored-procedure call without parentheses: T-SQL `EXEC` / `EXECUTE` and MySQL / MariaDB `CALL`.
     // The shared CallRegex requires a trailing `(`, which misses the dominant real-world form such as
@@ -1185,6 +1185,7 @@ public static class ReferenceExtractor
         var callableDefinitionNames = BuildCallableDefinitionNames(language, symbols);
         var dockerfileStageNames = BuildDockerfileStageNames(language, symbols);
         var shellCallableNames = BuildShellCallableNames(language, symbols);
+        var shellGlobalAliasNames = BuildShellGlobalAliasNames(language, symbols);
         var csharpUsingAliases = BuildCSharpUsingAliases(language, symbols, csharpKnownTypeNames);
         var csharpUsingStatics = BuildCSharpUsingStatics(language, symbols);
         var csharpValueReceiverNames = BuildCSharpValueReceiverNamesByContainingType(language, symbols);
@@ -2332,6 +2333,33 @@ public static class ReferenceExtractor
 
                     var callIndex = match.Groups["name"].Index;
                     AddCallLikeReference(name, callIndex);
+                }
+
+                if (shellGlobalAliasNames != null && shellGlobalAliasNames.Count > 0)
+                {
+                    var trimmedPreparedLine = preparedLine.TrimStart();
+                    if (!trimmedPreparedLine.StartsWith("alias", StringComparison.Ordinal))
+                    {
+                        foreach (var aliasName in shellGlobalAliasNames)
+                        {
+                            var searchIndex = 0;
+                            while (searchIndex < preparedLine.Length)
+                            {
+                                var aliasIndex = preparedLine.IndexOf(aliasName, searchIndex, StringComparison.Ordinal);
+                                if (aliasIndex < 0)
+                                    break;
+
+                                if (!IsShellGlobalAliasReferenceBoundary(preparedLine, aliasIndex, aliasName.Length))
+                                {
+                                    searchIndex = aliasIndex + aliasName.Length;
+                                    continue;
+                                }
+
+                                AddCallLikeReference(aliasName, aliasIndex);
+                                searchIndex = aliasIndex + aliasName.Length;
+                            }
+                        }
+                    }
                 }
             }
             else
@@ -6416,6 +6444,30 @@ public static class ReferenceExtractor
         return names;
     }
 
+    private static HashSet<string>? BuildShellGlobalAliasNames(string language, IReadOnlyList<SymbolRecord> symbols)
+    {
+        if (language != "shell")
+            return null;
+
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Kind != "alias" || string.IsNullOrWhiteSpace(symbol.Name))
+                continue;
+
+            var signature = symbol.Signature?.TrimStart();
+            if (string.IsNullOrWhiteSpace(signature))
+                continue;
+
+            if (!Regex.IsMatch(signature, @"^alias(?:\s+-[^\s=]+)*\s+-g\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                continue;
+
+            names.Add(symbol.Name);
+        }
+
+        return names;
+    }
+
     private static HashSet<string>? BuildDockerfileStageNames(string language, IReadOnlyList<SymbolRecord> symbols)
     {
         if (language != "dockerfile")
@@ -6432,6 +6484,21 @@ public static class ReferenceExtractor
 
         return names;
     }
+
+    private static bool IsShellGlobalAliasReferenceBoundary(string text, int startIndex, int length)
+    {
+        if (startIndex < 0 || length <= 0 || startIndex + length > text.Length)
+            return false;
+
+        if (startIndex > 0 && !IsShellGlobalAliasBoundarySeparator(text[startIndex - 1]))
+            return false;
+
+        var endIndex = startIndex + length;
+        return endIndex >= text.Length || IsShellGlobalAliasBoundarySeparator(text[endIndex]);
+    }
+
+    private static bool IsShellGlobalAliasBoundarySeparator(char ch) =>
+        char.IsWhiteSpace(ch) || ch is '|' or ';' or '&' or '{' or '}' or '(' or ')' or '!';
 
     private static bool IsCSharpUsingAliasTypeTarget(string targetQualifiedName, IReadOnlySet<string> csharpKnownTypeNames)
     {

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1415,7 +1415,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*(?:function\s+)?(?<name>\w+)\s*\(\s*\)\s*\{?", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*function\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             // Alias definitions / エイリアス定義
-            new("alias", new Regex(@"^\s*alias(?:\s+-[^\s=]+)*\s+(?<name>[A-Za-z_]\w*)\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("alias", new Regex(@"^\s*alias(?:\s+-[^\s=]+)*\s+(?<name>[A-Za-z_][A-Za-z0-9_-]*)\s*=", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["sql"] =
         [

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -200,20 +200,27 @@ public class ReferenceExtractorTests
     {
         const string content = """
             alias ll='ls -la'
+            alias my-grep='grep -n'
             alias -g G='| grep'
 
             run() {
               ll /tmp
-              G pattern
+              my-grep needle
+              echo foo G bar
+              foo=G
             }
             """;
 
         var symbols = SymbolExtractor.Extract(1, "shell", content);
         var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
 
-        Assert.Equal(2, references.Count(reference => reference.ReferenceKind == "call"));
+        Assert.Equal(3, references.Count(reference => reference.ReferenceKind == "call"));
         Assert.Contains(references, reference =>
             reference.SymbolName == "ll"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "my-grep"
             && reference.ReferenceKind == "call"
             && reference.ContainerName == "run");
         Assert.Contains(references, reference =>

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9913,7 +9913,7 @@ public class SymbolExtractorTests
     }
 
     [Fact]
-    public void Extract_Shell_DetectsFunctions()
+    public void Extract_Shell_DetectsFunctionsAndAliases()
     {
         var content = """
             function setup() {
@@ -9925,6 +9925,7 @@ public class SymbolExtractorTests
             }
 
             alias ll='ls -la'
+            alias my-grep='grep -n'
             alias -g G='| grep'
             """;
         var symbols = SymbolExtractor.Extract(1, "shell", content);
@@ -9932,6 +9933,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "setup");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "cleanup");
         Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "ll");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "my-grep");
         Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "G");
     }
 


### PR DESCRIPTION
## Summary
- Address the follow-up candidates from PR #1248 by widening shell alias support to hyphenated alias names and zsh global aliases.
- Keep shell alias call coverage aligned with the new definition forms so `references` can find both command-head alias calls and non-command global alias usages.
- Add tests for hyphenated alias definitions, global alias call detection, and a negative assignment case.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter 'FullyQualifiedName~Extract_Shell_DetectsFunctionsAndAliases|FullyQualifiedName~Extract_Shell_DetectsAliasCalls'`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release`

## Changelog
- `changelog.d/unreleased/+shell-alias-followups.fixed.md`

## Follow-up candidates addressed
- Hyphenated shell alias names.
- zsh `alias -g` usage in non-command positions.

## Follow-up candidates
- Broader shell alias syntax beyond the patterns covered here, if we decide to index more exotic shell constructs later.