### PR TITLE
Fix TypeScript dynamic import type queries

### DIFF
--- a/changelog.d/unreleased/+typescript-dynamic-import-type.fixed.md
+++ b/changelog.d/unreleased/+typescript-dynamic-import-type.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **TypeScript `typeof import("./mod")` now maps to an indexed import target** - dynamic `import("...")` module specifiers are indexed as `import` symbols, and bare `typeof import("./mod")` type queries now resolve to that concrete module target instead of disappearing as an unmapped type query.
+
+## 日本語
+
+- **TypeScript の `typeof import("./mod")` がインデックス済みの import ターゲットに紐づくようになりました** - dynamic `import("...")` の module specifier を `import` シンボルとして index し、bare な `typeof import("./mod")` 型クエリも、未解決のまま消えず concrete な module target に解決するようにしました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -1607,6 +1607,7 @@ public static class ReferenceExtractor
                     preparedLines,
                     i,
                     preparedLine,
+                    lines[i],
                     references,
                     seen,
                     fileId,
@@ -4468,6 +4469,7 @@ public static class ReferenceExtractor
         IReadOnlyList<string> preparedLines,
         int lineIndex,
         string preparedLine,
+        string rawLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -4488,14 +4490,38 @@ public static class ReferenceExtractor
             if (!IsTypeScriptTypeQueryContext(preparedLines, lineIndex, preparedLine, tokens, tokenIndex))
                 continue;
 
-            if (!TryExtractTypeScriptTypeQueryTarget(preparedLine, tokens[tokenIndex].Start + tokens[tokenIndex].Length, out var expressionStart, out var expressionLength))
+            if (!TryExtractTypeScriptTypeQueryTarget(
+                    rawLine,
+                    tokens[tokenIndex].Start + tokens[tokenIndex].Length,
+                    out var expressionStart,
+                    out var expressionLength,
+                    out var literalTarget))
                 continue;
 
+            if (literalTarget != null)
+            {
+                AddTypeReferenceSegment(
+                    references,
+                    seen,
+                    fileId,
+                    literalTarget,
+                    expressionStart,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(expressionStart),
+                    "typescript");
+                continue;
+            }
+
+            if (expressionStart < 0 || expressionStart >= rawLine.Length)
+                continue;
+
+            var expressionLengthSafe = Math.Min(expressionLength, rawLine.Length - expressionStart);
             AddTypeReferenceSegments(
                 references,
                 seen,
                 fileId,
-                preparedLine.Substring(expressionStart, expressionLength),
+                rawLine.Substring(expressionStart, expressionLengthSafe),
                 expressionStart,
                 context,
                 lineNumber,
@@ -5452,6 +5478,27 @@ public static class ReferenceExtractor
         return i;
     }
 
+    private static int SkipTypeScriptStringLiteral(string text, int startIndex)
+    {
+        char quote = text[startIndex];
+        int i = startIndex + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '\\' && i + 1 < text.Length)
+            {
+                i += 2;
+                continue;
+            }
+
+            if (text[i] == quote)
+                return i + 1;
+
+            i++;
+        }
+
+        return text.Length;
+    }
+
     private static int SkipJavaAnnotation(string text, int start)
     {
         int i = start + 1;
@@ -5986,10 +6033,12 @@ public static class ReferenceExtractor
         string line,
         int startIndex,
         out int targetStart,
-        out int targetLength)
+        out int targetLength,
+        out string? literalTarget)
     {
         targetStart = 0;
         targetLength = 0;
+        literalTarget = null;
 
         var cursor = startIndex;
         while (cursor < line.Length)
@@ -6001,8 +6050,18 @@ public static class ReferenceExtractor
             if (TryConsumeTypeScriptTypeQueryWrapper(line, cursor, "typeof", out cursor))
                 continue;
 
-            if (TryConsumeTypeScriptImportTypeWrapper(line, cursor, out cursor))
+            if (TryConsumeTypeScriptImportTypeWrapper(line, cursor, out cursor, out var importModuleStart, out var importModuleLength))
+            {
+                if (cursor >= line.Length || line[cursor] != '.')
+                {
+                    targetStart = importModuleStart;
+                    targetLength = importModuleLength;
+                    literalTarget = line.Substring(importModuleStart, importModuleLength);
+                    return targetLength > 0;
+                }
+
                 continue;
+            }
 
             if (line[cursor] == '(' || line[cursor] == '[')
             {
@@ -6056,9 +6115,13 @@ public static class ReferenceExtractor
     private static bool TryConsumeTypeScriptImportTypeWrapper(
         string line,
         int cursor,
-        out int nextCursor)
+        out int nextCursor,
+        out int moduleStart,
+        out int moduleLength)
     {
         nextCursor = cursor;
+        moduleStart = -1;
+        moduleLength = 0;
         if (cursor + "import".Length > line.Length
             || !line.AsSpan(cursor, "import".Length).Equals("import", StringComparison.Ordinal))
         {
@@ -6073,10 +6136,21 @@ public static class ReferenceExtractor
         if (nextIndex >= line.Length || line[nextIndex] != '(')
             return false;
 
+        var moduleQuoteIndex = SkipWhitespace(line, nextIndex + 1);
+        if (moduleQuoteIndex >= line.Length || line[moduleQuoteIndex] is not '\'' and not '"')
+            return false;
+
+        var moduleLiteralStart = moduleQuoteIndex + 1;
+        var moduleLiteralEnd = SkipTypeScriptStringLiteral(line, moduleQuoteIndex) - 1;
+        if (moduleLiteralEnd < moduleLiteralStart)
+            return false;
+
         var closeIndex = SkipBalanced(line, nextIndex, '(', ')');
         if (closeIndex <= nextIndex)
             return false;
 
+        moduleStart = moduleLiteralStart;
+        moduleLength = moduleLiteralEnd - moduleLiteralStart;
         nextCursor = closeIndex;
         return true;
     }

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -2470,6 +2470,9 @@ private sealed class RubyMaskState
             if (lang == "php")
                 ExtractPhpImportSymbols(symbols, line, i + 1);
 
+            if (lang is "javascript" or "typescript")
+                ExtractJavaScriptTypeScriptDynamicImportSymbols(fileId, line, structuralLine, i + 1, symbols);
+
             if (lang == "cpp" && TryAddCppIndentedAlias(fileId, line, i + 1, symbols))
                 continue;
 
@@ -7424,6 +7427,99 @@ private sealed class RubyMaskState
         ExtractJavaScriptTypeScriptReExportSymbols(fileId, lang, lines, sanitizedLines, symbols);
         ExtractJavaScriptTypeScriptCommonJsNamedExportAssignments(fileId, lang, lines, sanitizedLines, symbols, privateScopeColumns);
         ExtractJavaScriptTypeScriptExportedObjectLiteralProperties(fileId, lines, sanitizedLines, symbols, objectLiteralTargets);
+    }
+
+    private static void ExtractJavaScriptTypeScriptDynamicImportSymbols(
+        long fileId,
+        string rawLine,
+        string structuralLine,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        var searchStart = 0;
+        while (searchStart < rawLine.Length)
+        {
+            var importIndex = rawLine.IndexOf("import", searchStart, StringComparison.Ordinal);
+            if (importIndex < 0)
+                return;
+
+            searchStart = importIndex + "import".Length;
+
+            if (importIndex > 0 && (char.IsLetterOrDigit(rawLine[importIndex - 1]) || rawLine[importIndex - 1] is '_' or '$'))
+                continue;
+
+            var prefixEnd = importIndex;
+            while (prefixEnd > 0 && char.IsWhiteSpace(rawLine[prefixEnd - 1]))
+                prefixEnd--;
+
+            var tokenStart = prefixEnd;
+            while (tokenStart > 0 && (char.IsLetterOrDigit(rawLine[tokenStart - 1]) || rawLine[tokenStart - 1] is '_' or '$'))
+                tokenStart--;
+
+            // Skip type-query contexts like `typeof import("./mod")`; only real runtime
+            // dynamic imports should create the module-name symbol target.
+            if (tokenStart < prefixEnd)
+            {
+                var precedingToken = rawLine[tokenStart..prefixEnd];
+                if (precedingToken is "typeof" or "keyof")
+                    continue;
+            }
+
+            var cursor = SkipWhitespace(rawLine, importIndex + "import".Length);
+            if (cursor >= rawLine.Length || rawLine[cursor] != '(')
+                continue;
+
+            var moduleQuoteIndex = SkipWhitespace(rawLine, cursor + 1);
+            if (moduleQuoteIndex >= rawLine.Length || rawLine[moduleQuoteIndex] is not '\'' and not '"')
+                continue;
+
+            var moduleLiteralStart = moduleQuoteIndex + 1;
+            var moduleLiteralEnd = moduleLiteralStart;
+            while (moduleLiteralEnd < rawLine.Length)
+            {
+                if (rawLine[moduleLiteralEnd] == '\\' && moduleLiteralEnd + 1 < rawLine.Length)
+                {
+                    moduleLiteralEnd += 2;
+                    continue;
+                }
+
+                if (rawLine[moduleLiteralEnd] == rawLine[moduleQuoteIndex])
+                    break;
+
+                moduleLiteralEnd++;
+            }
+
+            if (moduleLiteralEnd < moduleLiteralStart)
+                continue;
+
+            if (moduleLiteralEnd >= rawLine.Length || rawLine[moduleLiteralEnd] != rawLine[moduleQuoteIndex])
+                continue;
+
+            var closeIndex = moduleLiteralEnd + 1;
+            while (closeIndex < rawLine.Length && char.IsWhiteSpace(rawLine[closeIndex]))
+                closeIndex++;
+
+            if (closeIndex >= rawLine.Length || rawLine[closeIndex] != ')')
+                continue;
+
+            var moduleName = rawLine.Substring(moduleLiteralStart, moduleLiteralEnd - moduleLiteralStart);
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "import",
+                    Name = moduleName,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    StartColumn = moduleLiteralStart,
+                    EndLine = lineNumber,
+                    Signature = rawLine.Trim(),
+                },
+                rawLine);
+        }
     }
 
     private static void ExtractJavaScriptTypeScriptQualifiedAssignments(

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18245,6 +18245,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
+    {
+        const string content = """
+            const loaded = import("./mod");
+            type ModuleNamespace = typeof import("./mod");
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(symbols, symbol =>
+            symbol.Kind == "import"
+            && symbol.Name == "./mod");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "./mod"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptRuntimeTypeof_OnOneLine_IsNotCapturedAsTypeReference()
     {
         const string content = """


### PR DESCRIPTION
## Summary
- Addressed the follow-up candidate from PR #1264 by mapping `typeof import("./mod")` to the concrete indexed `import` symbol for the module specifier.
- Dynamic `import("...")` calls now emit `import` symbols for their module specifier, and TypeScript type-query references reuse that concrete target instead of remaining unmapped.
- Kept the existing runtime `typeof` safeguards and added regression coverage for both the dynamic import mapping and wrapped type-query cases.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol|FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptTypeQueries_CaptureImportAndWrappedTargets|FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptMultilineTypeQueryContext_DoesNotLeakRuntimeReferences"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/ReferenceExtractor.cs src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/ReferenceExtractorTests.cs changelog.d/unreleased/+typescript-dynamic-import-type.fixed.md --json`

## Changelog
- Added `changelog.d/unreleased/+typescript-dynamic-import-type.fixed.md` using the fragment workflow. This is a non-issue change, so `issues` was intentionally omitted.

## Notes
- This PR explicitly follows up on the candidate called out in PR #1264 and resolves the `typeof import("./mod")` case against a concrete indexed symbol target.
- Adversarial review found no blocking/actionable issues.

## Follow-up candidates
- None identified.