### PR TITLE
Add Perl symbol and reference support

### DIFF
--- a/changelog.d/unreleased/+perl-search.fixed.md
+++ b/changelog.d/unreleased/+perl-search.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Perl package and subroutine symbols are now searchable** - `perl` files now index `package Foo::Bar;` as namespaces and `sub name { ... }` as functions, and Perl is included in reference extraction so `#` comments no longer leak false call hits.
+
+## 日本語
+
+- **Perl の package と subroutine が検索できるようになりました** - `perl` ファイルでは `package Foo::Bar;` を namespace、`sub name { ... }` を function として index し、reference extraction にも Perl を追加したので `#` コメントから誤った call が漏れなくなります。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -24,7 +24,7 @@ public static class ReferenceExtractor
     private static readonly HashSet<string> SupportedLanguages =
     [
         "python", "javascript", "typescript", "csharp", "go", "rust",
-        "java", "kotlin", "ruby", "c", "cpp", "php", "swift",
+        "java", "kotlin", "ruby", "perl", "c", "cpp", "php", "swift",
         "dart", "scala", "elixir", "lua", "vb", "fsharp", "sql", "cobol", "batch",
         "r", "powershell", "shell", "haskell",
         "gradle", "terraform", "protobuf", "dockerfile", "makefile",
@@ -15764,7 +15764,7 @@ public static class ReferenceExtractor
     }
 
     private static bool UsesHashComments(string lang) =>
-        lang is "python" or "ruby" or "php" or "elixir" or "r" or "powershell"
+        lang is "python" or "ruby" or "perl" or "php" or "elixir" or "r" or "powershell"
             or "shell" or "makefile" or "terraform" or "dockerfile" or "protobuf";
 
     private static bool UsesSlashComments(string lang) =>

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1223,6 +1223,13 @@ public static class SymbolExtractor
             new("class",    new Regex(@"^\s*module\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("import",   new Regex(@"^\s*require(?:_relative)?\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
         ],
+        ["perl"] =
+        [
+            // Perl package declarations / Perl の package 宣言
+            new("namespace", new Regex(@"^\s*package\s+(?<name>[\w:]+)\s*;", RegexOptions.Compiled), BodyStyle.None),
+            // Perl subroutines / Perl の subroutine
+            new("function", new Regex(@"^\s*sub\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+        ],
         ["c"] =
         [
             new("function", new Regex(CFunctionStartBlacklistPattern + @"(?<returnType>(?:\w+[\s*]+)+)" + CFunctionNameBlacklistPattern + @"(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -1223,7 +1223,7 @@ public class QueryCommandRunnerTests
                 $"{searchOnly} must advertise graph_queries=false");
         }
 
-        foreach (var searchOnly in new[] { "crystal", "clojure", "d", "erlang", "julia", "nim", "ocaml", "perl", "solidity", "tcl" })
+        foreach (var searchOnly in new[] { "crystal", "clojure", "d", "erlang", "julia", "nim", "ocaml", "solidity", "tcl" })
         {
             Assert.True(languages.ContainsKey(searchOnly), $"expected '{searchOnly}' to be listed");
             var entry = languages[searchOnly];
@@ -1232,6 +1232,12 @@ public class QueryCommandRunnerTests
             Assert.False(entry.GetProperty("graph_queries").GetBoolean(),
                 $"{searchOnly} must advertise graph_queries=false");
         }
+
+        Assert.True(languages.ContainsKey("perl"), "expected 'perl' to be listed");
+        Assert.True(languages["perl"].GetProperty("symbol_extraction").GetBoolean(),
+            "perl must advertise symbol_extraction=true");
+        Assert.True(languages["perl"].GetProperty("graph_queries").GetBoolean(),
+            "perl must advertise graph_queries=true");
 
         // Cython owns .pyx / .pxd exclusively; python keeps .py / .pyi / .pyw and Bazel filenames.
         // Cython は .pyx / .pxd を専有し、python は .py / .pyi / .pyw と Bazel ファイル名を維持。

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -196,6 +196,33 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Perl_DetectsCallsAndIgnoresHashComments()
+    {
+        const string content = """
+            package Example::Widget;
+
+            sub setup {
+              return 1;
+            }
+
+            sub run {
+              setup();
+              # setup() should stay ignored here
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "perl", content);
+        var references = ReferenceExtractor.Extract(1, "perl", content, symbols);
+
+        Assert.Contains(ReferenceExtractor.GetSupportedLanguages(), lang => lang == "perl");
+        Assert.Equal(1, references.Count(reference => reference.ReferenceKind == "call"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "setup"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_Shell_DetectsAliasCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12571,6 +12571,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Perl_DetectsPackageAndSub()
+    {
+        var content = """
+            package Example::Widget;
+
+            sub build {
+                return 1;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "perl", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "Example::Widget");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build");
+    }
+
+    [Fact]
     public void Extract_Ruby_IgnoresEndInsideStringsAndComments()
     {
         var content = "class UserService\n  def find_user(id)\n    puts \"the word end should not close this block\"\n    # end should not close this block either\n    id\n  end\nend";


### PR DESCRIPTION
## Summary

Added Perl-aware search coverage by indexing `package Foo::Bar;` as namespaces and `sub name { ... }` as functions, and by enabling Perl in reference extraction so `#` comments no longer generate false call hits.

## Validation

- `dotnet build`
- `dotnet test --filter "FullyQualifiedName~Perl"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs src/CodeIndex/Indexer/ReferenceExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/ReferenceExtractorTests.cs changelog.d/unreleased/+perl-search.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added bilingual fragment: `changelog.d/unreleased/+perl-search.fixed.md`

## Follow-up Candidates

- Add Perl `use` / `require` import extraction so module dependencies are searchable too.
- Add POD-aware handling before expanding Perl symbol extraction further, because `.pod` files are currently mapped to Perl and can contain documentation text rather than code.
