### PR TITLE
Normalize T-SQL language aliases

### DIFF
--- a/changelog.d/unreleased/+tsql-lang-aliases.fixed.md
+++ b/changelog.d/unreleased/+tsql-lang-aliases.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`--lang` now accepts common T-SQL spellings** — `cdidx search` and the other query commands now normalize `t-sql` and `transact-sql` to `sql`, so T-SQL users no longer need to remember the exact canonical filter spelling.
+
+## 日本語
+
+- **`--lang` が一般的な T-SQL 表記を受け付けるようになりました** — `cdidx search` を含む各種 query コマンドが `t-sql` と `transact-sql` を `sql` に正規化するため、T-SQL 利用時に canonical なフィルタ表記を覚えていなくても検索できます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -35,10 +35,12 @@ public static class QueryCommandRunner
         ["kt"] = "kotlin",
         ["kts"] = "kotlin",
         ["tsql"] = "sql",
+        ["transactsql"] = "sql",
     };
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
         ["yaml"] = ["yml"],
+        ["sql"] = ["tsql", "t-sql", "transact-sql", "sqlserver", "mssql"],
     };
     private static readonly HashSet<string> ValueTakingOptions =
     [
@@ -3013,7 +3015,10 @@ public static class QueryCommandRunner
     {
         if (langValue == null)
             return null;
-        var normalized = langValue.ToLowerInvariant();
+        var normalized = langValue
+            .ToLowerInvariant()
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal);
         return LangFilterAliases.TryGetValue(normalized, out var canonical) ? canonical : normalized;
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -104,6 +104,18 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void GetLanguageAliases_ReportsSqlDialectAliases()
+    {
+        var aliases = QueryCommandRunner.GetLanguageAliases("sql");
+
+        Assert.Contains("tsql", aliases);
+        Assert.Contains("t-sql", aliases);
+        Assert.Contains("transact-sql", aliases);
+        Assert.Contains("sqlserver", aliases);
+        Assert.Contains("mssql", aliases);
+    }
+
+    [Fact]
     public void ParseArgs_AllowsDashPrefixedPositionalQueryLiteral()
     {
         var options = QueryCommandRunner.ParseArgs(["--open-reports", "--db", "query.db"], jsonDefault: false, allowNamedQuery: true);
@@ -172,6 +184,9 @@ public class QueryCommandRunnerTests
     [InlineData("yml", "yaml")]
     [InlineData("kt", "kotlin")]
     [InlineData("KTS", "kotlin")]
+    [InlineData("T-SQL", "sql")]
+    [InlineData("transact-sql", "sql")]
+    [InlineData("transact sql", "sql")]
     public void ParseArgs_NormalizesLangAliases(string input, string expected)
     {
         var options = QueryCommandRunner.ParseArgs(["needle", "--lang", input], jsonDefault: false);
@@ -286,6 +301,37 @@ jobs:
                 "scripts/run.bat",
                 "batch",
                 $"echo {queryToken}\r\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--lang", input, "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData("T-SQL")]
+    [InlineData("transact-sql")]
+    [InlineData("transact sql")]
+    public void RunSearch_NormalizesSqlDialectLangAliases(string input)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_sql_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = "sql_lang_alias_3f7d21";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "sql/repro.sql",
+                "sql",
+                $"SELECT '{queryToken}';");
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
                 [queryToken, "--db", dbPath, "--lang", input, "--count"],


### PR DESCRIPTION
## Summary
- Normalize common T-SQL spellings in `--lang` before query dispatch so `t-sql` and `transact-sql` resolve to `sql`.
- Expose the same SQL dialect aliases in language display/completion helpers.
- Add coverage for CLI parsing, search counts, and alias listing.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests"`
- `dotnet test`

## Docs and changelog
- Added a bilingual fragment at `changelog.d/unreleased/+tsql-lang-aliases.fixed.md`.
- No additional docs updates were needed because this change only broadens accepted language aliases and keeps existing command behavior intact.

## Follow-up candidates
- Review whether other SQL-family spellings should be surfaced in the language display table if users request them.