### PR TITLE
Improve R namespace reference disambiguation from PR #1306 follow-up

### DIFF
--- a/changelog.d/unreleased/+r-namespace-references.fixed.md
+++ b/changelog.d/unreleased/+r-namespace-references.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **R namespace references now emit reference edges** — `pkg::fun` and `pkg:::fun` are now indexed as `reference` rows, so package-qualified symbols remain searchable even when they are not invoked as calls.
+- **R namespace references now emit package-qualified reference edges** — `pkg::fun` and `pkg:::fun` are now indexed both as leaf `reference` rows and as package-qualified `pkg::fun` / `pkg:::fun` rows, so namespace-specific searches can disambiguate same-named symbols.
 
 ## 日本語
 
-- **R の namespace 参照が reference edge として出るようになりました** — `pkg::fun` と `pkg:::fun` を `reference` 行として索引するため、package 修飾された symbol も call されていない場合に検索しやすくなります。
+- **R の namespace 参照が package 修飾つきの reference edge として出るようになりました** — `pkg::fun` と `pkg:::fun` を leaf の `reference` 行に加えて `pkg::fun` / `pkg:::fun` の package 修飾名でも索引するため、同名 symbol を namespace 単位で見分けながら検索できます。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -952,7 +952,7 @@ public static class ReferenceExtractor
     // R の namespace 参照 `pkg::fun` / `pkg:::fun` は、呼び出しでなくても reference として
     // 検索できるようにする。
     private static readonly Regex RNamespaceReferenceRegex = new(
-        @"(?<![\w.])(?<package>[\w.]+)::(?::)?(?<name>[\w.]+)",
+        @"(?<![\w.])(?<package>[\w.]+)(?<sep>:::?)(?<name>[\w.]+)",
         RegexOptions.Compiled);
 
     // Languages whose `@Decorator(args)` / `@Annotation(args)` / `@Attribute(args)` syntax
@@ -2742,9 +2742,12 @@ public static class ReferenceExtractor
             {
                 foreach (Match match in RNamespaceReferenceRegex.Matches(preparedLine))
                 {
+                    var package = match.Groups["package"].Value;
+                    var separator = match.Groups["sep"].Value;
                     var name = match.Groups["name"].Value;
                     if (definitionNames != null && definitionNames.Contains(name))
                         continue;
+                    AddReference(references, seen, fileId, $"{package}{separator}{name}", match.Groups["package"].Index, "reference", context, lineNumber, container);
                     AddReference(references, seen, fileId, name, match.Groups["name"].Index, "reference", context, lineNumber, container);
                 }
             }

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -2745,9 +2745,9 @@ public static class ReferenceExtractor
                     var package = match.Groups["package"].Value;
                     var separator = match.Groups["sep"].Value;
                     var name = match.Groups["name"].Value;
+                    AddReference(references, seen, fileId, $"{package}{separator}{name}", match.Groups["package"].Index, "reference", context, lineNumber, container);
                     if (definitionNames != null && definitionNames.Contains(name))
                         continue;
-                    AddReference(references, seen, fileId, $"{package}{separator}{name}", match.Groups["package"].Index, "reference", context, lineNumber, container);
                     AddReference(references, seen, fileId, name, match.Groups["name"].Index, "reference", context, lineNumber, container);
                 }
             }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -8058,6 +8058,35 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_PreservesQualifiedNamespaceReferencesWhenLeafIsDefinedLocally()
+    {
+        const string content = """
+            filter <- function(x) x
+
+            lookup <- function() {
+                dplyr::filter
+                base:::get
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "dplyr::filter"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "base:::get"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "filter"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "get"
+            && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_PowerShell_DetectsCallSites()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -8040,7 +8040,15 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "r", content, symbols);
 
         Assert.Contains(references, r =>
+            r.SymbolName == "dplyr::filter"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+        Assert.Contains(references, r =>
             r.SymbolName == "filter"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+        Assert.Contains(references, r =>
+            r.SymbolName == "base:::get"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "lookup");
         Assert.Contains(references, r =>

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -8061,10 +8061,8 @@ public class ReferenceExtractorTests
     public void Extract_R_PreservesQualifiedNamespaceReferencesWhenLeafIsDefinedLocally()
     {
         const string content = """
-            filter <- function(x) x
-
             lookup <- function() {
-                dplyr::filter
+                filter <- dplyr::filter
                 base:::get
             }
             """;
@@ -8077,9 +8075,6 @@ public class ReferenceExtractorTests
             && r.ReferenceKind == "reference");
         Assert.Contains(references, r =>
             r.SymbolName == "base:::get"
-            && r.ReferenceKind == "reference");
-        Assert.Contains(references, r =>
-            r.SymbolName == "filter"
             && r.ReferenceKind == "reference");
         Assert.Contains(references, r =>
             r.SymbolName == "get"


### PR DESCRIPTION
Addresses the follow-up candidate from PR #1306 by indexing R namespace accesses like `pkg::fun` and `pkg:::fun` as package-qualified `reference` rows in addition to leaf references.

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

Changelog:
- `changelog.d/unreleased/+r-namespace-references.fixed.md`