### PR TITLE
Improve C# search verbatim normalization

### DIFF
--- a/changelog.d/unreleased/+csharp-search-verbatim-snippets.fixed.md
+++ b/changelog.d/unreleased/+csharp-search-verbatim-snippets.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/SearchSnippetFormatter.cs
+  - tests/CodeIndex.Tests/SearchSnippetFormatterTests.cs
+---
+
+## English
+
+- **C# search snippets now normalize verbatim qualified names in all modes** — search excerpt generation now treats `@Foo.@Bar` and `Foo.Bar` as the same C# path even outside exact mode, so verbatim-qualified matches are highlighted consistently instead of depending on the source spelling.
+
+## 日本語
+
+- **C# の search snippet で verbatim 修飾名を全モードで正規化するようになりました** — search excerpt の生成時に exact 以外でも `@Foo.@Bar` と `Foo.Bar` を同じ C# の経路として扱うため、verbatim 修飾名の一致が source の綴りに左右されず一貫してハイライトされます。

--- a/src/CodeIndex/Cli/SearchSnippetFormatter.cs
+++ b/src/CodeIndex/Cli/SearchSnippetFormatter.cs
@@ -67,7 +67,7 @@ public static class SearchSnippetFormatter
         }
 
         var normalizedQuery = query.Trim();
-        var normalizeCSharpVerbatimNames = caseSensitive && string.Equals(lang, "csharp", StringComparison.OrdinalIgnoreCase);
+        var normalizeCSharpVerbatimNames = string.Equals(lang, "csharp", StringComparison.OrdinalIgnoreCase);
         if (normalizeCSharpVerbatimNames)
             normalizedQuery = CSharpVerbatimNameNormalizer.Normalize(normalizedQuery);
 

--- a/tests/CodeIndex.Tests/SearchSnippetFormatterTests.cs
+++ b/tests/CodeIndex.Tests/SearchSnippetFormatterTests.cs
@@ -86,6 +86,19 @@ public class SearchSnippetFormatterTests
     }
 
     [Fact]
+    public void BuildExcerpt_NormalizesCSharpVerbatimQualifiedNamesInNonExactSearch()
+    {
+        const string content = "namespace Demo;\nusing @Foo.@Bar;\n";
+
+        var excerpt = SearchSnippetFormatter.BuildExcerpt(content, "Foo.Bar", absoluteStartLine: 1, maxLines: 4, caseSensitive: false, lang: "csharp");
+
+        Assert.Equal([2], excerpt.MatchLines);
+        Assert.Single(excerpt.Highlights);
+        Assert.Contains("Foo.Bar", excerpt.Highlights[0].Terms);
+        Assert.Contains("using @Foo.@Bar;", excerpt.Lines);
+    }
+
+    [Fact]
     public void Format_TruncatedAfterOnly_WhenMatchIsNearStart()
     {
         // Match on line 1 with maxLines=2 out of 6 — truncated after only


### PR DESCRIPTION
## Summary
- Normalize C# verbatim-qualified names during search snippet extraction in all search modes.
- Add a regression test covering non-exact C# search snippets with `@Foo.@Bar`.
- Add a bilingual changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SearchSnippetFormatterTests|FullyQualifiedName~RunSearch_ExactSubstringTreatsCSharpGlobalQualifiedNamesAsCanonical|FullyQualifiedName~RunFind_ExactTreatsCSharpVerbatimQualifiedNamesAsCanonical"`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Notes
- No issue-linked auto-close references were provided for this task.