### PR TITLE
Normalize Java search language filters

### DIFF
--- a/changelog.d/unreleased/+java-search-language-filter-normalization.fixed.md
+++ b/changelog.d/unreleased/+java-search-language-filter-normalization.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Java search now normalizes canonical `Java` language filters too** — the database query layer now treats `Java` the same as `java` and `jav`, so direct search callers keep matching Java rows even when they pass the canonical language name in mixed case.
+
+## 日本語
+
+- **Java 検索で canonical な `Java` 言語フィルタも正規化するようになりました** — データベースのクエリ層で `Java` を `java` / `jav` と同一視するため、直接 search を呼ぶ側が canonical 名を大文字小文字混在で渡しても Java 行を取りこぼしません。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -802,6 +802,8 @@ public partial class DbReader
             return "typescript";
         if (string.Equals(compact, "typescript", StringComparison.OrdinalIgnoreCase))
             return "typescript";
+        if (string.Equals(compact, "java", StringComparison.OrdinalIgnoreCase))
+            return "java";
         if (string.Equals(compact, "jav", StringComparison.OrdinalIgnoreCase))
             return "java";
         if (string.Equals(compact, "cshtml", StringComparison.OrdinalIgnoreCase))

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -202,9 +202,11 @@ public class QueryCommandRunnerTests
 
     [Theory]
     [InlineData("jav")]
+    [InlineData("Java")]
+    [InlineData("JAVA")]
     [InlineData("j-a-v")]
     [InlineData("j av")]
-    public void NormalizeQueryLanguage_MapsJavaShorthand(string input)
+    public void NormalizeQueryLanguage_MapsJavaSpelling(string input)
     {
         Assert.Equal("java", DbReader.NormalizeQueryLanguage(input));
     }


### PR DESCRIPTION
## Summary
- Treat canonical `Java` spellings the same as `java` and `jav` in database-layer query normalization.
- Add a regression test covering mixed-case Java language filter inputs.
- Document the fix with an unreleased changelog fragment.

## Verification
- `dotnet test /Users/widthdom/CodeIndex/CodeIndex.sln --filter "NormalizeQueryLanguage_MapsJavaSpelling"`