### PR TITLE
Normalize YML lang aliases in search filters

### DIFF
--- a/changelog.d/unreleased/+yaml-lang-aliases.fixed.md
+++ b/changelog.d/unreleased/+yaml-lang-aliases.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`--lang yml` now resolves to `yaml`** — query commands accept the common YML shorthand as an alias, so `search`, `files`, `symbols`, and related filters no longer return zero rows when users pass the file-format name they expect.
+
+## 日本語
+
+- **`--lang yml` が `yaml` として解決されるようになりました** — クエリ系コマンドが YML の慣用表記を別名として受け付けるため、`search` / `files` / `symbols` などで、期待するファイル形式名をそのまま指定しても 0 件になりにくくなります。

--- a/changelog.d/unreleased/+yaml-lang-aliases.fixed.md
+++ b/changelog.d/unreleased/+yaml-lang-aliases.fixed.md
@@ -2,6 +2,7 @@
 category: fixed
 affected:
   - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
   - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
 ---
 

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -31,6 +31,7 @@ public static class QueryCommandRunner
         ["py3"] = "python",
         ["pyi"] = "python",
         ["pyw"] = "python",
+        ["yml"] = "yaml",
         ["kt"] = "kotlin",
         ["kts"] = "kotlin",
         ["tsql"] = "sql",

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -254,7 +254,7 @@ public partial class McpServer
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
 
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
-        var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
+        var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var snippetLines = SearchSnippetFormatter.ClampSnippetLines(args?["snippetLines"]?.GetValue<int>() ?? SearchSnippetFormatter.DefaultSnippetLines);
         if (TryGetValidatedMaxLineWidth(id, args, out var maxLineWidth) is JsonNode maxLineWidthError)
             return maxLineWidthError;
@@ -339,7 +339,7 @@ public partial class McpServer
         if (namesProvided && names.Count == 0)
             return CreateToolErrorResponse(id, "'names' is present but contains no usable entries (all were empty or whitespace).");
         var kind = args?["kind"]?.GetValue<string>()?.ToLowerInvariant();
-        var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
+        var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         if (TryGetValidatedMaxLineWidth(id, args, out var maxLineWidth) is JsonNode maxLineWidthError)
             return maxLineWidthError;
@@ -435,7 +435,7 @@ public partial class McpServer
             return CreateToolErrorResponse(id, "Add a real symbol name after the command; bare verbatim prefixes like `@` are not valid queries.");
 
         var kind = args?["kind"]?.GetValue<string>()?.ToLowerInvariant();
-        var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
+        var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         var includeBody = args?["includeBody"]?.GetValue<bool>() ?? false;
         var pathPatterns = ReadPathList(args, "path");
@@ -493,7 +493,7 @@ public partial class McpServer
             return CreateToolErrorResponse(id, "Add a real symbol name after the command; bare verbatim prefixes like `@` are not valid queries.");
 
         var kind = args?["kind"]?.GetValue<string>()?.ToLowerInvariant();
-        var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
+        var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         if (TryGetValidatedMaxLineWidth(id, args, out var maxLineWidth) is JsonNode maxLineWidthError)
             return maxLineWidthError;
@@ -560,7 +560,7 @@ public partial class McpServer
         var kind = args?["kind"]?.GetValue<string>()?.ToLowerInvariant();
         if (IsNonCallGraphReferenceKind(kind))
             return CreateToolErrorResponse(id, BuildNonCallGraphKindRejectionMessage("callers", kind!));
-        var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
+        var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         var pathPatterns = ReadPathList(args, "path");
         var excludePaths = ReadStringList(args, "excludePaths");
@@ -624,7 +624,7 @@ public partial class McpServer
         var kind = args?["kind"]?.GetValue<string>()?.ToLowerInvariant();
         if (IsNonCallGraphReferenceKind(kind))
             return CreateToolErrorResponse(id, BuildNonCallGraphKindRejectionMessage("callees", kind!));
-        var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
+        var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         var pathPatterns = ReadPathList(args, "path");
         var excludePaths = ReadStringList(args, "excludePaths");
@@ -680,7 +680,7 @@ public partial class McpServer
         var query = args?["query"]?.GetValue<string>();
         if (query != null && query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
-        var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
+        var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         var pathPatterns = ReadPathList(args, "path");
         var excludePaths = ReadStringList(args, "excludePaths");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -164,6 +164,7 @@ public class QueryCommandRunnerTests
     [InlineData("PY3", "python")]
     [InlineData("pyi", "python")]
     [InlineData("pyw", "python")]
+    [InlineData("yml", "yaml")]
     [InlineData("kt", "kotlin")]
     [InlineData("KTS", "kotlin")]
     public void ParseArgs_NormalizesLangAliases(string input, string expected)
@@ -215,6 +216,41 @@ public class QueryCommandRunnerTests
         String marker = ""{queryToken}"";
     }}
 }}");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--lang", input, "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
+        }
+    finally
+    {
+        TestProjectHelper.DeleteDirectory(projectRoot);
+    }
+}
+
+    [Theory]
+    [InlineData("yml")]
+    [InlineData("YML")]
+    public void RunSearch_NormalizesYamlLangAlias(string input)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_yaml_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = "yaml_lang_alias_3d5a19";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "config/workflow.yml",
+                "yaml",
+                $@"name: demo
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ""{queryToken}""");
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
                 [queryToken, "--db", dbPath, "--lang", input, "--count"],


### PR DESCRIPTION
## Summary

- Accept `--lang yml` as an alias for `yaml` in CLI query parsing.
- Apply the same normalization in MCP query handlers so search-oriented tools behave consistently.
- Add regression tests covering CLI parsing and search counts for YML-alias queries.

## Validation

- `dotnet test CodeIndex.sln --filter FullyQualifiedName~QueryCommandRunnerTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Manual smoke check: `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll files --lang yml --limit 5`
- Manual smoke check: `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search --lang yml --limit 3 'release'`

## Changelog

- Added fragment: `changelog.d/unreleased/+yaml-lang-aliases.fixed.md`

## Follow-up candidates

- Surface the `yml` alias in language completion/listing output if we want discoverability to match query acceptance.
- Consider whether other non-canonical file-format aliases should be normalized through the same helper if more formats need the same treatment.