### PR TITLE
Improve C search for legacy declarations

### DIFF
--- a/changelog.d/unreleased/+c-followup.fixed.md
+++ b/changelog.d/unreleased/+c-followup.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C search now covers older K&R-style declarations and more complex vendor attributes** — this follow-up to PR 1313 teaches `SymbolExtractor` to keep indexed names for old-style definitions such as `int legacy(a, b) int a; int b; { ... }` and for nested attribute forms such as `__attribute__((format(printf, 1, 2)))` or `__declspec(align(16))`, so annotated or legacy C functions stay searchable.
+
+## 日本語
+
+- **C 検索が古い K&R 形式の宣言と、より複雑な vendor 属性に対応しました** — PR 1313 の follow-up として、`SymbolExtractor` が `int legacy(a, b) int a; int b; { ... }` のような old-style 定義や、`__attribute__((format(printf, 1, 2)))` / `__declspec(align(16))` のような入れ子属性でも名前を索引するため、注釈付き・古い書き方の C 関数も引き続き検索できます。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -88,7 +88,7 @@ public static class SymbolExtractor
     // GCC/Clang/MSVC の attribute specifier は戻り値型の前や、戻り値型トークンの途中に現れる。
     // それらを戻り値型マッチャーに含めて、よくある注釈付き C 関数も `symbols` / `search` に出るようにする。
     private const string CAttributeSpecifierTokenPattern =
-        @"(?:__attribute__\s*\(\(.*?\)\)\s*|__declspec\s*\((?:[^()]|\([^()]*\))*\)\s*|_Noreturn\s+)";
+        @"(?:__attribute__\s*\(\((?:(?>[^()]+)|\((?<CAttributeDepth>)|\)(?<-CAttributeDepth>))*(?(CAttributeDepth)(?!))\)\)\s*|__declspec\s*\((?:(?>[^()]+)|\((?<CAttributeDepth>)|\)(?<-CAttributeDepth>))*(?(CAttributeDepth)(?!))\)\s*|_Noreturn\s+)";
     private const string CFunctionReturnTypePattern =
         @"(?<returnType>(?:(?:\w+[\s*]+)|" + CAttributeSpecifierTokenPattern + @")+)";
     private const string CSharpTypeSegmentPattern =
@@ -14840,6 +14840,8 @@ private sealed class RubyMaskState
         int bracketDepth = 0;
         bool inBlockComment = false;
         bool inString = false;
+        var allowKrParameterDeclarations = lang is "c" or "cpp";
+        bool sawTopLevelClosingParen = false;
 
         for (int i = startIndex; i < lines.Length; i++)
         {
@@ -14958,13 +14960,21 @@ private sealed class RubyMaskState
                 if (c == '(')
                     parenDepth++;
                 else if (c == ')' && parenDepth > 0)
+                {
                     parenDepth--;
+                    if (allowKrParameterDeclarations && parenDepth == 0)
+                        sawTopLevelClosingParen = true;
+                }
                 else if (c == '[')
                     bracketDepth++;
                 else if (c == ']' && bracketDepth > 0)
                     bracketDepth--;
                 else if (c == ';' && !opened)
+                {
+                    if (allowKrParameterDeclarations && sawTopLevelClosingParen && i > startIndex)
+                        continue;
                     return (startIndex + 1, null, null);
+                }
                 else if (c == '{')
                 {
                     if (parenDepth > 0 || bracketDepth > 0)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12857,6 +12857,35 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_C_DetectsKrStyleAndNestedAttributedFunctions()
+    {
+        var content = """
+            int legacy(a, b)
+                int a;
+                int b;
+            {
+                return a + b;
+            }
+
+            __attribute__((format(printf, 1, 2))) int log_message(const char *fmt, ...)
+            {
+                return 0;
+            }
+
+            __declspec(align(16)) int aligned_value(void)
+            {
+                return 1;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "legacy");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "log_message");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "aligned_value");
+    }
+
+    [Fact]
     public void Extract_C_DoesNotCapturePrimitiveTypesForFunctionPointerTypedefs()
     {
         // C: function-pointer typedefs and ordinary functions / C: 関数ポインタ typedef と通常関数


### PR DESCRIPTION
## Summary
- Follow-up to PR 1313: implemented the listed C search follow-up candidates.
- `SymbolExtractor` now keeps annotated C functions searchable when attributes use more complex nested argument shapes such as `__attribute__((format(printf, 1, 2)))` and `__declspec(align(16))`.
- `FindBraceRange` now tolerates K&R-style C parameter declaration lines between the function header and the opening brace, so old-style definitions remain indexed.
- Added a regression test that covers both the legacy K&R form and the nested attribute forms.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_C_DetectsKrStyleAndNestedAttributedFunctions"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`

## Docs and Changelog
- No user-facing docs changed in this PR.
- The behavior change is recorded in `changelog.d/unreleased/+c-followup.fixed.md`.

## Follow-up candidates
- None from PR 1313 were left in scope for this branch.