### PR TITLE
Index TypeScript import-equals declarations

### DIFF
--- a/changelog.d/unreleased/+typescript-import-equals.fixed.md
+++ b/changelog.d/unreleased/+typescript-import-equals.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **TypeScript `import = require(...)` declarations are now searchable as imports** — `cdidx` now indexes `import foo = require('bar')` forms so dependency lookups can find legacy TypeScript modules by path.
+
+## 日本語
+
+- **TypeScript の `import = require(...)` 宣言も import として検索できるようになりました** — `cdidx` は `import foo = require('bar')` 形式を index するため、従来型の TypeScript モジュールもパス指定で見つけやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -710,6 +710,7 @@ public static class SymbolExtractor
             new("interface", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("import", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?type\s+(?<name>\w+)(?:\s*<[^=]+>)?", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("enum",     new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:const\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("import",   new Regex($@"^\s*import\s+{JavaScriptTypeScriptIdentifierPattern}\s*=\s*require\s*\(\s*['""](?<name>[^'""]+)['""]\s*\)\s*;?\s*$", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*import\s+(?<name>.+?)\s+from\s+", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["csharp"] =

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -1720,6 +1720,19 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScript_DetectsImportEqualsRequireSurfaceSymbols()
+    {
+        var content = """
+            import fs = require('node:fs');
+            import path = require('./path-utils');
+            """;
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "node:fs");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "./path-utils");
+    }
+
+    [Fact]
     public void Extract_TypeScript_DetectsReExportSurfaceSymbolsWithImportAttributes()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Index TypeScript `import foo = require('bar')` declarations as import symbols so legacy dependency lookups can find modules by path.
- Added focused coverage for the new TS import-equals form.
- Added an unreleased bilingual changelog fragment.

## Validation
- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_TypeScript_DetectsImportEqualsRequireSurfaceSymbols"`
- `dotnet test CodeIndex.sln -c Release`

## Docs / Changelog
- Added `changelog.d/unreleased/+typescript-import-equals.fixed.md`.

## Follow-up candidates
- Index the local alias from `import foo = require('bar')` as well, if we want alias-based lookup parity with named imports.
- Consider whether trailing comments on `import = require(...)` lines should also be accepted.