### PR TITLE
Normalize JavaScript and TypeScript search aliases

### DIFF
--- a/changelog.d/unreleased/+javascript-lang-normalization.fixed.md
+++ b/changelog.d/unreleased/+javascript-lang-normalization.fixed.md
@@ -2,13 +2,16 @@
 category: fixed
 affected:
   - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
   - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
 ---
 
 ## English
 
 - **JavaScript search now normalizes `Javascript` spelling variants** — direct search calls now canonicalize the JavaScript language filter before applying the SQL `lang` predicate, so mixed-casing spellings like `Javascript` still return the indexed JavaScript rows users expect.
+- **JavaScript search now normalizes `Javascript`, `js`, and `jsx` spelling variants** — direct search calls now canonicalize the JavaScript language filter before applying the SQL `lang` predicate, so mixed-casing spellings like `Javascript`, `JS`, and `JSX` still return the indexed JavaScript rows users expect.
 
 ## 日本語
 
-- **JavaScript 検索で `Javascript` の表記ゆれを正規化するようになりました** — 直接検索呼び出しでも JavaScript の言語フィルタを SQL の `lang` 条件にかける前に canonical 化するため、`Javascript` のような表記ゆれでも期待どおり indexed 済みの JavaScript 行が返ります。
+- **JavaScript 検索で `Javascript`、`js`、`jsx` の表記ゆれを正規化するようになりました** — 直接検索呼び出しでも JavaScript の言語フィルタを SQL の `lang` 条件にかける前に canonical 化するため、`Javascript` / `JS` / `JSX` のような表記ゆれでも期待どおり indexed 済みの JavaScript 行が返ります。

--- a/changelog.d/unreleased/+javascript-lang-normalization.fixed.md
+++ b/changelog.d/unreleased/+javascript-lang-normalization.fixed.md
@@ -9,9 +9,8 @@ affected:
 
 ## English
 
-- **JavaScript search now normalizes `Javascript` spelling variants** — direct search calls now canonicalize the JavaScript language filter before applying the SQL `lang` predicate, so mixed-casing spellings like `Javascript` still return the indexed JavaScript rows users expect.
-- **JavaScript search now normalizes `Javascript`, `js`, and `jsx` spelling variants** — direct search calls now canonicalize the JavaScript language filter before applying the SQL `lang` predicate, so mixed-casing spellings like `Javascript`, `JS`, and `JSX` still return the indexed JavaScript rows users expect.
+- **JavaScript search now normalizes `Javascript`, `js`, `jsx`, `cjs`, and `mjs` spelling variants** — direct search calls now canonicalize the JavaScript language filter before applying the SQL `lang` predicate, so mixed-casing spellings like `Javascript`, `JS`, `JSX`, `CJS`, and `MJS` still return the indexed JavaScript rows users expect.
 
 ## 日本語
 
-- **JavaScript 検索で `Javascript`、`js`、`jsx` の表記ゆれを正規化するようになりました** — 直接検索呼び出しでも JavaScript の言語フィルタを SQL の `lang` 条件にかける前に canonical 化するため、`Javascript` / `JS` / `JSX` のような表記ゆれでも期待どおり indexed 済みの JavaScript 行が返ります。
+- **JavaScript 検索で `Javascript`、`js`、`jsx`、`cjs`、`mjs` の表記ゆれを正規化するようになりました** — 直接検索呼び出しでも JavaScript の言語フィルタを SQL の `lang` 条件にかける前に canonical 化するため、`Javascript` / `JS` / `JSX` / `CJS` / `MJS` のような表記ゆれでも期待どおり indexed 済みの JavaScript 行が返ります。

--- a/changelog.d/unreleased/+javascript-lang-normalization.fixed.md
+++ b/changelog.d/unreleased/+javascript-lang-normalization.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **JavaScript search now normalizes `Javascript` spelling variants** — direct search calls now canonicalize the JavaScript language filter before applying the SQL `lang` predicate, so mixed-casing spellings like `Javascript` still return the indexed JavaScript rows users expect.
+
+## 日本語
+
+- **JavaScript 検索で `Javascript` の表記ゆれを正規化するようになりました** — 直接検索呼び出しでも JavaScript の言語フィルタを SQL の `lang` 条件にかける前に canonical 化するため、`Javascript` のような表記ゆれでも期待どおり indexed 済みの JavaScript 行が返ります。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -23,6 +23,8 @@ public static class QueryCommandRunner
     private const string HotspotsGroupedByNameKind = "name_kind";
     private static readonly Dictionary<string, string> LangFilterAliases = new(StringComparer.Ordinal)
     {
+        ["js"] = "javascript",
+        ["jsx"] = "javascript",
         ["c#"] = "csharp",
         ["cs"] = "csharp",
         ["cshtml"] = "csharp",
@@ -47,6 +49,7 @@ public static class QueryCommandRunner
     };
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
+        ["javascript"] = ["js", "jsx"],
         ["csharp"] = ["cshtml", "razor"],
         ["yaml"] = ["yml"],
         ["typescript"] = ["ts", "tsx", "cts", "mts"],

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -25,6 +25,8 @@ public static class QueryCommandRunner
     {
         ["js"] = "javascript",
         ["jsx"] = "javascript",
+        ["cjs"] = "javascript",
+        ["mjs"] = "javascript",
         ["c#"] = "csharp",
         ["cs"] = "csharp",
         ["cshtml"] = "csharp",
@@ -49,7 +51,7 @@ public static class QueryCommandRunner
     };
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
-        ["javascript"] = ["js", "jsx"],
+        ["javascript"] = ["js", "jsx", "cjs", "mjs"],
         ["csharp"] = ["cshtml", "razor"],
         ["yaml"] = ["yml"],
         ["typescript"] = ["ts", "tsx", "cts", "mts"],

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -792,6 +792,8 @@ public partial class DbReader
             return "javascript";
         if (string.Equals(compact, "javascript", StringComparison.OrdinalIgnoreCase))
             return "javascript";
+        if (string.Equals(compact, "typescript", StringComparison.OrdinalIgnoreCase))
+            return "typescript";
         if (string.Equals(compact, "ts", StringComparison.OrdinalIgnoreCase))
             return "typescript";
         if (string.Equals(compact, "tsx", StringComparison.OrdinalIgnoreCase))

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -792,8 +792,6 @@ public partial class DbReader
             return "javascript";
         if (string.Equals(compact, "javascript", StringComparison.OrdinalIgnoreCase))
             return "javascript";
-        if (string.Equals(compact, "typescript", StringComparison.OrdinalIgnoreCase))
-            return "typescript";
         if (string.Equals(compact, "ts", StringComparison.OrdinalIgnoreCase))
             return "typescript";
         if (string.Equals(compact, "tsx", StringComparison.OrdinalIgnoreCase))
@@ -801,6 +799,8 @@ public partial class DbReader
         if (string.Equals(compact, "cts", StringComparison.OrdinalIgnoreCase))
             return "typescript";
         if (string.Equals(compact, "mts", StringComparison.OrdinalIgnoreCase))
+            return "typescript";
+        if (string.Equals(compact, "typescript", StringComparison.OrdinalIgnoreCase))
             return "typescript";
         if (string.Equals(compact, "cshtml", StringComparison.OrdinalIgnoreCase))
             return "csharp";

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -782,6 +782,10 @@ public partial class DbReader
             return null;
 
         var compact = lang.Replace("-", string.Empty, StringComparison.Ordinal).Replace(" ", string.Empty, StringComparison.Ordinal);
+        if (string.Equals(compact, "js", StringComparison.OrdinalIgnoreCase))
+            return "javascript";
+        if (string.Equals(compact, "jsx", StringComparison.OrdinalIgnoreCase))
+            return "javascript";
         if (string.Equals(compact, "javascript", StringComparison.OrdinalIgnoreCase))
             return "javascript";
         if (string.Equals(compact, "ts", StringComparison.OrdinalIgnoreCase))

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -786,6 +786,10 @@ public partial class DbReader
             return "javascript";
         if (string.Equals(compact, "jsx", StringComparison.OrdinalIgnoreCase))
             return "javascript";
+        if (string.Equals(compact, "cjs", StringComparison.OrdinalIgnoreCase))
+            return "javascript";
+        if (string.Equals(compact, "mjs", StringComparison.OrdinalIgnoreCase))
+            return "javascript";
         if (string.Equals(compact, "javascript", StringComparison.OrdinalIgnoreCase))
             return "javascript";
         if (string.Equals(compact, "ts", StringComparison.OrdinalIgnoreCase))

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -782,6 +782,8 @@ public partial class DbReader
             return null;
 
         var compact = lang.Replace("-", string.Empty, StringComparison.Ordinal).Replace(" ", string.Empty, StringComparison.Ordinal);
+        if (string.Equals(compact, "javascript", StringComparison.OrdinalIgnoreCase))
+            return "javascript";
         if (string.Equals(compact, "ts", StringComparison.OrdinalIgnoreCase))
             return "typescript";
         if (string.Equals(compact, "tsx", StringComparison.OrdinalIgnoreCase))

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -68,6 +68,26 @@ public class DbReaderTests : IDisposable
         Assert.Equal(1, counts.FileCount);
     }
 
+    [Theory]
+    [InlineData("js")]
+    [InlineData("JS")]
+    [InlineData("jsx")]
+    [InlineData("JSX")]
+    public void CountSearchResults_NormalizesJavascriptShorthandLangSpellings(string lang)
+    {
+        const string query = "JavaScriptShorthandToken";
+
+        InsertIndexedFile(
+            "src/javascript-shorthand.js",
+            "javascript",
+            $@"const marker = ""{query}"";");
+
+        var counts = _reader.CountSearchResults(query, lang: lang);
+
+        Assert.Equal(1, counts.Count);
+        Assert.Equal(1, counts.FileCount);
+    }
+
     private void SeedData()
     {
         const string authContent = "def authenticate(user, password):\n    if user == 'admin':\n        return True\n    return False";

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -90,6 +90,24 @@ public class DbReaderTests : IDisposable
         Assert.Equal(1, counts.FileCount);
     }
 
+    [Theory]
+    [InlineData("TypeScript")]
+    [InlineData("typescript")]
+    public void CountSearchResults_NormalizesTypeScriptSpelling(string lang)
+    {
+        const string query = "TypeScriptToken";
+
+        InsertIndexedFile(
+            "src/typescript-alias.ts",
+            "typescript",
+            $@"const marker = ""{query}"";");
+
+        var counts = _reader.CountSearchResults(query, lang: lang);
+
+        Assert.Equal(1, counts.Count);
+        Assert.Equal(1, counts.FileCount);
+    }
+
     private void SeedData()
     {
         const string authContent = "def authenticate(user, password):\n    if user == 'admin':\n        return True\n    return False";

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -52,6 +52,22 @@ public class DbReaderTests : IDisposable
         Assert.Equal(expected, DbReader.BuildPathLikePattern(input));
     }
 
+    [Fact]
+    public void CountSearchResults_NormalizesJavascriptLangSpelling()
+    {
+        const string query = "JavaScriptAliasToken";
+
+        InsertIndexedFile(
+            "src/javascript-alias.js",
+            "javascript",
+            $@"const marker = ""{query}"";");
+
+        var counts = _reader.CountSearchResults(query, lang: "Javascript");
+
+        Assert.Equal(1, counts.Count);
+        Assert.Equal(1, counts.FileCount);
+    }
+
     private void SeedData()
     {
         const string authContent = "def authenticate(user, password):\n    if user == 'admin':\n        return True\n    return False";

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -73,6 +73,8 @@ public class DbReaderTests : IDisposable
     [InlineData("JS")]
     [InlineData("jsx")]
     [InlineData("JSX")]
+    [InlineData("cjs")]
+    [InlineData("MJS")]
     public void CountSearchResults_NormalizesJavascriptShorthandLangSpellings(string lang)
     {
         const string query = "JavaScriptShorthandToken";

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -136,6 +136,15 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void GetLanguageAliases_ReportsJavascriptAliases()
+    {
+        var aliases = QueryCommandRunner.GetLanguageAliases("javascript");
+
+        Assert.Contains("js", aliases);
+        Assert.Contains("jsx", aliases);
+    }
+
+    [Fact]
     public void GetLanguageAliases_ReportsXmlAliases()
     {
         var aliases = QueryCommandRunner.GetLanguageAliases("xml");
@@ -311,6 +320,8 @@ public class QueryCommandRunnerTests
     [Theory]
     [InlineData("bat", "batch")]
     [InlineData("cmd", "batch")]
+    [InlineData("JS", "javascript")]
+    [InlineData("jsx", "javascript")]
     [InlineData("C#", "csharp")]
     [InlineData("cs", "csharp")]
     [InlineData("Java", "java")]
@@ -339,6 +350,8 @@ public class QueryCommandRunnerTests
     [InlineData("c#")]
     [InlineData("cs")]
     [InlineData("cshtml")]
+    [InlineData("js")]
+    [InlineData("JSX")]
     [InlineData("Java")]
     [InlineData("kt")]
     [InlineData("kts")]
@@ -379,6 +392,13 @@ public class QueryCommandRunnerTests
         String marker = ""{queryToken}"";
     }}
 }}");
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.js",
+                "javascript",
+                $@"function run() {{
+    const marker = ""{queryToken}"";
+}}");
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
                 [queryToken, "--db", dbPath, "--lang", input, "--count"],
@@ -393,6 +413,38 @@ public class QueryCommandRunnerTests
         TestProjectHelper.DeleteDirectory(projectRoot);
     }
 }
+
+    [Theory]
+    [InlineData("js")]
+    [InlineData("jsx")]
+    [InlineData("JS")]
+    [InlineData("JSX")]
+    public void RunSearch_NormalizesJavascriptLangAliases(string lang)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_javascript_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = $"javascript_lang_alias_{Guid.NewGuid():N}";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.js",
+                "javascript",
+                $@"const marker = ""{queryToken}"";");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--lang", lang, "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
 
     [Theory]
     [InlineData("yml")]
@@ -1728,6 +1780,8 @@ jobs:
 
         Assert.Contains(".cjs", javascript.GetProperty("extensions").EnumerateArray().Select(ext => ext.GetString()));
         Assert.Contains(".mjs", javascript.GetProperty("extensions").EnumerateArray().Select(ext => ext.GetString()));
+        Assert.Contains("js", javascript.GetProperty("aliases").EnumerateArray().Select(alias => alias.GetString()));
+        Assert.Contains("jsx", javascript.GetProperty("aliases").EnumerateArray().Select(alias => alias.GetString()));
         Assert.Contains(".cts", typescript.GetProperty("extensions").EnumerateArray().Select(ext => ext.GetString()));
         Assert.Contains(".mts", typescript.GetProperty("extensions").EnumerateArray().Select(ext => ext.GetString()));
         Assert.Contains(".m", objc.GetProperty("extensions").EnumerateArray().Select(ext => ext.GetString()));

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -142,6 +142,8 @@ public class QueryCommandRunnerTests
 
         Assert.Contains("js", aliases);
         Assert.Contains("jsx", aliases);
+        Assert.Contains("cjs", aliases);
+        Assert.Contains("mjs", aliases);
     }
 
     [Fact]
@@ -322,6 +324,8 @@ public class QueryCommandRunnerTests
     [InlineData("cmd", "batch")]
     [InlineData("JS", "javascript")]
     [InlineData("jsx", "javascript")]
+    [InlineData("cjs", "javascript")]
+    [InlineData("MJS", "javascript")]
     [InlineData("C#", "csharp")]
     [InlineData("cs", "csharp")]
     [InlineData("Java", "java")]
@@ -352,6 +356,8 @@ public class QueryCommandRunnerTests
     [InlineData("cshtml")]
     [InlineData("js")]
     [InlineData("JSX")]
+    [InlineData("cjs")]
+    [InlineData("MJS")]
     [InlineData("Java")]
     [InlineData("kt")]
     [InlineData("kts")]
@@ -429,6 +435,38 @@ public class QueryCommandRunnerTests
             TestProjectHelper.InsertIndexedFile(
                 dbPath,
                 "src/App.js",
+                "javascript",
+                $@"const marker = ""{queryToken}"";");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [queryToken, "--db", dbPath, "--lang", lang, "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData("cjs")]
+    [InlineData("mjs")]
+    [InlineData("CJS")]
+    [InlineData("MJS")]
+    public void RunSearch_NormalizesJavascriptExtensionStyleLangAliases(string lang)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_javascript_extension_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var queryToken = $"javascript_extension_lang_alias_{Guid.NewGuid():N}";
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.mjs",
                 "javascript",
                 $@"const marker = ""{queryToken}"";");
 


### PR DESCRIPTION
## Summary
- Normalize JavaScript search language filters so `Javascript`, `js`, `jsx`, `cjs`, and `mjs` all resolve to `javascript`.
- Normalize TypeScript search language filters so `TypeScript` and `typescript` resolve consistently to `typescript`.
- Keep the CLI alias/help surface aligned by advertising the same aliases in `languages` and completion data.
- Add regressions for DB search normalization, CLI parsing, and language listing output.

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.CountSearchResults_NormalizesTypeScriptSpelling|FullyQualifiedName~QueryCommandRunnerTests.NormalizeQueryLanguage_MapsTypeScriptShorthands|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_NormalizesCommonLanguageAliases"`