### PR TITLE
Index XAML type object elements

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-type-object-elements.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-type-object-elements.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **XAML `x:Type` object-element syntax is now indexed as searchable class symbols** — following up on PR #1331, the extractor now recognizes `<x:Type ... TypeName="..."/>` and related `x:TypeExtension` forms, so object-element markup can surface referenced types even when the type name is wrapped across lines.
+
+## 日本語
+
+- **XAML の `x:Type` object-element 構文を検索可能な class シンボルとして index するようになりました** — PR #1331 の follow-up として、`<x:Type ... TypeName="..."/>` および関連する `x:TypeExtension` 形を認識し、TypeName が複数行に折り返されていても object-element マークアップ内の参照型を拾えるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -204,6 +204,9 @@ public static class SymbolExtractor
     private static readonly Regex XamlTargetTypeRegex = new(
         @"\bTargetType\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlTypeObjectElementRegex = new(
+        @"<\s*x:Type(?:Extension)?\b[^>]*\bTypeName\s*=\s*[""'](?<value>[^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly Regex XamlNameRegex = new(
         @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -6960,6 +6963,7 @@ private sealed class RubyMaskState
 
         AddWrappedXamlTypeArgumentSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddWrappedXamlTypeBearingAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddXamlTypeObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
         {
@@ -7136,6 +7140,34 @@ private sealed class RubyMaskState
 
                 cursor = valueEnd + 1;
             }
+        }
+    }
+
+    private static void AddXamlTypeObjectElementSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        foreach (Match typeMatch in XamlTypeObjectElementRegex.Matches(rawText))
+        {
+            var value = NormalizeXamlKeyValue(typeMatch.Groups["value"].Value);
+            if (value.Length == 0)
+                continue;
+
+            var startLine = FindHtmlLineNumber(lineStarts, typeMatch.Index);
+            var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+            symbols.Add(new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "class",
+                Name = value,
+                Line = startLine,
+                StartLine = startLine,
+                EndLine = startLine,
+                Signature = lines[signatureIndex].Trim(),
+            });
         }
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -570,6 +570,55 @@ jobs:
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsXamlTypeObjectElements()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_type_object_elements");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "GenericPage.xaml"),
+                """
+                <ResourceDictionary
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:vm="clr-namespace:Sample.ViewModels">
+                    <DataTemplate.DataType>
+                        <x:Type TypeName=
+                            "vm:PersonViewModel" />
+                    </DataTemplate.DataType>
+                    <Style.TargetType>
+                        <x:TypeExtension TypeName=
+                            "{x:Type vm:CustomButton}" />
+                    </Style.TargetType>
+                </ResourceDictionary>
+                """);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json"],
+                _jsonOptions));
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["vm:PersonViewModel", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                _jsonOptions));
+
+            var rows = ParseJsonLines(stdout);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Single(rows);
+            Assert.Equal("vm:PersonViewModel", rows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("class", rows[0].RootElement.GetProperty("kind").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_ExactNameFindsPythonInitModuleAliases()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_python_init_module_aliases");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19895,6 +19895,30 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesTypeObjectElementsAcrossLines()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:vm="clr-namespace:Sample.ViewModels">
+                <DataTemplate.DataType>
+                    <x:Type TypeName=
+                        "vm:PersonViewModel" />
+                </DataTemplate.DataType>
+                <Style.TargetType>
+                    <x:TypeExtension TypeName=
+                        "{x:Type vm:CustomButton}" />
+                </Style.TargetType>
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:PersonViewModel");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:CustomButton");
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesCommonEventHandlers()
     {
         var content = """


### PR DESCRIPTION
## Summary

This PR implements the follow-up candidate from PR #1331 by indexing XAML `x:Type` object-element syntax as searchable `class` symbols.

- Recognizes `<x:Type ... TypeName="..." />` forms
- Recognizes related `x:TypeExtension` forms
- Normalizes wrapped `TypeName` values the same way as the existing XAML attribute-based paths

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesTypeObjectElementsAcrossLines|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsXamlTypeObjectElements"`
- `dotnet build CodeIndex.sln -c Release`
- Refreshed the local CodeIndex index with `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/QueryCommandRunnerTests.cs`

## Changelog

- Added [`changelog.d/unreleased/+xml-xaml-type-object-elements.fixed.md`](/Users/widthdom/Projects/mine/cdidx/CodeIndex2nd/changelog.d/unreleased/+xml-xaml-type-object-elements.fixed.md)
- This is a normal fragment; no `issues: []` front matter was added.

## Follow-up candidates

- A fuller XAML parser could still help if the project later needs to resolve additional markup shapes beyond attribute-based values and `x:Type` object elements.