### PR TITLE
[codex] add a Java language shorthand for search

### DIFF
--- a/changelog.d/unreleased/+java-lang-filter-alias.fixed.md
+++ b/changelog.d/unreleased/+java-lang-filter-alias.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Java search now accepts a shorthand `jav` language filter** — query commands normalize `jav` to `java` and advertise it in language help/completion, so Java searches work with the same style of shorthand already available for other major languages.
+
+## 日本語
+
+- **Java 検索で `jav` という省略形の言語フィルタを使えるようになりました** — クエリ系コマンドは `jav` を `java` に正規化し、言語ヘルプ / 補完にも表示するため、他の主要言語と同じ感覚で Java 検索を省略形でも実行できます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -38,6 +38,7 @@ public static class QueryCommandRunner
         ["pyw"] = "python",
         ["yml"] = "yaml",
         ["razor"] = "csharp",
+        ["jav"] = "java",
         ["kt"] = "kotlin",
         ["kts"] = "kotlin",
         ["ts"] = "typescript",
@@ -53,6 +54,7 @@ public static class QueryCommandRunner
     {
         ["javascript"] = ["js", "jsx", "cjs", "mjs"],
         ["csharp"] = ["cshtml", "razor"],
+        ["java"] = ["jav"],
         ["yaml"] = ["yml"],
         ["typescript"] = ["ts", "tsx", "cts", "mts"],
         ["rust"] = ["rs"],

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -802,6 +802,8 @@ public partial class DbReader
             return "typescript";
         if (string.Equals(compact, "typescript", StringComparison.OrdinalIgnoreCase))
             return "typescript";
+        if (string.Equals(compact, "jav", StringComparison.OrdinalIgnoreCase))
+            return "java";
         if (string.Equals(compact, "cshtml", StringComparison.OrdinalIgnoreCase))
             return "csharp";
         if (string.Equals(compact, "razor", StringComparison.OrdinalIgnoreCase))

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -136,6 +136,14 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void GetLanguageAliases_ReportsJavaAlias()
+    {
+        var aliases = QueryCommandRunner.GetLanguageAliases("java");
+
+        Assert.Contains("jav", aliases);
+    }
+
+    [Fact]
     public void GetLanguageAliases_ReportsJavascriptAliases()
     {
         var aliases = QueryCommandRunner.GetLanguageAliases("javascript");
@@ -190,6 +198,15 @@ public class QueryCommandRunnerTests
     public void NormalizeQueryLanguage_MapsRustShorthand(string input)
     {
         Assert.Equal("rust", DbReader.NormalizeQueryLanguage(input));
+    }
+
+    [Theory]
+    [InlineData("jav")]
+    [InlineData("j-a-v")]
+    [InlineData("j av")]
+    public void NormalizeQueryLanguage_MapsJavaShorthand(string input)
+    {
+        Assert.Equal("java", DbReader.NormalizeQueryLanguage(input));
     }
 
     [Fact]
@@ -8833,6 +8850,39 @@ jobs:
                 Assert.Equal("1", stdout.Trim());
                 Assert.Equal(string.Empty, stderr);
             }
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_WithJavaLangAliasFiltersJavaFiles()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_java_lang_alias");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.java",
+                "java",
+                """
+                public class App {
+                    String hit() {
+                        return "Java";
+                    }
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Java", "--db", dbPath, "--lang", "jav", "--count"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("1", stdout.Trim());
+            Assert.Equal(string.Empty, stderr);
         }
         finally
         {


### PR DESCRIPTION
## What changed
- Added `jav` as a shorthand `--lang` filter for Java search and related query commands.
- Wired the new alias through CLI language help/completions and database-side language normalization.
- Added regression tests covering alias discovery, normalization, and an end-to-end Java search invocation.

## Why
- Java had no shorthand language filter, while other major languages already exposed short aliases.
- This makes Java searches easier to type and keeps the CLI language-filter UX consistent.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter 'FullyQualifiedName~GetLanguageAliases_ReportsJavaAlias|FullyQualifiedName~NormalizeQueryLanguage_MapsJavaShorthand|FullyQualifiedName~RunSearch_WithJavaLangAliasFiltersJavaFiles'`
