### PR TITLE
Index wrapped XAML type-bearing attributes

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-wrapped-type-bearing.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-wrapped-type-bearing.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Wrapped XAML type-bearing attributes are now indexed as searchable class symbols** — continuing the follow-up work from PR #1329, the extractor now picks up `x:Class`, `x:DataType`, and `TargetType` values even when the attribute value is wrapped onto later lines, so `symbols` and `definition` can find the referenced types inside multiline XAML markup.
+
+## 日本語
+
+- **折り返しされた XAML の型関連属性を検索可能な class シンボルとして index するようになりました** — PR #1329 の follow-up として、`x:Class` / `x:DataType` / `TargetType` の値が後続行に折り返されていても拾えるようにし、`symbols` / `definition` が multiline XAML マークアップ内の参照型を見つけられるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -6807,6 +6807,7 @@ private sealed class RubyMaskState
         }
 
         AddWrappedXamlTypeArgumentSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddWrappedXamlTypeBearingAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
         {
@@ -6904,6 +6905,85 @@ private sealed class RubyMaskState
             }
 
             cursor = valueEnd + 1;
+        }
+    }
+
+    private static void AddWrappedXamlTypeBearingAttributeSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        // Handle XAML values that are split away from `=` onto later lines.
+        // `x:Class`, `x:DataType`, and `TargetType` are intentionally kept on the
+        // same normalization path as the line-based extractor so search results stay consistent.
+        foreach (var attributeName in new[] { "x:Class", "x:DataType", "TargetType" })
+        {
+            var cursor = 0;
+            while (cursor < rawText.Length)
+            {
+                var attributeIndex = rawText.IndexOf(attributeName, cursor, StringComparison.Ordinal);
+                if (attributeIndex < 0)
+                    break;
+
+                var equalsIndex = rawText.IndexOf('=', attributeIndex);
+                if (equalsIndex < 0)
+                {
+                    cursor = attributeIndex + 1;
+                    continue;
+                }
+
+                var quoteIndex = equalsIndex + 1;
+                while (quoteIndex < rawText.Length && char.IsWhiteSpace(rawText[quoteIndex]))
+                    quoteIndex++;
+
+                if (quoteIndex >= rawText.Length)
+                    break;
+
+                var quote = rawText[quoteIndex];
+                if (quote is not ('"' or '\''))
+                {
+                    cursor = quoteIndex + 1;
+                    continue;
+                }
+
+                var valueStart = quoteIndex + 1;
+                var valueEnd = valueStart;
+                while (valueEnd < rawText.Length && rawText[valueEnd] != quote)
+                    valueEnd++;
+
+                if (valueEnd >= rawText.Length)
+                {
+                    cursor = valueStart;
+                    continue;
+                }
+
+                if (FindHtmlLineNumber(lineStarts, valueEnd) == FindHtmlLineNumber(lineStarts, attributeIndex))
+                {
+                    cursor = valueEnd + 1;
+                    continue;
+                }
+
+                var value = NormalizeXamlKeyValue(rawText[valueStart..valueEnd]);
+                if (value.Length > 0)
+                {
+                    var startLine = FindHtmlLineNumber(lineStarts, attributeIndex);
+                    var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+                    symbols.Add(new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "class",
+                        Name = value,
+                        Line = startLine,
+                        StartLine = startLine,
+                        EndLine = startLine,
+                        Signature = lines[signatureIndex].Trim(),
+                    });
+                }
+
+                cursor = valueEnd + 1;
+            }
         }
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -520,25 +520,29 @@ jobs:
     }
 
     [Fact]
-    public void RunSymbols_ExactNameFindsWrappedXamlTypeArguments()
+    public void RunSymbols_ExactNameFindsWrappedXamlTypeBearingAttributes()
     {
-        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_wrapped_type_arguments");
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_wrapped_type_bearing");
         try
         {
             Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
             File.WriteAllText(
                 Path.Combine(projectRoot, "src", "GenericPage.xaml"),
                 """
-                <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                    xmlns:vm="clr-namespace:Sample.ViewModels"
-                                    xmlns:local="clr-namespace:Sample.Controls">
-                    <local:Pair
-                        x:TypeArguments="x:String,
-                                         vm:Outer(
-                                             vm:InnerModel,
-                                             x:Int32)" />
-                </ResourceDictionary>
+                <Window
+                    x:Class=
+                        "Sample.MainWindow"
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:vm="clr-namespace:Sample.ViewModels">
+                    <DataTemplate
+                        x:DataType=
+                            "vm:PersonViewModel">
+                        <Style
+                            TargetType=
+                                "{x:Type vm:CustomButton}" />
+                    </DataTemplate>
+                </Window>
                 """);
 
             var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
@@ -546,7 +550,7 @@ jobs:
                 [projectRoot, "--json"],
                 _jsonOptions));
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
-                ["vm:InnerModel", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                ["vm:PersonViewModel", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
                 _jsonOptions));
 
             var rows = ParseJsonLines(stdout);
@@ -556,7 +560,7 @@ jobs:
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.Single(rows);
-            Assert.Equal("vm:InnerModel", rows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("vm:PersonViewModel", rows[0].RootElement.GetProperty("name").GetString());
             Assert.Equal("class", rows[0].RootElement.GetProperty("kind").GetString());
         }
         finally

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19839,6 +19839,33 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesWrappedTypeBearingAttributesAcrossLines()
+    {
+        var content = """
+            <Window
+                x:Class=
+                    "Sample.MainWindow"
+                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                xmlns:vm="clr-namespace:Sample.ViewModels">
+                <DataTemplate
+                    x:DataType=
+                        "vm:PersonViewModel">
+                    <Style
+                        TargetType=
+                            "{x:Type vm:CustomButton}" />
+                </DataTemplate>
+            </Window>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Sample.MainWindow");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:PersonViewModel");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:CustomButton");
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesCommonEventHandlers()
     {
         var content = """


### PR DESCRIPTION
## Summary

This PR implements the follow-up candidate from PR #1329 by indexing wrapped multiline XAML type-bearing attributes as searchable `class` symbols.

- `x:Class`
- `x:DataType`
- `TargetType`

These values are now discoverable even when the attribute value is wrapped onto later lines in XAML markup.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesWrappedTypeBearingAttributesAcrossLines|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsWrappedXamlTypeBearingAttributes"`
- `dotnet build CodeIndex.sln -c Release`
- Refreshed the local CodeIndex index for the changed files with `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/QueryCommandRunnerTests.cs`

## Changelog

- Added [`changelog.d/unreleased/+xml-xaml-wrapped-type-bearing.fixed.md`](/Users/widthdom/Projects/mine/cdidx/CodeIndex2nd/changelog.d/unreleased/+xml-xaml-wrapped-type-bearing.fixed.md)
- This is a normal changelog fragment; no `issues: []` front matter was added.

## Follow-up candidates

- A fuller XAML parser could still help if the project later needs to resolve more markup shapes beyond wrapped multiline type-bearing attributes.