### PR TITLE
Index XAML DataType bindings

### DIFF
--- a/changelog.d/unreleased/+xaml-datatype.fixed.md
+++ b/changelog.d/unreleased/+xaml-datatype.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML `x:DataType` values are now indexed as class symbols** — markup that declares a binding context type can now surface the bound viewmodel or backing type in search results, making it easier to jump from XAML to the code that owns the data shape.
+
+## 日本語
+
+- **XAML の `x:DataType` が class シンボルとして索引化されるようになりました** — binding context の型を宣言した markup から、その viewmodel や backing type を検索結果に出せるようになり、XAML からデータ形状を持つコードへ辿りやすくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -143,6 +143,9 @@ public static class SymbolExtractor
     private static readonly Regex XamlClassRegex = new(
         @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlDataTypeRegex = new(
+        @"\bx:DataType\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex XamlNameRegex = new(
         @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -5368,6 +5371,23 @@ private sealed class RubyMaskState
             foreach (Match classMatch in XamlClassRegex.Matches(line))
             {
                 var value = classMatch.Groups["value"].Value.Trim();
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "class",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+
+            foreach (Match dataTypeMatch in XamlDataTypeRegex.Matches(line))
+            {
+                var value = NormalizeXamlKeyValue(dataTypeMatch.Groups["value"].Value);
                 if (value.Length == 0)
                     continue;
                 symbols.Add(new SymbolRecord

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19288,6 +19288,22 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesDataType()
+    {
+        var content = """
+            <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         x:DataType="{x:Type vm:MainViewModel}">
+                <Label Text="{Binding Title}" />
+            </ContentPage>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:MainViewModel");
+    }
+
+    [Fact]
     public void Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Addressed the follow-up candidates from PR #1255.
- Indexed XAML `x:DataType` values as `class` symbols so markup can surface the bound viewmodel or backing type in search results.
- Added regression coverage for `x:DataType` extraction.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesDataType|FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesCommonEventHandlers"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- No README or workflow docs changed; this is a non-breaking behavior improvement.
- Changelog fragment: `changelog.d/unreleased/+xaml-datatype.fixed.md`

## Follow-up candidates addressed

- This PR directly addresses the previous PR's request to explore deeper XAML navigation cues by indexing more markup-bound identifiers.
- Additional XAML binding patterns can be added later if we see recurring templates that still do not surface enough navigation targets.