### PR TITLE
Enhance exact search normalization for Java, Kotlin, and C#

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ cdidx search "TODO" --limit 50           # more results
 cdidx search "auth*"                     # trailing * acts as a prefix shorthand
 cdidx search "auth*" --fts               # raw FTS5 syntax when you need operators like NEAR/OR
 cdidx search "Run();" --exact-substring  # case-sensitive exact substring, no FTS5
-cdidx search "Foo.Bar" --lang csharp --exact-substring  # C# exact search/find also canonicalizes global:: / @ prefixes
+cdidx search "Foo.Bar" --lang csharp --exact-substring  # Java/Kotlin/C# exact search/find canonicalizes escaped source identifiers
 cdidx search "--open-reports" --path README.md --count  # quoted literal that starts with --
 cdidx search --query "--path" --path README.md  # search for an option-looking literal
 ```
@@ -1346,7 +1346,7 @@ cdidx search "TODO" --limit 50           # 結果数を増やす
 cdidx search "auth*"                     # 末尾の * は prefix 検索の shorthand
 cdidx search "auth*" --fts               # 生のFTS5構文。NEAR / OR などの演算子が必要なときだけ使う
 cdidx search "Run();" --exact-substring  # 大文字小文字区別の完全部分一致、FTS5 なし
-cdidx search "Foo.Bar" --lang csharp --exact-substring  # C# の exact 検索 / find は global:: / @ の表記も正規化する
+cdidx search "Foo.Bar" --lang csharp --exact-substring  # Java/Kotlin/C# の exact 検索 / find は escaped source identifier を正規化する
 cdidx search "--open-reports" --path README.md --count  # `--` で始まる引用済みリテラル
 cdidx search --query "--path" --path README.md  # オプションに見えるリテラルを検索
 ```

--- a/changelog.d/unreleased/+java-kotlin-csharp-search-exact-escapes.fixed.md
+++ b/changelog.d/unreleased/+java-kotlin-csharp-search-exact-escapes.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/ExactSourceSearchNormalizer.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - README.md
+---
+
+## English
+
+- **Java, Kotlin, and C# exact search now canonicalize escaped source identifiers** — exact `search` and `find` now treat Java Unicode escapes, Kotlin backticked identifiers, and C# verbatim / `global::` spellings as the same source identifier so canonical and source forms match consistently.
+
+## 日本語
+
+- **Java / Kotlin / C# の exact 検索で escaped source identifier を正規化するようになりました** — exact `search` / `find` では Java の Unicode escape、Kotlin の backticked identifier、C# の verbatim / `global::` 表記を同一視し、canonical と source の表記を一貫して検索できるようにしました。

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -352,6 +352,9 @@ public class DbContext : IDisposable
             "sql_normalize_csharp_verbatim_name",
             (string? text) => string.IsNullOrWhiteSpace(text) ? null : CSharpVerbatimNameNormalizer.Normalize(text));
         connection.CreateFunction(
+            "sql_normalize_exact_source_name",
+            (string? text, string? lang) => string.IsNullOrWhiteSpace(text) ? null : ExactSourceSearchNormalizer.Normalize(text, lang));
+        connection.CreateFunction(
             "sql_segment_count",
             (string? name) => string.IsNullOrWhiteSpace(name) ? (int?)null : SqlNameResolver.GetSegmentCount(name));
         connection.CreateFunction(

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -4821,17 +4821,16 @@ public partial class DbReader
             if (!TryLoadIndexedFileLines(path, out _, out _, out var lineMap) || lineMap.Count == 0)
                 continue;
 
-            var csharpExactSearch = exact && string.Equals(fileLang, "csharp", StringComparison.OrdinalIgnoreCase);
-            var searchQuery = csharpExactSearch ? StripCSharpVerbatimPrefixesForSearch(query) : query;
+            var searchQuery = exact ? ExactSourceSearchNormalizer.Normalize(query, fileLang) : query;
             for (int lineNumber = 1; lineNumber <= totalLines && results.Count < limit; lineNumber++)
             {
                 if (!lineMap.TryGetValue(lineNumber, out var lineText))
                     continue;
 
                 int[]? rawIndexMap = null;
-                var searchLine = lineText;
-                if (csharpExactSearch)
-                    searchLine = StripCSharpVerbatimPrefixesForSearch(lineText, out rawIndexMap);
+                var searchLine = exact
+                    ? ExactSourceSearchNormalizer.Normalize(lineText, fileLang, out rawIndexMap)
+                    : lineText;
                 var snippetStart = Math.Max(1, lineNumber - before);
                 var snippetEnd = Math.Min(totalLines, lineNumber + after);
                 var snippetLineNumbers = Enumerable.Range(snippetStart, snippetEnd - snippetStart + 1)
@@ -4910,15 +4909,14 @@ public partial class DbReader
             if (!TryLoadIndexedFileLines(path, out _, out _, out var lineMap) || lineMap.Count == 0)
                 continue;
 
-            var csharpExactSearch = exact && string.Equals(fileLang, "csharp", StringComparison.OrdinalIgnoreCase);
-            var searchQuery = csharpExactSearch ? StripCSharpVerbatimPrefixesForSearch(query) : query;
+            var searchQuery = exact ? ExactSourceSearchNormalizer.Normalize(query, fileLang) : query;
             var fileMatches = 0;
             for (int lineNumber = 1; lineNumber <= totalLines; lineNumber++)
             {
                 if (!lineMap.TryGetValue(lineNumber, out var lineText))
                     continue;
 
-                var searchLine = csharpExactSearch ? StripCSharpVerbatimPrefixesForSearch(lineText) : lineText;
+                var searchLine = exact ? ExactSourceSearchNormalizer.Normalize(lineText, fileLang) : lineText;
                 for (int searchStart = 0; searchStart < searchLine.Length;)
                 {
                     var matchColumn = searchLine.IndexOf(searchQuery, searchStart, comparison);
@@ -4938,16 +4936,6 @@ public partial class DbReader
         }
 
         return new QueryCountResult(count, fileCount);
-    }
-
-    private static string StripCSharpVerbatimPrefixesForSearch(string text)
-    {
-        return CSharpVerbatimNameNormalizer.Normalize(text);
-    }
-
-    private static string StripCSharpVerbatimPrefixesForSearch(string text, out int[]? rawIndexMap)
-    {
-        return CSharpVerbatimNameNormalizer.Normalize(text, out rawIndexMap);
     }
 
     /// <summary>

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -464,7 +464,7 @@ public partial class DbReader
     }
 
     private static string GetExactSearchTextSql(string valueSql, string langSql)
-        => $"CASE WHEN {langSql} = 'csharp' THEN sql_normalize_csharp_verbatim_name({valueSql}) " +
+        => $"CASE WHEN {langSql} IN ('csharp', 'java', 'kotlin') THEN sql_normalize_exact_source_name({valueSql}, {langSql}) " +
            $"WHEN {langSql} = 'sql' THEN sql_normalize_name({valueSql}) " +
            $"ELSE {valueSql} END";
 

--- a/src/CodeIndex/Database/ExactSourceSearchNormalizer.cs
+++ b/src/CodeIndex/Database/ExactSourceSearchNormalizer.cs
@@ -1,0 +1,239 @@
+namespace CodeIndex.Database;
+
+/// <summary>
+/// Normalizes escaped source identifiers for exact search across C#, Java, and Kotlin.
+/// C# / Java / Kotlin の exact 検索向けに、source 側の escaped identifier を正規化する。
+/// </summary>
+internal static class ExactSourceSearchNormalizer
+{
+    internal static string Normalize(string text, string? lang)
+    {
+        var kind = GetLanguageKind(lang);
+        return kind switch
+        {
+            SourceLanguageKind.CSharp => CSharpVerbatimNameNormalizer.Normalize(text),
+            SourceLanguageKind.Java => NormalizeJavaUnicodeEscapes(text),
+            SourceLanguageKind.Kotlin => NormalizeKotlin(text),
+            _ => text,
+        };
+    }
+
+    internal static string Normalize(string text, string? lang, out int[] rawIndexMap)
+    {
+        var kind = GetLanguageKind(lang);
+        return kind switch
+        {
+            SourceLanguageKind.CSharp => CSharpVerbatimNameNormalizer.Normalize(text, out rawIndexMap),
+            SourceLanguageKind.Java => NormalizeJavaUnicodeEscapes(text, out rawIndexMap),
+            SourceLanguageKind.Kotlin => NormalizeKotlin(text, out rawIndexMap),
+            _ => Identity(text, out rawIndexMap),
+        };
+    }
+
+    private static SourceLanguageKind GetLanguageKind(string? lang)
+        => string.IsNullOrWhiteSpace(lang) ? SourceLanguageKind.Other : lang.Trim().ToLowerInvariant() switch
+        {
+            "csharp" or "cs" => SourceLanguageKind.CSharp,
+            "java" => SourceLanguageKind.Java,
+            "kotlin" or "kt" or "kts" => SourceLanguageKind.Kotlin,
+            _ => SourceLanguageKind.Other,
+        };
+
+    private static string NormalizeJavaUnicodeEscapes(string text)
+    {
+        if (text.Length == 0 || text.IndexOf('\\') < 0)
+            return text;
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        bool changed = false;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (TryConsumeJavaUnicodeEscape(text, i, out var decoded, out var consumed))
+            {
+                sb.Append(decoded);
+                i += consumed - 1;
+                changed = true;
+                continue;
+            }
+
+            sb.Append(text[i]);
+        }
+
+        return changed ? sb.ToString() : text;
+    }
+
+    private static string NormalizeJavaUnicodeEscapes(string text, out int[] rawIndexMap)
+    {
+        if (text.Length == 0 || text.IndexOf('\\') < 0)
+            return Identity(text, out rawIndexMap);
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        var map = new System.Collections.Generic.List<int>(text.Length);
+        bool changed = false;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (TryConsumeJavaUnicodeEscape(text, i, out var decoded, out var consumed))
+            {
+                sb.Append(decoded);
+                map.Add(i);
+                i += consumed - 1;
+                changed = true;
+                continue;
+            }
+
+            sb.Append(text[i]);
+            map.Add(i);
+        }
+
+        if (!changed)
+            return Identity(text, out rawIndexMap);
+
+        rawIndexMap = map.ToArray();
+        return sb.ToString();
+    }
+
+    private static string NormalizeKotlin(string text)
+    {
+        if (text.Length == 0 || (text.IndexOf('`') < 0 && text.IndexOf('\\') < 0))
+            return text;
+
+        var decoded = NormalizeJavaUnicodeEscapes(text, out var decodedMap);
+        return StripKotlinBackticks(decoded, decodedMap, out _);
+    }
+
+    private static string NormalizeKotlin(string text, out int[] rawIndexMap)
+    {
+        if (text.Length == 0 || (text.IndexOf('`') < 0 && text.IndexOf('\\') < 0))
+            return Identity(text, out rawIndexMap);
+
+        var decoded = NormalizeJavaUnicodeEscapes(text, out var decodedMap);
+        if (decoded.IndexOf('`') < 0)
+        {
+            rawIndexMap = decodedMap;
+            return decoded;
+        }
+
+        return StripKotlinBackticks(decoded, decodedMap, out rawIndexMap);
+    }
+
+    private static string StripKotlinBackticks(string text, int[] sourceIndexMap, out int[] rawIndexMap)
+    {
+        var sb = new System.Text.StringBuilder(text.Length);
+        var map = new System.Collections.Generic.List<int>(text.Length);
+        bool atBoundary = true;
+        bool inBackticks = false;
+        bool changed = false;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (!inBackticks && atBoundary && c == '`')
+            {
+                inBackticks = true;
+                atBoundary = false;
+                changed = true;
+                continue;
+            }
+
+            if (inBackticks && c == '`')
+            {
+                inBackticks = false;
+                atBoundary = true;
+                changed = true;
+                continue;
+            }
+
+            sb.Append(c);
+            map.Add(sourceIndexMap[i]);
+            if (c == '.')
+            {
+                atBoundary = true;
+            }
+            else if (c == ':' && i + 1 < text.Length && text[i + 1] == ':')
+            {
+                sb.Append(':');
+                map.Add(sourceIndexMap[++i]);
+                atBoundary = true;
+            }
+            else
+            {
+                atBoundary = !IsIdentifierPartChar(c);
+            }
+        }
+
+        if (!changed)
+        {
+            rawIndexMap = sourceIndexMap;
+            return text;
+        }
+
+        rawIndexMap = map.ToArray();
+        return sb.ToString();
+    }
+
+    private static bool TryConsumeJavaUnicodeEscape(string text, int index, out char decoded, out int consumed)
+    {
+        decoded = default;
+        consumed = 0;
+        if (index >= text.Length || text[index] != '\\')
+            return false;
+
+        int i = index + 1;
+        int uCount = 0;
+        while (i < text.Length && text[i] == 'u')
+        {
+            uCount++;
+            i++;
+        }
+
+        if (uCount == 0 || i + 4 > text.Length)
+            return false;
+
+        int value = 0;
+        for (int j = 0; j < 4; j++)
+        {
+            char hex = text[i + j];
+            int nibble = hex switch
+            {
+                >= '0' and <= '9' => hex - '0',
+                >= 'a' and <= 'f' => hex - 'a' + 10,
+                >= 'A' and <= 'F' => hex - 'A' + 10,
+                _ => -1,
+            };
+            if (nibble < 0)
+                return false;
+            value = (value << 4) | nibble;
+        }
+
+        decoded = (char)value;
+        consumed = 1 + uCount + 4;
+        return true;
+    }
+
+    private static bool IsIdentifierStartChar(char c) =>
+        c == '_' || char.IsLetter(c);
+
+    private static bool IsIdentifierPartChar(char c) =>
+        IsIdentifierStartChar(c) || char.IsDigit(c);
+
+    private static string Identity(string text, out int[] rawIndexMap)
+    {
+        rawIndexMap = IdentityMap(text.Length);
+        return text;
+    }
+
+    private static int[] IdentityMap(int length)
+    {
+        var map = new int[length];
+        for (int i = 0; i < length; i++)
+            map[i] = i;
+        return map;
+    }
+
+    private enum SourceLanguageKind
+    {
+        Other,
+        CSharp,
+        Java,
+        Kotlin,
+    }
+}

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -7985,6 +7985,148 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSearch_ExactSubstringTreatsJavaUnicodeEscapesAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_java_unicode");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.java",
+                "java",
+                """
+                public class \u0046oo
+                {
+                    void match() {}
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Foo", "--db", dbPath, "--path", "src/App.java", "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunFind_ExactTreatsJavaUnicodeEscapesAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_java_unicode");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.java",
+                "java",
+                """
+                public class \u0046oo
+                {
+                    void match() {}
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["Foo", "--db", dbPath, "--path", "src/App.java", "--json", "--exact", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+            Assert.Equal(1, json.GetProperty("file_count").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_ExactSubstringTreatsKotlinBacktickedIdentifiersAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_kotlin_backticks");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.kt",
+                "kotlin",
+                """
+                fun `when`() {}
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["when", "--db", dbPath, "--path", "src/App.kt", "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunFind_ExactTreatsCSharpVerbatimQualifiedNamesAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_csharp_verbatim");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/app.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                using @Foo.@Bar;
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["Foo.Bar", "--db", dbPath, "--path", "src/app.cs", "--json", "--exact", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+            Assert.Equal(1, json.GetProperty("file_count").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void CSharpVerbatimNameNormalizer_StripsGlobalQualifierOnlyAtNamespaceStarts()
     {
         Assert.Equal("Foo.Bar", CSharpVerbatimNameNormalizer.Normalize("global::Foo.Bar"));
@@ -24987,6 +25129,42 @@ public class QueryCommandRunnerTests
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
                 ["Foo.Bar", "--db", dbPath, "--path", "src/global.cs", "--json", "--exact", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
+            Assert.Equal(1, json.GetProperty("file_count").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunFind_ExactTreatsKotlinBacktickedIdentifiersAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_kotlin_backticks");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.kt",
+                "kotlin",
+                """
+                fun `when`() {
+                    println("ok")
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["when", "--db", dbPath, "--path", "src/App.kt", "--json", "--exact", "--count"],
                 _jsonOptions));
 
             using var document = ParseJsonOutput(stdout);


### PR DESCRIPTION
Addresses the follow-up candidates from PR #1290 by extending exact search/find normalization to Java and Kotlin in addition to the existing C# handling.

Changes:
- Exact search/find now canonicalizes Java Unicode escapes, Kotlin backticked identifiers, and C# verbatim/global-qualified names.
- Added tests covering search and find exact matching for Java/Kotlin/C#.
- Updated the README and changelog fragment.

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunFind_ExactTreatsJavaUnicodeEscapesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunFind_ExactTreatsCSharpVerbatimQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsJavaUnicodeEscapesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunFind_ExactTreatsKotlinBacktickedIdentifiersAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsKotlinBacktickedIdentifiersAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsCSharpGlobalQualifiedNamesAsCanonical|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExactSubstringTreatsCSharpVerbatimQualifiedNamesAsCanonical"`
- `dotnet test`