### PR TITLE
[codex] Improve C# XAML search indexing

### DIFF
--- a/changelog.d/unreleased/+xaml-avalonia-bindings.fixed.md
+++ b/changelog.d/unreleased/+xaml-avalonia-bindings.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Avalonia binding paths are now indexed from XAML** — `{CompiledBinding ...}` and `{ReflectionBinding ...}` now emit searchable property symbols, matching the existing `{Binding ...}` path extraction for Avalonia XAML projects.
+
+## 日本語
+
+- **Avalonia の Binding path も XAML からインデックスされるようになりました** — `{CompiledBinding ...}` と `{ReflectionBinding ...}` を検索可能な property シンボルとして出力し、Avalonia XAML プロジェクトでも既存の `{Binding ...}` と同じように path を検索できるようにしました。

--- a/changelog.d/unreleased/+xaml-binding-element-name.fixed.md
+++ b/changelog.d/unreleased/+xaml-binding-element-name.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML `ElementName` binding references are now indexed** — `{Binding ElementName=SearchBox, Path=Text}`, `<Binding ElementName="RootPanel" />`, and `<Binding.ElementName>DetailsList</Binding.ElementName>` now emit searchable property symbols, improving navigation from bindings back to named XAML elements.
+
+## 日本語
+
+- **XAML の `ElementName` binding 参照もインデックスされるようになりました** — `{Binding ElementName=SearchBox, Path=Text}`、`<Binding ElementName="RootPanel" />`、`<Binding.ElementName>DetailsList</Binding.ElementName>` を検索可能な property シンボルとして出力し、binding から名前付き XAML 要素へたどりやすくしました。

--- a/changelog.d/unreleased/+xaml-object-binding-paths.fixed.md
+++ b/changelog.d/unreleased/+xaml-object-binding-paths.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML object-element binding paths are now indexed** — `<Binding Path="ViewModel.FirstName" />` and `<Binding.Path>Profile.DisplayName</Binding.Path>` now emit searchable property symbols, improving navigation for MultiBinding and property-element XAML forms.
+
+## 日本語
+
+- **XAML の object-element binding path もインデックスされるようになりました** — `<Binding Path="ViewModel.FirstName" />` や `<Binding.Path>Profile.DisplayName</Binding.Path>` を検索可能な property シンボルとして出力し、MultiBinding や property-element 形式の XAML ナビゲーションを改善します。

--- a/changelog.d/unreleased/+xaml-reference-targets.fixed.md
+++ b/changelog.d/unreleased/+xaml-reference-targets.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML `x:Reference` targets are now indexed** — `{x:Reference RootPanel}`, `{x:Reference Name=NamedTarget}`, `<x:Reference Name="ObjectTarget" />`, and `<x:Reference.Name>PropertyTarget</x:Reference.Name>` now emit searchable property symbols, improving navigation between XAML references and named elements.
+
+## 日本語
+
+- **XAML の `x:Reference` 参照先もインデックスされるようになりました** — `{x:Reference RootPanel}`、`{x:Reference Name=NamedTarget}`、`<x:Reference Name="ObjectTarget" />`、`<x:Reference.Name>PropertyTarget</x:Reference.Name>` を検索可能な property シンボルとして出力し、XAML の参照と名前付き要素の間をたどりやすくしました。

--- a/changelog.d/unreleased/+xaml-resource-references.fixed.md
+++ b/changelog.d/unreleased/+xaml-resource-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML resource references are now indexed** — `{StaticResource PrimaryBrush}` and `{DynamicResource ResourceKey={x:Static local:Keys.AccentBrush}}` now emit searchable property symbols, improving navigation between resource declarations and resource consumers.
+
+## 日本語
+
+- **XAML のリソース参照もインデックスされるようになりました** — `{StaticResource PrimaryBrush}` や `{DynamicResource ResourceKey={x:Static local:Keys.AccentBrush}}` を検索可能な property シンボルとして出力し、リソース宣言と利用箇所の間をたどりやすくしました。

--- a/changelog.d/unreleased/+xaml-template-binding.fixed.md
+++ b/changelog.d/unreleased/+xaml-template-binding.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML `TemplateBinding` properties are now indexed** — `{TemplateBinding Background}` and `{TemplateBinding Property=local:ButtonChrome.BorderBrush}` now emit searchable property symbols, improving ControlTemplate navigation in C#/XAML projects.
+
+## 日本語
+
+- **XAML の `TemplateBinding` プロパティもインデックスされるようになりました** — `{TemplateBinding Background}` や `{TemplateBinding Property=local:ButtonChrome.BorderBrush}` を検索可能な property シンボルとして出力し、C#/XAML プロジェクトの ControlTemplate ナビゲーションを改善します。

--- a/changelog.d/unreleased/+xaml-wrapped-search-attributes.fixed.md
+++ b/changelog.d/unreleased/+xaml-wrapped-search-attributes.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XAML wrapped search attributes are now indexed** — `x:Name`, `x:Key`, and common event handler attributes split across lines are now emitted as searchable symbols, so C#/XAML code-behind lookups still find names such as `SaveButton` and `OnSaveClicked`.
+
+## 日本語
+
+- **折り返された XAML 検索属性もインデックスされるようになりました** — 複数行に分割された `x:Name`、`x:Key`、一般的なイベントハンドラ属性を検索可能なシンボルとして出力し、`SaveButton` や `OnSaveClicked` のような C#/XAML コードビハインド名を引き続き見つけられるようにしました。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -709,6 +709,7 @@ public static partial class SymbolExtractor
 
         AddWrappedXamlTypeArgumentSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddWrappedXamlTypeBearingAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddWrappedXamlSearchAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypeObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypeMarkupSymbols(fileId, rawText, lines, lineStarts, symbols);
@@ -890,6 +891,129 @@ public static partial class SymbolExtractor
                 cursor = valueEnd + 1;
             }
         }
+    }
+
+    private static void AddWrappedXamlSearchAttributeSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        foreach (var occurrence in EnumerateWrappedXamlAttributeValues(rawText, lineStarts, "x:Name"))
+            AddXamlAttributeSymbol(fileId, lines, lineStarts, symbols, occurrence.AttributeIndex, "property", occurrence.Value.Trim());
+
+        foreach (var occurrence in EnumerateWrappedXamlAttributeValues(rawText, lineStarts, "x:Key"))
+            AddXamlAttributeSymbol(fileId, lines, lineStarts, symbols, occurrence.AttributeIndex, "property", NormalizeXamlKeyValue(occurrence.Value));
+
+        foreach (var attributeName in XamlEventAttributeNames)
+        {
+            foreach (var occurrence in EnumerateWrappedXamlAttributeValues(rawText, lineStarts, attributeName))
+                AddXamlAttributeSymbol(fileId, lines, lineStarts, symbols, occurrence.AttributeIndex, "function", occurrence.Value.Trim());
+        }
+    }
+
+    private static IEnumerable<(int AttributeIndex, string Value)> EnumerateWrappedXamlAttributeValues(
+        string rawText,
+        int[] lineStarts,
+        string attributeName)
+    {
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var attributeIndex = rawText.IndexOf(attributeName, cursor, StringComparison.Ordinal);
+            if (attributeIndex < 0)
+                yield break;
+
+            if (!TryReadXamlAttributeValue(rawText, attributeName, attributeIndex, out var valueStart, out var valueEnd))
+            {
+                cursor = attributeIndex + 1;
+                continue;
+            }
+
+            if (FindHtmlLineNumber(lineStarts, valueEnd) != FindHtmlLineNumber(lineStarts, attributeIndex))
+                yield return (attributeIndex, rawText[valueStart..valueEnd]);
+
+            cursor = valueEnd + 1;
+        }
+    }
+
+    private static bool TryReadXamlAttributeValue(
+        string rawText,
+        string attributeName,
+        int attributeIndex,
+        out int valueStart,
+        out int valueEnd)
+    {
+        valueStart = -1;
+        valueEnd = -1;
+
+        if (!IsXamlAttributeNameMatch(rawText, attributeIndex, attributeName.Length))
+            return false;
+
+        var cursor = attributeIndex + attributeName.Length;
+        while (cursor < rawText.Length && char.IsWhiteSpace(rawText[cursor]))
+            cursor++;
+
+        if (cursor >= rawText.Length || rawText[cursor] != '=')
+            return false;
+
+        cursor++;
+        while (cursor < rawText.Length && char.IsWhiteSpace(rawText[cursor]))
+            cursor++;
+
+        if (cursor >= rawText.Length)
+            return false;
+
+        var quote = rawText[cursor];
+        if (quote is not ('"' or '\''))
+            return false;
+
+        valueStart = cursor + 1;
+        valueEnd = valueStart;
+        while (valueEnd < rawText.Length && rawText[valueEnd] != quote)
+            valueEnd++;
+
+        return valueEnd < rawText.Length;
+    }
+
+    private static bool IsXamlAttributeNameMatch(string rawText, int index, int length)
+    {
+        if (index > 0 && IsXamlAttributeNameChar(rawText[index - 1]))
+            return false;
+
+        var after = index + length;
+        return after >= rawText.Length || !IsXamlAttributeNameChar(rawText[after]);
+    }
+
+    private static bool IsXamlAttributeNameChar(char c)
+        => IsXamlMarkupNameChar(c) || c == '-';
+
+    private static void AddXamlAttributeSymbol(
+        long fileId,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols,
+        int attributeIndex,
+        string kind,
+        string value)
+    {
+        value = value.Trim();
+        if (value.Length == 0)
+            return;
+
+        var startLine = FindHtmlLineNumber(lineStarts, attributeIndex);
+        var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+        symbols.Add(new SymbolRecord
+        {
+            FileId = fileId,
+            Kind = kind,
+            Name = value,
+            Line = startLine,
+            StartLine = startLine,
+            EndLine = startLine,
+            Signature = lines[signatureIndex].Trim(),
+        });
     }
 
     private static void AddXamlTypeObjectElementSymbols(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -715,6 +715,7 @@ public static partial class SymbolExtractor
         AddXamlTypeMarkupSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlStaticMemberTypeSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlResourceReferenceSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddXamlBindingElementNameSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlBindingObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
@@ -1016,6 +1017,101 @@ public static partial class SymbolExtractor
             EndLine = startLine,
             Signature = lines[signatureIndex].Trim(),
         });
+    }
+
+    private static void AddXamlBindingElementNameSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
+        {
+            if (!bindingMatch.Groups["kind"].Value.Equals("Binding", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = NormalizeXamlBindingElementNameValue(bindingMatch.Groups["content"].Value);
+            if (value.Length == 0)
+                continue;
+
+            AddXamlAttributeSymbol(fileId, lines, lineStarts, symbols, bindingMatch.Index, "property", value);
+        }
+
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var tagIndex = rawText.IndexOf("<Binding", cursor, StringComparison.Ordinal);
+            if (tagIndex < 0)
+                break;
+
+            var nameEnd = tagIndex + "<Binding".Length;
+            if (nameEnd < rawText.Length && IsXamlAttributeNameChar(rawText[nameEnd]))
+            {
+                cursor = nameEnd;
+                continue;
+            }
+
+            var tagEnd = FindXamlTagEnd(rawText, nameEnd);
+            if (tagEnd < 0)
+                break;
+
+            var elementNameAttributeIndex = IndexOfXamlAttributeInRange(rawText, "ElementName", nameEnd, tagEnd);
+            if (elementNameAttributeIndex >= 0
+                && TryReadXamlAttributeValue(rawText, "ElementName", elementNameAttributeIndex, out var valueStart, out var valueEnd)
+                && valueEnd <= tagEnd)
+            {
+                AddXamlAttributeSymbol(
+                    fileId,
+                    lines,
+                    lineStarts,
+                    symbols,
+                    elementNameAttributeIndex,
+                    "property",
+                    NormalizeXamlElementReferenceValue(rawText[valueStart..valueEnd]));
+            }
+
+            cursor = tagEnd + 1;
+        }
+
+        foreach (Match elementNameMatch in XamlBindingElementNamePropertyElementRegex.Matches(rawText))
+        {
+            var value = NormalizeXamlElementReferenceValue(elementNameMatch.Groups["value"].Value);
+            if (value.Length == 0)
+                continue;
+
+            AddXamlAttributeSymbol(fileId, lines, lineStarts, symbols, elementNameMatch.Index, "property", value);
+        }
+    }
+
+    private static string NormalizeXamlBindingElementNameValue(string content)
+    {
+        content = content.Trim();
+        if (content.Length == 0)
+            return "";
+
+        foreach (var argument in SplitTopLevelMarkupArguments(content))
+        {
+            var equalsIndex = IndexOfTopLevelEquals(argument);
+            if (equalsIndex < 0)
+                continue;
+
+            var argumentName = argument[..equalsIndex].Trim();
+            if (!string.Equals(argumentName, "ElementName", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = NormalizeXamlElementReferenceValue(argument[(equalsIndex + 1)..]);
+            if (value.Length > 0)
+                return value;
+        }
+
+        return "";
+    }
+
+    private static string NormalizeXamlElementReferenceValue(string value)
+    {
+        value = NormalizeXamlMarkupValue(value);
+        return value.Trim();
     }
 
     private static void AddXamlBindingObjectElementSymbols(
@@ -1787,10 +1883,22 @@ public static partial class SymbolExtractor
     private static IEnumerable<string> SplitTopLevelMarkupArguments(string value)
     {
         var braceDepth = 0;
+        char? quote = null;
         var start = 0;
         for (var i = 0; i < value.Length; i++)
         {
             var ch = value[i];
+            if (quote is { } activeQuote)
+            {
+                if (ch == activeQuote)
+                    quote = null;
+                continue;
+            }
+            if (ch is '"' or '\'')
+            {
+                quote = ch;
+                continue;
+            }
             if (ch == '{')
             {
                 braceDepth++;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -1231,15 +1231,18 @@ public static partial class SymbolExtractor
         if (content.Length == 0)
             return content;
 
+        var isTemplateBinding = kind.Equals("TemplateBinding", StringComparison.OrdinalIgnoreCase);
         var payload = kind.Equals("x:Bind", StringComparison.OrdinalIgnoreCase)
             ? $"x:Bind {content}"
-            : $"Binding {content}";
+            : isTemplateBinding
+                ? $"TemplateBinding {content}"
+                : $"Binding {content}";
 
-        var firstPath = NormalizeXamlBindingPath(payload);
+        var firstPath = NormalizeXamlBindingPath(payload, isTemplateBinding);
         return firstPath.Length > 0 ? firstPath : content;
     }
 
-    private static string NormalizeXamlBindingPath(string value)
+    private static string NormalizeXamlBindingPath(string value, bool allowPropertyArgument)
     {
         value = value.Trim();
         if (value.Length == 0)
@@ -1256,18 +1259,24 @@ public static partial class SymbolExtractor
         string? fallback = null;
         foreach (var argument in SplitTopLevelMarkupArguments(payload))
         {
-            var normalized = NormalizeXamlBindingArgument(argument);
-            if (normalized.Length == 0)
-                continue;
-
-            if (argument.IndexOf('=', StringComparison.Ordinal) >= 0)
+            var equalsIndex = IndexOfTopLevelEquals(argument);
+            if (equalsIndex >= 0)
             {
-                var argumentName = argument[..argument.IndexOf('=')].Trim();
-                if (string.Equals(argumentName, "Path", StringComparison.OrdinalIgnoreCase))
-                    return normalized;
+                var argumentName = argument[..equalsIndex].Trim();
+                if (string.Equals(argumentName, "Path", StringComparison.OrdinalIgnoreCase)
+                    || (allowPropertyArgument && string.Equals(argumentName, "Property", StringComparison.OrdinalIgnoreCase)))
+                {
+                    var pathValue = NormalizeXamlBindingPathValue(argument[(equalsIndex + 1)..]);
+                    if (pathValue.Length > 0)
+                        return pathValue;
+                }
 
                 continue;
             }
+
+            var normalized = NormalizeXamlBindingArgument(argument);
+            if (normalized.Length == 0)
+                continue;
 
             fallback ??= normalized;
         }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -714,6 +714,7 @@ public static partial class SymbolExtractor
         AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypeMarkupSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlStaticMemberTypeSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddXamlReferenceSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlResourceReferenceSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlBindingElementNameSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlBindingObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
@@ -1433,6 +1434,111 @@ public static partial class SymbolExtractor
         }
     }
 
+    private static void AddXamlReferenceSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        foreach (var prefix in XamlReferenceMarkupPrefixes)
+            AddXamlReferenceMarkupSymbols(fileId, rawText, lines, lineStarts, symbols, prefix);
+
+        foreach (var prefix in XamlReferenceObjectElementPrefixes)
+            AddXamlReferenceObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols, prefix);
+
+        foreach (Match nameMatch in XamlReferenceNamePropertyElementRegex.Matches(rawText))
+        {
+            var value = NormalizeXamlElementReferenceValue(nameMatch.Groups["value"].Value);
+            if (value.Length == 0)
+                continue;
+
+            AddXamlAttributeSymbol(fileId, lines, lineStarts, symbols, nameMatch.Index, "property", value);
+        }
+    }
+
+    private static void AddXamlReferenceMarkupSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols,
+        string prefix)
+    {
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var braceIndex = rawText.IndexOf(prefix, cursor, StringComparison.Ordinal);
+            if (braceIndex < 0)
+                break;
+
+            var afterPrefix = braceIndex + prefix.Length;
+            if (afterPrefix < rawText.Length && IsXamlMarkupNameChar(rawText[afterPrefix]))
+            {
+                cursor = afterPrefix;
+                continue;
+            }
+
+            var closingBraceIndex = FindMatchingBrace(rawText, braceIndex);
+            if (closingBraceIndex < 0)
+            {
+                cursor = braceIndex + 1;
+                continue;
+            }
+
+            var value = NormalizeXamlRequiredMarkupArgumentValue(rawText[braceIndex..(closingBraceIndex + 1)]);
+            if (value.Length > 0)
+                AddXamlAttributeSymbol(fileId, lines, lineStarts, symbols, braceIndex, "property", value);
+
+            cursor = closingBraceIndex + 1;
+        }
+    }
+
+    private static void AddXamlReferenceObjectElementSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols,
+        string prefix)
+    {
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var tagIndex = rawText.IndexOf(prefix, cursor, StringComparison.Ordinal);
+            if (tagIndex < 0)
+                break;
+
+            var nameEnd = tagIndex + prefix.Length;
+            if (nameEnd < rawText.Length && IsXamlAttributeNameChar(rawText[nameEnd]))
+            {
+                cursor = nameEnd;
+                continue;
+            }
+
+            var tagEnd = FindXamlTagEnd(rawText, nameEnd);
+            if (tagEnd < 0)
+                break;
+
+            var nameAttributeIndex = IndexOfXamlAttributeInRange(rawText, "Name", nameEnd, tagEnd);
+            if (nameAttributeIndex >= 0
+                && TryReadXamlAttributeValue(rawText, "Name", nameAttributeIndex, out var valueStart, out var valueEnd)
+                && valueEnd <= tagEnd)
+            {
+                AddXamlAttributeSymbol(
+                    fileId,
+                    lines,
+                    lineStarts,
+                    symbols,
+                    nameAttributeIndex,
+                    "property",
+                    NormalizeXamlElementReferenceValue(rawText[valueStart..valueEnd]));
+            }
+
+            cursor = tagEnd + 1;
+        }
+    }
+
     private static void AddXamlResourceReferenceSymbols(
         long fileId,
         string rawText,
@@ -1495,6 +1601,9 @@ public static partial class SymbolExtractor
     }
 
     private static string NormalizeXamlResourceReferenceValue(string value)
+        => NormalizeXamlRequiredMarkupArgumentValue(value);
+
+    private static string NormalizeXamlRequiredMarkupArgumentValue(string value)
     {
         value = value.Trim();
         if (value.Length == 0 || value[0] != '{')

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -714,6 +714,7 @@ public static partial class SymbolExtractor
         AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypeMarkupSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlStaticMemberTypeSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddXamlResourceReferenceSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlBindingObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
@@ -1334,6 +1335,96 @@ public static partial class SymbolExtractor
 
             cursor = closingBraceIndex + 1;
         }
+    }
+
+    private static void AddXamlResourceReferenceSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        foreach (var prefix in XamlResourceReferenceMarkupPrefixes)
+            AddXamlResourceReferenceSymbols(fileId, rawText, lines, lineStarts, symbols, prefix);
+    }
+
+    private static void AddXamlResourceReferenceSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols,
+        string prefix)
+    {
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var braceIndex = rawText.IndexOf(prefix, cursor, StringComparison.Ordinal);
+            if (braceIndex < 0)
+                break;
+
+            var afterPrefix = braceIndex + prefix.Length;
+            if (afterPrefix < rawText.Length && IsXamlMarkupNameChar(rawText[afterPrefix]))
+            {
+                cursor = afterPrefix;
+                continue;
+            }
+
+            var closingBraceIndex = FindMatchingBrace(rawText, braceIndex);
+            if (closingBraceIndex < 0)
+            {
+                cursor = braceIndex + 1;
+                continue;
+            }
+
+            var value = NormalizeXamlResourceReferenceValue(rawText[braceIndex..(closingBraceIndex + 1)]);
+            if (value.Length > 0)
+            {
+                var startLine = FindHtmlLineNumber(lineStarts, braceIndex);
+                var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = value,
+                    Line = startLine,
+                    StartLine = startLine,
+                    EndLine = startLine,
+                    Signature = lines[signatureIndex].Trim(),
+                });
+            }
+
+            cursor = closingBraceIndex + 1;
+        }
+    }
+
+    private static string NormalizeXamlResourceReferenceValue(string value)
+    {
+        value = value.Trim();
+        if (value.Length == 0 || value[0] != '{')
+            return value;
+
+        var closingBraceIndex = FindMatchingBrace(value, 0);
+        if (closingBraceIndex < 0)
+            return "";
+
+        var content = value[1..closingBraceIndex].Trim();
+        var payloadStart = FindTopLevelMarkupPayloadStart(content);
+        if (payloadStart < 0)
+            return "";
+
+        var payload = content[(payloadStart + 1)..].TrimStart();
+        if (payload.Length == 0)
+            return "";
+
+        foreach (var argument in SplitTopLevelMarkupArguments(payload))
+        {
+            var normalized = NormalizeXamlMarkupArgument(argument);
+            if (normalized.Length > 0)
+                return normalized;
+        }
+
+        return "";
     }
 
     private static bool IsXamlMarkupNameChar(char c)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -714,6 +714,7 @@ public static partial class SymbolExtractor
         AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlTypeMarkupSymbols(fileId, rawText, lines, lineStarts, symbols);
         AddXamlStaticMemberTypeSymbols(fileId, rawText, lines, lineStarts, symbols);
+        AddXamlBindingObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
         {
@@ -1014,6 +1015,129 @@ public static partial class SymbolExtractor
             EndLine = startLine,
             Signature = lines[signatureIndex].Trim(),
         });
+    }
+
+    private static void AddXamlBindingObjectElementSymbols(
+        long fileId,
+        string rawText,
+        string[] lines,
+        int[] lineStarts,
+        List<SymbolRecord> symbols)
+    {
+        var cursor = 0;
+        while (cursor < rawText.Length)
+        {
+            var tagIndex = rawText.IndexOf("<Binding", cursor, StringComparison.Ordinal);
+            if (tagIndex < 0)
+                break;
+
+            var nameEnd = tagIndex + "<Binding".Length;
+            if (nameEnd < rawText.Length && IsXamlAttributeNameChar(rawText[nameEnd]))
+            {
+                cursor = nameEnd;
+                continue;
+            }
+
+            var tagEnd = FindXamlTagEnd(rawText, nameEnd);
+            if (tagEnd < 0)
+                break;
+
+            var pathAttributeIndex = IndexOfXamlAttributeInRange(rawText, "Path", nameEnd, tagEnd);
+            if (pathAttributeIndex >= 0
+                && TryReadXamlAttributeValue(rawText, "Path", pathAttributeIndex, out var valueStart, out var valueEnd)
+                && valueEnd <= tagEnd)
+            {
+                AddXamlAttributeSymbol(
+                    fileId,
+                    lines,
+                    lineStarts,
+                    symbols,
+                    pathAttributeIndex,
+                    "property",
+                    NormalizeXamlBindingPathValue(rawText[valueStart..valueEnd]));
+            }
+
+            cursor = tagEnd + 1;
+        }
+
+        foreach (Match pathMatch in XamlBindingPathPropertyElementRegex.Matches(rawText))
+        {
+            var value = NormalizeXamlBindingPathValue(pathMatch.Groups["value"].Value);
+            if (value.Length == 0)
+                continue;
+
+            var startLine = FindHtmlLineNumber(lineStarts, pathMatch.Index);
+            var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+            symbols.Add(new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "property",
+                Name = value,
+                Line = startLine,
+                StartLine = startLine,
+                EndLine = startLine,
+                Signature = lines[signatureIndex].Trim(),
+            });
+        }
+    }
+
+    private static int FindXamlTagEnd(string rawText, int startIndex)
+    {
+        char? quote = null;
+        for (var i = startIndex; i < rawText.Length; i++)
+        {
+            var ch = rawText[i];
+            if (quote is { } activeQuote)
+            {
+                if (ch == activeQuote)
+                    quote = null;
+                continue;
+            }
+
+            if (ch is '"' or '\'')
+            {
+                quote = ch;
+                continue;
+            }
+
+            if (ch == '>')
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static int IndexOfXamlAttributeInRange(string rawText, string attributeName, int startIndex, int endIndex)
+    {
+        char? quote = null;
+        for (var i = startIndex; i < endIndex; i++)
+        {
+            var ch = rawText[i];
+            if (quote is { } activeQuote)
+            {
+                if (ch == activeQuote)
+                    quote = null;
+                continue;
+            }
+
+            if (ch is '"' or '\'')
+            {
+                quote = ch;
+                continue;
+            }
+
+            if (!rawText.AsSpan(i, endIndex - i).StartsWith(attributeName, StringComparison.Ordinal))
+                continue;
+
+            if (IsXamlAttributeNameMatch(rawText, i, attributeName.Length)
+                && TryReadXamlAttributeValue(rawText, attributeName, i, out _, out var valueEnd)
+                && valueEnd <= endIndex)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     private static void AddXamlTypeObjectElementSymbols(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -253,7 +253,7 @@ public static partial class SymbolExtractor
         @"\b(?:" + string.Join("|", XamlEventAttributeNames) + @")\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex XamlBindingRegex = new(
-        @"\{(?<kind>Binding|x:Bind)\b(?<content>(?:[^{}]|{[^{}]*})*)\}",
+        @"\{(?<kind>Binding|x:Bind|TemplateBinding)\b(?<content>(?:[^{}]|{[^{}]*})*)\}",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex ObjCCategoryDeclarationRegex = new(
         @"^\s*@(?:interface|implementation)\s+(?<class>\w+)\s*\(\s*(?<category>[^)]+?)\s*\)(?:\s*<[^>]+>)?",

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -261,12 +261,25 @@ public static partial class SymbolExtractor
     private static readonly Regex XamlBindingElementNamePropertyElementRegex = new(
         @"<\s*Binding\.ElementName\b[^>]*>(?<value>.*?)</\s*Binding\.ElementName\s*>",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+    private static readonly Regex XamlReferenceNamePropertyElementRegex = new(
+        @"<\s*(?<owner>x:Reference(?:Extension)?)\.Name\b[^>]*>(?<value>.*?)</\s*\k<owner>\.Name\s*>",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly string[] XamlResourceReferenceMarkupPrefixes =
     [
         "{StaticResource",
         "{StaticResourceExtension",
         "{DynamicResource",
         "{DynamicResourceExtension",
+    ];
+    private static readonly string[] XamlReferenceMarkupPrefixes =
+    [
+        "{x:ReferenceExtension",
+        "{x:Reference",
+    ];
+    private static readonly string[] XamlReferenceObjectElementPrefixes =
+    [
+        "<x:ReferenceExtension",
+        "<x:Reference",
     ];
     private static readonly Regex ObjCCategoryDeclarationRegex = new(
         @"^\s*@(?:interface|implementation)\s+(?<class>\w+)\s*\(\s*(?<category>[^)]+?)\s*\)(?:\s*<[^>]+>)?",

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -255,6 +255,9 @@ public static partial class SymbolExtractor
     private static readonly Regex XamlBindingRegex = new(
         @"\{(?<kind>Binding|x:Bind|TemplateBinding)\b(?<content>(?:[^{}]|{[^{}]*})*)\}",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex XamlBindingPathPropertyElementRegex = new(
+        @"<\s*Binding\.Path\b[^>]*>(?<value>.*?)</\s*Binding\.Path\s*>",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly Regex ObjCCategoryDeclarationRegex = new(
         @"^\s*@(?:interface|implementation)\s+(?<class>\w+)\s*\(\s*(?<category>[^)]+?)\s*\)(?:\s*<[^>]+>)?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -258,6 +258,13 @@ public static partial class SymbolExtractor
     private static readonly Regex XamlBindingPathPropertyElementRegex = new(
         @"<\s*Binding\.Path\b[^>]*>(?<value>.*?)</\s*Binding\.Path\s*>",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+    private static readonly string[] XamlResourceReferenceMarkupPrefixes =
+    [
+        "{StaticResource",
+        "{StaticResourceExtension",
+        "{DynamicResource",
+        "{DynamicResourceExtension",
+    ];
     private static readonly Regex ObjCCategoryDeclarationRegex = new(
         @"^\s*@(?:interface|implementation)\s+(?<class>\w+)\s*\(\s*(?<category>[^)]+?)\s*\)(?:\s*<[^>]+>)?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -258,6 +258,9 @@ public static partial class SymbolExtractor
     private static readonly Regex XamlBindingPathPropertyElementRegex = new(
         @"<\s*Binding\.Path\b[^>]*>(?<value>.*?)</\s*Binding\.Path\s*>",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+    private static readonly Regex XamlBindingElementNamePropertyElementRegex = new(
+        @"<\s*Binding\.ElementName\b[^>]*>(?<value>.*?)</\s*Binding\.ElementName\s*>",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
     private static readonly string[] XamlResourceReferenceMarkupPrefixes =
     [
         "{StaticResource",

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -225,8 +225,32 @@ public static partial class SymbolExtractor
     private static readonly Regex XamlKeyRegex = new(
         @"\bx:Key\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly string[] XamlEventAttributeNames =
+    [
+        "Clicked",
+        "Tapped",
+        "Loaded",
+        "Unloaded",
+        "SelectionChanged",
+        "TextChanged",
+        "CheckedChanged",
+        "Unchecked",
+        "SelectedIndexChanged",
+        "PointerPressed",
+        "PointerReleased",
+        "PointerEntered",
+        "PointerExited",
+        "Drop",
+        "DragOver",
+        "Completed",
+        "Appearing",
+        "Disappearing",
+        "NavigatedTo",
+        "NavigatedFrom",
+        "SizeChanged",
+    ];
     private static readonly Regex XamlEventHandlerRegex = new(
-        @"\b(?:Clicked|Tapped|Loaded|Unloaded|SelectionChanged|TextChanged|CheckedChanged|Unchecked|SelectedIndexChanged|PointerPressed|PointerReleased|PointerEntered|PointerExited|Drop|DragOver|Completed|Appearing|Disappearing|NavigatedTo|NavigatedFrom|SizeChanged)\s*=\s*[""'](?<value>[^""']+)[""']",
+        @"\b(?:" + string.Join("|", XamlEventAttributeNames) + @")\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex XamlBindingRegex = new(
         @"\{(?<kind>Binding|x:Bind)\b(?<content>(?:[^{}]|{[^{}]*})*)\}",

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -253,7 +253,7 @@ public static partial class SymbolExtractor
         @"\b(?:" + string.Join("|", XamlEventAttributeNames) + @")\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex XamlBindingRegex = new(
-        @"\{(?<kind>Binding|x:Bind|TemplateBinding)\b(?<content>(?:[^{}]|{[^{}]*})*)\}",
+        @"\{(?<kind>Binding|x:Bind|TemplateBinding|CompiledBinding|ReflectionBinding)\b(?<content>(?:[^{}]|{[^{}]*})*)\}",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex XamlBindingPathPropertyElementRegex = new(
         @"<\s*Binding\.Path\b[^>]*>(?<value>.*?)</\s*Binding\.Path\s*>",

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20386,6 +20386,36 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesStaticAndDynamicResourceKeys()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:local="clr-namespace:Sample.ViewModels">
+                <SolidColorBrush x:Key="PrimaryBrush" Color="Tomato" />
+                <SolidColorBrush x:Key="{x:Static local:Keys.WarningBrush}" Color="Orange" />
+                <TextBlock Foreground="{StaticResource PrimaryBrush}" />
+                <Border BorderBrush="{DynamicResource ResourceKey={x:Static Member={x:Type local:Keys}.AccentBrush}}" />
+                <TextBlock DataContext="{Binding Source={StaticResource ViewModelLocator}, Path=CurrentUser.DisplayName}" />
+                <TextBlock ToolTip="{StaticResource}" />
+                <Border Background="{DynamicResource ResourceKey=}" />
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+        var propertyNames = symbols.Where(s => s.Kind == "property").Select(s => s.Name).ToList();
+
+        Assert.Contains("PrimaryBrush", propertyNames);
+        Assert.Contains("local:Keys.WarningBrush", propertyNames);
+        Assert.Contains("local:Keys.AccentBrush", propertyNames);
+        Assert.Contains("ViewModelLocator", propertyNames);
+        Assert.Contains("DisplayName", propertyNames);
+        Assert.DoesNotContain("StaticResource", propertyNames);
+        Assert.DoesNotContain("DynamicResource", propertyNames);
+        Assert.DoesNotContain("ResourceKey", propertyNames);
+    }
+
+    [Fact]
     public void Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20333,6 +20333,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesTemplateBindingProperties()
+    {
+        var content = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:local="clr-namespace:Sample.Controls">
+                <ControlTemplate TargetType="{x:Type local:ButtonChrome}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding Property=local:ButtonChrome.BorderBrush}" />
+                </ControlTemplate>
+            </ResourceDictionary>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Background");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "BorderBrush");
+    }
+
+    [Fact]
     public void Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20333,6 +20333,33 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesCompiledAndReflectionBindingPaths()
+    {
+        var content = """
+            <Window xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                <StackPanel>
+                    <TextBlock Text="{CompiledBinding ViewModel.Title}" />
+                    <TextBox Text="{ReflectionBinding Path=Search.FilterText}" />
+                    <Button Command="{CompiledBinding
+                        Commands.Save}" />
+                    <TextBlock Tag="{CompiledBinding Path=Profile.DisplayName, ConverterParameter='Path=Ignored'}" />
+                </StackPanel>
+            </Window>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+        var propertyNames = symbols.Where(s => s.Kind == "property").Select(s => s.Name).ToList();
+
+        Assert.Contains("Title", propertyNames);
+        Assert.Contains("FilterText", propertyNames);
+        Assert.Contains("Save", propertyNames);
+        Assert.Contains("DisplayName", propertyNames);
+        Assert.DoesNotContain("Ignored", propertyNames);
+        Assert.DoesNotContain("ViewModel", propertyNames);
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesBindingElementNameReferences()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20275,6 +20275,40 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesWrappedSearchAttributesAcrossLines()
+    {
+        var content = """
+            <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:local="clr-namespace:Sample.ViewModels">
+                <ContentPage.Resources>
+                    <SolidColorBrush
+                        x:Key=
+                            "{x:Static Member={x:Type local:Keys}.AccentBrush}"
+                        Color="Tomato" />
+                </ContentPage.Resources>
+                <VerticalStackLayout>
+                    <Button
+                        x:Name=
+                            "SaveButton"
+                        Clicked=
+                            "OnSaveClicked" />
+                    <Entry
+                        TextChanged=
+                            "OnFilterTextChanged" />
+                </VerticalStackLayout>
+            </ContentPage>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "local:Keys.AccentBrush"));
+        Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "SaveButton"));
+        Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "OnSaveClicked"));
+        Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "OnFilterTextChanged"));
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesBindingPaths()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20353,6 +20353,39 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesObjectElementBindingPaths()
+    {
+        var content = """
+            <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:vm="clr-namespace:Sample.ViewModels">
+                <TextBlock>
+                    <TextBlock.Text>
+                        <MultiBinding StringFormat="{}{0} {1}">
+                            <Binding
+                                Source="{x:Reference Root}"
+                                ConverterParameter="Path='Ignored'"
+                                Path="ViewModel.FirstName" />
+                            <Binding Path="vm:PersonViewModel.LastName" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
+                <Binding.Path>
+                    Profile.DisplayName
+                </Binding.Path>
+            </ContentPage>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "FirstName");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "LastName");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DisplayName");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "Root");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "Ignored");
+    }
+
+    [Fact]
     public void Extract_Xml_NonXamlXmlDoesNotEmitXamlSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20315,7 +20315,7 @@ public class SymbolExtractorTests
             <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                          xmlns:vm="clr-namespace:Sample.ViewModels">
-                <StackPanel DataContext="{Binding Source={x:Reference Root}, Path=ViewModel}">
+                <StackPanel DataContext="{Binding Source=Root, Path=ViewModel}">
                     <Label Text="{Binding
                         Title}" />
                     <Button Command="{x:Bind
@@ -20395,7 +20395,7 @@ public class SymbolExtractorTests
                     <TextBlock.Text>
                         <MultiBinding StringFormat="{}{0} {1}">
                             <Binding
-                                Source="{x:Reference Root}"
+                                Source="Root"
                                 ConverterParameter="Path='Ignored'"
                                 Path="ViewModel.FirstName" />
                             <Binding Path="vm:PersonViewModel.LastName" />
@@ -20415,6 +20415,38 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DisplayName");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "Root");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "Ignored");
+    }
+
+    [Fact]
+    public void Extract_Xml_XamlCapturesXReferenceTargets()
+    {
+        var content = """
+            <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:local="clr-namespace:Sample.ViewModels">
+                <Grid>
+                    <TextBlock Text="{Binding Source={x:Reference RootPanel}, Path=Title}" />
+                    <TextBlock Text="{Binding Source={x:Reference Name=NamedTarget}, Path=Title}" />
+                    <TextBlock Text="{Binding Source={x:ReferenceExtension Name=ExtensionTarget}, Path=Title}" />
+                    <x:Reference ToolTip="Name='Ignored'" Name="ObjectTarget" />
+                    <x:Reference.Name>
+                        PropertyTarget
+                    </x:Reference.Name>
+                </Grid>
+            </ContentPage>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+        var propertyNames = symbols.Where(s => s.Kind == "property").Select(s => s.Name).ToList();
+
+        Assert.Contains("RootPanel", propertyNames);
+        Assert.Contains("NamedTarget", propertyNames);
+        Assert.Contains("ExtensionTarget", propertyNames);
+        Assert.Contains("ObjectTarget", propertyNames);
+        Assert.Contains("PropertyTarget", propertyNames);
+        Assert.Contains("Title", propertyNames);
+        Assert.DoesNotContain("Ignored", propertyNames);
+        Assert.DoesNotContain("x:Reference", propertyNames);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20333,6 +20333,38 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Xml_XamlCapturesBindingElementNameReferences()
+    {
+        var content = """
+            <ContentPage xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:vm="clr-namespace:Sample.ViewModels">
+                <Grid>
+                    <TextBlock Text="{Binding Text, ElementName=SearchBox}" />
+                    <Slider Value="{Binding ElementName=VolumeSlider, Path=Value}" />
+                    <TextBlock Tag="{Binding Path=Title, ConverterParameter='prefix, ElementName=Ignored'}" />
+                    <Binding
+                        ElementName="RootPanel"
+                        Path="DataContext.CurrentUser.Name" />
+                    <Binding.ElementName>
+                        DetailsList
+                    </Binding.ElementName>
+                </Grid>
+            </ContentPage>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+        var propertyNames = symbols.Where(s => s.Kind == "property").Select(s => s.Name).ToList();
+
+        Assert.Contains("SearchBox", propertyNames);
+        Assert.Contains("VolumeSlider", propertyNames);
+        Assert.Contains("RootPanel", propertyNames);
+        Assert.Contains("DetailsList", propertyNames);
+        Assert.Contains("Name", propertyNames);
+        Assert.DoesNotContain("Ignored", propertyNames);
+    }
+
+    [Fact]
     public void Extract_Xml_XamlCapturesTemplateBindingProperties()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Index more C#/XAML search targets, including wrapped `x:Name` / `x:Key` / event handler attributes.
- Add searchable symbols for `TemplateBinding`, object-element `Binding.Path`, `Binding.ElementName`, `x:Reference`, resource references, and Avalonia `CompiledBinding` / `ReflectionBinding` paths.
- Keep extraction quote-aware around object elements and markup arguments so converter parameters and tooltip text do not emit phantom symbols.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SymbolExtractorTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet build`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation And Changelog

- Added bilingual changelog fragments:
  - `changelog.d/unreleased/+xaml-wrapped-search-attributes.fixed.md`
  - `changelog.d/unreleased/+xaml-template-binding.fixed.md`
  - `changelog.d/unreleased/+xaml-object-binding-paths.fixed.md`
  - `changelog.d/unreleased/+xaml-resource-references.fixed.md`
  - `changelog.d/unreleased/+xaml-binding-element-name.fixed.md`
  - `changelog.d/unreleased/+xaml-reference-targets.fixed.md`
  - `changelog.d/unreleased/+xaml-avalonia-bindings.fixed.md`

## Follow-Up Candidates

- None currently.