### PR TITLE
Index XAML static member types

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-static-member-types.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-static-member-types.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **XAML `x:Static` member references now surface their containing types as searchable class symbols** — following up on PR #1333, the extractor now indexes type names referenced by `x:Static` expressions such as `x:Static local:Keys.AccentBrush` and `x:Static Member={x:Type local:Keys}.PrimaryStyleKey`, so resource-key style markup can still lead search to the owning type.
+
+## 日本語
+
+- **XAML の `x:Static` メンバー参照から包含 type を検索可能な class シンボルとして拾うようになりました** — PR #1333 の follow-up として、`x:Static local:Keys.AccentBrush` や `x:Static Member={x:Type local:Keys}.PrimaryStyleKey` のような式から type 名を index し、リソースキー系のマークアップでも所有 type に検索で辿れるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -6968,6 +6968,7 @@ private sealed class RubyMaskState
         AddWrappedXamlTypeBearingAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypeObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddXamlStaticMemberTypeSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
         {
@@ -7200,6 +7201,53 @@ private sealed class RubyMaskState
                 EndLine = startLine,
                 Signature = lines[signatureIndex].Trim(),
             });
+        }
+    }
+
+    private static void AddXamlStaticMemberTypeSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var braceIndex = rawText.IndexOf("{x:Static", cursor, StringComparison.Ordinal);
+            if (braceIndex < 0)
+                break;
+
+            var closingBraceIndex = FindMatchingBrace(rawText, braceIndex);
+            if (closingBraceIndex < 0)
+            {
+                cursor = braceIndex + 1;
+                continue;
+            }
+
+            var value = NormalizeXamlMarkupValue(rawText[braceIndex..(closingBraceIndex + 1)]);
+            var lastDot = value.LastIndexOf('.');
+            if (lastDot > 0)
+            {
+                var typeName = value[..lastDot].Trim();
+                if (typeName.Length > 0)
+                {
+                    var startLine = FindHtmlLineNumber(lineStarts, braceIndex);
+                    var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+                    symbols.Add(new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "class",
+                        Name = typeName,
+                        Line = startLine,
+                        StartLine = startLine,
+                        EndLine = startLine,
+                        Signature = lines[signatureIndex].Trim(),
+                    });
+                }
+            }
+
+            cursor = closingBraceIndex + 1;
         }
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -666,6 +666,52 @@ jobs:
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsXamlStaticMemberTypeReferences()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_static_member_types");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "GenericPage.xaml"),
+                """
+                <ResourceDictionary
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:Sample.ViewModels">
+                    <SolidColorBrush x:Key="{x:Static local:Keys.AccentBrush}" Color="Tomato" />
+                    <TextBlock Text="{x:Static local:App.DisplayName}" />
+                    <Style x:Key="{x:Static Member={x:Type local:Keys}.PrimaryStyleKey}">
+                        <Setter Property="Background" Value="Tomato" />
+                    </Style>
+                </ResourceDictionary>
+                """);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json"],
+                _jsonOptions));
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["local:App", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                _jsonOptions));
+
+            var rows = ParseJsonLines(stdout);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Single(rows);
+            Assert.Equal("local:App", rows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("class", rows[0].RootElement.GetProperty("kind").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_ExactNameFindsPythonInitModuleAliases()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_python_init_module_aliases");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19941,6 +19941,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesXStaticMemberTypeReferences()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:local="clr-namespace:Sample.ViewModels">
+                <SolidColorBrush x:Key="{x:Static local:Keys.AccentBrush}" Color="Tomato" />
+                <TextBlock Text="{x:Static local:App.DisplayName}" />
+                <Style x:Key="{x:Static Member={x:Type local:Keys}.PrimaryStyleKey}">
+                    <Setter Property="Background" Value="Tomato" />
+                </Style>
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "local:Keys");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "local:App");
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesCommonEventHandlers()
     {
         var content = """


### PR DESCRIPTION
## Summary

This PR implements the follow-up candidate from PR #1333 by indexing XAML `x:Static` member references as searchable `class` symbols.

- Recognizes `x:Static local:Keys.AccentBrush`
- Recognizes `x:Static Member={x:Type local:Keys}.PrimaryStyleKey`
- Normalizes the referenced type name so searches can land on the owning type instead of only the static member access

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesXStaticMemberTypeReferences|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsXamlStaticMemberTypeReferences"`
- `dotnet build CodeIndex.sln -c Release`
- Refreshed the local CodeIndex index with `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/SymbolExtractor.cs tests/CodeIndex.Tests/SymbolExtractorTests.cs tests/CodeIndex.Tests/QueryCommandRunnerTests.cs`

## Changelog

- Added [`changelog.d/unreleased/+xml-xaml-static-member-types.fixed.md`](/Users/widthdom/Projects/mine/cdidx/CodeIndex2nd/changelog.d/unreleased/+xml-xaml-static-member-types.fixed.md)
- This is a normal fragment; no `issues: []` front matter was added.

## Follow-up candidates

- A fuller XAML parser could still help if the project later needs to resolve additional markup shapes beyond attribute-based values, object elements, property elements, and `x:Static` member references.