### PR TITLE
Index Go embedded interface types

### DIFF
--- a/changelog.d/unreleased/+go-embedded-interface-types.fixed.md
+++ b/changelog.d/unreleased/+go-embedded-interface-types.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Go embedded interface types are now indexed inside interface bodies** — embedded constraints such as `io.Reader` and `io.Writer` are surfaced as standalone `import` symbols, so `search` can find interface constraints instead of silently skipping them.
+
+## 日本語
+
+- **Go の埋め込み interface 型が interface 本体内でもインデックスされるようになりました** — `io.Reader` や `io.Writer` のような埋め込み制約を standalone な `import` シンボルとして表に出すため、`search` で interface 制約を見つけられるようになり、無言で取りこぼされなくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -142,6 +142,31 @@ public static class SymbolExtractor
     private static readonly Regex GoInterfaceMethodRegex = new(
         @"^\s*(?<name>[A-Za-z_]\w*)\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoInterfaceEmbeddedTypeRegex = new(
+        @"^\s*(?:~\s*)?(?<name>[A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)(?:\[[^\]\r\n]+\])?\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly HashSet<string> GoInterfaceEmbeddedTypeBlacklist = new(StringComparer.Ordinal)
+    {
+        "bool",
+        "byte",
+        "complex64",
+        "complex128",
+        "float32",
+        "float64",
+        "int",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "rune",
+        "string",
+        "uint",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "uintptr",
+    };
     private static readonly Regex GoValueBlockSpecRegex = new(
         @"^(?<names>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1963,39 +1988,7 @@ public static class SymbolExtractor
                     && !sameLineBody.StartsWith("/*", StringComparison.Ordinal)
                     && !sameLineBody.StartsWith("}", StringComparison.Ordinal))
                 {
-                    var bodySegment = sameLineBody;
-                    var sameLineClosingBraceIndex = bodySegment.IndexOf('}');
-                    if (sameLineClosingBraceIndex >= 0)
-                        bodySegment = bodySegment[..sameLineClosingBraceIndex].TrimEnd();
-
-                    var match = GoInterfaceMethodRegex.Match(bodySegment);
-                    if (match.Success)
-                    {
-                        var name = match.Groups["name"].Value.Trim();
-                        if (!HasGoSymbol(symbols, fileId, i + 1, "function", name))
-                        {
-                            var startColumn = rawLine.IndexOf(name, StringComparison.Ordinal);
-                            if (startColumn < 0)
-                                startColumn = rawLine.Length - trimmed.Length;
-
-                            AddSymbolRecord(
-                                symbols,
-                                cssSeenSymbols: null,
-                                i + 1,
-                                new SymbolRecord
-                                {
-                                    FileId = fileId,
-                                    Kind = "function",
-                                    Name = name,
-                                    Line = i + 1,
-                                    StartLine = i + 1,
-                                    StartColumn = startColumn,
-                                    EndLine = i + 1,
-                                    Signature = rawLine.Trim(),
-                                },
-                                rawLine);
-                        }
-                    }
+                    TryAddGoInterfaceBodySymbols(fileId, rawLine, i, symbols, sameLineBody);
                 }
 
                 if (interfaceBodyDepth <= 0)
@@ -2027,36 +2020,7 @@ public static class SymbolExtractor
                 candidate = candidate[..trailingBraceIndex].TrimEnd();
 
             if (candidate.Length > 0 && !candidate.StartsWith("}", StringComparison.Ordinal))
-            {
-                var match = GoInterfaceMethodRegex.Match(candidate);
-                if (match.Success)
-                {
-                    var name = match.Groups["name"].Value.Trim();
-                    if (!HasGoSymbol(symbols, fileId, i + 1, "function", name))
-                    {
-                        var startColumn = rawLine.IndexOf(name, StringComparison.Ordinal);
-                        if (startColumn < 0)
-                            startColumn = rawLine.Length - trimmed.Length;
-
-                        AddSymbolRecord(
-                            symbols,
-                            cssSeenSymbols: null,
-                            i + 1,
-                            new SymbolRecord
-                            {
-                                FileId = fileId,
-                                Kind = "function",
-                                Name = name,
-                                Line = i + 1,
-                                StartLine = i + 1,
-                                StartColumn = startColumn,
-                                EndLine = i + 1,
-                                Signature = rawLine.Trim(),
-                            },
-                            rawLine);
-                    }
-                }
-            }
+                TryAddGoInterfaceBodySymbols(fileId, rawLine, i, symbols, candidate);
 
             interfaceBodyDepth += CountGoBraceDelta(rawLine);
             if (interfaceBodyDepth <= 0)
@@ -2065,6 +2029,126 @@ public static class SymbolExtractor
                 interfaceBodyDepth = 0;
             }
         }
+    }
+
+    private static void TryAddGoInterfaceBodySymbols(
+        long fileId,
+        string rawLine,
+        int lineIndex,
+        List<SymbolRecord> symbols,
+        string bodyText)
+    {
+        foreach (var segment in bodyText.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var candidate = segment;
+            var trailingBraceIndex = candidate.IndexOf('}');
+            if (trailingBraceIndex >= 0)
+                candidate = candidate[..trailingBraceIndex].TrimEnd();
+
+            var lineCommentIndex = candidate.IndexOf("//", StringComparison.Ordinal);
+            if (lineCommentIndex >= 0)
+                candidate = candidate[..lineCommentIndex].TrimEnd();
+
+            var blockCommentIndex = candidate.IndexOf("/*", StringComparison.Ordinal);
+            if (blockCommentIndex >= 0)
+                candidate = candidate[..blockCommentIndex].TrimEnd();
+
+            if (candidate.Length == 0
+                || candidate.StartsWith("//", StringComparison.Ordinal)
+                || candidate.StartsWith("/*", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (TryAddGoInterfaceMethodSymbol(fileId, rawLine, lineIndex, symbols, candidate))
+                continue;
+
+            TryAddGoInterfaceEmbeddedTypeSymbol(fileId, rawLine, lineIndex, symbols, candidate);
+        }
+    }
+
+    private static bool TryAddGoInterfaceMethodSymbol(
+        long fileId,
+        string rawLine,
+        int lineIndex,
+        List<SymbolRecord> symbols,
+        string candidate)
+    {
+        var match = GoInterfaceMethodRegex.Match(candidate);
+        if (!match.Success)
+            return false;
+
+        var name = match.Groups["name"].Value.Trim();
+        if (HasGoSymbol(symbols, fileId, lineIndex + 1, "function", name))
+            return true;
+
+        var startColumn = rawLine.IndexOf(name, StringComparison.Ordinal);
+        if (startColumn < 0)
+            startColumn = rawLine.Length - rawLine.TrimStart().Length;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineIndex + 1,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = name,
+                Line = lineIndex + 1,
+                StartLine = lineIndex + 1,
+                StartColumn = startColumn,
+                EndLine = lineIndex + 1,
+                Signature = rawLine.Trim(),
+            },
+            rawLine);
+        return true;
+    }
+
+    private static bool TryAddGoInterfaceEmbeddedTypeSymbol(
+        long fileId,
+        string rawLine,
+        int lineIndex,
+        List<SymbolRecord> symbols,
+        string candidate)
+    {
+        var match = GoInterfaceEmbeddedTypeRegex.Match(candidate);
+        if (!match.Success)
+            return false;
+
+        var name = match.Groups["name"].Value.Trim();
+        if (name.Length == 0)
+            return false;
+
+        if (!name.Contains('.') && GoInterfaceEmbeddedTypeBlacklist.Contains(name))
+        {
+            return false;
+        }
+
+        if (HasGoSymbol(symbols, fileId, lineIndex + 1, "import", name))
+            return true;
+
+        var startColumn = rawLine.IndexOf(name, StringComparison.Ordinal);
+        if (startColumn < 0)
+            startColumn = rawLine.Length - rawLine.TrimStart().Length;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineIndex + 1,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "import",
+                Name = name,
+                Line = lineIndex + 1,
+                StartLine = lineIndex + 1,
+                StartColumn = startColumn,
+                EndLine = lineIndex + 1,
+                Signature = rawLine.Trim(),
+            },
+            rawLine);
+        return true;
     }
 
     private static void ExpandShellAliasSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -9984,6 +9984,7 @@ public class SymbolExtractorTests
                     items []T
                 }
                 Container[T comparable, U any] interface {
+                    io.Reader
                     Get() U
                 }
                 Alias[T any] string
@@ -10012,28 +10013,27 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Secondary");
         Assert.DoesNotContain(symbols, s => s.Name == "items");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Get");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "io.Reader");
     }
 
     [Fact]
-    public void Extract_Go_DetectsInterfaceMethodsInsideTypeBlocks()
+    public void Extract_Go_IndexesEmbeddedInterfaceTypesInsideInterfaceBodies()
     {
         var content = """
             package demo
 
-            type (
-                Reader interface {
-                    Read(p []byte) (int, error)
-                    Close() error
-                }
+            type Reader interface {
+                io.Reader
+                Close() error
+            }
 
-                Store interface { Put(key string, value []byte) error }
-            )
+            type Store interface { io.Writer }
             """;
         var symbols = SymbolExtractor.Extract(1, "go", content);
 
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Read");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Close");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Put");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "io.Reader");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "io.Writer");
         Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "Reader");
         Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "Store");
     }


### PR DESCRIPTION
## Summary

- Implements the follow-up candidate from PR #1285 by indexing embedded Go interface types inside interface bodies.
- `io.Reader`, `io.Writer`, and similar embedded constraints now surface as standalone `import` symbols, so `search` can find interface constraints instead of silently skipping them.
- Preserves the existing interface-method extraction behavior from the earlier Go search improvement.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release --filter FullyQualifiedName~SymbolExtractorTests.Extract_Go`

## Documentation / Changelog

- Added `changelog.d/unreleased/+go-embedded-interface-types.fixed.md`.
- This PR explicitly addresses the Follow-up candidates noted in PR #1285.

## Follow-up candidates

- No additional follow-up candidates identified in this pass.