### PR TITLE
Broaden batch jump parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ The database reflects the working tree at the time of the last index. After swit
 | MSBuild | `.csproj`, `.fsproj`, `.vbproj`, `.props`, `.targets` | -- |
 | Shell | `.sh`, `.bash`, `.zsh`, `.fish` | command-style function calls |
 | PowerShell | `.ps1`, `.psm1`, `.psd1` | function/filter (scope prefixes), configuration, workflow, class constructors/methods/properties, enum values, Import-Module, using module/namespace/assembly |
-| Batch | `.bat`, `.cmd` | labels + `goto`/`call` targets |
+| Batch | `.bat`, `.cmd` | labels + `goto`/`call` targets, including inline/chained control flow |
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 Query-time `--lang tsql` is accepted as an alias for the SQL bucket.
@@ -1634,7 +1634,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | MSBuild | `.csproj`, `.fsproj`, `.vbproj`, `.props`, `.targets` | -- |
 | Shell | `.sh`, `.bash`, `.zsh`, `.fish` | 関数のコマンド構文呼び出し |
 | PowerShell | `.ps1`, `.psm1`, `.psd1` | 関数/フィルタ（scope プレフィックス付き）、configuration、workflow、class、enum、Import-Module、using module/namespace/assembly |
-| Batch | `.bat`, `.cmd` | ラベル + `goto`/`call` ターゲット |
+| Batch | `.bat`, `.cmd` | ラベル + `goto`/`call` ターゲット、inline / chained な制御フローも含む |
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 クエリ時の `--lang tsql` は SQL バケットの別名として受け付けられます。

--- a/changelog.d/unreleased/+bat-inline-jumps.changed.md
+++ b/changelog.d/unreleased/+bat-inline-jumps.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Batch jump parsing now handles inline `if errorlevel` and chained commands** — batch reference extraction now recognizes `if errorlevel 1 goto :label` and chained forms such as `goto :A & call :B`, so multi-step control flow is visible to `references`, `callers`, `callees`, and `impact`.
+
+## 日本語
+
+- **Batch のジャンプ解析が inline の `if errorlevel` と連結コマンドに対応しました** — batch の参照抽出が `if errorlevel 1 goto :label` や `goto :A & call :B` のような形も認識するようになり、複数ステップの制御フローが `references` / `callers` / `callees` / `impact` から見えるようになりました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -15102,12 +15102,14 @@ public static class ReferenceExtractor
             trimmed.StartsWith("do ", StringComparison.OrdinalIgnoreCase) ||
             trimmed.Equals("do", StringComparison.OrdinalIgnoreCase))
         {
-            var spaceIndex = trimmed.IndexOf(' ');
-            if (spaceIndex < 0)
+            var keywordEnd = 0;
+            while (keywordEnd < trimmed.Length && !char.IsWhiteSpace(trimmed[keywordEnd]))
+                keywordEnd++;
+            while (keywordEnd < trimmed.Length && char.IsWhiteSpace(trimmed[keywordEnd]))
+                keywordEnd++;
+            if (keywordEnd >= trimmed.Length)
                 return;
-            trimmed = trimmed[(spaceIndex + 1)..].TrimStart();
-            if (trimmed.Length == 0)
-                return;
+            trimmed = trimmed[keywordEnd..].TrimStart();
         }
 
         var match = BatchJumpTargetRegex.Match(trimmed);

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -54,10 +54,14 @@ public static class ReferenceExtractor
         @"^\s*PERFORM\s+(?!(?:VARYING|UNTIL|WITH|TIMES|TEST|THRU|THROUGH)\b)(?<name>[A-Z0-9][A-Z0-9-]*)(?:\s+(?:THRU|THROUGH)\s+(?<end>[A-Z0-9][A-Z0-9-]*))?",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
-    // Batch `goto :label` / `call :label` targets are line-oriented and do not use parentheses.
-    // batch の `goto :label` / `call :label` は行指向で、括弧を使わない。
-    private static readonly Regex BatchLabelTargetRegex = new(
-        @"^\s*@?\s*(?:goto|call)\s+:(?<name>[\w.\-]+)\b",
+    // Batch jump targets can appear as direct commands, chained commands, or inline `if` forms.
+    // batch のジャンプ先は、直書き・連結コマンド・`if` 併用の inline 形として現れうる。
+    private static readonly Regex BatchJumpTargetRegex = new(
+        @"\b(?<command>goto|call)\s+:(?<name>[\w.\-]+)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BatchConditionalJumpPrefixRegex = new(
+        @"^\s*@?\s*if\s+(?:not\s+)?(?:errorlevel\s+\d+|defined\s+\S+|exist\s+\S+|cmdextversion\s+\d+)\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     // Terraform dotted references are paren-less and therefore invisible to the shared CallRegex.
@@ -2320,13 +2324,16 @@ public static class ReferenceExtractor
 
             if (language is "batch" && !IsBatchCommentLine(originalLine))
             {
-                foreach (Match match in BatchLabelTargetRegex.Matches(preparedLine))
+                foreach (Match match in BatchJumpTargetRegex.Matches(preparedLine))
                 {
                     var name = match.Groups["name"].Value;
                     if (string.Equals(name, "eof", StringComparison.OrdinalIgnoreCase))
                         continue;
 
-                    var callIndex = match.Groups["name"].Index;
+                    var callIndex = match.Groups["command"].Index;
+                    if (!IsBatchJumpTargetContext(preparedLine, callIndex))
+                        continue;
+
                     var callContainer = ResolveContainerForCall(callIndex);
                     AddReference(references, seen, fileId, name, callIndex, "call", context, lineNumber, callContainer);
                 }
@@ -15039,5 +15046,44 @@ public static class ReferenceExtractor
             return true;
         var next = line[start + 3];
         return next == ' ' || next == '\t' || next == '\r' || next == '\n';
+    }
+
+    private static bool IsBatchJumpTargetContext(string line, int commandIndex)
+    {
+        var segmentStart = commandIndex;
+        while (segmentStart > 0 && char.IsWhiteSpace(line[segmentStart - 1]))
+            segmentStart--;
+
+        while (segmentStart > 0)
+        {
+            var previous = line[segmentStart - 1];
+            if (previous is '&' or '|' or '(' or ')')
+                break;
+            segmentStart--;
+        }
+
+        var prefix = line[segmentStart..commandIndex].TrimStart();
+        if (prefix.Length == 0)
+            return true;
+
+        if (prefix[0] == '@')
+        {
+            prefix = prefix[1..].TrimStart();
+            if (prefix.Length == 0)
+                return true;
+        }
+
+        if (prefix.StartsWith("if", StringComparison.OrdinalIgnoreCase))
+            return BatchConditionalJumpPrefixRegex.IsMatch(prefix);
+
+        if (prefix.Equals("else", StringComparison.OrdinalIgnoreCase) ||
+            prefix.StartsWith("else ", StringComparison.OrdinalIgnoreCase) ||
+            prefix.Equals("do", StringComparison.OrdinalIgnoreCase) ||
+            prefix.StartsWith("do ", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -57,11 +57,7 @@ public static class ReferenceExtractor
     // Batch jump targets can appear as direct commands, chained commands, or inline `if` forms.
     // batch のジャンプ先は、直書き・連結コマンド・`if` 併用の inline 形として現れうる。
     private static readonly Regex BatchJumpTargetRegex = new(
-        @"\b(?<command>goto|call)\s+:(?<name>[\w.\-]+)\b",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-
-    private static readonly Regex BatchConditionalJumpPrefixRegex = new(
-        @"^\s*@?\s*if\s+(?:not\s+)?(?:errorlevel\s+\d+|defined\s+\S+|exist\s+\S+|cmdextversion\s+\d+)\s*$",
+        @"^\s*@?\s*(?:(?:if\s+(?:not\s+)?(?:errorlevel\s+\d+|defined\s+\S+|exist\s+\S+|cmdextversion\s+\d+)\s+(?:\(\s*)?)?)?(?<command>goto|call)\s+:(?<name>[\w.\-]+)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     // Terraform dotted references are paren-less and therefore invisible to the shared CallRegex.
@@ -2324,18 +2320,34 @@ public static class ReferenceExtractor
 
             if (language is "batch" && !IsBatchCommentLine(originalLine))
             {
-                foreach (Match match in BatchJumpTargetRegex.Matches(preparedLine))
+                for (var segmentStart = 0; segmentStart < preparedLine.Length;)
                 {
-                    var name = match.Groups["name"].Value;
-                    if (string.Equals(name, "eof", StringComparison.OrdinalIgnoreCase))
-                        continue;
+                    var segmentEnd = segmentStart;
+                    while (segmentEnd < preparedLine.Length && preparedLine[segmentEnd] is not '&' and not '|')
+                        segmentEnd++;
 
-                    var callIndex = match.Groups["command"].Index;
-                    if (!IsBatchJumpTargetContext(preparedLine, callIndex))
-                        continue;
+                    ProcessBatchJumpSegment(
+                        preparedLine[segmentStart..segmentEnd],
+                        segmentStart,
+                        references,
+                        seen,
+                        context,
+                        fileId,
+                        lineNumber,
+                        ResolveContainerForCall);
 
-                    var callContainer = ResolveContainerForCall(callIndex);
-                    AddReference(references, seen, fileId, name, callIndex, "call", context, lineNumber, callContainer);
+                    var segment = preparedLine[segmentStart..segmentEnd].TrimStart();
+                    if (segment.Length > 0)
+                    {
+                        if (segment[0] == '@')
+                            segment = segment[1..].TrimStart();
+                        if (segment.Length > 0 && (segment.StartsWith("::", StringComparison.Ordinal) || IsBatchRemKeyword(segment, 0)))
+                            break;
+                    }
+
+                    segmentStart = segmentEnd;
+                    while (segmentStart < preparedLine.Length && (preparedLine[segmentStart] is '&' or '|' || char.IsWhiteSpace(preparedLine[segmentStart])))
+                        segmentStart++;
                 }
             }
 
@@ -15048,42 +15060,53 @@ public static class ReferenceExtractor
         return next == ' ' || next == '\t' || next == '\r' || next == '\n';
     }
 
-    private static bool IsBatchJumpTargetContext(string line, int commandIndex)
+    private static void ProcessBatchJumpSegment(
+        string segment,
+        int segmentOffset,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        string context,
+        long fileId,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
     {
-        var segmentStart = commandIndex;
-        while (segmentStart > 0 && char.IsWhiteSpace(line[segmentStart - 1]))
-            segmentStart--;
+        var trimmed = segment.TrimStart();
+        if (trimmed.Length == 0)
+            return;
 
-        while (segmentStart > 0)
+        if (trimmed[0] == '@')
         {
-            var previous = line[segmentStart - 1];
-            if (previous is '&' or '|' or '(' or ')')
-                break;
-            segmentStart--;
+            trimmed = trimmed[1..].TrimStart();
+            if (trimmed.Length == 0)
+                return;
         }
 
-        var prefix = line[segmentStart..commandIndex].TrimStart();
-        if (prefix.Length == 0)
-            return true;
+        if (trimmed.StartsWith("::", StringComparison.Ordinal) || IsBatchRemKeyword(trimmed, 0))
+            return;
 
-        if (prefix[0] == '@')
+        if (trimmed.StartsWith("else ", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Equals("else", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("do ", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Equals("do", StringComparison.OrdinalIgnoreCase))
         {
-            prefix = prefix[1..].TrimStart();
-            if (prefix.Length == 0)
-                return true;
+            var spaceIndex = trimmed.IndexOf(' ');
+            if (spaceIndex < 0)
+                return;
+            trimmed = trimmed[(spaceIndex + 1)..].TrimStart();
+            if (trimmed.Length == 0)
+                return;
         }
 
-        if (prefix.StartsWith("if", StringComparison.OrdinalIgnoreCase))
-            return BatchConditionalJumpPrefixRegex.IsMatch(prefix);
+        var match = BatchJumpTargetRegex.Match(trimmed);
+        if (!match.Success)
+            return;
 
-        if (prefix.Equals("else", StringComparison.OrdinalIgnoreCase) ||
-            prefix.StartsWith("else ", StringComparison.OrdinalIgnoreCase) ||
-            prefix.Equals("do", StringComparison.OrdinalIgnoreCase) ||
-            prefix.StartsWith("do ", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
+        var name = match.Groups["name"].Value;
+        if (string.Equals(name, "eof", StringComparison.OrdinalIgnoreCase))
+            return;
 
-        return false;
+        var commandIndex = segmentOffset + match.Groups["command"].Index;
+        var callContainer = resolveContainerForCall(commandIndex);
+        AddReference(references, seen, fileId, name, commandIndex, "call", context, lineNumber, callContainer);
     }
 }

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -15097,10 +15097,7 @@ public static class ReferenceExtractor
         if (trimmed.StartsWith("::", StringComparison.Ordinal) || IsBatchRemKeyword(trimmed, 0))
             return;
 
-        if (trimmed.StartsWith("else ", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.Equals("else", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.StartsWith("do ", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.Equals("do", StringComparison.OrdinalIgnoreCase))
+        if (StartsWithBatchWord(trimmed, "else") || StartsWithBatchWord(trimmed, "do"))
         {
             var keywordEnd = 0;
             while (keywordEnd < trimmed.Length && !char.IsWhiteSpace(trimmed[keywordEnd]))
@@ -15123,5 +15120,12 @@ public static class ReferenceExtractor
         var commandIndex = segmentOffset + match.Groups["command"].Index;
         var callContainer = resolveContainerForCall(commandIndex);
         AddReference(references, seen, fileId, name, commandIndex, "call", context, lineNumber, callContainer);
+    }
+
+    private static bool StartsWithBatchWord(string text, string word)
+    {
+        if (!text.StartsWith(word, StringComparison.OrdinalIgnoreCase))
+            return false;
+        return text.Length == word.Length || char.IsWhiteSpace(text[word.Length]);
     }
 }

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -2323,7 +2323,7 @@ public static class ReferenceExtractor
                 for (var segmentStart = 0; segmentStart < preparedLine.Length;)
                 {
                     var segmentEnd = segmentStart;
-                    while (segmentEnd < preparedLine.Length && preparedLine[segmentEnd] is not '&' and not '|')
+                    while (segmentEnd < preparedLine.Length && !IsBatchCommandSeparator(preparedLine, segmentEnd))
                         segmentEnd++;
 
                     ProcessBatchJumpSegment(
@@ -2346,7 +2346,7 @@ public static class ReferenceExtractor
                     }
 
                     segmentStart = segmentEnd;
-                    while (segmentStart < preparedLine.Length && (preparedLine[segmentStart] is '&' or '|' || char.IsWhiteSpace(preparedLine[segmentStart])))
+                    while (segmentStart < preparedLine.Length && (char.IsWhiteSpace(preparedLine[segmentStart]) || IsBatchCommandSeparator(preparedLine, segmentStart)))
                         segmentStart++;
                 }
             }
@@ -15058,6 +15058,19 @@ public static class ReferenceExtractor
             return true;
         var next = line[start + 3];
         return next == ' ' || next == '\t' || next == '\r' || next == '\n';
+    }
+
+    private static bool IsBatchCommandSeparator(string line, int index)
+    {
+        var c = line[index];
+        if (c is not '&' and not '|')
+            return false;
+
+        var caretCount = 0;
+        for (var i = index - 1; i >= 0 && line[i] == '^'; i--)
+            caretCount++;
+
+        return (caretCount & 1) == 0;
     }
 
     private static void ProcessBatchJumpSegment(

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6707,13 +6707,19 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
-    public void Extract_Batch_IndexesGotoAndCallTargets()
+    public void Extract_Batch_IndexesGotoCallAndInlineTargets()
     {
         const string content = """
             @echo off
             goto :Build
+            if errorlevel 1 goto :Retry
+            goto :Next & call :Build
+            call :Done && goto :Retry
             rem goto :Ignored
             :Build
+            :Retry
+            :Next
+            :Done
             call :Build
             :: call :Commented
             goto :EOF
@@ -6722,7 +6728,10 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "batch", content);
         var references = ReferenceExtractor.Extract(1, "batch", content, symbols);
 
-        Assert.Equal(2, references.Count(r => r.SymbolName == "Build" && r.ReferenceKind == "call"));
+        Assert.Equal(3, references.Count(r => r.SymbolName == "Build" && r.ReferenceKind == "call"));
+        Assert.Equal(2, references.Count(r => r.SymbolName == "Retry" && r.ReferenceKind == "call"));
+        Assert.Contains(references, r => r.SymbolName == "Next" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "Done" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "EOF" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Ignored" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Commented" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6715,6 +6715,7 @@ public class ReferenceExtractorTests
             if errorlevel 1 goto :Retry
             goto :Next & call :Build
             call :Done && goto :Retry
+            echo ^& goto :Quoted
             rem goto :Ignored
             :Build
             :Retry
@@ -6734,6 +6735,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "Done" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "EOF" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Ignored" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Quoted" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Commented" && r.ReferenceKind == "call");
     }
 


### PR DESCRIPTION
## Summary

- Addressed the follow-up candidate from PR #1258 by broadening batch jump parsing.
- `batch` reference extraction now recognizes inline `if errorlevel` forms and chained jump commands such as `goto :A & call :B`.
- Escaped separators like `^&` and `^|` are treated as literal characters, so they do not spawn false jump references.
- Added regression coverage for inline, chained, comment, and escaped-separator batch forms.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter ReferenceExtractorTests`
- Refreshed the local CodeIndex DB for the changed files with `cdidx index . --commits 81a0e73e`

## Docs and changelog

- Updated the batch language row in `README.md` to mention inline/chained control flow.
- Added `changelog.d/unreleased/+bat-inline-jumps.changed.md`.

## Follow-up candidates

- Broader batch condition parsing beyond the common `if errorlevel` / `defined` / `exist` / `cmdextversion` forms.
