### PR TITLE
[codex] Expand typed-language reference extraction

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -45,18 +45,19 @@ src/CodeIndex/
     GradleReferenceExtractor.cs — Gradle/Groovy-specific reference extraction for block and command-style DSL calls
     JavaScriptReferenceExtractor.cs — JavaScript/TypeScript-specific reference extraction for parenless zero-argument constructor calls
     JavaReferenceExtractor.cs — Java-specific reference extraction for constructor-chain rewrites, same-line constructor container recovery, type-position references, method references, `.class` literals, and module directives
-    KotlinReferenceExtractor.cs — Kotlin-specific reference extraction for trailing lambda calls and method references
+    KotlinReferenceExtractor.cs — Kotlin-specific reference extraction for trailing lambda calls, method references, and structural type-position references
     PhpReferenceExtractor.cs — PHP-specific reference extraction for static and object member access
     PowerShellReferenceExtractor.cs — PowerShell-specific reference extraction for cmdlet-style calls
     PythonReferenceExtractor.cs — Python-specific reference extraction for bare decorators
     RReferenceExtractor.cs    — R-specific reference extraction for namespace references
     RubyReferenceExtractor.cs — Ruby-specific reference extraction for command-style calls, block calls, and DSL target references
-    RustReferenceExtractor.cs — Rust-specific reference extraction for macro calls and raw identifier normalization
+    RustReferenceExtractor.cs — Rust-specific reference extraction for macro calls, raw identifier normalization, and structural type-position references
     ScalaReferenceExtractor.cs — Scala-specific reference extraction for trailing block calls and method references
     ShellReferenceExtractor.cs — Shell-specific reference extraction for command-style function calls, sources, and global aliases
-    SwiftReferenceExtractor.cs — Swift-specific reference extraction for trailing closure calls
+    SwiftReferenceExtractor.cs — Swift-specific reference extraction for trailing closure calls and structural type-position references
     TerraformReferenceExtractor.cs — Terraform-specific reference extraction for dotted dependency forms
     TypeScriptReferenceExtractor.cs — TypeScript-specific reference extraction entry point for type-position and declaration type references
+    TypedLanguageReferenceExtractor.cs — Shared scanner helpers for colon/arrow/heritage/generic type-position references in typed languages
     SqlReferenceExtractor.cs  — SQL-specific reference extraction for source/target dependencies, temp-object tracking, and procedure calls
     SymbolExtractor.cs        — Hybrid symbol extraction: compiled regexes for most languages, plus a lightweight JS/TS lexer/state machine for class-body methods and semicolon-terminated interface/abstract properties, Java method guards for generic type-parameter prefixes and statement keywords, C/C++ out-of-class member definitions / operators / concepts / inline namespaces / modules, CSS grouping/nesting selectors and selector lists / named at-rules, per-file hash-based duplicate bookkeeping for same-line restart suppression, scope filtering, and range resolution
     ReferenceExtractor.cs     — Orchestrates regex-based call/reference extraction across graph-supported languages, including JSX component open tags in `.jsx` / `.tsx` files, method-reference / method-group handoffs, shared call/instantiate paths, and a depth-aware fallback for nested-generic call sites (31 languages with graph queries)
@@ -1208,18 +1209,19 @@ src/CodeIndex/
     GradleReferenceExtractor.cs — Gradle/Groovy 固有の block / command-style DSL call 参照抽出
     JavaScriptReferenceExtractor.cs — JavaScript/TypeScript 固有の括弧なし zero-argument constructor call 参照抽出
     JavaReferenceExtractor.cs — Java 固有の constructor-chain 書き換え、same-line constructor container 復元、type-position reference、method reference、`.class` literal、module directive 参照抽出
-    KotlinReferenceExtractor.cs — Kotlin 固有の trailing lambda call と method reference 参照抽出
+    KotlinReferenceExtractor.cs — Kotlin 固有の trailing lambda call、method reference、構造的 type-position reference 参照抽出
     PhpReferenceExtractor.cs — PHP 固有の static access / object member access 参照抽出
     PowerShellReferenceExtractor.cs — PowerShell 固有の cmdlet 形式呼び出し参照抽出
     PythonReferenceExtractor.cs — Python 固有の bare decorator 参照抽出
     RReferenceExtractor.cs    — R 固有の namespace 参照抽出
     RubyReferenceExtractor.cs — Ruby 固有の command-style call、block call、DSL target 参照抽出
-    RustReferenceExtractor.cs — Rust 固有の macro call と raw identifier 正規化の参照抽出
+    RustReferenceExtractor.cs — Rust 固有の macro call、raw identifier 正規化、構造的 type-position reference 参照抽出
     ScalaReferenceExtractor.cs — Scala 固有の trailing block call と method reference 参照抽出
     ShellReferenceExtractor.cs — Shell 固有の command-style function call、source、global alias 参照抽出
-    SwiftReferenceExtractor.cs — Swift 固有の trailing closure call 参照抽出
+    SwiftReferenceExtractor.cs — Swift 固有の trailing closure call と構造的 type-position reference 参照抽出
     TerraformReferenceExtractor.cs — Terraform 固有の dotted dependency 形式の参照抽出
     TypeScriptReferenceExtractor.cs — TypeScript 固有の型位置・宣言型参照抽出エントリポイント
+    TypedLanguageReferenceExtractor.cs — 型付き言語の colon / arrow / heritage / generic type-position reference 用の共有スキャナヘルパー
     SqlReferenceExtractor.cs  — SQL 固有の source/target 依存、temp object 追跡、procedure call 参照抽出
     SymbolExtractor.cs        — ハイブリッドなシンボル抽出（大半はコンパイル済み正規表現、JS/TS は class body method と `;` 終端の interface/abstract property、Java は generic type-parameter prefix と statement keyword のガード、C/C++ のクラス外 member 定義・operator・concept・inline namespace・module、CSS の grouping/nesting セレクタ・same-line restart の重複抑止用のファイル単位ハッシュ管理・scope filtering・range 解決向けの軽量 lexer / state machine を追加、HTML はタグ構造を理解した文字単位 state machine で属性値・raw-text 本体・コメントをマスク）
     ReferenceExtractor.cs     — 対応言語向けの正規表現ベース参照抽出（型位置の `type_reference` エッジと nested generic 呼び出し向け depth-aware fallback を含む）

--- a/README.md
+++ b/README.md
@@ -72,17 +72,20 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 - [Integration Policy](INTEGRATION_POLICY.md): permitted CLI, JSON, MCP, and
   integration use.
 
-## License
+## License and Fair Source Use
 
-CodeIndex and official `cdidx` binaries are source-available / Fair Source-style
-software under [FSL-1.1-ALv2](LICENSE), unless a specific file or directory says
-otherwise. Integration materials may be Apache-2.0 where marked.
+CodeIndex and official `cdidx` binaries are source-available / Fair Source-style software
+under [FSL-1.1-ALv2](LICENSE), unless a specific file or directory says
+otherwise. Integration materials may be [Apache-2.0](LICENSES/Apache-2.0.txt)
+where marked.
 
 See [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md), [INTEGRATION_POLICY.md](INTEGRATION_POLICY.md),
 and [TRADEMARKS.md](TRADEMARKS.md) for commercial, integration, and naming
 details.
 
 # cdidx（日本語）
+
+![License](https://img.shields.io/badge/License-FSL--1.1--ALv2-orange)
 
 **ターミナルと MCP ワークフロー向けの、AI ネイティブなローカルコード検索です。**
 
@@ -142,11 +145,12 @@ cdidx mcp
   エージェント向けルール。
 - [統合ポリシー](INTEGRATION_POLICY.md): CLI、JSON、MCP、各種統合で許可される利用。
 
-## ライセンス
+## ライセンスと Fair Source の扱い
 
 CodeIndex と公式 `cdidx` バイナリは、ファイルやディレクトリで別途明記されない
-限り [FSL-1.1-ALv2](LICENSE) の source-available / Fair Source-style
-ソフトウェアです。統合用の素材は、明記されている場合 Apache-2.0 で利用できます。
+限り [FSL-1.1-ALv2](LICENSE) の source-available / Fair Source-style software
+です。統合用の素材は、明記されている場合 [Apache-2.0](LICENSES/Apache-2.0.txt)
+で利用できます。
 
 商用利用、統合、名称の扱いについては [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md)、
 [INTEGRATION_POLICY.md](INTEGRATION_POLICY.md)、[TRADEMARKS.md](TRADEMARKS.md) を

--- a/changelog.d/unreleased/+readme-license-policy.docs.md
+++ b/changelog.d/unreleased/+readme-license-policy.docs.md
@@ -1,0 +1,13 @@
+---
+category: docs
+affected:
+  - README.md
+---
+
+## English
+
+- **Restored README Fair Source license parity** — the Japanese README section now mirrors the English FSL badge, Fair Source heading, and Apache-2.0 license link expected by the repository license policy tests.
+
+## 日本語
+
+- **README の Fair Source ライセンス表記の整合性を復元しました** — 日本語版 README セクションでも、リポジトリのライセンスポリシーテストが期待する FSL バッジ、Fair Source 見出し、Apache-2.0 ライセンスリンクを英語版と揃えました。

--- a/changelog.d/unreleased/+reference-extractor-type-granularity.changed.md
+++ b/changelog.d/unreleased/+reference-extractor-type-granularity.changed.md
@@ -1,0 +1,19 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+  - src/CodeIndex/Indexer/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/SwiftReferenceExtractor.cs
+  - src/CodeIndex/Indexer/RustReferenceExtractor.cs
+  - src/CodeIndex/Indexer/TypedLanguageReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Expanded non-C# reference extraction granularity** — TypeScript, Kotlin, Swift, and Rust now index more structural `type_reference` edges from declarations, inheritance/implementation clauses, generic bounds, type tests/casts, and typed variables so symbol workflows can find dependencies with finer language-aware precision.
+
+## 日本語
+
+- **C# 以外の参照抽出粒度を拡張しました** — TypeScript、Kotlin、Swift、Rust で宣言、継承/実装句、generic 境界、型テスト/キャスト、型付き変数からより多くの構造的な `type_reference` エッジを索引化し、シンボル系ワークフローが依存関係をより細かい言語別精度で辿れるようになりました。

--- a/src/CodeIndex/Indexer/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/KotlinReferenceExtractor.cs
@@ -4,6 +4,9 @@ namespace CodeIndex.Indexer;
 
 internal static class KotlinReferenceExtractor
 {
+    private static readonly string[] DeclarationKeywords = ["val", "var"];
+    private static readonly string[] TypeOperatorKeywords = ["is", "as"];
+
     public static void EmitTrailingLambdaReferences(
         string preparedLine,
         Action<string, int> addCallLikeReference)
@@ -25,4 +28,210 @@ internal static class KotlinReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+
+    public static void EmitTypePositionReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitPrimaryConstructorTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        TypedLanguageReferenceExtractor.EmitColonVariableTypeReferences(
+            preparedLine,
+            DeclarationKeywords,
+            "kotlin",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+        TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
+            preparedLine,
+            TypeOperatorKeywords,
+            "kotlin",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
+
+    private static void EmitCallableSignatureTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var funIndex = ReferenceExtractor.FindTopLevelKeyword(preparedLine, "fun");
+        if (funIndex < 0)
+            return;
+
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(', funIndex + "fun".Length);
+        if (openParen <= funIndex)
+            return;
+
+        var closeParen = ReferenceExtractor.FindMatchingChar(preparedLine, openParen, '(', ')');
+        if (closeParen < 0)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitColonParameterTypeReferences(
+            preparedLine,
+            openParen + 1,
+            closeParen,
+            "kotlin",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+
+        var returnColon = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, closeParen + 1);
+        if (returnColon >= preparedLine.Length || preparedLine[returnColon] != ':')
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, returnColon + 1);
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+        if (typeEnd <= typeStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(typeStart, typeEnd - typeStart),
+            typeStart,
+            "kotlin",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(typeStart));
+    }
+
+    private static void EmitHeritageTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var trimmed = preparedLine.TrimStart();
+        if (!(trimmed.StartsWith("class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("data class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("sealed class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("interface ", StringComparison.Ordinal)
+              || trimmed.StartsWith("object ", StringComparison.Ordinal)
+              || trimmed.StartsWith("enum class ", StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':');
+        if (colonIndex < 0)
+            return;
+
+        var listStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+        var listEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, listStart, stopAtComma: false);
+        if (listEnd <= listStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitCommaSeparatedTypeListReferences(
+            preparedLine,
+            listStart,
+            listEnd,
+            "kotlin",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn,
+            trimTopLevelCallArguments: true);
+    }
+
+    private static void EmitPrimaryConstructorTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var trimmed = preparedLine.TrimStart();
+        if (!(trimmed.StartsWith("class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("data class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("sealed class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("enum class ", StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(');
+        if (openParen < 0)
+            return;
+
+        var closeParen = ReferenceExtractor.FindMatchingChar(preparedLine, openParen, '(', ')');
+        if (closeParen < 0)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitColonParameterTypeReferences(
+            preparedLine,
+            openParen + 1,
+            closeParen,
+            "kotlin",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
+
+    private static void EmitGenericBoundReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var genericOpenIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '<');
+        if (genericOpenIndex >= 0)
+        {
+            TypedLanguageReferenceExtractor.EmitGenericColonBoundReferences(
+                preparedLine,
+                genericOpenIndex,
+                "kotlin",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+        }
+
+        TypedLanguageReferenceExtractor.EmitWhereClauseTypeReferences(
+            preparedLine,
+            "kotlin",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
 }

--- a/src/CodeIndex/Indexer/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/KotlinReferenceExtractor.cs
@@ -52,16 +52,19 @@ internal static class KotlinReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
-        TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
-            preparedLine,
-            TypeOperatorKeywords,
-            "kotlin",
-            references,
-            seen,
-            fileId,
-            context,
-            lineNumber,
-            resolveContainerForColumn);
+        if (!preparedLine.TrimStart().StartsWith("import ", StringComparison.Ordinal))
+        {
+            TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
+                preparedLine,
+                TypeOperatorKeywords,
+                "kotlin",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+        }
     }
 
     private static void EmitCallableSignatureTypeReferences(

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -3455,6 +3455,19 @@ public static class ReferenceExtractor
         int lineNumber,
         SymbolRecord? container)
     {
+        if (TypedLanguageReferenceExtractor.TryEmitTypeScriptFunctionTypeExpressionReferences(
+                expression,
+                expressionStartInLine,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container))
+        {
+            return;
+        }
+
         for (int i = 0; i < expression.Length; i++)
         {
             char c = expression[i];

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -479,6 +479,29 @@ public static class ReferenceExtractor
         "nint", "nuint", "char", "float", "double", "decimal",
         "string", "object", "void", "dynamic", "var",
     };
+    private static readonly Dictionary<string, HashSet<string>> LanguageBuiltInTypeNames = new(StringComparer.Ordinal)
+    {
+        ["typescript"] = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "any", "bigint", "boolean", "false", "never", "null", "number", "object", "string",
+            "symbol", "true", "undefined", "unknown", "void",
+        },
+        ["kotlin"] = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Any", "Boolean", "Byte", "Char", "Double", "Float", "Int", "Long", "Nothing",
+            "Short", "String", "Unit",
+        },
+        ["swift"] = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Any", "Bool", "Character", "Double", "Float", "Int", "Int8", "Int16", "Int32", "Int64",
+            "Never", "Self", "String", "UInt", "UInt8", "UInt16", "UInt32", "UInt64", "Void",
+        },
+        ["rust"] = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Self", "bool", "char", "f32", "f64", "i8", "i16", "i32", "i64", "i128", "isize",
+            "str", "u8", "u16", "u32", "u64", "u128", "usize",
+        },
+    };
     // C# pattern-only keywords / literals that can appear after `is` / `case not` but are never
     // real user-defined types. Filter them before AddTypeExpressionSegments so `is not null`,
     // `is default`, and similar constant patterns do not surface phantom `type_reference` rows.
@@ -1198,6 +1221,40 @@ public static class ReferenceExtractor
                     context,
                     lineNumber,
                     ResolveContainerForCall);
+            }
+            else if (language == "kotlin")
+            {
+                KotlinReferenceExtractor.EmitTypePositionReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
+            }
+            else if (language == "swift")
+            {
+                SwiftReferenceExtractor.EmitTypePositionReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
+            }
+            else if (language == "rust")
+            {
+                RustReferenceExtractor.EmitTypePositionReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall,
+                    container);
             }
             else if (language == "css")
             {
@@ -1956,6 +2013,12 @@ public static class ReferenceExtractor
             return true;
         if (language == "csharp" && CSharpBuiltInTypeNames.Contains(segment))
             return true;
+        if (LanguageBuiltInTypeNames.TryGetValue(language, out var builtInTypes)
+            && builtInTypes.Contains(segment))
+        {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/CodeIndex/Indexer/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/ReferenceExtractor.cs
@@ -767,8 +767,9 @@ public static class ReferenceExtractor
         // プロパティ自身に帰属させる (issue #233 参照)。
         var containerCandidates = symbols
             .Where(symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null &&
-                             (symbol.Kind == "function" || symbol.Kind == "class"
-                              || symbol.Kind == "namespace" || symbol.Kind == "property"))
+                              (symbol.Kind == "function" || symbol.Kind == "class"
+                               || symbol.Kind == "struct" || symbol.Kind == "namespace"
+                               || symbol.Kind == "property"))
             .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
             .ToList();
         var csharpXmlDocAttachmentScopeCandidates = language == "csharp"

--- a/src/CodeIndex/Indexer/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/RustReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;
 
@@ -36,6 +37,268 @@ internal static class RustReferenceExtractor
             var callIndex = match.Groups["name"].Index;
             addCallLikeReference(name, callIndex);
         }
+    }
+
+    public static void EmitTypePositionReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        SymbolRecord? container)
+    {
+        EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
+        EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitFunctionSignatureTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var fnIndex = ReferenceExtractor.FindTopLevelKeyword(preparedLine, "fn");
+        if (fnIndex < 0)
+            return;
+
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(', fnIndex + 2);
+        if (openParen <= fnIndex)
+            return;
+
+        var closeParen = ReferenceExtractor.FindMatchingChar(preparedLine, openParen, '(', ')');
+        if (closeParen < 0)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitColonParameterTypeReferences(
+            preparedLine,
+            openParen + 1,
+            closeParen,
+            "rust",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+
+        var arrowIndex = TypedLanguageReferenceExtractor.FindTopLevelSequence(preparedLine, "->", closeParen + 1);
+        if (arrowIndex < 0)
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, arrowIndex + 2);
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+        if (typeEnd <= typeStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(typeStart, typeEnd - typeStart),
+            typeStart,
+            "rust",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(typeStart));
+    }
+
+    private static void EmitLetTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var letIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "let"))
+        {
+            var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':', letIndex + "let".Length);
+            if (colonIndex < 0)
+                continue;
+
+            var assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=', letIndex + "let".Length);
+            if (assignmentIndex >= 0 && assignmentIndex < colonIndex)
+                continue;
+
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                preparedLine.Substring(typeStart, typeEnd - typeStart),
+                typeStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(typeStart));
+        }
+    }
+
+    private static void EmitStructFieldTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (container?.Kind != "class")
+            return;
+
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':');
+        if (colonIndex < 0)
+            return;
+
+        var trimmed = preparedLine.TrimStart();
+        if (trimmed.StartsWith("fn ", StringComparison.Ordinal)
+            || trimmed.StartsWith("let ", StringComparison.Ordinal)
+            || trimmed.StartsWith("type ", StringComparison.Ordinal)
+            || trimmed.StartsWith("impl ", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+        if (typeEnd <= typeStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(typeStart, typeEnd - typeStart),
+            typeStart,
+            "rust",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+    }
+
+    private static void EmitImplAndTraitTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var implIndex = ReferenceExtractor.FindTopLevelKeyword(preparedLine, "impl");
+        if (implIndex >= 0)
+        {
+            var typeListStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, implIndex + "impl".Length);
+            var forIndex = ReferenceExtractor.FindTopLevelKeyword(preparedLine, "for");
+            var typeListEnd = forIndex >= 0
+                ? forIndex
+                : TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeListStart);
+
+            if (typeListEnd > typeListStart)
+            {
+                TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                    preparedLine.Substring(typeListStart, typeListEnd - typeListStart),
+                    typeListStart,
+                    "rust",
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(typeListStart));
+            }
+
+            if (forIndex >= 0)
+            {
+                var targetStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, forIndex + "for".Length);
+                var targetEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, targetStart);
+                if (targetEnd > targetStart)
+                {
+                    TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                        preparedLine.Substring(targetStart, targetEnd - targetStart),
+                        targetStart,
+                        "rust",
+                        references,
+                        seen,
+                        fileId,
+                        context,
+                        lineNumber,
+                        resolveContainerForColumn(targetStart));
+                }
+            }
+        }
+
+        var traitIndex = ReferenceExtractor.FindTopLevelKeyword(preparedLine, "trait");
+        if (traitIndex < 0)
+            return;
+
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':', traitIndex + "trait".Length);
+        if (colonIndex < 0)
+            return;
+
+        var boundsStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+        var boundsEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, boundsStart);
+        if (boundsEnd <= boundsStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(boundsStart, boundsEnd - boundsStart),
+            boundsStart,
+            "rust",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(boundsStart));
+    }
+
+    private static void EmitGenericBoundReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var genericOpenIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '<');
+        if (genericOpenIndex >= 0)
+        {
+            TypedLanguageReferenceExtractor.EmitGenericColonBoundReferences(
+                preparedLine,
+                genericOpenIndex,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+        }
+
+        TypedLanguageReferenceExtractor.EmitWhereClauseTypeReferences(
+            preparedLine,
+            "rust",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
     }
 
     public static string NormalizeIdentifier(string identifier)

--- a/src/CodeIndex/Indexer/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/RustReferenceExtractor.cs
@@ -156,7 +156,7 @@ internal static class RustReferenceExtractor
         int lineNumber,
         SymbolRecord? container)
     {
-        if (container?.Kind != "class")
+        if (container?.Kind is not "class" and not "struct")
             return;
 
         var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':');

--- a/src/CodeIndex/Indexer/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/RustReferenceExtractor.cs
@@ -51,6 +51,7 @@ internal static class RustReferenceExtractor
     {
         EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitTupleStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -147,6 +148,54 @@ internal static class RustReferenceExtractor
         }
     }
 
+    private static void EmitTupleStructFieldTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        SymbolRecord? container)
+    {
+        var structIndex = ReferenceExtractor.FindTopLevelKeyword(preparedLine, "struct");
+        if (structIndex < 0)
+            return;
+
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(', structIndex + "struct".Length);
+        if (openParen < 0)
+            return;
+
+        var closeParen = ReferenceExtractor.FindMatchingChar(preparedLine, openParen, '(', ')');
+        if (closeParen <= openParen)
+            return;
+
+        var fieldList = preparedLine.Substring(openParen + 1, closeParen - openParen - 1);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(fieldList))
+        {
+            var fragment = fieldList.Substring(segmentStart, segmentLength);
+            var typeStart = SkipRustTupleFieldPrefix(fragment);
+            if (typeStart >= fragment.Length)
+                continue;
+
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteStart = openParen + 1 + segmentStart + typeStart;
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                absoluteStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container ?? resolveContainerForColumn(absoluteStart));
+        }
+    }
+
     private static void EmitStructFieldTypeReferences(
         string preparedLine,
         List<ReferenceRecord> references,
@@ -188,6 +237,43 @@ internal static class RustReferenceExtractor
             lineNumber,
             container);
     }
+
+    private static int SkipRustTupleFieldPrefix(string fragment)
+    {
+        var index = 0;
+        while (index < fragment.Length && char.IsWhiteSpace(fragment[index]))
+            index++;
+
+        if (index + 3 > fragment.Length
+            || string.CompareOrdinal(fragment, index, "pub", 0, "pub".Length) != 0)
+        {
+            return index;
+        }
+
+        var afterPub = index + "pub".Length;
+        if (afterPub < fragment.Length && IsRustIdentifierPart(fragment[afterPub]))
+            return index;
+
+        index = afterPub;
+        while (index < fragment.Length && char.IsWhiteSpace(fragment[index]))
+            index++;
+
+        if (index < fragment.Length && fragment[index] == '(')
+        {
+            var closeParen = ReferenceExtractor.FindMatchingChar(fragment, index, '(', ')');
+            if (closeParen < 0)
+                return fragment.Length;
+
+            index = closeParen + 1;
+            while (index < fragment.Length && char.IsWhiteSpace(fragment[index]))
+                index++;
+        }
+
+        return index;
+    }
+
+    private static bool IsRustIdentifierPart(char ch) =>
+        ch == '_' || ch == '$' || char.IsLetterOrDigit(ch);
 
     private static void EmitImplAndTraitTypeReferences(
         string preparedLine,

--- a/src/CodeIndex/Indexer/SwiftReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/SwiftReferenceExtractor.cs
@@ -1,9 +1,178 @@
+using CodeIndex.Models;
+
 namespace CodeIndex.Indexer;
 
 internal static class SwiftReferenceExtractor
 {
+    private static readonly string[] DeclarationKeywords = ["let", "var"];
+    private static readonly string[] TypeOperatorKeywords = ["is", "as"];
+
     public static void EmitTrailingClosureReferences(
         string preparedLine,
         Action<string, int> addCallLikeReference)
         => TrailingLambdaReferenceExtractor.EmitReferences(preparedLine, addCallLikeReference);
+
+    public static void EmitTypePositionReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        TypedLanguageReferenceExtractor.EmitColonVariableTypeReferences(
+            preparedLine,
+            DeclarationKeywords,
+            "swift",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+        TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
+            preparedLine,
+            TypeOperatorKeywords,
+            "swift",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
+
+    private static void EmitGenericBoundReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var genericOpenIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '<');
+        if (genericOpenIndex >= 0)
+        {
+            TypedLanguageReferenceExtractor.EmitGenericColonBoundReferences(
+                preparedLine,
+                genericOpenIndex,
+                "swift",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+        }
+
+        TypedLanguageReferenceExtractor.EmitWhereClauseTypeReferences(
+            preparedLine,
+            "swift",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
+
+    private static void EmitCallableSignatureTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var funcIndex = ReferenceExtractor.FindTopLevelKeyword(preparedLine, "func");
+        if (funcIndex < 0)
+            return;
+
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(', funcIndex + "func".Length);
+        if (openParen <= funcIndex)
+            return;
+
+        var closeParen = ReferenceExtractor.FindMatchingChar(preparedLine, openParen, '(', ')');
+        if (closeParen < 0)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitColonParameterTypeReferences(
+            preparedLine,
+            openParen + 1,
+            closeParen,
+            "swift",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+
+        var arrowIndex = TypedLanguageReferenceExtractor.FindTopLevelSequence(preparedLine, "->", closeParen + 1);
+        if (arrowIndex < 0)
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, arrowIndex + 2);
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+        if (typeEnd <= typeStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(typeStart, typeEnd - typeStart),
+            typeStart,
+            "swift",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(typeStart));
+    }
+
+    private static void EmitHeritageTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var trimmed = preparedLine.TrimStart();
+        if (!(trimmed.StartsWith("class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("struct ", StringComparison.Ordinal)
+              || trimmed.StartsWith("protocol ", StringComparison.Ordinal)
+              || trimmed.StartsWith("enum ", StringComparison.Ordinal)
+              || trimmed.StartsWith("extension ", StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':');
+        if (colonIndex < 0)
+            return;
+
+        var listStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+        var listEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, listStart, stopAtComma: false);
+        if (listEnd <= listStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitCommaSeparatedTypeListReferences(
+            preparedLine,
+            listStart,
+            listEnd,
+            "swift",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
 }

--- a/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
@@ -354,6 +354,9 @@ internal static class TypeScriptReferenceExtractor
 
     private static bool IsImportBracePrefix(string text)
     {
+        if (text.IndexOf(';') >= 0 || ContainsTopLevelKeyword(text, "from"))
+            return false;
+
         const string importKeyword = "import";
         if (!text.StartsWith(importKeyword, StringComparison.Ordinal))
             return false;
@@ -364,6 +367,14 @@ internal static class TypeScriptReferenceExtractor
 
         return !IsTypeScriptIdentifierPart(text[index])
                && (char.IsWhiteSpace(text[index]) || text[index] is '{' or '*');
+    }
+
+    private static bool ContainsTopLevelKeyword(string text, string keyword)
+    {
+        foreach (var _ in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(text, keyword))
+            return true;
+
+        return false;
     }
 
     private static bool IsNamedExportBracePrefix(string text)

--- a/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
@@ -238,7 +238,9 @@ internal static class TypeScriptReferenceExtractor
                || trimmed.StartsWith("import{", StringComparison.Ordinal)
                || trimmed.StartsWith("export {", StringComparison.Ordinal)
                || trimmed.StartsWith("export{", StringComparison.Ordinal)
+               || trimmed.StartsWith("export * as ", StringComparison.Ordinal)
                || trimmed.StartsWith("export type {", StringComparison.Ordinal)
-               || trimmed.StartsWith("export type{", StringComparison.Ordinal);
+               || trimmed.StartsWith("export type{", StringComparison.Ordinal)
+               || trimmed.StartsWith("export type * as ", StringComparison.Ordinal);
     }
 }

--- a/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
@@ -33,6 +33,7 @@ internal static class TypeScriptReferenceExtractor
 
         EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitFunctionPropertyTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         TypedLanguageReferenceExtractor.EmitColonVariableTypeReferences(
             preparedLine,
             DeclarationKeywords,
@@ -166,7 +167,7 @@ internal static class TypeScriptReferenceExtractor
         if (typeStart >= preparedLine.Length)
             return;
 
-        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart, stopAtArrow: false);
         if (typeEnd <= typeStart)
             return;
 
@@ -180,5 +181,50 @@ internal static class TypeScriptReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn(typeStart));
+    }
+
+    private static void EmitFunctionPropertyTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':');
+        if (colonIndex < 0)
+            return;
+
+        var equalsIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=');
+        if (equalsIndex >= 0 && equalsIndex < colonIndex)
+            return;
+
+        var questionIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '?');
+        if (questionIndex >= 0 && questionIndex != colonIndex - 1)
+            return;
+
+        var prefix = preparedLine.Substring(0, colonIndex).TrimEnd();
+        if (prefix.Length == 0 || prefix.EndsWith(")", StringComparison.Ordinal))
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+        if (typeStart >= preparedLine.Length)
+            return;
+
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart, stopAtArrow: false);
+        if (typeEnd <= typeStart)
+            return;
+
+        var container = resolveContainerForColumn(typeStart);
+        TypedLanguageReferenceExtractor.TryEmitTypeScriptFunctionTypeExpressionReferences(
+            preparedLine.Substring(typeStart, typeEnd - typeStart),
+            typeStart,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
     }
 }

--- a/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
@@ -44,7 +44,7 @@ internal static class TypeScriptReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
-        if (!IsImportExportAliasLine(preparedLine))
+        if (!IsImportExportAliasLine(preparedLines, lineIndex, preparedLine))
         {
             TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
                 preparedLine,
@@ -231,12 +231,13 @@ internal static class TypeScriptReferenceExtractor
             container);
     }
 
-    private static bool IsImportExportAliasLine(string preparedLine)
+    private static bool IsImportExportAliasLine(IReadOnlyList<string> preparedLines, int lineIndex, string preparedLine)
     {
         var trimmed = preparedLine.TrimStart();
         return IsImportDeclarationLine(trimmed)
                || IsNamedExportLine(trimmed)
-               || IsExportStarAliasLine(trimmed);
+               || IsExportStarAliasLine(trimmed)
+               || IsInsideMultilineImportExportAlias(preparedLines, lineIndex, preparedLine);
     }
 
     private static bool IsImportDeclarationLine(string text)
@@ -285,6 +286,101 @@ internal static class TypeScriptReferenceExtractor
         index++;
         SkipWhitespace(text, ref index);
         return TryConsumeKeyword(text, "as", ref index);
+    }
+
+    private static bool IsInsideMultilineImportExportAlias(
+        IReadOnlyList<string> preparedLines,
+        int lineIndex,
+        string preparedLine)
+    {
+        var asIndex = -1;
+        foreach (var keywordIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "as"))
+        {
+            asIndex = keywordIndex;
+            break;
+        }
+
+        return asIndex >= 0 && IsInsideImportExportBraceAt(preparedLines, lineIndex, asIndex);
+    }
+
+    private static bool IsInsideImportExportBraceAt(IReadOnlyList<string> preparedLines, int lineIndex, int column)
+    {
+        var unmatchedClosingBraces = 0;
+        for (var currentLine = lineIndex; currentLine >= 0; currentLine--)
+        {
+            var line = preparedLines[currentLine];
+            var startColumn = currentLine == lineIndex ? Math.Min(column, line.Length) - 1 : line.Length - 1;
+            for (var index = startColumn; index >= 0; index--)
+            {
+                if (line[index] == '}')
+                {
+                    unmatchedClosingBraces++;
+                    continue;
+                }
+
+                if (line[index] != '{')
+                    continue;
+
+                if (unmatchedClosingBraces > 0)
+                {
+                    unmatchedClosingBraces--;
+                    continue;
+                }
+
+                return IsImportExportOpeningBrace(preparedLines, currentLine, index);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsImportExportOpeningBrace(IReadOnlyList<string> preparedLines, int openLineIndex, int openColumn)
+    {
+        var sameLinePrefix = preparedLines[openLineIndex].Substring(0, openColumn).Trim();
+        if (sameLinePrefix.Length > 0)
+            return IsImportBracePrefix(sameLinePrefix) || IsNamedExportBracePrefix(sameLinePrefix);
+
+        for (var lineIndex = openLineIndex - 1; lineIndex >= 0; lineIndex--)
+        {
+            var previousLine = preparedLines[lineIndex].Trim();
+            if (previousLine.Length == 0)
+                continue;
+
+            return IsImportBracePrefix(previousLine) || IsNamedExportBracePrefix(previousLine);
+        }
+
+        return false;
+    }
+
+    private static bool IsImportBracePrefix(string text)
+    {
+        const string importKeyword = "import";
+        if (!text.StartsWith(importKeyword, StringComparison.Ordinal))
+            return false;
+
+        var index = importKeyword.Length;
+        if (index >= text.Length)
+            return true;
+
+        return !IsTypeScriptIdentifierPart(text[index])
+               && (char.IsWhiteSpace(text[index]) || text[index] is '{' or '*');
+    }
+
+    private static bool IsNamedExportBracePrefix(string text)
+    {
+        var index = 0;
+        if (!TryConsumeKeyword(text, "export", ref index))
+            return false;
+
+        SkipWhitespace(text, ref index);
+        if (index >= text.Length)
+            return true;
+
+        if (!TryConsumeKeyword(text, "type", ref index))
+            return false;
+
+        SkipWhitespace(text, ref index);
+        return index >= text.Length;
     }
 
     private static bool TryConsumeKeyword(string text, string keyword, ref int index)

--- a/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
@@ -357,16 +357,22 @@ internal static class TypeScriptReferenceExtractor
         if (text.IndexOf(';') >= 0 || ContainsTopLevelKeyword(text, "from"))
             return false;
 
-        const string importKeyword = "import";
-        if (!text.StartsWith(importKeyword, StringComparison.Ordinal))
+        var index = 0;
+        if (!TryConsumeKeyword(text, "import", ref index))
             return false;
 
-        var index = importKeyword.Length;
+        SkipWhitespace(text, ref index);
         if (index >= text.Length)
             return true;
 
-        return !IsTypeScriptIdentifierPart(text[index])
-               && (char.IsWhiteSpace(text[index]) || text[index] is '{' or '*');
+        if (TryConsumeKeyword(text, "type", ref index))
+        {
+            SkipWhitespace(text, ref index);
+            if (index >= text.Length)
+                return true;
+        }
+
+        return text.TrimEnd().EndsWith(",", StringComparison.Ordinal);
     }
 
     private static bool ContainsTopLevelKeyword(string text, string keyword)

--- a/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
@@ -44,16 +44,19 @@ internal static class TypeScriptReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
-        TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
-            preparedLine,
-            TypeOperatorKeywords,
-            "typescript",
-            references,
-            seen,
-            fileId,
-            context,
-            lineNumber,
-            resolveContainerForColumn);
+        if (!IsImportExportAliasLine(preparedLine))
+        {
+            TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
+                preparedLine,
+                TypeOperatorKeywords,
+                "typescript",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+        }
     }
 
     public static void EmitDeclarationTypeReferences(
@@ -226,5 +229,16 @@ internal static class TypeScriptReferenceExtractor
             context,
             lineNumber,
             container);
+    }
+
+    private static bool IsImportExportAliasLine(string preparedLine)
+    {
+        var trimmed = preparedLine.TrimStart();
+        return trimmed.StartsWith("import ", StringComparison.Ordinal)
+               || trimmed.StartsWith("import{", StringComparison.Ordinal)
+               || trimmed.StartsWith("export {", StringComparison.Ordinal)
+               || trimmed.StartsWith("export{", StringComparison.Ordinal)
+               || trimmed.StartsWith("export type {", StringComparison.Ordinal)
+               || trimmed.StartsWith("export type{", StringComparison.Ordinal);
     }
 }

--- a/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
@@ -4,6 +4,9 @@ namespace CodeIndex.Indexer;
 
 internal static class TypeScriptReferenceExtractor
 {
+    private static readonly string[] DeclarationKeywords = ["const", "let", "var"];
+    private static readonly string[] TypeOperatorKeywords = ["as", "satisfies", "instanceof"];
+
     public static void EmitTypePositionReferences(
         IReadOnlyList<string> preparedLines,
         int lineIndex,
@@ -21,6 +24,29 @@ internal static class TypeScriptReferenceExtractor
             lineIndex,
             preparedLine,
             rawLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+
+        EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        TypedLanguageReferenceExtractor.EmitColonVariableTypeReferences(
+            preparedLine,
+            DeclarationKeywords,
+            "typescript",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+        TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
+            preparedLine,
+            TypeOperatorKeywords,
+            "typescript",
             references,
             seen,
             fileId,
@@ -46,5 +72,113 @@ internal static class TypeScriptReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+    }
+
+    private static void EmitHeritageTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var trimmed = preparedLine.TrimStart();
+        if (!(trimmed.StartsWith("class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("abstract class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("export class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("export abstract class ", StringComparison.Ordinal)
+              || trimmed.StartsWith("interface ", StringComparison.Ordinal)
+              || trimmed.StartsWith("export interface ", StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        EmitHeritageKeyword(preparedLine, "extends", references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitHeritageKeyword(preparedLine, "implements", references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitHeritageKeyword(
+        string preparedLine,
+        string keyword,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var keywordIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, keyword))
+        {
+            var listStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, keywordIndex + keyword.Length);
+            var listEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, listStart, stopAtComma: false);
+            if (listEnd <= listStart)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitCommaSeparatedTypeListReferences(
+                preparedLine,
+                listStart,
+                listEnd,
+                "typescript",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+        }
+    }
+
+    private static void EmitCallableSignatureTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(');
+        if (openParen <= 0)
+            return;
+
+        var closeParen = ReferenceExtractor.FindMatchingChar(preparedLine, openParen, '(', ')');
+        if (closeParen < 0)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitColonParameterTypeReferences(
+            preparedLine,
+            openParen + 1,
+            closeParen,
+            "typescript",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+
+        var returnColon = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, closeParen + 1);
+        if (returnColon >= preparedLine.Length || preparedLine[returnColon] != ':')
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, returnColon + 1);
+        if (typeStart >= preparedLine.Length)
+            return;
+
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+        if (typeEnd <= typeStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(typeStart, typeEnd - typeStart),
+            typeStart,
+            "typescript",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(typeStart));
     }
 }

--- a/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypeScriptReferenceExtractor.cs
@@ -234,13 +234,81 @@ internal static class TypeScriptReferenceExtractor
     private static bool IsImportExportAliasLine(string preparedLine)
     {
         var trimmed = preparedLine.TrimStart();
-        return trimmed.StartsWith("import ", StringComparison.Ordinal)
-               || trimmed.StartsWith("import{", StringComparison.Ordinal)
-               || trimmed.StartsWith("export {", StringComparison.Ordinal)
-               || trimmed.StartsWith("export{", StringComparison.Ordinal)
-               || trimmed.StartsWith("export * as ", StringComparison.Ordinal)
-               || trimmed.StartsWith("export type {", StringComparison.Ordinal)
-               || trimmed.StartsWith("export type{", StringComparison.Ordinal)
-               || trimmed.StartsWith("export type * as ", StringComparison.Ordinal);
+        return IsImportDeclarationLine(trimmed)
+               || IsNamedExportLine(trimmed)
+               || IsExportStarAliasLine(trimmed);
     }
+
+    private static bool IsImportDeclarationLine(string text)
+    {
+        const string importKeyword = "import";
+        if (!text.StartsWith(importKeyword, StringComparison.Ordinal))
+            return false;
+
+        var index = importKeyword.Length;
+        if (index >= text.Length || IsTypeScriptIdentifierPart(text[index]))
+            return false;
+
+        return char.IsWhiteSpace(text[index]) || text[index] is '{' or '*';
+    }
+
+    private static bool IsNamedExportLine(string text)
+    {
+        var index = 0;
+        if (!TryConsumeKeyword(text, "export", ref index))
+            return false;
+
+        SkipWhitespace(text, ref index);
+        if (index < text.Length && text[index] == '{')
+            return true;
+
+        if (!TryConsumeKeyword(text, "type", ref index))
+            return false;
+
+        SkipWhitespace(text, ref index);
+        return index < text.Length && text[index] == '{';
+    }
+
+    private static bool IsExportStarAliasLine(string text)
+    {
+        var index = 0;
+        if (!TryConsumeKeyword(text, "export", ref index))
+            return false;
+
+        SkipWhitespace(text, ref index);
+        if (TryConsumeKeyword(text, "type", ref index))
+            SkipWhitespace(text, ref index);
+
+        if (index >= text.Length || text[index] != '*')
+            return false;
+
+        index++;
+        SkipWhitespace(text, ref index);
+        return TryConsumeKeyword(text, "as", ref index);
+    }
+
+    private static bool TryConsumeKeyword(string text, string keyword, ref int index)
+    {
+        if (index + keyword.Length > text.Length
+            || string.CompareOrdinal(text, index, keyword, 0, keyword.Length) != 0)
+        {
+            return false;
+        }
+
+        var after = index + keyword.Length;
+        if (after < text.Length && IsTypeScriptIdentifierPart(text[after]))
+            return false;
+
+        index = after;
+        return true;
+    }
+
+    private static void SkipWhitespace(string text, ref int index)
+    {
+        while (index < text.Length && char.IsWhiteSpace(text[index]))
+            index++;
+    }
+
+    private static bool IsTypeScriptIdentifierPart(char ch) =>
+        ch == '_' || ch == '$' || char.IsLetterOrDigit(ch);
 }

--- a/src/CodeIndex/Indexer/TypedLanguageReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypedLanguageReferenceExtractor.cs
@@ -22,17 +22,146 @@ internal static class TypedLanguageReferenceExtractor
         if (length <= 0)
             return;
 
+        var normalizedExpression = expression.Substring(leading, length);
+        var normalizedStart = expressionStartInLine + leading;
+        if (language == "typescript"
+            && TryEmitTypeScriptFunctionTypeExpressionReferences(
+                normalizedExpression,
+                normalizedStart,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container))
+        {
+            return;
+        }
+
         ReferenceExtractor.AddTypeExpressionSegments(
             references,
             seen,
             fileId,
-            expression.Substring(leading, length),
-            expressionStartInLine + leading,
+            normalizedExpression,
+            normalizedStart,
             context,
             lineNumber,
             container,
             language,
             ignoredSegments);
+    }
+
+    public static bool TryEmitTypeScriptFunctionTypeExpressionReferences(
+        string expression,
+        int expressionStartInLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var leading = CountLeadingWhitespace(expression, 0, expression.Length);
+        var trailing = CountTrailingWhitespace(expression, leading, expression.Length - leading);
+        var length = expression.Length - leading - trailing;
+        if (length <= 0)
+            return false;
+
+        var normalizedExpression = expression.Substring(leading, length);
+        var normalizedStart = expressionStartInLine + leading;
+        var openParen = FindTopLevelChar(normalizedExpression, '(');
+        if (openParen < 0)
+            return false;
+
+        var prefix = normalizedExpression.Substring(0, openParen).Trim();
+        if (prefix.Length > 0 && !string.Equals(prefix, "new", StringComparison.Ordinal))
+            return false;
+
+        var closeParen = ReferenceExtractor.FindMatchingChar(normalizedExpression, openParen, '(', ')');
+        if (closeParen < 0)
+            return false;
+
+        var arrowIndex = FindTopLevelSequence(normalizedExpression, "=>", closeParen + 1);
+        if (arrowIndex < 0)
+            return false;
+
+        EmitTypeScriptFunctionParameterTypeReferences(
+            normalizedExpression,
+            normalizedStart,
+            openParen + 1,
+            closeParen,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+        var returnStart = SkipTypePrefixTrivia(normalizedExpression, arrowIndex + 2);
+        if (returnStart >= normalizedExpression.Length)
+            return true;
+
+        var returnEnd = FindTypeExpressionEnd(normalizedExpression, returnStart, stopAtComma: false, stopAtArrow: false);
+        if (returnEnd <= returnStart)
+            return true;
+
+        EmitTypeExpressionReferences(
+            normalizedExpression.Substring(returnStart, returnEnd - returnStart),
+            normalizedStart + returnStart,
+            "typescript",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+        return true;
+    }
+
+    private static void EmitTypeScriptFunctionParameterTypeReferences(
+        string expression,
+        int expressionStartInLine,
+        int paramStart,
+        int paramEnd,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (paramStart < 0 || paramEnd <= paramStart || paramStart >= expression.Length)
+            return;
+
+        paramEnd = Math.Min(paramEnd, expression.Length);
+        var parameterList = expression.Substring(paramStart, paramEnd - paramStart);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(parameterList))
+        {
+            var fragment = parameterList.Substring(segmentStart, segmentLength);
+            var colonIndex = FindTopLevelChar(fragment, ':');
+            if (colonIndex < 0)
+                continue;
+
+            var typeStart = SkipTypePrefixTrivia(fragment, colonIndex + 1);
+            if (typeStart >= fragment.Length)
+                continue;
+
+            var typeEnd = FindTypeExpressionEnd(fragment, typeStart, stopAtArrow: false);
+            if (typeEnd <= typeStart)
+                continue;
+
+            EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                expressionStartInLine + paramStart + segmentStart + typeStart,
+                "typescript",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container);
+        }
     }
 
     public static void EmitCommaSeparatedTypeListReferences(
@@ -110,7 +239,7 @@ internal static class TypedLanguageReferenceExtractor
             if (typeStart >= fragment.Length)
                 continue;
 
-            var typeEnd = FindTypeExpressionEnd(fragment, typeStart);
+            var typeEnd = FindTypeExpressionEndForLanguage(fragment, typeStart, language);
             if (typeEnd <= typeStart)
                 continue;
 
@@ -156,7 +285,7 @@ internal static class TypedLanguageReferenceExtractor
                 if (typeStart >= line.Length)
                     continue;
 
-                var typeEnd = FindTypeExpressionEnd(line, typeStart);
+                var typeEnd = FindTypeExpressionEndForLanguage(line, typeStart, language);
                 if (typeEnd <= typeStart)
                     continue;
 
@@ -193,7 +322,7 @@ internal static class TypedLanguageReferenceExtractor
                 if (typeStart >= line.Length)
                     continue;
 
-                var typeEnd = FindTypeExpressionEnd(line, typeStart);
+                var typeEnd = FindTypeExpressionEndForLanguage(line, typeStart, language);
                 if (typeEnd <= typeStart)
                     continue;
 
@@ -353,7 +482,7 @@ internal static class TypedLanguageReferenceExtractor
         }
     }
 
-    public static int FindTypeExpressionEnd(string text, int startIndex, bool stopAtComma = true)
+    public static int FindTypeExpressionEnd(string text, int startIndex, bool stopAtComma = true, bool stopAtArrow = true)
     {
         foreach (var (index, ch) in EnumerateTopLevelCharacters(text, startIndex))
         {
@@ -361,9 +490,13 @@ internal static class TypedLanguageReferenceExtractor
                 return index;
             if (ch is ';' or '{' or '}')
                 return index;
-            if (ch == '=')
-                return index;
             if (index + 2 <= text.Length && string.CompareOrdinal(text, index, "=>", 0, 2) == 0)
+            {
+                if (stopAtArrow)
+                    return index;
+                continue;
+            }
+            if (ch == '=')
                 return index;
             if (IsTopLevelStopKeyword(text, index, "where")
                 || IsTopLevelStopKeyword(text, index, "implements")
@@ -375,6 +508,9 @@ internal static class TypedLanguageReferenceExtractor
 
         return text.Length;
     }
+
+    private static int FindTypeExpressionEndForLanguage(string text, int startIndex, string language, bool stopAtComma = true)
+        => FindTypeExpressionEnd(text, startIndex, stopAtComma, stopAtArrow: language != "typescript");
 
     public static int SkipTypePrefixTrivia(string text, int index)
     {

--- a/src/CodeIndex/Indexer/TypedLanguageReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypedLanguageReferenceExtractor.cs
@@ -1,0 +1,531 @@
+using CodeIndex.Models;
+
+namespace CodeIndex.Indexer;
+
+internal static class TypedLanguageReferenceExtractor
+{
+    public static void EmitTypeExpressionReferences(
+        string expression,
+        int expressionStartInLine,
+        string language,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        IReadOnlySet<string>? ignoredSegments = null)
+    {
+        var leading = CountLeadingWhitespace(expression, 0, expression.Length);
+        var trailing = CountTrailingWhitespace(expression, leading, expression.Length - leading);
+        var length = expression.Length - leading - trailing;
+        if (length <= 0)
+            return;
+
+        ReferenceExtractor.AddTypeExpressionSegments(
+            references,
+            seen,
+            fileId,
+            expression.Substring(leading, length),
+            expressionStartInLine + leading,
+            context,
+            lineNumber,
+            container,
+            language,
+            ignoredSegments);
+    }
+
+    public static void EmitCommaSeparatedTypeListReferences(
+        string line,
+        int listStart,
+        int listEnd,
+        string language,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        bool trimTopLevelCallArguments = false)
+    {
+        if (listStart < 0 || listEnd <= listStart || listStart >= line.Length)
+            return;
+
+        listEnd = Math.Min(listEnd, line.Length);
+        var typeList = line.Substring(listStart, listEnd - listStart);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typeList))
+        {
+            var rawSegment = typeList.Substring(segmentStart, segmentLength);
+            var leading = CountLeadingWhitespace(rawSegment, 0, rawSegment.Length);
+            var trailing = CountTrailingWhitespace(rawSegment, leading, rawSegment.Length - leading);
+            var length = rawSegment.Length - leading - trailing;
+            if (length <= 0)
+                continue;
+
+            var expression = rawSegment.Substring(leading, length);
+            if (trimTopLevelCallArguments)
+                expression = TrimTopLevelCallArguments(expression);
+            if (expression.Length == 0)
+                continue;
+
+            var absoluteStart = listStart + segmentStart + leading;
+            EmitTypeExpressionReferences(
+                expression,
+                absoluteStart,
+                language,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(absoluteStart));
+        }
+    }
+
+    public static void EmitColonParameterTypeReferences(
+        string line,
+        int paramStart,
+        int paramEnd,
+        string language,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (paramStart < 0 || paramEnd <= paramStart || paramStart >= line.Length)
+            return;
+
+        paramEnd = Math.Min(paramEnd, line.Length);
+        var parameterList = line.Substring(paramStart, paramEnd - paramStart);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(parameterList))
+        {
+            var fragment = parameterList.Substring(segmentStart, segmentLength);
+            var colonIndex = FindTopLevelChar(fragment, ':');
+            if (colonIndex < 0)
+                continue;
+
+            var typeStart = SkipTypePrefixTrivia(fragment, colonIndex + 1);
+            if (typeStart >= fragment.Length)
+                continue;
+
+            var typeEnd = FindTypeExpressionEnd(fragment, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteStart = paramStart + segmentStart + typeStart;
+            EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                absoluteStart,
+                language,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(absoluteStart));
+        }
+    }
+
+    public static void EmitColonVariableTypeReferences(
+        string line,
+        IReadOnlyList<string> declarationKeywords,
+        string language,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var keyword in declarationKeywords)
+        {
+            foreach (var keywordIndex in EnumerateTopLevelKeywordIndices(line, keyword))
+            {
+                var declarationStart = keywordIndex + keyword.Length;
+                var colonIndex = FindTopLevelChar(line, ':', declarationStart);
+                if (colonIndex < 0)
+                    continue;
+
+                var assignmentIndex = FindTopLevelChar(line, '=', declarationStart);
+                if (assignmentIndex >= 0 && assignmentIndex < colonIndex)
+                    continue;
+
+                var typeStart = SkipTypePrefixTrivia(line, colonIndex + 1);
+                if (typeStart >= line.Length)
+                    continue;
+
+                var typeEnd = FindTypeExpressionEnd(line, typeStart);
+                if (typeEnd <= typeStart)
+                    continue;
+
+                EmitTypeExpressionReferences(
+                    line.Substring(typeStart, typeEnd - typeStart),
+                    typeStart,
+                    language,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(typeStart));
+            }
+        }
+    }
+
+    public static void EmitKeywordFollowingTypeReferences(
+        string line,
+        IReadOnlyList<string> keywords,
+        string language,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var keyword in keywords)
+        {
+            foreach (var keywordIndex in EnumerateTopLevelKeywordIndices(line, keyword))
+            {
+                var typeStart = SkipTypePrefixTrivia(line, keywordIndex + keyword.Length);
+                if (typeStart >= line.Length)
+                    continue;
+
+                var typeEnd = FindTypeExpressionEnd(line, typeStart);
+                if (typeEnd <= typeStart)
+                    continue;
+
+                EmitTypeExpressionReferences(
+                    line.Substring(typeStart, typeEnd - typeStart),
+                    typeStart,
+                    language,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(typeStart));
+            }
+        }
+    }
+
+    public static void EmitWhereClauseTypeReferences(
+        string line,
+        string language,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var whereIndex in EnumerateTopLevelKeywordIndices(line, "where"))
+        {
+            var clauseStart = whereIndex + "where".Length;
+            var clauseEnd = FindTypeExpressionEnd(line, clauseStart, stopAtComma: false);
+            if (clauseEnd <= clauseStart)
+                clauseEnd = line.Length;
+
+            var clause = line.Substring(clauseStart, clauseEnd - clauseStart);
+            foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(clause))
+            {
+                var fragment = clause.Substring(segmentStart, segmentLength);
+                var colonIndex = FindTopLevelChar(fragment, ':');
+                if (colonIndex < 0)
+                    continue;
+
+                var typeStart = SkipTypePrefixTrivia(fragment, colonIndex + 1);
+                if (typeStart >= fragment.Length)
+                    continue;
+
+                var typeEnd = FindTypeExpressionEnd(fragment, typeStart);
+                if (typeEnd <= typeStart)
+                    continue;
+
+                var absoluteStart = clauseStart + segmentStart + typeStart;
+                EmitTypeExpressionReferences(
+                    fragment.Substring(typeStart, typeEnd - typeStart),
+                    absoluteStart,
+                    language,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(absoluteStart));
+            }
+        }
+    }
+
+    public static void EmitGenericColonBoundReferences(
+        string line,
+        int genericOpenIndex,
+        string language,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (genericOpenIndex < 0 || genericOpenIndex >= line.Length || line[genericOpenIndex] != '<')
+            return;
+
+        var genericCloseIndex = ReferenceExtractor.FindMatchingChar(line, genericOpenIndex, '<', '>');
+        if (genericCloseIndex <= genericOpenIndex)
+            return;
+
+        var clause = line.Substring(genericOpenIndex + 1, genericCloseIndex - genericOpenIndex - 1);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(clause))
+        {
+            var fragment = clause.Substring(segmentStart, segmentLength);
+            var colonIndex = FindTopLevelChar(fragment, ':');
+            if (colonIndex < 0)
+                continue;
+
+            var typeStart = SkipTypePrefixTrivia(fragment, colonIndex + 1);
+            if (typeStart >= fragment.Length)
+                continue;
+
+            var typeEnd = FindTypeExpressionEnd(fragment, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteStart = genericOpenIndex + 1 + segmentStart + typeStart;
+            EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                absoluteStart,
+                language,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(absoluteStart));
+        }
+    }
+
+    public static int FindTopLevelChar(string text, char target, int startIndex = 0)
+    {
+        foreach (var (index, ch) in EnumerateTopLevelCharacters(text, startIndex))
+        {
+            if (ch == target)
+                return index;
+        }
+
+        return -1;
+    }
+
+    public static int FindTopLevelSequence(string text, string sequence, int startIndex = 0)
+    {
+        if (string.IsNullOrEmpty(sequence))
+            return -1;
+
+        foreach (var (index, _) in EnumerateTopLevelCharacters(text, startIndex))
+        {
+            if (index + sequence.Length <= text.Length
+                && string.CompareOrdinal(text, index, sequence, 0, sequence.Length) == 0)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    public static IEnumerable<int> EnumerateTopLevelKeywordIndices(string text, string keyword, int startIndex = 0)
+    {
+        foreach (var (index, _) in EnumerateTopLevelCharacters(text, startIndex))
+        {
+            if (index + keyword.Length > text.Length)
+                continue;
+            if (string.CompareOrdinal(text, index, keyword, 0, keyword.Length) != 0)
+                continue;
+            if (index > 0 && IsIdentifierPart(text[index - 1]))
+                continue;
+            var after = index + keyword.Length;
+            if (after < text.Length && IsIdentifierPart(text[after]))
+                continue;
+
+            yield return index;
+        }
+    }
+
+    public static int FindTypeExpressionEnd(string text, int startIndex, bool stopAtComma = true)
+    {
+        foreach (var (index, ch) in EnumerateTopLevelCharacters(text, startIndex))
+        {
+            if (ch == ',' && stopAtComma)
+                return index;
+            if (ch is ';' or '{' or '}')
+                return index;
+            if (ch == '=')
+                return index;
+            if (index + 2 <= text.Length && string.CompareOrdinal(text, index, "=>", 0, 2) == 0)
+                return index;
+            if (IsTopLevelStopKeyword(text, index, "where")
+                || IsTopLevelStopKeyword(text, index, "implements")
+                || IsTopLevelStopKeyword(text, index, "extends"))
+            {
+                return index;
+            }
+        }
+
+        return text.Length;
+    }
+
+    public static int SkipTypePrefixTrivia(string text, int index)
+    {
+        while (index < text.Length)
+        {
+            while (index < text.Length && char.IsWhiteSpace(text[index]))
+                index++;
+
+            if (index < text.Length && text[index] is '?' or '!')
+            {
+                index++;
+                continue;
+            }
+
+            break;
+        }
+
+        return index;
+    }
+
+    private static string TrimTopLevelCallArguments(string expression)
+    {
+        var openParen = FindTopLevelChar(expression, '(');
+        if (openParen <= 0)
+            return expression;
+
+        return expression.Substring(0, openParen).TrimEnd();
+    }
+
+    private static bool IsTopLevelStopKeyword(string text, int index, string keyword)
+    {
+        if (index + keyword.Length > text.Length)
+            return false;
+        if (string.CompareOrdinal(text, index, keyword, 0, keyword.Length) != 0)
+            return false;
+        if (index > 0 && IsIdentifierPart(text[index - 1]))
+            return false;
+        var after = index + keyword.Length;
+        return after >= text.Length || !IsIdentifierPart(text[after]);
+    }
+
+    private static IEnumerable<(int Index, char Character)> EnumerateTopLevelCharacters(string text, int startIndex)
+    {
+        var angleDepth = 0;
+        var parenDepth = 0;
+        var squareDepth = 0;
+        var braceDepth = 0;
+        for (var index = Math.Max(0, startIndex); index < text.Length; index++)
+        {
+            var ch = text[index];
+            if (ch is '\'' or '"')
+            {
+                index = SkipQuotedString(text, index);
+                continue;
+            }
+
+            if (ch == '/' && index + 1 < text.Length)
+            {
+                if (text[index + 1] == '/')
+                    yield break;
+                if (text[index + 1] == '*')
+                {
+                    index = SkipBlockComment(text, index + 2);
+                    continue;
+                }
+            }
+
+            if (angleDepth == 0 && parenDepth == 0 && squareDepth == 0 && braceDepth == 0)
+                yield return (index, ch);
+
+            switch (ch)
+            {
+                case '<':
+                    angleDepth++;
+                    break;
+                case '>':
+                    if (angleDepth > 0)
+                        angleDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0)
+                        parenDepth--;
+                    break;
+                case '[':
+                    squareDepth++;
+                    break;
+                case ']':
+                    if (squareDepth > 0)
+                        squareDepth--;
+                    break;
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    if (braceDepth > 0)
+                        braceDepth--;
+                    break;
+            }
+        }
+    }
+
+    private static int SkipQuotedString(string text, int startIndex)
+    {
+        var quote = text[startIndex];
+        for (var index = startIndex + 1; index < text.Length; index++)
+        {
+            if (text[index] == '\\' && index + 1 < text.Length)
+            {
+                index++;
+                continue;
+            }
+
+            if (text[index] == quote)
+                return index;
+        }
+
+        return text.Length - 1;
+    }
+
+    private static int SkipBlockComment(string text, int startIndex)
+    {
+        for (var index = startIndex; index + 1 < text.Length; index++)
+        {
+            if (text[index] == '*' && text[index + 1] == '/')
+                return index + 1;
+        }
+
+        return text.Length - 1;
+    }
+
+    private static int CountLeadingWhitespace(string text, int start, int length)
+    {
+        var end = Math.Min(text.Length, start + length);
+        var count = 0;
+        for (var index = start; index < end && char.IsWhiteSpace(text[index]); index++)
+            count++;
+        return count;
+    }
+
+    private static int CountTrailingWhitespace(string text, int start, int length)
+    {
+        var end = Math.Min(text.Length, start + length);
+        var count = 0;
+        for (var index = end - 1; index >= start && char.IsWhiteSpace(text[index]); index--)
+            count++;
+        return count;
+    }
+
+    private static bool IsIdentifierPart(char ch) =>
+        ch == '_' || ch == '$' || ch == '\'' || char.IsLetterOrDigit(ch);
+}

--- a/src/CodeIndex/Indexer/TypedLanguageReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/TypedLanguageReferenceExtractor.cs
@@ -322,7 +322,7 @@ internal static class TypedLanguageReferenceExtractor
                 if (typeStart >= line.Length)
                     continue;
 
-                var typeEnd = FindTypeExpressionEndForLanguage(line, typeStart, language);
+                var typeEnd = FindKeywordFollowingTypeExpressionEnd(line, typeStart, language);
                 if (typeEnd <= typeStart)
                     continue;
 
@@ -482,7 +482,12 @@ internal static class TypedLanguageReferenceExtractor
         }
     }
 
-    public static int FindTypeExpressionEnd(string text, int startIndex, bool stopAtComma = true, bool stopAtArrow = true)
+    public static int FindTypeExpressionEnd(
+        string text,
+        int startIndex,
+        bool stopAtComma = true,
+        bool stopAtArrow = true,
+        bool stopAtRuntimeOperator = false)
     {
         foreach (var (index, ch) in EnumerateTopLevelCharacters(text, startIndex))
         {
@@ -498,6 +503,8 @@ internal static class TypedLanguageReferenceExtractor
             }
             if (ch == '=')
                 return index;
+            if (stopAtRuntimeOperator && IsRuntimeExpressionOperatorTerminator(text, index, ch))
+                return index;
             if (IsTopLevelStopKeyword(text, index, "where")
                 || IsTopLevelStopKeyword(text, index, "implements")
                 || IsTopLevelStopKeyword(text, index, "extends"))
@@ -511,6 +518,31 @@ internal static class TypedLanguageReferenceExtractor
 
     private static int FindTypeExpressionEndForLanguage(string text, int startIndex, string language, bool stopAtComma = true)
         => FindTypeExpressionEnd(text, startIndex, stopAtComma, stopAtArrow: language != "typescript");
+
+    private static int FindKeywordFollowingTypeExpressionEnd(string text, int startIndex, string language)
+        => FindTypeExpressionEnd(
+            text,
+            startIndex,
+            stopAtArrow: language != "typescript",
+            stopAtRuntimeOperator: true);
+
+    private static bool IsRuntimeExpressionOperatorTerminator(string text, int index, char ch)
+    {
+        if (ch is ')' or ']' or '?' or ':' or '+' or '-' or '*' or '/' or '%')
+            return true;
+
+        if (index + 1 >= text.Length)
+            return false;
+
+        var next = text[index + 1];
+        return (ch == '&' && next == '&')
+               || (ch == '|' && next == '|')
+               || (ch == '?' && next == '?')
+               || (ch == '=' && next == '=')
+               || (ch == '!' && next == '=')
+               || (ch == '<' && next == '=')
+               || (ch == '>' && next == '=');
+    }
 
     public static int SkipTypePrefixTrivia(string text, int index)
     {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18875,6 +18875,11 @@ public class ReferenceExtractorTests
             export type {
                 Internal as PublicInternal
             } from "mod";
+            import Existing from "mod";
+
+            {
+                const checked = value as RealType;
+            }
             """;
 
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
@@ -18894,6 +18899,7 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "MultiBaz" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "PublicInternal" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "from" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "RealType" && r.ReferenceKind == "type_reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18863,6 +18863,18 @@ public class ReferenceExtractorTests
             import*as CompactImport from "mod";
             export*as CompactNamespace from "mod";
             export type*as CompactPublicNamespace from "mod";
+            import {
+                MultiFoo as MultiBar
+            } from "mod";
+            import DefaultThing, {
+                Secondary as SecondaryAlias
+            } from "mod";
+            export {
+                MultiExport as MultiBaz
+            } from "mod";
+            export type {
+                Internal as PublicInternal
+            } from "mod";
             """;
 
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
@@ -18877,6 +18889,10 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "CompactImport" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "CompactNamespace" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "CompactPublicNamespace" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "MultiBar" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "SecondaryAlias" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "MultiBaz" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "PublicInternal" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "from" && r.ReferenceKind == "type_reference");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18801,15 +18801,19 @@ public class ReferenceExtractorTests
     public void Extract_TypeScriptTypedDeclarations_CaptureStructuralTypeReferences()
     {
         const string content = """
-            interface Handler extends BaseHandler<Request>, Disposable {}
+            interface Handler extends BaseHandler<Request>, Disposable {
+                handle?: (callbackInput: Request) => Response;
+            }
 
             class Service extends BaseService implements Runnable, Closeable {
                 load(input: User, options?: LoadOptions): Promise<Result> {
                     const current: User = input as User;
+                    const handler: (variableInput: Request) => Response = makeHandler();
                     return build(current);
                 }
             }
 
+            type HandlerFactory = (factoryInput: Request) => Response;
             type UserPick = Pick<User, "id">;
 
             function runtime(input: unknown) {
@@ -18831,6 +18835,10 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "Promise" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Pick" && r.ReferenceKind == "type_reference");
+        Assert.Equal(3, references.Count(r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference"));
+        Assert.DoesNotContain(references, r => r.SymbolName == "callbackInput" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "variableInput" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "factoryInput" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "input" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "string" && r.ReferenceKind == "type_reference");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18851,6 +18851,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptImportExportAliases_DoNotEmitTypeReferences()
+    {
+        const string content = """
+            import * as Mod from "mod";
+            import { Foo as Bar } from "mod";
+            export { Foo as Baz } from "mod";
+            export type { Model as PublicModel } from "mod";
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "Mod" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Bar" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Baz" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "PublicModel" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "from" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_KotlinTypedDeclarations_CaptureStructuralTypeReferences()
     {
         const string content = """
@@ -18885,6 +18905,19 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "Any" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "enabledFlag" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "fallbackUser" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_KotlinImportAlias_DoesNotEmitTypeReference()
+    {
+        const string content = """
+            import com.example.Bar as Baz
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "Baz" && r.ReferenceKind == "type_reference");
     }
 
     [Fact]
@@ -18970,6 +19003,9 @@ public class ReferenceExtractorTests
             struct FieldOnly {
                 repo: Repository,
             }
+
+            struct UserId(Uuid);
+            pub struct Pair(pub User, Repository);
             """;
 
         var symbols = SymbolExtractor.Extract(1, "rust", content);
@@ -18980,6 +19016,9 @@ public class ReferenceExtractorTests
             && r.ReferenceKind == "type_reference"
             && r.ContainerKind == "struct"
             && r.ContainerName == "FieldOnly");
+        Assert.Contains(references, r => r.SymbolName == "Uuid" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18880,6 +18880,11 @@ public class ReferenceExtractorTests
             {
                 const checked = value as RealType;
             }
+            import "polyfill"
+
+            {
+                const checkedAfterSideEffect = value as AfterSideEffectType;
+            }
             """;
 
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
@@ -18900,6 +18905,7 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "PublicInternal" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "from" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RealType" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "AfterSideEffectType" && r.ReferenceKind == "type_reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18808,6 +18808,10 @@ public class ReferenceExtractorTests
             class Service extends BaseService implements Runnable, Closeable {
                 load(input: User, options?: LoadOptions): Promise<Result> {
                     const current: User = input as User;
+                    const active = current as User && current.enabledFlag;
+                    const fallback = current as User || fallbackValue;
+                    const ready = current instanceof Service && current.readyFlag;
+                    const checked = current satisfies Runnable ? current : fallbackValue;
                     const handler: (variableInput: Request) => Response = makeHandler();
                     return build(current);
                 }
@@ -18839,6 +18843,9 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "callbackInput" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "variableInput" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "factoryInput" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "enabledFlag" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "fallbackValue" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "readyFlag" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "input" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "string" && r.ReferenceKind == "type_reference");
     }
@@ -18851,12 +18858,13 @@ public class ReferenceExtractorTests
 
             class Service<T : Entity>(private val repo: Repository) : BaseService(repo), Runnable where T : Auditable {
                 val current: User = repo.load() as User
+                val fallback = repo.load() as User ?: fallbackUser
 
                 fun load(input: User, options: LoadOptions): Result<User> {
                     return input
                 }
 
-                fun check(value: Any) = value is User
+                fun check(value: Any) = value is User && value.enabledFlag
             }
             """;
 
@@ -18875,6 +18883,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "LoadOptions" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "Any" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "enabledFlag" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "fallbackUser" && r.ReferenceKind == "type_reference");
     }
 
     [Fact]
@@ -18891,6 +18901,10 @@ public class ReferenceExtractorTests
                 func cast(_ value: Any) -> User? {
                     return value as? User
                 }
+
+                func check(_ value: Any) -> Bool {
+                    return value is User && value.isReady
+                }
             }
             """;
 
@@ -18905,6 +18919,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "LoadOptions" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "Any" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "isReady" && r.ReferenceKind == "type_reference");
     }
 
     [Fact]
@@ -18946,6 +18961,25 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "Service" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "StoreImpl" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "self" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_RustStructFieldTypes_CaptureStructContainerReferences()
+    {
+        const string content = """
+            struct FieldOnly {
+                repo: Repository,
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "Repository"
+            && r.ReferenceKind == "type_reference"
+            && r.ContainerKind == "struct"
+            && r.ContainerName == "FieldOnly");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18798,6 +18798,149 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptTypedDeclarations_CaptureStructuralTypeReferences()
+    {
+        const string content = """
+            interface Handler extends BaseHandler<Request>, Disposable {}
+
+            class Service extends BaseService implements Runnable, Closeable {
+                load(input: User, options?: LoadOptions): Promise<Result> {
+                    const current: User = input as User;
+                    return build(current);
+                }
+            }
+
+            type UserPick = Pick<User, "id">;
+
+            function runtime(input: unknown) {
+                return typeof input === "string";
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "BaseHandler" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Disposable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "BaseService" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Runnable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Closeable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "LoadOptions" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Promise" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Pick" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "input" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "string" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_KotlinTypedDeclarations_CaptureStructuralTypeReferences()
+    {
+        const string content = """
+            interface Handler : BaseHandler<Request>, Closeable
+
+            class Service<T : Entity>(private val repo: Repository) : BaseService(repo), Runnable where T : Auditable {
+                val current: User = repo.load() as User
+
+                fun load(input: User, options: LoadOptions): Result<User> {
+                    return input
+                }
+
+                fun check(value: Any) = value is User
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "BaseHandler" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Closeable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Entity" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "BaseService" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Runnable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Auditable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "LoadOptions" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Any" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_SwiftTypedDeclarations_CaptureStructuralTypeReferences()
+    {
+        const string content = """
+            class Service<T: Entity>: BaseService, Runnable where T: Auditable {
+                var current: User
+
+                func load(_ input: User, options: LoadOptions) -> Result<User> {
+                    return make(input)
+                }
+
+                func cast(_ value: Any) -> User? {
+                    return value as? User
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        var references = ReferenceExtractor.Extract(1, "swift", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Entity" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "BaseService" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Runnable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Auditable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "LoadOptions" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Any" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_RustTypedDeclarations_CaptureStructuralTypeReferences()
+    {
+        const string content = """
+            trait Handler: Sendable {
+                fn handle(&self, input: Request) -> Result<Response, Error>;
+            }
+
+            struct Service<T: Store> where T: Clone {
+                repo: Repository,
+                current: Option<User>,
+            }
+
+            impl Handler for Service<StoreImpl> {
+                fn handle(&self, input: Request) -> Result<Response, Error> {
+                    let current: Option<User> = None;
+                    let repo: Repository = make_repo();
+                    finish(current, repo)
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Sendable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Error" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Store" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Clone" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Option" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Service" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "StoreImpl" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "self" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18858,6 +18858,8 @@ public class ReferenceExtractorTests
             import { Foo as Bar } from "mod";
             export { Foo as Baz } from "mod";
             export type { Model as PublicModel } from "mod";
+            export * as NamespaceMod from "mod";
+            export type * as PublicNamespace from "mod";
             """;
 
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
@@ -18867,6 +18869,8 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "Bar" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "Baz" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "PublicModel" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "NamespaceMod" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "PublicNamespace" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "from" && r.ReferenceKind == "type_reference");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -18860,6 +18860,9 @@ public class ReferenceExtractorTests
             export type { Model as PublicModel } from "mod";
             export * as NamespaceMod from "mod";
             export type * as PublicNamespace from "mod";
+            import*as CompactImport from "mod";
+            export*as CompactNamespace from "mod";
+            export type*as CompactPublicNamespace from "mod";
             """;
 
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
@@ -18871,6 +18874,9 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "PublicModel" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "NamespaceMod" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "PublicNamespace" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "CompactImport" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "CompactNamespace" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "CompactPublicNamespace" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "from" && r.ReferenceKind == "type_reference");
     }
 


### PR DESCRIPTION
## Summary
- Expand non-C# type-position `type_reference` extraction for TypeScript, Kotlin, Swift, and Rust.
- Add a shared typed-language extractor for declarations, heritage clauses, generic/where bounds, casts/type tests, and struct field types.
- Tighten TypeScript/Kotlin alias handling and Rust struct field coverage, including tuple/newtype structs.
- Restore README Fair Source license-policy parity required by existing license tests.

## Validation
- `dotnet build`
- `dotnet test --filter FullyQualifiedName~ReferenceExtractorTests`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `codex exec --ephemeral ...` adversarial review: `No blocking/actionable issues found.`