### PR TITLE
Improve Python init import search

### DIFF
--- a/changelog.d/unreleased/+python-init-direct-import-qualified-search.fixed.md
+++ b/changelog.d/unreleased/+python-init-direct-import-qualified-search.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Python `__init__.py` direct imports now index package-qualified module names** — when a package initializer re-exports a sibling module with `import submodule` or `import submodule as alias`, cdidx now adds the `package.submodule` search name alongside the local symbol so exact-name lookup can find the public module path too.
+
+## 日本語
+
+- **Python の `__init__.py` における direct import は package 修飾済みの module 名も索引するようになりました** — package initializer が `import submodule` や `import submodule as alias` で sibling module を再エクスポートしている場合、cdidx は local symbol に加えて `package.submodule` の検索名も追加するため、exact-name 検索で公開された module パスも見つけられます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -5092,6 +5092,17 @@ private sealed class RubyMaskState
                         ref searchStartColumn);
                 }
 
+                if (!treatAsFromImport && !string.IsNullOrEmpty(pythonModulePrefix))
+                {
+                    AddPythonImportEntry(
+                        line,
+                        absoluteStartColumn,
+                        $"{pythonModulePrefix}.{importedName}",
+                        entries,
+                        seenNames,
+                        ref searchStartColumn);
+                }
+
                 if (treatAsFromImport && !string.IsNullOrEmpty(normalizedModulePart))
                 {
                     AddPythonImportEntry(

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -440,6 +440,14 @@ public class QueryCommandRunnerTests
             Assert.Equal("1", moduleStdout.Trim());
             Assert.Equal(string.Empty, moduleStderr);
 
+            var (moduleNameExitCode, moduleNameStdout, moduleNameStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["package.subpkg.submodule", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, moduleNameExitCode);
+            Assert.Equal("1", moduleNameStdout.Trim());
+            Assert.Equal(string.Empty, moduleNameStderr);
+
             var (aliasExitCode, aliasStdout, aliasStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
                 ["package.subpkg.alias", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
                 _jsonOptions));

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -198,6 +198,7 @@ public class SymbolExtractorTests
         var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
 
         Assert.Contains("submodule", imports);
+        Assert.Contains("package.subpkg.submodule", imports);
         Assert.Contains("module_alias", imports);
         Assert.Contains("package.subpkg.module_alias", imports);
         Assert.Contains("helper", imports);


### PR DESCRIPTION
## Summary

- Python `__init__.py` direct imports now index the package-qualified module name in addition to the local symbol.
- This makes exact-name search find `package.submodule` for re-exported sibling modules imported with `import submodule` or `import submodule as alias`.
- Added regression coverage for the symbol indexer and CLI exact-name lookup.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~SymbolExtractorTests|FullyQualifiedName~QueryCommandRunnerTests"`

## Docs / Changelog

- Added `changelog.d/unreleased/+python-init-direct-import-qualified-search.fixed.md`.
- No direct `CHANGELOG.md` edit was made, per the fragment workflow.

## Follow-up candidates

- Consider whether dotted direct imports under `__init__.py` should continue to emit package-qualified names for every dotted prefix if that creates noisy exact-name matches in larger package trees.
