### PR TITLE
Improve Rust raw identifier search

### DIFF
--- a/changelog.d/unreleased/+rust-raw-identifiers-search.fixed.md
+++ b/changelog.d/unreleased/+rust-raw-identifiers-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Rust search now accepts raw identifiers without the `r#` prefix** — symbol and reference queries for names like `r#type` now resolve to the canonical stored form, so search entrypoints match Rust source spellings that use raw identifiers.
+
+## 日本語
+
+- **Rust 検索が `r#` プレフィックスなしの raw identifier を受け付けるようになりました** — `r#type` のような名前の symbol / reference query が、DB に保存されている正規化済みの形式へ解決されるため、raw identifier を使う Rust ソース表記でも検索入口が一致するようになります。

--- a/changelog.d/unreleased/+rust-raw-identifiers.fixed.md
+++ b/changelog.d/unreleased/+rust-raw-identifiers.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Rust raw identifiers now search by canonical names** — Rust symbol extraction strips `r#` from declared names before indexing, so `r#type` is stored and searched as `type`. Symbol search queries also keep matching the canonical name when users include the raw prefix.
+
+## 日本語
+
+- **Rust の raw identifier が canonical 名で検索できるようになりました** — Rust のシンボル抽出では宣言名から `r#` を取り除いて index するため、`r#type` は `type` として保存・検索されます。検索クエリ側も raw prefix を付けた入力を canonical 名に合わせて扱います。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -598,6 +598,9 @@ public partial class DbReader
         if (leafIndex >= 0)
             trimmed = trimmed[(leafIndex + 2)..].Trim();
 
+        if (trimmed.StartsWith("r#", StringComparison.Ordinal))
+            trimmed = trimmed[2..];
+
         return trimmed.Length == 0 ? null : trimmed;
     }
 

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -367,6 +367,13 @@ public static class ReferenceExtractor
     // `std::println!` / `log::info!` / `my_macro!` のような path-qualified 名も含めて拾い、
     // `macro_rules` 宣言キーワードは上の Rust ignore list で除外する。
     private static readonly Regex RustMacroCallRegex = new($@"(?<![\w$])(?<name>{FunctionalIdentifierPattern}(?:::{FunctionalIdentifierPattern})*)(?:<[^>\n]+>)?!\s*[\(\[\{{]", RegexOptions.Compiled);
+    // Rust raw identifiers such as `r#type()` are stored without the `r#` prefix, but the shared
+    // call regex cannot see them because `#` is not an identifier character. Use a Rust-only
+    // matcher for names that contain at least one raw segment and normalize the stored form below.
+    // Rust の raw identifier (`r#type()`) は保存時に `r#` を外すが、共通 CallRegex は `#` を
+    // 識別子文字として扱わないため見逃す。raw segment を含む Rust 専用 matcher を足し、
+    // 下で保存形式へ正規化する。
+    private static readonly Regex RustRawIdentifierCallRegex = new($@"(?<![\w$])(?<name>(?:(?:r#)?\w+::)*r#\w+(?:::(?:r#)?\w+)*)\s*\(", RegexOptions.Compiled);
     // Ruby command-syntax calls such as `puts "hi"`, `greet bob`, and `before_action :auth`
     // omit the trailing `(` that the shared CallRegex requires.
     // Ruby の command syntax 呼び出し (`puts "hi"` / `greet bob` / `before_action :auth`)
@@ -2272,7 +2279,12 @@ public static class ReferenceExtractor
             {
                 var normalizedName = language == "fsharp" && IsFSharpOperatorCallName(name)
                     ? $"operator {name}"
-                    : NormalizeAtPrefixedIdentifier(name);
+                    : language == "rust"
+                        ? NormalizeRustIdentifier(name)
+                        : NormalizeAtPrefixedIdentifier(name);
+
+                if (language == "rust" && IsRustFunctionDeclarationCallSite(preparedLine, callIndex))
+                    return;
 
                 // Suppress the same-line Java ctor declarator's self-call. CallRegex matches
                 // `CtorName(` at the declarator once per same-line ctor, but it is a declaration
@@ -2505,6 +2517,8 @@ public static class ReferenceExtractor
                 {
                     var name = match.Groups["name"].Value;
                     var callIndex = match.Groups["name"].Index;
+                    if (language == "rust" && IsRustRawIdentifierPrefix(preparedLine, callIndex))
+                        continue;
                     if (sqlSuppressedCallIndices != null && sqlSuppressedCallIndices.Contains(callIndex))
                         continue;
                     matchedCallIndices.Add(callIndex);
@@ -2626,6 +2640,13 @@ public static class ReferenceExtractor
 
             if (language == "rust")
             {
+                foreach (Match match in RustRawIdentifierCallRegex.Matches(preparedLine))
+                {
+                    var name = match.Groups["name"].Value;
+                    var callIndex = match.Groups["name"].Index;
+                    AddCallLikeReference(name, callIndex);
+                }
+
                 foreach (Match match in RustMacroCallRegex.Matches(preparedLine))
                 {
                     var name = match.Groups["name"].Value;
@@ -8481,6 +8502,36 @@ public static class ReferenceExtractor
         !string.IsNullOrEmpty(identifier) && identifier[0] == '@'
             ? identifier[1..]
             : identifier;
+
+    private static string NormalizeRustIdentifier(string identifier)
+    {
+        if (identifier.Length == 0)
+            return identifier;
+
+        var segments = identifier.Split("::");
+        for (var i = 0; i < segments.Length; i++)
+        {
+            var segment = segments[i];
+            if (segment.StartsWith("r#", StringComparison.Ordinal))
+                segments[i] = segment[2..];
+        }
+
+        return string.Join("::", segments);
+    }
+
+    private static bool IsRustFunctionDeclarationCallSite(string line, int callIndex)
+    {
+        if (callIndex <= 0)
+            return false;
+
+        var prefix = line[..callIndex].TrimEnd();
+        return prefix.EndsWith("fn", StringComparison.Ordinal);
+    }
+
+    private static bool IsRustRawIdentifierPrefix(string line, int callIndex) =>
+        callIndex >= 2
+        && line[callIndex - 2] == 'r'
+        && line[callIndex - 1] == '#';
 
     private static string NormalizeShellSourceTargetToken(string token)
     {

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -373,7 +373,7 @@ public static class ReferenceExtractor
     // Rust の raw identifier (`r#type()`) は保存時に `r#` を外すが、共通 CallRegex は `#` を
     // 識別子文字として扱わないため見逃す。raw segment を含む Rust 専用 matcher を足し、
     // 下で保存形式へ正規化する。
-    private static readonly Regex RustRawIdentifierCallRegex = new($@"(?<![\w$])(?<name>(?:(?:r#)?\w+::)*r#\w+(?:::(?:r#)?\w+)*)\s*\(", RegexOptions.Compiled);
+    private static readonly Regex RustRawIdentifierCallRegex = new($@"(?<![\w$])(?<name>(?:(?:r#)?\w+::)*r#\w+(?:::(?:r#)?\w+)*)(?:<[^>\n]+>)?\s*\(", RegexOptions.Compiled);
     // Ruby command-syntax calls such as `puts "hi"`, `greet bob`, and `before_action :auth`
     // omit the trailing `(` that the shared CallRegex requires.
     // Ruby の command syntax 呼び出し (`puts "hi"` / `greet bob` / `before_action :auth`)

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -1158,7 +1158,7 @@ public static class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:const|static)\s+(?<name>\w+)\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // fn with expanded modifiers: async, const, unsafe, default, extern (ABI optional) /
             // 拡張修飾子: async, const, unsafe, default, extern（ABI は省略可）
-            new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:(?:async|const|unsafe|default|extern(?:\s+""[^""]+"")?)\s+)*fn\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:(?:async|const|unsafe|default|extern(?:\s+""[^""]+"")?)\s+)*fn\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("struct",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:struct|union)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("enum",     new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum variants / `Red`, `Ok(T)`, `Circle { radius: f64 }`, `Point`
@@ -26024,11 +26024,15 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
             "cobol" => NormalizeCobolSymbolName(name),
             "fsharp" => NormalizeFSharpSymbolName(name),
             "kotlin" => NormalizeKotlinSymbolName(name, matchLine),
+            "rust" => NormalizeRustSymbolName(name),
             "swift" => NormalizeSwiftSymbolName(name),
             "sql" => NormalizeSqlSymbolName(name),
             _ => name,
         };
     }
+
+    private static string NormalizeRustSymbolName(string name) =>
+        name.StartsWith("r#", StringComparison.Ordinal) ? name[2..] : name;
 
     private static string NormalizeFSharpSymbolName(string name)
     {

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -186,11 +186,12 @@ public static class SymbolExtractor
         @"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?use\s+(?<body>.+);\s*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private readonly record struct RustUseSymbolOccurrence(string Name, int Line, int Column);
+    private const string RustIdentifierPattern = @"(?:r#)?\w+";
     private static readonly Regex RustMultilineImplForRegex = new(
-        @"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+.+?\s+for\s+(?<name>\w+)\b",
+        @"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+.+?\s+for\s+(?<name>" + RustIdentifierPattern + @")\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly Regex RustMultilineImplTypeRegex = new(
-        @"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+(?<name>\w+)(?!\s+for\b)\b",
+        @"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+(?<name>" + RustIdentifierPattern + @")(?!\s+for\b)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly Regex XamlClassRegex = new(
         @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']",
@@ -1153,25 +1154,25 @@ public static class SymbolExtractor
         ["rust"] =
         [
             // macro_rules! / マクロ定義
-            new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?macro_rules!\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?macro_rules!\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // const/static items / 定数・静的変数
-            new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:const|static)\s+(?<name>\w+)\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:const|static)\s+(?<name>(?:r#)?\w+)\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // fn with expanded modifiers: async, const, unsafe, default, extern (ABI optional) /
             // 拡張修飾子: async, const, unsafe, default, extern（ABI は省略可）
             new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:(?:async|const|unsafe|default|extern(?:\s+""[^""]+"")?)\s+)*fn\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("struct",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:struct|union)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("enum",     new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("struct",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:struct|union)\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("enum",     new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?enum\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum variants / `Red`, `Ok(T)`, `Circle { radius: f64 }`, `Point`
             new("property", new Regex(@"^\s{4,}(?<name>[A-Z][A-Za-z0-9_]*)\s*(?:\([^()\r\n]*\)|\{[^{}\r\n]*\})?\s*,?\s*$", RegexOptions.Compiled), BodyStyle.None),
-            new("interface", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?trait\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("interface", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?trait\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // impl Trait for Type / `unsafe impl Trait for Type` should attach to the type being extended.
             // `impl Trait for Type` / `unsafe impl Trait for Type` は、拡張先の型に紐づける。
-            new("class",    new Regex(@"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+.+?\s+for\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("class",    new Regex(@"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+(?<name>\w+)(?!\s+for\b)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+.+?\s+for\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+(?<name>(?:r#)?\w+)(?!\s+for\b)", RegexOptions.Compiled), BodyStyle.Brace),
             // mod / モジュール
-            new("namespace", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?mod\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("namespace", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?mod\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // type alias / 型エイリアス
-            new("import",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?type\s+(?<name>\w+)(?:\s*<[^=]+>)?", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("import",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?type\s+(?<name>(?:r#)?\w+)(?:\s*<[^=]+>)?", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?use\s+(?<name>.+);", RegexOptions.Compiled), BodyStyle.None, "visibility"),
         ],
         ["java"] =
@@ -26031,9 +26032,6 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
         };
     }
 
-    private static string NormalizeRustSymbolName(string name) =>
-        name.StartsWith("r#", StringComparison.Ordinal) ? name[2..] : name;
-
     private static string NormalizeFSharpSymbolName(string name)
     {
         if (name.Length >= 4 && name.StartsWith("``", StringComparison.Ordinal) && name.EndsWith("``", StringComparison.Ordinal))
@@ -26047,6 +26045,32 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
         }
 
         return name;
+    }
+
+    private static string NormalizeRustSymbolName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return name;
+
+        var trimmed = name.Trim();
+        if (trimmed.Length == 0)
+            return trimmed;
+
+        if (!trimmed.Contains("::", StringComparison.Ordinal))
+            return trimmed.StartsWith("r#", StringComparison.Ordinal)
+                ? trimmed[2..]
+                : trimmed;
+
+        var segments = trimmed.Split("::");
+        for (var i = 0; i < segments.Length; i++)
+        {
+            var segment = segments[i].Trim();
+            if (segment.StartsWith("r#", StringComparison.Ordinal))
+                segment = segment[2..];
+            segments[i] = segment;
+        }
+
+        return string.Join("::", segments);
     }
 
     private enum FSharpTypeBodyKind

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -187,6 +187,31 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_RustRawIdentifiersIgnoreRawPrefix()
+    {
+        InsertIndexedFile(
+            "src/raw.rs",
+            "rust",
+            """
+            pub fn r#type() {}
+
+            pub fn caller() {
+                r#type();
+            }
+            """);
+
+        var symbolResults = _reader.SearchSymbols("r#type", lang: "rust", exact: true);
+        var symbol = Assert.Single(symbolResults);
+        Assert.Equal("type", symbol.Name);
+        Assert.Equal("src/raw.rs", symbol.Path);
+
+        var referenceResults = _reader.SearchReferences("r#type", lang: "rust", exact: true);
+        var reference = Assert.Single(referenceResults);
+        Assert.Equal("type", reference.SymbolName);
+        Assert.Equal("src/raw.rs", reference.Path);
+    }
+
+    [Fact]
     public void RustQualifiedQueriesResolveAcrossGraphCommands()
     {
         InsertIndexedFile(

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -168,6 +168,23 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_RustRawIdentifiersIgnoreRawPrefixAndReferences()
+    {
+        InsertIndexedFile(
+            "src/lib.rs",
+            "rust",
+            """
+            pub fn r#type() {}
+            """);
+
+        var results = _reader.SearchSymbols("r#type", lang: "rust", exact: true);
+
+        var symbol = Assert.Single(results);
+        Assert.Equal("type", symbol.Name);
+        Assert.Equal("src/lib.rs", symbol.Path);
+    }
+
+    [Fact]
     public void SearchSymbols_RustQualifiedQueriesResolveToLeafNames()
     {
         InsertIndexedFile(


### PR DESCRIPTION
Summary:
- Normalize Rust raw identifiers during symbol search queries.
- Index Rust `fn` declarations with `r#` prefixes as canonical names.
- Match raw-identifier Rust call sites without duplicating the generic matcher.
- Add regression coverage for Rust raw identifier search.

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_CSharp_VerboseVerbatimIdentifiers_NormalizeCallsAndInstantiation|FullyQualifiedName~DbReaderTests.SearchSymbols_RustRawIdentifiersIgnoreRawPrefix|FullyQualifiedName~DbReaderTests.SearchSymbols_RustMacroQueriesIgnoreTrailingBang|FullyQualifiedName~DbReaderTests.SearchSymbols_RustQualifiedQueriesResolveToLeafNames|FullyQualifiedName~DbReaderTests.RustQualifiedQueriesResolveAcrossGraphCommands"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`