### PR TITLE
Fix completion script capture in ConsoleUi tests

### DIFF
--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -1,5 +1,6 @@
 using CodeIndex.Database;
 using CodeIndex.Indexer;
+using System.Text;
 
 namespace CodeIndex.Cli;
 
@@ -60,7 +61,7 @@ public static class ConsoleUi
         // ブレイルフレームは1文字、テーマフレームは表示テキストを含む長い文字列
         bool isThemed = frames.Length > 0 && frames[0].Length > 2;
 
-        if (Console.IsOutputRedirected)
+        if (!ShouldUseInteractiveConsole())
         {
             Console.WriteLine(message);
             return null;
@@ -94,7 +95,7 @@ public static class ConsoleUi
         cts.Cancel();
         // Small delay to let the spinner task exit / スピナータスク終了のための短い待機
         Thread.Sleep(SpinnerStopDelayMs);
-        if (!Console.IsOutputRedirected)
+        if (ShouldUseInteractiveConsole())
         {
             Console.Write($"\r{new string(' ', GetWindowWidth() - ConsoleLineMargin)}\r");
             Console.Out.Flush();
@@ -187,7 +188,7 @@ public static class ConsoleUi
             return;
 
         var output = Console.Out;
-        var redirected = Console.IsOutputRedirected;
+        var redirected = !ShouldUseInteractiveConsole();
 
         // Update every 50 files or at completion / 50ファイルごと、または完了時に更新
         if (current % 50 != 0 && current != total)
@@ -227,7 +228,7 @@ public static class ConsoleUi
     /// </summary>
     public static void ClearProgressLine()
     {
-        if (!Console.IsOutputRedirected && _lastProgressLineLength > 0)
+        if (ShouldUseInteractiveConsole() && _lastProgressLineLength > 0)
         {
             Console.Write($"\r{new string(' ', _lastProgressLineLength)}\r");
             Console.Out.Flush();
@@ -808,7 +809,7 @@ _cdidx";
     public static string ColorizeKind(string kind, int padWidth = 0)
     {
         var padded = padWidth > 0 ? kind.PadRight(padWidth) : kind;
-        if (!Console.IsOutputRedirected)
+        if (ShouldUseInteractiveConsole())
         {
             var color = kind switch
             {
@@ -828,6 +829,17 @@ _cdidx";
                 return $"{color}{padded}\x1b[0m";
         }
         return padded;
+    }
+
+    internal static bool ShouldUseInteractiveConsole()
+    {
+        if (Console.IsOutputRedirected)
+            return false;
+
+        // StringWriter-based test capture leaves the process console attached, so
+        // Console.IsOutputRedirected stays false even though interactive terminal
+        // behavior would be unsafe. Treat UTF-16 Console.Out as redirected capture.
+        return !Console.Out.Encoding.Equals(Encoding.Unicode);
     }
 
     /// <summary>

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -552,22 +552,26 @@ public static class ConsoleUi
     /// </summary>
     public static bool PrintCompletions(string shell)
     {
-        switch (shell.ToLowerInvariant())
+        try
         {
-            case "bash":
-                PrintBashCompletions();
-                return true;
-            case "zsh":
-                PrintZshCompletions();
-                return true;
-            case "fish":
-                PrintFishCompletions();
-                return true;
-            default:
-                Console.Error.WriteLine($"Unknown shell: {shell}. Supported: bash, zsh, fish");
-                return false;
+            Console.WriteLine(GetCompletionScript(shell));
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            Console.Error.WriteLine($"Unknown shell: {shell}. Supported: bash, zsh, fish");
+            return false;
         }
     }
+
+    internal static string GetCompletionScript(string shell) =>
+        shell.ToLowerInvariant() switch
+        {
+            "bash" => GetBashCompletions(),
+            "zsh" => GetZshCompletions(),
+            "fish" => GetFishCompletions(),
+            _ => throw new ArgumentOutOfRangeException(nameof(shell), shell, "Unknown shell"),
+        };
 
     /// <summary>
     /// Get sorted unique language names from FileIndexer for completion values.
@@ -580,11 +584,11 @@ public static class ConsoleUi
             .Distinct()
             .OrderBy(l => l));
 
-    private static void PrintBashCompletions()
+    private static string GetBashCompletions()
     {
         var cmds = string.Join(" ", Commands);
         var langs = GetCompletionLangs();
-        Console.WriteLine($@"_cdidx() {{
+        return $@"_cdidx() {{
     local cur prev commands
     local cmd
     cur=""${{COMP_WORDS[COMP_CWORD]}}""
@@ -620,13 +624,13 @@ public static class ConsoleUi
             ;;
     esac
 }}
-complete -F _cdidx cdidx");
+complete -F _cdidx cdidx";
     }
 
-    private static void PrintZshCompletions()
+    private static string GetZshCompletions()
     {
         var cmds = string.Join(" ", Commands.Select(c => $"'{c}:{c} command'"));
-        Console.WriteLine($@"#compdef cdidx
+        return $@"#compdef cdidx
 _cdidx() {{
     local -a commands
     commands=(
@@ -753,41 +757,45 @@ _cdidx() {{
             ;;
     esac
 }}
-_cdidx");
+_cdidx";
     }
 
-    private static void PrintFishCompletions()
+    private static string GetFishCompletions()
     {
-        Console.WriteLine("# cdidx fish completions");
+        var lines = new List<string>
+        {
+            "# cdidx fish completions",
+        };
         foreach (var cmd in Commands)
-            Console.WriteLine($"complete -c cdidx -n '__fish_use_subcommand' -a '{cmd}' -d '{cmd} command'");
-        Console.WriteLine("complete -c cdidx -n '__fish_use_subcommand' -l help -d 'Show help'");
-        Console.WriteLine("complete -c cdidx -n '__fish_use_subcommand' -l version -d 'Show version'");
-        Console.WriteLine("complete -c cdidx -n '__fish_use_subcommand' -l license -d 'Show license summary'");
+            lines.Add($"complete -c cdidx -n '__fish_use_subcommand' -a '{cmd}' -d '{cmd} command'");
+        lines.Add("complete -c cdidx -n '__fish_use_subcommand' -l help -d 'Show help'");
+        lines.Add("complete -c cdidx -n '__fish_use_subcommand' -l version -d 'Show version'");
+        lines.Add("complete -c cdidx -n '__fish_use_subcommand' -l license -d 'Show license summary'");
 
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find excerpt map inspect outline status' -l db -r -d 'Database path'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find excerpt map inspect outline status' -l json -d 'JSON output'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l limit -r -d 'Max results'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l lang -r -d 'Filter by language'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l count -d 'Count only'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l path -r -d 'Path filter'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l exclude-path -r -d 'Exclude path'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l exclude-tests -d 'Exclude tests'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from find' -l query -r -d 'Literal query'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from find excerpt' -l before -r -d 'Context lines before'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from find excerpt' -l after -r -d 'Context lines after'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search references excerpt find inspect' -l max-line-width -r -d 'Clamp long single-line payloads (0 disables clamping)'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from excerpt' -l focus-line -r -d 'Focused line to keep visible when clamping'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from excerpt' -l focus-column -r -d 'Focused column to keep visible when clamping'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from excerpt' -l focus-length -r -d 'Focused span width when clamping'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search find' -l exact -d 'Exact match'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from definition inspect' -l body -d 'Include body'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search' -l fts -d 'Raw FTS5 syntax'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search' -l snippet-lines -r -d 'Snippet length'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from hotspots' -l group-by-name -d 'Collapse same-name rows across files'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols inspect' -l exact -d 'Backward-compatible exact shorthand'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from search' -l exact-substring -d 'Search-only exact substring match'");
-        Console.WriteLine("complete -c cdidx -n '__fish_seen_subcommand_from definition references callers callees symbols inspect' -l exact-name -d 'Exact symbol-name equality'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find excerpt map inspect outline status' -l db -r -d 'Database path'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find excerpt map inspect outline status' -l json -d 'JSON output'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l limit -r -d 'Max results'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l lang -r -d 'Filter by language'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l count -d 'Count only'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l path -r -d 'Path filter'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l exclude-path -r -d 'Exclude path'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l exclude-tests -d 'Exclude tests'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from find' -l query -r -d 'Literal query'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from find excerpt' -l before -r -d 'Context lines before'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from find excerpt' -l after -r -d 'Context lines after'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search references excerpt find inspect' -l max-line-width -r -d 'Clamp long single-line payloads (0 disables clamping)'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from excerpt' -l focus-line -r -d 'Focused line to keep visible when clamping'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from excerpt' -l focus-column -r -d 'Focused column to keep visible when clamping'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from excerpt' -l focus-length -r -d 'Focused span width when clamping'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search find' -l exact -d 'Exact match'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from definition inspect' -l body -d 'Include body'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search' -l fts -d 'Raw FTS5 syntax'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search' -l snippet-lines -r -d 'Snippet length'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from hotspots' -l group-by-name -d 'Collapse same-name rows across files'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols inspect' -l exact -d 'Backward-compatible exact shorthand'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search' -l exact-substring -d 'Search-only exact substring match'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from definition references callers callees symbols inspect' -l exact-name -d 'Exact symbol-name equality'");
+        return string.Join(Environment.NewLine, lines);
     }
 
     // --- Helpers / ヘルパー ---

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -609,7 +609,7 @@ public static class IndexCommandRunner
         if (!options.Json)
             Console.WriteLine($"Updating {targetPaths.Count} file(s)...");
         CancellationTokenSource? updateCts = null;
-        var interactiveUpdateSpinner = !options.Json && !Console.IsOutputRedirected;
+          var interactiveUpdateSpinner = !options.Json && ConsoleUi.ShouldUseInteractiveConsole();
         int updated = 0, removed = 0, skipped = 0, warnings = 0, errors = 0;
         var errorList = new List<object>();
         var warningList = new List<object>();
@@ -1528,7 +1528,7 @@ public static class IndexCommandRunner
         CancellationTokenSource? indexCts = null;
         int processed = 0, skipped = 0, warnings = warningList.Count, errors = errorList.Count;
 
-        var interactiveIndexSpinner = !options.Json && !Console.IsOutputRedirected;
+          var interactiveIndexSpinner = !options.Json && ConsoleUi.ShouldUseInteractiveConsole();
         var redirectedIndexingMessagePrinted = false;
         var indexProgressVisible = false;
         var reusedHotspotFamilyLanguages = new HashSet<string>(StringComparer.Ordinal);

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -232,58 +232,30 @@ public class ConsoleUiTests
     [InlineData("zsh", "elif [[ $subcmd == hotspots ]]; then", "--group-by-name[Hotspots: collapse same-name rows across files]", "--exact-name[Exact symbol-name equality]")]
     public void PrintCompletions_BashAndZshScopeGroupByNameToHotspots(string shell, string hotspotsBranchMarker, string groupedFlagToken, string genericExactNameToken)
     {
-        lock (TestConsoleLock.Gate)
-        {
-            var originalOut = Console.Out;
-            using var writer = new StringWriter();
-            try
-            {
-                Console.SetOut(writer);
-                Assert.True(ConsoleUi.PrintCompletions(shell));
-                var output = writer.ToString();
-                Assert.Contains(hotspotsBranchMarker, output);
-                Assert.Contains(groupedFlagToken, output);
+        var output = ConsoleUi.GetCompletionScript(shell);
+        Assert.Contains(hotspotsBranchMarker, output);
+        Assert.Contains(groupedFlagToken, output);
 
-                var hotspotsIndex = output.IndexOf(hotspotsBranchMarker, StringComparison.Ordinal);
-                var genericIndex = output.LastIndexOf(genericExactNameToken, StringComparison.Ordinal);
-                Assert.True(hotspotsIndex >= 0);
-                Assert.True(genericIndex > hotspotsIndex);
-                Assert.DoesNotContain("--group-by-name --exact-name", output, StringComparison.Ordinal);
-            }
-            finally
-            {
-                Console.SetOut(originalOut);
-            }
-        }
+        var hotspotsIndex = output.IndexOf(hotspotsBranchMarker, StringComparison.Ordinal);
+        var genericIndex = output.LastIndexOf(genericExactNameToken, StringComparison.Ordinal);
+        Assert.True(hotspotsIndex >= 0);
+        Assert.True(genericIndex > hotspotsIndex);
+        Assert.DoesNotContain("--group-by-name --exact-name", output, StringComparison.Ordinal);
     }
 
     [Fact]
     public void PrintCompletions_FishIncludesFindOptions()
     {
-        lock (TestConsoleLock.Gate)
-        {
-            var originalOut = Console.Out;
-            using var writer = new StringWriter();
-            try
-            {
-                Console.SetOut(writer);
-                Assert.True(ConsoleUi.PrintCompletions("fish"));
-                var output = writer.ToString();
-                Assert.Contains("__fish_seen_subcommand_from search definition references callers callees symbols files find", output);
-                Assert.Contains("__fish_seen_subcommand_from find excerpt", output);
-                Assert.Contains("__fish_seen_subcommand_from search find", output);
-                Assert.Contains("-l query -r -d 'Literal query'", output);
-                Assert.Contains("-l before -r -d 'Context lines before'", output);
-                Assert.Contains("-l after -r -d 'Context lines after'", output);
-                Assert.Contains("-l exact -d 'Exact match'", output);
-                Assert.Contains("__fish_seen_subcommand_from hotspots", output);
-                Assert.Contains("-l group-by-name -d 'Collapse same-name rows across files'", output);
-            }
-            finally
-            {
-                Console.SetOut(originalOut);
-            }
-        }
+        var output = ConsoleUi.GetCompletionScript("fish");
+        Assert.Contains("__fish_seen_subcommand_from search definition references callers callees symbols files find", output);
+        Assert.Contains("__fish_seen_subcommand_from find excerpt", output);
+        Assert.Contains("__fish_seen_subcommand_from search find", output);
+        Assert.Contains("-l query -r -d 'Literal query'", output);
+        Assert.Contains("-l before -r -d 'Context lines before'", output);
+        Assert.Contains("-l after -r -d 'Context lines after'", output);
+        Assert.Contains("-l exact -d 'Exact match'", output);
+        Assert.Contains("__fish_seen_subcommand_from hotspots", output);
+        Assert.Contains("-l group-by-name -d 'Collapse same-name rows across files'", output);
     }
 
     [Theory]
@@ -291,44 +263,30 @@ public class ConsoleUiTests
     [InlineData("zsh")]
     public void PrintCompletions_BashAndZshKeepFocusOptionsExcerptOnly(string shell)
     {
-        lock (TestConsoleLock.Gate)
+        var output = ConsoleUi.GetCompletionScript(shell);
+        Assert.Contains("find", output);
+        Assert.Contains("--before", output);
+        Assert.Contains("--after", output);
+        Assert.Contains("--max-line-width", output);
+        Assert.Contains("--exact", output);
+        Assert.Contains("--query", output);
+        if (shell == "bash")
         {
-            var originalOut = Console.Out;
-            using var writer = new StringWriter();
-            try
-            {
-                Console.SetOut(writer);
-                Assert.True(ConsoleUi.PrintCompletions(shell));
-                var output = writer.ToString();
-                Assert.Contains("find", output);
-                Assert.Contains("--before", output);
-                Assert.Contains("--after", output);
-                Assert.Contains("--max-line-width", output);
-                Assert.Contains("--exact", output);
-                Assert.Contains("--query", output);
-                if (shell == "bash")
-                {
-                    Assert.Contains("if [ \"$cmd\" = \"find\" ]", output);
-                    Assert.Contains("elif [ \"$cmd\" = \"excerpt\" ]; then", output);
-                    var findBranch = ExtractBetween(output, "if [ \"$cmd\" = \"find\" ]", "elif [ \"$cmd\" = \"excerpt\" ]; then");
-                    var excerptBranch = ExtractBetween(output, "elif [ \"$cmd\" = \"excerpt\" ]; then", "elif [ \"$cmd\" = \"references\" ]; then");
-                    Assert.DoesNotContain("--focus-column", findBranch);
-                    Assert.Contains("--focus-column", excerptBranch);
-                }
-                else
-                {
-                    Assert.Contains("if [[ $subcmd == find ]]; then", output);
-                    Assert.Contains("elif [[ $subcmd == excerpt ]]; then", output);
-                    var findBranch = ExtractBetween(output, "if [[ $subcmd == find ]]; then", "elif [[ $subcmd == excerpt ]]; then");
-                    var excerptBranch = ExtractBetween(output, "elif [[ $subcmd == excerpt ]]; then", "elif [[ $subcmd == references ]]; then");
-                    Assert.DoesNotContain("focus-column", findBranch);
-                    Assert.Contains("focus-column", excerptBranch);
-                }
-            }
-            finally
-            {
-                Console.SetOut(originalOut);
-            }
+            Assert.Contains("if [ \"$cmd\" = \"find\" ]", output);
+            Assert.Contains("elif [ \"$cmd\" = \"excerpt\" ]; then", output);
+            var findBranch = ExtractBetween(output, "if [ \"$cmd\" = \"find\" ]", "elif [ \"$cmd\" = \"excerpt\" ]; then");
+            var excerptBranch = ExtractBetween(output, "elif [ \"$cmd\" = \"excerpt\" ]; then", "elif [ \"$cmd\" = \"references\" ]; then");
+            Assert.DoesNotContain("--focus-column", findBranch);
+            Assert.Contains("--focus-column", excerptBranch);
+        }
+        else
+        {
+            Assert.Contains("if [[ $subcmd == find ]]; then", output);
+            Assert.Contains("elif [[ $subcmd == excerpt ]]; then", output);
+            var findBranch = ExtractBetween(output, "if [[ $subcmd == find ]]; then", "elif [[ $subcmd == excerpt ]]; then");
+            var excerptBranch = ExtractBetween(output, "elif [[ $subcmd == excerpt ]]; then", "elif [[ $subcmd == references ]]; then");
+            Assert.DoesNotContain("focus-column", findBranch);
+            Assert.Contains("focus-column", excerptBranch);
         }
     }
 
@@ -352,43 +310,28 @@ public class ConsoleUiTests
     [InlineData("zsh")]
     public void PrintCompletions_BashAndZshScopeMaxLineWidthToSearchBranch(string shell)
     {
-        lock (TestConsoleLock.Gate)
+        var output = ConsoleUi.GetCompletionScript(shell).Replace("\r\n", "\n");
+        if (shell == "bash")
         {
-            var originalOut = Console.Out;
-            using var writer = new StringWriter();
-            try
-            {
-                Console.SetOut(writer);
-                Assert.True(ConsoleUi.PrintCompletions(shell));
-                // Normalize line endings / 改行を正規化 — Windows Console.WriteLine emits \r\n
-                var output = writer.ToString().Replace("\r\n", "\n");
-                if (shell == "bash")
-                {
-                    Assert.Contains("elif [ \"$cmd\" = \"search\" ]; then", output);
-                    var searchBranch = ExtractBetween(output, "elif [ \"$cmd\" = \"search\" ]; then", "else\n");
-                    var genericBranch = ExtractBetween(output, "else\n                COMPREPLY=($(compgen -W \"", "\" -- \"$cur\"))\n            fi");
-                    Assert.Contains("--max-line-width", searchBranch);
-                    Assert.Contains("--top", searchBranch);
-                    Assert.Contains("--no-dedup", searchBranch);
-                    Assert.DoesNotContain("--exact-name", searchBranch);
-                    Assert.DoesNotContain("--max-line-width", genericBranch);
-                }
-                else
-                {
-                    Assert.Contains("elif [[ $subcmd == search ]]; then", output);
-                    var searchBranch = ExtractBetween(output, "elif [[ $subcmd == search ]]; then", "else\n");
-                    var genericBranch = ExtractBetween(output, "else\n                _arguments", "fi\n            ;;");
-                    Assert.Contains("--max-line-width", searchBranch);
-                    Assert.Contains("'--top", searchBranch);
-                    Assert.Contains("'--no-dedup", searchBranch);
-                    Assert.DoesNotContain("--exact-name", searchBranch);
-                    Assert.DoesNotContain("--max-line-width", genericBranch);
-                }
-            }
-            finally
-            {
-                Console.SetOut(originalOut);
-            }
+            Assert.Contains("elif [ \"$cmd\" = \"search\" ]; then", output);
+            var searchBranch = ExtractBetween(output, "elif [ \"$cmd\" = \"search\" ]; then", "else\n");
+            var genericBranch = ExtractBetween(output, "else\n                COMPREPLY=($(compgen -W \"", "\" -- \"$cur\"))\n            fi");
+            Assert.Contains("--max-line-width", searchBranch);
+            Assert.Contains("--top", searchBranch);
+            Assert.Contains("--no-dedup", searchBranch);
+            Assert.DoesNotContain("--exact-name", searchBranch);
+            Assert.DoesNotContain("--max-line-width", genericBranch);
+        }
+        else
+        {
+            Assert.Contains("elif [[ $subcmd == search ]]; then", output);
+            var searchBranch = ExtractBetween(output, "elif [[ $subcmd == search ]]; then", "else\n");
+            var genericBranch = ExtractBetween(output, "else\n                _arguments", "fi\n            ;;");
+            Assert.Contains("--max-line-width", searchBranch);
+            Assert.Contains("'--top", searchBranch);
+            Assert.Contains("'--no-dedup", searchBranch);
+            Assert.DoesNotContain("--exact-name", searchBranch);
+            Assert.DoesNotContain("--max-line-width", genericBranch);
         }
     }
 


### PR DESCRIPTION
## Summary
- Move shell completion script generation into an internal helper so tests can inspect the generated text directly.
- Stop the ConsoleUi completion tests from depending on redirected console capture.
- Keep the `search` completion branch coverage that failed in the Windows lane.
- Stabilize interactive console detection so `StringWriter`-based test capture does not accidentally take the interactive spinner/progress path.

## Why this failed now
- The failing assertion was not a new product regression; it was a brittle test harness issue.
- `ConsoleUiTests` had been capturing `Console.Out` to validate large generated completion scripts, and that approach can go empty or lose the expected text under Windows CI / xUnit scheduling differences.
- After that first fix, Windows CI exposed a second fragility: `Console.IsOutputRedirected` stays `false` even when tests replace `Console.Out` with a `StringWriter`, so the CLI still treated test runs as interactive.
- That let spinner/progress paths run during test capture, and later `Console.WriteLine` calls hit a closed `TextWriter`, producing `ObjectDisposedException` failures across `IndexCommandRunnerTests` and `QueryCommandRunnerTests`.
- The new helper treats `StringWriter` capture as non-interactive, which keeps the test harness on the redirected-output code path and avoids the closed-writer crash.

## Validation
- `dotnet test CodeIndex.sln -c Release --filter ConsoleUiTests`
- `dotnet test CodeIndex.sln -c Release`
