### PR TITLE
Refine Python __all__ re-export search

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -77,7 +77,7 @@ Prefer the existing helper before writing new setup code.
 - `CreateTempProject(prefix)` creates a unique temp workspace.
 - `InitializeGitRepo(projectRoot)` initializes git and sets repo-local `user.name` and `user.email`.
 - `CreateProjectDb(projectRoot)` creates `<projectRoot>/.cdidx/codeindex.db`, initializes schema, and seeds `codeindex_meta.indexed_project_root` to match the project root.
-- `InsertIndexedFile(...)` inserts a realistic indexed file with content-derived checksum, chunks, symbols, and references.
+- `InsertIndexedFile(...)` inserts a realistic indexed file with content-derived checksum, chunks, symbols, and references, and now passes the file path into Python symbol extraction so `__init__.py`-based re-export tests can exercise qualified package names.
 - `RunGit(...)` executes git without shell quoting issues.
 - `DeleteDirectory(path)` retries temp-project cleanup and normalizes attributes. To avoid process-global cross-test interference, it only clears SQLite pools as a Windows-specific retry fallback after a delete failure.
 - `DeleteFile(path)` retries standalone temp-DB cleanup and uses the same Windows-specific SQLite pool release fallback when pooled handles block deletion.
@@ -229,7 +229,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 - `CreateTempProject(prefix)` は一意な一時ワークスペースを作成します。
 - `InitializeGitRepo(projectRoot)` は git を初期化し、repo-local の `user.name` と `user.email` を設定します。
 - `CreateProjectDb(projectRoot)` は `<projectRoot>/.cdidx/codeindex.db` を作成し、スキーマを初期化したうえで `codeindex_meta.indexed_project_root` に project root を書き込みます。
-- `InsertIndexedFile(...)` は内容由来の checksum、chunks、symbols、references を含む現実的なインデックス済みファイルを挿入します。
+- `InsertIndexedFile(...)` は内容由来の checksum、chunks、symbols、references を含む現実的なインデックス済みファイルを挿入し、Python の symbol extraction には file path も渡すため、`__init__.py` ベースの再エクスポートテストで package 修飾名を扱えます。
 - `RunGit(...)` は shell の quoting 問題に依存せず git を実行します。
 - `DeleteDirectory(path)` は temp project cleanup のリトライと属性正規化を扱います。プロセス全体への干渉を避けるため、SQLite pool の解放は Windows で削除に失敗した場合のリトライ時だけに限定します。
 - `DeleteFile(path)` は standalone な temp DB cleanup をリトライし、pooled handle が削除を妨げる場合は同じ Windows 向け SQLite pool 解放フォールバックを使います。

--- a/changelog.d/unreleased/+python-init-all-qualified-search.fixed.md
+++ b/changelog.d/unreleased/+python-init-all-qualified-search.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Python `__all__` re-exports now carry qualified package names in `__init__.py` files** — when a package `__init__.py` lists submodules in `__all__`, cdidx now indexes `package.submodule`-style names in addition to the leaf exports, so exact-name search can find re-exported modules more naturally.
+
+## 日本語
+
+- **Python の `__all__` 再エクスポートは `__init__.py` で修飾済み package 名も持つようになりました** — package の `__init__.py` が `__all__` に submodule を列挙している場合、cdidx は leaf export に加えて `package.submodule` 形式の名前も索引するため、exact-name 検索で再エクスポートされたモジュールを見つけやすくなります。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -922,7 +922,7 @@ public static class IndexCommandRunner
                 var fileId = writer.UpsertFile(record);
                 var chunks = ChunkSplitter.Split(fileId, content);
                 writer.InsertChunks(chunks);
-                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
+                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content, record.Path);
                 SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(absPath, record.Lang));
                 writer.InsertSymbols(symbols);
                 var references = ReferenceExtractor.Extract(fileId, record.Lang, content, symbols, record.Path);

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -2560,8 +2560,9 @@ private sealed class RubyMaskState
     /// <param name="fileId">The file ID in the database / データベース上のファイルID</param>
     /// <param name="lang">Detected language / 検出された言語</param>
     /// <param name="content">Full file content / ファイル全体の内容</param>
+    /// <param name="filePath">Relative file path when available / 利用可能なら相対ファイルパス</param>
     /// <returns>List of extracted symbols / 抽出されたシンボルのリスト</returns>
-    public static List<SymbolRecord> Extract(long fileId, string? lang, string content)
+    public static List<SymbolRecord> Extract(long fileId, string? lang, string content, string? filePath = null)
     {
         var originalLang = lang;
         lang = NormalizeLanguage(lang);
@@ -2606,6 +2607,9 @@ private sealed class RubyMaskState
             content = content.Replace("\r\n", "\n").Replace("\r", "\n");
         content = FileIndexer.StripLineLeadingBom(content);
         var lines = content.Split('\n');
+        var pythonModulePrefix = lang == "python"
+            ? GetPythonModulePrefix(filePath)
+            : null;
 
         // HTML has no brace/indent-scoped bodies, so the generic pattern loop's
         // "first match per line" semantics drop every additional symbol on the
@@ -4119,7 +4123,7 @@ private sealed class RubyMaskState
         if (lang == "cpp")
             ExtractCppSameLineClassBodyMembers(fileId, lines, symbols);
         if (lang == "python")
-            ExtractPythonAllExportSymbols(fileId, lines, symbols);
+            ExtractPythonAllExportSymbols(fileId, lines, symbols, pythonModulePrefix);
         AssignContainers(symbols, lines, csharpLineStartStates);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
         NormalizeKotlinSecondaryConstructorNames(symbols);
@@ -4330,7 +4334,11 @@ private sealed class RubyMaskState
         return entries.Count > 0 ? entries : null;
     }
 
-    private static void ExtractPythonAllExportSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    private static void ExtractPythonAllExportSymbols(
+        long fileId,
+        string[] lines,
+        List<SymbolRecord> symbols,
+        string? pythonModulePrefix)
     {
         for (var i = 0; i < lines.Length; i++)
         {
@@ -4356,6 +4364,28 @@ private sealed class RubyMaskState
                         Signature = lines[export.LineIndex].Trim(),
                     },
                     lines[export.LineIndex]);
+
+                if (!string.IsNullOrEmpty(pythonModulePrefix)
+                    && !string.Equals(export.Name, pythonModulePrefix, StringComparison.Ordinal)
+                    && !export.Name.StartsWith(pythonModulePrefix + ".", StringComparison.Ordinal))
+                {
+                    AddSymbolRecord(
+                        symbols,
+                        cssSeenSymbols: null,
+                        export.LineIndex + 1,
+                        new SymbolRecord
+                        {
+                            FileId = fileId,
+                            Kind = "import",
+                            Name = $"{pythonModulePrefix}.{export.Name}",
+                            Line = export.LineIndex + 1,
+                            StartLine = export.LineIndex + 1,
+                            StartColumn = export.StartColumn,
+                            EndLine = export.LineIndex + 1,
+                            Signature = lines[export.LineIndex].Trim(),
+                        },
+                        lines[export.LineIndex]);
+                }
             }
         }
     }
@@ -4686,6 +4716,25 @@ private sealed class RubyMaskState
 
             prefixStart = dotIndex + 1;
         }
+    }
+
+    private static string? GetPythonModulePrefix(string? filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            return null;
+
+        var normalizedPath = filePath.Replace('\\', '/');
+        if (!normalizedPath.EndsWith("/__init__.py", StringComparison.Ordinal)
+            && !string.Equals(normalizedPath, "__init__.py", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var modulePath = normalizedPath[..^"/__init__.py".Length];
+        if (modulePath.Length == 0)
+            return null;
+
+        return modulePath.Replace('/', '.').Trim('.');
     }
 
     private static int FindFirstNonWhitespaceColumn(string text)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1652,7 +1652,7 @@ public partial class McpServer
                 var fileId = writer.UpsertFile(record);
                 var chunks = ChunkSplitter.Split(fileId, content);
                 writer.InsertChunks(chunks);
-                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
+                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content, record.Path);
                 SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
                 writer.InsertSymbols(symbols);
                 var references = ReferenceExtractor.Extract(fileId, record.Lang, content, symbols, record.Path);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -386,6 +386,37 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsPythonQualifiedInitAllExports()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_python_qualified_init_all_exports");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "package/subpkg/__init__.py",
+                "python",
+                """
+                __all__ = [
+                    "submodule",
+                ]
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["package.subpkg.submodule", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunPublishedTrimmedCli_SerializesQueryJsonAndErrorJson()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_trimmed_publish");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -168,6 +168,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesQualifiedExportsFromInitModules()
+    {
+        var content = """
+            __all__ = [
+                "submodule",
+                "subpackage.tools",
+            ]
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content, "package/subpkg/__init__.py");
+        var exports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("submodule", exports);
+        Assert.Contains("package.subpkg.submodule", exports);
+        Assert.Contains("subpackage.tools", exports);
+        Assert.Contains("package.subpkg.subpackage.tools", exports);
+    }
+
+    [Fact]
     public void Extract_Python_HandlesUnclosedMultilineImportBlocksWithoutPhantomSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/TestProjectHelper.cs
+++ b/tests/CodeIndex.Tests/TestProjectHelper.cs
@@ -71,7 +71,7 @@ internal static class TestProjectHelper
             }
         ]);
 
-        var symbols = SymbolExtractor.Extract(fileId, lang, normalized);
+        var symbols = SymbolExtractor.Extract(fileId, lang, normalized, path);
         writer.InsertSymbols(symbols);
         writer.InsertReferences(ReferenceExtractor.Extract(fileId, lang, normalized, symbols));
     }


### PR DESCRIPTION
## Summary
- Addressed the follow-up candidates from PR #1284 by making Python `__all__` re-exports in `__init__.py` files index qualified package names as well as leaf export names.
- Threaded the file path into Python symbol extraction so package-prefix qualification can be derived for `__init__.py` files during indexing.
- Updated the shared test helper and added regression coverage for qualified `__all__` lookups.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Python_IndexesQualifiedExportsFromInitModules"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsPythonQualifiedInitAllExports"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunSearchAndSymbols_ExactQueriesSeePythonInitAllExports"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Cli/IndexCommandRunner.cs src/CodeIndex/Indexer/SymbolExtractor.cs src/CodeIndex/Mcp/McpToolHandlers.cs tests/CodeIndex.Tests/QueryCommandRunnerTests.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/TestProjectHelper.cs TESTING_GUIDE.md changelog.d/unreleased/+python-init-all-qualified-search.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Docs / Changelog
- Added bilingual fragment: `changelog.d/unreleased/+python-init-all-qualified-search.fixed.md`
- Updated `TESTING_GUIDE.md` because the shared `InsertIndexedFile(...)` helper now passes file paths into Python symbol extraction.

## Follow-up candidates addressed
- Python `__all__` export handling now expands to more module-like qualified names for re-exported submodules in `__init__.py` files.
- The heuristic remains constrained to `__init__.py` package files to keep the search signal focused.