### PR TITLE
Handle CSS descendant selector references

### DIFF
--- a/changelog.d/unreleased/+css-descendant-selector-reference.fixed.md
+++ b/changelog.d/unreleased/+css-descendant-selector-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **CSS descendant selectors now keep nested class references visible** — `ReferenceExtractor` no longer skips selector lists that start with an element selector, so patterns like `button .card` continue to index `.card` as a searchable reference.
+
+## 日本語
+
+- **CSS の descendant selector でも入れ子の class reference が見えるようになりました** — `ReferenceExtractor` は要素セレクタで始まる selector list もスキップしなくなり、`button .card` のようなパターンでも `.card` が検索可能な reference として index されます。

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -3218,7 +3218,7 @@ public static class ReferenceExtractor
                 foreach (var (partStart, partEnd) in EnumerateCssSelectorListSegments(selectorSegment))
                 {
                     var selectorPart = selectorSegment[partStart..partEnd];
-                    if (!LooksLikeCssSelectorSegment(selectorPart))
+                    if (!ContainsCssClassSelectorReferenceCandidate(selectorPart))
                         continue;
 
                     var selectorPartTrimStart = 0;
@@ -3252,17 +3252,6 @@ public static class ReferenceExtractor
 
             segmentStart = braceIndex + 1;
         }
-    }
-
-    private static bool LooksLikeCssSelectorSegment(string line)
-    {
-        var index = 0;
-        while (index < line.Length && char.IsWhiteSpace(line[index]))
-            index++;
-        if (index >= line.Length)
-            return false;
-
-        return line[index] is '.' or '#' or '[' or '*' or ':' or '&';
     }
 
     private static IEnumerable<(int Start, int End)> EnumerateCssSelectorListSegments(string selectorSegment)
@@ -3306,6 +3295,45 @@ public static class ReferenceExtractor
         }
 
         yield return (segmentStart, selectorSegment.Length);
+    }
+
+    private static bool ContainsCssClassSelectorReferenceCandidate(string selectorPart)
+    {
+        var bracketDepth = 0;
+        char quote = '\0';
+        for (var index = 0; index < selectorPart.Length; index++)
+        {
+            var ch = selectorPart[index];
+            if (quote != '\0')
+            {
+                if (ch == quote && (index == 0 || selectorPart[index - 1] != '\\'))
+                    quote = '\0';
+                continue;
+            }
+
+            if (ch is '\'' or '"')
+            {
+                quote = ch;
+                continue;
+            }
+
+            if (ch == '[')
+            {
+                bracketDepth++;
+                continue;
+            }
+
+            if (ch == ']' && bracketDepth > 0)
+            {
+                bracketDepth--;
+                continue;
+            }
+
+            if (bracketDepth == 0 && ch == '.')
+                return true;
+        }
+
+        return false;
     }
 
     private static bool IsCssAnimationNameToken(string token)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -527,6 +527,42 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Css_DescendantSelectors_KeepClassReferencesVisible()
+    {
+        const string content = """
+            .container {
+                button .card {
+                    color: red;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+        var references = ReferenceExtractor.Extract(1, "css", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == ".card"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
+    public void Extract_Css_QuotedAttributeSelectors_DoNotEmitClassReferences()
+    {
+        const string content = """
+            button[data-state=".card"] {
+                color: red;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+        var references = ReferenceExtractor.Extract(1, "css", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == ".card"
+            && reference.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_Terraform_DottedReferences_AreReferenced()
     {
         const string content = """


### PR DESCRIPTION
## Summary

This PR addresses the follow-up candidate from PR #1359.

- `ReferenceExtractor` now keeps nested class references visible in descendant CSS selectors like `button .card`.
- The scan now ignores quoted attribute values, so patterns like `button[data-state=".card"]` do not create false positives.
- Added regression coverage for both the descendant-selector case and the quoted-attribute negative case.
- Added a bilingual changelog fragment under `changelog.d/unreleased/`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog

- `changelog.d/unreleased/+css-descendant-selector-reference.fixed.md`

## Follow-up candidates

- None identified beyond the follow-up candidate from PR #1359 that this PR addresses.