### PR TITLE
Add Perl search extraction

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -358,6 +358,7 @@ Supported symbol kinds by language:
 | Rust | functions, macros, `const`, `static`, impl/type aliases, structs, unions, traits, enums | `use`, turbofish and structural type-position references | yes |
 | Swift | functions, classes, actors, structs, protocols, enums, stored properties | imports and trailing-closure calls | yes |
 | Ruby | `def`, Rails DSL, block calls, classes, modules, attributes | `require` | yes |
+| Perl | packages, subroutines, constants | `use`, `require`, `parent` / `base`, arrow method calls | yes |
 | C / C++ | functions, macros, structs, C++ classes, enums, enum classes | `#include`, type-position references | yes |
 | PHP | functions, constants, enum cases, classes, interfaces, traits, enums | `use`, `require`, `include` | yes |
 | Scala | `def`, classes, objects, traits, enums | imports, type aliases, block calls | yes |
@@ -381,7 +382,7 @@ For JavaScript / TypeScript, reference extraction also captures tagged template 
 
 SQL also emits `namespace` symbols for `CREATE SCHEMA`, but the summary table above does not have a dedicated namespace column. SQL graph extraction emits `reference` edges for named source/target forms such as `FROM`, `JOIN`, `INSERT INTO`, `UPDATE`, `TRUNCATE TABLE`, `DELETE FROM`, `DELETE ... USING`, and `MERGE ... USING`; procedure and table-valued-function calls stay on the `call` path.
 
-Additionally, 22 languages are detected and indexed as raw text without symbol extraction: cmake, clojure, crystal, dockerignore, d, editorconfig, erlang, gitignore, json, justfile, julia, markdown, nim, ocaml, perl, solidity, svelte, tcl, toml, vue, xml, yaml.
+Additionally, 21 languages are detected and indexed as raw text without symbol extraction: cmake, clojure, crystal, dockerignore, d, editorconfig, erlang, gitignore, json, justfile, julia, markdown, nim, ocaml, solidity, svelte, tcl, toml, vue, xml, yaml.
 
 VB.NET container patterns use `RegexOptions.IgnoreCase` plus `VisualBasicEnd`-based range tracking, so `Partial` spelling differences and multi-file type families still receive stable definition ranges and hotspot-family metadata.
 
@@ -1474,6 +1475,7 @@ LIMIT 20;
 | Rust | function、macro、`const`、`static`、impl/type alias、struct、union、trait、enum | `use`、turbofish、structural type-position reference | yes |
 | Swift | function、class、actor、struct、protocol、enum、stored property | import、trailing-closure call | yes |
 | Ruby | `def`、Rails DSL、block call、class、module、attribute | `require` | yes |
+| Perl | package、subroutine、constant | `use`、`require`、`parent` / `base`、arrow method call | yes |
 | C / C++ | function、macro、struct、C++ class、enum、enum class | `#include`、type-position reference | yes |
 | PHP | function、constant、enum case、class、interface、trait、enum | `use`、`require`、`include` | yes |
 | Scala | `def`、class、object、trait、enum | import、type alias、block call | yes |
@@ -1497,7 +1499,7 @@ JavaScript / TypeScript では、reference extraction が `` gql`...` ``、`` st
 
 SQL は `CREATE SCHEMA` から `namespace` シンボルも出力するが、上の要約表には namespace 専用列はない。SQL graph extraction は `FROM`、`JOIN`、`INSERT INTO`、`UPDATE`、`TRUNCATE TABLE`、`DELETE FROM`、`DELETE ... USING`、`MERGE ... USING` のような source/target 形を `reference` edge として出力し、procedure call と table-valued function 使用は `call` 経路に残す。
 
-他に22言語がテキスト検索用に検出されるがシンボル抽出パターンは未対応: cmake, clojure, crystal, dockerignore, d, editorconfig, erlang, gitignore, json, justfile, julia, markdown, nim, ocaml, perl, solidity, svelte, tcl, toml, vue, xml, yaml。
+他に21言語がテキスト検索用に検出されるがシンボル抽出パターンは未対応: cmake, clojure, crystal, dockerignore, d, editorconfig, erlang, gitignore, json, justfile, julia, markdown, nim, ocaml, solidity, svelte, tcl, toml, vue, xml, yaml。
 
 正規表現ベースの抽出は意図的にシンプルです。AST精度よりも速度とポータビリティを優先しています。
 

--- a/changelog.d/unreleased/+perl-search-enhancement.added.md
+++ b/changelog.d/unreleased/+perl-search-enhancement.added.md
@@ -1,0 +1,19 @@
+---
+category: added
+affected:
+  - DEVELOPER_GUIDE.md
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Perl.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/PerlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Perl search now indexes richer symbols and references** — Perl package declarations, imports, constants, attributed subroutines, module inheritance, constructor calls, and arrow method calls are now easier to navigate through symbols and references.
+
+## 日本語
+
+- **Perl 検索がより豊富なシンボルと参照をインデックスするようになりました** — Perl の package 宣言、import、constant、属性付き subroutine、モジュール継承、constructor 呼び出し、arrow method 呼び出しを symbols / references で辿りやすくしました。

--- a/src/CodeIndex/Indexer/References/Languages/PerlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PerlReferenceExtractor.cs
@@ -1,0 +1,161 @@
+using System.Text.RegularExpressions;
+using CodeIndex.Models;
+
+namespace CodeIndex.Indexer;
+
+internal static class PerlReferenceExtractor
+{
+    private static readonly Regex ModuleReferenceRegex = new(
+        @"^\s*(?:use|require)\s+(?<name>[\p{L}_][\w:]*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BaseModuleReferenceRegex = new(
+        @"^\s*use\s+(?:base|parent)\s+(?<args>.+?);?\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex QuotedModuleRegex = new(
+        @"['""](?<name>[\p{L}_][\w:]*)['""]|qw\s*\((?<names>[^)]*)\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex ArrowCallRegex = new(
+        @"(?<receiver>(?:[\p{L}_][\w:]*)|\$[\p{L}_]\w*)\s*->\s*(?<name>[\p{L}_]\w*)\s*(?:\(|\b)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static void EmitAdditionalReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall,
+        Action<string, int> addCallLikeReference)
+    {
+        EmitModuleReference(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForCall);
+        EmitBaseModuleReferences(originalLine, references, seen, fileId, context, lineNumber, resolveContainerForCall);
+        EmitArrowCallReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForCall, addCallLikeReference);
+    }
+
+    private static void EmitModuleReference(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        var match = ModuleReferenceRegex.Match(preparedLine);
+        if (!match.Success)
+            return;
+
+        var nameGroup = match.Groups["name"];
+        if (string.Equals(nameGroup.Value, "strict", StringComparison.Ordinal)
+            || string.Equals(nameGroup.Value, "warnings", StringComparison.Ordinal)
+            || string.Equals(nameGroup.Value, "constant", StringComparison.Ordinal)
+            || string.Equals(nameGroup.Value, "base", StringComparison.Ordinal)
+            || string.Equals(nameGroup.Value, "parent", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            nameGroup.Value,
+            nameGroup.Index,
+            "reference",
+            context,
+            lineNumber,
+            resolveContainerForCall(nameGroup.Index));
+    }
+
+    private static void EmitBaseModuleReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        var match = BaseModuleReferenceRegex.Match(originalLine);
+        if (!match.Success)
+            return;
+
+        var args = match.Groups["args"].Value;
+        var argsStart = match.Groups["args"].Index;
+        foreach (Match moduleMatch in QuotedModuleRegex.Matches(args))
+        {
+            if (moduleMatch.Groups["name"].Success)
+            {
+                AddBaseModuleReference(moduleMatch.Groups["name"].Value, argsStart + moduleMatch.Groups["name"].Index, references, seen, fileId, context, lineNumber, resolveContainerForCall);
+                continue;
+            }
+
+            if (!moduleMatch.Groups["names"].Success)
+                continue;
+
+            var names = moduleMatch.Groups["names"].Value;
+            var namesStart = argsStart + moduleMatch.Groups["names"].Index;
+            foreach (Match nameMatch in Regex.Matches(names, @"[\p{L}_][\w:]*", RegexOptions.CultureInvariant))
+                AddBaseModuleReference(nameMatch.Value, namesStart + nameMatch.Index, references, seen, fileId, context, lineNumber, resolveContainerForCall);
+        }
+    }
+
+    private static void AddBaseModuleReference(
+        string name,
+        int column,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            name,
+            column,
+            "type_reference",
+            context,
+            lineNumber,
+            resolveContainerForCall(column));
+    }
+
+    private static void EmitArrowCallReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall,
+        Action<string, int> addCallLikeReference)
+    {
+        foreach (Match match in ArrowCallRegex.Matches(preparedLine))
+        {
+            var nameGroup = match.Groups["name"];
+            addCallLikeReference(nameGroup.Value, nameGroup.Index);
+
+            var receiverGroup = match.Groups["receiver"];
+            if (!string.Equals(nameGroup.Value, "new", StringComparison.Ordinal) || receiverGroup.Value.StartsWith('$'))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                receiverGroup.Value,
+                receiverGroup.Index,
+                "instantiate",
+                context,
+                lineNumber,
+                resolveContainerForCall(receiverGroup.Index));
+        }
+    }
+}

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -168,6 +168,13 @@ public static partial class ReferenceExtractor
             "raise", "yield", "super", "include", "extend",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
+        ["perl"] = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "use", "require", "package", "sub", "my", "our", "local", "state",
+            "if", "elsif", "unless", "while", "until", "foreach", "for", "given", "when",
+            "print", "say", "die", "warn", "open", "close", "defined", "exists", "delete",
+            "bless", "ref", "scalar", "wantarray", "eval", "do",
+        },
         // F# contextual keywords / F# 文脈キーワード
         ["fsharp"] = new HashSet<string>(StringComparer.Ordinal)
         {
@@ -1841,6 +1848,19 @@ public static partial class ReferenceExtractor
                         lineNumber,
                         ResolveContainerForCall,
                         matchedCallIndices,
+                        AddCallLikeReference);
+                }
+                else if (language == "perl")
+                {
+                    PerlReferenceExtractor.EmitAdditionalReferences(
+                        preparedLine,
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        context,
+                        lineNumber,
+                        ResolveContainerForCall,
                         AddCallLikeReference);
                 }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Perl.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Perl.cs
@@ -1,0 +1,118 @@
+using System.Text.RegularExpressions;
+using CodeIndex.Models;
+
+namespace CodeIndex.Indexer;
+
+public static partial class SymbolExtractor
+{
+    private const string PerlIdentifierPattern = @"[\p{L}_][\p{L}\p{Nd}_]*";
+    private const string PerlQualifiedIdentifierPattern = PerlIdentifierPattern + @"(?:::" + PerlIdentifierPattern + @")*";
+    private static readonly Regex PerlHashConstantStartRegex = new(
+        @"^\s*use\s+constant\s+\{",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PerlHashConstantKeyRegex = new(
+        @"(?:^|,)\s*(?:""(?<quoted>[\p{L}_][\p{L}\p{Nd}_]*)""|'(?<quoted>[\p{L}_][\p{L}\p{Nd}_]*)'|(?<bare>[\p{L}_][\p{L}\p{Nd}_]*))\s*=>",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static void ExtractPerlHashConstantSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (!TryCollectPerlHashConstantBody(lines, i, out var body, out var lineSegments, out var endLineIndex, out var signature))
+                continue;
+
+            foreach (Match keyMatch in PerlHashConstantKeyRegex.Matches(body))
+            {
+                var nameGroup = keyMatch.Groups["bare"].Success
+                    ? keyMatch.Groups["bare"]
+                    : keyMatch.Groups["quoted"];
+                if (!nameGroup.Success)
+                    continue;
+
+                var (lineIndex, column) = ResolvePerlHashConstantBodyPosition(lineSegments, nameGroup.Index);
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    lineIndex + 1,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "function",
+                        Name = nameGroup.Value,
+                        Line = lineIndex + 1,
+                        StartLine = lineIndex + 1,
+                        EndLine = lineIndex + 1,
+                        StartColumn = column,
+                        Signature = signature,
+                    });
+            }
+
+            i = endLineIndex;
+        }
+    }
+
+    private readonly record struct PerlBodyLineSegment(int BodyStartIndex, int LineIndex, int ColumnOffset);
+
+    private static bool TryCollectPerlHashConstantBody(
+        string[] lines,
+        int startLineIndex,
+        out string body,
+        out List<PerlBodyLineSegment> lineSegments,
+        out int endLineIndex,
+        out string signature)
+    {
+        body = string.Empty;
+        lineSegments = [];
+        endLineIndex = startLineIndex;
+        signature = lines[startLineIndex].Trim();
+
+        var startLine = lines[startLineIndex];
+        var startMatch = PerlHashConstantStartRegex.Match(startLine);
+        if (!startMatch.Success)
+            return false;
+
+        var openBraceIndex = startLine.IndexOf('{', startMatch.Index + startMatch.Length - 1);
+        if (openBraceIndex < 0)
+            return false;
+
+        var builder = new System.Text.StringBuilder();
+        for (var lineIndex = startLineIndex; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var segmentStart = lineIndex == startLineIndex ? openBraceIndex + 1 : 0;
+            var closeBraceIndex = line.IndexOf('}', segmentStart);
+            var segmentEnd = closeBraceIndex >= 0 ? closeBraceIndex : line.Length;
+            if (segmentEnd > segmentStart)
+            {
+                lineSegments.Add(new PerlBodyLineSegment(builder.Length, lineIndex, segmentStart));
+                builder.Append(line, segmentStart, segmentEnd - segmentStart);
+            }
+
+            if (closeBraceIndex >= 0)
+            {
+                body = builder.ToString();
+                endLineIndex = lineIndex;
+                return true;
+            }
+
+            builder.Append('\n');
+        }
+
+        return false;
+    }
+
+    private static (int LineIndex, int Column) ResolvePerlHashConstantBodyPosition(
+        IReadOnlyList<PerlBodyLineSegment> lineSegments,
+        int bodyIndex)
+    {
+        var segment = lineSegments[0];
+        for (var i = 1; i < lineSegments.Count; i++)
+        {
+            if (lineSegments[i].BodyStartIndex > bodyIndex)
+                break;
+            segment = lineSegments[i];
+        }
+
+        return (segment.LineIndex, segment.ColumnOffset + bodyIndex - segment.BodyStartIndex);
+    }
+}

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1262,12 +1262,15 @@ public static partial class SymbolExtractor
         ["perl"] =
         [
             // Perl package declarations / Perl の package 宣言
-            new("namespace", new Regex(@"^\s*package\s+(?<name>[\w:]+)\s*;", RegexOptions.Compiled), BodyStyle.None),
+            new("namespace", new Regex(@"^\s*package\s+(?<name>" + PerlQualifiedIdentifierPattern + @")\b(?:\s+v?[\d._]+)?\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Perl constants are compile-time subroutines, so expose them as functions for navigation.
+            // Perl constant はコンパイル時 subroutine なので、ナビゲーション用に function として出す。
+            new("function", new Regex(@"^\s*use\s+constant\s+(?<name>" + PerlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
             // Perl module imports / Perl の module import
-            new("import", new Regex(@"^\s*use\s+(?<name>[\p{L}_][\w:]*)", RegexOptions.Compiled), BodyStyle.None),
-            new("import", new Regex(@"^\s*require\s+(?<name>[\p{L}_][\w:]*)", RegexOptions.Compiled), BodyStyle.None),
+            new("import", new Regex(@"^\s*use\s+(?<name>" + PerlQualifiedIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*require\s+(?<name>" + PerlQualifiedIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
             // Perl subroutines / Perl の subroutine
-            new("function", new Regex(@"^\s*sub\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*sub\s+(?<name>" + PerlIdentifierPattern + @")\b(?:\s*:[^{;]+)?", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
         ],
         ["c"] =
         [
@@ -3404,6 +3407,8 @@ public static partial class SymbolExtractor
             ExtractCppSameLineClassBodyMembers(fileId, lines, symbols);
         if (lang == "python")
             ExtractPythonAllExportSymbols(fileId, lines, symbols, pythonModulePrefix);
+        if (lang == "perl")
+            ExtractPerlHashConstantSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
         KotlinSymbolNameNormalizer.NormalizeSecondaryConstructorNames(symbols);

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -19843,4 +19843,43 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "define");
         Assert.DoesNotContain(references, r => r.SymbolName == "module");
     }
+
+    [Fact]
+    public void Extract_Perl_CapturesModuleInheritanceAndArrowCalls()
+    {
+        const string content = """
+            package My::App;
+
+            use My::Util;
+            use parent qw(My::Base My::Role);
+
+            sub render {
+                My::Widget->new();
+                $self->helper();
+                My::Util::format($self);
+            }
+
+            sub helper {
+                return 1;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "perl", content);
+        var references = ReferenceExtractor.Extract(1, "perl", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "My::Util" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "My::Base" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "My::Role" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "My::Widget" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r =>
+            r.SymbolName == "helper"
+            && r.ReferenceKind == "call"
+            && r.ContainerKind == "function"
+            && r.ContainerName == "render");
+        Assert.Contains(references, r =>
+            r.SymbolName == "format"
+            && r.ReferenceKind == "call"
+            && r.ContainerKind == "function"
+            && r.ContainerName == "render");
+    }
 }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20275,4 +20275,35 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "G");
         Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "H");
     }
+
+    [Fact]
+    public void Extract_Perl_CapturesPackagesImportsConstantsAndAttributedSubs()
+    {
+        var content = """
+            package My::App v1.2.3;
+
+            use parent 'My::Base';
+            use constant DEFAULT_LIMIT => 10;
+            use constant { SECOND_LIMIT => 20, 'THIRD_LIMIT' => 30 };
+            use constant {
+                FOURTH_LIMIT => 40,
+                "FIFTH_LIMIT" => 50,
+            };
+
+            sub render : prototype($) {
+                return DEFAULT_LIMIT;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "perl", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "My::App");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "parent");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "DEFAULT_LIMIT");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "SECOND_LIMIT");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "THIRD_LIMIT");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "FOURTH_LIMIT");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "FIFTH_LIMIT");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render");
+    }
 }


### PR DESCRIPTION
## Summary

- Add Perl-specific symbol extraction for packages, imports, single-name constants, hash-style constants including multi-line declarations, and attributed subroutines.
- Add Perl reference extraction for module imports, parent/base inheritance, constructor calls, and arrow method calls.
- Update extractor tests plus English/Japanese developer guide coverage.

## Validation

- `dotnet build -v minimal`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~SymbolExtractorTests|FullyQualifiedName~ReferenceExtractorTests" -v minimal`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `codex review --base origin/main`

## Documentation And Changelog

- Updated `DEVELOPER_GUIDE.md` in English and Japanese.
- Added changelog fragment: `changelog.d/unreleased/+perl-search-enhancement.added.md`.

No linked issue; this is non-issue feature work.