### PR TITLE
Normalize language aliases in DbReader

### DIFF
--- a/changelog.d/unreleased/+dbreader-language-alias-parity.fixed.md
+++ b/changelog.d/unreleased/+dbreader-language-alias-parity.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`--lang` now recognizes the app's supported language aliases more consistently** — `DbReader` now normalizes language filters using the full target-language set plus common alias spellings such as `c#`, `c++`, `f#`, `vb.net`, `py3`, and SQL dialect variants, so search/definition/reference queries no longer miss matches just because the user used a supported shorthand.
+
+## 日本語
+
+- **`--lang` がアプリの対象言語 alias をより一貫して認識するようになりました** — `DbReader` は対象言語の一覧に加えて `c#`、`c++`、`f#`、`vb.net`、`py3`、SQL 方言の表記ゆれなどの alias も正規化するため、検索 / 定義 / 参照クエリでサポート済みの短縮表記を使っても取りこぼしにくくなりました。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -21,40 +21,15 @@ public static class QueryCommandRunner
     internal const int ExactZeroHintProbeLimit = 1;
     internal const int ExactZeroHintSampleLimit = 5;
     private const string HotspotsGroupedByNameKind = "name_kind";
-    private static readonly Dictionary<string, string> LangFilterAliases = new(StringComparer.Ordinal)
-    {
-        ["js"] = "javascript",
-        ["jsx"] = "javascript",
-        ["cjs"] = "javascript",
-        ["mjs"] = "javascript",
-        ["c#"] = "csharp",
-        ["cs"] = "csharp",
-        ["cshtml"] = "csharp",
-        ["bat"] = "batch",
-        ["cmd"] = "batch",
-        ["py"] = "python",
-        ["py3"] = "python",
-        ["pyi"] = "python",
-        ["pyw"] = "python",
-        ["yml"] = "yaml",
-        ["razor"] = "csharp",
-        ["jav"] = "java",
-        ["kt"] = "kotlin",
-        ["kts"] = "kotlin",
-        ["ts"] = "typescript",
-        ["tsx"] = "typescript",
-        ["cts"] = "typescript",
-        ["mts"] = "typescript",
-        ["tsql"] = "sql",
-        ["transactsql"] = "sql",
-        ["xaml"] = "xml",
-        ["axaml"] = "xml",
-    };
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
         ["javascript"] = ["js", "jsx", "cjs", "mjs"],
-        ["csharp"] = ["cshtml", "razor"],
+        ["csharp"] = ["c#", "cs", "cshtml", "razor"],
         ["java"] = ["jav"],
+        ["cpp"] = ["c++", "cplusplus"],
+        ["fsharp"] = ["f#"],
+        ["vb"] = ["vb.net", "vbnet", "visual basic"],
+        ["python"] = ["py3"],
         ["yaml"] = ["yml"],
         ["typescript"] = ["ts", "tsx", "cts", "mts"],
         ["rust"] = ["rs"],
@@ -3032,13 +3007,7 @@ public static class QueryCommandRunner
 
     internal static string? NormalizeLangFilterValue(string? langValue)
     {
-        if (langValue == null)
-            return null;
-        var normalized = langValue
-            .ToLowerInvariant()
-            .Replace("-", string.Empty, StringComparison.Ordinal)
-            .Replace(" ", string.Empty, StringComparison.Ordinal);
-        return LangFilterAliases.TryGetValue(normalized, out var canonical) ? canonical : normalized;
+        return DbReader.NormalizeQueryLanguage(langValue);
     }
 
     internal static IReadOnlyList<string> GetLanguageAliases(string lang)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -29,7 +29,7 @@ public static class QueryCommandRunner
         ["cpp"] = ["c++", "cplusplus"],
         ["fsharp"] = ["f#"],
         ["vb"] = ["vb.net", "vbnet", "visual basic"],
-        ["python"] = ["py3"],
+        ["python"] = ["py3", "python3"],
         ["yaml"] = ["yml"],
         ["typescript"] = ["ts", "tsx", "cts", "mts"],
         ["rust"] = ["rs"],

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -803,6 +803,7 @@ public partial class DbReader
         AddQueryLanguageAlias(aliases, "cplusplus", "cpp");
         AddQueryLanguageAlias(aliases, "f#", "fsharp");
         AddQueryLanguageAlias(aliases, "jav", "java");
+        AddQueryLanguageAlias(aliases, "python3", "python");
         AddQueryLanguageAlias(aliases, "py3", "python");
         AddQueryLanguageAlias(aliases, "vb.net", "vb");
         AddQueryLanguageAlias(aliases, "vbnet", "vb");

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -31,6 +31,7 @@ public partial class DbReader
     private static readonly Regex CSharpUsingStaticImportRegex = new(@"^\s*(?:global\s+)?using\s+static\s+(?<target>[^;]+)", RegexOptions.Compiled);
     private static readonly Regex CSharpUsingAliasImportRegex = new(@"^\s*(?:global\s+)?using\s+(?!static\b)(?<alias>[^\s=;]+)\s*=\s*(?<target>[^;]+)", RegexOptions.Compiled);
     private static readonly Regex CSharpUsingNamespaceImportRegex = new(@"^\s*(?:global\s+)?using\s+(?!static\b)(?<target>[^;=]+)", RegexOptions.Compiled);
+    private static readonly IReadOnlyDictionary<string, string> QueryLanguageAliases = BuildQueryLanguageAliases();
     private readonly SqliteConnection _conn;
     private readonly bool _isReadOnly;
     private readonly HashSet<string> _fileColumns;
@@ -781,51 +782,55 @@ public partial class DbReader
         if (lang == null)
             return null;
 
-        var compact = lang.Replace("-", string.Empty, StringComparison.Ordinal).Replace(" ", string.Empty, StringComparison.Ordinal);
-        if (string.Equals(compact, "js", StringComparison.OrdinalIgnoreCase))
-            return "javascript";
-        if (string.Equals(compact, "jsx", StringComparison.OrdinalIgnoreCase))
-            return "javascript";
-        if (string.Equals(compact, "cjs", StringComparison.OrdinalIgnoreCase))
-            return "javascript";
-        if (string.Equals(compact, "mjs", StringComparison.OrdinalIgnoreCase))
-            return "javascript";
-        if (string.Equals(compact, "javascript", StringComparison.OrdinalIgnoreCase))
-            return "javascript";
-        if (string.Equals(compact, "ts", StringComparison.OrdinalIgnoreCase))
-            return "typescript";
-        if (string.Equals(compact, "tsx", StringComparison.OrdinalIgnoreCase))
-            return "typescript";
-        if (string.Equals(compact, "cts", StringComparison.OrdinalIgnoreCase))
-            return "typescript";
-        if (string.Equals(compact, "mts", StringComparison.OrdinalIgnoreCase))
-            return "typescript";
-        if (string.Equals(compact, "typescript", StringComparison.OrdinalIgnoreCase))
-            return "typescript";
-        if (string.Equals(compact, "java", StringComparison.OrdinalIgnoreCase))
-            return "java";
-        if (string.Equals(compact, "jav", StringComparison.OrdinalIgnoreCase))
-            return "java";
-        if (string.Equals(compact, "cshtml", StringComparison.OrdinalIgnoreCase))
-            return "csharp";
-        if (string.Equals(compact, "razor", StringComparison.OrdinalIgnoreCase))
-            return "csharp";
-        if (string.Equals(compact, "xaml", StringComparison.OrdinalIgnoreCase))
-            return "xml";
-        if (string.Equals(compact, "axaml", StringComparison.OrdinalIgnoreCase))
-            return "xml";
-        if (string.Equals(compact, "rs", StringComparison.OrdinalIgnoreCase))
-            return "rust";
-        return string.Equals(compact, "tsql", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(compact, "transactsql", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(compact, "mssql", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(compact, "sqlserver", StringComparison.OrdinalIgnoreCase)
-            ? "sql"
-            : lang;
+        var normalized = NormalizeQueryLanguageKey(lang);
+        return QueryLanguageAliases.TryGetValue(normalized, out var canonical)
+            ? canonical
+            : normalized;
     }
 
     internal static bool ContainsSqlLanguage(IEnumerable<string?> langs)
         => langs.Any(IsSqlLanguage);
+
+    private static IReadOnlyDictionary<string, string> BuildQueryLanguageAliases()
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (pattern, lang) in FileIndexer.GetLanguageExtensions())
+            AddQueryLanguageAlias(aliases, pattern, lang);
+
+        AddQueryLanguageAlias(aliases, "c#", "csharp");
+        AddQueryLanguageAlias(aliases, "c++", "cpp");
+        AddQueryLanguageAlias(aliases, "cplusplus", "cpp");
+        AddQueryLanguageAlias(aliases, "f#", "fsharp");
+        AddQueryLanguageAlias(aliases, "jav", "java");
+        AddQueryLanguageAlias(aliases, "py3", "python");
+        AddQueryLanguageAlias(aliases, "vb.net", "vb");
+        AddQueryLanguageAlias(aliases, "vbnet", "vb");
+        AddQueryLanguageAlias(aliases, "visual basic", "vb");
+        AddQueryLanguageAlias(aliases, "visualbasic", "vb");
+        AddQueryLanguageAlias(aliases, "sqlserver", "sql");
+        AddQueryLanguageAlias(aliases, "mssql", "sql");
+        AddQueryLanguageAlias(aliases, "transactsql", "sql");
+
+        return aliases;
+    }
+
+    private static void AddQueryLanguageAlias(IDictionary<string, string> aliases, string alias, string canonical)
+        => aliases.TryAdd(NormalizeQueryLanguageKey(alias), canonical);
+
+    private static string NormalizeQueryLanguageKey(string lang)
+    {
+        var builder = new StringBuilder(lang.Length);
+        foreach (var ch in lang.Trim())
+        {
+            if (char.IsWhiteSpace(ch) || ch is '-' or '_' or '.')
+                continue;
+
+            builder.Append(char.ToLowerInvariant(ch));
+        }
+
+        return builder.ToString();
+    }
 
     private static bool AllowSqlLeafFallbackForQuery(string query)
         => !SqlNameResolver.HasQualifier(query);

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -108,6 +108,29 @@ public class DbReaderTests : IDisposable
         Assert.Equal(1, counts.FileCount);
     }
 
+    [Theory]
+    [InlineData("src/csharp-alias.cs", "csharp", "c#")]
+    [InlineData("src/cpp-alias.cpp", "cpp", "c++")]
+    [InlineData("src/fsharp-alias.fs", "fsharp", "f#")]
+    [InlineData("src/vb-alias.vb", "vb", "vb.net")]
+    [InlineData("src/java-alias.java", "java", "jav")]
+    [InlineData("src/python-alias.py", "python", "py3")]
+    [InlineData("src/sql-alias.sql", "sql", "sqlserver")]
+    public void CountSearchResults_NormalizesCommonLanguageAliases(string path, string fileLang, string queryLang)
+    {
+        const string query = "CommonAliasToken";
+
+        InsertIndexedFile(
+            path,
+            fileLang,
+            $@"const marker = ""{query}"";");
+
+        var counts = _reader.CountSearchResults(query, lang: queryLang);
+
+        Assert.Equal(1, counts.Count);
+        Assert.Equal(1, counts.FileCount);
+    }
+
     private void SeedData()
     {
         const string authContent = "def authenticate(user, password):\n    if user == 'admin':\n        return True\n    return False";

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -115,6 +115,7 @@ public class DbReaderTests : IDisposable
     [InlineData("src/vb-alias.vb", "vb", "vb.net")]
     [InlineData("src/java-alias.java", "java", "jav")]
     [InlineData("src/python-alias.py", "python", "py3")]
+    [InlineData("src/python3-alias.py", "python", "python3")]
     [InlineData("src/sql-alias.sql", "sql", "sqlserver")]
     public void CountSearchResults_NormalizesCommonLanguageAliases(string path, string fileLang, string queryLang)
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -107,6 +107,7 @@ public class QueryCommandRunnerTests
     [InlineData("c#", "csharp")]
     [InlineData("c++", "cpp")]
     [InlineData("py3", "python")]
+    [InlineData("python3", "python")]
     [InlineData("sqlserver", "sql")]
     public void ParseArgs_NormalizesCommonLangAliases(string input, string expected)
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2019,14 +2019,10 @@ jobs:
 
         var lines = stdout.Split('\n').Select(line => line.TrimEnd('\r')).ToArray();
 
-        // Sanity: short rows still fit the fixed-width layout on a single line.
-        // 短い行は従来通り 1 行の固定幅レイアウトに収まる。
-        var csharpLine = lines.Single(line => line.StartsWith("csharp ", StringComparison.Ordinal));
-        Assert.Matches(@"^csharp\s+\.cs\s+\.cshtml\s+\.razor\s+cshtml\s+razor\s+yes\s+yes\s*$", csharpLine);
-
-        // Dockerfile / Makefile / Python / Ruby / MSBuild rows spill extensions to a continuation line.
-        // Dockerfile / Makefile / Python / Ruby / MSBuild 行は拡張子を継続行に退避する。
-        var wideLangs = new[] { "dockerfile", "makefile", "python", "ruby", "msbuild" };
+        // Rows with long extension / alias lists must spill onto a continuation line so the
+        // Symbols / Graph columns stay readable.
+        // 拡張子や alias が長い行は継続行に退避し、Symbols / Graph 列の可読性を保つ。
+        var wideLangs = new[] { "csharp", "dockerfile", "makefile", "python", "ruby", "msbuild" };
         foreach (var wide in wideLangs)
         {
             var headerIndex = Array.FindIndex(lines, line => line.StartsWith($"{wide} ", StringComparison.Ordinal));

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -103,6 +103,19 @@ public class QueryCommandRunnerTests
         Assert.Equal("myquery", options.Query);
     }
 
+    [Theory]
+    [InlineData("c#", "csharp")]
+    [InlineData("c++", "cpp")]
+    [InlineData("py3", "python")]
+    [InlineData("sqlserver", "sql")]
+    public void ParseArgs_NormalizesCommonLangAliases(string input, string expected)
+    {
+        var options = QueryCommandRunner.ParseArgs(["RunSearch", "--lang", input], jsonDefault: false, allowNamedQuery: true);
+
+        Assert.Equal("RunSearch", options.Query);
+        Assert.Equal(expected, options.Lang);
+    }
+
     [Fact]
     public void GetLanguageAliases_ReportsSqlDialectAliases()
     {
@@ -164,12 +177,20 @@ public class QueryCommandRunnerTests
     }
 
     [Theory]
-    [InlineData("transact-sql")]
-    [InlineData("transact sql")]
-    public void NormalizeQueryLanguage_MapsTransactSqlToSql(string input)
+    [InlineData("transact-sql", "sql")]
+    [InlineData("transact sql", "sql")]
+    [InlineData("sqlserver", "sql")]
+    [InlineData("mssql", "sql")]
+    [InlineData("c#", "csharp")]
+    [InlineData("c++", "cpp")]
+    [InlineData("f#", "fsharp")]
+    [InlineData("vb.net", "vb")]
+    [InlineData("py3", "python")]
+    public void NormalizeQueryLanguage_MapsCommonAliasesToCanonicalLanguages(string input, string expected)
     {
-        Assert.Equal("sql", DbReader.NormalizeQueryLanguage(input));
-        Assert.True(DbReader.IsSqlLanguage(input));
+        Assert.Equal(expected, DbReader.NormalizeQueryLanguage(input));
+        Assert.Equal(expected, QueryCommandRunner.NormalizeLangFilterValue(input));
+        Assert.Equal(expected == "sql", DbReader.IsSqlLanguage(input));
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- Centralized query-language normalization in `DbReader` so `--lang` and database-side filters accept the app's supported language set plus common alias spellings.
- Kept the CLI completion/display aliases aligned for the punctuation-heavy spellings we now normalize.
- Added tests for the new alias forms and kept existing JavaScript / TypeScript coverage.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter 'FullyQualifiedName~QueryCommandRunnerTests.ParseArgs_NormalizesCommonLangAliases|FullyQualifiedName~QueryCommandRunnerTests.NormalizeQueryLanguage_MapsCommonAliasesToCanonicalLanguages|FullyQualifiedName~DbReaderTests.CountSearchResults_NormalizesCommonLanguageAliases'`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter 'FullyQualifiedName~DbReaderTests.CountSearchResults_NormalizesJavascriptLangSpelling|FullyQualifiedName~DbReaderTests.CountSearchResults_NormalizesJavascriptShorthandLangSpellings|FullyQualifiedName~DbReaderTests.CountSearchResults_NormalizesTypeScriptSpelling'`

## Documentation / Changelog
- Added a bilingual fragment at `changelog.d/unreleased/+dbreader-language-alias-parity.fixed.md`.
- No direct `CHANGELOG.md` edits were made, per the repository workflow for ordinary implementation PRs.

## Follow-up candidates
- None.
