### PR TITLE
Improve R package import indexing

### DIFF
--- a/changelog.d/unreleased/+r-require-namespace.fixed.md
+++ b/changelog.d/unreleased/+r-require-namespace.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R package loads now index quoted names and `requireNamespace()` imports** — `library("pkg")`, `require("pkg")`, and `requireNamespace("pkg")` now produce import symbols, while `requireNamespace` is suppressed from call-style reference noise so R package usage stays searchable without extra chatter.
+
+## 日本語
+
+- **R の package 読み込みで引用付き名前と `requireNamespace()` を import として索引するようになりました** — `library("pkg")` / `require("pkg")` / `requireNamespace("pkg")` が import symbol を生成し、`requireNamespace` は call 由来のノイズからも除外されるため、R の package 利用を余計な雑音なしで検索しやすくなります。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -223,7 +223,7 @@ public static class ReferenceExtractor
         ["r"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "library", "cat", "paste", "paste0", "sprintf", "stop", "warning", "message",
-            "invisible", "tryCatch", "withCallingHandlers", "next", "break", "repeat",
+            "invisible", "tryCatch", "withCallingHandlers", "requireNamespace", "next", "break", "repeat",
         },
         // PowerShell keywords / PowerShell キーワード
         ["powershell"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1381,7 +1381,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setGeneric\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("import",   new Regex(@"^\s*(?:library|require)\s*\(\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?:library|require|requireNamespace)\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =
         [

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7977,6 +7977,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_IgnoresRequireNamespaceLoaders()
+    {
+        const string content = """
+            library("ggplot2")
+            requireNamespace("jsonlite", quietly = TRUE)
+            require(dplyr)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "requireNamespace");
+        Assert.DoesNotContain(references, r => r.SymbolName == "library");
+        Assert.Contains(references, r => r.SymbolName == "require" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_PowerShell_DetectsCallSites()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -16080,6 +16080,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsQuotedLibraryAndRequireNamespaceImports()
+    {
+        // R: quoted package loads and requireNamespace should both index as imports.
+        // R: 引用付き package load と requireNamespace も import として索引する。
+        var content = """
+            library("ggplot2")
+            requireNamespace("jsonlite", quietly = TRUE)
+            require(dplyr)
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "ggplot2");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "jsonlite");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "dplyr");
+    }
+
+    [Fact]
     public void Extract_R_DetectsBacktickEscapedFunctionNames()
     {
         // Backtick-escaped names are valid R identifiers / バッククォート付きの名前は R の有効な識別子


### PR DESCRIPTION
## Summary
- Index R package loads written as `library("pkg")`, `require("pkg")`, and `requireNamespace("pkg")` as import symbols.
- Suppress `requireNamespace` from R call-reference noise so it does not clutter `references` and graph output.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet build CodeIndex.sln -c Release`

## Docs / Changelog
- Added `changelog.d/unreleased/+r-require-namespace.fixed.md`.
- No `CHANGELOG.md` edit was made because this is an ordinary implementation PR.

## Follow-up candidates
- R namespace references such as `pkg::fun` and `pkg:::fun` are still not emitted as reference edges.