### PR TITLE
Add `ts` alias for TypeScript search filtering

### DIFF
--- a/changelog.d/unreleased/+typescript-lang-alias.fixed.md
+++ b/changelog.d/unreleased/+typescript-lang-alias.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`--lang ts` now filters TypeScript results** — query commands treat `ts` as `typescript`, and TypeScript is now listed among the language aliases, so searches and completions accept the common shorthand instead of requiring the full language name.
+
+## 日本語
+
+- **`--lang ts` で TypeScript の結果を絞り込めるようになりました** — クエリ系コマンドで `ts` を `typescript` として扱い、TypeScript も言語別名として列挙するため、検索や補完で長い正式名を毎回入力しなくても済みます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -34,12 +34,14 @@ public static class QueryCommandRunner
         ["yml"] = "yaml",
         ["kt"] = "kotlin",
         ["kts"] = "kotlin",
+        ["ts"] = "typescript",
         ["tsql"] = "sql",
         ["transactsql"] = "sql",
     };
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
         ["yaml"] = ["yml"],
+        ["typescript"] = ["ts"],
         ["sql"] = ["tsql", "t-sql", "transact-sql", "transactsql", "sqlserver", "mssql"],
     };
     private static readonly HashSet<string> ValueTakingOptions =

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -782,6 +782,8 @@ public partial class DbReader
             return null;
 
         var compact = lang.Replace("-", string.Empty, StringComparison.Ordinal).Replace(" ", string.Empty, StringComparison.Ordinal);
+        if (string.Equals(compact, "ts", StringComparison.OrdinalIgnoreCase))
+            return "typescript";
         return string.Equals(compact, "tsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "transactsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "mssql", StringComparison.OrdinalIgnoreCase)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -116,6 +116,14 @@ public class QueryCommandRunnerTests
         Assert.Contains("mssql", aliases);
     }
 
+    [Fact]
+    public void GetLanguageAliases_ReportsTypeScriptAlias()
+    {
+        var aliases = QueryCommandRunner.GetLanguageAliases("typescript");
+
+        Assert.Contains("ts", aliases);
+    }
+
     [Theory]
     [InlineData("transact-sql")]
     [InlineData("transact sql")]
@@ -123,6 +131,13 @@ public class QueryCommandRunnerTests
     {
         Assert.Equal("sql", DbReader.NormalizeQueryLanguage(input));
         Assert.True(DbReader.IsSqlLanguage(input));
+    }
+
+    [Fact]
+    public void NormalizeQueryLanguage_MapsTsToTypeScript()
+    {
+        Assert.Equal("typescript", DbReader.NormalizeQueryLanguage("ts"));
+        Assert.False(DbReader.IsSqlLanguage("ts"));
     }
 
     [Fact]
@@ -8517,6 +8532,37 @@ jobs:
             Assert.Equal(CommandExitCodes.Success, withExclude.Result);
             Assert.Equal("0", withExclude.Stdout.Trim());
             Assert.Equal(string.Empty, withExclude.Stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_WithTypeScriptLangAliasFiltersTypeScriptFiles()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_typescript_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/app.ts",
+                "typescript",
+                """
+                export function hit() {
+                    return "TypeScript";
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["TypeScript", "--db", dbPath, "--lang", "ts", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Accept `--lang ts` as an alias for `typescript` in query commands and reader-level language normalization.
- Expose the TypeScript alias in language metadata.
- Add tests covering alias discovery and TypeScript-filtered search.
- Include the required changelog fragment.

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.GetLanguageAliases_ReportsTypeScriptAlias|FullyQualifiedName~QueryCommandRunnerTests.NormalizeQueryLanguage_MapsTsToTypeScript|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_WithTypeScriptLangAliasFiltersTypeScriptFiles"`