### PR TITLE
Add R setAs alias coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Perl | `.pl`, `.pm`, `.t`, `.pod` | -- |
 | Solidity | `.sol` | -- |
 | Tcl | `.tcl`, `.tk` | -- |
-| R | `.r`, `.R` | yes (function assignments, methods::setClass/methods::setClassUnion/methods::setOldClass/R6::R6Class/methods::setRefClass with named arguments, methods::setValidity, R6 inherit and public/private/active methods, methods::setGeneric/methods::setMethod with named arguments, library/require) |
+| R | `.r`, `.R` | yes (function assignments, methods::setClass/methods::setClassUnion/methods::setAs/methods::setOldClass/R6::R6Class/methods::setRefClass with named arguments, methods::setValidity, R6 inherit and public/private/active methods, methods::setGeneric/methods::setMethod with named arguments, library/require) |
 | Haskell | `.hs`, `.lhs` | yes |
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |

--- a/changelog.d/unreleased/+r-followup-10.fixed.md
+++ b/changelog.d/unreleased/+r-followup-10.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - README.md
+---
+
+## English
+
+- **R search now recognizes `methods::setAs` class aliases** — following up on PR #1269, `cdidx` now extracts both sides of `methods::setAs(from = ..., to = ...)` as searchable class symbols, extending the existing R object-system constructor coverage.
+
+## 日本語
+
+- **R の検索が `methods::setAs` の class alias に対応しました** — PR #1269 の follow-up として、`cdidx` は `methods::setAs(from = ..., to = ...)` の両側を検索可能な class シンボルとして抽出するようになり、既存の R オブジェクトシステム constructor 抽出がさらに広がりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1337,6 +1337,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setAs\s*\(.*?\b(?:to|Class)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setValidity\s*\(\s*(?:(?:Class|class|classes|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setGeneric\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15918,11 +15918,13 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_R_DetectsS4AndReferenceClassDefinitions()
     {
-        // R: setClass, setClassUnion, setRefClass, R6Class, setGeneric, setMethod, inherit metadata / R: setClass、setClassUnion、setRefClass、R6Class、setGeneric、setMethod、inherit メタデータ
+        // R: setClass, setClassUnion, setAs, setRefClass, R6Class, setGeneric, setMethod, inherit metadata / R: setClass、setClassUnion、setAs、setRefClass、R6Class、setGeneric、setMethod、inherit メタデータ
         var content = """
             methods::setClass(Class = "Person", slots = c(name = "character"))
 
             methods::setClassUnion(name = Renderable, c(Person, Widget))
+
+            methods::setAs(from = "SourceClass", to = TargetClass, function(from) from)
 
             methods::setRefClass(classname = Widget, fields = list(value = "numeric"))
 
@@ -15946,6 +15948,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Renderable");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "TargetClass");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Widget");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "LegacyThing");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Thing");


### PR DESCRIPTION
This PR is a follow-up to PR #1269 and addresses its follow-up candidates.

Summary:
- Extend R symbol extraction so `methods::setAs(from = ..., to = ...)` contributes the target class name as a searchable class symbol.
- Keep the existing R constructor coverage intact, including `methods::setClass`, `methods::setRefClass`, `methods::setClassUnion`, `methods::setOldClass`, `methods::setValidity`, `R6::R6Class`, `methods::setGeneric`, `methods::setMethod`, and R6 `public` / `private` / `active` method extraction.
- Update the R coverage note in `README.md`.
- Add a changelog fragment at `changelog.d/unreleased/+r-followup-10.fixed.md`.

Validation:
- `dotnet build`
- `dotnet test CodeIndex.sln --no-build --filter FullyQualifiedName~Extract_R_DetectsS4AndReferenceClassDefinitions --verbosity minimal`
- `dotnet test CodeIndex.sln --no-build --verbosity minimal`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

Follow-up candidates:
- Add support for additional R constructor aliases if new nonstandard named parameters show up in the repository.
- Expand R6 parsing further if more complex generator layouts or metadata become important for search.