### PR TITLE
Add PHP object-member navigation references

### DIFF
--- a/changelog.d/unreleased/+php-object-member-navigation.fixed.md
+++ b/changelog.d/unreleased/+php-object-member-navigation.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP object-member navigation now emits searchable references** — `->member` and `?->member` accesses are now indexed as `reference` edges, while method calls continue to flow through the existing PHP call matcher. This makes property and chained member lookups searchable without adding duplicate call noise.
+
+## 日本語
+
+- **PHP の object-member navigation が検索可能な reference として索引されるようになりました** — `->member` と `?->member` のアクセスを `reference` edge として index し、method call は従来の PHP call matcher にそのまま流すようにしました。これにより、property や連鎖した member lookup を重複した call ノイズなしで検索できます。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -310,6 +310,9 @@ public static class ReferenceExtractor
     private static readonly Regex PhpStaticAccessRegex = new(
         @"(?<![\w$\\])(?<name>(?:\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))::(?<member>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PhpObjectMemberAccessRegex = new(
+        @"(?:\?->|->)\s*(?<name>[A-Za-z_]\w*)(?!\s*\()",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CssCustomPropertyReferenceRegex = new(@"\bvar\(\s*--(?<name>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CssAnimationNameReferenceRegex = new(@"\banimation-name\s*:\s*(?<name>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CssAnimationShorthandValueRegex = new(@"\banimation\s*:\s*(?<value>[^;{}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -2210,6 +2213,15 @@ public static class ReferenceExtractor
             if (language == "php")
             {
                 EmitPhpStaticAccessReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
+                EmitPhpObjectMemberAccessReferences(
                     preparedLine,
                     references,
                     seen,
@@ -8637,6 +8649,31 @@ public static class ReferenceExtractor
                     lineNumber,
                     container);
             }
+        }
+    }
+
+    private static void EmitPhpObjectMemberAccessReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in PhpObjectMemberAccessRegex.Matches(preparedLine))
+        {
+            var nameGroup = match.Groups["name"];
+            AddReference(
+                references,
+                seen,
+                fileId,
+                nameGroup.Value,
+                nameGroup.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
         }
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6546,6 +6546,38 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpObjectMemberAccess_EmitsReferencesForProperties()
+    {
+        const string content = """
+            <?php
+            class User {
+                public string $name;
+
+                public function greet(): string {
+                    return "hi";
+                }
+            }
+
+            function inspect(User $user): void {
+                $user->name;
+                $user?->profile->display_name;
+                $user->greet();
+                $user?->greet();
+            }
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "name" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "profile" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "display_name" && reference.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "greet" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "greet" && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_PhpLanguageConstructCalls_AreIgnored()
     {
         const string content = """


### PR DESCRIPTION
Addresses the PHP object-member navigation follow-up candidate called out in PR #1322.

This change adds PHP `->member` and `?->member` extraction as searchable `reference` edges while leaving existing PHP method calls on the current call matcher.

Validation:
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_PhpObjectMemberAccess_EmitsReferencesForProperties|FullyQualifiedName~Extract_PhpStaticAccess"`
- `dotnet test`

Changelog fragment:
- `changelog.d/unreleased/+php-object-member-navigation.fixed.md`

Follow-up candidates:
- PHP dynamic member access like `$obj->{$name}` is still out of scope. If real-world search misses show up there, that is the next candidate.