### PR TITLE
Improve Rust qualified macro search

### DIFF
--- a/changelog.d/unreleased/+rust-qualified-macro-search.fixed.md
+++ b/changelog.d/unreleased/+rust-qualified-macro-search.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Rust exact macro queries now keep their qualified path** — exact searches for qualified Rust macro invocations no longer collapse to the leaf name first, so `crate::macros::build!` resolves the intended path-specific reference instead of overmatching sibling macros.
+
+## 日本語
+
+- **Rust の exact な macro クエリが qualified path を保持するようになりました** — qualified な Rust macro 呼び出しの exact search では leaf 名に潰さず、そのまま path を使って照合するため、`crate::macros::build!` が sibling macro に誤って広がらず、意図した参照だけを返します。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -681,7 +681,7 @@ public partial class DbReader
         if (macroQuery.Length == 0)
             return null;
 
-        if (exact && isMacroQuery && macroQuery.Contains("::", StringComparison.Ordinal) && macroQuery.Contains("r#", StringComparison.Ordinal))
+        if (exact && isMacroQuery && macroQuery.Contains("::", StringComparison.Ordinal))
             return NormalizeRustQualifiedMacroQuery(macroQuery);
 
         var leafIndex = macroQuery.LastIndexOf("::", StringComparison.Ordinal);

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -457,6 +457,26 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchReferences_RustQualifiedMacroInvocationsStayPathAware()
+    {
+        InsertIndexedFile(
+            "src/macros.rs",
+            "rust",
+            """
+            fn main() {
+                crate::macros::build!();
+                crate::other::build!();
+            }
+            """);
+
+        var results = _reader.SearchReferences("crate::macros::build!", lang: "rust", exact: true);
+
+        var reference = Assert.Single(results);
+        Assert.Equal("crate::macros::build", reference.SymbolName);
+        Assert.Equal("src/macros.rs", reference.Path);
+    }
+
+    [Fact]
     public void RustQualifiedQueriesResolveAcrossGraphCommands()
     {
         InsertIndexedFile(


### PR DESCRIPTION
## Summary
- Preserve qualified Rust macro paths for exact graph/reference searches instead of collapsing them to leaf names first.
- Add a regression test for path-specific Rust macro reference lookup.
- Add a bilingual changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.SearchReferences_RustQualifiedMacroInvocationsStayPathAware|FullyQualifiedName~DbReaderTests.SearchReferences_RustQualifiedRawMacroInvocationsStayPathAware|FullyQualifiedName~DbReaderTests.RustQualifiedQueriesResolveAcrossGraphCommands"`
- `dotnet test`
- `dotnet build`

## Review
- Adversarial review completed locally on `origin/main..HEAD`.

## Notes
- No GitHub issue was provided for this task, so there is no `Fixes #...` line.