### PR TITLE
Improve C++ .hh header indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ The database reflects the working tree at the time of the last index. After swit
 | Kotlin | `.kt`, `.kts` | yes |
 | Ruby | `.rb`, `.rake`, `.gemspec`, `.podspec`, `Gemfile`, `Rakefile`, `Podfile`, `Guardfile`, `Capfile`, `Vagrantfile` | yes |
 | C | `.c`, `.h` | yes |
-| C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | yes |
+| C++ | `.cpp`, `.cc`, `.cxx`, `.hh`, `.hpp`, `.hxx` | yes |
 | PHP | `.php` | yes |
 | Swift | `.swift` | yes |
 | Dart | `.dart` | yes |
@@ -1612,7 +1612,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | Kotlin | `.kt`, `.kts` | yes |
 | Ruby | `.rb`, `.rake`, `.gemspec`, `.podspec`, `Gemfile`, `Rakefile`, `Podfile`, `Guardfile`, `Capfile`, `Vagrantfile` | yes |
 | C | `.c`, `.h` | yes |
-| C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | yes |
+| C++ | `.cpp`, `.cc`, `.cxx`, `.hh`, `.hpp`, `.hxx` | yes |
 | PHP | `.php` | yes |
 | Swift | `.swift` | yes |
 | Dart | `.dart` | yes |

--- a/changelog.d/unreleased/+cpp-hh.fixed.md
+++ b/changelog.d/unreleased/+cpp-hh.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - README.md
+---
+
+## English
+
+- **C++ `.hh` headers are now indexed as C++** — `FileIndexer` recognizes `.hh` as `cpp`, so C++ headers in that common naming style now participate in symbol and reference search instead of being left to the C fallback.
+
+## 日本語
+
+- **C++ の `.hh` ヘッダーを C++ として index するようになりました** — `FileIndexer` が `.hh` を `cpp` として認識するため、その一般的な命名規則の C++ ヘッダーも C のフォールバックに落ちず、symbol / reference search に参加します。

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -116,6 +116,7 @@ public class FileIndexer
         [".cc"]     = "cpp",
         [".cxx"]    = "cpp",
         [".h"]      = "c",       // Could be C or C++; defaults to C for symbol extraction
+        [".hh"]     = "cpp",
         [".hpp"]    = "cpp",
         [".hxx"]    = "cpp",
         [".cs"]     = "csharp",

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -126,6 +126,7 @@ public class FileIndexerTests
     [InlineData("GNUmakefile.am", "makefile")]
     [InlineData("kernel.cu", "cuda")]
     [InlineData("kernel.cuh", "cuda")]
+    [InlineData("header.hh", "cpp")]
     [InlineData("shader.glsl", "glsl")]
     [InlineData("shader.vert", "glsl")]
     [InlineData("shader.frag", "glsl")]
@@ -482,6 +483,7 @@ public class FileIndexerTests
         // Objective-C は独立バケットにし、`.m` / `.mm` をスキップせずに index する。
         Assert.Equal("objc", map[".m"]);
         Assert.Equal("objc", map[".mm"]);
+        Assert.Equal("cpp", map[".hh"]);
     }
 
     [Fact]


### PR DESCRIPTION
Summary:
- Recognize `.hh` files as `cpp` so common C++ headers participate in symbol and reference search.
- Update the C++ extension tables in both README language matrices.
- Add regression coverage for language detection and extension exports.
- Add a bilingual changelog fragment under `changelog.d/unreleased/`.

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~FileIndexerTests`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

Review:
- Adversarial review of `origin/main..HEAD` found no blocking or actionable issues.

Follow-up candidates:
- Consider a content-based heuristic for `.h` files that are actually C++ headers, so common mixed-extension codebases get better C++ symbol/search coverage without changing the default C fallback blindly.

Notes:
- This PR is not tied to a GitHub issue, so no `Fixes #...` line is included.