### PR TITLE
Index XAML type markup extensions

### DIFF
--- a/changelog.d/unreleased/+xaml-type-markup.fixed.md
+++ b/changelog.d/unreleased/+xaml-type-markup.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **XAML `x:Type` markup extensions now surface their referenced types as searchable class symbols** — the extractor now scans generic `{x:Type ...}` and `{x:TypeExtension ...}` markup extensions in addition to the existing type-bearing attributes and property/object elements, so type references embedded in ordinary attribute values are discoverable by `symbols` and `RunSymbols`.
+
+## 日本語
+
+- **XAML の `x:Type` markup extension から参照 type を検索可能な class シンボルとして拾うようになりました** — 既存の type-bearing 属性や property/object element に加えて、一般的な `{x:Type ...}` / `{x:TypeExtension ...}` markup extension も走査するようにし、通常の属性値に埋め込まれた type 参照も `symbols` と `RunSymbols` から辿れるようにしました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -6968,6 +6968,7 @@ private sealed class RubyMaskState
         AddWrappedXamlTypeBearingAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypeObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddXamlTypeMarkupSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlStaticMemberTypeSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
@@ -7204,6 +7205,70 @@ private sealed class RubyMaskState
         }
     }
 
+    private static void AddXamlTypeMarkupSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        AddXamlMarkupExtensionTypeSymbols(fileId, rawText, lines, lineStarts, symbols, "{x:TypeExtension", false);
+        AddXamlMarkupExtensionTypeSymbols(fileId, rawText, lines, lineStarts, symbols, "{x:Type", true);
+    }
+
+    private static void AddXamlMarkupExtensionTypeSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols,
+        string prefix,
+        bool rejectNameCharAfterPrefix)
+    {
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var braceIndex = rawText.IndexOf(prefix, cursor, StringComparison.Ordinal);
+            if (braceIndex < 0)
+                break;
+
+            var afterPrefix = braceIndex + prefix.Length;
+            if (rejectNameCharAfterPrefix
+                && afterPrefix < rawText.Length
+                && IsXamlMarkupNameChar(rawText[afterPrefix]))
+            {
+                cursor = afterPrefix;
+                continue;
+            }
+
+            var closingBraceIndex = FindMatchingBrace(rawText, braceIndex);
+            if (closingBraceIndex < 0)
+            {
+                cursor = braceIndex + 1;
+                continue;
+            }
+
+            var value = NormalizeXamlMarkupValue(rawText[braceIndex..(closingBraceIndex + 1)]);
+            if (value.Length > 0)
+            {
+                var startLine = FindHtmlLineNumber(lineStarts, braceIndex);
+                var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "class",
+                    Name = value,
+                    Line = startLine,
+                    StartLine = startLine,
+                    EndLine = startLine,
+                    Signature = lines[signatureIndex].Trim(),
+                });
+            }
+
+            cursor = closingBraceIndex + 1;
+        }
+    }
+
     private static void AddXamlStaticMemberTypeSymbols(
         long fileId,
         string rawText,
@@ -7250,6 +7315,9 @@ private sealed class RubyMaskState
             cursor = closingBraceIndex + 1;
         }
     }
+
+    private static bool IsXamlMarkupNameChar(char c)
+        => char.IsLetterOrDigit(c) || c == '_' || c == ':' || c == '.';
 
     private static string NormalizeXamlKeyValue(string value)
     {

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -7248,6 +7248,12 @@ private sealed class RubyMaskState
                 continue;
             }
 
+            if (ShouldSkipXamlMarkupExtensionSymbol(rawText, braceIndex))
+            {
+                cursor = closingBraceIndex + 1;
+                continue;
+            }
+
             var value = NormalizeXamlMarkupValue(rawText[braceIndex..(closingBraceIndex + 1)]);
             if (value.Length > 0)
             {
@@ -7267,6 +7273,29 @@ private sealed class RubyMaskState
 
             cursor = closingBraceIndex + 1;
         }
+    }
+
+    private static bool ShouldSkipXamlMarkupExtensionSymbol(string rawText, int braceIndex)
+    {
+        var tagStart = rawText.LastIndexOf('<', braceIndex);
+        if (tagStart < 0 || tagStart > braceIndex)
+            return false;
+
+        var tagEnd = rawText.IndexOf('>', tagStart);
+        if (tagEnd >= 0 && tagEnd < braceIndex)
+            return false;
+
+        var tagSlice = rawText[tagStart..braceIndex];
+        if (tagSlice.IndexOf("<x:Type", StringComparison.OrdinalIgnoreCase) >= 0
+            || tagSlice.IndexOf("<x:TypeExtension", StringComparison.OrdinalIgnoreCase) >= 0)
+        {
+            return true;
+        }
+
+        if (tagSlice.IndexOf("TargetType=", StringComparison.OrdinalIgnoreCase) >= 0)
+            return true;
+
+        return false;
     }
 
     private static void AddXamlStaticMemberTypeSymbols(

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -666,6 +666,50 @@ jobs:
     }
 
     [Fact]
+    public void RunSymbols_ExactNameFindsXamlTypeMarkupExtensions()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_type_markup_extensions");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "GenericPage.xaml"),
+                """
+                <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                             xmlns:vm="clr-namespace:Sample.ViewModels">
+                    <ContentPage.Resources>
+                        <ControlTemplate TargetType="{x:Type vm:PersonViewModel}" />
+                        <TextBlock ToolTip="{x:TypeExtension TypeName=vm:CustomButton}" />
+                    </ContentPage.Resources>
+                </ContentPage>
+                """);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json"],
+                _jsonOptions));
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["vm:CustomButton", "--db", dbPath, "--json", "--exact-name", "--lang", "xml"],
+                _jsonOptions));
+
+            var rows = ParseJsonLines(stdout);
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Single(rows);
+            Assert.Equal("vm:CustomButton", rows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("class", rows[0].RootElement.GetProperty("kind").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_ExactNameFindsXamlStaticMemberTypeReferences()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_xaml_static_member_types");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19941,6 +19941,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesTypeMarkupExtensions()
+    {
+        var content = """
+            <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:vm="clr-namespace:Sample.ViewModels">
+                <ContentPage.Resources>
+                    <ControlTemplate TargetType="{x:Type vm:PersonViewModel}" />
+                    <TextBlock ToolTip="{x:TypeExtension TypeName=vm:CustomButton}" />
+                </ContentPage.Resources>
+            </ContentPage>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:PersonViewModel");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "vm:CustomButton");
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesXStaticMemberTypeReferences()
     {
         var content = """


### PR DESCRIPTION
## Summary

This PR addresses the follow-up candidate from PR #1334 by indexing generic XAML `{x:Type ...}` and `{x:TypeExtension ...}` markup extensions as searchable `class` symbols, in addition to the existing type-bearing attributes and object / property elements.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Xml_XamlCapturesTypeMarkupExtensions|FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_ExactNameFindsXamlTypeMarkupExtensions"`
- `dotnet build CodeIndex.sln -c Release`

## Changelog

- Added `changelog.d/unreleased/+xaml-type-markup.fixed.md`

## Follow-up candidates

- None identified beyond the markup-extension coverage added here.