### PR TITLE
Index XAML TargetType values

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-targettype.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-targettype.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **XAML `TargetType` values are now indexed as searchable class symbols** — `Style`, `ControlTemplate`, and similar XAML elements now surface their `TargetType` values alongside `x:DataType`, so `symbols` and `definition` can find controls declared through XML markup instead of only matching the raw text.
+
+## 日本語
+
+- **XAML の `TargetType` 値を検索可能な class シンボルとして index するようになりました** — `Style` や `ControlTemplate` などの XAML 要素で指定された `TargetType` を `x:DataType` と同様に拾うため、`symbols` / `definition` で XML マークアップ経由のコントロール定義を raw text だけに頼らず見つけられるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -189,6 +189,9 @@ public static class SymbolExtractor
     private static readonly Regex XamlDataTypeRegex = new(
         @"\bx:DataType\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlTargetTypeRegex = new(
+        @"\bTargetType\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex XamlNameRegex = new(
         @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -6517,6 +6520,23 @@ private sealed class RubyMaskState
             foreach (Match dataTypeMatch in XamlDataTypeRegex.Matches(line))
             {
                 var value = NormalizeXamlKeyValue(dataTypeMatch.Groups["value"].Value);
+                if (value.Length == 0)
+                    continue;
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "class",
+                    Name = value,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                });
+            }
+
+            foreach (Match targetTypeMatch in XamlTargetTypeRegex.Matches(line))
+            {
+                var value = NormalizeXamlKeyValue(targetTypeMatch.Groups["value"].Value);
                 if (value.Length == 0)
                     continue;
                 symbols.Add(new SymbolRecord

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2074,6 +2074,59 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsXamlTargetType()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_target_type");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "MainPage.xaml"),
+                """
+                <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                             xmlns:vm="clr-namespace:Sample.ViewModels">
+                    <ContentPage.Resources>
+                        <Style TargetType="Button" />
+                        <ControlTemplate TargetType="{x:Type vm:CustomButton}" />
+                    </ContentPage.Resources>
+                </ContentPage>
+                """);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json"],
+                _jsonOptions));
+            var (buttonExitCode, buttonStdout, buttonStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["Button", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                _jsonOptions));
+            var (customButtonExitCode, customButtonStdout, customButtonStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["vm:CustomButton", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                _jsonOptions));
+
+            var buttonRows = ParseJsonLines(buttonStdout);
+            var customButtonRows = ParseJsonLines(customButtonStdout);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+            Assert.Equal(CommandExitCodes.Success, buttonExitCode);
+            Assert.Equal(string.Empty, buttonStderr);
+            Assert.Single(buttonRows);
+            Assert.Equal("Button", buttonRows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("class", buttonRows[0].RootElement.GetProperty("kind").GetString());
+            Assert.Equal(CommandExitCodes.Success, customButtonExitCode);
+            Assert.Equal(string.Empty, customButtonStderr);
+            Assert.Single(customButtonRows);
+            Assert.Equal("vm:CustomButton", customButtonRows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("class", customButtonRows[0].RootElement.GetProperty("kind").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_RejectsOversizedMultiNameBatches()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_oversize");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19643,6 +19643,32 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesTargetTypeAndDataType()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:vm="clr-namespace:Sample.ViewModels">
+                <Style TargetType="Button">
+                    <Setter Property="Background" Value="Tomato" />
+                </Style>
+                <ControlTemplate TargetType="{x:Type vm:CustomButton}">
+                    <Grid />
+                </ControlTemplate>
+                <DataTemplate x:DataType="vm:PersonViewModel">
+                    <TextBlock Text="{Binding FullName}" />
+                </DataTemplate>
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Button");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:CustomButton");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:PersonViewModel");
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesCommonEventHandlers()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Index XAML `TargetType` values as searchable `class` symbols.
- Add unit and CLI coverage so the new XML/XAML lookup path is exercised end to end.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesTargetTypeAndDataType|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsXamlTargetType"`
- `dotnet build CodeIndex.sln -c Release`

## Docs and Changelog
- Added `changelog.d/unreleased/+xml-xaml-targettype.fixed.md`.
- No `CHANGELOG.md` edits were needed because this is an ordinary implementation change.

## Follow-up candidates
- Consider capturing additional XAML type-bearing attributes such as `x:TypeArguments` if broader markup navigation becomes a goal.