### PR TITLE
Index XAML type property elements

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-type-property-elements.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-type-property-elements.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **XAML `x:Type.TypeName` property-element syntax is now indexed as searchable class symbols** — following up on PR #1332, the extractor now recognizes property-element forms such as `<x:Type.TypeName>` and `<x:TypeExtension.TypeName>`, so type names can still be searched when markup uses property-element syntax instead of attributes or object elements.
+
+## 日本語
+
+- **XAML の `x:Type.TypeName` property-element 構文を検索可能な class シンボルとして index するようになりました** — PR #1332 の follow-up として、`<x:Type.TypeName>` や `<x:TypeExtension.TypeName>` のような property-element 形を認識し、属性や object-element ではなく property-element 構文を使っていても参照型を検索できるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -207,6 +207,9 @@ public static class SymbolExtractor
     private static readonly Regex XamlTypeObjectElementRegex = new(
         @"<\s*x:Type(?:Extension)?\b[^>]*\bTypeName\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+    private static readonly Regex XamlTypePropertyElementRegex = new(
+        @"<\s*(?<owner>x:Type(?:Extension)?)\.TypeName\b[^>]*>(?<value>.*?)</\s*\k<owner>\.TypeName\s*>",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly Regex XamlNameRegex = new(
         @"\bx:Name\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -6964,6 +6967,7 @@ private sealed class RubyMaskState
         AddWrappedXamlTypeArgumentSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddWrappedXamlTypeBearingAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypeObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
         {
@@ -7151,6 +7155,34 @@ private sealed class RubyMaskState
         List<SymbolRecord> symbols)
     {
         foreach (Match typeMatch in XamlTypeObjectElementRegex.Matches(rawText))
+        {
+            var value = NormalizeXamlKeyValue(typeMatch.Groups["value"].Value);
+            if (value.Length == 0)
+                continue;
+
+            var startLine = FindHtmlLineNumber(lineStarts, typeMatch.Index);
+            var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+            symbols.Add(new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "class",
+                Name = value,
+                Line = startLine,
+                StartLine = startLine,
+                EndLine = startLine,
+                Signature = lines[signatureIndex].Trim(),
+            });
+        }
+    }
+
+    private static void AddXamlTypePropertyElementSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        foreach (Match typeMatch in XamlTypePropertyElementRegex.Matches(rawText))
         {
             var value = NormalizeXamlKeyValue(typeMatch.Groups["value"].Value);
             if (value.Length == 0)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -619,6 +619,53 @@ jobs:
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsXamlTypePropertyElements()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_type_property_elements");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "GenericPage.xaml"),
+                """
+                <ResourceDictionary
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:vm="clr-namespace:Sample.ViewModels">
+                    <x:Type.TypeName>
+                        vm:PersonViewModel
+                    </x:Type.TypeName>
+                    <x:TypeExtension.TypeName>
+                        {x:Type vm:CustomButton}
+                    </x:TypeExtension.TypeName>
+                </ResourceDictionary>
+                """);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json"],
+                _jsonOptions));
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["vm:PersonViewModel", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                _jsonOptions));
+
+            var rows = ParseJsonLines(stdout);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Single(rows);
+            Assert.Equal("vm:PersonViewModel", rows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("class", rows[0].RootElement.GetProperty("kind").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_ExactNameFindsPythonInitModuleAliases()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_python_init_module_aliases");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19919,6 +19919,28 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesTypePropertyElementsAcrossLines()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:vm="clr-namespace:Sample.ViewModels">
+                <x:Type.TypeName>
+                    vm:PersonViewModel
+                </x:Type.TypeName>
+                <x:TypeExtension.TypeName>
+                    {x:Type vm:CustomButton}
+                </x:TypeExtension.TypeName>
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:PersonViewModel");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:CustomButton");
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesCommonEventHandlers()
     {
         var content = """


### PR DESCRIPTION
## Summary

This PR implements the follow-up candidate from PR #1332 by indexing XAML `x:Type.TypeName` property-element syntax as searchable `class` symbols.

- Recognizes `<x:Type.TypeName>` property elements
- Recognizes `<x:TypeExtension.TypeName>` property elements
- Normalizes wrapped property-element values the same way as the existing XAML attribute/object-element paths

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesTypePropertyElementsAcrossLines|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsXamlTypePropertyElements"`
- `dotnet build CodeIndex.sln -c Release`
- Refreshed the local CodeIndex index with `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/QueryCommandRunnerTests.cs`

## Changelog

- Added [`changelog.d/unreleased/+xml-xaml-type-property-elements.fixed.md`](/Users/widthdom/Projects/mine/cdidx/CodeIndex2nd/changelog.d/unreleased/+xml-xaml-type-property-elements.fixed.md)
- This is a normal fragment; no `issues: []` front matter was added.

## Follow-up candidates

- A fuller XAML parser could still help if the project later needs to resolve additional markup shapes beyond attribute-based values, object elements, and property elements.