### PR TITLE
Improve Rust search language aliasing

### DIFF
--- a/changelog.d/unreleased/+rust-lang-alias-search.fixed.md
+++ b/changelog.d/unreleased/+rust-lang-alias-search.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Rust search now accepts `rs` as a language alias** — query commands normalize `rs`, `r-s`, and `r s` to `rust`, and the CLI help alias list now advertises the shorthand, so Rust searches work with the form many users type first.
+
+## 日本語
+
+- **Rust 検索で `rs` を言語別名として受け付けるようになりました** — クエリ系コマンドが `rs`、`r-s`、`r s` を `rust` に正規化し、CLI の別名一覧にも短縮形が載るため、Rust 検索を多くの利用者が最初に入力する表記で実行できます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -50,6 +50,7 @@ public static class QueryCommandRunner
         ["csharp"] = ["cshtml", "razor"],
         ["yaml"] = ["yml"],
         ["typescript"] = ["ts", "tsx", "cts", "mts"],
+        ["rust"] = ["rs"],
         ["sql"] = ["tsql", "t-sql", "transact-sql", "transactsql", "sqlserver", "mssql"],
         ["xml"] = ["xaml", "axaml"],
     };

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -798,6 +798,8 @@ public partial class DbReader
             return "xml";
         if (string.Equals(compact, "axaml", StringComparison.OrdinalIgnoreCase))
             return "xml";
+        if (string.Equals(compact, "rs", StringComparison.OrdinalIgnoreCase))
+            return "rust";
         return string.Equals(compact, "tsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "transactsql", StringComparison.OrdinalIgnoreCase)
             || string.Equals(compact, "mssql", StringComparison.OrdinalIgnoreCase)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -128,6 +128,14 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void GetLanguageAliases_ReportsRustAlias()
+    {
+        var aliases = QueryCommandRunner.GetLanguageAliases("rust");
+
+        Assert.Contains("rs", aliases);
+    }
+
+    [Fact]
     public void GetLanguageAliases_ReportsXmlAliases()
     {
         var aliases = QueryCommandRunner.GetLanguageAliases("xml");
@@ -162,6 +170,15 @@ public class QueryCommandRunnerTests
     public void NormalizeQueryLanguage_MapsXamlShorthandsToXml(string input)
     {
         Assert.Equal("xml", DbReader.NormalizeQueryLanguage(input));
+    }
+
+    [Theory]
+    [InlineData("rs")]
+    [InlineData("r-s")]
+    [InlineData("r s")]
+    public void NormalizeQueryLanguage_MapsRustShorthand(string input)
+    {
+        Assert.Equal("rust", DbReader.NormalizeQueryLanguage(input));
     }
 
     [Fact]
@@ -240,6 +257,41 @@ public class QueryCommandRunnerTests
                         <TextBlock Text="{{queryToken}}" />
                     </Grid>
                 </Window>
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--lang", lang, "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData("rs")]
+    [InlineData("r-s")]
+    [InlineData("r s")]
+    public void RunSearch_RecognizesRustLanguageAlias(string lang)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_rust_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = $"rust_lang_alias_{Guid.NewGuid():N}";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/lib.rs",
+                "rust",
+                $$"""
+                pub fn hit() {
+                    let _ = "{{queryToken}}";
+                }
                 """);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(


### PR DESCRIPTION
## Summary
- Normalize `rs` to `rust` in shared language filtering so Rust searches accept the common shorthand
- Advertise `rs` in the CLI language alias list
- Add regression coverage for search, normalization, and alias reporting

## Verification
- `dotnet test CodeIndex.sln --filter "FullyQualifiedName~DbReaderTests.SearchSymbols_RustMacroQueriesIgnoreTrailingBang|FullyQualifiedName~DbReaderTests.SearchSymbols_RustQualifiedQueriesResolveToLeafNames|FullyQualifiedName~QueryCommandRunnerTests.GetLanguageAliases_ReportsRustAlias|FullyQualifiedName~QueryCommandRunnerTests.NormalizeQueryLanguage_MapsRustShorthand|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_RecognizesRustLanguageAlias"`