### PR TITLE
Fix JavaScript CommonJS bracket export search

### DIFF
--- a/changelog.d/unreleased/+javascript-commonjs-bracket-exports.fixed.md
+++ b/changelog.d/unreleased/+javascript-commonjs-bracket-exports.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **JavaScript CommonJS search now resolves bracket-notation exports to leaf names** — exact symbol and reference searches now normalize `module.exports["foo"]` and `exports['bar']` to the exported leaf name, so JavaScript CommonJS queries behave consistently across dot and bracket syntax.
+
+## 日本語
+
+- **JavaScript の CommonJS 検索でブラケット記法の export を leaf 名へ解決するようになりました** — exact な symbol / reference 検索が `module.exports["foo"]` と `exports['bar']` を export 先の leaf 名へ正規化するため、JavaScript CommonJS の query がドット記法とブラケット記法の間で一貫して動作します。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -693,10 +693,18 @@ public partial class DbReader
             return null;
 
         var commonJsPrefixLength = 0;
-        if (trimmed.StartsWith("module.exports.", StringComparison.Ordinal))
-            commonJsPrefixLength = "module.exports.".Length;
-        else if (trimmed.StartsWith("exports.", StringComparison.Ordinal))
-            commonJsPrefixLength = "exports.".Length;
+        if (trimmed.StartsWith("module.exports", StringComparison.Ordinal))
+        {
+            var nextIndex = "module.exports".Length;
+            if (trimmed.Length > nextIndex && trimmed[nextIndex] is '.' or '[')
+                commonJsPrefixLength = nextIndex;
+        }
+        else if (trimmed.StartsWith("exports", StringComparison.Ordinal))
+        {
+            var nextIndex = "exports".Length;
+            if (trimmed.Length > nextIndex && trimmed[nextIndex] is '.' or '[')
+                commonJsPrefixLength = nextIndex;
+        }
 
         if (commonJsPrefixLength == 0)
             return trimmed;
@@ -705,11 +713,44 @@ public partial class DbReader
         if (trimmed.Length == 0)
             return null;
 
+        trimmed = trimmed.TrimStart();
+        if (trimmed.StartsWith(".", StringComparison.Ordinal))
+            trimmed = trimmed[1..].TrimStart();
+
+        var bracketLeaf = NormalizeJavaScriptBracketLeaf(trimmed);
+        if (bracketLeaf != null)
+            return bracketLeaf;
+
         var leafIndex = trimmed.LastIndexOf('.');
         if (leafIndex >= 0)
             trimmed = trimmed[(leafIndex + 1)..];
 
+        bracketLeaf = NormalizeJavaScriptBracketLeaf(trimmed);
+        if (bracketLeaf != null)
+            return bracketLeaf;
+
         return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static string? NormalizeJavaScriptBracketLeaf(string query)
+    {
+        var trimmed = query.Trim();
+        if (trimmed.Length < 3 || trimmed[0] != '[' || trimmed[^1] != ']')
+            return null;
+
+        var inner = trimmed[1..^1].Trim();
+        if (inner.Length < 2)
+            return null;
+
+        var quote = inner[0];
+        if (quote is not '\'' and not '"')
+            return null;
+
+        if (inner[^1] != quote)
+            return null;
+
+        var leaf = inner[1..^1].Trim();
+        return leaf.Length == 0 ? null : leaf;
     }
 
     private static string? NormalizeRustSymbolSearchQuery(string? query, bool exact = false)

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -590,7 +590,7 @@ public static class SymbolExtractor
         RegexOptions.Compiled);
 
     private static readonly Regex JavaScriptTypeScriptCommonJsNamedExportAssignmentRegex = new(
-        $@"^\s*(?:module\.exports|exports)\.(?<name>{JavaScriptTypeScriptIdentifierPattern})(?:\s*:\s*[^=]+?)?\s*(?<![=!<>])=(?![=>])\s*(?<rhs>.*)$",
+        $@"^\s*(?:module\.exports|exports)(?:\.(?<name>{JavaScriptTypeScriptIdentifierPattern})|\[\s*['""](?<bracketName>[^'""]*)['""]\s*\])(?:\s*:\s*[^=]+?)?\s*(?<![=!<>])=(?![=>])\s*(?<rhs>.*)$",
         RegexOptions.Compiled);
 
     private static readonly Regex JavaScriptTypeScriptQualifiedAssignmentRegex = new(
@@ -9388,6 +9388,7 @@ private sealed class RubyMaskState
                 || TryGetGroup(bindingMatch, "visibility") == "export"
                 || bindingMatch.Groups["exportsAlias"].Success
                 || bindingMatch.Groups["moduleExportsAlias"].Success
+                || bindingMatch.Groups["bracketName"].Success
                 || bindingMatch.Groups["moduleExports"].Success;
             if (!isExported
                 && IsJavaScriptTypeScriptMatchInNamespaceScope(privateScopeColumns, i, match.Index, sanitizedLine))
@@ -10278,7 +10279,13 @@ private sealed class RubyMaskState
                     continue;
                 }
 
-                var name = match.Groups["name"].Value;
+                var name = TryGetGroup(match, "name")
+                    ?? GetJavaScriptTypeScriptCommonJsBracketName(rawLines[i], absoluteMatchIndex + match.Groups["bracketName"].Index, match.Groups["bracketName"].Length);
+                if (name == null)
+                {
+                    statementStart = FindNextJavaScriptTypeScriptStatementStart(sanitizedLine, statementStart + 1);
+                    continue;
+                }
                 if (!TryCollectJavaScriptTypeScriptAssignedRhs(
                         rawLines,
                         sanitizedLines,
@@ -10373,6 +10380,15 @@ private sealed class RubyMaskState
                 statementStart = FindNextJavaScriptTypeScriptStatementStart(sanitizedLines[i], rhsEndColumn + 1);
             }
         }
+    }
+
+    private static string? GetJavaScriptTypeScriptCommonJsBracketName(string rawLine, int startColumn, int length)
+    {
+        if (length <= 0 || startColumn < 0 || startColumn + length > rawLine.Length)
+            return null;
+
+        var rawName = rawLine.Substring(startColumn, length).Trim();
+        return rawName.Length == 0 ? null : rawName;
     }
 
     private static void ExtractJavaScriptTypeScriptExportedObjectLiteralProperties(

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -275,6 +275,33 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_JavaScriptCommonJsBracketExportQueriesResolveToLeafNames()
+    {
+        InsertIndexedFile(
+            "src/commonjs-bracket.js",
+            "javascript",
+            """
+            module.exports["foo"] = function foo() { return 1; };
+            function caller() {
+                foo();
+            }
+            exports['bar'] = 42;
+            """);
+
+        var foo = Assert.Single(_reader.SearchSymbols("module.exports[\"foo\"]", lang: "javascript", exact: true));
+        Assert.Equal("foo", foo.Name);
+        Assert.Equal("src/commonjs-bracket.js", foo.Path);
+
+        var bar = Assert.Single(_reader.SearchSymbols("exports['bar']", lang: "javascript", exact: true));
+        Assert.Equal("bar", bar.Name);
+        Assert.Equal("src/commonjs-bracket.js", bar.Path);
+
+        var references = _reader.SearchReferences("module.exports[\"foo\"]", lang: "javascript", exact: true);
+        Assert.NotEmpty(references);
+        Assert.Contains(references, reference => reference.SymbolName == "foo" && reference.ContainerName == "caller" && reference.Path == "src/commonjs-bracket.js");
+    }
+
+    [Fact]
     public void SearchSymbols_JavaScriptQualifiedQueriesOutsideCommonJsRemainExact()
     {
         InsertIndexedFile(


### PR DESCRIPTION
## Summary
- Extend JavaScript CommonJS named-export extraction so bracket notation like `module.exports["foo"] = function foo() {}` and `exports['bar'] = 42` indexes the exported leaf name.
- Normalize bracket-notation CommonJS queries to the leaf name so exact symbol and reference searches resolve consistently.
- Add a regression test for bracket-notation JavaScript CommonJS export queries.

## Validation
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog
- Fragment: `changelog.d/unreleased/+javascript-commonjs-bracket-exports.fixed.md`
- No additional docs updates were needed beyond the changelog fragment.

## Follow-up candidates
- None.