### PR TITLE
Fix changelog tool root detection

### DIFF
--- a/tests/CodeIndex.Tests/ChangelogToolTests.cs
+++ b/tests/CodeIndex.Tests/ChangelogToolTests.cs
@@ -5,6 +5,34 @@ namespace CodeIndex.Tests;
 public sealed class ChangelogToolTests
 {
     [Fact]
+    public void ProgramMainCheckUsesAssemblyFallbackFromUnrelatedDirectory()
+    {
+        var unrelatedDirectory = Path.Combine(Path.GetTempPath(), "codeindex-changelog-main-test", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(unrelatedDirectory);
+        var previousDirectory = Directory.GetCurrentDirectory();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        using var outWriter = new StringWriter();
+        using var errorWriter = new StringWriter();
+        Directory.SetCurrentDirectory(unrelatedDirectory);
+        Console.SetOut(outWriter);
+        Console.SetError(errorWriter);
+        try
+        {
+            var exitCode = CodeIndex.Changelog.Program.Main(["check"]);
+
+            Assert.True(exitCode == 0, $"exitCode={exitCode}\nstdout: {outWriter}\nstderr: {errorWriter}");
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+            Directory.SetCurrentDirectory(previousDirectory);
+            Directory.Delete(unrelatedDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void PrepareMovesFragmentsIntoReleaseAndUpdatesFooter()
     {
         using var scope = new TestRepositoryScope();

--- a/tools/CodeIndex.Changelog/Program.cs
+++ b/tools/CodeIndex.Changelog/Program.cs
@@ -16,7 +16,7 @@ public static class Program
                 return args.Length == 0 ? 1 : 0;
             }
 
-            var root = FindRepositoryRoot(Directory.GetCurrentDirectory());
+            var root = FindRepositoryRoot();
             var tool = new ChangelogTool(root);
 
             var command = args[0];
@@ -102,7 +102,22 @@ public static class Program
         return new ParsedOptions(version, releaseDate.Value);
     }
 
-    private static string FindRepositoryRoot(string startDirectory)
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = Directory.GetCurrentDirectory();
+        var assemblyDirectory = Path.GetDirectoryName(typeof(Program).Assembly.Location);
+
+        foreach (var startDirectory in new[] { currentDirectory, assemblyDirectory }.Where(directory => !string.IsNullOrWhiteSpace(directory)).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var root = TryFindRepositoryRoot(startDirectory!);
+            if (root is not null)
+                return root;
+        }
+
+        throw new ChangelogException("Could not locate the repository root.");
+    }
+
+    private static string? TryFindRepositoryRoot(string startDirectory)
     {
         var current = new DirectoryInfo(startDirectory);
         while (current is not null)
@@ -116,7 +131,7 @@ public static class Program
             current = current.Parent;
         }
 
-        throw new ChangelogException("Could not locate the repository root.");
+        return null;
     }
 
     private sealed record ParsedOptions(Version Version, DateOnly ReleaseDate);


### PR DESCRIPTION
## Summary
- Make the changelog tool discover the repository root from either the current directory or the assembly location.
- Add a regression test that runs `Program.Main(["check"])` from an unrelated directory.

## Validation
- `dotnet test CodeIndex.sln -c Release --filter ChangelogToolTests`
