### PR TITLE
Address follow-up candidates from PR 1346

### DIFF
--- a/changelog.d/unreleased/+cshtml-razor-discoverability.fixed.md
+++ b/changelog.d/unreleased/+cshtml-razor-discoverability.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Razor language aliases are now discoverable in language help and completion** — `languages` and `--lang` help now surface `cshtml` and `razor`, and shell completions include those aliases so published CLI users can find the new search filters.
+
+## 日本語
+
+- **Razor の言語エイリアスが language help と補完で見つけやすくなりました** — `languages` と `--lang` のヘルプで `cshtml` と `razor` が表示され、シェル補完にも含まれるため、公開済み CLI から新しい検索フィルタを見つけやすくなります。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -385,7 +385,7 @@ public static class ConsoleUi
         Console.WriteLine("  --db <path>                Database file path (default: .cdidx/codeindex.db in current directory)");
         Console.WriteLine("  --json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)");
         Console.WriteLine("  --limit <n>, --top <n>     Max results to return (default: 20)");
-        Console.WriteLine("  --lang <lang>              Filter by language (aliases: bat, cmd, ts, tsx, cts, mts)");
+        Console.WriteLine("  --lang <lang>              Filter by language (aliases: bat, cmd, cshtml, razor, ts, tsx, cts, mts)");
         Console.WriteLine("  --path <glob>              Restrict matches to glob-style path patterns (* and ?)");
         Console.WriteLine("  --query <query>            Pass a query literal, useful when the query starts with '-'");
         Console.WriteLine("  --exclude-path <glob>      Exclude glob-style path patterns (* and ?) (repeatable)");
@@ -777,7 +777,7 @@ _cdidx";
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find excerpt map inspect outline status' -l db -r -d 'Database path'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find excerpt map inspect outline status' -l json -d 'JSON output'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l limit -r -d 'Max results'");
-        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l lang -r -d 'Filter by language'");
+        lines.Add($"complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l lang -r -a '{GetCompletionLangs()}' -d 'Filter by language'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l count -d 'Count only'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l path -r -d 'Path filter'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l exclude-path -r -d 'Exclude path'");

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -45,6 +45,7 @@ public static class QueryCommandRunner
     };
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
+        ["csharp"] = ["cshtml", "razor"],
         ["yaml"] = ["yml"],
         ["typescript"] = ["ts", "tsx", "cts", "mts"],
         ["sql"] = ["tsql", "t-sql", "transact-sql", "transactsql", "sqlserver", "mssql"],

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -59,7 +59,7 @@ public class ConsoleUiTests
         Assert.Contains("cdidx unused [--db <path>] [--json] [--limit <n>] [--kind <kind>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count]", output);
         Assert.Contains("cdidx hotspots [--db <path>] [--json] [--limit <n>] [--kind <kind>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count] [--group-by-name]", output);
         Assert.Contains("--json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)", output);
-        Assert.Contains("--lang <lang>              Filter by language (aliases: bat, cmd, ts, tsx, cts, mts)", output);
+        Assert.Contains("--lang <lang>              Filter by language (aliases: bat, cmd, cshtml, razor, ts, tsx, cts, mts)", output);
         Assert.Contains("--group-by-name            hotspots: collapse rows sharing (name, kind) across files into one line", output);
         Assert.Contains("cdidx search \"Run();\" --exact-substring        Case-sensitive exact substring search", output);
         Assert.Contains("cdidx search --query --path --path README.md   Search for a literal option token", output);
@@ -209,6 +209,8 @@ public class ConsoleUiTests
                 Assert.Contains(groupByNameToken, output);
                 Assert.Contains(licenseToken, output);
                 Assert.Contains(maxLineWidthToken, output);
+                Assert.Contains("cshtml", output);
+                Assert.Contains("razor", output);
                 if (shell == "zsh")
                     Assert.Contains("--max-line-width[Clamp long single-line contexts (0 disables clamping)]:number", output);
                 if (shell is "bash" or "zsh")

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -969,6 +969,46 @@ jobs:
     }
 
     [Theory]
+    [InlineData("cshtml")]
+    [InlineData("razor")]
+    public void RunPublishedTrimmedCli_SearchSupportsCSharpRazorAliases(string lang)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_trimmed_lang_alias_publish");
+        var publishDir = Path.Combine(Path.GetTempPath(), $"cdidx_query_trimmed_lang_alias_publish_{Guid.NewGuid():N}");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = $"TrimmedPublishLangAliasNeedle_{Guid.NewGuid():N}";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "web/Views/Home/Index.cshtml",
+                "csharp",
+                $$"""
+                @{
+                    var marker = "{{queryToken}}";
+                }
+                """);
+
+            var publishedDll = PublishTrimmedCli(publishDir);
+
+            var (exitCode, stdout, stderr) = RunPublishedCli(publishedDll, publishDir, "search", queryToken, "--db", dbPath, "--lang", lang, "--count", "--json");
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+
+            using var document = JsonDocument.Parse(stdout);
+            Assert.Equal(1, document.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, document.RootElement.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TestProjectHelper.DeleteDirectory(projectRoot);
+            TestProjectHelper.DeleteDirectory(publishDir);
+        }
+    }
+
+    [Theory]
     [InlineData("definition", "--focus-column", "10")]
     [InlineData("definition", "--max-line-width", "10")]
     [InlineData("search", "--focus-column", "10")]
@@ -1612,6 +1652,23 @@ jobs:
         Assert.Contains(".htm", extensions);
         Assert.Contains(".xhtml", extensions);
         Assert.Contains(".shtml", extensions);
+    }
+
+    [Fact]
+    public void RunLanguages_JsonListsCSharpRazorAliases()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunLanguages(["--json"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+
+        using var document = ParseJsonOutput(stdout);
+        var languages = document.RootElement.GetProperty("languages");
+        var csharp = languages.EnumerateArray().First(lang => lang.GetProperty("lang").GetString() == "csharp");
+        var aliases = csharp.GetProperty("aliases").EnumerateArray().Select(alias => alias.GetString()).ToList();
+
+        Assert.Contains("cshtml", aliases);
+        Assert.Contains("razor", aliases);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -1783,7 +1783,7 @@ jobs:
         // Sanity: short rows still fit the fixed-width layout on a single line.
         // 短い行は従来通り 1 行の固定幅レイアウトに収まる。
         var csharpLine = lines.Single(line => line.StartsWith("csharp ", StringComparison.Ordinal));
-        Assert.Matches(@"^csharp\s+\.cs\s+\.cshtml\s+\.razor\s+-\s+yes\s+yes\s*$", csharpLine);
+        Assert.Matches(@"^csharp\s+\.cs\s+\.cshtml\s+\.razor\s+cshtml\s+razor\s+yes\s+yes\s*$", csharpLine);
 
         // Dockerfile / Makefile / Python / Ruby / MSBuild rows spill extensions to a continuation line.
         // Dockerfile / Makefile / Python / Ruby / MSBuild 行は拡張子を継続行に退避する。


### PR DESCRIPTION
## Summary
- surface `cshtml` and `razor` in `languages` output and `--lang` help/completions
- add an end-to-end published CLI regression for `search --lang cshtml`/`razor`
- include a changelog fragment for the discoverability change

## Context
This PR addresses the follow-up candidates called out in PR #1346.

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests.PrintCompletions_KnownShell_ReturnsTrue|FullyQualifiedName~ConsoleUiTests.PrintUsage_WithoutBanner_HidesAsciiArtAndEasterEggFlags|FullyQualifiedName~QueryCommandRunnerTests.RunLanguages_JsonListsCSharpRazorAliases|FullyQualifiedName~QueryCommandRunnerTests.RunPublishedTrimmedCli_"`