### PR TITLE
[codex] Add shell source reference indexing

### DIFF
--- a/changelog.d/unreleased/+shell-source-reference-search.fixed.md
+++ b/changelog.d/unreleased/+shell-source-reference-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Shell `source` file loads are now indexed as references** — shell scripts that load another script with `source ./env.sh` now emit `reference` edges for the imported path, which makes dependency-style searches and reference lookups more complete on Linux shell projects.
+
+## 日本語
+
+- **Shell の `source` によるファイル読込を参照として索引するようになりました** — `source ./env.sh` で別スクリプトを読み込む shell スクリプトは、読み込まれたパスに対して `reference` エッジを出力するため、Linux shell プロジェクトでの依存関係検索と参照検索がより完全になります。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -496,6 +496,13 @@ public static class ReferenceExtractor
     private static readonly Regex ShellCommandCallRegex = new(
         @"(?:^\s*(?!(?:if|then|do|else|elif|while|until|time|fi)\b)|[|;&{]\s*|&&\s*|\|\|\s*|!\s+|\b(?:if|then|do|else|elif|while|until|time)\s+)(?<name>[A-Za-z_][A-Za-z0-9_-]*)(?=\s|$|[;|&}])",
         RegexOptions.Compiled);
+    // Shell `source` / `.` invocations load other scripts, so surface the referenced path
+    // as a `reference` edge for dependency-style search.
+    // Shell の `source` / `.` 呼び出しは他スクリプトを読み込むため、依存関係検索用に
+    // 参照エッジとして対象パスを出す。
+    private static readonly Regex ShellSourceReferenceRegex = new(
+        @"(?:^\s*(?!(?:if|then|do|else|elif|while|until|time|fi)\b)|[|;&{]\s*|&&\s*|\|\|\s*|!\s+|\b(?:if|then|do|else|elif|while|until|time)\s+)(?:source|\.)\s+(?<name>(?:'[^']*'|""[^""]*""|[^;\s&#|}]+))",
+        RegexOptions.Compiled);
     // SQL stored-procedure call without parentheses: T-SQL `EXEC` / `EXECUTE` and MySQL / MariaDB `CALL`.
     // The shared CallRegex requires a trailing `(`, which misses the dominant real-world form such as
     // `EXEC dbo.sp_Target;`, `EXEC dbo.sp_Target @x = 1, @y = 2;`, `CALL sp_Helper;`, and the bracketed
@@ -2384,6 +2391,16 @@ public static class ReferenceExtractor
 
                     var callIndex = match.Groups["name"].Index;
                     AddCallLikeReference(name, callIndex);
+                }
+
+                foreach (Match match in ShellSourceReferenceRegex.Matches(preparedLine))
+                {
+                    var name = NormalizeShellSourceTargetToken(match.Groups["name"].Value);
+                    if (string.IsNullOrWhiteSpace(name))
+                        continue;
+
+                    var sourceIndex = match.Groups["name"].Index;
+                    AddReference(references, seen, fileId, name, sourceIndex, "reference", context, lineNumber, ResolveContainerForCall(sourceIndex));
                 }
 
                 if (shellGlobalAliasNames != null && shellGlobalAliasNames.Count > 0)
@@ -8363,6 +8380,19 @@ public static class ReferenceExtractor
         !string.IsNullOrEmpty(identifier) && identifier[0] == '@'
             ? identifier[1..]
             : identifier;
+
+    private static string NormalizeShellSourceTargetToken(string token)
+    {
+        var trimmed = token.Trim();
+        if (trimmed.Length >= 2)
+        {
+            var quote = trimmed[0];
+            if ((quote == '\'' || quote == '"') && trimmed[^1] == quote)
+                return trimmed[1..^1];
+        }
+
+        return trimmed;
+    }
 
     private static void EmitCssScssReferences(
         string preparedLine,

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -268,6 +268,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Shell_DetectsSourcedFileReferences()
+    {
+        const string content = """
+            run() {
+              source ./env.sh
+              echo done
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+        var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
+
+        Assert.Single(references, reference => reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "./env.sh"
+            && reference.ReferenceKind == "reference"
+            && reference.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_CobolPerform_CapturesParagraphLevelCallReference()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Index shell `source` file loads as `reference` edges so dependency-style searches can find sourced scripts.
- Added a focused regression test covering unquoted `source ./env.sh` handling in `ReferenceExtractor`.
- Added a bilingual changelog fragment under `changelog.d/unreleased/`.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_Shell"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`

## Documentation / Changelog

- Changelog fragment: `changelog.d/unreleased/+shell-source-reference-search.fixed.md`
- No additional docs update was needed because the behavior change is limited to shell reference extraction and is covered by the changelog fragment.

## Follow-up candidates

- Support additional shell load forms such as quoted operands or dot-sourcing if we want broader shell dependency coverage.
