### PR TITLE
Fix progress output under redirected console

### DIFF
--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -186,6 +186,9 @@ public static class ConsoleUi
         if (total <= 0)
             return;
 
+        var output = Console.Out;
+        var redirected = Console.IsOutputRedirected;
+
         // Update every 50 files or at completion / 50ファイルごと、または完了時に更新
         if (current % 50 != 0 && current != total)
             return;
@@ -200,21 +203,21 @@ public static class ConsoleUi
         var bar = new string('\u2588', filled) + new string('\u2591', barWidth - filled);
         var line = $"{spinner} {bar} {pct * 100,5:F1}%  [{current:N0}/{total:N0}]";
 
-        if (!Console.IsOutputRedirected)
+        if (!redirected)
         {
-            Console.Write($"\r{line}");
-            Console.Out.Flush();
+            output.Write($"\r{line}");
+            output.Flush();
             _lastProgressLineLength = line.Length;
             if (current == total)
             {
-                Console.WriteLine();
+                output.WriteLine();
                 _lastProgressLineLength = 0;
             }
         }
         else
         {
             // Fallback for redirected output / リダイレクト時はフォールバック
-            Console.WriteLine(line.TrimStart());
+            output.WriteLine(line.TrimStart());
         }
     }
 


### PR DESCRIPTION
## Summary
Fix `ConsoleUi.PrintProgress` so it writes to the captured console writer instead of re-resolving `Console.Out` on the final newline.

## Root Cause
`PrintProgress` used `Console.WriteLine()` for the completion newline. When tests temporarily replace `Console.Out`, that late global lookup can hit a closed `TextWriter` and throw `ObjectDisposedException`.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --configuration Release --filter "FullyQualifiedName~ConsoleUiTests.PrintProgress_InitialRender_ShowsZeroPercent" --nologo`
- `dotnet test CodeIndex.sln --configuration Release --no-build --nologo --logger "trx;LogFileName=test_results.trx" --results-directory ./TestResults`

## Documentation / Changelog
No docs or changelog update was needed; this is a test-stability fix with no user-facing command surface change.