### PR TITLE
Normalize C# global:: prefixes in exact search

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ cdidx search "TODO" --limit 50           # more results
 cdidx search "auth*"                     # trailing * acts as a prefix shorthand
 cdidx search "auth*" --fts               # raw FTS5 syntax when you need operators like NEAR/OR
 cdidx search "Run();" --exact-substring  # case-sensitive exact substring, no FTS5
+cdidx search "Foo.Bar" --lang csharp --exact-substring  # C# exact search also canonicalizes global:: / @ prefixes
 cdidx search "--open-reports" --path README.md --count  # quoted literal that starts with --
 cdidx search --query "--path" --path README.md  # search for an option-looking literal
 ```
@@ -1337,6 +1338,7 @@ cdidx search "TODO" --limit 50           # 結果数を増やす
 cdidx search "auth*"                     # 末尾の * は prefix 検索の shorthand
 cdidx search "auth*" --fts               # 生のFTS5構文。NEAR / OR などの演算子が必要なときだけ使う
 cdidx search "Run();" --exact-substring  # 大文字小文字区別の完全部分一致、FTS5 なし
+cdidx search "Foo.Bar" --lang csharp --exact-substring  # C# の exact 検索は global:: / @ の表記も正規化する
 cdidx search "--open-reports" --path README.md --count  # `--` で始まる引用済みリテラル
 cdidx search --query "--path" --path README.md  # オプションに見えるリテラルを検索
 ```

--- a/changelog.d/unreleased/+csharp-search-global-qualified.fixed.md
+++ b/changelog.d/unreleased/+csharp-search-global-qualified.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/CSharpVerbatimNameNormalizer.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - README.md
+---
+
+## English
+
+- **C# exact substring search now canonicalizes `global::` prefixes** — `search` in `--exact` / `--exact-substring` mode now treats `global::Foo.Bar` the same as `Foo.Bar`, matching the existing verbatim `@` normalization so C# queries find canonical and source spellings consistently.
+
+## 日本語
+
+- **C# の exact / exact-substring 検索で `global::` 接頭辞を正規化するようになりました** — `search` の `--exact` / `--exact-substring` モードで `global::Foo.Bar` を `Foo.Bar` と同一視し、既存の verbatim `@` 正規化と同じく C# の canonical 表記と source 表記を一貫して検索できるようにしました。

--- a/src/CodeIndex/Database/CSharpVerbatimNameNormalizer.cs
+++ b/src/CodeIndex/Database/CSharpVerbatimNameNormalizer.cs
@@ -1,20 +1,28 @@
 namespace CodeIndex.Database;
 
 /// <summary>
-/// Normalizes C# verbatim identifiers by stripping `@` only at identifier boundaries.
-/// C# の verbatim 識別子を正規化し、識別子境界の `@` だけを除去する。
+/// Normalizes C# verbatim identifiers by stripping `@` and `global::` at identifier boundaries.
+/// C# の verbatim 識別子を正規化し、識別子境界の `@` と `global::` を除去する。
 /// </summary>
 internal static class CSharpVerbatimNameNormalizer
 {
     internal static string Normalize(string text)
     {
-        if (text.Length == 0 || text.IndexOf('@') < 0)
+        if (text.Length == 0
+            || (text.IndexOf('@') < 0 && text.IndexOf("global::", StringComparison.Ordinal) < 0))
             return text;
 
         var sb = new System.Text.StringBuilder(text.Length);
         bool atBoundary = true;
         for (int i = 0; i < text.Length; i++)
         {
+            if (atBoundary && TryConsumeGlobalQualifier(text, i))
+            {
+                i += GlobalQualifier.Length - 1;
+                atBoundary = true;
+                continue;
+            }
+
             char c = text[i];
             if (atBoundary && c == '@'
                 && i + 1 < text.Length
@@ -37,7 +45,7 @@ internal static class CSharpVerbatimNameNormalizer
             }
             else
             {
-                atBoundary = false;
+                atBoundary = !IsCSharpIdentifierPartChar(c);
             }
         }
 
@@ -52,7 +60,7 @@ internal static class CSharpVerbatimNameNormalizer
             return text;
         }
 
-        if (text.IndexOf('@') < 0)
+        if (text.IndexOf('@') < 0 && text.IndexOf("global::", StringComparison.Ordinal) < 0)
         {
             rawIndexMap = BuildIdentityMap(text.Length);
             return text;
@@ -63,6 +71,13 @@ internal static class CSharpVerbatimNameNormalizer
         bool atBoundary = true;
         for (int i = 0; i < text.Length; i++)
         {
+            if (atBoundary && TryConsumeGlobalQualifier(text, i))
+            {
+                i += GlobalQualifier.Length - 1;
+                atBoundary = true;
+                continue;
+            }
+
             char c = text[i];
             if (atBoundary && c == '@'
                 && i + 1 < text.Length
@@ -86,7 +101,7 @@ internal static class CSharpVerbatimNameNormalizer
             }
             else
             {
-                atBoundary = false;
+                atBoundary = !IsCSharpIdentifierPartChar(c);
             }
         }
 
@@ -102,6 +117,15 @@ internal static class CSharpVerbatimNameNormalizer
         return map;
     }
 
+    private static bool TryConsumeGlobalQualifier(string text, int index) =>
+        index + GlobalQualifier.Length <= text.Length
+        && text.AsSpan(index, GlobalQualifier.Length).SequenceEqual(GlobalQualifier.AsSpan());
+
+    private const string GlobalQualifier = "global::";
+
     private static bool IsCSharpIdentifierStartChar(char c) =>
         c == '_' || char.IsLetter(c);
+
+    private static bool IsCSharpIdentifierPartChar(char c) =>
+        IsCSharpIdentifierStartChar(c) || char.IsDigit(c);
 }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -7916,6 +7916,77 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void CSharpVerbatimNameNormalizer_StripsGlobalQualifierOnlyAtIdentifierBoundaries()
+    {
+        Assert.Equal("Foo.Bar", CSharpVerbatimNameNormalizer.Normalize("global::Foo.Bar"));
+        Assert.Equal("notglobal::Foo.Bar", CSharpVerbatimNameNormalizer.Normalize("notglobal::Foo.Bar"));
+    }
+
+    [Fact]
+    public void RunSearch_ExactSubstringTreatsCSharpGlobalQualifiedNamesAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_csharp_global");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/global.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                public class GlobalQualified
+                {
+                    public void Match()
+                    {
+                        var value = global::Foo.Bar;
+                    }
+                }
+                """);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/plain.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                public class PlainQualified
+                {
+                    public void Match()
+                    {
+                        var value = Foo.Bar;
+                    }
+                }
+                """);
+
+            var (globalExitCode, globalStdout, globalStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Foo.Bar", "--db", dbPath, "--path", "src/global.cs", "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+            using var globalDocument = ParseJsonOutput(globalStdout);
+
+            var (qualifiedExitCode, qualifiedStdout, qualifiedStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["global::Foo.Bar", "--db", dbPath, "--path", "src/plain.cs", "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+            using var qualifiedDocument = ParseJsonOutput(qualifiedStdout);
+
+            Assert.Equal(CommandExitCodes.Success, globalExitCode);
+            Assert.Equal(string.Empty, globalStderr);
+            Assert.Equal(1, globalDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, globalDocument.RootElement.GetProperty("files").GetInt32());
+
+            Assert.Equal(CommandExitCodes.Success, qualifiedExitCode);
+            Assert.Equal(string.Empty, qualifiedStderr);
+            Assert.Equal(1, qualifiedDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, qualifiedDocument.RootElement.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSearch_ExactSubstringKeepsNormalizationScopedToCSharp()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_csharp_scope");


### PR DESCRIPTION
## Summary
- Canonicalize `global::` prefixes in C# exact search so `global::Foo.Bar` and `Foo.Bar` match consistently.
- Keep the change scoped to `search` and cover the boundary behavior with regression tests.
- Add a changelog fragment and README examples for the new exact-search behavior.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.CSharpVerbatimNameNormalizer_StripsGlobalQualifierOnlyAtIdentifierBoundaries|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsCSharpGlobalQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringKeepsNormalizationScopedToCSharp"`
- `dotnet test`

## Notes
- Changelog fragment: `changelog.d/unreleased/+csharp-search-global-qualified.fixed.md`

## Follow-up candidates
- Mirror the same `global::` canonicalization in `find` exact mode if you want `find` and `search` to stay behaviorally aligned.
- If you want a stricter language-syntax interpretation, consider limiting `global::` stripping to namespace-start positions only, not any identifier boundary.