### PR TITLE
Handle Perl imports and POD sections

### DIFF
--- a/changelog.d/unreleased/+perl-import-pod.fixed.md
+++ b/changelog.d/unreleased/+perl-import-pod.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/StructuralLineMasker.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Perl imports and POD sections are now handled more accurately** - `use` and `require` statements now index module dependencies as `import` symbols, while POD blocks are masked so documentation text in `*.pod` files does not leak fake packages or calls into search results.
+
+## 日本語
+
+- **Perl の import と POD セクションをより正確に扱うようになりました** - `use` / `require` 文は module dependency を `import` symbol として index し、POD ブロックはマスクすることで `*.pod` の文書テキストが偽の package / call として検索結果に漏れなくなります。

--- a/src/CodeIndex/Indexer/StructuralLineMasker.cs
+++ b/src/CodeIndex/Indexer/StructuralLineMasker.cs
@@ -103,9 +103,47 @@ internal static class StructuralLineMasker
             case "scala":
                 MaskScalaTripleStringContents(maskedLines);
                 break;
+            case "perl":
+                MaskPerlPodSections(maskedLines);
+                break;
         }
 
         return maskedLines;
+    }
+
+    private static void MaskPerlPodSections(string[] lines)
+    {
+        var inPod = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var trimmed = line.TrimStart();
+            if (trimmed.Length == 0)
+            {
+                if (inPod)
+                    lines[i] = new string(' ', line.Length);
+                continue;
+            }
+
+            if (IsPerlPodDirectiveLine(trimmed))
+            {
+                lines[i] = new string(' ', line.Length);
+                inPod = !string.Equals(trimmed, "=cut", StringComparison.Ordinal);
+                continue;
+            }
+
+            if (inPod)
+                lines[i] = new string(' ', line.Length);
+        }
+    }
+
+    private static bool IsPerlPodDirectiveLine(string trimmedLine)
+    {
+        return trimmedLine.StartsWith("=", StringComparison.Ordinal)
+            && trimmedLine.Length > 1
+            && (trimmedLine[1] == 'c' && trimmedLine.Length >= 4 && string.Equals(trimmedLine[..4], "=cut", StringComparison.Ordinal)
+                || char.IsLetter(trimmedLine[1]));
     }
 
     private static void MaskCSharpRawStringContents(string[] lines)

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1240,8 +1240,8 @@ public static class SymbolExtractor
             // Perl package declarations / Perl の package 宣言
             new("namespace", new Regex(@"^\s*package\s+(?<name>[\w:]+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             // Perl module imports / Perl の module import
-            new("import", new Regex(@"^\s*use\s+(?<name>[\w:]+)", RegexOptions.Compiled), BodyStyle.None),
-            new("import", new Regex(@"^\s*require\s+(?<name>[\w:]+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import", new Regex(@"^\s*use\s+(?<name>[\p{L}_][\w:]*)", RegexOptions.Compiled), BodyStyle.None),
+            new("import", new Regex(@"^\s*require\s+(?<name>[\p{L}_][\w:]*)", RegexOptions.Compiled), BodyStyle.None),
             // Perl subroutines / Perl の subroutine
             new("function", new Regex(@"^\s*sub\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
         ],

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1239,6 +1239,9 @@ public static class SymbolExtractor
         [
             // Perl package declarations / Perl の package 宣言
             new("namespace", new Regex(@"^\s*package\s+(?<name>[\w:]+)\s*;", RegexOptions.Compiled), BodyStyle.None),
+            // Perl module imports / Perl の module import
+            new("import", new Regex(@"^\s*use\s+(?<name>[\w:]+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import", new Regex(@"^\s*require\s+(?<name>[\w:]+)", RegexOptions.Compiled), BodyStyle.None),
             // Perl subroutines / Perl の subroutine
             new("function", new Regex(@"^\s*sub\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
         ],

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -199,6 +199,10 @@ public class ReferenceExtractorTests
     public void Extract_Perl_DetectsCallsAndIgnoresHashComments()
     {
         const string content = """
+            =pod
+            setup();
+            =cut
+
             package Example::Widget;
 
             sub setup {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12588,6 +12588,37 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Perl_DetectsImportsAndIgnoresPod()
+    {
+        var content = """
+            =pod
+            package Fake::Doc;
+            use Fake::InPod;
+            =cut
+
+            use strict;
+            use Foo::Bar;
+            require Baz::Qux;
+
+            package Example::Widget;
+
+            sub build {
+                return 1;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "perl", content);
+
+        Assert.DoesNotContain(symbols, s => s.Name == "Fake::Doc");
+        Assert.DoesNotContain(symbols, s => s.Name == "Fake::InPod");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "strict");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Foo::Bar");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Baz::Qux");
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "Example::Widget");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build");
+    }
+
+    [Fact]
     public void Extract_Ruby_IgnoresEndInsideStringsAndComments()
     {
         var content = "class UserService\n  def find_user(id)\n    puts \"the word end should not close this block\"\n    # end should not close this block either\n    id\n  end\nend";


### PR DESCRIPTION
## Summary

This PR addresses the follow-up candidates from PR #1314.

Perl search now:

- indexes `use` and `require` statements as `import` symbols;
- masks POD sections so documentation text in `*.pod` files does not leak fake packages or calls into search results.

## Validation

- `dotnet build`
- `dotnet test --filter "FullyQualifiedName~Perl"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added bilingual fragment: `changelog.d/unreleased/+perl-import-pod.fixed.md`

## Follow-up Candidates

- None at this time.
