### PR TITLE
Promote C++-style .h headers by content

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,9 @@ The database reflects the working tree at the time of the last index. After swit
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |
 | Razor/Blazor | `.cshtml`, `.razor` | yes (as C#) |
+
+`.h` ファイルは既定では C のままですが、`namespace`、`template`、`using`、`class`、`std::` などの明確な C++ マーカーを含むヘッダーは、index 時に `cpp` へ昇格します。
+
 | Protobuf | `.proto` | yes |
 | GraphQL | `.graphql`, `.gql` | yes |
 | Gradle | `.gradle` | yes |
@@ -653,6 +656,9 @@ The database reflects the working tree at the time of the last index. After swit
 | Shell | `.sh`, `.bash`, `.zsh`, `.fish` | command-style function calls |
 | PowerShell | `.ps1`, `.psm1`, `.psd1` | function/filter (scope prefixes), configuration, workflow, class constructors/methods/properties, enum values, Import-Module, using module/namespace/assembly |
   | Batch | `.bat`, `.cmd` | labels + `goto`/`call` targets, including inline/chained control flow and `if` comparison forms |
+
+`.h` files stay on the C path by default, but headers that clearly look like C++ source are promoted to `cpp` at index time when they contain unmistakable markers such as `namespace`, `template`, `using`, `class`, or `std::`.
+
 | CMake | `.cmake`, `CMakeLists.txt` | -- |
 | SQL | `.sql`, `.pgsql`, `.tsql`, `.plsql`, `.pks`, `.pkb`, `.pls`, `.plb`, `.psql` | yes |
 Query-time `--lang tsql` is accepted as an alias for the SQL bucket.
@@ -668,6 +674,8 @@ T-SQL `CREATE AGGREGATE` / `ALTER AGGREGATE` and `CREATE/ALTER ASSEMBLY` / `XML 
 | Vue | `.vue` | -- |
 | Svelte | `.svelte` | -- |
 | Terraform | `.tf` | -- |
+
+`.h` files stay on the C path by default, but headers that clearly look like C++ source are promoted to `cpp` at index time when they contain unmistakable markers such as `namespace`, `template`, `using`, `class`, or `std::`.
 
 JavaScript/TypeScript symbol extraction also surfaces barrel re-exports such as `export * from`, `export * as ns from`, `export { foo as bar } from`, `export type { User } from`, `export type * from`, and `export type * as ns from`, including commented forms, multiline named re-export clauses, multiline `export *` / `export * as ns` layouts, import-attributes suffixes such as `with { type: 'json' }` / `assert { type: 'json' }`, and valid minified forms such as `export*from` / `export{foo as bar}from`. These re-exports preserve both the exported property surface and the source-module `import` rows. It also surfaces direct CommonJS named exports like `module.exports.foo = function () {}` / `exports.baz = value`, including same-line and multiline parenthesized wrappers plus TypeScript generic arrow RHS such as `module.exports.fn = <T>(x: T) => x`, `module.exports.foo = <T>(\n  value: T\n) => value`, and constrained/async variants, while keeping identifier prefixes like `functionCall()` / `classyThing` as ordinary property values. Exported object-literal alias/shorthand properties such as `module.exports = { foo: inner }` / `module.exports = { foo, bar }` are also surfaced.
 
@@ -1624,6 +1632,9 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 | F# | `.fs`, `.fsx`, `.fsi` | yes |
 | VB.NET | `.vb`, `.vbs` | yes |
 | Razor/Blazor | `.cshtml`, `.razor` | yes (as C#) |
+
+`.h` ファイルは既定では C のままですが、`namespace`、`template`、`using`、`class`、`std::` などの明確な C++ マーカーを含むヘッダーは、index 時に `cpp` へ昇格します。
+
 | Protobuf | `.proto` | yes |
 | GraphQL | `.graphql`, `.gql` | yes |
 | Gradle | `.gradle` | yes |

--- a/changelog.d/unreleased/+cpp-h-heuristic.fixed.md
+++ b/changelog.d/unreleased/+cpp-h-heuristic.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - README.md
+---
+
+## English
+
+- **C++-style `.h` headers now promote to `cpp` when the content makes it obvious** — `FileIndexer` keeps plain `.h` files on the C path by default, but upgrades headers that clearly contain C++ markers such as `namespace`, `template`, `using`, `class`, or `std::` so symbol and reference search uses the richer C++ extraction.
+
+## 日本語
+
+- **C++ らしい `.h` ヘッダーは内容から明白な場合に `cpp` へ昇格するようになりました** — `FileIndexer` は通常の `.h` を既定で C のまま扱いますが、`namespace`、`template`、`using`、`class`、`std::` などの C++ マーカーが明確なヘッダーは C++ 抽出を使うように切り替え、symbol / reference search を強化します。

--- a/src/CodeIndex/Indexer/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/FileIndexer.cs
@@ -893,7 +893,7 @@ public class FileIndexer
     internal static bool IsIgnoreFilePath(string path)
         => IgnoreFileNames.Contains(Path.GetFileName(path), StringComparer.OrdinalIgnoreCase);
 
-    internal static LanguageDetectionResult TryDetectLanguage(string filePath)
+    internal static LanguageDetectionResult TryDetectLanguage(string filePath, string? content = null)
     {
         // Exact filename matching beats extension lookup so manifest-style filenames like
         // `pyproject.toml` can map to a project language instead of the generic file type.
@@ -918,12 +918,83 @@ public class FileIndexer
 
         var ext = Path.GetExtension(filePath);
         if (LangMap.TryGetValue(ext, out var lang))
+        {
+            if (lang == "c" && string.Equals(ext, ".h", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(content))
+            {
+                var cppHeaderLanguage = TryDetectCppHeaderLanguage(content);
+                if (cppHeaderLanguage != null)
+                    return new LanguageDetectionResult(FileProbeStatus.Supported, cppHeaderLanguage);
+            }
+
             return new LanguageDetectionResult(FileProbeStatus.Supported, lang);
+        }
 
         if (!string.IsNullOrEmpty(ext))
             return new LanguageDetectionResult(FileProbeStatus.Unsupported, null);
 
         return TryDetectLanguageFromShebang(filePath);
+    }
+
+    private static string? TryDetectCppHeaderLanguage(string content)
+    {
+        const int maxLines = 200;
+        var remaining = content.AsSpan();
+        var inspectedLines = 0;
+
+        while (remaining.Length > 0 && inspectedLines < maxLines)
+        {
+            var newlineIndex = remaining.IndexOf('\n');
+            var line = newlineIndex >= 0 ? remaining[..newlineIndex] : remaining;
+            if (line.Length > 0 && line[^1] == '\r')
+                line = line[..^1];
+
+            if (LooksLikeCppHeaderLine(line))
+                return "cpp";
+
+            if (newlineIndex < 0)
+                break;
+
+            remaining = remaining[(newlineIndex + 1)..];
+            inspectedLines++;
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikeCppHeaderLine(ReadOnlySpan<char> line)
+    {
+        line = line.Trim();
+        if (line.IsEmpty)
+            return false;
+
+        if (line.StartsWith("//") || line.StartsWith("/*") || line.StartsWith("*"))
+            return false;
+
+        if (line.StartsWith("namespace ", StringComparison.Ordinal)
+            || line.StartsWith("template ", StringComparison.Ordinal)
+            || line.StartsWith("template<", StringComparison.Ordinal)
+            || line.StartsWith("using ", StringComparison.Ordinal)
+            || line.StartsWith("class ", StringComparison.Ordinal)
+            || line.StartsWith("enum class ", StringComparison.Ordinal)
+            || line.StartsWith("enum struct ", StringComparison.Ordinal)
+            || line.StartsWith("public:", StringComparison.Ordinal)
+            || line.StartsWith("private:", StringComparison.Ordinal)
+            || line.StartsWith("protected:", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (line.Contains("constexpr ", StringComparison.Ordinal)
+            || line.Contains("consteval ", StringComparison.Ordinal)
+            || line.Contains("constinit ", StringComparison.Ordinal)
+            || line.Contains("decltype(", StringComparison.Ordinal)
+            || line.Contains("friend ", StringComparison.Ordinal)
+            || line.Contains("std::", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     internal static bool CanIndexFile(string filePath)
@@ -1608,7 +1679,7 @@ public class FileIndexer
         var record = new FileRecord
         {
             Path = NormalizePathSeparators(relativePath),
-            Lang = TryDetectLanguage(absolutePath).Language,
+            Lang = TryDetectLanguage(absolutePath, content).Language,
             Size = info.Length,
             Lines = lineCount,
             Checksum = checksum,

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -602,6 +602,79 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void BuildRecordWithRawBytes_CppStyleHeaderContentIsDetectedAsCpp()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var path = Path.Combine(tempDir, "widget.h");
+            var content = """
+                #pragma once
+
+                namespace demo {
+                template <typename T>
+                class Widget {
+                public:
+                    constexpr Widget() = default;
+                };
+                }
+                """;
+            File.WriteAllText(path, content);
+
+            var indexer = new FileIndexer(tempDir);
+            var (record, decodedContent, _, _) = indexer.BuildRecordWithRawBytes(path);
+
+            Assert.Equal("cpp", record.Lang);
+            Assert.Equal(content.Replace("\r\n", "\n"), decodedContent);
+
+            var symbols = SymbolExtractor.Extract(1, record.Lang!, decodedContent).ToList();
+            Assert.Contains(symbols, symbol => symbol.Kind == "namespace" && symbol.Name == "demo");
+            Assert.Contains(symbols, symbol => symbol.Kind == "class" && symbol.Name == "Widget");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BuildRecordWithRawBytes_CStyleHeaderContentStaysC()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var path = Path.Combine(tempDir, "legacy.h");
+            var content = """
+                #ifndef LEGACY_H
+                #define LEGACY_H
+
+                struct legacy_point {
+                    int x;
+                    int y;
+                };
+
+                #endif
+                """;
+            File.WriteAllText(path, content);
+
+            var indexer = new FileIndexer(tempDir);
+            var (record, decodedContent, _, _) = indexer.BuildRecordWithRawBytes(path);
+
+            Assert.Equal("c", record.Lang);
+            Assert.Equal(content.Replace("\r\n", "\n"), decodedContent);
+
+            var symbols = SymbolExtractor.Extract(1, record.Lang!, decodedContent).ToList();
+            Assert.DoesNotContain(symbols, symbol => symbol.Kind == "class");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void ScanFiles_SkipsExcludedDirectories()
     {
         // Create a temp directory structure to test scanning


### PR DESCRIPTION
Summary:
- Add a content-based heuristic so `.h` files with unmistakable C++ markers are indexed as `cpp`.
- Keep plain `.h` files on the C path when they do not look like C++.
- Add regression coverage for both C++-style and C-style headers.
- Update README language guidance and add a bilingual changelog fragment.
- This addresses the follow-up candidate from PR #1287.

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~FileIndexerTests`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

Review:
- Adversarial review of `origin/main..HEAD` found no blocking or actionable issues.

Notes:
- This PR is not tied to a GitHub issue, so no `Fixes #...` line is included.