### PR TITLE
[codex] csharp search canonicalization

### DIFF
--- a/changelog.d/unreleased/+csharp-search-literal-safe-canonicalization.fixed.md
+++ b/changelog.d/unreleased/+csharp-search-literal-safe-canonicalization.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **C# literal-safe `search` now canonicalizes verbatim and `global::` spellings before FTS matching** — queries like `global::Foo.Bar` and `@Foo.@Bar` now search the same indexed C# text as `Foo.Bar`, so default search no longer misses canonical source spellings when the query uses C#-specific escapes.
+
+## 日本語
+
+- **C# の literal-safe `search` で verbatim / `global::` 表記を FTS 前に正規化するようになりました** — `global::Foo.Bar` や `@Foo.@Bar` のようなクエリでも、`Foo.Bar` と同じ C# インデックス済みテキストを検索するため、C# 固有の escape 表記が原因で canonical な source 表記を取りこぼさなくなります。

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -286,6 +286,7 @@ public partial class DbReader
             return [];
 
         lang = NormalizeQueryLanguage(lang);
+        var normalizedQuery = rawQuery ? query : NormalizeLiteralSearchQuery(query, lang);
         using var cmd = _conn.CreateCommand();
         string sql;
 
@@ -305,7 +306,7 @@ public partial class DbReader
         }
         else
         {
-            var sanitizedQuery = rawQuery ? query : SanitizeFtsQuery(query);
+            var sanitizedQuery = rawQuery ? query : SanitizeFtsQuery(normalizedQuery);
             sql = @"
                 SELECT f.path, f.lang, c.start_line, c.end_line, c.content,
                        rank
@@ -326,8 +327,8 @@ public partial class DbReader
         cmd.CommandText = sql;
         if (exact)
             cmd.Parameters.AddWithValue("@exactQuery", query);
-        cmd.Parameters.AddWithValue("@rankingQuery", query.Trim());
-        cmd.Parameters.AddWithValue("@rankingQueryPrefix", $"{EscapeLikeQuery(query.Trim())}%");
+        cmd.Parameters.AddWithValue("@rankingQuery", normalizedQuery.Trim());
+        cmd.Parameters.AddWithValue("@rankingQueryPrefix", $"{EscapeLikeQuery(normalizedQuery.Trim())}%");
         cmd.Parameters.AddWithValue("@limit", limit);
         if (lang != null)
             cmd.Parameters.AddWithValue("@lang", lang);
@@ -365,6 +366,7 @@ public partial class DbReader
             return new QueryCountResult(0, 0);
 
         lang = NormalizeQueryLanguage(lang);
+        var normalizedQuery = rawQuery ? query : NormalizeLiteralSearchQuery(query, lang);
         using var cmd = _conn.CreateCommand();
         string sql;
 
@@ -382,7 +384,7 @@ public partial class DbReader
         }
         else
         {
-            var sanitizedQuery = rawQuery ? query : SanitizeFtsQuery(query);
+            var sanitizedQuery = rawQuery ? query : SanitizeFtsQuery(normalizedQuery);
             sql = @"
                 SELECT f.path, c.start_line, c.end_line,
                        rank
@@ -403,8 +405,8 @@ public partial class DbReader
         cmd.CommandText = sql;
         if (exact)
             cmd.Parameters.AddWithValue("@exactQuery", query);
-        cmd.Parameters.AddWithValue("@rankingQuery", query.Trim());
-        cmd.Parameters.AddWithValue("@rankingQueryPrefix", $"{EscapeLikeQuery(query.Trim())}%");
+        cmd.Parameters.AddWithValue("@rankingQuery", normalizedQuery.Trim());
+        cmd.Parameters.AddWithValue("@rankingQueryPrefix", $"{EscapeLikeQuery(normalizedQuery.Trim())}%");
         if (lang != null)
             cmd.Parameters.AddWithValue("@lang", lang);
         if (since != null && _fileColumns.Contains("modified"))
@@ -454,6 +456,11 @@ public partial class DbReader
 
         return new QueryCountResult(count, fileCount);
     }
+
+    private static string NormalizeLiteralSearchQuery(string query, string? lang) =>
+        string.Equals(lang, "csharp", StringComparison.OrdinalIgnoreCase)
+            ? ExactSourceSearchNormalizer.Normalize(query, lang)
+            : query;
 
     private static bool IsFtsQuerySyntaxError(SqliteException ex)
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -9089,6 +9089,56 @@ jobs:
     }
 
     [Fact]
+    public void RunSearch_TreatsCSharpVerbatimQualifiedNamesAsCanonicalInLiteralSafeSearch()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_csharp_literal_safe_canonical");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/app.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                public class CanonicalQualified
+                {
+                    public void Match()
+                    {
+                        var first = Foo.Bar;
+                        var second = Foo.Bar;
+                    }
+                }
+                """);
+
+            var (globalExitCode, globalStdout, globalStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["global::Foo.Bar", "--db", dbPath, "--path", "src/app.cs", "--lang", "csharp", "--json", "--count"],
+                _jsonOptions));
+            using var globalDocument = ParseJsonOutput(globalStdout);
+
+            var (verbatimExitCode, verbatimStdout, verbatimStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["@Foo.@Bar", "--db", dbPath, "--path", "src/app.cs", "--lang", "csharp", "--json", "--count"],
+                _jsonOptions));
+            using var verbatimDocument = ParseJsonOutput(verbatimStdout);
+
+            Assert.Equal(CommandExitCodes.Success, globalExitCode);
+            Assert.Equal(string.Empty, globalStderr);
+            Assert.Equal(1, globalDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, globalDocument.RootElement.GetProperty("files").GetInt32());
+
+            Assert.Equal(CommandExitCodes.Success, verbatimExitCode);
+            Assert.Equal(string.Empty, verbatimStderr);
+            Assert.Equal(1, verbatimDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, verbatimDocument.RootElement.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSearch_ExactSubstringKeepsNormalizationScopedToCSharp()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_csharp_scope");


### PR DESCRIPTION
## What changed
- Normalize C# verbatim and `global::` spellings before literal-safe `search` builds its FTS query and ranking keys.
- Add a regression test that verifies `search --lang csharp` finds canonical `Foo.Bar` content when queried as `global::Foo.Bar` or `@Foo.@Bar`.
- Add a changelog fragment for the user-visible behavior change.

## Why
- Exact C# search already canonicalized these spellings, but literal-safe `search` still used the raw query text for matching and ordering.
- That meant C#-specific escapes could miss canonical source spellings even though the indexed content was otherwise searchable.

## Impact
- C# users can now search canonical source spellings using common escaped forms in literal-safe search when the search is scoped to C#.
- The change stays scoped to C# and does not alter raw FTS query mode.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunSearch_TreatsCSharpVerbatimQualifiedNamesAsCanonicalInLiteralSafeSearch|FullyQualifiedName~RunSearch_ExactSubstringTreatsCSharpGlobalQualifiedNamesAsCanonical"`