### PR TITLE
Index multiline Rust use trees

### DIFF
--- a/changelog.d/unreleased/+rust-multiline-use.fixed.md
+++ b/changelog.d/unreleased/+rust-multiline-use.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Rust `use` trees now index across line breaks** — symbol extraction now reads multi-line Rust `use` statements before splitting the tree, so formatted imports like `use std::{ ... }` and `pub(crate) use crate::{ ... }` surface the same import symbols as single-line forms.
+
+## 日本語
+
+- **Rust の `use` tree を改行またぎで索引するようになりました** — symbol extraction が複数行の Rust `use` 文を先にまとめてから tree を分解するため、`use std::{ ... }` や `pub(crate) use crate::{ ... }` のような整形済み import でも 1 行版と同じ import symbol が出るようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -139,9 +139,12 @@ public static class SymbolExtractor
     private static readonly Regex GoValueBlockSpecRegex = new(
         @"^(?<names>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex RustUseStartRegex = new(
+        @"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?use\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex RustUseStatementRegex = new(
         @"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?use\s+(?<body>.+);\s*$",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly Regex XamlClassRegex = new(
         @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -2234,7 +2237,10 @@ public static class SymbolExtractor
         for (var i = 0; i < lines.Length; i++)
         {
             var line = lines[i];
-            var match = RustUseStatementRegex.Match(line);
+            if (!TryReadRustUseStatement(lines, i, out var statement, out var endLineIndex))
+                continue;
+
+            var match = RustUseStatementRegex.Match(statement);
             if (!match.Success)
                 continue;
 
@@ -2271,7 +2277,54 @@ public static class SymbolExtractor
                     },
                     line);
             }
+
+            i = endLineIndex;
         }
+    }
+
+    private static bool TryReadRustUseStatement(string[] lines, int startIndex, out string statement, out int endIndex)
+    {
+        statement = string.Empty;
+        endIndex = startIndex;
+
+        var firstLine = lines[startIndex];
+        if (!RustUseStartRegex.IsMatch(firstLine))
+            return false;
+
+        var builder = new StringBuilder(firstLine.Length + 32);
+        var braceDepth = 0;
+
+        for (var i = startIndex; i < lines.Length; i++)
+        {
+            var current = lines[i];
+            if (i > startIndex)
+                builder.Append('\n');
+            builder.Append(current);
+
+            foreach (var ch in current)
+            {
+                switch (ch)
+                {
+                    case '{':
+                        braceDepth++;
+                        break;
+                    case '}':
+                        if (braceDepth > 0)
+                            braceDepth--;
+                        break;
+                    case ';':
+                        if (braceDepth == 0)
+                        {
+                            statement = builder.ToString();
+                            endIndex = i;
+                            return true;
+                        }
+                        break;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static void CollectRustUseSymbolNames(string body, ISet<string> names, string? prefix = null)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11126,6 +11126,33 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Rust_DetectsMultilineUseTrees()
+    {
+        var content = """
+            use std::{
+                fmt::Display,
+                io::{Result as IoResult, Write},
+            };
+            pub(crate) use crate::{
+                net::Client,
+                net::server::Server as NetServer,
+            };
+            """;
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "std::fmt::Display");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Display");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "std::io::Result as IoResult");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "IoResult");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "std::io::Write");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Write");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "crate::net::Client");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Client");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "crate::net::server::Server as NetServer");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "NetServer");
+    }
+
+    [Fact]
     public void Extract_Rust_MapsImplBlocksToImplementingType()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Extend Rust symbol extraction so multi-line `use` trees are collected before splitting, which keeps formatted imports searchable.
- Add a regression test covering nested and aliased multi-line `use` trees.
- Add a bilingual changelog fragment for the user-visible indexing improvement.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test`
- Rebuilt and refreshed the local index with the committed change: `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog

- `changelog.d/unreleased/+rust-multiline-use.fixed.md`

## Follow-up candidates

- Map multi-line Rust `use` items back to precise per-name line/column positions instead of using the first-line fallback.
- Consider whether other Rust declarations with common multi-line formatting need similar statement-level collection.