### PR TITLE
Fix Swift exact symbol search aliases

### DIFF
--- a/changelog.d/unreleased/+swift-exact-backtick-search.fixed.md
+++ b/changelog.d/unreleased/+swift-exact-backtick-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Swift exact symbol search now matches backtick-escaped identifiers by plain name** — exact symbol queries such as `repeat` now also resolve declarations stored as `` `repeat` ``, so Swift search behaves more like the other language-specific exact-name normalizers.
+
+## 日本語
+
+- **Swift の exact symbol search でバッククォート付き識別子を素の名前でも引けるようにしました** — `repeat` のような exact クエリが `` `repeat` `` として保存された Swift 宣言にも一致するようになり、他言語の exact-name 正規化と同じ感覚で検索できるようになりました。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -225,13 +225,19 @@ public partial class DbReader
                 ? string.Join(" OR ", effectiveQueries.Select((queryValue, idx) =>
                 {
                     var allowLeafFallback = !SqlNameResolver.HasQualifier(queryValue);
+                    var swiftBacktickAlias = ComputeSwiftBacktickAlias(queryValue, lang);
+                    var swiftBacktickClause = swiftBacktickAlias != null
+                        ? _foldReady
+                            ? $" OR s.name_folded = @query{idx}SwiftBacktickAlias"
+                            : $" OR s.name = @query{idx}SwiftBacktickAlias COLLATE NOCASE"
+                        : string.Empty;
                     return _foldReady
                         ? allowLeafFallback
-                            ? $"(s.name_folded = @query{idx} OR (f.lang = 'sql' AND ((sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name_folded(s.name) = @query{idx}NormalizedFolded) OR sql_leaf_name_folded(s.name) = @query{idx}LeafFolded)))"
-                            : $"(s.name_folded = @query{idx} OR (f.lang = 'sql' AND sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name_folded(s.name) = @query{idx}NormalizedFolded))"
+                            ? $"(s.name_folded = @query{idx}{swiftBacktickClause} OR (f.lang = 'sql' AND ((sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name_folded(s.name) = @query{idx}NormalizedFolded) OR sql_leaf_name_folded(s.name) = @query{idx}LeafFolded)))"
+                            : $"(s.name_folded = @query{idx}{swiftBacktickClause} OR (f.lang = 'sql' AND sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name_folded(s.name) = @query{idx}NormalizedFolded))"
                         : allowLeafFallback
-                            ? $"(s.name = @query{idx} COLLATE NOCASE OR (f.lang = 'sql' AND ((sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name(s.name) = @query{idx}Normalized COLLATE NOCASE) OR sql_leaf_name(s.name) = @query{idx}Leaf COLLATE NOCASE)))"
-                            : $"(s.name = @query{idx} COLLATE NOCASE OR (f.lang = 'sql' AND sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name(s.name) = @query{idx}Normalized COLLATE NOCASE))";
+                            ? $"(s.name = @query{idx} COLLATE NOCASE{swiftBacktickClause} OR (f.lang = 'sql' AND ((sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name(s.name) = @query{idx}Normalized COLLATE NOCASE) OR sql_leaf_name(s.name) = @query{idx}Leaf COLLATE NOCASE)))"
+                            : $"(s.name = @query{idx} COLLATE NOCASE{swiftBacktickClause} OR (f.lang = 'sql' AND sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name(s.name) = @query{idx}Normalized COLLATE NOCASE))";
                 }))
                 : string.Join(" OR ", effectiveQueries.Select((_, idx) => $"(s.name LIKE @query{idx} ESCAPE '\\' OR (f.lang = 'sql' AND sql_normalize_name(s.name) LIKE @query{idx}NormalizedLike ESCAPE '\\'))"));
             sql += $" AND ({orClauses})";
@@ -263,6 +269,13 @@ public partial class DbReader
                 cmd.Parameters.AddWithValue($"@query{i}LeafFolded", NameFold.Fold(SqlNameResolver.GetLeafName(value)) ?? SqlNameResolver.GetLeafName(value));
                 cmd.Parameters.AddWithValue($"@query{i}SegmentCount", SqlNameResolver.GetSegmentCount(value));
                 cmd.Parameters.AddWithValue($"@query{i}NormalizedLike", $"%{EscapeLikeQuery(SqlNameResolver.NormalizeQualifiedName(value))}%");
+                var swiftBacktickAlias = ComputeSwiftBacktickAlias(value, lang);
+                if (swiftBacktickAlias != null)
+                {
+                    cmd.Parameters.AddWithValue($"@query{i}SwiftBacktickAlias", _foldReady
+                        ? NameFold.Fold(swiftBacktickAlias) ?? swiftBacktickAlias
+                        : swiftBacktickAlias);
+                }
             }
         }
         if (kind != null)
@@ -355,13 +368,19 @@ public partial class DbReader
                 ? string.Join(" OR ", effectiveQueries.Select((queryValue, idx) =>
                 {
                     var allowLeafFallback = !SqlNameResolver.HasQualifier(queryValue);
+                    var swiftBacktickAlias = ComputeSwiftBacktickAlias(queryValue, lang);
+                    var swiftBacktickClause = swiftBacktickAlias != null
+                        ? _foldReady
+                            ? $" OR s.name_folded = @query{idx}SwiftBacktickAlias"
+                            : $" OR s.name = @query{idx}SwiftBacktickAlias COLLATE NOCASE"
+                        : string.Empty;
                     return _foldReady
                         ? allowLeafFallback
-                            ? $"(s.name_folded = @query{idx} OR (f.lang = 'sql' AND ((sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name_folded(s.name) = @query{idx}NormalizedFolded) OR sql_leaf_name_folded(s.name) = @query{idx}LeafFolded)))"
-                            : $"(s.name_folded = @query{idx} OR (f.lang = 'sql' AND sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name_folded(s.name) = @query{idx}NormalizedFolded))"
+                            ? $"(s.name_folded = @query{idx}{swiftBacktickClause} OR (f.lang = 'sql' AND ((sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name_folded(s.name) = @query{idx}NormalizedFolded) OR sql_leaf_name_folded(s.name) = @query{idx}LeafFolded)))"
+                            : $"(s.name_folded = @query{idx}{swiftBacktickClause} OR (f.lang = 'sql' AND sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name_folded(s.name) = @query{idx}NormalizedFolded))"
                         : allowLeafFallback
-                            ? $"(s.name = @query{idx} COLLATE NOCASE OR (f.lang = 'sql' AND ((sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name(s.name) = @query{idx}Normalized COLLATE NOCASE) OR sql_leaf_name(s.name) = @query{idx}Leaf COLLATE NOCASE)))"
-                            : $"(s.name = @query{idx} COLLATE NOCASE OR (f.lang = 'sql' AND sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name(s.name) = @query{idx}Normalized COLLATE NOCASE))";
+                            ? $"(s.name = @query{idx} COLLATE NOCASE{swiftBacktickClause} OR (f.lang = 'sql' AND ((sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name(s.name) = @query{idx}Normalized COLLATE NOCASE) OR sql_leaf_name(s.name) = @query{idx}Leaf COLLATE NOCASE)))"
+                            : $"(s.name = @query{idx} COLLATE NOCASE{swiftBacktickClause} OR (f.lang = 'sql' AND sql_segment_count(s.name) = @query{idx}SegmentCount AND sql_normalize_name(s.name) = @query{idx}Normalized COLLATE NOCASE))";
                 }))
                 : string.Join(" OR ", effectiveQueries.Select((_, idx) => $"(s.name LIKE @query{idx} ESCAPE '\\' OR (f.lang = 'sql' AND sql_normalize_name(s.name) LIKE @query{idx}NormalizedLike ESCAPE '\\'))"));
             sql += $" AND ({orClauses})";
@@ -401,6 +420,13 @@ public partial class DbReader
                 cmd.Parameters.AddWithValue($"@query{idx}LeafFolded", NameFold.Fold(SqlNameResolver.GetLeafName(effectiveQueries[idx])) ?? SqlNameResolver.GetLeafName(effectiveQueries[idx]));
                 cmd.Parameters.AddWithValue($"@query{idx}SegmentCount", SqlNameResolver.GetSegmentCount(effectiveQueries[idx]));
                 cmd.Parameters.AddWithValue($"@query{idx}NormalizedLike", $"%{EscapeLikeQuery(SqlNameResolver.NormalizeQualifiedName(effectiveQueries[idx]))}%");
+                var swiftBacktickAlias = ComputeSwiftBacktickAlias(effectiveQueries[idx], lang);
+                if (swiftBacktickAlias != null)
+                {
+                    cmd.Parameters.AddWithValue($"@query{idx}SwiftBacktickAlias", _foldReady
+                        ? NameFold.Fold(swiftBacktickAlias) ?? swiftBacktickAlias
+                        : swiftBacktickAlias);
+                }
             }
         }
         var preferLiteralExactMatch = effectiveQueries != null && effectiveQueries.Count == 1;
@@ -580,6 +606,33 @@ public partial class DbReader
             return NormalizeJavaScriptSymbolSearchQuery(query);
 
         return NormalizeCSharpVerbatimQuery(query, lang);
+    }
+
+    private static string? ComputeSwiftBacktickAlias(string? query, string? lang)
+    {
+        if (!string.Equals(lang, "swift", StringComparison.OrdinalIgnoreCase) || string.IsNullOrWhiteSpace(query))
+            return null;
+
+        var trimmed = query.Trim();
+        if (trimmed.Length == 0)
+            return null;
+
+        if (trimmed.IndexOfAny(['`', ':', '/', '<', '>', '(', ')', '[', ']', ' ']) >= 0)
+            return null;
+
+        var lastDot = trimmed.LastIndexOf('.');
+        if (lastDot < 0)
+            return $"`{trimmed}`";
+
+        if (lastDot == 0 || lastDot == trimmed.Length - 1)
+            return null;
+
+        var prefix = trimmed[..(lastDot + 1)];
+        var leaf = trimmed[(lastDot + 1)..];
+        if (leaf.IndexOf('.') >= 0)
+            return null;
+
+        return $"{prefix}`{leaf}`";
     }
 
     private static string? NormalizeJavaScriptSymbolSearchQuery(string? query)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -327,6 +327,74 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_SwiftExactQueriesMatchBacktickEscapedIdentifiers()
+    {
+        InsertIndexedFile(
+            "src/swift.swift",
+            "swift",
+            """
+            public struct Store {
+                public func `repeat`() {}
+            }
+            """);
+
+        var plainResults = _reader.SearchSymbols("repeat", lang: "swift", exact: true);
+        var escapedResults = _reader.SearchSymbols("`repeat`", lang: "swift", exact: true);
+
+        var plain = Assert.Single(plainResults);
+        var escaped = Assert.Single(escapedResults);
+
+        Assert.Equal("`repeat`", plain.Name);
+        Assert.Equal("src/swift.swift", plain.Path);
+        Assert.Equal(plain.Name, escaped.Name);
+        Assert.Equal(plain.Path, escaped.Path);
+    }
+
+    [Fact]
+    public void SearchSymbols_SwiftExactQueriesMatchQualifiedBacktickEscapedIdentifiers()
+    {
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/qualified.swift",
+            Lang = "swift",
+            Size = 64,
+            Lines = 1,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertChunks([new ChunkRecord
+        {
+            FileId = fileId,
+            ChunkIndex = 0,
+            StartLine = 1,
+            EndLine = 1,
+            Content = "MyType.`repeat`",
+        }]);
+        _writer.InsertSymbols([new SymbolRecord
+        {
+            FileId = fileId,
+            Kind = "function",
+            Name = "MyType.`repeat`",
+            Line = 1,
+            StartLine = 1,
+            EndLine = 1,
+            BodyStartLine = 1,
+            BodyEndLine = 1,
+            Signature = "func MyType.`repeat`() {}",
+        }]);
+
+        var plainResults = _reader.SearchSymbols("MyType.repeat", lang: "swift", exact: true);
+        var escapedResults = _reader.SearchSymbols("MyType.`repeat`", lang: "swift", exact: true);
+
+        var plain = Assert.Single(plainResults);
+        var escaped = Assert.Single(escapedResults);
+
+        Assert.Equal("MyType.`repeat`", plain.Name);
+        Assert.Equal("src/qualified.swift", plain.Path);
+        Assert.Equal(plain.Name, escaped.Name);
+        Assert.Equal(plain.Path, escaped.Path);
+    }
+
+    [Fact]
     public void SearchReferences_RustRawMacroInvocationsIgnoreRawPrefixAndBang()
     {
         InsertIndexedFile(


### PR DESCRIPTION
## Summary
- Add Swift-specific exact-search aliases so plain queries can match backtick-escaped symbol names
- Extend the aliasing to qualified Swift names by escaping the final segment
- Add regression tests for unqualified and qualified Swift cases

## Verification
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.SearchSymbols_SwiftExactQueriesMatchBacktickEscapedIdentifiers|FullyQualifiedName~DbReaderTests.SearchSymbols_SwiftExactQueriesMatchQualifiedBacktickEscapedIdentifiers|FullyQualifiedName~DbReaderTests.SearchSymbols_RustRawIdentifiersIgnoreRawPrefix|FullyQualifiedName~DbReaderTests.SearchSymbols_JavaScriptCommonJsExportQueriesResolveToLeafNames"`