### PR TITLE
Improve Rust raw macro search

### DIFF
--- a/changelog.d/unreleased/+rust-raw-macro-invocations.fixed.md
+++ b/changelog.d/unreleased/+rust-raw-macro-invocations.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Rust raw identifier macro calls are now searchable** — the Rust call extractor recognizes invocations such as `r#type!()` and `crate::r#type!()`, so reference search and graph navigation keep matching the canonical stored name instead of dropping raw-identifier macro sites.
+
+## 日本語
+
+- **Rust の raw identifier を使った macro 呼び出しも検索できるようになりました** — Rust の call extractor が `r#type!()` や `crate::r#type!()` のような呼び出しを認識するため、reference search や graph navigation が raw identifier の macro site を落とさず、保存済みの canonical 名に一致し続けます。

--- a/changelog.d/unreleased/+rust-raw-macro-invocations.fixed.md
+++ b/changelog.d/unreleased/+rust-raw-macro-invocations.fixed.md
@@ -8,8 +8,8 @@ affected:
 
 ## English
 
-- **Rust raw identifier macro calls are now searchable** — the Rust call extractor recognizes invocations such as `r#type!()` and `crate::r#type!()`, so reference search and graph navigation keep matching the canonical stored name instead of dropping raw-identifier macro sites.
+- **Rust raw identifier macro calls are now captured in reference data** — the Rust call extractor recognizes invocations such as `r#type!()` and `crate::r#type!()`, so raw-identifier macro sites are no longer dropped and bare exact searches such as `r#type!` resolve to the canonical stored name.
 
 ## 日本語
 
-- **Rust の raw identifier を使った macro 呼び出しも検索できるようになりました** — Rust の call extractor が `r#type!()` や `crate::r#type!()` のような呼び出しを認識するため、reference search や graph navigation が raw identifier の macro site を落とさず、保存済みの canonical 名に一致し続けます。
+- **Rust の raw identifier を使った macro 呼び出しが reference data に載るようになりました** — Rust の call extractor が `r#type!()` や `crate::r#type!()` のような呼び出しを認識するため、raw identifier の macro site が落ちなくなり、`r#type!` のような bare な exact search も保存済みの canonical 名に解決されます。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -336,6 +336,7 @@ public static class ReferenceExtractor
     private static readonly Regex InlineBlockCommentRegex = new(@"/\*.*?\*/", RegexOptions.Compiled);
     private const string CSharpIdentifierPattern = @"@?[_\p{L}]\w*";
     private const string FunctionalIdentifierPattern = @"@?[_\p{L}\$][\w$]*";
+    private const string RustIdentifierPattern = @"(?:r#)?[_\p{L}][\w$]*";
     private const string FSharpIdentifierPattern = @"(?:``[^`]+``|[_\p{L}][\w']*)";
     private const string CSharpTypeExpressionPattern =
         @"(?:global::)?(?:"
@@ -366,7 +367,7 @@ public static class ReferenceExtractor
     // Rust の macro 呼び出しは共通の末尾 `(` ではなく `!` の後に `()` / `[]` / `{}` を取る。
     // `std::println!` / `log::info!` / `my_macro!` のような path-qualified 名も含めて拾い、
     // `macro_rules` 宣言キーワードは上の Rust ignore list で除外する。
-    private static readonly Regex RustMacroCallRegex = new($@"(?<![\w$])(?<name>{FunctionalIdentifierPattern}(?:::{FunctionalIdentifierPattern})*)(?:<[^>\n]+>)?!\s*[\(\[\{{]", RegexOptions.Compiled);
+    private static readonly Regex RustMacroCallRegex = new($@"(?<![\w$])(?<name>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:<[^>\n]+>)?!\s*[\(\[\{{]", RegexOptions.Compiled);
     // Rust raw identifiers such as `r#type()` are stored without the `r#` prefix, but the shared
     // call regex cannot see them because `#` is not an identifier character. Use a Rust-only
     // matcher for names that contain at least one raw segment and normalize the stored form below.

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -271,6 +271,25 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchReferences_RustRawMacroInvocationsIgnoreRawPrefixAndBang()
+    {
+        InsertIndexedFile(
+            "src/raw.rs",
+            "rust",
+            """
+            fn main() {
+                r#type!();
+            }
+            """);
+
+        var results = _reader.SearchReferences("r#type!", lang: "rust", exact: true);
+
+        var reference = Assert.Single(results);
+        Assert.Equal("type", reference.SymbolName);
+        Assert.Equal("src/raw.rs", reference.Path);
+    }
+
+    [Fact]
     public void RustQualifiedQueriesResolveAcrossGraphCommands()
     {
         InsertIndexedFile(

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -162,6 +162,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustMacroCalls_CaptureRawIdentifierNames()
+    {
+        const string content = """
+            fn main() {
+                r#type!();
+                crate::r#type!();
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        var callReferences = references.Where(reference => reference.ReferenceKind == "call").ToList();
+        Assert.Equal(2, callReferences.Count);
+        Assert.Contains(callReferences, reference =>
+            reference.SymbolName == "type"
+            && reference.ContainerName == "main");
+        Assert.Contains(callReferences, reference =>
+            reference.SymbolName == "crate::type"
+            && reference.ContainerName == "main");
+    }
+
+    [Fact]
     public void Extract_Shell_DetectsCommandStyleFunctionCalls()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Teach the Rust call extractor to recognize raw-identifier macro invocations such as `r#type!()`.
- Add coverage for raw macro extraction and for exact Rust reference search on bare raw macro spellings.
- Add a bilingual changelog fragment documenting the behavior change.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Rust"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/ReferenceExtractor.cs tests/CodeIndex.Tests/ReferenceExtractorTests.cs tests/CodeIndex.Tests/DbReaderTests.cs changelog.d/unreleased/+rust-raw-macro-invocations.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/+rust-raw-macro-invocations.fixed.md`

## Follow-up candidates

- Exact Rust search for path-qualified raw macro calls such as `crate::r#type!()` could be made stricter if we want path-aware macro queries to behave differently from bare raw macro queries.