### PR TITLE
Improve JavaScript CommonJS search

### DIFF
--- a/changelog.d/unreleased/+javascript-commonjs-search.fixed.md
+++ b/changelog.d/unreleased/+javascript-commonjs-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **JavaScript CommonJS export queries now resolve to leaf symbols** — exact symbol searches now normalize `module.exports.foo` and `exports.bar` to the canonical leaf name, so CommonJS export surfaces are searchable with the same spelling users see in extracted symbols.
+
+## 日本語
+
+- **JavaScript の CommonJS export クエリが leaf シンボルへ解決されるようになりました** — exact symbol search で `module.exports.foo` や `exports.bar` を canonical な leaf 名へ正規化するため、CommonJS export surface を抽出済みシンボルと同じ綴りで検索できます。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -591,11 +591,16 @@ public partial class DbReader
         if (trimmed.Length == 0)
             return null;
 
+        var commonJsPrefixLength = 0;
         if (trimmed.StartsWith("module.exports.", StringComparison.Ordinal))
-            trimmed = trimmed["module.exports.".Length..];
+            commonJsPrefixLength = "module.exports.".Length;
         else if (trimmed.StartsWith("exports.", StringComparison.Ordinal))
-            trimmed = trimmed["exports.".Length..];
+            commonJsPrefixLength = "exports.".Length;
 
+        if (commonJsPrefixLength == 0)
+            return trimmed;
+
+        trimmed = trimmed[commonJsPrefixLength..];
         if (trimmed.Length == 0)
             return null;
 

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -576,7 +576,34 @@ public partial class DbReader
         if (!string.IsNullOrWhiteSpace(lang) && string.Equals(lang, "rust", StringComparison.OrdinalIgnoreCase))
             return NormalizeRustSymbolSearchQuery(query);
 
+        if (!string.IsNullOrWhiteSpace(lang) && string.Equals(lang, "javascript", StringComparison.OrdinalIgnoreCase))
+            return NormalizeJavaScriptSymbolSearchQuery(query);
+
         return NormalizeCSharpVerbatimQuery(query, lang);
+    }
+
+    private static string? NormalizeJavaScriptSymbolSearchQuery(string? query)
+    {
+        if (query == null)
+            return null;
+
+        var trimmed = query.Trim();
+        if (trimmed.Length == 0)
+            return null;
+
+        if (trimmed.StartsWith("module.exports.", StringComparison.Ordinal))
+            trimmed = trimmed["module.exports.".Length..];
+        else if (trimmed.StartsWith("exports.", StringComparison.Ordinal))
+            trimmed = trimmed["exports.".Length..];
+
+        if (trimmed.Length == 0)
+            return null;
+
+        var leafIndex = trimmed.LastIndexOf('.');
+        if (leafIndex >= 0)
+            trimmed = trimmed[(leafIndex + 1)..];
+
+        return trimmed.Length == 0 ? null : trimmed;
     }
 
     private static string? NormalizeRustSymbolSearchQuery(string? query)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -168,6 +168,33 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_JavaScriptCommonJsExportQueriesResolveToLeafNames()
+    {
+        InsertIndexedFile(
+            "src/commonjs.js",
+            "javascript",
+            """
+            module.exports.foo = function foo() { return 1; };
+            function caller() {
+                foo();
+            }
+            exports.bar = 42;
+            """);
+
+        var foo = Assert.Single(_reader.SearchSymbols("module.exports.foo", lang: "javascript", exact: true));
+        Assert.Equal("foo", foo.Name);
+        Assert.Equal("src/commonjs.js", foo.Path);
+
+        var bar = Assert.Single(_reader.SearchSymbols("exports.bar", lang: "javascript", exact: true));
+        Assert.Equal("bar", bar.Name);
+        Assert.Equal("src/commonjs.js", bar.Path);
+
+        var references = _reader.SearchReferences("module.exports.foo", lang: "javascript", exact: true);
+        Assert.NotEmpty(references);
+        Assert.Contains(references, reference => reference.SymbolName == "foo" && reference.ContainerName == "caller" && reference.Path == "src/commonjs.js");
+    }
+
+    [Fact]
     public void SearchSymbols_RustRawIdentifiersIgnoreRawPrefixAndReferences()
     {
         InsertIndexedFile(

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -195,6 +195,21 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_JavaScriptQualifiedQueriesOutsideCommonJsRemainExact()
+    {
+        InsertIndexedFile(
+            "src/logger.js",
+            "javascript",
+            """
+            const logger = {
+                log() {}
+            };
+            """);
+
+        Assert.Empty(_reader.SearchSymbols("logger.log", lang: "javascript", exact: true));
+    }
+
+    [Fact]
     public void SearchSymbols_RustRawIdentifiersIgnoreRawPrefixAndReferences()
     {
         InsertIndexedFile(


### PR DESCRIPTION
## Summary
- Normalize JavaScript CommonJS export queries (`module.exports.*` and `exports.*`) to the canonical leaf symbol for exact search.
- Keep non-CommonJS dotted JavaScript queries exact so unrelated lookups are not broadened.
- Add regression coverage for JavaScript symbol search, shared reference search, and a non-CommonJS exact-query guard.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.SearchSymbols_JavaScriptCommonJsExportQueriesResolveToLeafNames|FullyQualifiedName~DbReaderTests.SearchSymbols_JavaScriptQualifiedQueriesOutsideCommonJsRemainExact"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet build`

## Documentation / Changelog
- Added `changelog.d/unreleased/+javascript-commonjs-search.fixed.md`

## Follow-up candidates
- None.
