### PR TITLE
Index wrapped XAML type arguments

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-typearguments-nested.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-typearguments-nested.fixed.md
@@ -8,8 +8,8 @@ affected:
 
 ## English
 
-- **XAML `x:TypeArguments` now expands nested generic constructor shapes** — continuing the follow-up work from PR #1320, the extractor now recursively peels generic type arguments like `Outer(Inner(A, B), C)` so `symbols` and `definition` can find the referenced types inside more complex XAML markup.
+- **XAML `x:TypeArguments` now expands nested and wrapped generic constructor shapes** — continuing the follow-up work from PR #1320, the extractor now recursively peels generic type arguments like `Outer(Inner(A, B), C)` even when they are wrapped across lines, so `symbols` and `definition` can find the referenced types inside more complex XAML markup.
 
 ## 日本語
 
-- **XAML の `x:TypeArguments` が入れ子の generic constructor 形状を展開するようになりました** — PR #1320 の follow-up として、`Outer(Inner(A, B), C)` のような generic 型引数を再帰的に展開し、`symbols` / `definition` がより複雑な XAML マークアップ内の参照型も見つけられるようになりました。
+- **XAML の `x:TypeArguments` が入れ子かつ折り返し付きの generic constructor 形状を展開するようになりました** — PR #1320 の follow-up として、`Outer(Inner(A, B), C)` のような generic 型引数を改行をまたいでいても再帰的に展開し、`symbols` / `definition` がより複雑な XAML マークアップ内の参照型も見つけられるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -6803,6 +6803,8 @@ private sealed class RubyMaskState
             }
         }
 
+        AddWrappedXamlTypeArgumentSymbols(fileId, rawText, lines, lineStarts, symbols);
+
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
         {
             var value = NormalizeXamlBindingValue(bindingMatch.Groups["kind"].Value, bindingMatch.Groups["content"].Value);
@@ -6824,6 +6826,82 @@ private sealed class RubyMaskState
         }
 
         return symbols;
+    }
+
+    private static void AddWrappedXamlTypeArgumentSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var attributeIndex = rawText.IndexOf("x:TypeArguments", cursor, StringComparison.Ordinal);
+            if (attributeIndex < 0)
+                break;
+
+            var equalsIndex = rawText.IndexOf('=', attributeIndex);
+            if (equalsIndex < 0)
+            {
+                cursor = attributeIndex + 1;
+                continue;
+            }
+
+            var quoteIndex = equalsIndex + 1;
+            while (quoteIndex < rawText.Length && char.IsWhiteSpace(rawText[quoteIndex]))
+                quoteIndex++;
+
+            if (quoteIndex >= rawText.Length)
+                break;
+
+            var quote = rawText[quoteIndex];
+            if (quote is not ('"' or '\''))
+            {
+                cursor = quoteIndex + 1;
+                continue;
+            }
+
+            var valueStart = quoteIndex + 1;
+            var valueEnd = valueStart;
+            while (valueEnd < rawText.Length && rawText[valueEnd] != quote)
+                valueEnd++;
+
+            if (valueEnd >= rawText.Length)
+            {
+                cursor = valueStart;
+                continue;
+            }
+
+            if (FindHtmlLineNumber(lineStarts, valueEnd) == FindHtmlLineNumber(lineStarts, attributeIndex))
+            {
+                cursor = valueEnd + 1;
+                continue;
+            }
+
+            var value = rawText[valueStart..valueEnd];
+            if (value.Length > 0)
+            {
+                var startLine = FindHtmlLineNumber(lineStarts, attributeIndex);
+                var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+                foreach (var normalized in NormalizeXamlTypeArgumentsValue(value))
+                {
+                    symbols.Add(new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "class",
+                        Name = normalized,
+                        Line = startLine,
+                        StartLine = startLine,
+                        EndLine = startLine,
+                        Signature = lines[signatureIndex].Trim(),
+                    });
+                }
+            }
+
+            cursor = valueEnd + 1;
+        }
     }
 
     private static string NormalizeXamlKeyValue(string value)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -520,9 +520,9 @@ jobs:
     }
 
     [Fact]
-    public void RunSymbols_ExactNameFindsXamlTypeArguments()
+    public void RunSymbols_ExactNameFindsWrappedXamlTypeArguments()
     {
-        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_type_arguments");
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_wrapped_type_arguments");
         try
         {
             Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
@@ -533,7 +533,11 @@ jobs:
                                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                                     xmlns:vm="clr-namespace:Sample.ViewModels"
                                     xmlns:local="clr-namespace:Sample.Controls">
-                    <local:Pair x:TypeArguments="x:String, vm:Outer(vm:InnerModel, x:Int32)" />
+                    <local:Pair
+                        x:TypeArguments="x:String,
+                                         vm:Outer(
+                                             vm:InnerModel,
+                                             x:Int32)" />
                 </ResourceDictionary>
                 """);
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19784,6 +19784,30 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesWrappedTypeArgumentsAcrossLines()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:vm="clr-namespace:Sample.ViewModels"
+                                xmlns:local="clr-namespace:Sample.Controls">
+                <local:Pair
+                    x:TypeArguments="x:String,
+                                     vm:Outer(
+                                         vm:InnerModel,
+                                         x:Int32)" />
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "x:String");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:Outer");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:InnerModel");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "x:Int32");
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesCommonEventHandlers()
     {
         var content = """


### PR DESCRIPTION
## Summary
- This PR implements the follow-up candidate from PR #1325 by making XAML `x:TypeArguments` extraction work across wrapped multiline attribute values.
- The extractor now captures type arguments even when the attribute value is split across lines, while preserving the existing nested type expansion behavior.
- Added unit and CLI coverage for the wrapped multiline shape.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesWrappedTypeArgumentsAcrossLines|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsWrappedXamlTypeArguments"`
- `dotnet build CodeIndex.sln -c Release`

## Docs and Changelog
- Added `changelog.d/unreleased/+xml-xaml-typearguments-nested.fixed.md`.
- No `CHANGELOG.md` edits were needed because this is an ordinary implementation change.

## Follow-up candidates
- A full XAML parser could still help if the project needs to resolve additional markup shapes beyond wrapped multiline `x:TypeArguments` values.