### PR TITLE
Expand shell alias follow-up coverage

### DIFF
--- a/changelog.d/unreleased/+shell-alias-broader-followup.fixed.md
+++ b/changelog.d/unreleased/+shell-alias-broader-followup.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Shell alias extraction now handles multiple alias definitions on one line** — shell parsing now expands additional `alias name=value` tokens that appear after the first alias command in the same statement, so definitions like `alias ll='ls -la' gs='git status'` are indexed correctly.
+
+## 日本語
+
+- **shell の alias 抽出で、1 行に複数書かれた定義も扱えるようになりました** — 同じ文の中に続けて書かれた追加の `alias name=value` トークンも展開し、`alias ll='ls -la' gs='git status'` のような定義を正しくインデックスします。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1907,6 +1907,234 @@ public static class SymbolExtractor
         return true;
     }
 
+    private static void ExpandShellAliasSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            foreach (var (tokenStart, tokenEnd) in EnumerateShellAliasDefinitions(line))
+            {
+                var token = line[tokenStart..tokenEnd];
+                var equalsIndex = token.IndexOf('=');
+                if (equalsIndex <= 0)
+                    continue;
+
+                var name = token[..equalsIndex].Trim();
+                if (!IsShellAliasName(name))
+                    continue;
+
+                if (HasShellAliasSymbol(symbols, fileId, i + 1, name))
+                    continue;
+
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    i + 1,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "alias",
+                        Name = name,
+                        Line = i + 1,
+                        StartLine = i + 1,
+                        StartColumn = tokenStart,
+                        EndLine = i + 1,
+                        Signature = line.Trim(),
+                    },
+                    line);
+            }
+        }
+    }
+
+    private static IEnumerable<(int Start, int End)> EnumerateShellAliasDefinitions(string line)
+    {
+        var segmentStart = 0;
+        while (segmentStart < line.Length)
+        {
+            var segmentEnd = FindShellAliasSegmentEnd(line, segmentStart);
+            var segment = line[segmentStart..segmentEnd];
+            var trimmedSegment = segment.TrimStart();
+            var trimmedOffset = segment.Length - trimmedSegment.Length;
+
+            if (trimmedSegment.StartsWith("alias", StringComparison.Ordinal))
+            {
+                var cursor = trimmedOffset + "alias".Length;
+                while (TryReadShellAliasToken(segment, ref cursor, out var tokenStart, out var tokenEnd))
+                {
+                    var token = segment[tokenStart..tokenEnd];
+                    if (token.Length == 0)
+                        continue;
+
+                    if (token[0] == '-' && token.IndexOf('=') < 0)
+                        continue;
+
+                    if (token.IndexOf('=') > 0)
+                        yield return (segmentStart + tokenStart, segmentStart + tokenEnd);
+                }
+            }
+
+            if (segmentEnd >= line.Length)
+                break;
+
+            segmentStart = segmentEnd + 1;
+            if (segmentStart < line.Length && line[segmentEnd] == '&' && segmentEnd + 1 < line.Length && line[segmentEnd + 1] == '&')
+                segmentStart++;
+            else if (segmentStart < line.Length && line[segmentEnd] == '|' && segmentEnd + 1 < line.Length && line[segmentEnd + 1] == '|')
+                segmentStart++;
+        }
+    }
+
+    private static int FindShellAliasSegmentEnd(string line, int startIndex)
+    {
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+        var escapeNext = false;
+
+        for (var i = startIndex; i < line.Length; i++)
+        {
+            var ch = line[i];
+            if (escapeNext)
+            {
+                escapeNext = false;
+                continue;
+            }
+
+            if (inSingleQuote)
+            {
+                if (ch == '\'')
+                    inSingleQuote = false;
+                continue;
+            }
+
+            if (inDoubleQuote)
+            {
+                if (ch == '"')
+                {
+                    inDoubleQuote = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                    escapeNext = true;
+                continue;
+            }
+
+            if (ch == '#')
+                return i;
+
+            if (ch == '\'')
+            {
+                inSingleQuote = true;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inDoubleQuote = true;
+                continue;
+            }
+
+            if (ch == ';' || ch == '|' || ch == '&')
+                return i;
+
+            if (ch == '\\')
+                escapeNext = true;
+        }
+
+        return line.Length;
+    }
+
+    private static bool TryReadShellAliasToken(string segment, ref int cursor, out int tokenStart, out int tokenEnd)
+    {
+        tokenStart = -1;
+        tokenEnd = -1;
+
+        while (cursor < segment.Length && char.IsWhiteSpace(segment[cursor]))
+            cursor++;
+
+        if (cursor >= segment.Length)
+            return false;
+
+        if (segment[cursor] is ';' or '|' or '&' or '#')
+            return false;
+
+        tokenStart = cursor;
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+        var escapeNext = false;
+
+        while (cursor < segment.Length)
+        {
+            var ch = segment[cursor];
+            if (escapeNext)
+            {
+                escapeNext = false;
+                cursor++;
+                continue;
+            }
+
+            if (inSingleQuote)
+            {
+                if (ch == '\'')
+                    inSingleQuote = false;
+                cursor++;
+                continue;
+            }
+
+            if (inDoubleQuote)
+            {
+                if (ch == '"')
+                {
+                    inDoubleQuote = false;
+                    cursor++;
+                    continue;
+                }
+
+                if (ch == '\\')
+                    escapeNext = true;
+                cursor++;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(ch) || ch is ';' or '|' or '&' or '#')
+                break;
+
+            if (ch == '\'')
+            {
+                inSingleQuote = true;
+                cursor++;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inDoubleQuote = true;
+                cursor++;
+                continue;
+            }
+
+            if (ch == '\\')
+                escapeNext = true;
+
+            cursor++;
+        }
+
+        tokenEnd = cursor;
+        return tokenEnd > tokenStart;
+    }
+
+    private static bool HasShellAliasSymbol(List<SymbolRecord> symbols, long fileId, int lineNumber, string name)
+    {
+        return symbols.Any(symbol =>
+            symbol.FileId == fileId
+            && symbol.Line == lineNumber
+            && symbol.Kind == "alias"
+            && string.Equals(symbol.Name, name, StringComparison.Ordinal));
+    }
+
+    private static bool IsShellAliasName(string name) =>
+        Regex.IsMatch(name, @"^[A-Za-z_][A-Za-z0-9_-]*$", RegexOptions.CultureInvariant);
+
     private static bool HasGoSymbol(List<SymbolRecord> symbols, long fileId, int lineNumber, string kind, string name)
     {
         return symbols.Any(symbol =>
@@ -3879,12 +4107,14 @@ private sealed class RubyMaskState
             ExtractGoGroupedDeclarations(fileId, lines, symbols);
         if (lang == "cpp")
             ExtractCppSameLineClassBodyMembers(fileId, lines, symbols);
-        AssignContainers(symbols, lines, csharpLineStartStates);
-        MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
-        NormalizeKotlinSecondaryConstructorNames(symbols);
-        PopulateDeclaredContainerQualifiedNames(symbols);
-        return symbols;
-    }
+          AssignContainers(symbols, lines, csharpLineStartStates);
+          MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
+          NormalizeKotlinSecondaryConstructorNames(symbols);
+          if (lang == "shell")
+              ExpandShellAliasSymbols(fileId, lines, symbols);
+          PopulateDeclaredContainerQualifiedNames(symbols);
+          return symbols;
+      }
 
     private static void ExtractSvelteReactiveSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
     {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -230,6 +230,44 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Shell_DetectsMultipleAliasDefinitionsAndCalls()
+    {
+        const string content = """
+            alias ll='ls -la' gs='git status'
+            alias -g G='| grep' H='| head'
+
+            run() {
+              ll /tmp
+              gs
+              echo foo G bar
+              H pattern
+              foo=G
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+        var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
+
+        Assert.Equal(4, references.Count(reference => reference.ReferenceKind == "call"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "ll"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "gs"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "G"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "H"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_CobolPerform_CapturesParagraphLevelCallReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -3250,6 +3250,22 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Shell_DetectsMultipleAliasDefinitions()
+    {
+        var content = """
+            alias ll='ls -la' gs='git status'
+            alias -g G='| grep' H='| head'
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "ll");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "gs");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "G");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "H");
+    }
+
+    [Fact]
     public void Extract_TypeScript_DetectsAccessorClassFields()
     {
         var content = """
@@ -19373,5 +19389,19 @@ public class SymbolExtractorTests
         }
 
         throw new InvalidOperationException("Could not locate repository root / リポジトリルートを特定できませんでした");
+    }
+    [Fact]
+    public void Extract_Shell_DetectsMultipleAliases()
+    {
+        var content = """
+            alias ll='ls -la' gs='git status'
+            alias -g G='| grep' H='| head'
+            """;
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "ll");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "gs");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "G");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "H");
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses the follow-up candidates from PR #1265 by broadening shell alias extraction.

- shell alias parsing now expands multiple `alias name=value` definitions that appear on the same line
- shell alias symbols are still deduplicated against the existing single-alias extraction path
- tests cover symbol extraction and call/reference extraction for the multi-alias form

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter 'FullyQualifiedName~Extract_Shell_DetectsMultipleAliases|FullyQualifiedName~Extract_Shell_DetectsAliasCalls|FullyQualifiedName~Extract_Shell_DetectsMultipleAliasDefinitions'`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release`

## Changelog

- Added `changelog.d/unreleased/+shell-alias-broader-followup.fixed.md`

## Follow-up candidates

- None identified in this change.
