### PR TITLE
Fix Rust multiline fn header columns

### DIFF
--- a/changelog.d/unreleased/+rust-multiline-fn.fixed.md
+++ b/changelog.d/unreleased/+rust-multiline-fn.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Rust multiline `fn` headers now keep their symbol positions** — wrapped function signatures are collected as a single statement before matching, so `pub unsafe extern` headers and similar multiline forms still index the function name on the correct line and column.
+
+## 日本語
+
+- **Rust の複数行 `fn` ヘッダが symbol 位置を保持するようになりました** — 折り返された関数シグネチャを 1 つの statement としてまとめてから照合するため、`pub unsafe extern` のような複数行形式でも関数名を正しい行・列で索引できるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -4105,19 +4105,21 @@ private sealed class RubyMaskState
                                 symbols,
                                 cssSeenSymbols,
                                 startLine,
-                                new SymbolRecord
-                                {
-                                    FileId = fileId,
-                                    Kind = kind,
-                                    Name = name,
-                                    Line = startLine,
-                                    StartLine = startLine,
-                                    StartColumn = csharpSingleLineCollapsedMatch
-                                        ? csharpSignatureRawStartColumn
-                                        : absoluteStartColumn,
-                                    EndLine = Math.Max(startLine, endLine),
-                                    BodyStartLine = bodyStartLine,
-                                    BodyEndLine = bodyEndLine,
+                                    new SymbolRecord
+                                    {
+                                        FileId = fileId,
+                                        Kind = kind,
+                                        Name = name,
+                                        Line = startLine,
+                                        StartLine = startLine,
+                                        StartColumn = lang == "rust" && pattern.Kind == "function"
+                                            ? match.Groups["name"].Index
+                                            : (csharpSingleLineCollapsedMatch
+                                                ? csharpSignatureRawStartColumn
+                                                : absoluteStartColumn),
+                                        EndLine = Math.Max(startLine, endLine),
+                                        BodyStartLine = bodyStartLine,
+                                        BodyEndLine = bodyEndLine,
                                     Signature = signature,
                                     Visibility = TryGetGroup(match, pattern.VisibilityGroup),
                                     ReturnType = NormalizeMetadata(rawReturnType),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11311,6 +11311,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Rust_DetectsMultilineFnHeaders()
+    {
+        var content = """
+            pub unsafe extern "C"
+            fn exported_api<T>(
+                value: T,
+            ) -> T
+            where
+                T: Copy,
+            {
+                value
+            }
+        """;
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+
+        var symbol = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "exported_api");
+        Assert.Equal(2, symbol.Line);
+        Assert.Equal(7, symbol.StartColumn);
+    }
+
+    [Fact]
     public void Extract_Go_DetectsTypeAliasAndConst()
     {
         var content = "type Handler struct {\n}\ntype ID = string\ntype Callback func(int) int\ntype Logger interface {\n}\n\nconst (\n    MaxRetries = 3\n    DefaultTimeout = 30\n)\n\nvar GlobalConfig Config";


### PR DESCRIPTION
## Summary

- Address the follow-up candidate from PR #1299 by keeping Rust multiline `fn` headers on the correct line and column.
- Rust function symbols now use the identifier column instead of the declaration start column, so wrapped headers remain searchable with accurate positions.

## Validation

- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Rust_DetectsMultilineFnHeaders|FullyQualifiedName~SymbolExtractorTests.Extract_Rust_DetectsMultilineImplBlocks"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Documentation / Changelog

- Added `changelog.d/unreleased/+rust-multiline-fn.fixed.md`

## Follow-up candidates

- This PR addresses the follow-up candidate called out in PR #1299.
- No additional follow-up candidates were identified for this change.
