### PR TITLE
Handle multi-line XAML bindings

### DIFF
--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -5674,6 +5674,15 @@ private sealed class RubyMaskState
         if (!hasXamlNamespace)
             return [];
 
+        var rawText = string.Join('\n', lines);
+        var lineStarts = new int[lines.Length];
+        var lineCursor = 0;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            lineStarts[i] = lineCursor;
+            lineCursor += lines[i].Length + 1;
+        }
+
         var symbols = new List<SymbolRecord>();
         for (var i = 0; i < lines.Length; i++)
         {
@@ -5746,23 +5755,6 @@ private sealed class RubyMaskState
                 });
             }
 
-            foreach (Match bindingMatch in XamlBindingRegex.Matches(line))
-            {
-                var value = NormalizeXamlBindingValue(bindingMatch.Groups["kind"].Value, bindingMatch.Groups["content"].Value);
-                if (value.Length == 0)
-                    continue;
-                symbols.Add(new SymbolRecord
-                {
-                    FileId = fileId,
-                    Kind = "property",
-                    Name = value,
-                    Line = i + 1,
-                    StartLine = i + 1,
-                    EndLine = i + 1,
-                    Signature = line.Trim(),
-                });
-            }
-
             foreach (Match handlerMatch in XamlEventHandlerRegex.Matches(line))
             {
                 var value = handlerMatch.Groups["value"].Value.Trim();
@@ -5779,6 +5771,26 @@ private sealed class RubyMaskState
                     Signature = line.Trim(),
                 });
             }
+        }
+
+        foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
+        {
+            var value = NormalizeXamlBindingValue(bindingMatch.Groups["kind"].Value, bindingMatch.Groups["content"].Value);
+            if (value.Length == 0)
+                continue;
+
+            var startLine = FindHtmlLineNumber(lineStarts, bindingMatch.Index);
+            var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+            symbols.Add(new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "property",
+                Name = value,
+                Line = startLine,
+                StartLine = startLine,
+                EndLine = startLine,
+                Signature = lines[signatureIndex].Trim(),
+            });
         }
 
         return symbols;

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -5846,6 +5846,8 @@ private sealed class RubyMaskState
                 var argumentName = argument[..argument.IndexOf('=')].Trim();
                 if (string.Equals(argumentName, "Path", StringComparison.OrdinalIgnoreCase))
                     return normalized;
+
+                continue;
             }
 
             fallback ??= normalized;

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19402,6 +19402,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "ViewModel");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Title");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "SaveCommand");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "Root");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19389,8 +19389,10 @@ public class SymbolExtractorTests
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                          xmlns:vm="clr-namespace:Sample.ViewModels">
                 <StackPanel DataContext="{Binding Source={x:Reference Root}, Path=ViewModel}">
-                    <Label Text="{Binding Title}" />
-                    <Button Command="{x:Bind ViewModel.SaveCommand}" />
+                    <Label Text="{Binding
+                        Title}" />
+                    <Button Command="{x:Bind
+                        ViewModel.SaveCommand}" />
                 </StackPanel>
             </ContentPage>
             """;


### PR DESCRIPTION
## Summary

- Addressed the follow-up candidates from PR #1271.
- Extended XAML binding extraction so multi-line `Binding` and `x:Bind` expressions are indexed as `property` symbols too.
- Preserved the earlier XAML handler and binding-path coverage while making the binding scan file-wide instead of line-bound.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesBindingPaths|FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesCommonEventHandlers"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- No README or workflow docs changed; this is a non-breaking behavior improvement.
- Changelog fragment: `changelog.d/unreleased/+xaml-binding-paths.fixed.md`

## Follow-up candidates addressed

- This PR directly addresses the previous PR's follow-up candidate for multi-line binding expressions.
- More exotic nested binding shapes can be added later if they show up in real templates.