### PR TITLE
Fix SQLite open contention on concurrent reads

### DIFF
--- a/changelog.d/unreleased/+sqlite-concurrent-open-timeout.fixed.md
+++ b/changelog.d/unreleased/+sqlite-concurrent-open-timeout.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1364
+affected:
+  - src/CodeIndex/Database/DbContext.cs
+---
+
+## English
+
+- **SQLite connection setup now enables `busy_timeout` before the first setup PRAGMA** — `DbContext` applies the timeout immediately after opening the connection, before registering functions or switching journal mode, so concurrent read opens are less likely to fail with transient `database is locked` errors on macOS.
+
+## 日本語
+
+- **SQLite の接続初期化で最初の setup PRAGMA より前に `busy_timeout` を有効化するようにしました** — `DbContext` は接続を開いた直後、関数登録や journal mode 切り替えの前にタイムアウトを設定するため、macOS での並行 read open が一時的な `database is locked` で失敗しにくくなります。

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -127,9 +127,9 @@ public class DbContext : IDisposable
             {
                 _connection = new SqliteConnection($"Data Source={dbPath}");
                 _connection.Open();
+                Execute("PRAGMA busy_timeout=5000");
                 RegisterConnectionFunctions(_connection);
                 _isReadOnly = true;
-                Execute("PRAGMA busy_timeout=5000");
                 return;
             }
 
@@ -151,6 +151,7 @@ public class DbContext : IDisposable
                 () => new SqliteConnection(builder.ConnectionString),
                 static connection => connection.Open(),
                 static milliseconds => System.Threading.Thread.Sleep(milliseconds));
+            Execute("PRAGMA busy_timeout=5000");
             RegisterConnectionFunctions(_connection);
 
             // Enable WAL mode and verify it was applied / WALモードを有効にし適用を確認
@@ -170,13 +171,10 @@ public class DbContext : IDisposable
             // immutable=1 を付けないと SQLite は -shm/-wal を触ろうとして CANTOPEN で落ちることがある。
             _connection?.Dispose();
             _connection = OpenReadOnly(dbPath);
+            Execute("PRAGMA busy_timeout=5000");
             RegisterConnectionFunctions(_connection);
             _isReadOnly = true;
         }
-
-        // Set busy timeout to avoid immediate SQLITE_BUSY errors on concurrent access
-        // 同時アクセス時の即座のSQLITE_BUSYエラーを回避するためビジータイムアウトを設定
-        Execute("PRAGMA busy_timeout=5000");
 
         if (!_isReadOnly)
         {


### PR DESCRIPTION
## Summary
- Move SQLite `busy_timeout` ahead of the first setup PRAGMA in `DbContext` so concurrent opens are less likely to trip transient locks.
- Keep the changelog updated with the macOS flaky-read fix.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConcurrencyTests"`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Changelog
- `changelog.d/unreleased/+sqlite-concurrent-open-timeout.fixed.md`

Fixes #1364

## Follow-up Candidates
- None identified.