### PR TITLE
Add TypeScript export as namespace search support

### DIFF
--- a/changelog.d/unreleased/+typescript-export-as-namespace.fixed.md
+++ b/changelog.d/unreleased/+typescript-export-as-namespace.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **TypeScript `export as namespace` declarations are now searchable as namespaces** — `SymbolExtractor` now recognizes UMD-style `export as namespace Foo;` declarations, so legacy declaration files expose their namespace anchors to `search` and other symbol-driven flows.
+
+## 日本語
+
+- **TypeScript の `export as namespace` 宣言を namespace として検索できるようになりました** — `SymbolExtractor` が UMD 形式の `export as namespace Foo;` 宣言を認識するため、古い declaration file でも namespace の検索アンカーが `search` などの symbol ベースの処理に現れます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -743,9 +743,9 @@ public static class SymbolExtractor
               // namespace/module — supports both identifier (namespace Foo) and quoted ambient (declare module 'express')
               // 名前空間・モジュール — 識別子形式と引用符付きアンビエント形式の両方に対応
               new("namespace", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:namespace|module)\s+['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("namespace", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:namespace|module)\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("interface", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("import", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?type\s+(?<name>\w+)(?:\s*<[^=]+>)?", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+              new("namespace", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:namespace|module)\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+              new("interface", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+              new("import", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?type\s+(?<name>\w+)(?:\s*<[^=]+>)?", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("enum",     new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:const\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("import",   new Regex(@"^\s*import\s+(?<name>.+?)\s+from\s+", RegexOptions.Compiled), BodyStyle.None),
         ],

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -736,11 +736,13 @@ public static class SymbolExtractor
             // x + 1;`）は BodyStyle.Brace 側で先勝ちし、こちらで上書きされない。
             // Closes #240.
             new("function", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:const|let|var)\s+(?<name>[A-Z]\w*)\s*(?::\s*.+?)?\s*=\s*(?:React\.(?:memo|forwardRef|lazy)\s*" + TypeScriptOptionalHocTypeArgsPattern + @"\(|styled[.(`]|connect\s*" + TypeScriptOptionalHocTypeArgsPattern + @"\(|memo\s*" + TypeScriptOptionalHocTypeArgsPattern + @"\(|forwardRef\s*" + TypeScriptOptionalHocTypeArgsPattern + @"\(|lazy\s*" + TypeScriptOptionalHocTypeArgsPattern + @"\(|observer\s*" + TypeScriptOptionalHocTypeArgsPattern + @"\(|with[A-Z]\w*\s*" + TypeScriptOptionalHocTypeArgsPattern + @"\()", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            // Abstract class, declare class / 抽象クラス、declare クラス
-            new("class",    new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:default\s+)?(?:(?:abstract|declare)\s+)*class\s+(?<name>(?!(?:extends|implements)\b)\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            // namespace/module — supports both identifier (namespace Foo) and quoted ambient (declare module 'express')
-            // 名前空間・モジュール — 識別子形式と引用符付きアンビエント形式の両方に対応
-            new("namespace", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:namespace|module)\s+['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+              // Abstract class, declare class / 抽象クラス、declare クラス
+              new("class",    new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:default\s+)?(?:(?:abstract|declare)\s+)*class\s+(?<name>(?!(?:extends|implements)\b)\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+              // UMD namespace export / UMD 名前空間エクスポート
+              new("namespace", new Regex($@"^\s*export\s+as\s+namespace\s+(?<name>{JavaScriptTypeScriptIdentifierPattern})", RegexOptions.Compiled), BodyStyle.None),
+              // namespace/module — supports both identifier (namespace Foo) and quoted ambient (declare module 'express')
+              // 名前空間・モジュール — 識別子形式と引用符付きアンビエント形式の両方に対応
+              new("namespace", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:namespace|module)\s+['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("namespace", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:namespace|module)\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("interface", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("import", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?type\s+(?<name>\w+)(?:\s*<[^=]+>)?", RegexOptions.Compiled), BodyStyle.None, "visibility"),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -3343,6 +3343,19 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScript_DetectsExportAsNamespace()
+    {
+        var content = """
+            export as namespace LegacyWidgets;
+            export as namespace $Widgets;
+            """;
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "LegacyWidgets");
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "$Widgets");
+    }
+
+    [Fact]
     public void Extract_TypeScript_DetectsDeclarationOnlyMembersInDeclareClassAndInterface()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Added TypeScript symbol extraction support for `export as namespace Foo;` declarations.
- Covered the new behavior with a focused regression test.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_TypeScript_DetectsExportAsNamespace|FullyQualifiedName~SymbolExtractorTests.Extract_TypeScript_DetectsAbstractClassAndNamespace"`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`

## Documentation / Changelog
- Added `changelog.d/unreleased/+typescript-export-as-namespace.fixed.md`.

## Follow-up candidates
- None identified during this change.
