### PR TITLE
Surface YML in language discovery

### DIFF
--- a/changelog.d/unreleased/+yaml-lang-discoverability.fixed.md
+++ b/changelog.d/unreleased/+yaml-lang-discoverability.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **YML now appears in language discovery output** — `cdidx languages`, MCP `languages`, and shell completion now surface `yml` alongside `yaml`, so discoverability matches the query alias that `--lang yml` already accepts.
+
+## 日本語
+
+- **YML が言語探索結果に表示されるようになりました** — `cdidx languages`、MCP の `languages`、および shell completion が `yaml` と並んで `yml` を出すため、`--lang yml` で受け付ける別名と discoverability が一致します。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -582,6 +582,7 @@ public static class ConsoleUi
         string.Join(" ", FileIndexer.GetLanguageExtensions().Values
             .Append("bat")
             .Append("cmd")
+            .Concat(QueryCommandRunner.GetCompletionLanguageAliases())
             .Distinct()
             .OrderBy(l => l));
 

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -36,6 +36,7 @@ internal sealed record QueryPathErrorJsonResult(
 internal sealed record LanguageEntryJsonResult(
     [property: JsonPropertyName("lang")] string Lang,
     [property: JsonPropertyName("extensions")] List<string> Extensions,
+    [property: JsonPropertyName("aliases")] List<string> Aliases,
     [property: JsonPropertyName("symbol_extraction")] bool SymbolExtraction,
     [property: JsonPropertyName("graph_queries")] bool GraphQueries);
 

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -36,6 +36,10 @@ public static class QueryCommandRunner
         ["kts"] = "kotlin",
         ["tsql"] = "sql",
     };
+    private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
+    {
+        ["yaml"] = ["yml"],
+    };
     private static readonly HashSet<string> ValueTakingOptions =
     [
         "--db",
@@ -2570,13 +2574,13 @@ public static class QueryCommandRunner
 
         // Build a consolidated view: language -> (extensions, hasSymbols, hasGraph)
         // 統合ビュー: 言語 -> (拡張子, シンボル対応, グラフ対応)
-        var allLangs = new Dictionary<string, (List<string> Extensions, bool Symbols, bool Graph)>(StringComparer.Ordinal);
+        var allLangs = new Dictionary<string, (List<string> Extensions, List<string> Aliases, bool Symbols, bool Graph)>(StringComparer.Ordinal);
 
         foreach (var (ext, lang) in langExtensions)
         {
             if (!allLangs.TryGetValue(lang, out var info))
             {
-                info = (new List<string>(), symbolLangs.Contains(lang), graphLangs.Contains(lang));
+                info = (new List<string>(), GetLanguageAliases(lang).ToList(), symbolLangs.Contains(lang), graphLangs.Contains(lang));
                 allLangs[lang] = info;
             }
             info.Extensions.Add(ext);
@@ -2590,6 +2594,7 @@ public static class QueryCommandRunner
             var entries = sorted.Select(kv => new LanguageEntryJsonResult(
                 kv.Key,
                 kv.Value.Extensions.OrderBy(e => e).ToList(),
+                kv.Value.Aliases.OrderBy(a => a).ToList(),
                 kv.Value.Symbols,
                 kv.Value.Graph)).ToList();
             Console.WriteLine(JsonSerializer.Serialize(new LanguagesJsonResult(entries), CliJsonSerializerContext.Default.LanguagesJsonResult));
@@ -2601,21 +2606,26 @@ public static class QueryCommandRunner
             // 拡張子が短い場合は固定幅テーブル、長い場合は継続行に退避させることで、
             // Symbols / Graph 列が拡張子文字列に埋もれないようにする。
             const int ExtensionColumnWidth = 36;
-            Console.WriteLine($"{"Language",-14} {"Extensions",-36} {"Symbols",-9} {"Graph",-7}");
-            Console.WriteLine(new string('-', 66));
+            const int AliasColumnWidth = 12;
+            Console.WriteLine($"{"Language",-14} {"Extensions",-36} {"Aliases",-12} {"Symbols",-9} {"Graph",-7}");
+            Console.WriteLine(new string('-', 79));
             foreach (var (lang, info) in sorted)
             {
                 var exts = string.Join(" ", info.Extensions.OrderBy(e => e));
+                var aliases = string.Join(" ", info.Aliases.OrderBy(a => a));
+                var aliasCell = string.IsNullOrWhiteSpace(aliases) ? "-" : aliases;
                 var sym = info.Symbols ? "yes" : "-";
                 var graph = info.Graph ? "yes" : "-";
-                if (exts.Length <= ExtensionColumnWidth)
+                if (exts.Length <= ExtensionColumnWidth && aliases.Length <= AliasColumnWidth)
                 {
-                    Console.WriteLine($"{lang,-14} {exts,-36} {sym,-9} {graph,-7}");
+                    Console.WriteLine($"{lang,-14} {exts,-36} {aliasCell,-12} {sym,-9} {graph,-7}");
                 }
                 else
                 {
-                    Console.WriteLine($"{lang,-14} {"",-36} {sym,-9} {graph,-7}");
+                    Console.WriteLine($"{lang,-14} {"",-36} {"",-12} {sym,-9} {graph,-7}");
                     Console.WriteLine($"  Extensions: {exts}");
+                    if (!string.IsNullOrWhiteSpace(aliases))
+                        Console.WriteLine($"  Aliases: {aliases}");
                 }
             }
             Console.Error.WriteLine($"\n({sorted.Count} languages)");
@@ -3005,6 +3015,12 @@ public static class QueryCommandRunner
         var normalized = langValue.ToLowerInvariant();
         return LangFilterAliases.TryGetValue(normalized, out var canonical) ? canonical : normalized;
     }
+
+    internal static IReadOnlyList<string> GetLanguageAliases(string lang)
+        => LanguageDisplayAliases.TryGetValue(lang, out var aliases) ? aliases : [];
+
+    internal static IReadOnlyCollection<string> GetCompletionLanguageAliases()
+        => LanguageDisplayAliases.Values.SelectMany(aliases => aliases).ToArray();
 
     private static bool TryResolveSearchExactMode(QueryCommandOptions options, out bool exact, out string? error)
     {

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1491,12 +1491,12 @@ public partial class McpServer
         var graphLangs = ReferenceExtractor.GetSupportedLanguages();
 
         // Build consolidated language info / 統合言語情報を構築
-        var allLangs = new Dictionary<string, (List<string> Extensions, bool Symbols, bool Graph)>(StringComparer.Ordinal);
+        var allLangs = new Dictionary<string, (List<string> Extensions, List<string> Aliases, bool Symbols, bool Graph)>(StringComparer.Ordinal);
         foreach (var (ext, lang) in langExtensions)
         {
             if (!allLangs.TryGetValue(lang, out var info))
             {
-                info = (new List<string>(), symbolLangs.Contains(lang), graphLangs.Contains(lang));
+                info = (new List<string>(), QueryCommandRunner.GetLanguageAliases(lang).ToList(), symbolLangs.Contains(lang), graphLangs.Contains(lang));
                 allLangs[lang] = info;
             }
             info.Extensions.Add(ext);
@@ -1514,6 +1514,7 @@ public partial class McpServer
             {
                 ["lang"] = lang,
                 ["extensions"] = extArray,
+                ["aliases"] = new JsonArray(info.Aliases.OrderBy(alias => alias).Select(alias => JsonValue.Create(alias)).ToArray()),
                 ["symbol_extraction"] = info.Symbols,
                 ["graph_queries"] = info.Graph,
             });

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -292,7 +292,7 @@ public class ConsoleUiTests
     }
 
     [Fact]
-    public void GetCompletionLangs_IncludesWindowsBatchAliases()
+    public void GetCompletionLangs_IncludesWindowsBatchAndYamlAliases()
     {
         var method = typeof(ConsoleUi).GetMethod("GetCompletionLangs", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
 
@@ -304,6 +304,7 @@ public class ConsoleUiTests
         Assert.Contains("bat", tokens);
         Assert.Contains("batch", tokens);
         Assert.Contains("cmd", tokens);
+        Assert.Contains("yml", tokens);
     }
 
     [Theory]

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -3635,6 +3635,9 @@ public class McpServerTests : IDisposable
         Assert.False(markdown["symbol_extraction"]!.GetValue<bool>());
         Assert.False(markdown["graph_queries"]!.GetValue<bool>());
 
+        var yaml = languages.First(l => l!["lang"]!.GetValue<string>() == "yaml")!;
+        Assert.Contains("yml", yaml["aliases"]!.AsArray().Select(e => e!.GetValue<string>()));
+
         // Pin #215: HTML must report symbol_extraction=true and list all four
         // extensions so AI tools discover HTML support via the MCP languages tool.
         // #215 を pin: HTML は symbol_extraction=true で、.html / .htm / .xhtml / .shtml

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -1331,6 +1331,10 @@ jobs:
                 $"{searchOnly} must advertise graph_queries=false");
         }
 
+        var yamlAliases = languages["yaml"].GetProperty("aliases").EnumerateArray()
+            .Select(alias => alias.GetString()).ToList();
+        Assert.Contains("yml", yamlAliases);
+
         Assert.True(languages.ContainsKey("perl"), "expected 'perl' to be listed");
         Assert.True(languages["perl"].GetProperty("symbol_extraction").GetBoolean(),
             "perl must advertise symbol_extraction=true");
@@ -1398,7 +1402,7 @@ jobs:
         // Sanity: short rows still fit the fixed-width layout on a single line.
         // 短い行は従来通り 1 行の固定幅レイアウトに収まる。
         var csharpLine = lines.Single(line => line.StartsWith("csharp ", StringComparison.Ordinal));
-        Assert.Matches(@"^csharp\s+\.cs\s+\.cshtml\s+\.razor\s+yes\s+yes\s*$", csharpLine);
+        Assert.Matches(@"^csharp\s+\.cs\s+\.cshtml\s+\.razor\s+-\s+yes\s+yes\s*$", csharpLine);
 
         // Dockerfile / Makefile / Python / Ruby / MSBuild rows spill extensions to a continuation line.
         // Dockerfile / Makefile / Python / Ruby / MSBuild 行は拡張子を継続行に退避する。
@@ -1418,6 +1422,10 @@ jobs:
             var continuation = lines[headerIndex + 1];
             Assert.StartsWith("  Extensions: ", continuation);
         }
+
+        var yamlIndex = Array.FindIndex(lines, line => line.StartsWith("yaml ", StringComparison.Ordinal));
+        Assert.True(yamlIndex >= 0, "expected row for yaml");
+        Assert.Contains("yml", lines[yamlIndex]);
 
         // Spot-check: the continuation line for dockerfile contains both the bare filename and the
         // `<Prefix><suffix>` pseudo-entry added for Issue #189 follow-up.


### PR DESCRIPTION
## Summary

- Addressed the follow-up candidates from PR #1318 by surfacing `yml` in language discovery output.
- Added `aliases` to `cdidx languages` JSON and human-readable output so `yaml` now advertises `yml` directly.
- Updated MCP `languages` responses and shell completion so discoverability matches the `--lang yml` alias.

## Validation

- `dotnet test CodeIndex.sln --filter "FullyQualifiedName~QueryCommandRunnerTests|FullyQualifiedName~ConsoleUiTests|FullyQualifiedName~McpServerTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Manual smoke check: `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll languages --json`

## Changelog

- Added fragment: `changelog.d/unreleased/+yaml-lang-discoverability.fixed.md`

## Follow-up candidates

- None from PR #1318 remain for this path; the YML alias is now shown in discovery, completion, and MCP output.