### PR TITLE
Improve TypeScript generic type alias search

### DIFF
--- a/changelog.d/unreleased/+typescript-generic-type-aliases.fixed.md
+++ b/changelog.d/unreleased/+typescript-generic-type-aliases.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **TypeScript generic type aliases now stay searchable when they use default type parameters** — `SymbolExtractor` now recognizes `type Foo<T = string> = ...`-style aliases instead of missing them, so TypeScript symbol search covers a common generic form that previously fell through.
+
+## 日本語
+
+- **TypeScript の generic type alias が default type parameter を使っていても検索対象に残るようになりました** — `SymbolExtractor` が `type Foo<T = string> = ...` 形式の alias を取りこぼさず認識するため、TypeScript の symbol search でよくある generic 形式を拾えるようになりました。

--- a/src/CodeIndex/Indexer/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/SymbolExtractor.cs
@@ -276,6 +276,13 @@ public static class SymbolExtractor
     // 以上の丸括弧ネストは実 HOC シグネチャでは極めて稀で、ReDoS 安全に受理するには完全
     // な bracket walker が必要になるため、それぞれ 3 段・1 段で打ち切る。#240 解消。
     private const string TypeScriptOptionalHocTypeArgsPattern = @"(?:<(?:[^<>()=]|=>?|\((?:[^()]|\([^()]*\))*\)|<(?:[^<>()=]|=>?|\((?:[^()]|\([^()]*\))*\)|<(?:[^<>()=]|=>?|\((?:[^()]|\([^()]*\))*\))*>)*>)*>\s*)?";
+    // Optional TypeScript generic parameter list that may follow a `type` alias name.
+    // Allow defaulted parameters (`T = string`) in addition to constraints and nested
+    // type expressions so generic aliases stay searchable.
+    // `type` エイリアス名の後に続く TypeScript の generic parameter list（オプション）。
+    // `T = string` のような default 付き parameter に加え、constraint や入れ子の
+    // type expression も許容して generic alias を検索対象に残す。
+    private const string TypeScriptOptionalTypeParameterListPattern = @"(?:<(?:[^<>()=]|=(?!>)|=>?|\((?:[^()]|\([^()]*\))*\)|<(?:[^<>()=]|=(?!>)|=>?|\((?:[^()]|\([^()]*\))*\)|<(?:[^<>()=]|=(?!>)|=>?|\((?:[^()]|\([^()]*\))*\))*>)*>)*>\s*)?";
 
     private enum BodyStyle
     {
@@ -714,7 +721,7 @@ public static class SymbolExtractor
             // Include optional `*` between `function` and name for generator functions (e.g. `function* gen()`, `async function* asyncGen()`)
             // `function` と名前の間に任意の `*` を許容し、ジェネレータ関数 (`function* gen()`, `async function* asyncGen()`) にも対応
             new("function", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?(?:async\s+)?function(?:\s+|\s*\*\s*)(?<name>\w+)\s*[\(<]", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("import", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?type\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("import", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:declare\s+)?type\s+(?<name>\w+)" + TypeScriptOptionalTypeParameterListPattern + @"\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("property", new Regex(@"^\s*(?:(?<visibility>export)\s+)?declare\s+(?:const|let|var)\s+(?<name>\w+)(?::\s*[^;=]+)?\s*;", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>export)\s+)?(?:const|let|var)\s+(?<name>\w+)\s*(?::\s*.+?)?\s*=\s*(?:async\s+)?(?:\([^)]*\)|[^=])\s*=>", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // HOC-wrapped / call-result component bindings — same narrow HOC-prefix set

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -3679,6 +3679,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScript_DetectsGenericTypeAliasesWithDefaultTypeParameters()
+    {
+        var content = """
+            export type Result<T = string> = { value: T };
+            """;
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Result");
+    }
+
+    [Fact]
     public void Extract_TypeScript_DetectsInlineDefaultExportMultipleMethods()
     {
         var content = "export default class { first(): void {} second(): void {} }";


### PR DESCRIPTION
Summary:
- Teach the TypeScript symbol extractor to recognize generic type aliases that use default type parameters, so search no longer misses `type Foo<T = string> = ...` forms.
- Add a regression test for the new TypeScript shape.
- Add a bilingual changelog fragment under `changelog.d/unreleased/`.

Validation:
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

Review:
- No blocking/actionable issues found.