### PR TITLE
Track multiline Rust impl headers

### DIFF
--- a/changelog.d/unreleased/+rust-multiline-impl.fixed.md
+++ b/changelog.d/unreleased/+rust-multiline-impl.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Rust multiline `impl` headers now keep their symbol positions** — wrapped `unsafe impl` / `impl ... for ...` blocks are now collected as a single statement before matching, so the implementing type is indexed even when the header spans several lines.
+
+## 日本語
+
+- **Rust の複数行 `impl` ヘッダが symbol 位置を保持するようになりました** — 折り返された `unsafe impl` / `impl ... for ...` ブロックを 1 つの statement としてまとめてから照合するため、ヘッダが複数行にまたがっても実装対象型を索引できるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -177,6 +177,12 @@ public static class SymbolExtractor
         @"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?use\s+(?<body>.+);\s*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private readonly record struct RustUseSymbolOccurrence(string Name, int Line, int Column);
+    private static readonly Regex RustMultilineImplForRegex = new(
+        @"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+.+?\s+for\s+(?<name>\w+)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+    private static readonly Regex RustMultilineImplTypeRegex = new(
+        @"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+(?<name>\w+)(?!\s+for\b)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly Regex XamlClassRegex = new(
         @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -2532,6 +2538,49 @@ public static class SymbolExtractor
         }
     }
 
+    private static void ExtractRustMultilineImplSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (!TryReadRustImplStatement(lines, i, out var statement, out var lineStarts, out var endLineIndex))
+                continue;
+
+            if (endLineIndex <= i)
+                continue;
+
+            var match = RustMultilineImplForRegex.Match(statement);
+            if (!match.Success)
+                match = RustMultilineImplTypeRegex.Match(statement);
+            if (!match.Success)
+                continue;
+
+            var name = match.Groups["name"].Value.Trim();
+            if (name.Length == 0)
+                continue;
+
+            var position = GetRustStatementPosition(match.Groups["name"].Index, lineStarts, i + 1);
+            if (HasRustSymbol(symbols, fileId, position.Line, "class", name))
+                continue;
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                position.Line,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "class",
+                    Name = name,
+                    Line = position.Line,
+                    StartLine = position.Line,
+                    StartColumn = position.Column,
+                    EndLine = position.Line,
+                    Signature = statement.Trim(),
+                },
+                lines[position.Line - 1]);
+        }
+    }
+
     private static bool TryReadRustUseStatement(string[] lines, int startIndex, out string statement, out List<int> lineStarts, out int endIndex)
     {
         statement = string.Empty;
@@ -2580,6 +2629,58 @@ public static class SymbolExtractor
         }
 
         return false;
+    }
+
+    private static bool TryReadRustImplStatement(string[] lines, int startIndex, out string statement, out List<int> lineStarts, out int endIndex)
+    {
+        statement = string.Empty;
+        lineStarts = [];
+        endIndex = startIndex;
+
+        var firstLine = lines[startIndex];
+        if (!firstLine.TrimStart().StartsWith("impl", StringComparison.Ordinal) && !firstLine.TrimStart().StartsWith("unsafe impl", StringComparison.Ordinal))
+            return false;
+
+        var builder = new StringBuilder(firstLine.Length + 32);
+        lineStarts.Add(0);
+
+        for (var i = startIndex; i < lines.Length; i++)
+        {
+            var current = lines[i];
+            if (i > startIndex)
+            {
+                builder.Append('\n');
+                lineStarts.Add(builder.Length);
+            }
+            builder.Append(current);
+
+            if (current.Contains('{'))
+            {
+                statement = builder.ToString();
+                endIndex = i;
+                return endIndex > startIndex;
+            }
+        }
+
+        return false;
+    }
+
+    private readonly record struct RustStatementPosition(int Line, int Column);
+
+    private static RustStatementPosition GetRustStatementPosition(int statementIndex, IReadOnlyList<int> lineStarts, int startLineNumber)
+    {
+        var lineIndex = 0;
+        for (var i = lineStarts.Count - 1; i >= 0; i--)
+        {
+            if (lineStarts[i] <= statementIndex)
+            {
+                lineIndex = i;
+                break;
+            }
+        }
+
+        var column = statementIndex - lineStarts[lineIndex] + 1;
+        return new RustStatementPosition(startLineNumber + lineIndex, column);
     }
 
     private static void CollectRustUseSymbolOccurrences(
@@ -4471,6 +4572,8 @@ private sealed class RubyMaskState
             ExtractSvelteReactiveSymbols(fileId, lines, symbols);
         if (lang == "rust")
             ExtractRustUseSymbols(fileId, lines, symbols);
+        if (lang == "rust")
+            ExtractRustMultilineImplSymbols(fileId, lines, symbols);
         if (lang == "go")
             ExtractGoGroupedDeclarations(fileId, lines, symbols);
         if (lang == "cpp")

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11255,6 +11255,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Rust_DetectsMultilineImplBlocks()
+    {
+        var content = """
+            struct Wrapped<T>(T);
+            trait Trait {}
+
+            unsafe impl<T>
+                Trait
+                for
+                Wrapped<T>
+            {
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Wrapped" && s.Line == 7 && s.StartColumn == 5);
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "Trait" && s.Line == 4);
+    }
+
+    [Fact]
     public void Extract_Go_DetectsTypeAliasAndConst()
     {
         var content = "type Handler struct {\n}\ntype ID = string\ntype Callback func(int) int\ntype Logger interface {\n}\n\nconst (\n    MaxRetries = 3\n    DefaultTimeout = 30\n)\n\nvar GlobalConfig Config";


### PR DESCRIPTION
## Summary

- Address the `Follow-up candidates` item from PR #1294 by adding statement-level tracking for multiline Rust `impl` headers.
- Keep Rust `impl ... for ...` and `unsafe impl ... for ...` blocks searchable even when the header wraps across several lines.
- Preserve precise line and column positions for the implementing type and add regression coverage for the multiline case.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test`
- Rebuilt and refreshed the local index with the committed change: `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/+rust-multiline-impl.fixed.md`

## Follow-up candidates

- Consider whether other Rust declaration forms with common multiline formatting should receive the same statement-level tracking.

## Context

- This PR explicitly implements the follow-up candidate from PR #1294 about other Rust declarations that need the same multiline position tracking as `use` items.