### PR TITLE
Expand nested XAML type arguments

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-typearguments-nested.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-typearguments-nested.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **XAML `x:TypeArguments` now expands nested generic constructor shapes** — continuing the follow-up work from PR #1320, the extractor now recursively peels generic type arguments like `Outer(Inner(A, B), C)` so `symbols` and `definition` can find the referenced types inside more complex XAML markup.
+
+## 日本語
+
+- **XAML の `x:TypeArguments` が入れ子の generic constructor 形状を展開するようになりました** — PR #1320 の follow-up として、`Outer(Inner(A, B), C)` のような generic 型引数を再帰的に展開し、`symbols` / `definition` がより複雑な XAML マークアップ内の参照型も見つけられるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -6805,7 +6805,58 @@ private sealed class RubyMaskState
         {
             var normalized = NormalizeXamlMarkupArgument(argument);
             if (normalized.Length > 0)
-                yield return normalized;
+            {
+                foreach (var expanded in ExpandXamlTypeArgument(normalized))
+                    yield return expanded;
+            }
+        }
+    }
+
+    private static IEnumerable<string> ExpandXamlTypeArgument(string value)
+    {
+        // Peel nested generic constructor shapes recursively so XAML type arguments like
+        // `Outer(Inner(A, B), C)` still surface every referenced type name.
+        value = value.Trim();
+        if (value.Length == 0)
+            yield break;
+
+        var payloadStart = FindTopLevelTypeConstructorStart(value);
+        if (payloadStart < 0)
+        {
+            yield return value;
+            yield break;
+        }
+
+        var payloadEnd = FindMatchingTypeConstructorEnd(value, payloadStart);
+        if (payloadEnd < 0)
+        {
+            yield return value;
+            yield break;
+        }
+
+        var prefix = value[..payloadStart].Trim();
+        if (prefix.Length > 0)
+            yield return prefix;
+
+        var payload = value[(payloadStart + 1)..payloadEnd].Trim();
+        if (payload.Length > 0)
+        {
+            foreach (var nestedArgument in SplitTopLevelTypeArguments(payload))
+            {
+                var nestedNormalized = NormalizeXamlMarkupArgument(nestedArgument);
+                if (nestedNormalized.Length == 0)
+                    continue;
+
+                foreach (var nestedExpanded in ExpandXamlTypeArgument(nestedNormalized))
+                    yield return nestedExpanded;
+            }
+        }
+
+        var suffix = value[(payloadEnd + 1)..].Trim();
+        if (suffix.Length > 0)
+        {
+            foreach (var expanded in ExpandXamlTypeArgument(suffix))
+                yield return expanded;
         }
     }
 
@@ -6841,6 +6892,92 @@ private sealed class RubyMaskState
             }
             if (braceDepth == 0 && (char.IsWhiteSpace(ch) || ch == ','))
                 return i;
+        }
+
+        return -1;
+    }
+
+    private static int FindTopLevelTypeConstructorStart(string value)
+    {
+        var braceDepth = 0;
+        var parenDepth = 0;
+        var angleDepth = 0;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (ch == '{')
+            {
+                braceDepth++;
+                continue;
+            }
+            if (ch == '}')
+            {
+                if (braceDepth > 0)
+                    braceDepth--;
+                continue;
+            }
+            if (ch == '(' || ch == '<')
+            {
+                if (braceDepth == 0 && parenDepth == 0 && angleDepth == 0)
+                    return i;
+
+                if (ch == '(')
+                    parenDepth++;
+                else
+                    angleDepth++;
+                continue;
+            }
+            if (ch == ')')
+            {
+                if (parenDepth > 0)
+                    parenDepth--;
+                continue;
+            }
+            if (ch == '>')
+            {
+                if (angleDepth > 0)
+                    angleDepth--;
+                continue;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindMatchingTypeConstructorEnd(string value, int startIndex)
+    {
+        var open = value[startIndex];
+        var close = open == '(' ? ')' : '>';
+        var depth = 0;
+        var braceDepth = 0;
+        for (var i = startIndex; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (ch == '{')
+            {
+                braceDepth++;
+                continue;
+            }
+            if (ch == '}')
+            {
+                if (braceDepth > 0)
+                    braceDepth--;
+                continue;
+            }
+            if (braceDepth > 0)
+                continue;
+
+            if (ch == open)
+            {
+                depth++;
+                continue;
+            }
+            if (ch == close)
+            {
+                depth--;
+                if (depth == 0)
+                    return i;
+            }
         }
 
         return -1;

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -528,7 +528,7 @@ jobs:
                                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                                     xmlns:vm="clr-namespace:Sample.ViewModels"
                                     xmlns:local="clr-namespace:Sample.Controls">
-                    <local:Pair x:TypeArguments="x:String, vm:PersonViewModel" />
+                    <local:Pair x:TypeArguments="x:String, vm:Outer(vm:InnerModel, x:Int32)" />
                 </ResourceDictionary>
                 """);
 
@@ -537,7 +537,7 @@ jobs:
                 [projectRoot, "--json"],
                 _jsonOptions));
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
-                ["vm:PersonViewModel", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                ["vm:InnerModel", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
                 _jsonOptions));
 
             var rows = ParseJsonLines(stdout);
@@ -547,7 +547,7 @@ jobs:
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.Single(rows);
-            Assert.Equal("vm:PersonViewModel", rows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("vm:InnerModel", rows[0].RootElement.GetProperty("name").GetString());
             Assert.Equal("class", rows[0].RootElement.GetProperty("kind").GetString());
         }
         finally

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19747,6 +19747,7 @@ public class SymbolExtractorTests
                                 xmlns:local="clr-namespace:Sample.Controls">
                 <local:Pair x:TypeArguments="x:String, vm:PersonViewModel" />
                 <local:Factory x:TypeArguments="{x:Type vm:CustomButton}" />
+                <local:Nested x:TypeArguments="vm:Outer(x:String, vm:InnerModel)" />
             </ResourceDictionary>
             """;
 
@@ -19755,6 +19756,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "x:String");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:PersonViewModel");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:CustomButton");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:Outer");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:InnerModel");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- This PR implements the follow-up candidate from PR #1320 by expanding nested XAML `x:TypeArguments` shapes recursively.
- The extractor now peels generic constructor forms like `Outer(Inner(A, B), C)` so referenced inner types are indexed as searchable `class` symbols.
- Added unit and CLI coverage for both the simple and nested forms.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesTypeArgumentsAsClassSymbols|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsXamlTypeArguments"`
- `dotnet build CodeIndex.sln -c Release`

## Docs and Changelog
- Added `changelog.d/unreleased/+xml-xaml-typearguments-nested.fixed.md`.
- No `CHANGELOG.md` edits were needed because this is an ordinary implementation change.

## Follow-up candidates
- A full XAML parser could still help if the project needs to resolve additional markup shapes beyond nested generic constructor forms.