### PR TITLE
Index XAML type arguments

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-typearguments.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-typearguments.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **XAML `x:TypeArguments` values are now indexed as searchable class symbols** — continuing the follow-up work from PR #1316, generic XAML declarations now surface each type argument so `symbols` and `definition` can find the referenced types instead of treating the generic markup as an opaque string.
+
+## 日本語
+
+- **XAML の `x:TypeArguments` 値を検索可能な class シンボルとして index するようになりました** — PR #1316 の follow-up として、generic な XAML 宣言で使われる各 type argument を拾うため、`symbols` / `definition` で generic マークアップ全体を不透明な文字列として扱わず、参照先の型を直接見つけられるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -198,6 +198,9 @@ public static class SymbolExtractor
     private static readonly Regex XamlDataTypeRegex = new(
         @"\bx:DataType\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlTypeArgumentsRegex = new(
+        @"\bx:TypeArguments\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex XamlTargetTypeRegex = new(
         @"\bTargetType\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -6543,6 +6546,23 @@ private sealed class RubyMaskState
                 });
             }
 
+            foreach (Match typeArgumentsMatch in XamlTypeArgumentsRegex.Matches(line))
+            {
+                foreach (var value in NormalizeXamlTypeArgumentsValue(typeArgumentsMatch.Groups["value"].Value))
+                {
+                    symbols.Add(new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "class",
+                        Name = value,
+                        Line = i + 1,
+                        StartLine = i + 1,
+                        EndLine = i + 1,
+                        Signature = line.Trim(),
+                    });
+                }
+            }
+
             foreach (Match targetTypeMatch in XamlTargetTypeRegex.Matches(line))
             {
                 var value = NormalizeXamlKeyValue(targetTypeMatch.Groups["value"].Value);
@@ -6768,6 +6788,20 @@ private sealed class RubyMaskState
         return value;
     }
 
+    private static IEnumerable<string> NormalizeXamlTypeArgumentsValue(string value)
+    {
+        value = value.Trim();
+        if (value.Length == 0)
+            yield break;
+
+        foreach (var argument in SplitTopLevelTypeArguments(value))
+        {
+            var normalized = NormalizeXamlMarkupArgument(argument);
+            if (normalized.Length > 0)
+                yield return normalized;
+        }
+    }
+
     private static string NormalizeXamlMarkupArgument(string value)
     {
         value = value.Trim();
@@ -6848,6 +6882,62 @@ private sealed class RubyMaskState
                 continue;
             }
             if (braceDepth == 0 && ch == ',')
+            {
+                var segment = value[start..i].Trim();
+                if (segment.Length > 0)
+                    yield return segment;
+                start = i + 1;
+            }
+        }
+
+        var tail = value[start..].Trim();
+        if (tail.Length > 0)
+            yield return tail;
+    }
+
+    private static IEnumerable<string> SplitTopLevelTypeArguments(string value)
+    {
+        var braceDepth = 0;
+        var parenDepth = 0;
+        var angleDepth = 0;
+        var start = 0;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (ch == '{')
+            {
+                braceDepth++;
+                continue;
+            }
+            if (ch == '}')
+            {
+                if (braceDepth > 0)
+                    braceDepth--;
+                continue;
+            }
+            if (ch == '(')
+            {
+                parenDepth++;
+                continue;
+            }
+            if (ch == ')')
+            {
+                if (parenDepth > 0)
+                    parenDepth--;
+                continue;
+            }
+            if (ch == '<')
+            {
+                angleDepth++;
+                continue;
+            }
+            if (ch == '>')
+            {
+                if (angleDepth > 0)
+                    angleDepth--;
+                continue;
+            }
+            if (braceDepth == 0 && parenDepth == 0 && angleDepth == 0 && ch == ',')
             {
                 var segment = value[start..i].Trim();
                 if (segment.Length > 0)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -479,6 +479,48 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsXamlTypeArguments()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_type_arguments");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "GenericPage.xaml"),
+                """
+                <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                    xmlns:vm="clr-namespace:Sample.ViewModels"
+                                    xmlns:local="clr-namespace:Sample.Controls">
+                    <local:Pair x:TypeArguments="x:String, vm:PersonViewModel" />
+                </ResourceDictionary>
+                """);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json"],
+                _jsonOptions));
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["vm:PersonViewModel", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                _jsonOptions));
+
+            var rows = ParseJsonLines(stdout);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Single(rows);
+            Assert.Equal("vm:PersonViewModel", rows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("class", rows[0].RootElement.GetProperty("kind").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_ExactNameFindsPythonInitModuleAliases()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_python_init_module_aliases");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19692,6 +19692,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesTypeArgumentsAsClassSymbols()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:vm="clr-namespace:Sample.ViewModels"
+                                xmlns:local="clr-namespace:Sample.Controls">
+                <local:Pair x:TypeArguments="x:String, vm:PersonViewModel" />
+                <local:Factory x:TypeArguments="{x:Type vm:CustomButton}" />
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "x:String");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:PersonViewModel");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:CustomButton");
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesCommonEventHandlers()
     {
         var content = """


### PR DESCRIPTION
## Summary
- This PR implements the follow-up candidate from PR #1316 by indexing XAML `x:TypeArguments` values.
- Generic XAML declarations now surface each type argument as a searchable `class` symbol.
- Added unit and CLI coverage for the new extraction path.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesTypeArgumentsAsClassSymbols|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsXamlTypeArguments"`
- `dotnet build CodeIndex.sln -c Release`

## Docs and Changelog
- Added `changelog.d/unreleased/+xml-xaml-typearguments.fixed.md`.
- No `CHANGELOG.md` edits were needed because this is an ordinary implementation change.

## Follow-up candidates
- Broader XAML markup navigation could still benefit from a full parser if more complex generic shapes need to be resolved beyond top-level type arguments.