### PR TITLE
Index Go interface methods for search

### DIFF
--- a/changelog.d/unreleased/+go-interface-methods.fixed.md
+++ b/changelog.d/unreleased/+go-interface-methods.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Go interface methods are now indexed as functions** — `search`, `definition`, and other symbol-driven flows now surface method names declared inside Go interface bodies, including grouped `type (...)` blocks and single-line interface bodies.
+
+## 日本語
+
+- **Go の interface メソッドが function としてインデックスされるようになりました** — Go の interface 本体内で宣言されたメソッド名が `search` / `definition` などのシンボル駆動フローに現れるようになり、`type (...)` の grouped block や 1 行 interface body も対象になります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -136,6 +136,12 @@ public static class SymbolExtractor
     private static readonly Regex GoTypeBlockSpecRegex = new(
         @"^(?<name>\w+)(?:\[[^\]]+\])?\s+(?:(?<kind>struct|interface)\b|.+)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoInterfaceHeaderRegex = new(
+        @"^\s*(?:type\s+)?\w+(?:\[[^\]]+\])?\s+interface\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoInterfaceMethodRegex = new(
+        @"^\s*(?<name>[A-Za-z_]\w*)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex GoValueBlockSpecRegex = new(
         @"^(?<names>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1915,6 +1921,152 @@ public static class SymbolExtractor
         return true;
     }
 
+    private static void ExtractGoInterfaceMethods(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        var awaitingInterfaceBody = false;
+        var inInterfaceBody = false;
+        var interfaceBodyDepth = 0;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var rawLine = lines[i];
+            var trimmed = rawLine.TrimStart();
+
+            if (!inInterfaceBody)
+            {
+                if (!awaitingInterfaceBody)
+                {
+                    if (!GoInterfaceHeaderRegex.IsMatch(trimmed))
+                        continue;
+                }
+                else if (trimmed.Length == 0
+                    || trimmed.StartsWith("//", StringComparison.Ordinal)
+                    || trimmed.StartsWith("/*", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var openBraceIndex = rawLine.IndexOf('{');
+                if (openBraceIndex < 0)
+                {
+                    awaitingInterfaceBody = true;
+                    continue;
+                }
+
+                inInterfaceBody = true;
+                awaitingInterfaceBody = false;
+                interfaceBodyDepth = CountGoBraceDelta(rawLine);
+
+                var sameLineBody = rawLine[(openBraceIndex + 1)..].TrimStart();
+                if (sameLineBody.Length > 0
+                    && !sameLineBody.StartsWith("//", StringComparison.Ordinal)
+                    && !sameLineBody.StartsWith("/*", StringComparison.Ordinal)
+                    && !sameLineBody.StartsWith("}", StringComparison.Ordinal))
+                {
+                    var bodySegment = sameLineBody;
+                    var sameLineClosingBraceIndex = bodySegment.IndexOf('}');
+                    if (sameLineClosingBraceIndex >= 0)
+                        bodySegment = bodySegment[..sameLineClosingBraceIndex].TrimEnd();
+
+                    var match = GoInterfaceMethodRegex.Match(bodySegment);
+                    if (match.Success)
+                    {
+                        var name = match.Groups["name"].Value.Trim();
+                        if (!HasGoSymbol(symbols, fileId, i + 1, "function", name))
+                        {
+                            var startColumn = rawLine.IndexOf(name, StringComparison.Ordinal);
+                            if (startColumn < 0)
+                                startColumn = rawLine.Length - trimmed.Length;
+
+                            AddSymbolRecord(
+                                symbols,
+                                cssSeenSymbols: null,
+                                i + 1,
+                                new SymbolRecord
+                                {
+                                    FileId = fileId,
+                                    Kind = "function",
+                                    Name = name,
+                                    Line = i + 1,
+                                    StartLine = i + 1,
+                                    StartColumn = startColumn,
+                                    EndLine = i + 1,
+                                    Signature = rawLine.Trim(),
+                                },
+                                rawLine);
+                        }
+                    }
+                }
+
+                if (interfaceBodyDepth <= 0)
+                {
+                    inInterfaceBody = false;
+                    interfaceBodyDepth = 0;
+                }
+
+                continue;
+            }
+
+            if (trimmed.Length == 0
+                || trimmed.StartsWith("//", StringComparison.Ordinal)
+                || trimmed.StartsWith("/*", StringComparison.Ordinal))
+            {
+                interfaceBodyDepth += CountGoBraceDelta(rawLine);
+                if (interfaceBodyDepth <= 0)
+                {
+                    inInterfaceBody = false;
+                    interfaceBodyDepth = 0;
+                }
+
+                continue;
+            }
+
+            var candidate = trimmed;
+            var trailingBraceIndex = candidate.IndexOf('}');
+            if (trailingBraceIndex >= 0)
+                candidate = candidate[..trailingBraceIndex].TrimEnd();
+
+            if (candidate.Length > 0 && !candidate.StartsWith("}", StringComparison.Ordinal))
+            {
+                var match = GoInterfaceMethodRegex.Match(candidate);
+                if (match.Success)
+                {
+                    var name = match.Groups["name"].Value.Trim();
+                    if (!HasGoSymbol(symbols, fileId, i + 1, "function", name))
+                    {
+                        var startColumn = rawLine.IndexOf(name, StringComparison.Ordinal);
+                        if (startColumn < 0)
+                            startColumn = rawLine.Length - trimmed.Length;
+
+                        AddSymbolRecord(
+                            symbols,
+                            cssSeenSymbols: null,
+                            i + 1,
+                            new SymbolRecord
+                            {
+                                FileId = fileId,
+                                Kind = "function",
+                                Name = name,
+                                Line = i + 1,
+                                StartLine = i + 1,
+                                StartColumn = startColumn,
+                                EndLine = i + 1,
+                                Signature = rawLine.Trim(),
+                            },
+                            rawLine);
+                    }
+                }
+            }
+
+            interfaceBodyDepth += CountGoBraceDelta(rawLine);
+            if (interfaceBodyDepth <= 0)
+            {
+                inInterfaceBody = false;
+                interfaceBodyDepth = 0;
+            }
+        }
+    }
+
     private static void ExpandShellAliasSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
     {
         for (var i = 0; i < lines.Length; i++)
@@ -2155,6 +2307,7 @@ public static class SymbolExtractor
     private static void ExtractGoGroupedDeclarations(long fileId, string[] lines, List<SymbolRecord> symbols)
     {
         string? blockKind = null;
+        ExtractGoInterfaceMethods(fileId, lines, symbols);
         var typeBodyDepth = 0;
 
         for (var i = 0; i < lines.Length; i++)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9991,7 +9991,31 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Primary");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Secondary");
         Assert.DoesNotContain(symbols, s => s.Name == "items");
-        Assert.DoesNotContain(symbols, s => s.Name == "Get");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Get");
+    }
+
+    [Fact]
+    public void Extract_Go_DetectsInterfaceMethodsInsideTypeBlocks()
+    {
+        var content = """
+            package demo
+
+            type (
+                Reader interface {
+                    Read(p []byte) (int, error)
+                    Close() error
+                }
+
+                Store interface { Put(key string, value []byte) error }
+            )
+            """;
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Read");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Close");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Put");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "Reader");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "Store");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Index Go interface method declarations as `function` symbols so they show up in `search`, `definition`, and other symbol-driven flows.
- Keep the existing grouped `type (...)` declaration handling intact while adding a dedicated interface-body scan.
- Cover both multi-line interface bodies and single-line interface bodies in tests.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release --filter FullyQualifiedName~SymbolExtractorTests.Extract_Go`

## Documentation / Changelog

- Added `changelog.d/unreleased/+go-interface-methods.fixed.md`.

## Follow-up candidates

- Go embedded interface entries inside `interface` bodies, such as `io.Reader`, are still ignored as standalone symbols. If we want more navigable interface constraints, that could be indexed in a follow-up change.