### PR TITLE
Normalize XAML aliases to XML search

### DIFF
--- a/changelog.d/unreleased/+xml-xaml-lang-aliases.fixed.md
+++ b/changelog.d/unreleased/+xml-xaml-lang-aliases.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **XAML language aliases now resolve to XML search** — query filters now canonicalize `xaml` and `axaml` to `xml`, so indexed `.xaml` and `.axaml` files stay searchable whether users type the file format name or the canonical language name.
+
+## 日本語
+
+- **XAML の言語別名が XML 検索に正規化されるようになりました** — クエリフィルタが `xaml` と `axaml` を `xml` に正規化するため、`xml` で索引された `.xaml` / `.axaml` ファイルをファイル形式名でも canonical な言語名でも検索できます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -42,6 +42,8 @@ public static class QueryCommandRunner
         ["mts"] = "typescript",
         ["tsql"] = "sql",
         ["transactsql"] = "sql",
+        ["xaml"] = "xml",
+        ["axaml"] = "xml",
     };
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
@@ -49,6 +51,7 @@ public static class QueryCommandRunner
         ["yaml"] = ["yml"],
         ["typescript"] = ["ts", "tsx", "cts", "mts"],
         ["sql"] = ["tsql", "t-sql", "transact-sql", "transactsql", "sqlserver", "mssql"],
+        ["xml"] = ["xaml", "axaml"],
     };
     private static readonly HashSet<string> ValueTakingOptions =
     [

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -794,6 +794,10 @@ public partial class DbReader
             return "csharp";
         if (string.Equals(compact, "razor", StringComparison.OrdinalIgnoreCase))
             return "csharp";
+        if (string.Equals(compact, "xaml", StringComparison.OrdinalIgnoreCase))
+            return "xml";
+        if (string.Equals(compact, "axaml", StringComparison.OrdinalIgnoreCase))
+            return "xml";
         return string.Equals(compact, "tsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "transactsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "mssql", StringComparison.OrdinalIgnoreCase)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -467,6 +467,31 @@ public class DbReaderTests : IDisposable
     }
 
     [Theory]
+    [InlineData("xaml")]
+    [InlineData("axaml")]
+    public void Search_FiltersByXamlLanguageAliases(string lang)
+    {
+        var queryToken = $"xaml_alias_{Guid.NewGuid():N}";
+
+        InsertIndexedFile(
+            "src/MainWindow.xaml",
+            "xml",
+            $$"""
+            <Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                <Grid>
+                    <TextBlock Text="{{queryToken}}" />
+                </Grid>
+            </Window>
+            """);
+
+        var results = _reader.Search(queryToken, lang: lang);
+
+        Assert.Single(results);
+        Assert.Equal("src/MainWindow.xaml", results[0].Path);
+    }
+
+    [Theory]
     [InlineData("cshtml")]
     [InlineData("razor")]
     public void Search_FiltersByCSharpRazorAliases(string lang)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -127,6 +127,15 @@ public class QueryCommandRunnerTests
         Assert.Contains("mts", aliases);
     }
 
+    [Fact]
+    public void GetLanguageAliases_ReportsXmlAliases()
+    {
+        var aliases = QueryCommandRunner.GetLanguageAliases("xml");
+
+        Assert.Contains("xaml", aliases);
+        Assert.Contains("axaml", aliases);
+    }
+
     [Theory]
     [InlineData("transact-sql")]
     [InlineData("transact sql")]
@@ -145,6 +154,14 @@ public class QueryCommandRunnerTests
     {
         Assert.Equal("typescript", DbReader.NormalizeQueryLanguage(input));
         Assert.False(DbReader.IsSqlLanguage(input));
+    }
+
+    [Theory]
+    [InlineData("xaml")]
+    [InlineData("axaml")]
+    public void NormalizeQueryLanguage_MapsXamlShorthandsToXml(string input)
+    {
+        Assert.Equal("xml", DbReader.NormalizeQueryLanguage(input));
     }
 
     [Fact]
@@ -195,6 +212,43 @@ public class QueryCommandRunnerTests
             Assert.Equal(CommandExitCodes.Success, xmlExitCode);
             Assert.Equal("0", xmlStdout.Trim());
             Assert.Equal(string.Empty, xmlStderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData("xaml")]
+    [InlineData("axaml")]
+    public void RunSearch_RecognizesXamlLanguageAliases(string lang)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_xaml_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = $"xaml_lang_alias_{Guid.NewGuid():N}";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/MainWindow.xaml",
+                "xml",
+                $$"""
+                <Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    <Grid>
+                        <TextBlock Text="{{queryToken}}" />
+                    </Grid>
+                </Window>
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--lang", lang, "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Canonicalize `xaml` and `axaml` to `xml` in query language normalization
- Surface `xaml` / `axaml` as XML aliases in CLI language help
- Add regression tests for the reader and CLI search paths
- Add a changelog fragment for the fix

## Verification
- `dotnet test /Users/widthdom/CodeIndex/tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests|FullyQualifiedName~QueryCommandRunnerTests"`
- `dotnet test /Users/widthdom/CodeIndex/tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.Search_FiltersByXamlLanguageAliases|FullyQualifiedName~QueryCommandRunnerTests.NormalizeQueryLanguage_MapsXamlShorthandsToXml|FullyQualifiedName~QueryCommandRunnerTests.GetLanguageAliases_ReportsXmlAliases|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_RecognizesXamlLanguageAliases"`