### PR TITLE
Refine Python init import qualification

### DIFF
--- a/changelog.d/unreleased/+python-init-direct-import-dotted-prefix-noise.fixed.md
+++ b/changelog.d/unreleased/+python-init-direct-import-dotted-prefix-noise.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Python `__init__.py` direct imports no longer over-qualify dotted import paths** — when a package initializer imports a dotted module path such as `import package.submodule as alias`, cdidx now avoids synthesizing an extra `package.package.submodule`-style exact-name candidate, reducing noisy matches in larger package trees while keeping the useful leaf and alias lookups.
+
+## 日本語
+
+- **Python の `__init__.py` における direct import は dotted な import path を過剰に修飾しなくなりました** — package initializer が `import package.submodule as alias` のように dotted module path を import する場合、cdidx は `package.package.submodule` のような余計な exact-name 候補を生成しないため、大きな package tree でのノイズを減らしつつ leaf / alias の検索性は維持します。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -5094,7 +5094,9 @@ private sealed class RubyMaskState
                         ref searchStartColumn);
                 }
 
-                if (!treatAsFromImport && !string.IsNullOrEmpty(pythonModulePrefix))
+                if (!treatAsFromImport
+                    && !string.IsNullOrEmpty(pythonModulePrefix)
+                    && !importedName.Contains('.'))
                 {
                     AddPythonImportEntry(
                         line,

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -429,6 +429,7 @@ public class QueryCommandRunnerTests
                 "python",
                 """
                 import submodule as module_alias
+                import package.submodule as external_alias
                 from . import helper as alias
                 """);
 
@@ -447,6 +448,22 @@ public class QueryCommandRunnerTests
             Assert.Equal(CommandExitCodes.Success, moduleNameExitCode);
             Assert.Equal("1", moduleNameStdout.Trim());
             Assert.Equal(string.Empty, moduleNameStderr);
+
+            var (externalExitCode, externalStdout, externalStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["package.submodule", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, externalExitCode);
+            Assert.Equal("1", externalStdout.Trim());
+            Assert.Equal(string.Empty, externalStderr);
+
+            var (noisyExitCode, noisyStdout, noisyStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["package.subpkg.package.submodule", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, noisyExitCode);
+            Assert.Equal("0", noisyStdout.Trim());
+            Assert.Equal(string.Empty, noisyStderr);
 
             var (aliasExitCode, aliasStdout, aliasStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
                 ["package.subpkg.alias", "--db", dbPath, "--lang", "python", "--exact-name", "--count"],

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -191,6 +191,7 @@ public class SymbolExtractorTests
     {
         var content = """
             import submodule as module_alias
+            import package.submodule as external_alias
             from . import helper as alias
             """;
 
@@ -201,6 +202,10 @@ public class SymbolExtractorTests
         Assert.Contains("package.subpkg.submodule", imports);
         Assert.Contains("module_alias", imports);
         Assert.Contains("package.subpkg.module_alias", imports);
+        Assert.Contains("package.submodule", imports);
+        Assert.DoesNotContain("package.subpkg.package.submodule", imports);
+        Assert.Contains("external_alias", imports);
+        Assert.Contains("package.subpkg.external_alias", imports);
         Assert.Contains("helper", imports);
         Assert.Contains("alias", imports);
         Assert.Contains("package.subpkg.alias", imports);


### PR DESCRIPTION
## Summary

- Followed up on PR #1305's candidate to reduce noisy exact-name matches from Python `__init__.py` direct imports.
- `__init__.py` direct imports now avoid synthesizing package-qualified names for already dotted import paths such as `import package.submodule as alias`.
- Kept the useful leaf and alias lookups, and added regression coverage for the narrower behavior.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~SymbolExtractorTests|FullyQualifiedName~QueryCommandRunnerTests"`

## Docs / Changelog

- Added `changelog.d/unreleased/+python-init-direct-import-dotted-prefix-noise.fixed.md`.
- No direct `CHANGELOG.md` edit was made, per the fragment workflow.

## Follow-up candidates

- None.
