### PR TITLE
Refine Python __init__.py alias search

### DIFF
--- a/changelog.d/unreleased/+python-init-alias-qualified-search.fixed.md
+++ b/changelog.d/unreleased/+python-init-alias-qualified-search.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Python `__init__.py` alias re-exports now index qualified package names** — when a package initializer re-exports a module or alias with `import` / `from . import ... as ...`, cdidx now adds `package.alias`-style names alongside the leaf symbol so exact-name search can find those public re-exports.
+
+## 日本語
+
+- **Python の `__init__.py` における alias 再エクスポートは修飾済み package 名でも索引されます** — package initializer が `import` や `from . import ... as ...` で module や alias を再エクスポートしている場合、cdidx は leaf symbol に加えて `package.alias` 形式の名前も追加するため、exact-name 検索で公開 re-export を見つけやすくなります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -3801,7 +3801,7 @@ private sealed class RubyMaskState
                     if (!suppressJavaStatementSymbol)
                     {
                         var pythonImportEntries = lang == "python" && pattern.Kind == "import"
-                            ? TryExpandPythonImportSymbols(lines, i, absoluteStartColumn)
+                            ? TryExpandPythonImportSymbols(lines, i, absoluteStartColumn, pythonModulePrefix)
                             : null;
                         var declaratorEntries = lang == "csharp"
                             && pattern.Kind == "property"
@@ -4560,7 +4560,11 @@ private sealed class RubyMaskState
     private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAssignmentRegex = new(@"^\s*__all__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static List<PythonImportSymbolEntry>? TryExpandPythonImportSymbols(string[] lines, int lineIndex, int absoluteStartColumn)
+    private static List<PythonImportSymbolEntry>? TryExpandPythonImportSymbols(
+        string[] lines,
+        int lineIndex,
+        int absoluteStartColumn,
+        string? pythonModulePrefix)
     {
         var line = lines[lineIndex];
         if (absoluteStartColumn < 0 || absoluteStartColumn >= line.Length)
@@ -4591,7 +4595,8 @@ private sealed class RubyMaskState
                 directImportSpecs,
                 entries,
                 seenNames,
-                treatAsFromImport: false);
+                treatAsFromImport: false,
+                pythonModulePrefix);
             return entries.Count > 0 ? entries : null;
         }
 
@@ -4609,7 +4614,8 @@ private sealed class RubyMaskState
                 modulePart,
                 fromImportSpecs,
                 entries,
-                seenNames))
+                seenNames,
+                pythonModulePrefix))
         {
             return entries.Count > 0 ? entries : null;
         }
@@ -4621,7 +4627,8 @@ private sealed class RubyMaskState
             fromImportSpecs,
             entries,
             seenNames,
-            treatAsFromImport: true);
+            treatAsFromImport: true,
+            pythonModulePrefix);
         return entries.Count > 0 ? entries : null;
     }
 
@@ -4784,7 +4791,8 @@ private sealed class RubyMaskState
         string modulePart,
         string importSpecs,
         List<PythonImportSymbolEntry> entries,
-        HashSet<string> seenNames)
+        HashSet<string> seenNames,
+        string? pythonModulePrefix)
     {
         if (!importSpecs.StartsWith('(') || importSpecs.EndsWith(')'))
             return false;
@@ -4835,7 +4843,8 @@ private sealed class RubyMaskState
                             fragment,
                             entries,
                             seenNames,
-                            treatAsFromImport: true);
+                            treatAsFromImport: true,
+                            pythonModulePrefix);
                     }
 
                     return true;
@@ -4848,7 +4857,8 @@ private sealed class RubyMaskState
                     fragment,
                     entries,
                     seenNames,
-                    treatAsFromImport: true);
+                    treatAsFromImport: true,
+                    pythonModulePrefix);
             }
 
             if (currentLineIndex + 1 >= lines.Length)
@@ -4867,7 +4877,8 @@ private sealed class RubyMaskState
         string importedNames,
         List<PythonImportSymbolEntry> entries,
         HashSet<string> seenNames,
-        bool treatAsFromImport)
+        bool treatAsFromImport,
+        string? pythonModulePrefix)
     {
         importedNames = importedNames.Trim();
         if (importedNames.Length == 0)
@@ -4924,6 +4935,21 @@ private sealed class RubyMaskState
                 && (!string.Equals(localName, importedName, StringComparison.Ordinal) || treatAsFromImport))
             {
                 AddPythonImportEntry(line, absoluteStartColumn, localName, entries, seenNames, ref searchStartColumn);
+            }
+
+            if (string.IsNullOrEmpty(pythonModulePrefix))
+                continue;
+
+            if (aliasIndex >= 0
+                || (!treatAsFromImport && string.Equals(localName, importedName, StringComparison.Ordinal)))
+            {
+                AddPythonImportEntry(
+                    line,
+                    absoluteStartColumn,
+                    $"{pythonModulePrefix}.{localName}",
+                    entries,
+                    seenNames,
+                    ref searchStartColumn);
             }
         }
     }

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -4940,8 +4940,7 @@ private sealed class RubyMaskState
             if (string.IsNullOrEmpty(pythonModulePrefix))
                 continue;
 
-            if (aliasIndex >= 0
-                || (!treatAsFromImport && string.Equals(localName, importedName, StringComparison.Ordinal)))
+            if (aliasIndex >= 0)
             {
                 AddPythonImportEntry(
                     line,

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -417,6 +417,44 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsPythonInitModuleAliases()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_python_init_module_aliases");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "package/subpkg/__init__.py",
+                "python",
+                """
+                import submodule
+                from . import helper as alias
+                """);
+
+            var (moduleExitCode, moduleStdout, moduleStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["package.subpkg.submodule", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, moduleExitCode);
+            Assert.Equal("1", moduleStdout.Trim());
+            Assert.Equal(string.Empty, moduleStderr);
+
+            var (aliasExitCode, aliasStdout, aliasStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["package.subpkg.alias", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, aliasExitCode);
+            Assert.Equal("1", aliasStdout.Trim());
+            Assert.Equal(string.Empty, aliasStderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunPublishedTrimmedCli_SerializesQueryJsonAndErrorJson()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_trimmed_publish");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -428,12 +428,12 @@ public class QueryCommandRunnerTests
                 "package/subpkg/__init__.py",
                 "python",
                 """
-                import submodule
+                import submodule as module_alias
                 from . import helper as alias
                 """);
 
             var (moduleExitCode, moduleStdout, moduleStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
-                ["package.subpkg.submodule", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                ["package.subpkg.module_alias", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
                 _jsonOptions));
 
             Assert.Equal(CommandExitCodes.Success, moduleExitCode);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -187,6 +187,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesQualifiedModuleAliasesFromInitModules()
+    {
+        var content = """
+            import submodule
+            from . import helper as alias
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content, "package/subpkg/__init__.py");
+        var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("submodule", imports);
+        Assert.Contains("package.subpkg.submodule", imports);
+        Assert.Contains("helper", imports);
+        Assert.Contains("alias", imports);
+        Assert.Contains("package.subpkg.alias", imports);
+    }
+
+    [Fact]
     public void Extract_Python_HandlesUnclosedMultilineImportBlocksWithoutPhantomSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -190,7 +190,7 @@ public class SymbolExtractorTests
     public void Extract_Python_IndexesQualifiedModuleAliasesFromInitModules()
     {
         var content = """
-            import submodule
+            import submodule as module_alias
             from . import helper as alias
             """;
 
@@ -198,7 +198,8 @@ public class SymbolExtractorTests
         var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
 
         Assert.Contains("submodule", imports);
-        Assert.Contains("package.subpkg.submodule", imports);
+        Assert.Contains("module_alias", imports);
+        Assert.Contains("package.subpkg.module_alias", imports);
         Assert.Contains("helper", imports);
         Assert.Contains("alias", imports);
         Assert.Contains("package.subpkg.alias", imports);


### PR DESCRIPTION
## Summary
- Followed up on the follow-up candidates from PR #1292 by making Python `__init__.py` explicit alias re-exports searchable with qualified package names.
- Threaded the package prefix through Python import expansion so explicit alias re-exports in package initializers can be found via exact-name search as `package.alias`.
- Added regression coverage for both symbol extraction and CLI exact-name lookups, plus a new changelog fragment.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Python_IndexesQualifiedModuleAliasesFromInitModules"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsPythonInitModuleAliases"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsPythonDottedImportPrefixes"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/QueryCommandRunnerTests.cs changelog.d/unreleased/+python-init-alias-qualified-search.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Follow-up candidates addressed
- Qualified searchability now extends beyond `__all__` exports to explicit alias re-exports in `__init__.py` package initializers.
- The change is constrained to `__init__.py` package initializers and explicit alias patterns to avoid broadening ordinary member imports.