### PR TITLE
Add F# operator reference support

### DIFF
--- a/changelog.d/unreleased/+fsharp-operator-references.fixed.md
+++ b/changelog.d/unreleased/+fsharp-operator-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# operator usages are now indexed as references** — symbolic operator forms such as `x ++ y`, `x >>= f`, and `(++)` now emit searchable `call`-style references, so `references` and `callers` can surface operator call sites alongside ordinary function calls.
+
+## 日本語
+
+- **F# の operator 使用箇所が reference としてインデックスされるようになりました** — `x ++ y` / `x >>= f` / `(++)` のような symbolic operator 形も検索可能な `call` 風 reference を出すため、`references` / `callers` で通常の関数呼び出しと同様に operator の呼び出し箇所を辿れるようになりました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -463,7 +463,7 @@ public static class ReferenceExtractor
     private static readonly HashSet<string> FSharpIgnoredOperatorCallNames = new(StringComparer.Ordinal)
     {
         "->", "<-", "..", "<|", "<||", "<|||", "|>", "||>", "|||>", "|>>", "<<", ">>", "<<<", ">>>",
-        "&&", "||", "::", "<>", "<=", ">=", "**",
+        "&&", "&&&", "||", "|||", "::", "<>", "<=", ">=", "**", "@@", ":>", ":?", ":=",
     };
     // Scala's `name { ... }` / `name { x => ... }` block-call form does not use trailing `(`,
     // so the shared CallRegex cannot see it. Use a Scala-specific pass so idiomatic block calls

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -448,6 +448,23 @@ public static class ReferenceExtractor
             (?<name>{FSharpIdentifierPattern})\b
             (?=\s+(?:{FSharpIdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+    // F# symbolic operator usages such as `x ++ y`, `x >>= f`, and `(++)` should also
+    // surface as searchable references. The matcher intentionally stays conservative by
+    // excluding standard F# operators that already have dedicated syntax or would create
+    // excessive noise in call graphs.
+    // F# の symbolic operator 使用 (`x ++ y` / `x >>= f` / `(++)`) も検索可能な reference として
+    // 出す。標準 F# operator は専用構文やノイズの多さを考慮して除外し、保守的に拾う。
+    private static readonly Regex FSharpOperatorCallRegex = new(
+        @"(?<![\w$])(?<name>[!%&*+\-./:<=>?@^|~]{2,})(?![\w$])",
+        RegexOptions.Compiled);
+    private static readonly Regex FSharpOperatorDefinitionCallRegex = new(
+        @"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*\((?<name>[!%&*+\-./:<=>?@^|~]{2,})\)",
+        RegexOptions.Compiled);
+    private static readonly HashSet<string> FSharpIgnoredOperatorCallNames = new(StringComparer.Ordinal)
+    {
+        "->", "<-", "..", "<|", "<||", "<|||", "|>", "||>", "|||>", "|>>", "<<", ">>", "<<<", ">>>",
+        "&&", "||", "::", "<>", "<=", ">=", "**",
+    };
     // Scala's `name { ... }` / `name { x => ... }` block-call form does not use trailing `(`,
     // so the shared CallRegex cannot see it. Use a Scala-specific pass so idiomatic block calls
     // such as `foreach {}`, `Try {}`, and `synchronized {}` still contribute `call` edges.
@@ -2211,7 +2228,9 @@ public static class ReferenceExtractor
 
             void AddCallLikeReference(string name, int callIndex)
             {
-                var normalizedName = NormalizeAtPrefixedIdentifier(name);
+                var normalizedName = language == "fsharp" && IsFSharpOperatorCallName(name)
+                    ? $"operator {name}"
+                    : NormalizeAtPrefixedIdentifier(name);
 
                 // Suppress the same-line Java ctor declarator's self-call. CallRegex matches
                 // `CtorName(` at the declarator once per same-line ctor, but it is a declaration
@@ -2259,6 +2278,20 @@ public static class ReferenceExtractor
                     && IsInsideCSharpAttributeRange(csharpAttrRangesOnLine, callIndex);
                 var metadataKind = TryClassifyMetadataReference(language, preparedLine, callIndex, insideCSharpAttributeRange);
                 AddReference(references, seen, fileId, normalizedName, callIndex, metadataKind ?? "call", context, lineNumber, callContainer);
+            }
+
+            static bool IsFSharpOperatorCallName(string name)
+            {
+                if (name.Length < 2)
+                    return false;
+
+                foreach (var ch in name)
+                {
+                    if ("!%&*+-./:<=>?@^|~".IndexOf(ch) < 0)
+                        return false;
+                }
+
+                return true;
             }
 
             void EmitRubyCommandTargetReferences(string name, int callIndex)
@@ -2470,6 +2503,24 @@ public static class ReferenceExtractor
                     foreach (Match match in FSharpSpaceApplicationCallRegex.Matches(preparedLine))
                     {
                         var name = match.Groups["name"].Value;
+                        var callIndex = match.Groups["name"].Index;
+                        AddCallLikeReference(name, callIndex);
+                    }
+
+                    foreach (Match match in FSharpOperatorCallRegex.Matches(preparedLine))
+                    {
+                        var name = match.Groups["name"].Value;
+                        if (FSharpIgnoredOperatorCallNames.Contains(name))
+                            continue;
+
+                        var definitionMatch = FSharpOperatorDefinitionCallRegex.Match(preparedLine);
+                        if (definitionMatch.Success
+                            && string.Equals(definitionMatch.Groups["name"].Value, name, StringComparison.Ordinal)
+                            && match.Groups["name"].Index == definitionMatch.Groups["name"].Index)
+                        {
+                            continue;
+                        }
+
                         var callIndex = match.Groups["name"].Index;
                         AddCallLikeReference(name, callIndex);
                     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7918,6 +7918,35 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsOperatorCalls()
+    {
+        const string content = """
+            let (++) left right = left + right
+            let (>>=) value binder = binder value
+
+            let build value =
+                value ++ value
+
+            let compose value =
+                value >>= (fun next -> next + 1)
+
+            let lifted = (++ )
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Equal(2, references.Count(r => r.SymbolName == "operator ++" && r.ReferenceKind == "call"));
+        Assert.Equal(1, references.Count(r => r.SymbolName == "operator >>=" && r.ReferenceKind == "call"));
+        Assert.Contains(references, r => r.SymbolName == "operator ++" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "operator >>=" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "operator +" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "operator ->" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "operator ++" && r.Line == 1);
+        Assert.DoesNotContain(references, r => r.SymbolName == "operator >>=" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsSpaceSeparatedApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7927,6 +7927,9 @@ public class ReferenceExtractorTests
             let build value =
                 value ++ value
 
+            let casted value =
+                value :> obj
+
             let compose value =
                 value >>= (fun next -> next + 1)
 
@@ -7941,6 +7944,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "operator ++" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "operator >>=" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "operator +" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "operator :>" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "operator ->" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "operator ++" && r.Line == 1);
         Assert.DoesNotContain(references, r => r.SymbolName == "operator >>=" && r.Line == 2);


### PR DESCRIPTION
## Summary
- Implements the follow-up candidate from PR #1297 by indexing F# operator usages as references.
- Symbolic operator forms such as `x ++ y`, `x >>= f`, and `(++)` now emit searchable `call`-style references.
- Standard F# operators are excluded so the new matcher stays conservative and avoids noisy built-in hits.

## Validation
- `dotnet test CodeIndex.sln --filter FullyQualifiedName~Extract_FSharp_`

## Documentation / Changelog
- Added `changelog.d/unreleased/+fsharp-operator-references.fixed.md`.

## Follow-up candidates
- None for this PR.