### PR TITLE
[codex] Expand shell source reference support

### DIFF
--- a/changelog.d/unreleased/+shell-source-followups.fixed.md
+++ b/changelog.d/unreleased/+shell-source-followups.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Shell source-reference indexing now handles quoted operands and dot-sourcing** — `source "./quoted env.sh"` and `. ./lib/common.sh` now emit `reference` edges for the sourced file path, making Linux shell dependency searches and file lookups more complete.
+
+## 日本語
+
+- **Shell の source 参照索引が quoted operand と dot-sourcing に対応しました** — `source "./quoted env.sh"` と `. ./lib/common.sh` が参照先のファイルパスに対して `reference` エッジを出力するようになり、Linux shell の依存関係検索とファイル検索がより完全になります。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -513,6 +513,13 @@ public static class ReferenceExtractor
     private static readonly Regex ShellCommandCallRegex = new(
         @"(?:^\s*(?!(?:if|then|do|else|elif|while|until|time|fi)\b)|[|;&{]\s*|&&\s*|\|\|\s*|!\s+|\b(?:if|then|do|else|elif|while|until|time)\s+)(?<name>[A-Za-z_][A-Za-z0-9_-]*)(?=\s|$|[;|&}])",
         RegexOptions.Compiled);
+    // Shell `source` / `.` invocations load other scripts. Capture the operand as a
+    // `reference` edge so dependency-style search can find imported files too.
+    // Shell の `source` / `.` 呼び出しは他スクリプトを読み込む。読み込まれる operand を
+    // `reference` エッジとして出すことで、依存関係ベースの検索でも辿れるようにする。
+    private static readonly Regex ShellSourceReferenceRegex = new(
+        @"(?:^\s*(?!(?:if|then|do|else|elif|while|until|time|fi)\b)|[|;&{]\s*|&&\s*|\|\|\s*|!\s+|\b(?:if|then|do|else|elif|while|until|time)\s+)(?:source|\.)\s+(?<name>(?:'[^']*'|""[^""]*""|[^;\s&#|}]+))",
+        RegexOptions.Compiled);
     // SQL stored-procedure call without parentheses: T-SQL `EXEC` / `EXECUTE` and MySQL / MariaDB `CALL`.
     // The shared CallRegex requires a trailing `(`, which misses the dominant real-world form such as
     // `EXEC dbo.sp_Target;`, `EXEC dbo.sp_Target @x = 1, @y = 2;`, `CALL sp_Helper;`, and the bracketed
@@ -2425,6 +2432,17 @@ public static class ReferenceExtractor
 
                     var callIndex = match.Groups["name"].Index;
                     AddCallLikeReference(name, callIndex);
+                }
+
+                var shellSourceLine = StripShellComment(originalLine);
+                foreach (Match match in ShellSourceReferenceRegex.Matches(shellSourceLine))
+                {
+                    var name = NormalizeShellSourceTargetToken(match.Groups["name"].Value);
+                    if (string.IsNullOrWhiteSpace(name))
+                        continue;
+
+                    var sourceIndex = match.Groups["name"].Index;
+                    AddReference(references, seen, fileId, name, sourceIndex, "reference", context, lineNumber, ResolveContainerForCall(sourceIndex));
                 }
 
                 if (shellGlobalAliasNames != null && shellGlobalAliasNames.Count > 0)
@@ -8433,6 +8451,76 @@ public static class ReferenceExtractor
         !string.IsNullOrEmpty(identifier) && identifier[0] == '@'
             ? identifier[1..]
             : identifier;
+
+    private static string NormalizeShellSourceTargetToken(string token)
+    {
+        var trimmed = token.Trim();
+        if (trimmed.Length >= 2)
+        {
+            var quote = trimmed[0];
+            if ((quote == '\'' || quote == '"') && trimmed[^1] == quote)
+                return trimmed[1..^1];
+        }
+
+        return trimmed;
+    }
+
+    private static string StripShellComment(string line)
+    {
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+        var escapeNext = false;
+
+        for (var i = 0; i < line.Length; i++)
+        {
+            var ch = line[i];
+            if (escapeNext)
+            {
+                escapeNext = false;
+                continue;
+            }
+
+            if (inSingleQuote)
+            {
+                if (ch == '\'')
+                    inSingleQuote = false;
+                continue;
+            }
+
+            if (inDoubleQuote)
+            {
+                if (ch == '"')
+                {
+                    inDoubleQuote = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                    escapeNext = true;
+                continue;
+            }
+
+            if (ch == '#')
+                return line[..i];
+
+            if (ch == '\'')
+            {
+                inSingleQuote = true;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inDoubleQuote = true;
+                continue;
+            }
+
+            if (ch == '\\')
+                escapeNext = true;
+        }
+
+        return line;
+    }
 
     private static void EmitCssScssReferences(
         string preparedLine,

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -268,6 +268,36 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Shell_DetectsSourcedFileReferences()
+    {
+        const string content = """
+            run() {
+              source ./env.sh
+              source "./quoted env.sh"
+              . ./lib/common.sh
+              echo done
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+        var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
+
+        Assert.Equal(3, references.Count(reference => reference.ReferenceKind == "reference"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "./env.sh"
+            && reference.ReferenceKind == "reference"
+            && reference.ContainerName == "run");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "./quoted env.sh"
+            && reference.ReferenceKind == "reference"
+            && reference.ContainerName == "run");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "./lib/common.sh"
+            && reference.ReferenceKind == "reference"
+            && reference.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_CobolPerform_CapturesParagraphLevelCallReference()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Implements the follow-up candidates from PR #1307.
- Shell source-reference indexing now handles unquoted `source ./env.sh`, quoted operands such as `source "./quoted env.sh"`, and dot-sourcing such as `. ./lib/common.sh`.
- The extractor emits `reference` edges for sourced file paths so Linux shell dependency searches and lookups are more complete.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_Shell"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`

## Documentation / Changelog

- Changelog fragment: `changelog.d/unreleased/+shell-source-followups.fixed.md`
- No docs update was needed beyond the changelog fragment because this is a targeted shell reference extraction enhancement.

## Follow-up candidates

- None.
