### PR TITLE
Fix cshtml search language aliases

### DIFF
--- a/changelog.d/unreleased/+cshtml-lang-aliases.fixed.md
+++ b/changelog.d/unreleased/+cshtml-lang-aliases.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Razor pages now accept `cshtml` and `razor` as C# language filters** — `search --lang cshtml` and `search --lang razor` now normalize to `csharp`, so Razor/Blazor files stay searchable through the CLI and database query APIs.
+
+## 日本語
+
+- **Razor ページで `cshtml` と `razor` を C# の言語フィルタとして使えるようにしました** — `search --lang cshtml` と `search --lang razor` が `csharp` に正規化されるため、Razor/Blazor ファイルを CLI と DB クエリ API の両方から引き続き検索できます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -25,6 +25,7 @@ public static class QueryCommandRunner
     {
         ["c#"] = "csharp",
         ["cs"] = "csharp",
+        ["cshtml"] = "csharp",
         ["bat"] = "batch",
         ["cmd"] = "batch",
         ["py"] = "python",
@@ -32,6 +33,7 @@ public static class QueryCommandRunner
         ["pyi"] = "python",
         ["pyw"] = "python",
         ["yml"] = "yaml",
+        ["razor"] = "csharp",
         ["kt"] = "kotlin",
         ["kts"] = "kotlin",
         ["ts"] = "typescript",

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -790,6 +790,10 @@ public partial class DbReader
             return "typescript";
         if (string.Equals(compact, "mts", StringComparison.OrdinalIgnoreCase))
             return "typescript";
+        if (string.Equals(compact, "cshtml", StringComparison.OrdinalIgnoreCase))
+            return "csharp";
+        if (string.Equals(compact, "razor", StringComparison.OrdinalIgnoreCase))
+            return "csharp";
         return string.Equals(compact, "tsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "transactsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "mssql", StringComparison.OrdinalIgnoreCase)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -466,6 +466,25 @@ public class DbReaderTests : IDisposable
         Assert.Empty(pyResults);
     }
 
+    [Theory]
+    [InlineData("cshtml")]
+    [InlineData("razor")]
+    public void Search_FiltersByCSharpRazorAliases(string lang)
+    {
+        var queryToken = $"razor_lang_alias_{Guid.NewGuid():N}";
+        InsertIndexedFile(
+            "web/Views/Home/Index.cshtml",
+            "csharp",
+            $@"@{{
+    var marker = ""{queryToken}"";
+}}");
+
+        var results = _reader.Search(queryToken, lang: lang);
+
+        Assert.Single(results);
+        Assert.Equal("web/Views/Home/Index.cshtml", results[0].Path);
+    }
+
     [Fact]
     public void Search_RespectsLimit()
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -232,9 +232,11 @@ public class QueryCommandRunnerTests
     [Theory]
     [InlineData("c#")]
     [InlineData("cs")]
+    [InlineData("cshtml")]
     [InlineData("Java")]
     [InlineData("kt")]
     [InlineData("kts")]
+    [InlineData("razor")]
     public void RunSearch_NormalizesCommonLanguageAliases(string input)
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_lang_alias");


### PR DESCRIPTION
## Summary
- accept `cshtml` and `razor` as C# language filters in the CLI and DB query layer
- add tests covering CLI parsing and `DbReader.Search` language filtering
- add a changelog fragment for the behavior change

## Verification
- `dotnet test /Users/widthdom/CodeIndex/CodeIndex.sln --filter "FullyQualifiedName~CodeIndex.Tests.QueryCommandRunnerTests|FullyQualifiedName~CodeIndex.Tests.DbReaderTests"`

## Follow-up candidates
- Surface `cshtml`/`razor` in the `languages` command alias display and completion help so the new filters are discoverable.
- Add one end-to-end CLI test that invokes the published `cdidx search --lang cshtml` binary path, not just the in-process runner.