### PR TITLE
Align C# exact normalization between search and find

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ cdidx search "TODO" --limit 50           # more results
 cdidx search "auth*"                     # trailing * acts as a prefix shorthand
 cdidx search "auth*" --fts               # raw FTS5 syntax when you need operators like NEAR/OR
 cdidx search "Run();" --exact-substring  # case-sensitive exact substring, no FTS5
-cdidx search "Foo.Bar" --lang csharp --exact-substring  # C# exact search also canonicalizes global:: / @ prefixes
+cdidx search "Foo.Bar" --lang csharp --exact-substring  # C# exact search/find also canonicalizes global:: / @ prefixes
 cdidx search "--open-reports" --path README.md --count  # quoted literal that starts with --
 cdidx search --query "--path" --path README.md  # search for an option-looking literal
 ```
@@ -1338,7 +1338,7 @@ cdidx search "TODO" --limit 50           # 結果数を増やす
 cdidx search "auth*"                     # 末尾の * は prefix 検索の shorthand
 cdidx search "auth*" --fts               # 生のFTS5構文。NEAR / OR などの演算子が必要なときだけ使う
 cdidx search "Run();" --exact-substring  # 大文字小文字区別の完全部分一致、FTS5 なし
-cdidx search "Foo.Bar" --lang csharp --exact-substring  # C# の exact 検索は global:: / @ の表記も正規化する
+cdidx search "Foo.Bar" --lang csharp --exact-substring  # C# の exact 検索 / find は global:: / @ の表記も正規化する
 cdidx search "--open-reports" --path README.md --count  # `--` で始まる引用済みリテラル
 cdidx search --query "--path" --path README.md  # オプションに見えるリテラルを検索
 ```

--- a/changelog.d/unreleased/+csharp-search-find-global-qualified.fixed.md
+++ b/changelog.d/unreleased/+csharp-search-find-global-qualified.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/CSharpVerbatimNameNormalizer.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - README.md
+---
+
+## English
+
+- **C# exact `search` / `find` now canonicalize `global::` only at namespace starts** — `global::Foo.Bar` matches `Foo.Bar` in exact mode, while mid-path text such as `Foo.global::Bar` is left untouched. `find` now follows the same rule as `search`.
+
+## 日本語
+
+- **C# の exact `search` / `find` で `global::` を namespace 開始位置に限って正規化するようになりました** — exact モードでは `global::Foo.Bar` を `Foo.Bar` と同一視しつつ、`Foo.global::Bar` のような途中の文字列はそのまま残します。`find` も `search` と同じルールに追従します。

--- a/src/CodeIndex/Database/CSharpVerbatimNameNormalizer.cs
+++ b/src/CodeIndex/Database/CSharpVerbatimNameNormalizer.cs
@@ -1,8 +1,8 @@
 namespace CodeIndex.Database;
 
 /// <summary>
-/// Normalizes C# verbatim identifiers by stripping `@` and `global::` at identifier boundaries.
-/// C# の verbatim 識別子を正規化し、識別子境界の `@` と `global::` を除去する。
+/// Normalizes C# verbatim identifiers by stripping `@` and `global::` at valid name starts.
+/// C# の verbatim 識別子を正規化し、有効な名前開始位置の `@` と `global::` を除去する。
 /// </summary>
 internal static class CSharpVerbatimNameNormalizer
 {
@@ -119,7 +119,22 @@ internal static class CSharpVerbatimNameNormalizer
 
     private static bool TryConsumeGlobalQualifier(string text, int index) =>
         index + GlobalQualifier.Length <= text.Length
-        && text.AsSpan(index, GlobalQualifier.Length).SequenceEqual(GlobalQualifier.AsSpan());
+        && text.AsSpan(index, GlobalQualifier.Length).SequenceEqual(GlobalQualifier.AsSpan())
+        && IsGlobalQualifierNamespaceStart(text, index);
+
+    private static bool IsGlobalQualifierNamespaceStart(string text, int index)
+    {
+        for (int i = index - 1; i >= 0; i--)
+        {
+            char c = text[i];
+            if (char.IsWhiteSpace(c))
+                continue;
+
+            return c != '.' && c != ':';
+        }
+
+        return true;
+    }
 
     private const string GlobalQualifier = "global::";
 

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -4942,94 +4942,13 @@ public partial class DbReader
 
     private static string StripCSharpVerbatimPrefixesForSearch(string text)
     {
-        if (text.Length == 0 || text.IndexOf('@') < 0)
-            return text;
-
-        var sb = new System.Text.StringBuilder(text.Length);
-        bool atBoundary = true;
-        for (int i = 0; i < text.Length; i++)
-        {
-            char c = text[i];
-            if (atBoundary && c == '@'
-                && i + 1 < text.Length
-                && IsCSharpIdentifierStartChar(text[i + 1]))
-            {
-                atBoundary = false;
-                continue;
-            }
-
-            sb.Append(c);
-            if (c == '.')
-            {
-                atBoundary = true;
-            }
-            else if (c == ':' && i + 1 < text.Length && text[i + 1] == ':')
-            {
-                sb.Append(':');
-                i++;
-                atBoundary = true;
-            }
-            else
-            {
-                atBoundary = false;
-            }
-        }
-
-        return sb.Length == text.Length ? text : sb.ToString();
+        return CSharpVerbatimNameNormalizer.Normalize(text);
     }
 
     private static string StripCSharpVerbatimPrefixesForSearch(string text, out int[]? rawIndexMap)
     {
-        if (text.Length == 0 || text.IndexOf('@') < 0)
-        {
-            rawIndexMap = null;
-            return text;
-        }
-
-        var sb = new System.Text.StringBuilder(text.Length);
-        var map = new List<int>(text.Length);
-        bool atBoundary = true;
-        for (int i = 0; i < text.Length; i++)
-        {
-            char c = text[i];
-            if (atBoundary && c == '@'
-                && i + 1 < text.Length
-                && IsCSharpIdentifierStartChar(text[i + 1]))
-            {
-                atBoundary = false;
-                continue;
-            }
-
-            sb.Append(c);
-            map.Add(i);
-            if (c == '.')
-            {
-                atBoundary = true;
-            }
-            else if (c == ':' && i + 1 < text.Length && text[i + 1] == ':')
-            {
-                sb.Append(':');
-                map.Add(++i);
-                atBoundary = true;
-            }
-            else
-            {
-                atBoundary = false;
-            }
-        }
-
-        if (sb.Length == text.Length)
-        {
-            rawIndexMap = null;
-            return text;
-        }
-
-        rawIndexMap = map.ToArray();
-        return sb.ToString();
+        return CSharpVerbatimNameNormalizer.Normalize(text, out rawIndexMap);
     }
-
-    private static bool IsCSharpIdentifierStartChar(char c) =>
-        c == '_' || char.IsLetter(c);
 
     /// <summary>
     /// Reconstruct one indexed file into an ordered line map.

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -7954,10 +7954,10 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
-    public void CSharpVerbatimNameNormalizer_StripsGlobalQualifierOnlyAtIdentifierBoundaries()
+    public void CSharpVerbatimNameNormalizer_StripsGlobalQualifierOnlyAtNamespaceStarts()
     {
         Assert.Equal("Foo.Bar", CSharpVerbatimNameNormalizer.Normalize("global::Foo.Bar"));
-        Assert.Equal("notglobal::Foo.Bar", CSharpVerbatimNameNormalizer.Normalize("notglobal::Foo.Bar"));
+        Assert.Equal("Foo.global::Bar", CSharpVerbatimNameNormalizer.Normalize("Foo.global::Bar"));
     }
 
     [Fact]
@@ -24922,6 +24922,48 @@ public class QueryCommandRunnerTests
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.Equal(2, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+            Assert.Equal(1, json.GetProperty("file_count").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunFind_ExactTreatsCSharpGlobalQualifiedNamesAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_csharp_global");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/global.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                public class GlobalQualified
+                {
+                    public void Match()
+                    {
+                        var value = global::Foo.Bar;
+                    }
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["Foo.Bar", "--db", dbPath, "--path", "src/global.cs", "--json", "--exact", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
             Assert.Equal(1, json.GetProperty("files").GetInt32());
             Assert.Equal(1, json.GetProperty("file_count").GetInt32());
         }


### PR DESCRIPTION
## Summary
- Address the follow-up candidates from PR #1290 by extending C# `global::` canonicalization to `find` exact mode as well as `search` exact mode.
- Tighten the normalization rule so `global::` is only stripped at valid namespace-start positions, leaving mid-path text such as `Foo.global::Bar` untouched.
- Update regression coverage, README examples, and the changelog fragment accordingly.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.CSharpVerbatimNameNormalizer_StripsGlobalQualifierOnlyAtNamespaceStarts|FullyQualifiedName~QueryCommandRunnerTests.RunFind_ExactTreatsCSharpGlobalQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsCSharpGlobalQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringKeepsNormalizationScopedToCSharp"`
- `dotnet test`

## Notes
- Changelog fragment: `changelog.d/unreleased/+csharp-search-find-global-qualified.fixed.md`
- This PR specifically resolves the follow-up candidates called out in PR #1290.