### PR TITLE
Address PR 1340 follow-up candidates

### DIFF
--- a/changelog.d/unreleased/+sql-language-alias-parity.fixed.md
+++ b/changelog.d/unreleased/+sql-language-alias-parity.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **SQL-family language aliases now normalize consistently across the query stack** — `transact-sql` and `transact sql` now resolve to `sql` the same way `tsql`, `mssql`, and `sqlserver` do, so SQL users get the same behavior whether the spelling reaches the CLI parser or the database reader directly.
+- **SQL-family language aliases now normalize consistently across the query stack** — `transact-sql`, `transact sql`, and the surfaced `transactsql` spelling now resolve to `sql` the same way `tsql`, `mssql`, and `sqlserver` do, so SQL users get the same behavior whether the spelling reaches the CLI parser or the database reader directly.
 
 ## 日本語
 
-- **SQL 系の言語別名がクエリスタック全体で一貫して正規化されるようになりました** — `transact-sql` と `transact sql` も `tsql`、`mssql`、`sqlserver` と同様に `sql` へ解決されるため、CLI パーサー経由でも DB reader 直呼びでも同じ挙動になります。
+- **SQL 系の言語別名がクエリスタック全体で一貫して正規化されるようになりました** — `transact-sql`、`transact sql`、そして表示される `transactsql` 表記も `tsql`、`mssql`、`sqlserver` と同様に `sql` へ解決されるため、CLI パーサー経由でも DB reader 直呼びでも同じ挙動になります。

--- a/changelog.d/unreleased/+sql-language-alias-parity.fixed.md
+++ b/changelog.d/unreleased/+sql-language-alias-parity.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **SQL-family language aliases now normalize consistently across the query stack** — `transact-sql` and `transact sql` now resolve to `sql` the same way `tsql`, `mssql`, and `sqlserver` do, so SQL users get the same behavior whether the spelling reaches the CLI parser or the database reader directly.
+
+## 日本語
+
+- **SQL 系の言語別名がクエリスタック全体で一貫して正規化されるようになりました** — `transact-sql` と `transact sql` も `tsql`、`mssql`、`sqlserver` と同様に `sql` へ解決されるため、CLI パーサー経由でも DB reader 直呼びでも同じ挙動になります。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -40,7 +40,7 @@ public static class QueryCommandRunner
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
         ["yaml"] = ["yml"],
-        ["sql"] = ["tsql", "t-sql", "transact-sql", "sqlserver", "mssql"],
+        ["sql"] = ["tsql", "t-sql", "transact-sql", "transactsql", "sqlserver", "mssql"],
     };
     private static readonly HashSet<string> ValueTakingOptions =
     [

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -783,6 +783,7 @@ public partial class DbReader
 
         var compact = lang.Replace("-", string.Empty, StringComparison.Ordinal).Replace(" ", string.Empty, StringComparison.Ordinal);
         return string.Equals(compact, "tsql", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(compact, "transactsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "mssql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "sqlserver", StringComparison.OrdinalIgnoreCase)
             ? "sql"

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -111,6 +111,7 @@ public class QueryCommandRunnerTests
         Assert.Contains("tsql", aliases);
         Assert.Contains("t-sql", aliases);
         Assert.Contains("transact-sql", aliases);
+        Assert.Contains("transactsql", aliases);
         Assert.Contains("sqlserver", aliases);
         Assert.Contains("mssql", aliases);
     }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -115,6 +115,15 @@ public class QueryCommandRunnerTests
         Assert.Contains("mssql", aliases);
     }
 
+    [Theory]
+    [InlineData("transact-sql")]
+    [InlineData("transact sql")]
+    public void NormalizeQueryLanguage_MapsTransactSqlToSql(string input)
+    {
+        Assert.Equal("sql", DbReader.NormalizeQueryLanguage(input));
+        Assert.True(DbReader.IsSqlLanguage(input));
+    }
+
     [Fact]
     public void ParseArgs_AllowsDashPrefixedPositionalQueryLiteral()
     {


### PR DESCRIPTION
## Summary
- Addressed the Follow-up candidates from PR #1340 by making SQL-family language handling consistent across the query stack.
- `DbReader.NormalizeQueryLanguage` now treats `transactsql` as `sql` alongside the existing T-SQL aliases.
- The SQL language display/completion alias table now surfaces `transactsql` as well.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests"`

## Docs and changelog
- Added a bilingual fragment at `changelog.d/unreleased/+sql-language-alias-parity.fixed.md`.
- No additional docs updates were needed because this is a backwards-compatible alias/parity fix.

## Follow-up candidates from PR 1340
- Addressed the original follow-up by surfacing and normalizing the remaining SQL-family spelling `transactsql`.
- No additional follow-up candidates remain from that PR.
