### PR TITLE
Index R namespace references

### DIFF
--- a/changelog.d/unreleased/+r-namespace-references.fixed.md
+++ b/changelog.d/unreleased/+r-namespace-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R namespace references now emit reference edges** — `pkg::fun` and `pkg:::fun` are now indexed as `reference` rows, so package-qualified symbols remain searchable even when they are not invoked as calls.
+
+## 日本語
+
+- **R の namespace 参照が reference edge として出るようになりました** — `pkg::fun` と `pkg:::fun` を `reference` 行として索引するため、package 修飾された symbol も call されていない場合に検索しやすくなります。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -2745,7 +2745,7 @@ public static class ReferenceExtractor
                     var name = match.Groups["name"].Value;
                     if (definitionNames != null && definitionNames.Contains(name))
                         continue;
-                    AddReference(references, seen, fileId, name, match.Index, "reference", context, lineNumber, container);
+                    AddReference(references, seen, fileId, name, match.Groups["name"].Index, "reference", context, lineNumber, container);
                 }
             }
         }

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -947,6 +947,14 @@ public static class ReferenceExtractor
         @"^\s*@(?<name>[_\p{L}]\w*(?:\.[_\p{L}]\w*)*)\s*(?:#.*)?$",
         RegexOptions.Compiled);
 
+    // R namespace references like `pkg::fun` and `pkg:::fun` should be searchable as
+    // references even when they are not invoked as calls.
+    // R の namespace 参照 `pkg::fun` / `pkg:::fun` は、呼び出しでなくても reference として
+    // 検索できるようにする。
+    private static readonly Regex RNamespaceReferenceRegex = new(
+        @"(?<![\w.])(?<package>[\w.]+)::(?::)?(?<name>[\w.]+)",
+        RegexOptions.Compiled);
+
     // Languages whose `@Decorator(args)` / `@Annotation(args)` / `@Attribute(args)` syntax
     // should produce `annotation` reference rows rather than `call` rows (issue #293).
     // Swift uses `@available(...)`, `@objc`, `@MainActor`, etc. as compile-time metadata;
@@ -2727,6 +2735,17 @@ public static class ReferenceExtractor
                     if (definitionNames != null && definitionNames.Contains(name))
                         continue;
                     AddReference(references, seen, fileId, match, "decorator", context, lineNumber, container);
+                }
+            }
+
+            if (language == "r")
+            {
+                foreach (Match match in RNamespaceReferenceRegex.Matches(preparedLine))
+                {
+                    var name = match.Groups["name"].Value;
+                    if (definitionNames != null && definitionNames.Contains(name))
+                        continue;
+                    AddReference(references, seen, fileId, name, match.Index, "reference", context, lineNumber, container);
                 }
             }
         }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -8027,6 +8027,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsNamespaceReferenceOperators()
+    {
+        const string content = """
+            lookup <- function() {
+                dplyr::filter
+                base:::get
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "filter"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+        Assert.Contains(references, r =>
+            r.SymbolName == "get"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+    }
+
+    [Fact]
     public void Extract_PowerShell_DetectsCallSites()
     {
         const string content = """


### PR DESCRIPTION
## Summary
- Implements the follow-up candidate from PR #1302 by indexing R namespace accesses like `pkg::fun` and `pkg:::fun` as `reference` rows.
- Keeps the existing `library()` / `require()` / `requireNamespace()` import handling intact.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet build CodeIndex.sln -c Release`

## Docs / Changelog
- Added `changelog.d/unreleased/+r-namespace-references.fixed.md`.
- No `CHANGELOG.md` edit was made because this is an ordinary implementation PR.

## Follow-up candidates
- R namespace references are currently indexed by leaf symbol name only; package-qualified disambiguation is still not modeled.
- This PR specifically addresses the follow-up candidate called out in PR #1302.