### PR TITLE
Improve C search for annotated functions

### DIFF
--- a/changelog.d/unreleased/+c-attributes.fixed.md
+++ b/changelog.d/unreleased/+c-attributes.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C functions with GCC/Clang/MSVC attribute specifiers now remain searchable** — `SymbolExtractor` now skips common attribute blocks such as `__attribute__((...))`, `__declspec(...)`, and `_Noreturn` when they appear before or between the return type and function name, so annotated C functions like `__attribute__((noreturn)) void die(void)` and `static inline __attribute__((always_inline)) int add(int, int)` surface in `symbols`.
+
+## 日本語
+
+- **GCC/Clang/MSVC の attribute specifier 付き C 関数も検索できるようになりました** — `SymbolExtractor` が `__attribute__((...))`、`__declspec(...)`、`_Noreturn` のような attribute ブロックを、戻り値型の前や戻り値型と関数名の間でスキップするため、`__attribute__((noreturn)) void die(void)` や `static inline __attribute__((always_inline)) int add(int, int)` のような注釈付き C 関数が `symbols` に現れるようになります。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -82,6 +82,15 @@ public static class SymbolExtractor
     private const string CppDecltypePattern =
         @"decltype\s*\((?:(?>[^()]+)|\((?<CppDecltypeDepth>)|\)(?<-CppDecltypeDepth>))*(?(CppDecltypeDepth)(?!))\)";
     private const string CppFunctionReturnTypeAtomPattern = @"(?:" + CppDecltypePattern + @"|[\w:<>~]+)";
+    // GCC/Clang/MSVC attribute specifiers can appear before the return type or between return
+    // type tokens. Keep them inside the function return-type matcher so common annotated C
+    // functions still surface in `symbols` / `search`.
+    // GCC/Clang/MSVC の attribute specifier は戻り値型の前や、戻り値型トークンの途中に現れる。
+    // それらを戻り値型マッチャーに含めて、よくある注釈付き C 関数も `symbols` / `search` に出るようにする。
+    private const string CAttributeSpecifierTokenPattern =
+        @"(?:__attribute__\s*\(\(.*?\)\)\s*|__declspec\s*\((?:[^()]|\([^()]*\))*\)\s*|_Noreturn\s+)";
+    private const string CFunctionReturnTypePattern =
+        @"(?<returnType>(?:(?:\w+[\s*]+)|" + CAttributeSpecifierTokenPattern + @")+)";
     private const string CSharpTypeSegmentPattern =
         @"(?:" + CSharpTypeTokenCharsPattern + @"+(?:" + CSharpTupleGroupPattern + CSharpTypeTokenCharsPattern + @"*)*|" + CSharpTupleGroupPattern + CSharpTypeTokenCharsPattern + @"*)";
     private const string CSharpTypePattern =
@@ -1225,7 +1234,7 @@ public static class SymbolExtractor
         ],
         ["c"] =
         [
-            new("function", new Regex(CFunctionStartBlacklistPattern + @"(?<returnType>(?:\w+[\s*]+)+)" + CFunctionNameBlacklistPattern + @"(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(CFunctionStartBlacklistPattern + CFunctionReturnTypePattern + CFunctionNameBlacklistPattern + @"(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
             // #define macros / #define マクロ
             new("function", new Regex(@"^\s*#\s*define\s+(?<name>[A-Za-z_]\w*)\(", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*#\s*define\s+(?<name>[A-Za-z_]\w*)(?=\s|$)", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12834,6 +12834,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_C_DetectsAttributedFunctions()
+    {
+        var content = """
+            __attribute__((noreturn)) void die(void) {
+            }
+
+            static inline __attribute__((always_inline)) int add(int a, int b) {
+                return a + b;
+            }
+
+            __declspec(dllexport) int exported(void) {
+                return 0;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "die");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "add");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "exported");
+    }
+
+    [Fact]
     public void Extract_C_DoesNotCapturePrimitiveTypesForFunctionPointerTypedefs()
     {
         // C: function-pointer typedefs and ordinary functions / C: 関数ポインタ typedef と通常関数


### PR DESCRIPTION
## Summary
- Teach C symbol extraction to skip GCC/Clang/MSVC attribute specifiers when they appear before or inside the return-type token sequence, so annotated functions remain searchable.
- Add a regression test that covers both leading and infix attribute forms.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_C_DetectsAttributedFunctions"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Docs and Changelog
- No user-facing docs changed in this PR.
- The behavior change is recorded in `changelog.d/unreleased/+c-attributes.fixed.md`.

## Follow-up candidates
- Add coverage for other C declaration forms that show up in the wild, such as older K&R-style declarations or vendor-specific attributes with more complex argument shapes.