### PR TITLE
Add query metadata to JSON search output

### DIFF
--- a/changelog.d/unreleased/+json-search-query-metadata.added.md
+++ b/changelog.d/unreleased/+json-search-query-metadata.added.md
@@ -1,0 +1,15 @@
+---
+category: added
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/SearchSnippetFormatter.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **JSON search output now includes the original query string** — each compact `search` result row now carries `query`, and zero-result JSON payloads for `search` also include `query` so machine consumers can correlate results with the exact search input.
+
+## 日本語
+
+- **JSON 形式の search 出力に元の検索文字列が含まれるようになりました** — `search` の compact 結果行に `query` を追加し、`search` の 0 件 JSON payload にも `query` を含めることで、機械処理側で結果と検索入力を正確に対応付けやすくしました。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -113,7 +113,7 @@ public static class QueryCommandRunner
                 if (counts.Count == 0)
                 {
                     Console.WriteLine(options.Json
-                        ? BuildJsonZeroResultPayload(reader, jsonOptions, includeFiles: true).ToJsonString(jsonOptions)
+                        ? BuildJsonZeroResultPayload(reader, jsonOptions, includeFiles: true, query: options.Query).ToJsonString(jsonOptions)
                         : "0");
                     return CommandExitCodes.Success;
                 }
@@ -128,7 +128,7 @@ public static class QueryCommandRunner
             if (results.Count == 0)
             {
                 if (options.Json)
-                    Console.WriteLine(BuildJsonZeroResultPayload(reader, jsonOptions, resultsKey: "results").ToJsonString(jsonOptions));
+                    Console.WriteLine(BuildJsonZeroResultPayload(reader, jsonOptions, resultsKey: "results", query: options.Query).ToJsonString(jsonOptions));
                 else if (!options.Json)
                 {
                     Console.Error.WriteLine("No results found.");
@@ -3353,6 +3353,7 @@ public static class QueryCommandRunner
         DbReader reader,
         JsonSerializerOptions jsonOptions,
         string? resultsKey = null,
+        string? query = null,
         ExactZeroHintResult? exactZeroHint = null,
         bool includeFiles = false,
         bool? graphTableAvailable = null,
@@ -3365,6 +3366,8 @@ public static class QueryCommandRunner
             ["count"] = 0,
         };
 
+        if (query != null)
+            payload["query"] = query;
         if (resultsKey != null)
             payload[resultsKey] = new JsonArray();
         if (includeFiles)

--- a/src/CodeIndex/Cli/SearchSnippetFormatter.cs
+++ b/src/CodeIndex/Cli/SearchSnippetFormatter.cs
@@ -34,6 +34,7 @@ public static class SearchSnippetFormatter
         var excerpt = BuildExcerpt(result.Content, query, result.StartLine, maxLines, caseSensitive, maxLineWidth, lang ?? result.Lang);
         return new CompactSearchResult
         {
+            Query = query,
             Path = result.Path,
             Lang = result.Lang,
             ChunkStartLine = result.StartLine,
@@ -311,6 +312,7 @@ public static class SearchSnippetFormatter
 
 public sealed class CompactSearchResult
 {
+    public string Query { get; set; } = string.Empty;
     public string Path { get; set; } = string.Empty;
     public string? Lang { get; set; }
     public int ChunkStartLine { get; set; }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2545,6 +2545,9 @@ public class QueryCommandRunnerTests
             Assert.Equal(string.Empty, indexStderr);
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
+            var rows = ParseJsonLines(stdout).Select(document => document.RootElement).ToList();
+            Assert.Single(rows);
+            Assert.Equal("TARGET", rows[0].GetProperty("query").GetString());
             Assert.Contains(longLine, stdout);
             Assert.DoesNotContain("...(+", stdout);
         }
@@ -9760,6 +9763,7 @@ public class QueryCommandRunnerTests
             Assert.Equal(CommandExitCodes.NotFound, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.Equal(0, json.GetProperty("count").GetInt32());
+            Assert.Equal("MissingTarget", json.GetProperty("query").GetString());
             Assert.Equal(0, json.GetProperty("results").GetArrayLength());
             Assert.Equal(1, json.GetProperty("indexed_file_count").GetInt32());
             Assert.True(json.TryGetProperty("indexed_at", out _));
@@ -9788,6 +9792,7 @@ public class QueryCommandRunnerTests
             Assert.Equal(CommandExitCodes.NotFound, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.Equal(0, json.GetProperty("count").GetInt32());
+            Assert.Equal("MissingTarget", json.GetProperty("query").GetString());
             Assert.Equal(0, json.GetProperty("results").GetArrayLength());
             Assert.Equal(0, json.GetProperty("indexed_file_count").GetInt32());
             Assert.Equal(JsonValueKind.Null, json.GetProperty("indexed_at").ValueKind);
@@ -9821,6 +9826,7 @@ public class QueryCommandRunnerTests
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.Equal(0, json.GetProperty("count").GetInt32());
+            Assert.Equal("MissingTarget", json.GetProperty("query").GetString());
             Assert.Equal(0, json.GetProperty("files").GetInt32());
             Assert.Equal(1, json.GetProperty("indexed_file_count").GetInt32());
             Assert.True(json.TryGetProperty("indexed_at", out _));
@@ -9849,6 +9855,7 @@ public class QueryCommandRunnerTests
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.Equal(0, json.GetProperty("count").GetInt32());
+            Assert.Equal("MissingTarget", json.GetProperty("query").GetString());
             Assert.Equal(0, json.GetProperty("files").GetInt32());
             Assert.Equal(0, json.GetProperty("indexed_file_count").GetInt32());
             Assert.Equal(JsonValueKind.Null, json.GetProperty("indexed_at").ValueKind);


### PR DESCRIPTION
## Summary

- Add the original search query to compact JSON `search` result rows.
- Add the original query to zero-result JSON payloads for `search`, including `--count` output.
- Keep the text output unchanged.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- Targeted test pass for the updated `RunSearch` JSON cases

## Changelog

- Added fragment: `changelog.d/unreleased/+json-search-query-metadata.added.md`

## Review

- Adversarial review against `origin/main..HEAD`: no blocking/actionable issues found.

## Follow-up candidates

- Consider adding the same `query` metadata to non-zero `search --count` JSON payloads for symmetry.
- Consider exposing additional search parameters in JSON rows if machine consumers need more provenance.