### PR TITLE
Add F# operator search support

### DIFF
--- a/changelog.d/unreleased/+fsharp-operator-search.fixed.md
+++ b/changelog.d/unreleased/+fsharp-operator-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# operator definitions are now indexed for search** — `let (++)`-style operator bindings are normalized to searchable `function` symbols, so `symbols`, `definition`, and related lookups can find them instead of skipping the operator form.
+
+## 日本語
+
+- **F# の operator 定義が検索対象としてインデックスされるようになりました** — `let (++)` のような operator binding を検索可能な `function` シンボルに正規化することで、`symbols` / `definition` などの検索で operator 形が取りこぼされなくなりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -2910,6 +2910,9 @@ private sealed class RubyMaskState
             if (lang == "fsharp" && TryAddFSharpActivePatternSymbols(symbols, fileId, line, i + 1))
                 continue;
 
+            if (lang == "fsharp" && TryAddFSharpOperatorSymbols(symbols, fileId, line, i + 1))
+                continue;
+
             if (lang == "php")
                 ExtractPhpImportSymbols(symbols, line, i + 1);
 
@@ -24586,6 +24589,13 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
         if (name.Length >= 4 && name.StartsWith("``", StringComparison.Ordinal) && name.EndsWith("``", StringComparison.Ordinal))
             return name[2..^2];
 
+        if (name.Length >= 2 && name[0] == '(' && name[^1] == ')')
+        {
+            var operatorName = name[1..^1].Trim();
+            if (operatorName.Length > 0)
+                return $"operator {operatorName}";
+        }
+
         return name;
     }
 
@@ -24607,6 +24617,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
     private static readonly Regex FSharpUnionCaseRegex = new(@"^\|?\s*(?<name>(?:``[^`]+``|[_\p{L}][\w']*))(?:\s+of\b.*)?$", RegexOptions.Compiled);
     private static readonly Regex FSharpActivePatternDefinitionRegex = new(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*\(\|(?<cases>.+?)\|\)", RegexOptions.Compiled);
     private static readonly Regex FSharpActivePatternNameRegex = new(@"^(?:``[^`]+``|[_\p{L}][\w']*)$", RegexOptions.Compiled);
+    private static readonly Regex FSharpOperatorDefinitionRegex = new(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>\((?!\|)[^)\s]+\))(?:\s+(?:\w+|\())?", RegexOptions.Compiled);
 
     private static bool TryAddFSharpTypeMemberSymbols(List<SymbolRecord> symbols, long fileId, string line, int lineNumber, ref FSharpTypeBodyState state)
     {
@@ -24868,6 +24879,30 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
         }
 
         return emittedAny;
+    }
+
+    private static bool TryAddFSharpOperatorSymbols(List<SymbolRecord> symbols, long fileId, string line, int lineNumber)
+    {
+        var match = FSharpOperatorDefinitionRegex.Match(line);
+        if (!match.Success)
+            return false;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineNumber,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = NormalizeFSharpSymbolName(match.Groups["name"].Value),
+                Line = lineNumber,
+                StartLine = lineNumber,
+                EndLine = lineNumber,
+                Signature = line.Trim(),
+            },
+            rawLine: line);
+        return true;
     }
 
     private static string NormalizeCSharpSymbolName(string name, Match match, string matchLine)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -13065,6 +13065,22 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsOperatorDefinitions()
+    {
+        var content = """
+            module MyApp.Operators
+
+            let (++) left right = left + right
+            let inline (>>=) value binder = binder value
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "operator ++");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "operator >>=");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsUnionCasesAndRecordFields()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Index F# operator bindings such as `let (++)` as searchable `function` symbols.
- Keep the existing F# active pattern and regular binding coverage intact.
- Add regression coverage for operator definitions in `SymbolExtractorTests`.

## Validation
- `dotnet test CodeIndex.sln --filter FullyQualifiedName~Extract_FSharp_`

## Documentation / Changelog
- Added `changelog.d/unreleased/+fsharp-operator-search.fixed.md`.
- No additional docs updates were needed beyond the changelog fragment for this behavior change.

## Follow-up candidates
- Add F# reference extraction for operator usages so `references` and `callers` can surface operator call sites too.