### PR TITLE
Improve PHP static access references

### DIFF
--- a/changelog.d/unreleased/+php-static-access-search.fixed.md
+++ b/changelog.d/unreleased/+php-static-access-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP static access now leaves searchable type references on the class side** — `Foo::bar()`, `Foo::CONST`, and `Foo::class` now emit `type_reference` edges for the class name, while `self::`, `static::`, and `parent::` stay suppressed so PHP class search picks up the useful static-access sites without adding pseudo-type noise.
+
+## 日本語
+
+- **PHP の静的アクセスでクラス側に検索可能な type reference を出すようになりました** — `Foo::bar()`、`Foo::CONST`、`Foo::class` からクラス名への `type_reference` を追加し、`self::`、`static::`、`parent::` は抑止したままにすることで、PHP のクラス検索で有用な static access を拾いつつ pseudo-type のノイズを増やさないようにしました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -8533,12 +8533,15 @@ public static class ReferenceExtractor
     {
         foreach (Match match in PhpStaticAccessRegex.Matches(preparedLine))
         {
-            var rawName = match.Groups["name"].Value.TrimStart('\\');
-            if (rawName.Length == 0)
+            var nameGroup = match.Groups["name"];
+            var rawName = nameGroup.Value;
+            var trimmedName = rawName.TrimStart('\\');
+            if (trimmedName.Length == 0)
                 continue;
 
-            var shortNameStart = rawName.LastIndexOf('\\') + 1;
-            var shortName = rawName[shortNameStart..];
+            var leadingBackslashCount = rawName.Length - trimmedName.Length;
+            var shortNameStart = trimmedName.LastIndexOf('\\') + 1;
+            var shortName = trimmedName[shortNameStart..];
             if (shortName.Length == 0)
                 continue;
 
@@ -8549,7 +8552,7 @@ public static class ReferenceExtractor
                 continue;
             }
 
-            var nameIndex = match.Groups["name"].Index + shortNameStart;
+            var nameIndex = nameGroup.Index + leadingBackslashCount + shortNameStart;
             AddReference(references, seen, fileId, shortName, nameIndex, "type_reference", context, lineNumber, container);
         }
     }

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -307,6 +307,9 @@ public static class ReferenceExtractor
     private static readonly Regex StringLiteralRegex = new(
         "\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'|`(?:\\\\.|[^`\\\\])*`",
         RegexOptions.Compiled);
+    private static readonly Regex PhpStaticAccessRegex = new(
+        @"(?<![\w$\\])(?<name>(?:\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))::(?<member>[A-Za-z_]\w*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CssCustomPropertyReferenceRegex = new(@"\bvar\(\s*--(?<name>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CssAnimationNameReferenceRegex = new(@"\banimation-name\s*:\s*(?<name>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CssAnimationShorthandValueRegex = new(@"\banimation\s*:\s*(?<value>[^;{}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -2195,6 +2198,18 @@ public static class ReferenceExtractor
             if (language == "css")
             {
                 EmitCssScssReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+            }
+
+            if (language == "php")
+            {
+                EmitPhpStaticAccessReferences(
                     preparedLine,
                     references,
                     seen,
@@ -8504,6 +8519,38 @@ public static class ReferenceExtractor
                 context,
                 lineNumber,
                 container);
+        }
+    }
+
+    private static void EmitPhpStaticAccessReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in PhpStaticAccessRegex.Matches(preparedLine))
+        {
+            var rawName = match.Groups["name"].Value.TrimStart('\\');
+            if (rawName.Length == 0)
+                continue;
+
+            var shortNameStart = rawName.LastIndexOf('\\') + 1;
+            var shortName = rawName[shortNameStart..];
+            if (shortName.Length == 0)
+                continue;
+
+            if (string.Equals(shortName, "self", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(shortName, "static", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(shortName, "parent", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var nameIndex = match.Groups["name"].Index + shortNameStart;
+            AddReference(references, seen, fileId, shortName, nameIndex, "type_reference", context, lineNumber, container);
         }
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6494,6 +6494,45 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpStaticAccess_EmitsTypeReferencesForClassSide()
+    {
+        const string content = """
+            <?php
+            namespace App\Models;
+
+            class Config {
+                public const VERSION = '1.0';
+
+                public static function rebuild(): void {}
+
+                public function touch(): void {
+                    self::rebuild();
+                    static::rebuild();
+                }
+            }
+
+            enum Priority: int {
+                case Low = 1;
+            }
+
+            function inspect(): void {
+                Config::rebuild();
+                Config::VERSION;
+                Priority::Low;
+            }
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "Config" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Priority" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "self" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "static" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_PhpLanguageConstructCalls_AreIgnored()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Add a PHP-specific static-access matcher so `Foo::bar()`, `Foo::CONST`, and `Foo::class` emit `type_reference` rows for the class side.
- Keep `self::`, `static::`, and `parent::` suppressed so the new signal stays focused on real search targets.
- Add a regression test that covers static access and enum case access in PHP.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Php"`
- `dotnet test`

## Documentation / Changelog

- Added fragment: `changelog.d/unreleased/+php-static-access-search.fixed.md`

## Follow-up Candidates

- Consider whether PHP object-member navigation should also get a language-specific matcher if search misses prove common in real projects.
- Consider whether a future PHP matcher should emit a richer namespace-qualified target alongside the short class name for fully-qualified static access.
