### PR TITLE
Broaden batch condition parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ The database reflects the working tree at the time of the last index. After swit
 | MSBuild | `.csproj`, `.fsproj`, `.vbproj`, `.props`, `.targets` | -- |
 | Shell | `.sh`, `.bash`, `.zsh`, `.fish` | command-style function calls |
 | PowerShell | `.ps1`, `.psm1`, `.psd1` | function/filter (scope prefixes), configuration, workflow, class constructors/methods/properties, enum values, Import-Module, using module/namespace/assembly |
-| Batch | `.bat`, `.cmd` | labels + `goto`/`call` targets, including inline/chained control flow |
+  | Batch | `.bat`, `.cmd` | labels + `goto`/`call` targets, including inline/chained control flow and `if` comparison forms |
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 Query-time `--lang tsql` is accepted as an alias for the SQL bucket.
@@ -1634,7 +1634,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | MSBuild | `.csproj`, `.fsproj`, `.vbproj`, `.props`, `.targets` | -- |
 | Shell | `.sh`, `.bash`, `.zsh`, `.fish` | 関数のコマンド構文呼び出し |
 | PowerShell | `.ps1`, `.psm1`, `.psd1` | 関数/フィルタ（scope プレフィックス付き）、configuration、workflow、class、enum、Import-Module、using module/namespace/assembly |
-| Batch | `.bat`, `.cmd` | ラベル + `goto`/`call` ターゲット、inline / chained な制御フローも含む |
+  | Batch | `.bat`, `.cmd` | ラベル + `goto`/`call` ターゲット、inline / chained な制御フローに加えて `if` 比較式も含む |
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 クエリ時の `--lang tsql` は SQL バケットの別名として受け付けられます。

--- a/changelog.d/unreleased/+bat-if-comparisons.changed.md
+++ b/changelog.d/unreleased/+bat-if-comparisons.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **Batch `if` comparison forms now contribute `goto` / `call` targets** — reference extraction broadens batch jump parsing beyond the common `errorlevel` / `defined` / `exist` / `cmdextversion` prefixes, so comparison-style `if` lines such as `if /i "%MODE%"=="release" goto :Release` are indexed as call targets too.
+
+## 日本語
+
+- **Batch の `if` 比較式でも `goto` / `call` ターゲットを拾うようになりました** — reference extraction が batch の jump 解析を、従来の `errorlevel` / `defined` / `exist` / `cmdextversion` だけでなく比較式ベースの `if` にも広げたため、`if /i "%MODE%"=="release" goto :Release` のような行も call target として索引されます。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -54,10 +54,12 @@ public static class ReferenceExtractor
         @"^\s*PERFORM\s+(?!(?:VARYING|UNTIL|WITH|TIMES|TEST|THRU|THROUGH)\b)(?<name>[A-Z0-9][A-Z0-9-]*)(?:\s+(?:THRU|THROUGH)\s+(?<end>[A-Z0-9][A-Z0-9-]*))?",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
-    // Batch jump targets can appear as direct commands, chained commands, or inline `if` forms.
+    // Batch jump targets can appear as direct commands, chained commands, or inline `if`
+    // forms, including comparison-based conditions such as `if /i "%a%"=="b" goto :X`.
     // batch のジャンプ先は、直書き・連結コマンド・`if` 併用の inline 形として現れうる。
+    // 比較式ベースの `if /i "%a%"=="b" goto :X` のような形も含めて扱う。
     private static readonly Regex BatchJumpTargetRegex = new(
-        @"^\s*@?\s*(?:(?:if\s+(?:not\s+)?(?:errorlevel\s+\d+|defined\s+\S+|exist\s+\S+|cmdextversion\s+\d+)\s+(?:\(\s*)?)?)?(?<command>goto|call)\s+:(?<name>[\w.\-]+)\b",
+        @"^\s*@?\s*(?:(?:if\s+(?:/i\s+)?(?:not\s+)?(?:(?:errorlevel\s+\d+|defined\s+\S+|exist\s+\S+|cmdextversion\s+\d+)|(?:[^()\r\n]+?\s*(?:==|equ|neq|lss|leq|gtr|geq)\s*[^()\r\n]+?))\s+(?:\(\s*)?)?)?(?<command>goto|call)\s+:(?<name>[\w.\-]+)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     // Terraform dotted references are paren-less and therefore invisible to the shared CallRegex.

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6741,11 +6741,15 @@ public class ReferenceExtractorTests
             goto :Next & call :Build
             call :Done && goto :Retry
             echo ^& goto :Quoted
+            if /i "%MODE%"=="release" goto :Release
+            if not "debug"=="release" call :Fallback
             rem goto :Ignored
             :Build
             :Retry
             :Next
             :Done
+            :Release
+            :Fallback
             call :Build
             :: call :Commented
             goto :EOF
@@ -6758,6 +6762,8 @@ public class ReferenceExtractorTests
         Assert.Equal(2, references.Count(r => r.SymbolName == "Retry" && r.ReferenceKind == "call"));
         Assert.Contains(references, r => r.SymbolName == "Next" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "Done" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "Release" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "Fallback" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "EOF" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Ignored" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Quoted" && r.ReferenceKind == "call");


### PR DESCRIPTION
## Summary

- Addressed the follow-up candidate from PR #1267 by broadening batch `if` parsing beyond the common `errorlevel` / `defined` / `exist` / `cmdextversion` forms.
- Batch comparison-style conditions such as `if /i "%MODE%"=="release" goto :Release` are now indexed as `call` targets too.
- Updated the README language table in both English and Japanese to mention the broader batch control-flow coverage.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter ReferenceExtractorTests`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits f9089692`

## Changelog

- Added `changelog.d/unreleased/+bat-if-comparisons.changed.md`.
- This is a non-issue follow-up, so the fragment omits `issues` entirely.

## Review

- Adversarial review: no blocking or actionable issues found.

## Follow-up candidate addressed

- This PR resolves the follow-up candidate listed in PR #1267: broader batch condition parsing beyond the common forms.