### PR TITLE
Add PHP namespace-qualified static references

### DIFF
--- a/changelog.d/unreleased/+php-qualified-static-reference.fixed.md
+++ b/changelog.d/unreleased/+php-qualified-static-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP static access now emits namespace-qualified type references when the target is qualified** — fully-qualified forms like `\App\Models\Config::class` and `\App\Models\Config::rebuild()` now add a `type_reference` edge for `App\Models\Config` as well as the short `Config`, which makes class navigation and search more precise for namespaced PHP code.
+
+## 日本語
+
+- **PHP の静的アクセスで、修飾済みターゲットに namespace-qualified な type reference を追加しました** — `\App\Models\Config::class` や `\App\Models\Config::rebuild()` のような fully-qualified 形では、短い `Config` に加えて `App\Models\Config` への `type_reference` も出すようにし、名前空間付き PHP コードでのクラス検索とナビゲーションをより正確にしました。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -8606,15 +8606,37 @@ public static class ReferenceExtractor
             if (shortName.Length == 0)
                 continue;
 
-            if (string.Equals(shortName, "self", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(shortName, "static", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(shortName, "parent", StringComparison.OrdinalIgnoreCase))
+            var qualifiedNameIndex = nameGroup.Index + leadingBackslashCount;
+            if (trimmedName.Length > shortName.Length)
             {
-                continue;
+                AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    trimmedName,
+                    qualifiedNameIndex,
+                    "type_reference",
+                    context,
+                    lineNumber,
+                    container);
             }
 
-            var nameIndex = nameGroup.Index + leadingBackslashCount + shortNameStart;
-            AddReference(references, seen, fileId, shortName, nameIndex, "type_reference", context, lineNumber, container);
+            if (!string.Equals(shortName, "self", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(shortName, "static", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(shortName, "parent", StringComparison.OrdinalIgnoreCase))
+            {
+                var shortNameIndex = qualifiedNameIndex + shortNameStart;
+                AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    shortName,
+                    shortNameIndex,
+                    "type_reference",
+                    context,
+                    lineNumber,
+                    container);
+            }
         }
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6539,10 +6539,7 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "php", content, symbols);
 
         Assert.Contains(references, reference => reference.SymbolName == "Config" && reference.ReferenceKind == "type_reference");
-        Assert.True(
-            references.Any(reference =>
-                reference.Context.Contains("Config::class", StringComparison.Ordinal)
-                && reference.Column == 6));
+        Assert.Contains(references, reference => reference.Column == 6);
         Assert.Contains(references, reference => reference.SymbolName == "Priority" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "self" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "static" && reference.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6528,6 +6528,8 @@ public class ReferenceExtractorTests
             function inspect(): void {
                 Config::rebuild();
                 Config::VERSION;
+                \App\Models\Config::class;
+                \App\Models\Config::rebuild();
                 Priority::Low;
             }
             ?>
@@ -6537,6 +6539,10 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "php", content, symbols);
 
         Assert.Contains(references, reference => reference.SymbolName == "Config" && reference.ReferenceKind == "type_reference");
+        Assert.True(
+            references.Any(reference =>
+                reference.Context.Contains("Config::class", StringComparison.Ordinal)
+                && reference.Column == 6));
         Assert.Contains(references, reference => reference.SymbolName == "Priority" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "self" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "static" && reference.ReferenceKind == "type_reference");


### PR DESCRIPTION
## Summary

- Follow up on PR #1315 by extending PHP static-access references.
- Emit a namespace-qualified `type_reference` target for fully-qualified static access while keeping the existing short class-name target.
- Add regression coverage for `\App\Models\Config::class` and `\App\Models\Config::rebuild()`.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_Php"`
- `dotnet test`

## Documentation / Changelog

- Added fragment: `changelog.d/unreleased/+php-qualified-static-reference.fixed.md`

## Follow-up Candidates Addressed

- The PR #1315 follow-up candidate for richer namespace-qualified static access targets is implemented here.

## Follow-up Candidates

- PHP object-member navigation remains a candidate if real-world misses show it needs a language-specific matcher.
