### PR TITLE
Improve Python from-import search

### DIFF
--- a/changelog.d/unreleased/+python-from-import-search.fixed.md
+++ b/changelog.d/unreleased/+python-from-import-search.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Python from-imports now index qualified module paths for search** — `from package import submodule` and similar forms now add `package.submodule`-style import symbols in addition to the leaf names, so exact-name searches can find re-export and nested-import patterns more naturally.
+
+## 日本語
+
+- **Python の from-import でも修飾済みモジュール名を検索用に索引するようになりました** — `from package import submodule` のような形でも `package.submodule` 形式の import symbol を leaf 名と併せて追加するため、exact-name 検索で re-export や入れ子 import を見つけやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -4292,6 +4292,7 @@ private sealed class RubyMaskState
             AddPythonImportSpecEntries(
                 line,
                 absoluteStartColumn,
+                modulePart: null,
                 directImportSpecs,
                 entries,
                 seenNames,
@@ -4310,6 +4311,7 @@ private sealed class RubyMaskState
                 lines,
                 lineIndex,
                 absoluteStartColumn + fromImportMatch.Groups["imports"].Index,
+                modulePart,
                 fromImportSpecs,
                 entries,
                 seenNames))
@@ -4320,6 +4322,7 @@ private sealed class RubyMaskState
         AddPythonImportSpecEntries(
             line,
             absoluteStartColumn + fromImportMatch.Groups["imports"].Index,
+            modulePart,
             fromImportSpecs,
             entries,
             seenNames,
@@ -4457,6 +4460,7 @@ private sealed class RubyMaskState
         string[] lines,
         int startLineIndex,
         int importsStartColumn,
+        string modulePart,
         string importSpecs,
         List<PythonImportSymbolEntry> entries,
         HashSet<string> seenNames)
@@ -4506,6 +4510,7 @@ private sealed class RubyMaskState
                         AddPythonImportSpecEntries(
                             currentLine,
                             fragmentStartColumn,
+                            modulePart,
                             fragment,
                             entries,
                             seenNames,
@@ -4518,6 +4523,7 @@ private sealed class RubyMaskState
                 AddPythonImportSpecEntries(
                     currentLine,
                     fragmentStartColumn,
+                    modulePart,
                     fragment,
                     entries,
                     seenNames,
@@ -4536,6 +4542,7 @@ private sealed class RubyMaskState
     private static void AddPythonImportSpecEntries(
         string line,
         int absoluteStartColumn,
+        string? modulePart,
         string importedNames,
         List<PythonImportSymbolEntry> entries,
         HashSet<string> seenNames,
@@ -4549,6 +4556,9 @@ private sealed class RubyMaskState
             importedNames = importedNames[1..^1].Trim();
 
         var searchStartColumn = absoluteStartColumn;
+        var normalizedModulePart = treatAsFromImport
+            ? modulePart?.Trim().TrimStart('.').TrimEnd('.')
+            : null;
         foreach (var rawSpec in importedNames.Split(','))
         {
             var spec = rawSpec.Trim();
@@ -4572,6 +4582,17 @@ private sealed class RubyMaskState
                         line,
                         absoluteStartColumn,
                         importedName,
+                        entries,
+                        seenNames,
+                        ref searchStartColumn);
+                }
+
+                if (treatAsFromImport && !string.IsNullOrEmpty(normalizedModulePart))
+                {
+                    AddPythonImportEntry(
+                        line,
+                        absoluteStartColumn,
+                        $"{normalizedModulePart}.{importedName}",
                         entries,
                         seenNames,
                         ref searchStartColumn);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -310,6 +310,44 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsPythonFromImportQualifiedNames()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_python_from_import_qualified");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/app.py",
+                "python",
+                """
+                from package import submodule as alias
+                from .helpers import build
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["package.submodule", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
+
+            var (relativeExitCode, relativeStdout, relativeStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["helpers.build", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, relativeExitCode);
+            Assert.Equal("1", relativeStdout.Trim());
+            Assert.Equal(string.Empty, relativeStderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSearchAndSymbols_ExactQueriesSeePythonInitAllExports()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_python_init_all_exports");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -113,6 +113,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_ExpandsFromImportQualifiedNamesForSearchability()
+    {
+        var content = """
+            from package import submodule as alias
+            from .helpers import build
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var imports = symbols.Where(symbol => symbol.Kind == "import").ToList();
+
+        Assert.Contains(imports, symbol => symbol.Name == "package");
+        Assert.Contains(imports, symbol => symbol.Name == "package.submodule");
+        Assert.Contains(imports, symbol => symbol.Name == "submodule");
+        Assert.Contains(imports, symbol => symbol.Name == "alias");
+        Assert.Contains(imports, symbol => symbol.Name == "helpers");
+        Assert.Contains(imports, symbol => symbol.Name == "helpers.build");
+        Assert.Contains(imports, symbol => symbol.Name == "build");
+    }
+
+    [Fact]
     public void Extract_Python_ExpandsDottedImportPrefixesForSearchability()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Added Python search indexing for qualified `from ... import ...` module paths, so exact-name lookups can find patterns like `package.submodule` and `helpers.build`.
- Covered the behavior with unit tests and a CLI regression test.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsPythonFromImportQualifiedNames"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsPythonDottedImportPrefixes"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/QueryCommandRunnerTests.cs changelog.d/unreleased/+python-from-import-search.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog
- Added bilingual fragment: `changelog.d/unreleased/+python-from-import-search.fixed.md`
- No additional docs were needed because this is a non-breaking search enhancement.

## Follow-up candidates
- Consider whether Python `__all__` export handling should also expand to more module-like qualified names when the package re-exports submodules.
- Consider a broader heuristic for Python re-export patterns that keeps precision high while capturing more module aliasing cases.