### PR TITLE
Improve Go type declaration symbols

### DIFF
--- a/changelog.d/unreleased/+go-type-symbols.fixed.md
+++ b/changelog.d/unreleased/+go-type-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Go `type` declarations now keep a type-like symbol kind** — named Go types and aliases were previously indexed as `import` entries when they were not `struct` or `interface` declarations. They now appear as `class` symbols so searches and symbol browsing reflect the actual declaration type.
+
+## 日本語
+
+- **Go の `type` 宣言が type 系のシンボル種別を維持するようになりました** — `struct` / `interface` 以外の Go の名前付き型やエイリアスが、これまで `import` として索引されていました。これらを `class` シンボルとして扱うことで、検索やシンボル閲覧が実際の宣言種別に近づきます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1788,7 +1788,7 @@ public static class SymbolExtractor
             ? "struct"
             : Regex.IsMatch(normalizedTypeText, @"\binterface\b")
                 ? "interface"
-                : "import";
+                : "class";
         if (HasGoSymbol(symbols, fileId, lineIndex + 1, kind, name))
             return true;
         var startColumn = rawLine.IndexOf(name, StringComparison.Ordinal);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -407,6 +407,37 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Go_DetectsNamedTypesAndAliasesAsClassSymbols()
+    {
+        var content = """
+            package demo
+
+            type Identifier = string
+            type Count int
+
+            type (
+                Alias = otherpkg.Value
+                Score uint64
+                Node struct {
+                    ID Identifier
+                }
+                Reader interface {
+                    Read([]byte) (int, error)
+                }
+            )
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Identifier");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Count");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Alias");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Score");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Node");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Reader");
+    }
+
+    [Fact]
     public void Extract_Cpp_DetectsQualifiedDefinitionsConceptsAndModules()
     {
         var content = """
@@ -9903,7 +9934,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Stack");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Container");
-        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Alias");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Alias");
     }
 
     [Fact]
@@ -9936,7 +9967,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Stack");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Container");
-        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Alias");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Alias");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "MaxRetries");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DefaultTimeout");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Named");


### PR DESCRIPTION
## Summary

- Treat Go `type` declarations that are not `struct` or `interface` as `class` symbols instead of `import` symbols.
- Add regression coverage for standalone and grouped Go type declarations.
- Add a bilingual changelog fragment for the behavior change.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/+go-type-symbols.fixed.md`.
- No other docs required; the change is limited to Go symbol classification and test coverage.

## Follow-up candidates

- None identified.
