### PR TITLE
Tighten exact Rust raw macro reference search

### DIFF
--- a/changelog.d/unreleased/+rust-raw-macro-qualified-search.fixed.md
+++ b/changelog.d/unreleased/+rust-raw-macro-qualified-search.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Rust exact reference search now keeps qualified raw macro spellings path-aware** — queries such as `crate::r#type!` stay on the qualified `crate::type` form instead of collapsing to the bare leaf, so the follow-up candidate from PR #1342 is addressed without changing the broader bare `r#type!` behavior.
+
+## 日本語
+
+- **Rust の exact な reference search で qualified な raw macro 表記を path-aware のまま扱うようにしました** — `crate::r#type!` のような query は bare な leaf へ潰さず `crate::type` のまま扱うため、PR #1342 の follow-up candidate を解消しつつ、bare な `r#type!` の挙動はそのまま維持しています。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -955,7 +955,7 @@ public partial class DbReader
     {
         maxLineWidth = LineWidthFormatter.ClampMaxLineWidth(maxLineWidth);
         lang = NormalizeQueryLanguage(lang);
-        query = NormalizeSymbolSearchQuery(query, lang) ?? query ?? string.Empty;
+        query = NormalizeSymbolSearchQuery(query, lang, exact) ?? query ?? string.Empty;
         if (!_hasReferencesTable)
             return new List<ReferenceResult>();
 
@@ -3056,7 +3056,7 @@ public partial class DbReader
 
     public int CountSearchReferences(string? query = null, int limit = 20, string? lang = null, string? referenceKind = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool exact = false)
     {
-        query = NormalizeSymbolSearchQuery(query, lang) ?? query ?? string.Empty;
+        query = NormalizeSymbolSearchQuery(query, lang, exact) ?? query ?? string.Empty;
         if (ShouldApplyCSharpUsingStaticConstantPatternReferenceFilter(lang, referenceKind, exact))
             return SearchReferences(query, limit, lang, referenceKind, pathPatterns, excludePathPatterns, excludeTests, exact).Count;
 
@@ -3156,7 +3156,7 @@ public partial class DbReader
     public QueryCountResult CountSearchReferencesTotal(string? query = null, string? lang = null, string? referenceKind = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool exact = false)
     {
         lang = NormalizeQueryLanguage(lang);
-        query = NormalizeSymbolSearchQuery(query, lang) ?? query ?? string.Empty;
+        query = NormalizeSymbolSearchQuery(query, lang, exact) ?? query ?? string.Empty;
         if (ShouldApplyCSharpUsingStaticConstantPatternReferenceFilter(lang, referenceKind, exact))
             return CountSearchReferencesTotalWithUsingStaticFilter(query, lang, referenceKind, pathPatterns, excludePathPatterns, excludeTests, exact);
 
@@ -3281,7 +3281,7 @@ public partial class DbReader
         if (string.IsNullOrWhiteSpace(query) || IsBareVerbatimQueryToken(query))
             return new List<CallerResult>();
         lang = NormalizeQueryLanguage(lang);
-        query = NormalizeSymbolSearchQuery(query, lang) ?? query ?? string.Empty;
+        query = NormalizeSymbolSearchQuery(query, lang, exact) ?? query ?? string.Empty;
         if (!_hasReferencesTable) return new List<CallerResult>();
         using var cmd = _conn.CreateCommand();
         var referenceLineJoin = ReferenceLineJoinSql("r");
@@ -3421,7 +3421,7 @@ public partial class DbReader
         if (string.IsNullOrWhiteSpace(query) || IsBareVerbatimQueryToken(query))
             return 0;
         lang = NormalizeQueryLanguage(lang);
-        query = NormalizeSymbolSearchQuery(query, lang) ?? query ?? string.Empty;
+        query = NormalizeSymbolSearchQuery(query, lang, exact) ?? query ?? string.Empty;
         if (!_hasReferencesTable) return 0;
         using var cmd = _conn.CreateCommand();
         var referenceLineJoin = ReferenceLineJoinSql("r");
@@ -3597,7 +3597,7 @@ public partial class DbReader
         if (string.IsNullOrWhiteSpace(query) || IsBareVerbatimQueryToken(query))
             return new List<CalleeResult>();
         lang = NormalizeQueryLanguage(lang);
-        query = NormalizeSymbolSearchQuery(query, lang) ?? query ?? string.Empty;
+        query = NormalizeSymbolSearchQuery(query, lang, exact) ?? query ?? string.Empty;
         if (!_hasReferencesTable) return new List<CalleeResult>();
         using var cmd = _conn.CreateCommand();
 
@@ -3731,7 +3731,7 @@ public partial class DbReader
         if (string.IsNullOrWhiteSpace(query) || IsBareVerbatimQueryToken(query))
             return 0;
         lang = NormalizeQueryLanguage(lang);
-        query = NormalizeSymbolSearchQuery(query, lang) ?? query ?? string.Empty;
+        query = NormalizeSymbolSearchQuery(query, lang, exact) ?? query ?? string.Empty;
         if (!_hasReferencesTable) return 0;
         using var cmd = _conn.CreateCommand();
         var groupedSql = @"

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -571,10 +571,10 @@ public partial class DbReader
             : new QueryCountResult(0, 0);
     }
 
-    private static string? NormalizeSymbolSearchQuery(string? query, string? lang)
+    private static string? NormalizeSymbolSearchQuery(string? query, string? lang, bool exact = false)
     {
         if (!string.IsNullOrWhiteSpace(lang) && string.Equals(lang, "rust", StringComparison.OrdinalIgnoreCase))
-            return NormalizeRustSymbolSearchQuery(query);
+            return NormalizeRustSymbolSearchQuery(query, exact);
 
         if (!string.IsNullOrWhiteSpace(lang) && string.Equals(lang, "javascript", StringComparison.OrdinalIgnoreCase))
             return NormalizeJavaScriptSymbolSearchQuery(query);
@@ -611,7 +611,7 @@ public partial class DbReader
         return trimmed.Length == 0 ? null : trimmed;
     }
 
-    private static string? NormalizeRustSymbolSearchQuery(string? query)
+    private static string? NormalizeRustSymbolSearchQuery(string? query, bool exact = false)
     {
         if (query == null)
             return null;
@@ -620,20 +620,37 @@ public partial class DbReader
         if (trimmed.Length == 0)
             return null;
 
-        if (trimmed.EndsWith("!", StringComparison.Ordinal))
-            trimmed = trimmed[..^1].TrimEnd();
+        var macroQuery = trimmed;
+        var isMacroQuery = macroQuery.EndsWith("!", StringComparison.Ordinal);
+        if (isMacroQuery)
+            macroQuery = macroQuery[..^1].TrimEnd();
 
-        if (trimmed.Length == 0)
+        if (macroQuery.Length == 0)
             return null;
 
-        var leafIndex = trimmed.LastIndexOf("::", StringComparison.Ordinal);
+        if (exact && isMacroQuery && macroQuery.Contains("::", StringComparison.Ordinal) && macroQuery.Contains("r#", StringComparison.Ordinal))
+            return NormalizeRustQualifiedMacroQuery(macroQuery);
+
+        var leafIndex = macroQuery.LastIndexOf("::", StringComparison.Ordinal);
         if (leafIndex >= 0)
-            trimmed = trimmed[(leafIndex + 2)..].Trim();
+            macroQuery = macroQuery[(leafIndex + 2)..].Trim();
 
-        if (trimmed.StartsWith("r#", StringComparison.Ordinal))
-            trimmed = trimmed[2..];
+        if (macroQuery.StartsWith("r#", StringComparison.Ordinal))
+            macroQuery = macroQuery[2..];
 
-        return trimmed.Length == 0 ? null : trimmed;
+        return macroQuery.Length == 0 ? null : macroQuery;
+    }
+
+    private static string? NormalizeRustQualifiedMacroQuery(string query)
+    {
+        var segments = query
+            .Split("::", StringSplitOptions.None)
+            .Select(segment => segment.Trim())
+            .Where(segment => segment.Length > 0)
+            .Select(segment => segment.StartsWith("r#", StringComparison.Ordinal) ? segment[2..] : segment)
+            .ToList();
+
+        return segments.Count == 0 ? null : string.Join("::", segments);
     }
 
     /// <summary>

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -290,6 +290,25 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchReferences_RustQualifiedRawMacroInvocationsStayPathAware()
+    {
+        InsertIndexedFile(
+            "src/raw.rs",
+            "rust",
+            """
+            fn main() {
+                crate::r#type!();
+            }
+            """);
+
+        var results = _reader.SearchReferences("crate::r#type!", lang: "rust", exact: true);
+
+        var reference = Assert.Single(results);
+        Assert.Equal("crate::type", reference.SymbolName);
+        Assert.Equal("src/raw.rs", reference.Path);
+    }
+
+    [Fact]
     public void RustQualifiedQueriesResolveAcrossGraphCommands()
     {
         InsertIndexedFile(


### PR DESCRIPTION
## Summary

This PR addresses the follow-up candidate from PR #1342 by making exact Rust reference search path-aware for qualified raw macro calls such as `crate::r#type!()`.

## Changes

- Preserve qualified raw macro spellings during exact Rust reference normalization.
- Keep bare raw macro lookups unchanged.
- Add regression coverage for both bare and qualified raw macro searches.
- Add a changelog fragment in the standard unreleased fixed format.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.SearchReferences_Rust"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Rust"`