### PR TITLE
Follow up Dockerfile search coverage

### DIFF
--- a/changelog.d/unreleased/+dockerfile-followups.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-followups.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Dockerfile search now handles lowercase instructions and `ENV` declarations** — `cdidx` now recognizes `from` / `as` in addition to uppercase `FROM` / `AS`, and indexes `ENV` variable names alongside `ARG`, so modern Dockerfiles stay searchable regardless of instruction casing.
+
+## 日本語
+
+- **Dockerfile 検索が小文字の命令と `ENV` 宣言に対応しました** — `cdidx` は大文字の `FROM` / `AS` だけでなく `from` / `as` も認識し、`ARG` に加えて `ENV` の変数名も索引するようになったため、命令の大文字小文字に依存せず現代的な Dockerfile を検索できます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1412,9 +1412,9 @@ public static class SymbolExtractor
         ],
         ["dockerfile"] =
         [
-            new("property", new Regex(@"^\s*ARG\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),  // Named stage / 名前付きステージ
-            new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled), BodyStyle.None),  // Base image / ベースイメージ
+            new("property", new Regex(@"^\s*(?:ARG|ENV)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
+            new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],
         ["protobuf"] =
         [

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -671,6 +671,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileFromStageReferences_IndexLowercaseInstructions()
+    {
+        const string content = """
+            from golang:1.21 as builder
+
+            from builder as build2
+
+            copy --from=builder /src/app /usr/local/bin/app
+
+            from alpine:3.20
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Equal(2, references.Count(reference =>
+            reference.SymbolName == "builder"
+            && reference.ReferenceKind == "call"));
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "alpine:3.20");
+    }
+
+    [Fact]
     public void Extract_DockerfileCopyFromReferences_IndexStageDependencies()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -17311,6 +17311,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsLowercaseInstructionsAndEnvSymbols()
+    {
+        var content = """
+            from --platform=$BUILDPLATFORM golang:1.22 as builder
+            env APP_HOME=/app
+            env PATH=/usr/local/bin:$PATH
+            from --platform=linux/amd64 alpine:3.20
+            """;
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "builder");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "alpine:3.20");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "APP_HOME");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "PATH");
+        Assert.Equal(4, symbols.Count);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Make Dockerfile `FROM` / `AS` matching case-insensitive so lowercase instruction forms are indexed and referenced the same way as uppercase forms.
- Index Dockerfile `ENV` variable names alongside `ARG` so common environment declarations are searchable.
- Add regression tests for lowercase `from` / `as`, `ENV` symbols, and lowercase Dockerfile stage references.
- This PR follows up on the candidates listed in PR #1263.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter Dockerfile`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/ReferenceExtractorTests.cs changelog.d/unreleased/+dockerfile-followups.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog

- `changelog.d/unreleased/+dockerfile-followups.fixed.md`

## Follow-up candidates

- None.