### PR TITLE
Expand TypeScript `--lang` shorthands

### DIFF
--- a/changelog.d/unreleased/+typescript-lang-family-followup.fixed.md
+++ b/changelog.d/unreleased/+typescript-lang-family-followup.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **TypeScript language shorthands now cover the full file-extension family** — `--lang` accepts `ts`, `tsx`, `cts`, and `mts`, the language metadata/completion aliases surface the same set, and the CLI help text now advertises them so TypeScript-family files can be filtered with the shorthand that matches their extension.
+
+## 日本語
+
+- **TypeScript の言語 shorthand が拡張子ファミリー全体をカバーするようになりました** — `--lang` は `ts` / `tsx` / `cts` / `mts` を受け付け、言語メタデータと補完の alias も同じ集合を返し、CLI の help でもその alias 群を案内するため、TypeScript 系ファイルを拡張子に沿った shorthand で絞り込めます。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -385,7 +385,7 @@ public static class ConsoleUi
         Console.WriteLine("  --db <path>                Database file path (default: .cdidx/codeindex.db in current directory)");
         Console.WriteLine("  --json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)");
         Console.WriteLine("  --limit <n>, --top <n>     Max results to return (default: 20)");
-        Console.WriteLine("  --lang <lang>              Filter by language (aliases: bat, cmd)");
+        Console.WriteLine("  --lang <lang>              Filter by language (aliases: bat, cmd, ts, tsx, cts, mts)");
         Console.WriteLine("  --path <glob>              Restrict matches to glob-style path patterns (* and ?)");
         Console.WriteLine("  --query <query>            Pass a query literal, useful when the query starts with '-'");
         Console.WriteLine("  --exclude-path <glob>      Exclude glob-style path patterns (* and ?) (repeatable)");

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -35,13 +35,16 @@ public static class QueryCommandRunner
         ["kt"] = "kotlin",
         ["kts"] = "kotlin",
         ["ts"] = "typescript",
+        ["tsx"] = "typescript",
+        ["cts"] = "typescript",
+        ["mts"] = "typescript",
         ["tsql"] = "sql",
         ["transactsql"] = "sql",
     };
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
         ["yaml"] = ["yml"],
-        ["typescript"] = ["ts"],
+        ["typescript"] = ["ts", "tsx", "cts", "mts"],
         ["sql"] = ["tsql", "t-sql", "transact-sql", "transactsql", "sqlserver", "mssql"],
     };
     private static readonly HashSet<string> ValueTakingOptions =

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -784,6 +784,12 @@ public partial class DbReader
         var compact = lang.Replace("-", string.Empty, StringComparison.Ordinal).Replace(" ", string.Empty, StringComparison.Ordinal);
         if (string.Equals(compact, "ts", StringComparison.OrdinalIgnoreCase))
             return "typescript";
+        if (string.Equals(compact, "tsx", StringComparison.OrdinalIgnoreCase))
+            return "typescript";
+        if (string.Equals(compact, "cts", StringComparison.OrdinalIgnoreCase))
+            return "typescript";
+        if (string.Equals(compact, "mts", StringComparison.OrdinalIgnoreCase))
+            return "typescript";
         return string.Equals(compact, "tsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "transactsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "mssql", StringComparison.OrdinalIgnoreCase)

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -59,7 +59,7 @@ public class ConsoleUiTests
         Assert.Contains("cdidx unused [--db <path>] [--json] [--limit <n>] [--kind <kind>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count]", output);
         Assert.Contains("cdidx hotspots [--db <path>] [--json] [--limit <n>] [--kind <kind>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count] [--group-by-name]", output);
         Assert.Contains("--json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)", output);
-        Assert.Contains("--lang <lang>              Filter by language (aliases: bat, cmd)", output);
+        Assert.Contains("--lang <lang>              Filter by language (aliases: bat, cmd, ts, tsx, cts, mts)", output);
         Assert.Contains("--group-by-name            hotspots: collapse rows sharing (name, kind) across files into one line", output);
         Assert.Contains("cdidx search \"Run();\" --exact-substring        Case-sensitive exact substring search", output);
         Assert.Contains("cdidx search --query --path --path README.md   Search for a literal option token", output);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -122,6 +122,9 @@ public class QueryCommandRunnerTests
         var aliases = QueryCommandRunner.GetLanguageAliases("typescript");
 
         Assert.Contains("ts", aliases);
+        Assert.Contains("tsx", aliases);
+        Assert.Contains("cts", aliases);
+        Assert.Contains("mts", aliases);
     }
 
     [Theory]
@@ -133,11 +136,15 @@ public class QueryCommandRunnerTests
         Assert.True(DbReader.IsSqlLanguage(input));
     }
 
-    [Fact]
-    public void NormalizeQueryLanguage_MapsTsToTypeScript()
+    [Theory]
+    [InlineData("ts")]
+    [InlineData("tsx")]
+    [InlineData("cts")]
+    [InlineData("mts")]
+    public void NormalizeQueryLanguage_MapsTypeScriptShorthands(string input)
     {
-        Assert.Equal("typescript", DbReader.NormalizeQueryLanguage("ts"));
-        Assert.False(DbReader.IsSqlLanguage("ts"));
+        Assert.Equal("typescript", DbReader.NormalizeQueryLanguage(input));
+        Assert.False(DbReader.IsSqlLanguage(input));
     }
 
     [Fact]
@@ -209,6 +216,9 @@ public class QueryCommandRunnerTests
     [InlineData("yml", "yaml")]
     [InlineData("kt", "kotlin")]
     [InlineData("KTS", "kotlin")]
+    [InlineData("tsx", "typescript")]
+    [InlineData("CTS", "typescript")]
+    [InlineData("mts", "typescript")]
     [InlineData("T-SQL", "sql")]
     [InlineData("transact-sql", "sql")]
     [InlineData("transact sql", "sql")]
@@ -8540,7 +8550,7 @@ jobs:
     }
 
     [Fact]
-    public void RunSearch_WithTypeScriptLangAliasFiltersTypeScriptFiles()
+    public void RunSearch_WithTypeScriptLangAliasesFiltersTypeScriptFiles()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_typescript_lang_alias");
         try
@@ -8556,13 +8566,16 @@ jobs:
                 }
                 """);
 
-            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
-                ["TypeScript", "--db", dbPath, "--lang", "ts", "--count"],
-                _jsonOptions));
+            foreach (var langAlias in new[] { "ts", "tsx", "cts", "mts" })
+            {
+                var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                    ["TypeScript", "--db", dbPath, "--lang", langAlias, "--count"],
+                    _jsonOptions));
 
-            Assert.Equal(CommandExitCodes.Success, exitCode);
-            Assert.Equal("1", stdout.Trim());
-            Assert.Equal(string.Empty, stderr);
+                Assert.Equal(CommandExitCodes.Success, exitCode);
+                Assert.Equal("1", stdout.Trim());
+                Assert.Equal(string.Empty, stderr);
+            }
         }
         finally
         {


### PR DESCRIPTION
This PR addresses the follow-up candidates from PR #1344 by expanding the TypeScript `--lang` shorthand family to include `tsx`, `cts`, and `mts`.

Changes:
- Accept `ts`, `tsx`, `cts`, and `mts` as TypeScript language shorthands.
- Surface the same aliases in language metadata, completions, and CLI help.
- Add targeted tests covering alias normalization and end-to-end search filtering.
- Include a changelog fragment in `changelog.d/unreleased/`.

Verification:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests.PrintUsage_WithoutBanner_HidesAsciiArtAndEasterEggFlags|FullyQualifiedName~ConsoleUiTests.PrintUsage_QueryLinesMatchImplementedOptions|FullyQualifiedName~QueryCommandRunnerTests.GetLanguageAliases_ReportsTypeScriptAlias|FullyQualifiedName~QueryCommandRunnerTests.NormalizeQueryLanguage_MapsTypeScriptShorthands|FullyQualifiedName~QueryCommandRunnerTests.ParseArgs_NormalizesLangAliases|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_WithTypeScriptLangAliasesFiltersTypeScriptFiles"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`