### PR TITLE
Add query metadata to count JSON output

### DIFF
--- a/changelog.d/unreleased/+json-search-count-query-metadata.added.md
+++ b/changelog.d/unreleased/+json-search-count-query-metadata.added.md
@@ -1,0 +1,15 @@
+---
+category: added
+affected:
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **JSON `search --count` output now includes the original query on non-zero results** — count-based JSON search payloads now carry `query` alongside `count` and `files`, so machine consumers can correlate the summary with the exact search input.
+
+## 日本語
+
+- **JSON 形式の `search --count` 出力が非0件でも元の検索文字列を含むようになりました** — count ベースの JSON search payload に `count` と `files` に加えて `query` も載せることで、要約結果と検索入力を機械処理側で正確に対応付けられるようにしました。

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -22,7 +22,8 @@ internal sealed record QueryCountJsonResult(
 
 internal sealed record QueryCountFilesJsonResult(
     [property: JsonPropertyName("count")] int Count,
-    [property: JsonPropertyName("files")] int Files);
+    [property: JsonPropertyName("files")] int Files,
+    [property: JsonPropertyName("query")] string Query);
 
 internal sealed record QueryFindCountJsonResult(
     [property: JsonPropertyName("count")] int Count,

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -120,7 +120,7 @@ public static class QueryCommandRunner
                 }
 
                 Console.WriteLine(options.Json
-                    ? JsonSerializer.Serialize(new QueryCountFilesJsonResult(counts.Count, counts.FileCount), CliJsonSerializerContext.Default.QueryCountFilesJsonResult)
+                    ? JsonSerializer.Serialize(new QueryCountFilesJsonResult(counts.Count, counts.FileCount, options.Query), CliJsonSerializerContext.Default.QueryCountFilesJsonResult)
                     : $"{counts.Count}");
                 return CommandExitCodes.Success;
             }
@@ -181,7 +181,7 @@ public static class QueryCommandRunner
         if (exact && options.Query is not null && IsBareVerbatimQueryToken(options.Query) && options.CountOnly && string.Equals(options.Lang, "csharp", StringComparison.OrdinalIgnoreCase))
         {
             Console.WriteLine(options.Json
-                ? JsonSerializer.Serialize(new QueryCountFilesJsonResult(0, 0), CliJsonSerializerContext.Default.QueryCountFilesJsonResult)
+                ? JsonSerializer.Serialize(new QueryCountFilesJsonResult(0, 0, options.Query), CliJsonSerializerContext.Default.QueryCountFilesJsonResult)
                 : "0");
             return CommandExitCodes.Success;
         }
@@ -716,8 +716,9 @@ public static class QueryCommandRunner
         {
             if (exactBareVerbatimOnly && options.CountOnly)
             {
+                var countQuery = options.Query ?? string.Join(" ", options.ExtraNames);
                 Console.WriteLine(options.Json
-                    ? JsonSerializer.Serialize(new QueryCountFilesJsonResult(0, 0), CliJsonSerializerContext.Default.QueryCountFilesJsonResult)
+                    ? JsonSerializer.Serialize(new QueryCountFilesJsonResult(0, 0, countQuery), CliJsonSerializerContext.Default.QueryCountFilesJsonResult)
                     : "0");
                 return CommandExitCodes.Success;
             }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -133,14 +133,19 @@ public class QueryCommandRunnerTests
                 """);
 
             var (msbuildExitCode, msbuildStdout, msbuildStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
-                [queryToken, "--db", dbPath, "--lang", "msbuild", "--count"],
+                [queryToken, "--db", dbPath, "--lang", "msbuild", "--json", "--count"],
                 _jsonOptions));
             var (xmlExitCode, xmlStdout, xmlStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
                 [queryToken, "--db", dbPath, "--lang", "xml", "--count"],
                 _jsonOptions));
 
+            using var msbuildDocument = ParseJsonOutput(msbuildStdout);
+            var msbuildJson = msbuildDocument.RootElement;
+
             Assert.Equal(CommandExitCodes.Success, msbuildExitCode);
-            Assert.Equal("1", msbuildStdout.Trim());
+            Assert.Equal(1, msbuildJson.GetProperty("count").GetInt32());
+            Assert.Equal(1, msbuildJson.GetProperty("files").GetInt32());
+            Assert.Equal(queryToken, msbuildJson.GetProperty("query").GetString());
             Assert.Equal(string.Empty, msbuildStderr);
 
             Assert.Equal(CommandExitCodes.Success, xmlExitCode);


### PR DESCRIPTION
## Summary

- Address the follow-up candidate from PR #1319 by adding `query` to non-zero `search --count` JSON payloads.
- Keep zero-result `search --count` JSON payloads consistent with the same query metadata.
- Leave text output unchanged.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`

## Changelog

- Added fragment: `changelog.d/unreleased/+json-search-count-query-metadata.added.md`

## Review

- Adversarial review against `origin/main..HEAD`: no blocking/actionable issues found.

## Follow-up candidates

- None. PR #1319 follow-up candidates were addressed in this branch.