### PR TITLE
[codex] Improve C#/Java/Kotlin generic type reference search

### DIFF
--- a/changelog.d/unreleased/+catch-exception-type-references.fixed.md
+++ b/changelog.d/unreleased/+catch-exception-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Catch-clause exception types are now indexed for C#, Java, and Kotlin** - `catch (IOException ex)`, Java multi-catch, and Kotlin `catch (ex: IOException)` now emit `type_reference` rows for the exception type without treating catch variables as types.
+
+## 日本語
+
+- **C# / Java / Kotlin の catch 節の例外型がインデックスされるようになりました** - `catch (IOException ex)`、Java multi-catch、Kotlin の `catch (ex: IOException)` が例外型への `type_reference` を出力し、catch 変数は型として扱わないようにしました。

--- a/changelog.d/unreleased/+csharp-anti-constraint-type-refs.fixed.md
+++ b/changelog.d/unreleased/+csharp-anti-constraint-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# anti-constraint keywords no longer become type references** - `where T : allows ref struct` now avoids `allows` / `ref` keyword noise while keeping real constraint types.
+
+## 日本語
+
+- **C# の anti-constraint keyword が型参照として混ざらないようになりました** - `where T : allows ref struct` で `allows` / `ref` の keyword ノイズを避けつつ、実際の制約型は維持します。

--- a/changelog.d/unreleased/+csharp-constraint-keyword-type-refs.fixed.md
+++ b/changelog.d/unreleased/+csharp-constraint-keyword-type-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# generic constraint keywords no longer become type references** - `where T : unmanaged` and `where T : notnull` now avoid keyword noise while preserving real constraint types such as `IContract`.
+
+## 日本語
+
+- **C# の generic constraint keyword が型参照として混ざらないようになりました** - `where T : unmanaged` や `where T : notnull` では keyword ノイズを避けつつ、`IContract` のような実際の制約型は維持します。

--- a/changelog.d/unreleased/+csharp-generic-signature-type-params.fixed.md
+++ b/changelog.d/unreleased/+csharp-generic-signature-type-params.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# generic signatures no longer emit type-parameter self references** - declarations such as `class Demo<T> : Base<T>` and `T Pick<T>(T value)` now keep real types while suppressing generic parameter noise.
+
+## 日本語
+
+- **C# の generic signature が型パラメータ自身を型参照として出さないようになりました** - `class Demo<T> : Base<T>` や `T Pick<T>(T value)` では実際の型を残しつつ、generic parameter のノイズを抑制します。

--- a/changelog.d/unreleased/+csharp-generic-type-keyword-params.fixed.md
+++ b/changelog.d/unreleased/+csharp-generic-type-keyword-params.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# generic type keywords no longer emit type-parameter self references** - single-line generic methods using `typeof(T)` or `nameof(T)` now suppress the generic parameter while keeping real type keyword targets searchable.
+
+## 日本語
+
+- **C# の generic type keyword が型パラメータ自身を型参照として出さないようになりました** - `typeof(T)` や `nameof(T)` を使う単一行 generic method では generic parameter を抑制し、実際の type keyword 対象型は検索可能なままにします。

--- a/changelog.d/unreleased/+csharp-generic-type-operator-params.fixed.md
+++ b/changelog.d/unreleased/+csharp-generic-type-operator-params.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# generic type operators no longer emit type-parameter self references** - single-line generic methods such as `value is T` and `value as T` now suppress the generic parameter while preserving real `is`/`as` target types.
+
+## 日本語
+
+- **C# の generic type operator が型パラメータ自身を型参照として出さないようになりました** - `value is T` / `value as T` のような単一行 generic method では generic parameter を抑制し、実際の `is` / `as` 対象型は保持します。

--- a/changelog.d/unreleased/+csharp-type-keyword-generic-args.fixed.md
+++ b/changelog.d/unreleased/+csharp-type-keyword-generic-args.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# compile-time type keyword references now include nested generic arguments** — `typeof(List<Payload>)`, `default(Dictionary<string, Payload>)`, and similar `nameof` / `sizeof` / `default` forms now emit `type_reference` rows for user types inside generic argument lists while still filtering C# built-in aliases.
+
+## 日本語
+
+- **C# の compile-time type keyword 参照で nested generic 引数も検索できるようになりました** — `typeof(List<Payload>)` や `default(Dictionary<string, Payload>)`、同種の `nameof` / `sizeof` / `default` で、generic 引数内のユーザー定義型も `type_reference` として発行します。C# built-in alias は引き続き除外します。

--- a/changelog.d/unreleased/+csharp-unicode-exact-search.fixed.md
+++ b/changelog.d/unreleased/+csharp-unicode-exact-search.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - src/CodeIndex/Database/ExactSourceSearchNormalizer.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **C# exact search now canonicalizes Unicode-escaped identifiers** — C# exact substring search now decodes `\uXXXX` and `\UXXXXXXXX` source escapes before applying existing `@identifier` and `global::` normalization, matching the escaped-identifier behavior already shared with Java and Kotlin.
+
+## 日本語
+
+- **C# exact 検索が Unicode escape 付き識別子を正規化するようになりました** — C# の exact substring 検索は既存の `@identifier` / `global::` 正規化の前に `\uXXXX` と `\UXXXXXXXX` の source escape をデコードし、Java / Kotlin と共有している escaped identifier の検索挙動に揃えるようになりました。

--- a/changelog.d/unreleased/+generic-invocation-type-args.fixed.md
+++ b/changelog.d/unreleased/+generic-invocation-type-args.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C#, Java, and Kotlin generic invocation type arguments are now searchable as type references** — generic constructor/function calls such as `new List<Payload>()`, `Collections.<Result>emptyList()`, and `read<Result>()` now emit `type_reference` rows for their type arguments after the existing call/instantiate guards accept the invocation.
+
+## 日本語
+
+- **C# / Java / Kotlin の generic 呼び出し型引数を型参照として検索できるようになりました** — `new List<Payload>()`、`Collections.<Result>emptyList()`、`read<Result>()` のような generic constructor / function 呼び出しで、既存の call / instantiate guard が受理した呼び出しの型引数を `type_reference` として発行します。

--- a/changelog.d/unreleased/+java-annotated-instanceof-types.fixed.md
+++ b/changelog.d/unreleased/+java-annotated-instanceof-types.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Java annotated `instanceof` patterns now keep the tested type reference** — forms such as `value instanceof final @NonNull Payload payload` now emit `Payload` as a `type_reference` while keeping `NonNull` as annotation metadata.
+
+## 日本語
+
+- **Java の annotation 付き `instanceof` pattern で検査対象型を拾えるようになりました** — `value instanceof final @NonNull Payload payload` のような形で、`Payload` を `type_reference` として発行し、`NonNull` は annotation metadata として扱います。

--- a/changelog.d/unreleased/+java-array-constructor-method-refs.fixed.md
+++ b/changelog.d/unreleased/+java-array-constructor-method-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Java array constructor method references now point at the component type** - `Widget[]::new` and `demo.Widget[][]::new` are indexed as instantiations of `Widget` / `demo.Widget` instead of missing the edge or keeping array suffix noise.
+
+## 日本語
+
+- **Java の配列コンストラクタ method reference が要素型を指すようになりました** - `Widget[]::new` や `demo.Widget[][]::new` を、配列 suffix ノイズではなく `Widget` / `demo.Widget` の instantiate として索引化します。

--- a/changelog.d/unreleased/+java-generic-callable-type-params.fixed.md
+++ b/changelog.d/unreleased/+java-generic-callable-type-params.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Java generic callable signatures no longer emit type-parameter self references** - signatures such as `<T extends Comparable<T>> T pick(T input)` now keep real bound types while suppressing `T` as type-reference noise.
+
+## 日本語
+
+- **Java の generic callable signature が型パラメータ自身を型参照として出さないようになりました** - `<T extends Comparable<T>> T pick(T input)` のような signature では実際の制約型を残しつつ、`T` の type_reference ノイズを抑制します。

--- a/changelog.d/unreleased/+java-generic-heritage-type-params.fixed.md
+++ b/changelog.d/unreleased/+java-generic-heritage-type-params.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Java generic heritage clauses no longer emit type-parameter self references** - declarations such as `class Box<T> extends Base<T> implements Handler<T>` now keep `Base` / `Handler` while suppressing `T` noise.
+
+## 日本語
+
+- **Java の generic heritage 句が型パラメータ自身を型参照として出さないようになりました** - `class Box<T> extends Base<T> implements Handler<T>` では `Base` / `Handler` を残しつつ、`T` のノイズを抑制します。

--- a/changelog.d/unreleased/+java-generic-throws-type-params.fixed.md
+++ b/changelog.d/unreleased/+java-generic-throws-type-params.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Java generic throws clauses no longer emit type-parameter self references** - `public <E extends Failure> void run() throws E` keeps the real bound type while suppressing the generic exception parameter.
+
+## 日本語
+
+- **Java の generic throws 句が型パラメータ自身を型参照として出さないようになりました** - `public <E extends Failure> void run() throws E` では実際の bound 型を残しつつ、generic exception parameter のノイズを抑制します。

--- a/changelog.d/unreleased/+jvm-doc-links.fixed.md
+++ b/changelog.d/unreleased/+jvm-doc-links.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Java and Kotlin documentation links now emit searchable type references** — Javadoc links such as `{@link User#save()}` / `@see Helper` and KDoc links such as `[User.name]` now populate `type_reference` rows on the documented symbol, matching the existing C# XML-doc `cref` search behavior.
+
+## 日本語
+
+- **Java / Kotlin のドキュメントリンクを型参照として検索できるようになりました** — `{@link User#save()}` / `@see Helper` のような Javadoc link と `[User.name]` のような KDoc link を、既存の C# XML-doc `cref` と同じく documented symbol 上の `type_reference` として発行します。

--- a/changelog.d/unreleased/+jvm-generic-owner-method-refs.fixed.md
+++ b/changelog.d/unreleased/+jvm-generic-owner-method-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **JVM method references now accept generic owner types** - Java references such as `Box<String>::new` and `Box<String>::open` are indexed against `Box` / `open` instead of being missed or carrying generic suffix noise.
+
+## 日本語
+
+- **JVM method reference が generic owner type を扱えるようになりました** - `Box<String>::new` や `Box<String>::open` のような Java 参照を見逃さず、generic suffix ノイズなしで `Box` / `open` に紐づけます。

--- a/changelog.d/unreleased/+jvm-method-reference-owner-types.fixed.md
+++ b/changelog.d/unreleased/+jvm-method-reference-owner-types.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/ScalaReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Java and Kotlin method references now index owner types** — callable references such as `String::trim` and `User::name` now emit `type_reference` rows for their type-like owners while still avoiding lowercase receiver objects such as `xs::iterator`.
+
+## 日本語
+
+- **Java / Kotlin のメソッド参照で owner 型も検索できるようになりました** — `String::trim` や `User::name` のような callable reference で、型らしい owner を `type_reference` として発行します。一方で `xs::iterator` のような小文字 receiver object は除外します。

--- a/changelog.d/unreleased/+kotlin-backtick-annotations.fixed.md
+++ b/changelog.d/unreleased/+kotlin-backtick-annotations.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin backticked annotations now emit canonical metadata references** - usages such as ``@`Fancy Name` `` and ``@`Fancy Name`("x")`` now record annotation references to `Fancy Name`.
+
+## 日本語
+
+- **Kotlin の backtick 付き annotation を canonical な metadata 参照として記録するようになりました** - ``@`Fancy Name` `` や ``@`Fancy Name`("x")`` で、`Fancy Name` への annotation 参照を記録します。

--- a/changelog.d/unreleased/+kotlin-backtick-class-literals.fixed.md
+++ b/changelog.d/unreleased/+kotlin-backtick-class-literals.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin backticked class literals now emit canonical type references** - `` `Display Name`::class `` now records `Display Name` as the referenced type, matching the declaration symbol name.
+
+## 日本語
+
+- **Kotlin の backtick 付き class literal を canonical な型参照として記録するようになりました** - `` `Display Name`::class `` で、宣言側の symbol 名と同じ `Display Name` を参照型として記録します。

--- a/changelog.d/unreleased/+kotlin-backtick-constructor-calls.fixed.md
+++ b/changelog.d/unreleased/+kotlin-backtick-constructor-calls.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin backticked constructor calls now emit canonical instantiation references** - `` `Display Name`() `` now records an `instantiate` edge to `Display Name`, matching the class declaration symbol.
+
+## 日本語
+
+- **Kotlin の backtick 付き constructor call を canonical な instantiate 参照として記録するようになりました** - `` `Display Name`() `` で、class 宣言の symbol 名と同じ `Display Name` への `instantiate` edge を記録します。

--- a/changelog.d/unreleased/+kotlin-backtick-method-reference-names.fixed.md
+++ b/changelog.d/unreleased/+kotlin-backtick-method-reference-names.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin backticked method-reference names now emit canonical call references** - ``User::`render name` `` now records the call as `render name`, matching the declaration symbol name.
+
+## 日本語
+
+- **Kotlin の backtick 付き method reference 名を canonical な call 参照として記録するようになりました** - ``User::`render name` `` で、宣言側の symbol 名と同じ `render name` を call として記録します。

--- a/changelog.d/unreleased/+kotlin-backtick-method-reference-owners.fixed.md
+++ b/changelog.d/unreleased/+kotlin-backtick-method-reference-owners.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin backticked method-reference owners now emit canonical type references** - `` `Display Name`::render `` now records `Display Name` as the owner type dependency while still indexing the `render` call.
+
+## 日本語
+
+- **Kotlin の backtick 付き method reference owner を canonical な型参照として記録するようになりました** - `` `Display Name`::render `` で、`render` の call に加えて owner 型 `Display Name` を依存として記録します。

--- a/changelog.d/unreleased/+kotlin-backtick-symbol-search.fixed.md
+++ b/changelog.d/unreleased/+kotlin-backtick-symbol-search.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/KotlinSymbolNameNormalizer.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Kotlin backticked declarations now use canonical symbol names** - declarations whose names are Kotlin keywords or contain spaces / punctuation are indexed without the source-only backticks, so exact-name definition search can find them by their canonical names.
+
+## 日本語
+
+- **Kotlin の backtick 付き宣言を canonical な symbol 名でインデックスするようになりました** - Kotlin keyword や空白 / 記号を含む名前の宣言を source-only な backtick なしで保持し、exact-name の definition 検索で canonical 名から見つけられるようにしました。

--- a/changelog.d/unreleased/+kotlin-backtick-type-references.fixed.md
+++ b/changelog.d/unreleased/+kotlin-backtick-type-references.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin backticked type references now use canonical names** - type positions such as ``val value: `Display Name` `` now emit `Display Name` as a `type_reference`, matching the canonical symbol name used for the declaration.
+
+## 日本語
+
+- **Kotlin の backtick 付き型参照を canonical 名で発行するようになりました** - ``val value: `Display Name` `` のような型位置で、宣言側と同じ canonical symbol 名 `Display Name` を `type_reference` として記録します。

--- a/changelog.d/unreleased/+kotlin-class-literals.fixed.md
+++ b/changelog.d/unreleased/+kotlin-class-literals.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin class literals now index their type target** — `User::class` and `User::class.java` now emit `type_reference` rows for `User`, matching C# `typeof(User)` and Java `User.class` behavior while avoiding raw `class` call noise.
+
+## 日本語
+
+- **Kotlin の class literal が対象型をインデックスするようになりました** — `User::class` と `User::class.java` が `User` への `type_reference` を出力し、C# の `typeof(User)` と Java の `User.class` と同じように検索できるようにしつつ、raw な `class` call ノイズは抑止します。

--- a/changelog.d/unreleased/+kotlin-constructor-delegation.fixed.md
+++ b/changelog.d/unreleased/+kotlin-constructor-delegation.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin secondary constructor delegation now resolves to the delegated type** — `constructor(...) : this(...)` now indexes a call to the enclosing class and `constructor(...) : super(...)` indexes a call to the superclass, while suppressing raw `constructor` / `this` / `super` keyword call noise to match the existing C# and Java constructor-chain behavior.
+
+## 日本語
+
+- **Kotlin のセカンダリコンストラクタ委譲が委譲先の型へ解決されるようになりました** — `constructor(...) : this(...)` は外側クラスへの call、`constructor(...) : super(...)` は superclass への call としてインデックスされ、raw な `constructor` / `this` / `super` keyword call ノイズは抑止されるため、C# / Java の既存のコンストラクタ連鎖挙動と揃いました。

--- a/changelog.d/unreleased/+kotlin-constructor-instantiates.fixed.md
+++ b/changelog.d/unreleased/+kotlin-constructor-instantiates.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin same-file constructor calls now index as instantiations** - `User()` and `Profile(...)` calls to classes defined in the same Kotlin file now emit `instantiate` references, aligning constructor search with C# and Java while keeping PascalCase functions and annotations out of instantiation results.
+
+## 日本語
+
+- **Kotlin の同一ファイル constructor 呼び出しが instantiation としてインデックスされるようになりました** - 同じ Kotlin ファイル内で定義された class への `User()` や `Profile(...)` が `instantiate` 参照を出力し、C# / Java の constructor 検索に揃えつつ、PascalCase function や annotation は instantiation 結果に含めないようにしました。

--- a/changelog.d/unreleased/+kotlin-extension-function-receivers.fixed.md
+++ b/changelog.d/unreleased/+kotlin-extension-function-receivers.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin extension function receivers are now indexed as type references** — declarations such as `fun User.render()` and `fun Box<User>.unwrap()` now emit receiver type dependencies so `references User` can find extension functions that target that type.
+
+## 日本語
+
+- **Kotlin の extension function receiver を型参照として索引化するようになりました** — `fun User.render()` や `fun Box<User>.unwrap()` のような宣言で receiver 型の依存を発行し、`references User` から対象型への拡張関数を見つけられます。

--- a/changelog.d/unreleased/+kotlin-extension-property-receivers.fixed.md
+++ b/changelog.d/unreleased/+kotlin-extension-property-receivers.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin extension property receivers are now indexed as type references** — declarations such as `val User.displayName: String` and `var Box<User>.selected: User` now emit receiver type dependencies for `references` and `impact`.
+
+## 日本語
+
+- **Kotlin の extension property receiver を型参照として索引化するようになりました** — `val User.displayName: String` や `var Box<User>.selected: User` のような宣言で receiver 型の依存を発行し、`references` / `impact` で追跡できます。

--- a/changelog.d/unreleased/+kotlin-generic-bound-type-params.fixed.md
+++ b/changelog.d/unreleased/+kotlin-generic-bound-type-params.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin generic signatures no longer emit type-parameter self references** - signatures and bounds such as `input: T`, `T : Comparable<T>`, and `where T : Handler<T>` now keep the real referenced types while suppressing `T` as type-reference noise.
+
+## 日本語
+
+- **Kotlin の generic signature が型パラメータ自身を型参照として出さないようになりました** - `input: T`、`T : Comparable<T>`、`where T : Handler<T>` では実際の参照型を残しつつ、`T` の type_reference ノイズを抑制します。

--- a/changelog.d/unreleased/+kotlin-generic-class-literal-params.fixed.md
+++ b/changelog.d/unreleased/+kotlin-generic-class-literal-params.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin generic class literals no longer emit type-parameter self references** - `T::class` inside single-line generic functions now suppresses the generic parameter while real class literals such as `User::class` remain searchable.
+
+## 日本語
+
+- **Kotlin の generic class literal が型パラメータ自身を型参照として出さないようになりました** - 単一行 generic function 内の `T::class` では generic parameter を抑制し、`User::class` のような実際の class literal は検索可能なままにします。

--- a/changelog.d/unreleased/+kotlin-generic-parameter-scope.fixed.md
+++ b/changelog.d/unreleased/+kotlin-generic-parameter-scope.fixed.md
@@ -1,0 +1,13 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+---
+
+## English
+
+- **Kotlin generic parameter suppression now only uses declaration generic clauses** - type arguments such as `Box<User>` and `Producer<out Payload>` are no longer mistaken for generic parameter declarations.
+
+## 日本語
+
+- **Kotlin の generic parameter 抑制が宣言 generic 句だけを見るようになりました** - `Box<User>` や `Producer<out Payload>` のような型引数を generic parameter 宣言と誤認しないようにしました。

--- a/changelog.d/unreleased/+kotlin-generic-type-operator-params.fixed.md
+++ b/changelog.d/unreleased/+kotlin-generic-type-operator-params.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin generic type operators no longer emit type-parameter self references** - `value is T` and `value as T` inside generic functions now suppress the generic parameter while keeping real cast/test target types searchable.
+
+## 日本語
+
+- **Kotlin の generic type operator が型パラメータ自身を型参照として出さないようになりました** - generic function 内の `value is T` / `value as T` では generic parameter を抑制し、実際の cast/test 対象型は検索可能なままにします。

--- a/changelog.d/unreleased/+kotlin-type-projection-modifiers.fixed.md
+++ b/changelog.d/unreleased/+kotlin-type-projection-modifiers.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin type projection modifiers are no longer indexed as type references** - type positions such as `Producer<out Payload>` and `Consumer<in Payload>` now keep `Payload` as the dependency without adding `out` or `in` noise.
+
+## 日本語
+
+- **Kotlin の type projection modifier が型参照として混ざらないようになりました** - `Producer<out Payload>` や `Consumer<in Payload>` の型位置で、`Payload` だけを依存として残し、`out` / `in` のノイズを追加しません。

--- a/changelog.d/unreleased/+kotlin-type-use-annotation-refs.fixed.md
+++ b/changelog.d/unreleased/+kotlin-type-use-annotation-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin type-use annotations no longer appear as type references** — annotated type positions such as `val value: @Fancy Payload` now keep `Payload` as the `type_reference` dependency while leaving `Fancy` as metadata instead of a phantom type.
+
+## 日本語
+
+- **Kotlin の type-use annotation が型参照として混ざらないようになりました** — `val value: @Fancy Payload` のような型位置では、`Payload` を `type_reference` として残しつつ、`Fancy` は metadata として扱い phantom な型参照にしません。

--- a/changelog.d/unreleased/+kotlin-use-site-annotation-type-refs.fixed.md
+++ b/changelog.d/unreleased/+kotlin-use-site-annotation-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin use-site annotations no longer leak into type references** - type positions such as `@field:Fancy Payload` now keep `Fancy` as annotation metadata while recording `Payload` as the type dependency.
+
+## 日本語
+
+- **Kotlin の use-site annotation が型参照へ混ざらないようになりました** - `@field:Fancy Payload` のような型位置で、`Fancy` は annotation metadata として扱い、`Payload` を型依存として記録します。

--- a/changelog.d/unreleased/+unicode-escaped-symbol-names.fixed.md
+++ b/changelog.d/unreleased/+unicode-escaped-symbol-names.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/CSharpSymbolNameNormalizer.cs
+  - src/CodeIndex/Indexer/Symbols/JavaSymbolNameNormalizer.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **C# and Java Unicode-escaped declarations now index under canonical symbol names** - declarations whose identifiers use source-only Unicode escape syntax now appear in symbol and exact-name definition searches by their decoded names.
+
+## 日本語
+
+- **C# / Java の Unicode escape 付き宣言を canonical な symbol 名でインデックスするようになりました** - source-only な Unicode escape 構文を使った識別子の宣言を decode 済みの名前で保持し、symbol 検索や exact-name definition 検索で見つけられるようにしました。

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -459,7 +459,7 @@ public partial class DbReader
 
     private static string NormalizeLiteralSearchQuery(string query, string? lang) =>
         string.Equals(lang, "csharp", StringComparison.OrdinalIgnoreCase)
-            ? ExactSourceSearchNormalizer.Normalize(query, lang)
+            ? CSharpVerbatimNameNormalizer.Normalize(query)
             : query;
 
     private static bool IsFtsQuerySyntaxError(SqliteException ex)

--- a/src/CodeIndex/Database/ExactSourceSearchNormalizer.cs
+++ b/src/CodeIndex/Database/ExactSourceSearchNormalizer.cs
@@ -11,7 +11,7 @@ internal static class ExactSourceSearchNormalizer
         var kind = GetLanguageKind(lang);
         return kind switch
         {
-            SourceLanguageKind.CSharp => CSharpVerbatimNameNormalizer.Normalize(text),
+            SourceLanguageKind.CSharp => NormalizeCSharp(text),
             SourceLanguageKind.Java => NormalizeJavaUnicodeEscapes(text),
             SourceLanguageKind.Kotlin => NormalizeKotlin(text),
             _ => text,
@@ -23,7 +23,7 @@ internal static class ExactSourceSearchNormalizer
         var kind = GetLanguageKind(lang);
         return kind switch
         {
-            SourceLanguageKind.CSharp => CSharpVerbatimNameNormalizer.Normalize(text, out rawIndexMap),
+            SourceLanguageKind.CSharp => NormalizeCSharp(text, out rawIndexMap),
             SourceLanguageKind.Java => NormalizeJavaUnicodeEscapes(text, out rawIndexMap),
             SourceLanguageKind.Kotlin => NormalizeKotlin(text, out rawIndexMap),
             _ => Identity(text, out rawIndexMap),
@@ -38,6 +38,65 @@ internal static class ExactSourceSearchNormalizer
             "kotlin" or "kt" or "kts" => SourceLanguageKind.Kotlin,
             _ => SourceLanguageKind.Other,
         };
+
+    private static string NormalizeCSharp(string text)
+    {
+        if (text.Length == 0
+            || (text.IndexOf('@') < 0
+                && text.IndexOf("global::", StringComparison.Ordinal) < 0
+                && text.IndexOf('\\') < 0))
+            return text;
+
+        var decoded = NormalizeCSharpUnicodeEscapes(text, out _);
+        return CSharpVerbatimNameNormalizer.Normalize(decoded);
+    }
+
+    private static string NormalizeCSharp(string text, out int[] rawIndexMap)
+    {
+        if (text.Length == 0)
+            return Identity(text, out rawIndexMap);
+
+        if (text.IndexOf('@') < 0
+            && text.IndexOf("global::", StringComparison.Ordinal) < 0
+            && text.IndexOf('\\') < 0)
+            return Identity(text, out rawIndexMap);
+
+        var decoded = NormalizeCSharpUnicodeEscapes(text, out var decodedMap);
+        var normalized = CSharpVerbatimNameNormalizer.Normalize(decoded, out var normalizedMap);
+        rawIndexMap = RemapIndexMap(normalizedMap, decodedMap);
+        return normalized;
+    }
+
+    private static string NormalizeCSharpUnicodeEscapes(string text, out int[] rawIndexMap)
+    {
+        if (text.Length == 0 || text.IndexOf('\\') < 0)
+            return Identity(text, out rawIndexMap);
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        var map = new System.Collections.Generic.List<int>(text.Length);
+        bool changed = false;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (TryConsumeCSharpUnicodeEscape(text, i, out var decoded, out var consumed))
+            {
+                sb.Append(decoded);
+                for (int j = 0; j < decoded.Length; j++)
+                    map.Add(i);
+                i += consumed - 1;
+                changed = true;
+                continue;
+            }
+
+            sb.Append(text[i]);
+            map.Add(i);
+        }
+
+        if (!changed)
+            return Identity(text, out rawIndexMap);
+
+        rawIndexMap = map.ToArray();
+        return sb.ToString();
+    }
 
     private static string NormalizeJavaUnicodeEscapes(string text)
     {
@@ -170,6 +229,39 @@ internal static class ExactSourceSearchNormalizer
         return sb.ToString();
     }
 
+    private static bool TryConsumeCSharpUnicodeEscape(string text, int index, out string decoded, out int consumed)
+    {
+        decoded = string.Empty;
+        consumed = 0;
+        if (index + 2 > text.Length || text[index] != '\\')
+            return false;
+
+        var escapeMarker = text[index + 1];
+        if (escapeMarker == 'u')
+        {
+            if (!TryReadHexScalar(text, index + 2, 4, out var value))
+                return false;
+
+            decoded = ((char)value).ToString();
+            consumed = 6;
+            return true;
+        }
+
+        if (escapeMarker == 'U')
+        {
+            if (!TryReadHexScalar(text, index + 2, 8, out var value)
+                || value > 0x10FFFF
+                || (value >= 0xD800 && value <= 0xDFFF))
+                return false;
+
+            decoded = char.ConvertFromUtf32(value);
+            consumed = 10;
+            return true;
+        }
+
+        return false;
+    }
+
     private static bool TryConsumeJavaUnicodeEscape(string text, int index, out char decoded, out int consumed)
     {
         decoded = default;
@@ -209,6 +301,35 @@ internal static class ExactSourceSearchNormalizer
         return true;
     }
 
+    private static bool TryReadHexScalar(string text, int start, int length, out int value)
+    {
+        value = 0;
+        if (start + length > text.Length)
+            return false;
+
+        long scalar = 0;
+        for (int j = 0; j < length; j++)
+        {
+            char hex = text[start + j];
+            int nibble = hex switch
+            {
+                >= '0' and <= '9' => hex - '0',
+                >= 'a' and <= 'f' => hex - 'a' + 10,
+                >= 'A' and <= 'F' => hex - 'A' + 10,
+                _ => -1,
+            };
+            if (nibble < 0)
+                return false;
+
+            scalar = (scalar << 4) | (long)nibble;
+            if (scalar > int.MaxValue)
+                return false;
+        }
+
+        value = (int)scalar;
+        return true;
+    }
+
     private static bool IsIdentifierStartChar(char c) =>
         c == '_' || char.IsLetter(c);
 
@@ -219,6 +340,30 @@ internal static class ExactSourceSearchNormalizer
     {
         rawIndexMap = IdentityMap(text.Length);
         return text;
+    }
+
+    private static int[] RemapIndexMap(int[] normalizedMap, int[] sourceMap)
+    {
+        if (normalizedMap.Length == sourceMap.Length)
+        {
+            bool identity = true;
+            for (int i = 0; i < normalizedMap.Length; i++)
+            {
+                if (normalizedMap[i] != i)
+                {
+                    identity = false;
+                    break;
+                }
+            }
+
+            if (identity)
+                return sourceMap;
+        }
+
+        var map = new int[normalizedMap.Length];
+        for (int i = 0; i < normalizedMap.Length; i++)
+            map[i] = sourceMap[normalizedMap[i]];
+        return map;
     }
 
     private static int[] IdentityMap(int length)

--- a/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
@@ -693,7 +693,16 @@ internal static class JavaReferenceExtractor
         EmitKeywordTypeListReferences(preparedLine, "permits", references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitThrowsReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        ReferenceExtractor.EmitDeclarationTypeReferences("java", preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        ReferenceExtractor.EmitDeclarationTypeReferences(
+            "java",
+            preparedLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn,
+            CollectGenericParameterNamesForDeclaration(preparedLine));
 
         foreach (Match match in InstanceofRegex.Matches(preparedLine))
         {
@@ -763,6 +772,49 @@ internal static class JavaReferenceExtractor
     {
         EmitCallableGenericBoundReferences(line, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitNamedTypeGenericBoundReferences(line, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static HashSet<string> CollectGenericParameterNamesForDeclaration(string line)
+    {
+        if (ReferenceExtractor.TryFindCallableParameterList(line, "java", out var callableNameStart, out _, out _))
+        {
+            var headerEnd = callableNameStart;
+            if (ReferenceExtractor.TryGetCallableReturnTypeSpan(line, callableNameStart, "java", out var typeStart, out _))
+                headerEnd = typeStart;
+
+            if (headerEnd > 0)
+                return CollectGenericParameterNamesFromHeader(line.Substring(0, headerEnd));
+        }
+
+        var tokens = ReferenceExtractor.GetTopLevelTokenSpans(line);
+        if (tokens.Count < 2)
+            return [];
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            var token = line.Substring(tokens[i].Start, tokens[i].Length);
+            if (token is not ("class" or "interface" or "enum" or "record"))
+                continue;
+            var nameIndex = i + 1;
+            if (nameIndex >= tokens.Count)
+                return [];
+            return CollectGenericParameterNamesFromHeader(line.Substring(tokens[nameIndex].Start, tokens[nameIndex].Length));
+        }
+
+        return [];
+    }
+
+    private static HashSet<string> CollectGenericParameterNamesFromHeader(string header)
+    {
+        int openAngle = header.IndexOf('<');
+        if (openAngle < 0)
+            return [];
+
+        int closeAngle = ReferenceExtractor.FindMatchingChar(header, openAngle, '<', '>');
+        if (closeAngle < 0)
+            return [];
+
+        return CollectGenericParameterNames(header.Substring(openAngle + 1, closeAngle - openAngle - 1));
     }
 
     private static void EmitCallableGenericBoundReferences(

--- a/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
@@ -989,6 +989,7 @@ internal static class JavaReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
         => JvmMethodReferenceExtractor.EmitMethodReferenceReferences(
+            "java",
             preparedLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
@@ -688,9 +688,37 @@ internal static class JavaReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForColumn,
         SymbolRecord? container)
     {
-        EmitKeywordTypeListReferences(preparedLine, "extends", references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        EmitKeywordTypeListReferences(preparedLine, "implements", references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        EmitKeywordTypeListReferences(preparedLine, "permits", references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        var genericParameterNames = CollectGenericParameterNamesForDeclaration(preparedLine);
+        EmitKeywordTypeListReferences(
+            preparedLine,
+            "extends",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn,
+            genericParameterNames);
+        EmitKeywordTypeListReferences(
+            preparedLine,
+            "implements",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn,
+            genericParameterNames);
+        EmitKeywordTypeListReferences(
+            preparedLine,
+            "permits",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn,
+            genericParameterNames);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitThrowsReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         ReferenceExtractor.EmitDeclarationTypeReferences(
@@ -702,7 +730,7 @@ internal static class JavaReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn,
-            CollectGenericParameterNamesForDeclaration(preparedLine));
+            genericParameterNames);
 
         foreach (Match match in InstanceofRegex.Matches(preparedLine))
         {
@@ -728,7 +756,8 @@ internal static class JavaReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         int keywordIndex = ReferenceExtractor.FindTopLevelKeyword(line, keyword);
         if (keywordIndex < 0)
@@ -757,7 +786,8 @@ internal static class JavaReferenceExtractor
                 context,
                 lineNumber,
                 resolveContainerForColumn(absoluteStart),
-                "java");
+                "java",
+                ignoredSegments: ignoredSegments);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
@@ -720,7 +720,7 @@ internal static class JavaReferenceExtractor
             resolveContainerForColumn,
             genericParameterNames);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        EmitThrowsReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitThrowsReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, genericParameterNames);
         ReferenceExtractor.EmitDeclarationTypeReferences(
             "java",
             preparedLine,
@@ -1030,7 +1030,8 @@ internal static class JavaReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         int keywordIndex = ReferenceExtractor.FindTopLevelKeyword(line, "throws");
         if (keywordIndex < 0)
@@ -1058,7 +1059,8 @@ internal static class JavaReferenceExtractor
                 context,
                 lineNumber,
                 resolveContainerForColumn(absoluteStart),
-                "java");
+                "java",
+                ignoredSegments);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
@@ -26,7 +26,7 @@ internal static class JavaReferenceExtractor
     // Java type test (`instanceof Foo`).
     // Java の型テスト (`instanceof Foo`)。
     private static readonly Regex InstanceofRegex = new(
-        @"(?<![\w$])instanceof\s+(?<type>[A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*(?:\s*<[^)\];{}]+>)?(?:\s*\[\s*\])*)",
+        @"(?<![\w$])instanceof\s+(?:(?:final|@[A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*(?:\s*\([^)]*\))?)\s+)*(?<type>[A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*(?:\s*<[^)\];{}]+>)?(?:\s*\[\s*\])*)",
         RegexOptions.Compiled);
 
     // Java constructor chain statement (first statement of a constructor body): `this(0);` / `super(42);`.

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -20,6 +20,58 @@ internal static class KotlinReferenceExtractor
     private static readonly string[] DeclarationKeywords = ["val", "var"];
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
 
+    public static HashSet<string> BuildConstructorTypeNames(string language, IReadOnlyList<SymbolRecord> symbols)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        if (language != "kotlin")
+            return names;
+
+        var callableNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Kind == "function" && !string.IsNullOrWhiteSpace(symbol.Name))
+                callableNames.Add(symbol.Name);
+        }
+
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Kind != "class" || string.IsNullOrWhiteSpace(symbol.Name))
+                continue;
+            if (!IsConstructableClassSymbol(symbol))
+                continue;
+            if (callableNames.Contains(symbol.Name))
+                continue;
+
+            names.Add(symbol.Name);
+        }
+
+        return names;
+    }
+
+    public static bool IsConstructorCallName(string name, IReadOnlySet<string> constructorTypeNames)
+        => constructorTypeNames.Contains(name);
+
+    private static bool IsConstructableClassSymbol(SymbolRecord symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol.Signature))
+            return false;
+
+        var tokens = symbol.Signature.Split(
+            [' ', '\t', '\r', '\n', '('],
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var index = 0;
+        while (index < tokens.Length && tokens[index] is "public" or "private" or "protected" or "internal" or "expect" or "actual" or "abstract" or "sealed" or "data" or "open" or "final" or "value" or "inner")
+            index++;
+
+        if (index >= tokens.Length)
+            return true;
+
+        if (tokens[index] == "annotation" && index + 1 < tokens.Length && tokens[index + 1] == "class")
+            return false;
+
+        return tokens[index] is not ("object" or "companion");
+    }
+
     public static void EmitTrailingLambdaReferences(
         string preparedLine,
         Action<string, int> addCallLikeReference)

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -14,7 +14,7 @@ internal static class KotlinReferenceExtractor
     // Kotlin class literal。末尾セグメントを型名らしい形に絞り、`value::class` のような
     // 式レシーバーを type_reference 化しない。
     private static readonly Regex ClassLiteralRegex = new(
-        @"(?<![\w$])(?<type>(?:[_\p{L}][\w$]*\.)*[_\p{Lu}][\w$]*)\s*::\s*class\b",
+        @"(?<![\w$])(?<type>(?:(?:[_\p{L}][\w$]*|`[^`\r\n]+`)\.)*(?:[_\p{Lu}][\w$]*|`[^`\r\n]+`))\s*::\s*class\b",
         RegexOptions.Compiled);
 
     private static readonly string[] DeclarationKeywords = ["val", "var"];
@@ -107,7 +107,7 @@ internal static class KotlinReferenceExtractor
         foreach (Match match in ClassLiteralRegex.Matches(preparedLine))
         {
             var typeGroup = match.Groups["type"];
-            ReferenceExtractor.AddTypeReferenceSegments(
+            ReferenceExtractor.AddTypeExpressionSegments(
                 references,
                 seen,
                 fileId,

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -287,7 +287,8 @@ internal static class KotlinReferenceExtractor
                 fileId,
                 context,
                 lineNumber,
-                resolveContainerForColumn);
+                resolveContainerForColumn,
+                genericParameterNames);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -259,11 +259,12 @@ internal static class KotlinReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
     {
-        EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        EmitPrimaryConstructorTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        EmitExtensionPropertyReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        var genericParameterNames = CollectGenericParameterNames(preparedLine);
+        EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, genericParameterNames);
+        EmitPrimaryConstructorTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, genericParameterNames);
+        EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, genericParameterNames);
+        EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, genericParameterNames);
+        EmitExtensionPropertyReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, genericParameterNames);
         TypedLanguageReferenceExtractor.EmitColonVariableTypeReferences(
             preparedLine,
             DeclarationKeywords,
@@ -273,7 +274,8 @@ internal static class KotlinReferenceExtractor
             fileId,
             context,
             lineNumber,
-            resolveContainerForColumn);
+            resolveContainerForColumn,
+            genericParameterNames);
         if (!preparedLine.TrimStart().StartsWith("import ", StringComparison.Ordinal))
         {
             TypedLanguageReferenceExtractor.EmitKeywordFollowingTypeReferences(
@@ -296,7 +298,8 @@ internal static class KotlinReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments)
     {
         var funIndex = ReferenceExtractor.FindTopLevelKeyword(preparedLine, "fun");
         if (funIndex < 0)
@@ -319,7 +322,8 @@ internal static class KotlinReferenceExtractor
             fileId,
             context,
             lineNumber,
-            resolveContainerForColumn);
+            resolveContainerForColumn,
+            ignoredSegments);
 
         TypedLanguageReferenceExtractor.EmitColonParameterTypeReferences(
             preparedLine,
@@ -331,7 +335,8 @@ internal static class KotlinReferenceExtractor
             fileId,
             context,
             lineNumber,
-            resolveContainerForColumn);
+            resolveContainerForColumn,
+            ignoredSegments);
 
         var returnColon = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, closeParen + 1);
         if (returnColon >= preparedLine.Length || preparedLine[returnColon] != ':')
@@ -351,7 +356,8 @@ internal static class KotlinReferenceExtractor
             fileId,
             context,
             lineNumber,
-            resolveContainerForColumn(typeStart));
+            resolveContainerForColumn(typeStart),
+            ignoredSegments);
     }
 
     private static void EmitExtensionFunctionReceiverTypeReferences(
@@ -363,7 +369,8 @@ internal static class KotlinReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments)
     {
         var headStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, funIndex + "fun".Length);
         if (headStart >= openParen)
@@ -398,7 +405,8 @@ internal static class KotlinReferenceExtractor
             fileId,
             context,
             lineNumber,
-            resolveContainerForColumn(headStart));
+            resolveContainerForColumn(headStart),
+            ignoredSegments);
     }
 
     private static void EmitExtensionPropertyReceiverTypeReferences(
@@ -408,7 +416,8 @@ internal static class KotlinReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments)
     {
         foreach (var keyword in DeclarationKeywords)
         {
@@ -447,7 +456,8 @@ internal static class KotlinReferenceExtractor
                     fileId,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(declarationStart));
+                    resolveContainerForColumn(declarationStart),
+                    ignoredSegments);
             }
         }
     }
@@ -505,7 +515,8 @@ internal static class KotlinReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments)
     {
         var trimmed = preparedLine.TrimStart();
         if (!(trimmed.StartsWith("class ", StringComparison.Ordinal)
@@ -538,7 +549,8 @@ internal static class KotlinReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn,
-            trimTopLevelCallArguments: true);
+            trimTopLevelCallArguments: true,
+            ignoredSegments: ignoredSegments);
     }
 
     private static void EmitPrimaryConstructorTypeReferences(
@@ -548,7 +560,8 @@ internal static class KotlinReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments)
     {
         var trimmed = preparedLine.TrimStart();
         if (!(trimmed.StartsWith("class ", StringComparison.Ordinal)
@@ -577,7 +590,8 @@ internal static class KotlinReferenceExtractor
             fileId,
             context,
             lineNumber,
-            resolveContainerForColumn);
+            resolveContainerForColumn,
+            ignoredSegments);
     }
 
     private static void EmitGenericBoundReferences(
@@ -587,7 +601,8 @@ internal static class KotlinReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? genericParameterNames)
     {
         var genericOpenIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '<');
         if (genericOpenIndex >= 0)
@@ -601,7 +616,8 @@ internal static class KotlinReferenceExtractor
                 fileId,
                 context,
                 lineNumber,
-                resolveContainerForColumn);
+                resolveContainerForColumn,
+                genericParameterNames);
         }
 
         TypedLanguageReferenceExtractor.EmitWhereClauseTypeReferences(
@@ -612,7 +628,67 @@ internal static class KotlinReferenceExtractor
             fileId,
             context,
             lineNumber,
-            resolveContainerForColumn);
+            resolveContainerForColumn,
+            genericParameterNames);
+    }
+
+    private static HashSet<string> CollectGenericParameterNames(string preparedLine)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var genericOpenIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '<');
+        if (genericOpenIndex < 0)
+            return names;
+
+        var genericCloseIndex = ReferenceExtractor.FindMatchingChar(preparedLine, genericOpenIndex, '<', '>');
+        if (genericCloseIndex <= genericOpenIndex)
+            return names;
+
+        var clause = preparedLine.Substring(genericOpenIndex + 1, genericCloseIndex - genericOpenIndex - 1);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(clause))
+        {
+            var fragment = clause.Substring(segmentStart, segmentLength);
+            if (TryReadGenericParameterName(fragment, out var name))
+                names.Add(name);
+        }
+
+        return names;
+    }
+
+    private static bool TryReadGenericParameterName(string fragment, out string name)
+    {
+        name = string.Empty;
+        var index = 0;
+        while (index < fragment.Length)
+        {
+            while (index < fragment.Length && char.IsWhiteSpace(fragment[index]))
+                index++;
+
+            if (index >= fragment.Length)
+                return false;
+
+            if (fragment[index] == '@')
+            {
+                index = ReferenceExtractor.SkipJavaAnnotation(fragment, index);
+                continue;
+            }
+
+            var tokenStart = index;
+            if (!ReferenceExtractor.IsJavaIdentifierPart(fragment[index]))
+                return false;
+
+            index++;
+            while (index < fragment.Length && ReferenceExtractor.IsJavaIdentifierPart(fragment[index]))
+                index++;
+
+            var token = fragment.Substring(tokenStart, index - tokenStart);
+            if (token is "reified" or "in" or "out")
+                continue;
+
+            name = token;
+            return true;
+        }
+
+        return false;
     }
 
     private static SymbolRecord? FindEnclosingKotlinConstructor(

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -16,6 +16,9 @@ internal static class KotlinReferenceExtractor
     private static readonly Regex ClassLiteralRegex = new(
         @"(?<![\w$])(?<type>(?:(?:[_\p{L}][\w$]*|`[^`\r\n]+`)\.)*(?:[_\p{Lu}][\w$]*|`[^`\r\n]+`))\s*::\s*class\b",
         RegexOptions.Compiled);
+    private static readonly Regex BacktickConstructorCallRegex = new(
+        @"(?<![\w$])(?<name>`[^`\r\n]+`)(?:\s*<[^()\r\n]+>)?\s*\(",
+        RegexOptions.Compiled);
 
     private static readonly string[] DeclarationKeywords = ["val", "var"];
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
@@ -72,6 +75,31 @@ internal static class KotlinReferenceExtractor
         return tokens[index] is not ("object" or "companion");
     }
 
+    private static bool IsBacktickConstructorDeclarationSite(string line, int nameIndex)
+    {
+        var cursor = nameIndex - 1;
+        while (cursor >= 0 && char.IsWhiteSpace(line[cursor]))
+            cursor--;
+        if (cursor < 0)
+            return false;
+
+        var end = cursor + 1;
+        while (cursor >= 0 && ReferenceExtractor.IsJavaIdentifierPart(line[cursor]))
+            cursor--;
+        var start = cursor + 1;
+        if (start >= end)
+            return false;
+
+        return line.Substring(start, end - start) is "class" or "interface" or "object" or "fun" or "constructor";
+    }
+
+    private static string StripBacktickIdentifier(string name)
+    {
+        if (name.Length >= 2 && name[0] == '`' && name[^1] == '`')
+            return name[1..^1];
+        return name;
+    }
+
     public static void EmitTrailingLambdaReferences(
         string preparedLine,
         Action<string, int> addCallLikeReference)
@@ -117,6 +145,42 @@ internal static class KotlinReferenceExtractor
                 lineNumber,
                 container,
                 "kotlin");
+        }
+    }
+
+    public static void EmitBacktickConstructorReferences(
+        string preparedLine,
+        IReadOnlySet<string> constructorTypeNames,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (constructorTypeNames.Count == 0)
+            return;
+
+        foreach (Match match in BacktickConstructorCallRegex.Matches(preparedLine))
+        {
+            var nameGroup = match.Groups["name"];
+            if (IsBacktickConstructorDeclarationSite(preparedLine, nameGroup.Index))
+                continue;
+
+            var name = StripBacktickIdentifier(nameGroup.Value);
+            if (!constructorTypeNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameGroup.Index,
+                "instantiate",
+                context,
+                lineNumber,
+                resolveContainerForColumn(nameGroup.Index));
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -245,6 +245,17 @@ internal static class KotlinReferenceExtractor
         if (closeParen < 0)
             return;
 
+        EmitExtensionFunctionReceiverTypeReferences(
+            preparedLine,
+            funIndex,
+            openParen,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+
         TypedLanguageReferenceExtractor.EmitColonParameterTypeReferences(
             preparedLine,
             openParen + 1,
@@ -276,6 +287,99 @@ internal static class KotlinReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn(typeStart));
+    }
+
+    private static void EmitExtensionFunctionReceiverTypeReferences(
+        string preparedLine,
+        int funIndex,
+        int openParen,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var headStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, funIndex + "fun".Length);
+        if (headStart >= openParen)
+            return;
+
+        if (preparedLine[headStart] == '<')
+        {
+            var genericClose = ReferenceExtractor.FindMatchingChar(preparedLine, headStart, '<', '>');
+            if (genericClose < 0 || genericClose >= openParen)
+                return;
+            headStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, genericClose + 1);
+            if (headStart >= openParen)
+                return;
+        }
+
+        var receiverDot = FindLastTopLevelChar(preparedLine, '.', headStart, openParen);
+        if (receiverDot <= headStart)
+            return;
+
+        var receiverEnd = receiverDot;
+        while (receiverEnd > headStart && char.IsWhiteSpace(preparedLine[receiverEnd - 1]))
+            receiverEnd--;
+        if (receiverEnd <= headStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(headStart, receiverEnd - headStart),
+            headStart,
+            "kotlin",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(headStart));
+    }
+
+    private static int FindLastTopLevelChar(string text, char target, int startIndex, int endIndex)
+    {
+        var angleDepth = 0;
+        var parenDepth = 0;
+        var squareDepth = 0;
+        var braceDepth = 0;
+        var last = -1;
+        var end = Math.Min(text.Length, endIndex);
+        for (var i = Math.Max(0, startIndex); i < end; i++)
+        {
+            var ch = text[i];
+            if (angleDepth == 0 && parenDepth == 0 && squareDepth == 0 && braceDepth == 0 && ch == target)
+                last = i;
+
+            switch (ch)
+            {
+                case '<':
+                    angleDepth++;
+                    break;
+                case '>':
+                    if (angleDepth > 0) angleDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0) parenDepth--;
+                    break;
+                case '[':
+                    squareDepth++;
+                    break;
+                case ']':
+                    if (squareDepth > 0) squareDepth--;
+                    break;
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    if (braceDepth > 0) braceDepth--;
+                    break;
+            }
+        }
+
+        return last;
     }
 
     private static void EmitHeritageTypeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -86,6 +86,7 @@ internal static class KotlinReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
         => JvmMethodReferenceExtractor.EmitMethodReferenceReferences(
+            "kotlin",
             preparedLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -132,6 +132,7 @@ internal static class KotlinReferenceExtractor
         int lineNumber,
         SymbolRecord? container)
     {
+        var genericParameterNames = CollectGenericParameterNames(preparedLine);
         foreach (Match match in ClassLiteralRegex.Matches(preparedLine))
         {
             var typeGroup = match.Groups["type"];
@@ -144,7 +145,8 @@ internal static class KotlinReferenceExtractor
                 context,
                 lineNumber,
                 container,
-                "kotlin");
+                "kotlin",
+                genericParameterNames);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -199,6 +199,7 @@ internal static class KotlinReferenceExtractor
         EmitPrimaryConstructorTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitExtensionPropertyReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         TypedLanguageReferenceExtractor.EmitColonVariableTypeReferences(
             preparedLine,
             DeclarationKeywords,
@@ -334,6 +335,57 @@ internal static class KotlinReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn(headStart));
+    }
+
+    private static void EmitExtensionPropertyReceiverTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var keyword in DeclarationKeywords)
+        {
+            foreach (var keywordIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, keyword))
+            {
+                var declarationStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, keywordIndex + keyword.Length);
+                if (declarationStart >= preparedLine.Length)
+                    continue;
+
+                var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':', declarationStart);
+                var assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=', declarationStart);
+                var declarationEnd = preparedLine.Length;
+                if (colonIndex >= 0)
+                    declarationEnd = Math.Min(declarationEnd, colonIndex);
+                if (assignmentIndex >= 0)
+                    declarationEnd = Math.Min(declarationEnd, assignmentIndex);
+                if (declarationEnd <= declarationStart)
+                    continue;
+
+                var receiverDot = FindLastTopLevelChar(preparedLine, '.', declarationStart, declarationEnd);
+                if (receiverDot <= declarationStart)
+                    continue;
+
+                var receiverEnd = receiverDot;
+                while (receiverEnd > declarationStart && char.IsWhiteSpace(preparedLine[receiverEnd - 1]))
+                    receiverEnd--;
+                if (receiverEnd <= declarationStart)
+                    continue;
+
+                TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                    preparedLine.Substring(declarationStart, receiverEnd - declarationStart),
+                    declarationStart,
+                    "kotlin",
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(declarationStart));
+            }
+        }
     }
 
     private static int FindLastTopLevelChar(string text, char target, int startIndex, int endIndex)

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -637,11 +637,34 @@ internal static class KotlinReferenceExtractor
 
     private static HashSet<string> CollectGenericParameterNames(string preparedLine)
     {
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        var genericOpenIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '<');
-        if (genericOpenIndex < 0)
-            return names;
+        foreach (var funIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "fun"))
+        {
+            var genericOpenIndex = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, funIndex + "fun".Length);
+            if (genericOpenIndex < preparedLine.Length && preparedLine[genericOpenIndex] == '<')
+                return CollectGenericParameterNamesFromClause(preparedLine, genericOpenIndex);
+        }
 
+        foreach (var keyword in new[] { "class", "interface", "typealias" })
+        {
+            foreach (var keywordIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, keyword))
+            {
+                var nameStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, keywordIndex + keyword.Length);
+                var nameEnd = ConsumeKotlinDeclarationName(preparedLine, nameStart);
+                if (nameEnd <= nameStart)
+                    continue;
+
+                var genericOpenIndex = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, nameEnd);
+                if (genericOpenIndex < preparedLine.Length && preparedLine[genericOpenIndex] == '<')
+                    return CollectGenericParameterNamesFromClause(preparedLine, genericOpenIndex);
+            }
+        }
+
+        return [];
+    }
+
+    private static HashSet<string> CollectGenericParameterNamesFromClause(string preparedLine, int genericOpenIndex)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
         var genericCloseIndex = ReferenceExtractor.FindMatchingChar(preparedLine, genericOpenIndex, '<', '>');
         if (genericCloseIndex <= genericOpenIndex)
             return names;
@@ -655,6 +678,24 @@ internal static class KotlinReferenceExtractor
         }
 
         return names;
+    }
+
+    private static int ConsumeKotlinDeclarationName(string preparedLine, int startIndex)
+    {
+        if (startIndex >= preparedLine.Length)
+            return startIndex;
+
+        if (preparedLine[startIndex] == '`')
+        {
+            var close = preparedLine.IndexOf('`', startIndex + 1);
+            return close < 0 ? startIndex : close + 1;
+        }
+
+        var index = startIndex;
+        while (index < preparedLine.Length && ReferenceExtractor.IsJavaIdentifierPart(preparedLine[index]))
+            index++;
+
+        return index;
     }
 
     private static bool TryReadGenericParameterName(string fragment, out string name)

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -1,9 +1,14 @@
+using System.Text.RegularExpressions;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;
 
 internal static class KotlinReferenceExtractor
 {
+    // Kotlin secondary constructor delegation: `constructor(x: Int) : this(x)` / `: super(x)`.
+    // Kotlin セカンダリコンストラクタ委譲。
+    private static readonly Regex CtorDelegationRegex = new(@":\s*(?<kind>this|super)\s*\(", RegexOptions.Compiled);
+
     private static readonly string[] DeclarationKeywords = ["val", "var"];
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
 
@@ -28,6 +33,72 @@ internal static class KotlinReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+
+    public static void EmitCtorDelegationReferences(
+        string preparedLine,
+        IReadOnlyList<SymbolRecord> enclosingTypeCandidates,
+        IReadOnlyList<SymbolRecord> symbols,
+        string[] structuralLines,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var matches = CtorDelegationRegex.Matches(preparedLine);
+        if (matches.Count == 0)
+            return;
+
+        var enclosingType = ReferenceExtractor.FindInnermostClassLike(enclosingTypeCandidates, lineNumber);
+        if (enclosingType == null)
+            return;
+
+        var ctorContainer = container;
+        if (ctorContainer == null
+            || ctorContainer.Kind != "function"
+            || !string.Equals(ctorContainer.Name, enclosingType.Name, StringComparison.Ordinal))
+        {
+            ctorContainer = FindEnclosingKotlinConstructor(symbols, enclosingType, lineNumber) ?? ctorContainer;
+        }
+
+        foreach (Match match in matches)
+        {
+            var kindToken = match.Groups["kind"].Value;
+            string? target;
+            if (kindToken == "this")
+            {
+                target = enclosingType.Name;
+            }
+            else
+            {
+                // Secondary constructors call `super(...)` from the constructor line, while the
+                // superclass type lives on the enclosing class header. Reconstruct the header so
+                // multi-line signatures can resolve the same way C# and Java constructor chains do.
+                // `super(...)` の呼び先は外側クラスヘッダ上の superclass なので、
+                // 複数行ヘッダも拾えるよう structuralLines から再構築する。
+                var (_, _, headerText) = ReferenceExtractor.CollectCSharpRecordHeader(
+                    structuralLines,
+                    enclosingType.StartLine);
+                target = ParseKotlinBaseType(headerText);
+                if (string.IsNullOrWhiteSpace(target))
+                    target = ParseKotlinBaseType(enclosingType.Signature);
+                if (string.IsNullOrWhiteSpace(target))
+                    continue;
+            }
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                target!,
+                match.Groups["kind"].Index,
+                "call",
+                context,
+                lineNumber,
+                ctorContainer);
+        }
+    }
 
     public static void EmitTypePositionReferences(
         string preparedLine,
@@ -236,5 +307,169 @@ internal static class KotlinReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+    }
+
+    private static SymbolRecord? FindEnclosingKotlinConstructor(
+        IReadOnlyList<SymbolRecord> symbols,
+        SymbolRecord enclosingType,
+        int lineNumber)
+    {
+        SymbolRecord? best = null;
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Kind != "function")
+                continue;
+            if (!string.Equals(symbol.ContainerName, enclosingType.Name, StringComparison.Ordinal)
+                && !IsWithinSymbolRange(enclosingType, symbol.StartLine))
+            {
+                continue;
+            }
+
+            var signature = symbol.Signature?.TrimStart();
+            var isSecondaryConstructor = !string.IsNullOrWhiteSpace(signature)
+                && (signature.StartsWith("constructor", StringComparison.Ordinal)
+                    || signature.StartsWith("public constructor", StringComparison.Ordinal)
+                    || signature.StartsWith("private constructor", StringComparison.Ordinal)
+                    || signature.StartsWith("protected constructor", StringComparison.Ordinal)
+                    || signature.StartsWith("internal constructor", StringComparison.Ordinal));
+            if (!isSecondaryConstructor
+                && !string.Equals(symbol.Name, enclosingType.Name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (symbol.StartLine > lineNumber)
+                continue;
+            var symbolEnd = symbol.BodyEndLine ?? symbol.EndLine;
+            if (symbolEnd < lineNumber)
+                continue;
+
+            if (best == null || symbol.StartLine >= best.StartLine)
+                best = symbol;
+        }
+
+        return best;
+    }
+
+    private static bool IsWithinSymbolRange(SymbolRecord container, int lineNumber)
+    {
+        var start = container.BodyStartLine ?? container.StartLine;
+        var end = container.BodyEndLine ?? container.EndLine;
+        return lineNumber >= start && lineNumber <= end;
+    }
+
+    private static string? ParseKotlinBaseType(string? signature)
+    {
+        if (string.IsNullOrWhiteSpace(signature))
+            return null;
+
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(signature, ':');
+        if (colonIndex < 0)
+            return null;
+
+        var listStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(signature, colonIndex + 1);
+        var listEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(
+            signature,
+            listStart,
+            stopAtComma: false);
+        if (listEnd <= listStart)
+            return null;
+
+        var typeList = signature.Substring(listStart, listEnd - listStart);
+        string? fallback = null;
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typeList))
+        {
+            var segment = typeList.Substring(segmentStart, segmentLength).Trim();
+            if (segment.Length == 0)
+                continue;
+
+            var typeName = ExtractKotlinBareTypeName(segment);
+            if (string.IsNullOrWhiteSpace(typeName))
+                continue;
+
+            if (TypedLanguageReferenceExtractor.FindTopLevelChar(segment, '(') >= 0)
+                return typeName;
+
+            fallback ??= typeName;
+        }
+
+        return fallback;
+    }
+
+    private static string? ExtractKotlinBareTypeName(string segment)
+    {
+        var trimmed = TrimTopLevelByClause(segment.Trim());
+        if (trimmed.Length == 0)
+            return null;
+
+        var callIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(trimmed, '(');
+        if (callIndex > 0)
+            trimmed = trimmed.Substring(0, callIndex).TrimEnd();
+
+        var lastSegmentStart = 0;
+        var endIndex = trimmed.Length;
+        var angleDepth = 0;
+        for (var i = 0; i < trimmed.Length; i++)
+        {
+            var ch = trimmed[i];
+            if (ch == '<')
+            {
+                if (angleDepth == 0)
+                    endIndex = Math.Min(endIndex, i);
+                angleDepth++;
+            }
+            else if (ch == '>')
+            {
+                if (angleDepth > 0)
+                    angleDepth--;
+            }
+            else if (angleDepth == 0 && ch == '.')
+            {
+                lastSegmentStart = i + 1;
+            }
+        }
+
+        if (endIndex < lastSegmentStart)
+            endIndex = trimmed.Length;
+
+        var typeName = trimmed.Substring(lastSegmentStart, endIndex - lastSegmentStart).Trim();
+        return typeName.Length > 0 ? typeName : null;
+    }
+
+    private static string TrimTopLevelByClause(string segment)
+    {
+        var angleDepth = 0;
+        var parenDepth = 0;
+        for (var i = 0; i < segment.Length; i++)
+        {
+            var ch = segment[i];
+            if (ch == '<')
+            {
+                angleDepth++;
+            }
+            else if (ch == '>')
+            {
+                if (angleDepth > 0)
+                    angleDepth--;
+            }
+            else if (ch == '(')
+            {
+                parenDepth++;
+            }
+            else if (ch == ')')
+            {
+                if (parenDepth > 0)
+                    parenDepth--;
+            }
+            else if (angleDepth == 0
+                     && parenDepth == 0
+                     && i + 4 <= segment.Length
+                     && string.CompareOrdinal(segment, i, " by ", 0, 4) == 0)
+            {
+                return segment.Substring(0, i).TrimEnd();
+            }
+        }
+
+        return segment;
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -9,6 +9,14 @@ internal static class KotlinReferenceExtractor
     // Kotlin セカンダリコンストラクタ委譲。
     private static readonly Regex CtorDelegationRegex = new(@":\s*(?<kind>this|super)\s*\(", RegexOptions.Compiled);
 
+    // Kotlin class literals: `User::class` / `User::class.java`. The final segment must look
+    // type-like so expression receivers such as `value::class` do not become type references.
+    // Kotlin class literal。末尾セグメントを型名らしい形に絞り、`value::class` のような
+    // 式レシーバーを type_reference 化しない。
+    private static readonly Regex ClassLiteralRegex = new(
+        @"(?<![\w$])(?<type>(?:[_\p{L}][\w$]*\.)*[_\p{Lu}][\w$]*)\s*::\s*class\b",
+        RegexOptions.Compiled);
+
     private static readonly string[] DeclarationKeywords = ["val", "var"];
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
 
@@ -33,6 +41,31 @@ internal static class KotlinReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+
+    public static void EmitClassLiteralReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in ClassLiteralRegex.Matches(preparedLine))
+        {
+            var typeGroup = match.Groups["type"];
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                typeGroup.Value,
+                typeGroup.Index,
+                context,
+                lineNumber,
+                container,
+                "kotlin");
+        }
+    }
 
     public static void EmitCtorDelegationReferences(
         string preparedLine,

--- a/src/CodeIndex/Indexer/References/Languages/ScalaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/ScalaReferenceExtractor.cs
@@ -41,6 +41,7 @@ internal static class ScalaReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
         => JvmMethodReferenceExtractor.EmitMethodReferenceReferences(
+            "scala",
             preparedLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -405,7 +405,8 @@ public static partial class ReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         var trimmed = line.TrimStart();
         if (!(trimmed.Contains(" class ", StringComparison.Ordinal)
@@ -444,8 +445,102 @@ public static partial class ReferenceExtractor
                 context,
                 lineNumber,
                 resolveContainerForColumn(absoluteStart),
-                "csharp");
+                "csharp",
+                ignoredSegments: ignoredSegments);
         }
+    }
+
+    private static HashSet<string> CollectCSharpGenericParameterNamesForDeclaration(string line)
+    {
+        if (TryFindCallableParameterList(line, "csharp", out var callableNameStart, out var paramStart, out _))
+        {
+            var nameEnd = callableNameStart;
+            while (nameEnd < line.Length && IsTypeExpressionIdentifierPart("csharp", line[nameEnd]))
+                nameEnd++;
+
+            var genericOpen = SkipWhitespace(line, nameEnd);
+            if (genericOpen < paramStart && genericOpen < line.Length && line[genericOpen] == '<')
+                return CollectCSharpGenericParameterNamesFromClause(line, genericOpen);
+        }
+
+        var tokens = GetTopLevelTokenSpans(line);
+        if (tokens.Count < 2)
+            return [];
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            var token = line.Substring(tokens[i].Start, tokens[i].Length);
+            if (token is not ("class" or "struct" or "interface" or "record" or "delegate"))
+                continue;
+            var nameIndex = i + 1;
+            if (nameIndex >= tokens.Count)
+                return [];
+            var nameToken = line.Substring(tokens[nameIndex].Start, tokens[nameIndex].Length);
+            var genericOpen = nameToken.IndexOf('<');
+            if (genericOpen < 0)
+                return [];
+            return CollectCSharpGenericParameterNamesFromClause(line, tokens[nameIndex].Start + genericOpen);
+        }
+
+        return [];
+    }
+
+    private static HashSet<string> CollectCSharpGenericParameterNamesFromClause(string line, int genericOpen)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var genericClose = FindMatchingChar(line, genericOpen, '<', '>');
+        if (genericClose <= genericOpen)
+            return names;
+
+        var clause = line.Substring(genericOpen + 1, genericClose - genericOpen - 1);
+        foreach (var (segmentStart, segmentLength) in SplitTopLevelCommaSpans(clause))
+        {
+            var fragment = clause.Substring(segmentStart, segmentLength);
+            if (TryReadCSharpGenericParameterName(fragment, out var name))
+                names.Add(name);
+        }
+
+        return names;
+    }
+
+    private static bool TryReadCSharpGenericParameterName(string fragment, out string name)
+    {
+        name = string.Empty;
+        var index = 0;
+        while (index < fragment.Length)
+        {
+            while (index < fragment.Length && char.IsWhiteSpace(fragment[index]))
+                index++;
+
+            if (index >= fragment.Length)
+                return false;
+
+            if (fragment[index] == '[')
+            {
+                var close = FindMatchingChar(fragment, index, '[', ']');
+                if (close < 0)
+                    return false;
+                index = close + 1;
+                continue;
+            }
+
+            var tokenStart = index;
+            if (!IsTypeExpressionIdentifierStart("csharp", fragment[index]))
+                return false;
+
+            index++;
+            while (index < fragment.Length && IsTypeExpressionIdentifierPart("csharp", fragment[index]))
+                index++;
+
+            var token = NormalizeCSharpIdentifier(fragment.Substring(tokenStart, index - tokenStart));
+            if (token is "in" or "out")
+                continue;
+
+            name = token;
+            return true;
+        }
+
+        return false;
     }
 
     private static void EmitCSharpWhereConstraintReferences(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1139,6 +1139,264 @@ public static partial class ReferenceExtractor
             || (language == "java" && trimmed.StartsWith("enum ", StringComparison.Ordinal));
     }
 
+    internal static void EmitCatchTypeReferences(
+        string language,
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (language is not ("csharp" or "java" or "kotlin"))
+            return;
+
+        var catchIndex = FindTopLevelKeyword(line, "catch");
+        if (catchIndex < 0)
+            return;
+
+        var openParen = line.IndexOf('(', catchIndex + "catch".Length);
+        if (openParen < 0)
+            return;
+
+        var closeParen = FindMatchingChar(line, openParen, '(', ')');
+        if (closeParen < 0 || closeParen <= openParen + 1)
+            return;
+
+        var clauseStart = openParen + 1;
+        var clause = line.Substring(clauseStart, closeParen - clauseStart);
+        if (language == "kotlin")
+        {
+            EmitKotlinCatchTypeReference(
+                clause,
+                clauseStart,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+            return;
+        }
+
+        EmitCStyleCatchTypeReferences(
+            language,
+            clause,
+            clauseStart,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
+
+    private static void EmitKotlinCatchTypeReference(
+        string clause,
+        int clauseStartInLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(clause, ':');
+        if (colonIndex < 0)
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(clause, colonIndex + 1);
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(clause, typeStart);
+        if (typeEnd <= typeStart)
+            return;
+
+        var absoluteStart = clauseStartInLine + typeStart;
+        AddTypeExpressionSegments(
+            references,
+            seen,
+            fileId,
+            clause.Substring(typeStart, typeEnd - typeStart),
+            absoluteStart,
+            context,
+            lineNumber,
+            resolveContainerForColumn(absoluteStart),
+            "kotlin");
+    }
+
+    private static void EmitCStyleCatchTypeReferences(
+        string language,
+        string clause,
+        int clauseStartInLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var start = SkipCatchParameterPrefix(language, clause, 0);
+        var end = clause.Length;
+        while (end > start && char.IsWhiteSpace(clause[end - 1]))
+            end--;
+        if (end <= start)
+            return;
+
+        var typeEnd = FindCatchTypeEndBeforeVariable(language, clause, start, end);
+        if (typeEnd <= start)
+            return;
+
+        var typeExpression = clause.Substring(start, typeEnd - start);
+        foreach (var (segmentStart, segmentLength) in SplitTopLevelPipeSpans(typeExpression))
+        {
+            var leading = CountLeadingWhitespace(typeExpression, segmentStart, segmentLength);
+            var trimmedLength = segmentLength - leading;
+            while (trimmedLength > 0 && char.IsWhiteSpace(typeExpression[segmentStart + leading + trimmedLength - 1]))
+                trimmedLength--;
+            if (trimmedLength <= 0)
+                continue;
+
+            var absoluteStart = clauseStartInLine + start + segmentStart + leading;
+            AddTypeExpressionSegments(
+                references,
+                seen,
+                fileId,
+                typeExpression.Substring(segmentStart + leading, trimmedLength),
+                absoluteStart,
+                context,
+                lineNumber,
+                resolveContainerForColumn(absoluteStart),
+                language);
+        }
+    }
+
+    private static int SkipCatchParameterPrefix(string language, string clause, int start)
+    {
+        var i = start;
+        while (i < clause.Length)
+        {
+            while (i < clause.Length && char.IsWhiteSpace(clause[i]))
+                i++;
+
+            if (language == "java" && i < clause.Length && clause[i] == '@')
+            {
+                i = SkipJavaAnnotation(clause, i) + 1;
+                continue;
+            }
+
+            if (language == "java" && IsWordAt(clause, i, "final"))
+            {
+                i += "final".Length;
+                continue;
+            }
+
+            break;
+        }
+
+        return i;
+    }
+
+    private static int FindCatchTypeEndBeforeVariable(string language, string clause, int start, int end)
+    {
+        if (!TryFindLastIdentifier(clause, start, end, out var lastStart, out _))
+            return end;
+
+        var before = clause.Substring(start, lastStart - start).TrimEnd();
+        if (language == "csharp" && before.EndsWith("@", StringComparison.Ordinal))
+        {
+            var prefix = before.Substring(0, before.Length - 1).TrimEnd();
+            if (prefix.Length == 0
+                || prefix.EndsWith(".", StringComparison.Ordinal)
+                || prefix.EndsWith("::", StringComparison.Ordinal))
+            {
+                return end;
+            }
+
+            return lastStart - 1;
+        }
+
+        if (before.Length == 0
+            || before.EndsWith(".", StringComparison.Ordinal)
+            || before.EndsWith("::", StringComparison.Ordinal))
+        {
+            return end;
+        }
+
+        return lastStart;
+    }
+
+    private static bool TryFindLastIdentifier(string text, int start, int end, out int identifierStart, out int identifierEnd)
+    {
+        identifierStart = -1;
+        identifierEnd = -1;
+        var i = end - 1;
+        while (i >= start && char.IsWhiteSpace(text[i]))
+            i--;
+        if (i < start || !IsJavaIdentifierPart(text[i]))
+            return false;
+
+        identifierEnd = i + 1;
+        while (i >= start && IsJavaIdentifierPart(text[i]))
+            i--;
+        identifierStart = i + 1;
+        return identifierStart < identifierEnd;
+    }
+
+    private static List<(int Start, int Length)> SplitTopLevelPipeSpans(string text)
+    {
+        var spans = new List<(int Start, int Length)>();
+        var angleDepth = 0;
+        var parenDepth = 0;
+        var squareDepth = 0;
+        var start = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            switch (text[i])
+            {
+                case '<':
+                    angleDepth++;
+                    break;
+                case '>':
+                    if (angleDepth > 0)
+                        angleDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0)
+                        parenDepth--;
+                    break;
+                case '[':
+                    squareDepth++;
+                    break;
+                case ']':
+                    if (squareDepth > 0)
+                        squareDepth--;
+                    break;
+                case '|' when angleDepth == 0 && parenDepth == 0 && squareDepth == 0:
+                    spans.Add((start, i - start));
+                    start = i + 1;
+                    break;
+            }
+        }
+
+        spans.Add((start, text.Length - start));
+        return spans;
+    }
+
+    private static bool IsWordAt(string text, int index, string word)
+    {
+        if (index + word.Length > text.Length)
+            return false;
+        if (string.CompareOrdinal(text, index, word, 0, word.Length) != 0)
+            return false;
+        if (index > 0 && IsJavaIdentifierPart(text[index - 1]))
+            return false;
+        var after = index + word.Length;
+        return after >= text.Length || !IsJavaIdentifierPart(text[after]);
+    }
+
     private static bool TryFindFirstTopLevelCSharpArrow(string text, out int arrowIndex)
     {
         arrowIndex = -1;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1562,7 +1562,7 @@ public static partial class ReferenceExtractor
         for (int i = 0; i < expression.Length; i++)
         {
             char c = expression[i];
-            if (language == "java" && c == '@')
+            if (language is "java" or "kotlin" && c == '@')
             {
                 i = SkipJavaAnnotation(expression, i);
                 continue;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1849,6 +1849,20 @@ public static partial class ReferenceExtractor
     internal static int SkipJavaAnnotation(string text, int start)
     {
         int i = start + 1;
+        var annotationStart = i;
+        while (i < text.Length && IsJavaIdentifierPart(text[i]))
+            i++;
+        if (i < text.Length && text[i] == ':')
+        {
+            i++;
+            while (i < text.Length && char.IsWhiteSpace(text[i]))
+                i++;
+        }
+        else
+        {
+            i = annotationStart;
+        }
+
         if (i < text.Length && text[i] == '`')
         {
             var closeIndex = text.IndexOf('`', i + 1);

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1605,6 +1605,12 @@ public static partial class ReferenceExtractor
             if (language == "csharp")
                 segment = NormalizeCSharpIdentifier(rawSegment);
 
+            if (language == "kotlin" && KotlinTypeProjectionModifierNames.Contains(segment))
+            {
+                i--;
+                continue;
+            }
+
             if (i + 1 < expression.Length && expression[i] == ':' && expression[i + 1] == ':')
             {
                 i++;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1568,6 +1568,28 @@ public static partial class ReferenceExtractor
                 continue;
             }
 
+            if (language == "kotlin" && c == '`')
+            {
+                var closeIndex = expression.IndexOf('`', i + 1);
+                if (closeIndex < 0)
+                    continue;
+
+                var backtickSegment = expression.Substring(i + 1, closeIndex - i - 1);
+                AddTypeReferenceSegment(
+                    references,
+                    seen,
+                    fileId,
+                    backtickSegment,
+                    expressionStartInLine + i,
+                    context,
+                    lineNumber,
+                    container,
+                    language,
+                    ignoredSegments: ignoredSegments);
+                i = closeIndex;
+                continue;
+            }
+
             if (!IsTypeExpressionIdentifierStart(language, c))
                 continue;
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -507,7 +507,8 @@ public static partial class ReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         if (TryFindCallableParameterList(line, language, out var callableNameStart, out var paramStart, out var paramEnd))
         {
@@ -522,7 +523,8 @@ public static partial class ReferenceExtractor
                     typeStart,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(typeStart));
+                    resolveContainerForColumn(typeStart),
+                    ignoredSegments);
             }
 
             EmitParameterTypeReferences(
@@ -535,7 +537,8 @@ public static partial class ReferenceExtractor
                 fileId,
                 context,
                 lineNumber,
-                resolveContainerForColumn);
+                resolveContainerForColumn,
+                ignoredSegments);
         }
 
         if (TryGetSimpleDeclarationTypeSpan(line, language, out var declarationTypeStart, out var declarationTypeLength))
@@ -549,7 +552,8 @@ public static partial class ReferenceExtractor
                 declarationTypeStart,
                 context,
                 lineNumber,
-                resolveContainerForColumn(declarationTypeStart));
+                resolveContainerForColumn(declarationTypeStart),
+                ignoredSegments);
         }
     }
 
@@ -795,7 +799,8 @@ public static partial class ReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         if (paramEnd <= paramStart)
             return;
@@ -817,7 +822,8 @@ public static partial class ReferenceExtractor
                 absoluteStart,
                 context,
                 lineNumber,
-                resolveContainerForColumn(absoluteStart));
+                resolveContainerForColumn(absoluteStart),
+                ignoredSegments);
         }
     }
 
@@ -830,7 +836,8 @@ public static partial class ReferenceExtractor
         int expressionStartInLine,
         string context,
         int lineNumber,
-        SymbolRecord? container)
+        SymbolRecord? container,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         if (language == "typescript")
         {
@@ -855,7 +862,8 @@ public static partial class ReferenceExtractor
             context,
             lineNumber,
             container,
-            language);
+            language,
+            ignoredSegments: ignoredSegments);
     }
 
     private static void AddTypeScriptTypeExpressionSegments(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -320,6 +320,84 @@ public static partial class ReferenceExtractor
         }
     }
 
+    internal static void EmitJvmDocLinkReferences(
+        string language,
+        string docText,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        int columnOffset,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in JvmDocInlineLinkRegex.Matches(docText))
+            EmitJvmDocTargetReference(language, match.Groups["target"], references, seen, fileId, columnOffset, context, lineNumber, container);
+
+        foreach (Match match in JvmDocSeeReferenceRegex.Matches(docText))
+            EmitJvmDocTargetReference(language, match.Groups["target"], references, seen, fileId, columnOffset, context, lineNumber, container);
+
+        if (language == "kotlin")
+        {
+            foreach (Match match in KDocBracketLinkRegex.Matches(docText))
+                EmitJvmDocTargetReference(language, match.Groups["target"], references, seen, fileId, columnOffset, context, lineNumber, container);
+        }
+    }
+
+    private static void EmitJvmDocTargetReference(
+        string language,
+        Group targetGroup,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        int columnOffset,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var normalized = NormalizeJvmDocLinkTarget(targetGroup.Value);
+        if (normalized.Length == 0)
+            return;
+
+        AddTypeExpressionSegments(
+            references,
+            seen,
+            fileId,
+            normalized,
+            columnOffset + targetGroup.Index + CountLeadingTrimmedJvmDocTargetChars(targetGroup.Value),
+            context,
+            lineNumber,
+            container,
+            language);
+    }
+
+    private static string NormalizeJvmDocLinkTarget(string target)
+    {
+        var text = target.Trim();
+        if (text.Length == 0)
+            return string.Empty;
+        if (text[0] is '<' or '"' or '\'' || text.Contains("://", StringComparison.Ordinal))
+            return string.Empty;
+
+        var paren = text.IndexOf('(');
+        if (paren >= 0)
+            text = text.Substring(0, paren);
+
+        var label = text.IndexOf('|');
+        if (label >= 0)
+            text = text.Substring(0, label);
+
+        return text.Trim().Replace('#', '.');
+    }
+
+    private static int CountLeadingTrimmedJvmDocTargetChars(string target)
+    {
+        var count = 0;
+        while (count < target.Length && char.IsWhiteSpace(target[count]))
+            count++;
+        return count;
+    }
+
     private static void TryEmitCSharpBaseListReferences(
         string line,
         List<ReferenceRecord> references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1849,8 +1849,19 @@ public static partial class ReferenceExtractor
     internal static int SkipJavaAnnotation(string text, int start)
     {
         int i = start + 1;
-        while (i < text.Length && (IsJavaIdentifierPart(text[i]) || text[i] == '.'))
-            i++;
+        if (i < text.Length && text[i] == '`')
+        {
+            var closeIndex = text.IndexOf('`', i + 1);
+            if (closeIndex < 0)
+                return start;
+            i = closeIndex + 1;
+        }
+        else
+        {
+            while (i < text.Length && (IsJavaIdentifierPart(text[i]) || text[i] == '.'))
+                i++;
+        }
+
         if (i < text.Length && text[i] == '(')
         {
             int close = FindMatchingChar(text, i, '(', ')');

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -464,6 +464,7 @@ public static partial class ReferenceExtractor
             if (nameGroup.Success && nameGroup.Value.Length > 0)
                 genericParameterNames.Add(nameGroup.Value);
         }
+        genericParameterNames.UnionWith(CSharpWhereConstraintIgnoredSegments);
 
         foreach (Match match in CSharpWhereClauseRegex.Matches(line))
         {

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -465,6 +465,148 @@ public static partial class ReferenceExtractor
         return true;
     }
 
+    private static bool TryGetJvmDocCommentSpan(
+        string originalLine,
+        bool inDelimitedDocComment,
+        out int commentStart,
+        out int commentEndExclusive,
+        out int sameLineDeclarationStartColumn,
+        out bool nextDelimitedDocComment)
+    {
+        commentStart = -1;
+        commentEndExclusive = -1;
+        sameLineDeclarationStartColumn = -1;
+        nextDelimitedDocComment = inDelimitedDocComment;
+
+        var lineStart = 0;
+        while (lineStart < originalLine.Length && char.IsWhiteSpace(originalLine[lineStart]))
+            lineStart++;
+
+        if (!inDelimitedDocComment)
+        {
+            if (lineStart + 3 > originalLine.Length
+                || originalLine[lineStart] != '/'
+                || originalLine[lineStart + 1] != '*'
+                || originalLine[lineStart + 2] != '*')
+            {
+                return false;
+            }
+
+            commentStart = lineStart + 3;
+        }
+        else
+        {
+            commentStart = lineStart;
+            if (commentStart < originalLine.Length && originalLine[commentStart] == '*')
+            {
+                if (commentStart + 1 < originalLine.Length && originalLine[commentStart + 1] == '/')
+                {
+                    commentEndExclusive = commentStart;
+                    nextDelimitedDocComment = false;
+                    sameLineDeclarationStartColumn = GetJvmSameLineDeclarationStartColumn(originalLine, commentStart);
+                    return true;
+                }
+
+                commentStart++;
+                if (commentStart < originalLine.Length && originalLine[commentStart] == ' ')
+                    commentStart++;
+            }
+        }
+
+        var closeIndex = originalLine.IndexOf("*/", commentStart, StringComparison.Ordinal);
+        if (closeIndex >= 0)
+        {
+            commentEndExclusive = closeIndex;
+            nextDelimitedDocComment = false;
+            sameLineDeclarationStartColumn = GetJvmSameLineDeclarationStartColumn(originalLine, closeIndex);
+        }
+        else
+        {
+            commentEndExclusive = originalLine.Length;
+            nextDelimitedDocComment = true;
+        }
+
+        return true;
+    }
+
+    private static int GetJvmSameLineDeclarationStartColumn(string originalLine, int commentEndExclusive)
+    {
+        if (commentEndExclusive + 1 >= originalLine.Length
+            || originalLine[commentEndExclusive] != '*'
+            || originalLine[commentEndExclusive + 1] != '/')
+        {
+            return -1;
+        }
+
+        var column = commentEndExclusive + 2;
+        while (column < originalLine.Length && char.IsWhiteSpace(originalLine[column]))
+            column++;
+
+        return column < originalLine.Length ? column : -1;
+    }
+
+    private static SymbolRecord? FindJvmDocumentedContainer(
+        IReadOnlyList<SymbolRecord> candidates,
+        IReadOnlyList<string> originalLines,
+        string structuralLine,
+        int lineNumber,
+        int sameLineDeclarationStartColumn)
+    {
+        var innermostContainer = FindInnermostContainer(candidates, lineNumber);
+        if (innermostContainer?.Kind is "function" or "property")
+            return null;
+
+        var sameLineCandidate = FindSameLineDocumentedContainer(
+            candidates,
+            structuralLine,
+            lineNumber,
+            sameLineDeclarationStartColumn);
+        if (sameLineCandidate != null)
+            return sameLineCandidate;
+
+        SymbolRecord? best = null;
+        foreach (var candidate in candidates)
+        {
+            if (candidate.StartLine <= lineNumber)
+                continue;
+            if (!HasOnlyJvmDocTriviaBeforeDeclaration(originalLines, lineNumber, candidate.StartLine))
+                continue;
+
+            if (best == null
+                || candidate.StartLine < best.StartLine
+                || (candidate.StartLine == best.StartLine
+                    && ((candidate.BodyEndLine ?? candidate.EndLine) - (candidate.BodyStartLine ?? candidate.StartLine))
+                       < ((best.BodyEndLine ?? best.EndLine) - (best.BodyStartLine ?? best.StartLine))))
+            {
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    private static bool HasOnlyJvmDocTriviaBeforeDeclaration(
+        IReadOnlyList<string> originalLines,
+        int docLineNumber,
+        int declarationLineNumber)
+    {
+        for (var lineIndex = docLineNumber; lineIndex < declarationLineNumber - 1 && lineIndex < originalLines.Count; lineIndex++)
+        {
+            var trimmed = originalLines[lineIndex].TrimStart();
+            if (trimmed.Length == 0
+                || trimmed.StartsWith("/**", StringComparison.Ordinal)
+                || trimmed.StartsWith("*", StringComparison.Ordinal)
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
     private static SymbolRecord? FindDocumentedContainer(
         IReadOnlyList<SymbolRecord> candidates,
         string structuralLine,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -1849,7 +1849,12 @@ public static partial class ReferenceExtractor
             ? MaskPythonSingleLineFStrings(line)
             : line;
         if (lang != "cobol")
-            result = StringLiteralRegex.Replace(result, "\"\"");
+        {
+            var stringLiteralRegex = lang == "kotlin"
+                ? NonBacktickStringLiteralRegex
+                : StringLiteralRegex;
+            result = stringLiteralRegex.Replace(result, "\"\"");
+        }
         result = InlineBlockCommentRegex.Replace(result, " ");
 
         if (UsesHashComments(lang))

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -2536,7 +2536,7 @@ public static partial class ReferenceExtractor
             : string.Equals(token, "new", StringComparison.Ordinal);
     }
 
-    private static readonly HashSet<string> KotlinGenericInvocationTypeArgumentIgnoredSegments = new(StringComparer.Ordinal)
+    private static readonly HashSet<string> KotlinTypeProjectionModifierNames = new(StringComparer.Ordinal)
     {
         "in", "out",
     };
@@ -2568,7 +2568,7 @@ public static partial class ReferenceExtractor
             return;
 
         var ignoredSegments = language == "kotlin"
-            ? KotlinGenericInvocationTypeArgumentIgnoredSegments
+            ? KotlinTypeProjectionModifierNames
             : null;
 
         AddTypeExpressionSegments(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -2389,7 +2389,149 @@ public static partial class ReferenceExtractor
             : string.Equals(token, "new", StringComparison.Ordinal);
     }
 
+    private static readonly HashSet<string> KotlinGenericInvocationTypeArgumentIgnoredSegments = new(StringComparer.Ordinal)
+    {
+        "in", "out",
+    };
+
     private readonly record struct NestedGenericCallCandidate(string Name, int NameIndex);
+
+    private static void EmitGenericInvocationTypeArgumentReferences(
+        string language,
+        string preparedLine,
+        int nameIndex,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (language is not ("csharp" or "java" or "kotlin"))
+            return;
+
+        if (!TryGetPostNameGenericInvocationTypeArgumentSpan(preparedLine, nameIndex, out var argumentsStart, out var argumentsLength)
+            && (language != "java"
+                || !TryGetJavaExplicitGenericInvocationTypeArgumentSpan(preparedLine, nameIndex, out argumentsStart, out argumentsLength)))
+        {
+            return;
+        }
+
+        if (argumentsLength <= 0)
+            return;
+
+        var ignoredSegments = language == "kotlin"
+            ? KotlinGenericInvocationTypeArgumentIgnoredSegments
+            : null;
+
+        AddTypeExpressionSegments(
+            references,
+            seen,
+            fileId,
+            preparedLine.Substring(argumentsStart, argumentsLength),
+            argumentsStart,
+            context,
+            lineNumber,
+            container,
+            language,
+            ignoredSegments);
+    }
+
+    private static bool TryGetPostNameGenericInvocationTypeArgumentSpan(
+        string preparedLine,
+        int nameIndex,
+        out int argumentsStart,
+        out int argumentsLength)
+    {
+        argumentsStart = -1;
+        argumentsLength = 0;
+
+        if (nameIndex < 0 || nameIndex >= preparedLine.Length || !IsAtAwareAsciiIdentifierStart(preparedLine, nameIndex))
+            return false;
+
+        var scan = ConsumeAtAwareAsciiIdentifier(preparedLine, nameIndex);
+        if (scan + 1 < preparedLine.Length
+            && preparedLine[scan] == '?'
+            && preparedLine[scan + 1] == '.')
+        {
+            scan += 2;
+        }
+
+        if (scan >= preparedLine.Length || preparedLine[scan] != '<')
+            return false;
+
+        var closeAngle = FindMatchingChar(preparedLine, scan, '<', '>');
+        if (closeAngle <= scan)
+            return false;
+
+        var after = closeAngle + 1;
+        while (after < preparedLine.Length && char.IsWhiteSpace(preparedLine[after]))
+            after++;
+
+        if (after >= preparedLine.Length || preparedLine[after] != '(')
+            return false;
+
+        argumentsStart = scan + 1;
+        argumentsLength = closeAngle - scan - 1;
+        return true;
+    }
+
+    private static bool TryGetJavaExplicitGenericInvocationTypeArgumentSpan(
+        string preparedLine,
+        int nameIndex,
+        out int argumentsStart,
+        out int argumentsLength)
+    {
+        argumentsStart = -1;
+        argumentsLength = 0;
+
+        var closeAngle = nameIndex - 1;
+        while (closeAngle >= 0 && char.IsWhiteSpace(preparedLine[closeAngle]))
+            closeAngle--;
+
+        if (closeAngle < 0 || preparedLine[closeAngle] != '>')
+            return false;
+
+        var openAngle = FindMatchingOpenChar(preparedLine, closeAngle, '<', '>');
+        if (openAngle < 0)
+            return false;
+
+        var beforeOpen = openAngle - 1;
+        while (beforeOpen >= 0 && char.IsWhiteSpace(preparedLine[beforeOpen]))
+            beforeOpen--;
+
+        if (beforeOpen < 0 || preparedLine[beforeOpen] != '.')
+            return false;
+
+        argumentsStart = openAngle + 1;
+        argumentsLength = closeAngle - openAngle - 1;
+        return true;
+    }
+
+    private static int FindMatchingOpenChar(string text, int closeIndex, char openChar, char closeChar)
+    {
+        if (closeIndex < 0 || closeIndex >= text.Length || text[closeIndex] != closeChar)
+            return -1;
+
+        var depth = 0;
+        for (var i = closeIndex; i >= 0; i--)
+        {
+            if (text[i] == closeChar)
+            {
+                depth++;
+                continue;
+            }
+
+            if (text[i] != openChar)
+                continue;
+
+            depth--;
+            if (depth == 0)
+                return i;
+        }
+
+        return -1;
+    }
 
     private static IEnumerable<NestedGenericCallCandidate> EnumerateNestedGenericCallCandidates(
         string preparedLine,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1347,6 +1347,19 @@ public static partial class ReferenceExtractor
             // キーワード呼び出しの外にある型位置参照（継承リスト、宣言型、generic 制約、
             // throws、型テスト、XML doc cref）。`references` / `impact` では依存として扱うが、
             // 既定の `callers` / `callees` では呼び出しエッジではない。issue #256 参照。
+            if (language is "csharp" or "java" or "kotlin")
+            {
+                EmitCatchTypeReferences(
+                    language,
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
+            }
+
             if (language == "csharp")
             {
                 CSharpReferenceExtractor.EmitTypePositionReferences(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1389,6 +1389,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                KotlinReferenceExtractor.EmitBacktickConstructorReferences(
+                    preparedLine,
+                    kotlinConstructorTypeNames,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
             }
 
             // Type-position references without an introducing keyword-call: base lists,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1731,7 +1731,10 @@ public static partial class ReferenceExtractor
                     ResolveContainerForCall);
             }
 
-            void AddCallLikeReference(string name, int callIndex)
+            void AddCallLikeReference(string name, int callIndex) =>
+                _ = TryAddCallLikeReference(name, callIndex);
+
+            bool TryAddCallLikeReference(string name, int callIndex)
             {
                 var normalizedName = language == "fsharp" && FSharpReferenceExtractor.IsOperatorCallName(name)
                     ? $"operator {name}"
@@ -1740,7 +1743,7 @@ public static partial class ReferenceExtractor
                         : NormalizeAtPrefixedIdentifier(name);
 
                 if (language == "rust" && RustReferenceExtractor.IsFunctionDeclarationCallSite(preparedLine, callIndex))
-                    return;
+                    return false;
 
                 // Suppress the same-line Java ctor declarator's self-call. CallRegex matches
                 // `CtorName(` at the declarator once per same-line ctor, but it is a declaration
@@ -1752,7 +1755,7 @@ public static partial class ReferenceExtractor
                     && callIndex == javaSameLineCtor.Value.NameIndex
                     && string.Equals(normalizedName, javaSameLineCtor.Value.Synthetic.Name, StringComparison.Ordinal))
                 {
-                    return;
+                    return false;
                 }
 
                   // C# positional patterns such as `case Point(var x, var y):` are type-pattern
@@ -1764,21 +1767,21 @@ public static partial class ReferenceExtractor
                   var isCSharpPatternHeadCallSite = language == "csharp"
                       && CSharpReferenceExtractor.IsPatternHeadCallSite(preparedLines, i, preparedLine, callIndex);
                   if (isCSharpPatternHeadCallSite)
-                      return;
+                      return false;
 
                 var callContainer = ResolveContainerForCall(callIndex);
                 if (IsConstructorCallName(language, preparedLine, callIndex))
                 {
                     AddReference(references, seen, fileId, normalizedName, callIndex, "instantiate", context, lineNumber, callContainer);
-                    return;
+                    return true;
                 }
                 if (IsIgnoredCallName(language, name))
                 {
                     if (!(language == "scala" && string.Equals(name, "foreach", StringComparison.Ordinal)))
-                        return;
+                        return false;
                 }
                 if (ShouldSuppressDefinitionCall(normalizedName, callIndex))
-                    return;
+                    return false;
 
                 // issue #293: reclassify C# attribute / Java/Kotlin/Scala/TypeScript annotation
                 // usages with arguments so they do not pollute the call-graph as phantom `call` rows.
@@ -1790,16 +1793,17 @@ public static partial class ReferenceExtractor
                 if (metadataKind != null)
                 {
                     AddReference(references, seen, fileId, normalizedName, callIndex, metadataKind, context, lineNumber, callContainer);
-                    return;
+                    return true;
                 }
 
                 if (language == "kotlin" && KotlinReferenceExtractor.IsConstructorCallName(normalizedName, kotlinConstructorTypeNames))
                 {
                     AddReference(references, seen, fileId, normalizedName, callIndex, "instantiate", context, lineNumber, callContainer);
-                    return;
+                    return true;
                 }
 
                 AddReference(references, seen, fileId, normalizedName, callIndex, "call", context, lineNumber, callContainer);
+                return true;
             }
 
             if (language is "batch")
@@ -1874,7 +1878,19 @@ public static partial class ReferenceExtractor
                     if (sqlSuppressedCallIndices != null && sqlSuppressedCallIndices.Contains(callIndex))
                         continue;
                     matchedCallIndices.Add(callIndex);
-                    AddCallLikeReference(name, callIndex);
+                    if (TryAddCallLikeReference(name, callIndex))
+                    {
+                        EmitGenericInvocationTypeArgumentReferences(
+                            language,
+                            preparedLine,
+                            callIndex,
+                            references,
+                            seen,
+                            fileId,
+                            context,
+                            lineNumber,
+                            ResolveContainerForCall(callIndex));
+                    }
                     if (language == "ruby")
                         RubyReferenceExtractor.EmitCommandTargetReferences(
                             name,
@@ -1970,7 +1986,21 @@ public static partial class ReferenceExtractor
                 // depth-aware な fallback を足し、`Foo<Bar<int>>()` や `new Dict<K, List<V>>()` でも
                 // `call` / `instantiate` を発行する。issue #263 参照。
                 foreach (var candidate in EnumerateNestedGenericCallCandidates(preparedLine, matchedCallIndices))
-                    AddCallLikeReference(candidate.Name, candidate.NameIndex);
+                {
+                    if (TryAddCallLikeReference(candidate.Name, candidate.NameIndex))
+                    {
+                        EmitGenericInvocationTypeArgumentReferences(
+                            language,
+                            preparedLine,
+                            candidate.NameIndex,
+                            references,
+                            seen,
+                            fileId,
+                            context,
+                            lineNumber,
+                            ResolveContainerForCall(candidate.NameIndex));
+                    }
+                }
             }
 
             if (language == "rust")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2621,9 +2621,10 @@ public static partial class ReferenceExtractor
         SymbolRecord? container,
         ref CSharpMultiLineTypePatternState pendingCSharpMultiLineTypePattern)
     {
-        TryEmitCSharpBaseListReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        var csharpGenericParameterNames = CollectCSharpGenericParameterNamesForDeclaration(preparedLine);
+        TryEmitCSharpBaseListReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, csharpGenericParameterNames);
         EmitCSharpWhereConstraintReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
-        EmitDeclarationTypeReferences("csharp", preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitDeclarationTypeReferences("csharp", preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, csharpGenericParameterNames);
 
         foreach (Match match in CSharpIsAsTypeTestRegex.Matches(preparedLine))
         {

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -982,6 +982,7 @@ public static partial class ReferenceExtractor
         var csharpQualifiedConstantPatternMemberLookup = BuildCSharpQualifiedConstantPatternMemberLookup(language, symbols);
         var csharpQualifiedTypePatternLookup = BuildCSharpQualifiedTypePatternLookup(language, symbols);
         var csharpKnownTypeNames = BuildCSharpKnownTypeNames(language, symbols);
+        var kotlinConstructorTypeNames = KotlinReferenceExtractor.BuildConstructorTypeNames(language, symbols);
         var callableDefinitionNames = BuildCallableDefinitionNames(language, symbols);
         var dockerfileStageNames = DockerfileReferenceExtractor.BuildStageNames(language, symbols);
         var shellCallableNames = ShellReferenceExtractor.BuildCallableNames(language, symbols);
@@ -1786,7 +1787,19 @@ public static partial class ReferenceExtractor
                 var insideCSharpAttributeRange = csharpAttrRangesOnLine != null
                     && IsInsideCSharpAttributeRange(csharpAttrRangesOnLine, callIndex);
                 var metadataKind = TryClassifyMetadataReference(language, preparedLine, callIndex, insideCSharpAttributeRange);
-                AddReference(references, seen, fileId, normalizedName, callIndex, metadataKind ?? "call", context, lineNumber, callContainer);
+                if (metadataKind != null)
+                {
+                    AddReference(references, seen, fileId, normalizedName, callIndex, metadataKind, context, lineNumber, callContainer);
+                    return;
+                }
+
+                if (language == "kotlin" && KotlinReferenceExtractor.IsConstructorCallName(normalizedName, kotlinConstructorTypeNames))
+                {
+                    AddReference(references, seen, fileId, normalizedName, callIndex, "instantiate", context, lineNumber, callContainer);
+                    return;
+                }
+
+                AddReference(references, seen, fileId, normalizedName, callIndex, "call", context, lineNumber, callContainer);
             }
 
             if (language is "batch")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1328,6 +1328,17 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
             }
+            else if (language is "kotlin")
+            {
+                KotlinReferenceExtractor.EmitClassLiteralReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+            }
 
             // Type-position references without an introducing keyword-call: base lists,
             // declaration types, generic constraints, throws clauses, type tests, and

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -703,6 +703,9 @@ public static partial class ReferenceExtractor
     private static readonly Regex NoArgAnnotationRegex = new(
         @"(?<![\w)])@(?:[A-Za-z_]\w*\s*:\s*)?(?:[A-Za-z_]\w*\s*\.\s*)*(?<name>[A-Za-z_]\w*)\b(?!\s*[.(])",
         RegexOptions.Compiled);
+    private static readonly Regex KotlinBacktickAnnotationRegex = new(
+        @"(?<![\w)])@(?:[A-Za-z_]\w*\s*:\s*)?(?<name>`[^`\r\n]+`)(?:\s*\([^)\r\n]*\))?",
+        RegexOptions.Compiled);
 
 
     // Languages whose `@Decorator(args)` / `@Annotation(args)` / `@Attribute(args)` syntax
@@ -795,6 +798,13 @@ public static partial class ReferenceExtractor
     private static bool IsUnsupportedCSharpEnumMemberSymbol(string? lang, string? kind, string? containerKind)
     {
         return false;
+    }
+
+    private static string NormalizeKotlinBacktickIdentifier(string name)
+    {
+        if (name.Length >= 2 && name[0] == '`' && name[^1] == '`')
+            return name[1..^1];
+        return name;
     }
 
     /// <summary>
@@ -2214,6 +2224,20 @@ public static partial class ReferenceExtractor
             }
             else if (AnnotationLanguages.Contains(language))
             {
+                if (language == "kotlin")
+                {
+                    foreach (Match match in KotlinBacktickAnnotationRegex.Matches(preparedLine))
+                    {
+                        var nameGroup = match.Groups["name"];
+                        var name = NormalizeKotlinBacktickIdentifier(nameGroup.Value);
+                        if (IsIgnoredCallName(language, name))
+                            continue;
+                        if (definitionNames != null && definitionNames.Contains(name))
+                            continue;
+                        AddReference(references, seen, fileId, name, nameGroup.Index, "annotation", context, lineNumber, container);
+                    }
+                }
+
                 foreach (Match match in NoArgAnnotationRegex.Matches(preparedLine))
                 {
                     var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2454,6 +2454,7 @@ public static partial class ReferenceExtractor
     {
         int i = startIndex;
         int parenDepth = 0;
+        int angleDepth = 0;
         bool expectSegment = true;
         while (i < line.Length)
         {
@@ -2470,10 +2471,12 @@ public static partial class ReferenceExtractor
 
             if (c == ',')
             {
-                if (parenDepth == 0)
+                if (parenDepth == 0 && angleDepth == 0)
                     return;
-                // Tuple element separator inside `typeof((Foo, Bar))` — keep scanning.
-                // `typeof((Foo, Bar))` のタプル要素区切りは続けて走査する。
+                // Tuple or generic argument separator inside `typeof((Foo, Bar))` /
+                // `typeof(List<Foo, Bar>)` — keep scanning.
+                // `typeof((Foo, Bar))` のタプル要素区切りや `typeof(List<Foo, Bar>)`
+                // の generic 引数区切りは続けて走査する。
                 i++;
                 expectSegment = true;
                 continue;
@@ -2521,7 +2524,19 @@ public static partial class ReferenceExtractor
 
             if (c == '<')
             {
-                i = SkipBalanced(line, i, '<', '>');
+                angleDepth++;
+                i++;
+                expectSegment = true;
+                continue;
+            }
+
+            if (c == '>')
+            {
+                if (angleDepth == 0)
+                    return;
+                angleDepth--;
+                i++;
+                expectSegment = false;
                 continue;
             }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -98,6 +98,14 @@ public static partial class ReferenceExtractor
         {
             "instanceof", "super", "this", "assert", "throws", "extends", "implements", "synchronized",
         },
+        // Kotlin constructor delegation is rewritten by KotlinReferenceExtractor, so suppress the
+        // declaration/delegation keywords that generic CallRegex would otherwise index as calls.
+        // Kotlin の constructor 委譲は KotlinReferenceExtractor で書き換えるため、
+        // 汎用 CallRegex が拾う宣言・委譲 keyword 自体は call として残さない。
+        ["kotlin"] = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "constructor", "super", "this",
+        },
         // Rust macro declaration keywords / Rust マクロ宣言キーワード
         // `macro_rules!` declarations will be seen by the Rust macro-call regex below, but they are
         // declaration sites rather than call sites, so suppress the keyword itself.
@@ -1274,7 +1282,8 @@ public static partial class ReferenceExtractor
                 }
             }
 
-            // Constructor chain-call rewrites: C# `: this(...)` / `: base(...)` and Java `this(...)` / `super(...)`
+            // Constructor chain-call rewrites: C# `: this(...)` / `: base(...)`, Java `this(...)` / `super(...)`,
+            // and Kotlin `constructor(...) : this(...)` / `: super(...)`.
             // コンストラクタ連鎖呼び出しの書き換え
             if (language is "csharp")
             {
@@ -1285,6 +1294,12 @@ public static partial class ReferenceExtractor
             else if (language is "java")
             {
                 JavaReferenceExtractor.EmitCtorChainReferences(
+                    preparedLine, enclosingTypeCandidates, symbols, structuralLines,
+                    references, seen, fileId, context, lineNumber, container);
+            }
+            else if (language is "kotlin")
+            {
+                KotlinReferenceExtractor.EmitCtorDelegationReferences(
                     preparedLine, enclosingTypeCandidates, symbols, structuralLines,
                     references, seen, fileId, context, lineNumber, container);
             }

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -350,6 +350,9 @@ public static partial class ReferenceExtractor
     private static readonly Regex StringLiteralRegex = new(
         "\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'|`(?:\\\\.|[^`\\\\])*`",
         RegexOptions.Compiled);
+    private static readonly Regex NonBacktickStringLiteralRegex = new(
+        "\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'",
+        RegexOptions.Compiled);
     private static readonly Regex InlineBlockCommentRegex = new(@"/\*.*?\*/", RegexOptions.Compiled);
     internal const string CSharpIdentifierPattern = @"@?[_\p{L}]\w*";
     private const string FunctionalIdentifierPattern = @"@?[_\p{L}\$][\w$]*";

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -594,7 +594,7 @@ public static partial class ReferenceExtractor
     };
     private static readonly HashSet<string> CSharpWhereConstraintIgnoredSegments = new(StringComparer.Ordinal)
     {
-        "notnull", "unmanaged",
+        "allows", "notnull", "ref", "unmanaged",
     };
     private static readonly Dictionary<string, HashSet<string>> LanguageBuiltInTypeNames = new(StringComparer.Ordinal)
     {

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -592,6 +592,10 @@ public static partial class ReferenceExtractor
         "nint", "nuint", "char", "float", "double", "decimal",
         "string", "object", "void", "dynamic", "var",
     };
+    private static readonly HashSet<string> CSharpWhereConstraintIgnoredSegments = new(StringComparer.Ordinal)
+    {
+        "notnull", "unmanaged",
+    };
     private static readonly Dictionary<string, HashSet<string>> LanguageBuiltInTypeNames = new(StringComparer.Ordinal)
     {
         ["typescript"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2650,7 +2650,8 @@ public static partial class ReferenceExtractor
                         context,
                         lineNumber,
                         resolveContainerForColumn(logicalTypeIndex),
-                        "csharp")))
+                        "csharp",
+                        csharpGenericParameterNames)))
             {
                 continue;
             }
@@ -2686,7 +2687,8 @@ public static partial class ReferenceExtractor
                 context,
                 lineNumber,
                 resolveContainerForColumn(typeGroup.Index),
-                "csharp");
+                "csharp",
+                csharpGenericParameterNames);
         }
 
         EmitCSharpCaseTypePatternReferences(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1374,12 +1374,13 @@ public static partial class ReferenceExtractor
             // 末尾の `(` を持たず CallRegex では取れないコンパイル時の型/メンバ参照。issue #253 参照。
             if (language is "csharp")
             {
+                var csharpGenericParameterNames = CollectCSharpGenericParameterNamesForDeclaration(preparedLine);
                 foreach (Match match in CSharpTypeKeywordIntroRegex.Matches(preparedLine))
                 {
                     int parenIndex = match.Index + match.Length - 1; // position of '(' / '(' の位置
                     ExtractCSharpTypeKeywordSegments(
                         references, seen, fileId, preparedLine, parenIndex + 1,
-                        context, lineNumber, container, language);
+                        context, lineNumber, container, language, csharpGenericParameterNames);
                 }
             }
             else if (language is "java")
@@ -2490,7 +2491,8 @@ public static partial class ReferenceExtractor
         string context,
         int lineNumber,
         SymbolRecord? container,
-        string language)
+        string language,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         int i = startIndex;
         int parenDepth = 0;
@@ -2547,6 +2549,12 @@ public static partial class ReferenceExtractor
                 {
                     i += 2;
                     expectSegment = true;
+                    continue;
+                }
+
+                if (ignoredSegments?.Contains(segment) == true)
+                {
+                    expectSegment = false;
                     continue;
                 }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -559,6 +559,17 @@ public static partial class ReferenceExtractor
     private static readonly Regex CSharpDocCrefRegex = new(
         @"<(?:see|seealso)\s+cref\s*=\s*""(?<cref>[^""]+)""",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    // Javadoc / KDoc cross-reference links (`{@link Foo#bar}`, `@see Foo`, `[Foo.bar]`).
+    // Javadoc / KDoc の cross-reference link。
+    private static readonly Regex JvmDocInlineLinkRegex = new(
+        @"\{@(?:link|linkplain|value)\s+(?<target>[^\s}]+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex JvmDocSeeReferenceRegex = new(
+        @"(?:^|\s)@(?:see|throws|exception)\s+(?<target>[^\s}]+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex KDocBracketLinkRegex = new(
+        @"\[(?<target>#?(?:[_\p{L}][\w$]*|`[^`\r\n]+`)(?:(?:\.|#)(?:[_\p{L}][\w$]*|`[^`\r\n]+`))*)\](?!\s*(?:\(|\[))",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     // Java primitive type names that can precede `.class` (e.g. `int.class`, `void.class`).
     // Skipped from reference rows because they are language-level keywords, not indexed types.
     // `int.class` 等に現れる Java のプリミティブ型。インデックス対象の型ではないため除外する。
@@ -1027,6 +1038,7 @@ public static partial class ReferenceExtractor
         var pendingCSharpMultiLineTypePattern = default(CSharpMultiLineTypePatternState);
         var sqlState = language == "sql" ? SqlReferenceExtractor.CreateState() : null;
         var csharpInDelimitedDocComment = false;
+        var jvmInDelimitedDocComment = false;
 
         for (int i = 0; i < lines.Length; i++)
         {
@@ -1082,6 +1094,41 @@ public static partial class ReferenceExtractor
                     }
                 }
                 csharpInDelimitedDocComment = nextCsharpDelimitedDocComment;
+            }
+            else if (language is "java" or "kotlin"
+                     && TryGetJvmDocCommentSpan(
+                         originalLine,
+                         jvmInDelimitedDocComment,
+                         out var jvmDocCommentStartIndex,
+                         out var jvmDocCommentEndExclusive,
+                         out var jvmSameLineDeclarationStartColumn,
+                         out var nextJvmDelimitedDocComment))
+            {
+                if (jvmDocCommentEndExclusive > jvmDocCommentStartIndex)
+                {
+                    var docContainer = FindJvmDocumentedContainer(
+                        containerCandidates,
+                        lines,
+                        structuralLines[i],
+                        lineNumber,
+                        jvmSameLineDeclarationStartColumn);
+                    if (docContainer != null)
+                    {
+                        var docText = originalLine[jvmDocCommentStartIndex..jvmDocCommentEndExclusive];
+                        EmitJvmDocLinkReferences(
+                            language,
+                            docText,
+                            references,
+                            seen,
+                            fileId,
+                            jvmDocCommentStartIndex,
+                            docText.Trim(),
+                            lineNumber,
+                            docContainer);
+                    }
+                }
+
+                jvmInDelimitedDocComment = nextJvmDelimitedDocComment;
             }
 
             if (string.IsNullOrWhiteSpace(preparedLine))

--- a/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
@@ -25,6 +25,9 @@ internal static class JvmMethodReferenceExtractor
             var nameGroup = match.Groups["name"];
             var container = resolveContainerForColumn(nameGroup.Index);
 
+            if (string.Equals(nameGroup.Value, "class", StringComparison.Ordinal))
+                continue;
+
             if (string.Equals(nameGroup.Value, "new", StringComparison.Ordinal))
             {
                 var ownerGroup = match.Groups["owner"];

--- a/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
@@ -7,9 +7,10 @@ internal static class JvmMethodReferenceExtractor
 {
     private const string FunctionalIdentifierPattern = @"@?[_\p{L}\$][\w$]*";
     private const string JvmMethodReferenceIdentifierPattern = @"(?:@?[_\p{L}\$][\w$]*|`[^`\r\n]+`)";
+    private const string JvmMethodReferenceOwnerSegmentPattern = JvmMethodReferenceIdentifierPattern + @"(?:\s*\[\s*\])*";
 
     private static readonly Regex MethodReferenceRegex = new(
-        $@"(?<![\w$])(?:(?<owner>(?:this|super|{JvmMethodReferenceIdentifierPattern}(?:\.{JvmMethodReferenceIdentifierPattern})*))\s*)?::\s*(?<name>{JvmMethodReferenceIdentifierPattern}|new)(?=\s*(?:[;,)\]]|$))",
+        $@"(?<![\w$])(?:(?<owner>(?:this|super|{JvmMethodReferenceOwnerSegmentPattern}(?:\.{JvmMethodReferenceOwnerSegmentPattern})*))\s*)?::\s*(?<name>{JvmMethodReferenceIdentifierPattern}|new)(?=\s*(?:[;,)\]]|$))",
         RegexOptions.Compiled);
 
     public static void EmitMethodReferenceReferences(
@@ -38,11 +39,15 @@ internal static class JvmMethodReferenceExtractor
                 if (ownerGroup.Value is "this" or "super")
                     continue;
 
+                var ownerName = StripJvmArraySuffixes(ownerGroup.Value);
+                if (ownerName.Length == 0)
+                    continue;
+
                 ReferenceExtractor.AddReference(
                     references,
                     seen,
                     fileId,
-                    ownerGroup.Value,
+                    ownerName,
                     ownerGroup.Index,
                     "instantiate",
                     context,
@@ -73,11 +78,12 @@ internal static class JvmMethodReferenceExtractor
         if (ownerGroup.Value is "this" or "super")
             return;
 
-        var leafStartInOwner = FindLastUnquotedDot(ownerGroup.Value) + 1;
-        if (leafStartInOwner >= ownerGroup.Value.Length)
+        var ownerName = StripJvmArraySuffixes(ownerGroup.Value);
+        var leafStartInOwner = FindLastUnquotedDot(ownerName) + 1;
+        if (leafStartInOwner >= ownerName.Length)
             return;
 
-        var leaf = StripBacktickIdentifier(ownerGroup.Value[leafStartInOwner..]);
+        var leaf = StripBacktickIdentifier(ownerName[leafStartInOwner..]);
         if (!IsLikelyJvmTypeName(leaf))
             return;
 
@@ -91,6 +97,34 @@ internal static class JvmMethodReferenceExtractor
             lineNumber,
             container,
             language);
+    }
+
+    private static string StripJvmArraySuffixes(string name)
+    {
+        var end = name.Length;
+        while (true)
+        {
+            var closeIndex = SkipWhitespaceBackward(name, end - 1);
+            if (closeIndex < 0 || name[closeIndex] != ']')
+                break;
+
+            var openIndex = SkipWhitespaceBackward(name, closeIndex - 1);
+            if (openIndex < 0 || name[openIndex] != '[')
+                break;
+
+            end = openIndex;
+            while (end > 0 && char.IsWhiteSpace(name[end - 1]))
+                end--;
+        }
+
+        return end == name.Length ? name : name[..end];
+    }
+
+    private static int SkipWhitespaceBackward(string text, int index)
+    {
+        while (index >= 0 && char.IsWhiteSpace(text[index]))
+            index--;
+        return index;
     }
 
     private static int FindLastUnquotedDot(string text)

--- a/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 using CodeIndex.Models;
 
@@ -7,7 +8,8 @@ internal static class JvmMethodReferenceExtractor
 {
     private const string FunctionalIdentifierPattern = @"@?[_\p{L}\$][\w$]*";
     private const string JvmMethodReferenceIdentifierPattern = @"(?:@?[_\p{L}\$][\w$]*|`[^`\r\n]+`)";
-    private const string JvmMethodReferenceOwnerSegmentPattern = JvmMethodReferenceIdentifierPattern + @"(?:\s*\[\s*\])*";
+    private const string JvmMethodReferenceTypeArgumentListPattern = @"(?:\s*<[^<>\r\n]*(?:<[^<>\r\n]*>[^<>\r\n]*)*>)?";
+    private const string JvmMethodReferenceOwnerSegmentPattern = JvmMethodReferenceIdentifierPattern + JvmMethodReferenceTypeArgumentListPattern + @"(?:\s*\[\s*\])*";
 
     private static readonly Regex MethodReferenceRegex = new(
         $@"(?<![\w$])(?:(?<owner>(?:this|super|{JvmMethodReferenceOwnerSegmentPattern}(?:\.{JvmMethodReferenceOwnerSegmentPattern})*))\s*)?::\s*(?<name>{JvmMethodReferenceIdentifierPattern}|new)(?=\s*(?:[;,)\]]|$))",
@@ -39,7 +41,7 @@ internal static class JvmMethodReferenceExtractor
                 if (ownerGroup.Value is "this" or "super")
                     continue;
 
-                var ownerName = StripJvmArraySuffixes(ownerGroup.Value);
+                var ownerName = StripJvmOwnerTypeDecorations(ownerGroup.Value);
                 if (ownerName.Length == 0)
                     continue;
 
@@ -78,7 +80,7 @@ internal static class JvmMethodReferenceExtractor
         if (ownerGroup.Value is "this" or "super")
             return;
 
-        var ownerName = StripJvmArraySuffixes(ownerGroup.Value);
+        var ownerName = StripJvmOwnerTypeDecorations(ownerGroup.Value);
         var leafStartInOwner = FindLastUnquotedDot(ownerName) + 1;
         if (leafStartInOwner >= ownerName.Length)
             return;
@@ -97,6 +99,51 @@ internal static class JvmMethodReferenceExtractor
             lineNumber,
             container,
             language);
+    }
+
+    private static string StripJvmOwnerTypeDecorations(string name)
+    {
+        var withoutGenerics = StripJvmGenericArguments(name);
+        return StripJvmArraySuffixes(withoutGenerics);
+    }
+
+    private static string StripJvmGenericArguments(string name)
+    {
+        StringBuilder? builder = null;
+        var genericDepth = 0;
+        var inBacktickIdentifier = false;
+
+        foreach (var ch in name)
+        {
+            if (ch == '`')
+            {
+                if (genericDepth == 0)
+                    (builder ??= new StringBuilder(name.Length)).Append(ch);
+                inBacktickIdentifier = !inBacktickIdentifier;
+                continue;
+            }
+
+            if (!inBacktickIdentifier)
+            {
+                if (ch == '<')
+                {
+                    genericDepth++;
+                    builder ??= new StringBuilder(name.Length);
+                    continue;
+                }
+
+                if (ch == '>' && genericDepth > 0)
+                {
+                    genericDepth--;
+                    continue;
+                }
+            }
+
+            if (genericDepth == 0)
+                (builder ??= new StringBuilder(name.Length)).Append(ch);
+        }
+
+        return builder?.ToString() ?? name;
     }
 
     private static string StripJvmArraySuffixes(string name)

--- a/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
@@ -6,9 +6,10 @@ namespace CodeIndex.Indexer;
 internal static class JvmMethodReferenceExtractor
 {
     private const string FunctionalIdentifierPattern = @"@?[_\p{L}\$][\w$]*";
+    private const string JvmMethodReferenceIdentifierPattern = @"(?:@?[_\p{L}\$][\w$]*|`[^`\r\n]+`)";
 
     private static readonly Regex MethodReferenceRegex = new(
-        $@"(?<![\w$])(?:(?<owner>(?:this|super|{FunctionalIdentifierPattern}(?:\.{FunctionalIdentifierPattern})*))\s*)?::\s*(?<name>{FunctionalIdentifierPattern}|new)\b(?=\s*(?:[;,)\]]|$))",
+        $@"(?<![\w$])(?:(?<owner>(?:this|super|{JvmMethodReferenceIdentifierPattern}(?:\.{JvmMethodReferenceIdentifierPattern})*))\s*)?::\s*(?<name>{JvmMethodReferenceIdentifierPattern}|new)\b(?=\s*(?:[;,)\]]|$))",
         RegexOptions.Compiled);
 
     public static void EmitMethodReferenceReferences(
@@ -72,11 +73,11 @@ internal static class JvmMethodReferenceExtractor
         if (ownerGroup.Value is "this" or "super")
             return;
 
-        var leafStartInOwner = ownerGroup.Value.LastIndexOf('.') + 1;
+        var leafStartInOwner = FindLastUnquotedDot(ownerGroup.Value) + 1;
         if (leafStartInOwner >= ownerGroup.Value.Length)
             return;
 
-        var leaf = ownerGroup.Value[leafStartInOwner..];
+        var leaf = StripBacktickIdentifier(ownerGroup.Value[leafStartInOwner..]);
         if (!IsLikelyJvmTypeName(leaf))
             return;
 
@@ -90,6 +91,33 @@ internal static class JvmMethodReferenceExtractor
             lineNumber,
             container,
             language);
+    }
+
+    private static int FindLastUnquotedDot(string text)
+    {
+        var last = -1;
+        var inBacktickIdentifier = false;
+        for (var index = 0; index < text.Length; index++)
+        {
+            var ch = text[index];
+            if (ch == '`')
+            {
+                inBacktickIdentifier = !inBacktickIdentifier;
+                continue;
+            }
+
+            if (!inBacktickIdentifier && ch == '.')
+                last = index;
+        }
+
+        return last;
+    }
+
+    private static string StripBacktickIdentifier(string name)
+    {
+        if (name.Length >= 2 && name[0] == '`' && name[^1] == '`')
+            return name[1..^1];
+        return name;
     }
 
     private static bool IsLikelyJvmTypeName(string name)

--- a/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
@@ -9,7 +9,7 @@ internal static class JvmMethodReferenceExtractor
     private const string JvmMethodReferenceIdentifierPattern = @"(?:@?[_\p{L}\$][\w$]*|`[^`\r\n]+`)";
 
     private static readonly Regex MethodReferenceRegex = new(
-        $@"(?<![\w$])(?:(?<owner>(?:this|super|{JvmMethodReferenceIdentifierPattern}(?:\.{JvmMethodReferenceIdentifierPattern})*))\s*)?::\s*(?<name>{JvmMethodReferenceIdentifierPattern}|new)\b(?=\s*(?:[;,)\]]|$))",
+        $@"(?<![\w$])(?:(?<owner>(?:this|super|{JvmMethodReferenceIdentifierPattern}(?:\.{JvmMethodReferenceIdentifierPattern})*))\s*)?::\s*(?<name>{JvmMethodReferenceIdentifierPattern}|new)(?=\s*(?:[;,)\]]|$))",
         RegexOptions.Compiled);
 
     public static void EmitMethodReferenceReferences(
@@ -52,7 +52,7 @@ internal static class JvmMethodReferenceExtractor
             }
 
             EmitOwnerTypeReference(language, ownerGroup, references, seen, fileId, context, lineNumber, container);
-            AddChainReference(references, seen, fileId, nameGroup.Value, nameGroup.Index, context, lineNumber, container);
+            AddChainReference(references, seen, fileId, language, nameGroup.Value, nameGroup.Index, context, lineNumber, container);
         }
     }
 
@@ -133,12 +133,14 @@ internal static class JvmMethodReferenceExtractor
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
+        string language,
         string name,
         int column,
         string context,
         int lineNumber,
         SymbolRecord? container)
     {
+        name = NormalizeMethodReferenceName(language, name);
         var dedupeKey = $"{lineNumber}:{column}:call:{name}";
         if (!seen.Add(dedupeKey))
             return;
@@ -155,4 +157,7 @@ internal static class JvmMethodReferenceExtractor
             ContainerName = container?.Name,
         });
     }
+
+    private static string NormalizeMethodReferenceName(string language, string name)
+        => language == "kotlin" ? StripBacktickIdentifier(name) : name;
 }

--- a/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
@@ -12,6 +12,7 @@ internal static class JvmMethodReferenceExtractor
         RegexOptions.Compiled);
 
     public static void EmitMethodReferenceReferences(
+        string language,
         string preparedLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
@@ -24,13 +25,13 @@ internal static class JvmMethodReferenceExtractor
         {
             var nameGroup = match.Groups["name"];
             var container = resolveContainerForColumn(nameGroup.Index);
+            var ownerGroup = match.Groups["owner"];
 
             if (string.Equals(nameGroup.Value, "class", StringComparison.Ordinal))
                 continue;
 
             if (string.Equals(nameGroup.Value, "new", StringComparison.Ordinal))
             {
-                var ownerGroup = match.Groups["owner"];
                 if (!ownerGroup.Success || ownerGroup.Value.Length == 0)
                     continue;
                 if (ownerGroup.Value is "this" or "super")
@@ -49,8 +50,55 @@ internal static class JvmMethodReferenceExtractor
                 continue;
             }
 
+            EmitOwnerTypeReference(language, ownerGroup, references, seen, fileId, context, lineNumber, container);
             AddChainReference(references, seen, fileId, nameGroup.Value, nameGroup.Index, context, lineNumber, container);
         }
+    }
+
+    private static void EmitOwnerTypeReference(
+        string language,
+        Group ownerGroup,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (language is not ("java" or "kotlin"))
+            return;
+        if (!ownerGroup.Success || ownerGroup.Value.Length == 0)
+            return;
+        if (ownerGroup.Value is "this" or "super")
+            return;
+
+        var leafStartInOwner = ownerGroup.Value.LastIndexOf('.') + 1;
+        if (leafStartInOwner >= ownerGroup.Value.Length)
+            return;
+
+        var leaf = ownerGroup.Value[leafStartInOwner..];
+        if (!IsLikelyJvmTypeName(leaf))
+            return;
+
+        ReferenceExtractor.AddTypeReferenceSegment(
+            references,
+            seen,
+            fileId,
+            leaf,
+            ownerGroup.Index + leafStartInOwner,
+            context,
+            lineNumber,
+            container,
+            language);
+    }
+
+    private static bool IsLikelyJvmTypeName(string name)
+    {
+        if (name.Length == 0)
+            return false;
+
+        var index = name[0] == '@' ? 1 : 0;
+        return index < name.Length && char.IsUpper(name[index]);
     }
 
     private static void AddChainReference(

--- a/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
@@ -318,7 +318,8 @@ internal static class TypedLanguageReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         foreach (var keyword in keywords)
         {
@@ -341,7 +342,8 @@ internal static class TypedLanguageReferenceExtractor
                     fileId,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(typeStart));
+                    resolveContainerForColumn(typeStart),
+                    ignoredSegments);
             }
         }
     }

--- a/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
@@ -175,7 +175,8 @@ internal static class TypedLanguageReferenceExtractor
         string context,
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn,
-        bool trimTopLevelCallArguments = false)
+        bool trimTopLevelCallArguments = false,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         if (listStart < 0 || listEnd <= listStart || listStart >= line.Length)
             return;
@@ -207,7 +208,8 @@ internal static class TypedLanguageReferenceExtractor
                 fileId,
                 context,
                 lineNumber,
-                resolveContainerForColumn(absoluteStart));
+                resolveContainerForColumn(absoluteStart),
+                ignoredSegments);
         }
     }
 
@@ -221,7 +223,8 @@ internal static class TypedLanguageReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         if (paramStart < 0 || paramEnd <= paramStart || paramStart >= line.Length)
             return;
@@ -253,7 +256,8 @@ internal static class TypedLanguageReferenceExtractor
                 fileId,
                 context,
                 lineNumber,
-                resolveContainerForColumn(absoluteStart));
+                resolveContainerForColumn(absoluteStart),
+                ignoredSegments);
         }
     }
 
@@ -266,7 +270,8 @@ internal static class TypedLanguageReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         foreach (var keyword in declarationKeywords)
         {
@@ -298,7 +303,8 @@ internal static class TypedLanguageReferenceExtractor
                     fileId,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(typeStart));
+                    resolveContainerForColumn(typeStart),
+                    ignoredSegments);
             }
         }
     }
@@ -348,7 +354,8 @@ internal static class TypedLanguageReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         foreach (var whereIndex in EnumerateTopLevelKeywordIndices(line, "where"))
         {
@@ -383,7 +390,8 @@ internal static class TypedLanguageReferenceExtractor
                     fileId,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(absoluteStart));
+                    resolveContainerForColumn(absoluteStart),
+                    ignoredSegments);
             }
         }
     }
@@ -397,7 +405,8 @@ internal static class TypedLanguageReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         if (genericOpenIndex < 0 || genericOpenIndex >= line.Length || line[genericOpenIndex] != '<')
             return;
@@ -432,7 +441,8 @@ internal static class TypedLanguageReferenceExtractor
                 fileId,
                 context,
                 lineNumber,
-                resolveContainerForColumn(absoluteStart));
+                resolveContainerForColumn(absoluteStart),
+                ignoredSegments);
         }
     }
 

--- a/src/CodeIndex/Indexer/Symbols/CSharpSymbolNameNormalizer.cs
+++ b/src/CodeIndex/Indexer/Symbols/CSharpSymbolNameNormalizer.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using CodeIndex.Database;
 
 namespace CodeIndex.Indexer;
 
@@ -23,8 +24,8 @@ internal static class CSharpSymbolNameNormalizer
         if (name == "this" && match.Value.Contains("this", StringComparison.Ordinal) && match.Value.Contains('[', StringComparison.Ordinal))
             return "Item";
 
-        // The `@` escape is source syntax only; persisted names use the same canonical
-        // spelling as writer-side import and base-type resolution.
+        // Source-only identifier escapes are not part of the persisted symbol contract.
+        // Keep exact-name lookup on the canonical spelling used by import and base-type resolution.
         return NormalizeVerbatimIdentifiers(name);
     }
 
@@ -154,29 +155,15 @@ internal static class CSharpSymbolNameNormalizer
 
     private static string NormalizeVerbatimIdentifiers(string value)
     {
-        if (string.IsNullOrEmpty(value) || value.IndexOf('@', StringComparison.Ordinal) < 0)
-            return value;
-
-        StringBuilder? builder = null;
-        var segmentStart = 0;
-
-        for (var index = 0; index < value.Length; index++)
+        if (string.IsNullOrEmpty(value)
+            || (value.IndexOf('@', StringComparison.Ordinal) < 0
+                && value.IndexOf("global::", StringComparison.Ordinal) < 0
+                && value.IndexOf('\\', StringComparison.Ordinal) < 0))
         {
-            if (!IsVerbatimIdentifierPrefix(value, index))
-                continue;
-
-            builder ??= new StringBuilder(value.Length);
-            if (index > segmentStart)
-                builder.Append(value, segmentStart, index - segmentStart);
-            segmentStart = index + 1;
+            return value;
         }
 
-        if (builder is null)
-            return value;
-
-        if (segmentStart < value.Length)
-            builder.Append(value, segmentStart, value.Length - segmentStart);
-        return builder.ToString();
+        return ExactSourceSearchNormalizer.Normalize(value, "csharp");
     }
 
     internal static bool IsVerbatimIdentifierPrefix(string value, int index)

--- a/src/CodeIndex/Indexer/Symbols/JavaSymbolNameNormalizer.cs
+++ b/src/CodeIndex/Indexer/Symbols/JavaSymbolNameNormalizer.cs
@@ -1,0 +1,14 @@
+using CodeIndex.Database;
+
+namespace CodeIndex.Indexer;
+
+internal static class JavaSymbolNameNormalizer
+{
+    internal static string Normalize(string name)
+    {
+        if (string.IsNullOrEmpty(name) || name.IndexOf('\\', StringComparison.Ordinal) < 0)
+            return name;
+
+        return ExactSourceSearchNormalizer.Normalize(name, "java");
+    }
+}

--- a/src/CodeIndex/Indexer/Symbols/KotlinSymbolNameNormalizer.cs
+++ b/src/CodeIndex/Indexer/Symbols/KotlinSymbolNameNormalizer.cs
@@ -6,15 +6,23 @@ internal static class KotlinSymbolNameNormalizer
 {
     internal static string Normalize(string name, string matchLine)
     {
+        var normalizedName = StripBacktickIdentifier(name);
         var trimmedLine = matchLine.TrimStart();
         if (!trimmedLine.StartsWith("companion object", StringComparison.Ordinal))
-            return name;
+            return normalizedName;
 
-        var trimmedName = name.Trim();
+        var trimmedName = normalizedName.Trim();
         return string.IsNullOrWhiteSpace(trimmedName)
             || string.Equals(trimmedName, "companion object", StringComparison.Ordinal)
             ? "Companion"
-            : name;
+            : normalizedName;
+    }
+
+    private static string StripBacktickIdentifier(string name)
+    {
+        if (name.Length >= 2 && name[0] == '`' && name[^1] == '`')
+            return name[1..^1];
+        return name;
     }
 
     internal static void NormalizeSecondaryConstructorNames(List<SymbolRecord> symbols)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -3544,7 +3544,7 @@ public static partial class SymbolExtractor
         {
             FileId = fileId,
             Kind = "enum",
-            Name = match.Groups["name"].Value.Trim(),
+            Name = CSharpSymbolNameNormalizer.Normalize(match.Groups["name"].Value.Trim(), match, maskedSnippet),
             Line = start.LineIndex + 1,
             StartLine = start.LineIndex + 1,
             EndLine = endExclusive.LineIndex + 1,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -111,6 +111,7 @@ public static partial class SymbolExtractor
         @"(?:<(?:(?>[^<>]+)|<(?<JavaMethodTypeParameterDepth>)|>(?<-JavaMethodTypeParameterDepth>))*(?(JavaMethodTypeParameterDepth)(?!))>\s+)?";
     private const string JavaReturnTypePattern =
         @"(?:" + JavaQualifiedIdentifierPattern + @"(?:\s*<[^;=(){}]+>)?(?:\s*\[\s*\])*)";
+    private const string KotlinIdentifierPattern = @"(?:\w+|`[^`\r\n]+`)";
     private static readonly Regex CobolProgramIdLineRegex = new(
         @"^\s*(?:IDENTIFICATION\s+DIVISION\.\s*)?PROGRAM-ID\.\s*(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -1282,26 +1283,26 @@ public static partial class SymbolExtractor
         ["kotlin"] =
         [
             // Companion object / コンパニオンオブジェクト
-            new("class",    new Regex(@"^\s*companion\s+object(?:\s+(?<name>\w+))?", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex($@"^\s*companion\s+object(?:\s+(?<name>{KotlinIdentifierPattern}))?", RegexOptions.Compiled), BodyStyle.Brace),
             // Interface / インターフェース
             // Kotlin fun interface / Kotlin の fun interface も interface として扱う。
-            new("interface", new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:sealed|expect|actual)\s+)*(?:fun\s+)?interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("interface", new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:sealed|expect|actual)\s+)*(?:fun\s+)?interface\s+(?<name>{KotlinIdentifierPattern})", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum class / enum クラス
-            new("enum",     new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:expect|actual)\s+)*enum\s+class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("enum",     new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:expect|actual)\s+)*enum\s+class\s+(?<name>{KotlinIdentifierPattern})", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Class/object with expanded modifiers: data, sealed, value, inner, annotation, expect, actual
             // クラス/オブジェクト — 拡張修飾子対応: data, sealed, value, inner, annotation, expect, actual
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:abstract|data|sealed|open|inner|value|annotation|expect|actual)\s+)*(?:class|object)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:abstract|data|sealed|open|inner|value|annotation|expect|actual)\s+)*(?:class|object)\s+(?<name>{KotlinIdentifierPattern})", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Function / 関数 (including extension, secondary constructor, override, and abstract forms)
             // 関数 — 拡張・セカンダリコンストラクタ・override・abstract 形を含む
-            new("function", new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:suspend|inline|infix|operator|tailrec|external|expect|actual|abstract|override|open|final)\s+)*fun\s+(?:\w+(?:<[^>]+>)?\.)?(?<name>\w+)\s*[\(<](?:.*?\))?(?::\s*(?<returnType>[^ {=]+))?", RegexOptions.Compiled), BodyStyle.Brace, "visibility", "returnType"),
+            new("function", new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:suspend|inline|infix|operator|tailrec|external|expect|actual|abstract|override|open|final)\s+)*fun\s+(?:{KotlinIdentifierPattern}(?:<[^>]+>)?\.)?(?<name>{KotlinIdentifierPattern})\s*[\(<](?:.*?\))?(?::\s*(?<returnType>[^ {{=]+))?", RegexOptions.Compiled), BodyStyle.Brace, "visibility", "returnType"),
             // Secondary constructor / セカンダリコンストラクタ
             new("function", new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*constructor\s*\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum entry / enum エントリ
-            new("property", new Regex(@"^\s{2,}(?<name>[A-Z][A-Z0-9_]*)\s*(?:\((?<returnType>[^)]*)\))?\s*(?:,|\{|;)?\s*$", RegexOptions.Compiled), BodyStyle.Brace, "returnType"),
+            new("property", new Regex($@"^\s{{2,}}(?<name>(?:[A-Z][A-Z0-9_]*|`[^`\r\n]+`))\s*(?:\((?<returnType>[^)]*)\))?\s*(?:,|\{{|;)?\s*$", RegexOptions.Compiled), BodyStyle.Brace, "returnType"),
             // Top-level val/var property / トップレベルプロパティ
-            new("property", new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:const|lateinit|override)\s+)?(?:val|var)\s+(?<name>\w+)\s*[=:]", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("property", new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:const|lateinit|override)\s+)?(?:val|var)\s+(?<name>{KotlinIdentifierPattern})\s*[=:]", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Type alias / 型エイリアス
-            new("import",   new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*typealias\s+(?<name>\w+)(?:\s*<[^=]+>)?\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("import",   new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*typealias\s+(?<name>{KotlinIdentifierPattern})(?:\s*<[^=]+>)?\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*import\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["ruby"] =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -67,9 +67,12 @@ public static partial class SymbolExtractor
     // 深さ 0 で見えた comma だけを tuple 判定に使う。
     private const string CSharpTupleGroupPattern =
         @"\((?>(?:[^(),]+|\((?<TupleDepth>)|\)(?<-TupleDepth>)|(?(TupleDepth),|(?<TupleComma>,))))*(?(TupleDepth)(?!))(?(TupleComma)|(?!))\)";
-    private const string CSharpIdentifierPattern = @"@?[_\p{L}]\w*";
+    private const string CSharpUnicodeEscapePattern = @"\\(?:u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})";
+    private const string CSharpIdentifierPattern =
+        @"@?(?:[_\p{L}]|" + CSharpUnicodeEscapePattern + @")(?:\w|" + CSharpUnicodeEscapePattern + @")*";
     private const string CSharpNamespacePattern = CSharpIdentifierPattern + @"(?:\." + CSharpIdentifierPattern + @")*";
     private const string CSharpTypeTokenCharsPattern = @"[\w@?.<>\[\],:*]";
+    private const string CSharpTypeTokenPattern = @"(?:" + CSharpUnicodeEscapePattern + @"|" + CSharpTypeTokenCharsPattern + @")";
     private const string SqlQualifiedIdentifierSegmentPattern = @"(?:\[(?:[^\]\r\n]|\]\])+\]|""[^""]+""|[\w$#]+)";
     private const string SqlQualifiedIdentifierPattern =
         @"(?:" + SqlQualifiedIdentifierSegmentPattern + @")(?:\s*\.\s*(?:" + SqlQualifiedIdentifierSegmentPattern + @"))*";
@@ -97,7 +100,7 @@ public static partial class SymbolExtractor
     private const string CFunctionReturnTypePattern =
         @"(?<returnType>(?:(?:\w+[\s*]+)|" + CAttributeSpecifierTokenPattern + @")+)";
     private const string CSharpTypeSegmentPattern =
-        @"(?:" + CSharpTypeTokenCharsPattern + @"+(?:" + CSharpTupleGroupPattern + CSharpTypeTokenCharsPattern + @"*)*|" + CSharpTupleGroupPattern + CSharpTypeTokenCharsPattern + @"*)";
+        @"(?:" + CSharpTypeTokenPattern + @"+(?:" + CSharpTupleGroupPattern + CSharpTypeTokenPattern + @"*)*|" + CSharpTupleGroupPattern + CSharpTypeTokenPattern + @"*)";
     private const string CSharpTypePattern =
         @"(?:(?:global::)?(?:" + CSharpTypeSegmentPattern + @")(?:\s+(?:" + CSharpTypeSegmentPattern + @"))*" + CSharpTupleSuffixPattern + @")";
     private const string CSharpMethodTypeParameterListPattern =
@@ -105,7 +108,9 @@ public static partial class SymbolExtractor
     private static readonly Regex CSharpPartialFunctionDeclarationSignatureRegex = new(
         $@"^(?:(?:{CSharpVisibilityPattern}|abstract|async|extern|new|override|sealed|static|unsafe|virtual)\s+)*partial\s+",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private const string JavaIdentifierPattern = @"[\p{L}_$][\p{L}\p{Nd}_$]*";
+    private const string JavaUnicodeEscapePattern = @"\\u+[0-9A-Fa-f]{4}";
+    private const string JavaIdentifierPattern =
+        @"(?:[\p{L}_$]|" + JavaUnicodeEscapePattern + @")(?:[\p{L}\p{Nd}_$]|" + JavaUnicodeEscapePattern + @")*";
     private const string JavaQualifiedIdentifierPattern = JavaIdentifierPattern + @"(?:\s*\.\s*" + JavaIdentifierPattern + @")*";
     private const string JavaMethodTypeParameterPattern =
         @"(?:<(?:(?>[^<>]+)|<(?<JavaMethodTypeParameterDepth>)|>(?<-JavaMethodTypeParameterDepth>))*(?(JavaMethodTypeParameterDepth)(?!))>\s+)?";
@@ -516,8 +521,8 @@ public static partial class SymbolExtractor
     // enum 宣言 — visibility は任意で、修飾子の順序は自由。非 visibility 修飾子として `file`
     // （ファイルスコープ enum）と `new`（派生型でのネスト enum 隠蔽）を受け付ける。Closes #353.
     private static readonly Regex CSharpEnumDeclarationRegex = new($@"^\s*(?:(?<visibility>public|private|protected\s+internal|private\s+protected|protected|internal)\s+|(?:file|new)\s+)*enum\s+(?<name>{CSharpIdentifierPattern})", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex CSharpEnumMemberRegex = new(@"^\s*(?<name>@?[_\p{L}]\w*)\s*(?:=\s*(?:-?\d|0x|@?[_\p{L}]\w*(?:\s*\|\s*@?[_\p{L}]\w*)*)[^""']*)?,?\s*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex CSharpEnumMemberNameRegex = new(@"^\s*(?<name>@?[_\p{L}]\w*)\b", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CSharpEnumMemberRegex = new($@"^\s*(?<name>{CSharpIdentifierPattern})\s*(?:=\s*(?:-?\d|0x|{CSharpIdentifierPattern}(?:\s*\|\s*{CSharpIdentifierPattern})*)[^""']*)?,?\s*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CSharpEnumMemberNameRegex = new($@"^\s*(?<name>{CSharpIdentifierPattern})\b", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex JavaCompactConstructorRegex = new(
         @"^\s*(?:(?<visibility>public|private|protected)\s+)?(?<name>\w+)\s*(?=\{|$)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -851,14 +856,12 @@ public static partial class SymbolExtractor
         ],
         ["csharp"] =
         [
-            // Verbatim-identifier segments (`@Foo.@Bar`) are accepted per segment via
-            // `CSharpNamespacePattern` / `CSharpIdentifierPattern` (both built from `@?[_\p{L}]\w*`)
-            // and later canonicalized to `Foo.Bar` by `NormalizeCSharpSymbolName`. See the iter-6 /
-            // iter-7 notes around `StripCSharpVerbatimPrefixes` for the shared canonical-form policy.
-            // verbatim 識別子の各セグメント（`@Foo.@Bar`）を `CSharpNamespacePattern` /
-            // `CSharpIdentifierPattern`（どちらも `@?[_\p{L}]\w*`）経由で受け入れ、
-            // `NormalizeCSharpSymbolName` で `Foo.Bar` に canonical 化する。iter-6 / iter-7 の
-            // `StripCSharpVerbatimPrefixes` 周辺コメントを参照。
+            // Verbatim and Unicode-escaped identifier segments (`@Foo.@Bar`, `\u0046oo`) are
+            // accepted via `CSharpNamespacePattern` / `CSharpIdentifierPattern` and later
+            // canonicalized by `CSharpSymbolNameNormalizer`.
+            // verbatim / Unicode escape 識別子の各セグメントを `CSharpNamespacePattern` /
+            // `CSharpIdentifierPattern` 経由で受け入れ、`CSharpSymbolNameNormalizer` で
+            // canonical 化する。
             new("namespace", new Regex($@"^\s*namespace\s+(?<name>{CSharpNamespacePattern})\s*;", RegexOptions.Compiled), BodyStyle.None),  // file-scoped namespace (C# 10+)
             new("namespace", new Regex($@"^\s*namespace\s+(?<name>{CSharpNamespacePattern})", RegexOptions.Compiled), BodyStyle.Brace),  // block-scoped namespace
             // extern alias (must precede using directives per C# spec) — captures assembly-alias reconciliation
@@ -1252,20 +1255,20 @@ public static partial class SymbolExtractor
         ["java"] =
         [
             // Package declaration / package 宣言
-            new("namespace", new Regex(@"^\s*package\s+(?<name>[\w.]+)\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("namespace", new Regex($@"^\s*package\s+(?<name>{JavaQualifiedIdentifierPattern})\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
             // Module declaration (Java 9+ module-info.java) / モジュール宣言（Java 9+ の module-info.java）
-            new("namespace", new Regex(@"^\s*(?:open\s+)?module\s+(?<name>[\w.]+)\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
+            new("namespace", new Regex($@"^\s*(?:open\s+)?module\s+(?<name>{JavaQualifiedIdentifierPattern})\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
             // Annotation type (@interface) / アノテーション型
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|protected)?\s*@interface\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex($@"^\s*(?<visibility>public|private|protected)?\s*@interface\s+(?<name>{JavaIdentifierPattern})", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
             // record (Java 16+) — must come before general class pattern / record は一般クラスパターンの前に配置
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|final|abstract|sealed|non-sealed|strictfp)\s+)*record\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex($@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|final|abstract|sealed|non-sealed|strictfp)\s+)*record\s+(?<name>{JavaIdentifierPattern})", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
             // Interface / インターフェース
-            new("interface", new Regex(@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|abstract|sealed|non-sealed|strictfp)\s+)*interface\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
+            new("interface", new Regex($@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|abstract|sealed|non-sealed|strictfp)\s+)*interface\s+(?<name>{JavaIdentifierPattern})", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
             // Enum / enum
-            new("enum",     new Regex(@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|strictfp)\s+)*enum\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
+            new("enum",     new Regex($@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|strictfp)\s+)*enum\s+(?<name>{JavaIdentifierPattern})", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
             // Class — with extended modifiers (final, sealed, static, abstract, strictfp)
             // クラス — 拡張修飾子対応（final, sealed, static, abstract, strictfp）
-            new("class",    new Regex(@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|final|abstract|sealed|non-sealed|strictfp)\s+)*class\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex($@"^\s*(?<visibility>public|private|protected)?\s*(?:(?:static|final|abstract|sealed|non-sealed|strictfp)\s+)*class\s+(?<name>{JavaIdentifierPattern})", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, "visibility"),
             // Static final field (Java equivalent of C# const) — order-flexible and annotation-friendly.
             // static final フィールド — 語順柔軟かつアノテーション併用にも対応。
             new("function", new Regex($@"^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?<visibility>public|private|protected)?\s*(?=(?:(?:static|final|transient|volatile)\s+)*static\b)(?=(?:(?:static|final|transient|volatile)\s+)*final\b)(?:(?:static|final|transient|volatile)\s+)*(?<returnType>{JavaReturnTypePattern})\s+(?<name>[A-Z_]\w*)\s*=", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, "visibility", "returnType"),
@@ -7502,6 +7505,7 @@ public static partial class SymbolExtractor
             "csharp" => CSharpSymbolNameNormalizer.Normalize(name, match, matchLine),
             "cobol" => CobolSymbolNameNormalizer.Normalize(name),
             "fsharp" => FSharpSymbolNameNormalizer.Normalize(name),
+            "java" => JavaSymbolNameNormalizer.Normalize(name),
             "kotlin" => KotlinSymbolNameNormalizer.Normalize(name, matchLine),
             "rust" => RustSymbolNameNormalizer.Normalize(name),
             "smalltalk" => NormalizeSmalltalkSelectorName(name),

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -9141,6 +9141,59 @@ jobs:
     }
 
     [Fact]
+    public void RunDefinition_ExactNameFindsUnicodeEscapedCSharpAndJavaSymbols()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_definition_exact_unicode_escapes");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/Escaped.cs",
+                "csharp",
+                "namespace Demo.\\u004eames;\n\n"
+                + "public class \\u0046oo\n"
+                + "{\n"
+                + "    public void \\u0042ar() { }\n"
+                + "}\n");
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.java",
+                "java",
+                "package demo.\\u0061pp;\n\n"
+                + "public class \\u004aavaFoo {\n"
+                + "    public void \\u0062ar() { }\n"
+                + "}\n");
+
+            var (csharpExitCode, csharpStdout, csharpStderr) = CaptureConsole(() => QueryCommandRunner.RunDefinition(
+                ["Bar", "--db", dbPath, "--json", "--lang", "csharp", "--kind", "function", "--exact-name"],
+                _jsonOptions));
+            var csharpRows = ParseJsonLines(csharpStdout);
+
+            var (javaExitCode, javaStdout, javaStderr) = CaptureConsole(() => QueryCommandRunner.RunDefinition(
+                ["bar", "--db", dbPath, "--json", "--lang", "java", "--kind", "function", "--exact-name"],
+                _jsonOptions));
+            var javaRows = ParseJsonLines(javaStdout);
+
+            Assert.Equal(CommandExitCodes.Success, csharpExitCode);
+            Assert.Equal(string.Empty, csharpStderr);
+            Assert.Single(csharpRows);
+            Assert.Equal("Bar", csharpRows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("Foo", csharpRows[0].RootElement.GetProperty("container_name").GetString());
+
+            Assert.Equal(CommandExitCodes.Success, javaExitCode);
+            Assert.Equal(string.Empty, javaStderr);
+            Assert.Single(javaRows);
+            Assert.Equal("bar", javaRows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("JavaFoo", javaRows[0].RootElement.GetProperty("container_name").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunFind_ExactTreatsJavaUnicodeEscapesAsCanonical()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_java_unicode");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -9211,6 +9211,42 @@ jobs:
     }
 
     [Fact]
+    public void RunDefinition_ExactNameFindsKotlinBacktickedSymbolNames()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_definition_exact_kotlin_backticks");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.kt",
+                "kotlin",
+                """
+                class `when` {
+                    fun `is`(): Int = 1
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunDefinition(
+                ["is", "--db", dbPath, "--json", "--lang", "kotlin", "--kind", "function", "--exact-name"],
+                _jsonOptions));
+
+            var rows = ParseJsonLines(stdout);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Single(rows);
+            Assert.Equal("is", rows[0].RootElement.GetProperty("name").GetString());
+            Assert.Equal("function", rows[0].RootElement.GetProperty("kind").GetString());
+            Assert.Equal("when", rows[0].RootElement.GetProperty("container_name").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunFind_ExactTreatsCSharpVerbatimQualifiedNamesAsCanonical()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_csharp_verbatim");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -9254,6 +9254,19 @@ jobs:
     }
 
     [Fact]
+    public void ExactSourceSearchNormalizer_DecodesCSharpUnicodeEscapesBeforeVerbatimCleanup()
+    {
+        const string text = "global::@\\u0063lass.\\U00000046oo";
+
+        var normalized = ExactSourceSearchNormalizer.Normalize(text, "csharp", out var rawIndexMap);
+
+        Assert.Equal("class.Foo", normalized);
+        Assert.Equal(normalized.Length, rawIndexMap.Length);
+        Assert.Equal(text.IndexOf('\\'), rawIndexMap[0]);
+        Assert.Equal(text.LastIndexOf('\\'), rawIndexMap[6]);
+    }
+
+    [Fact]
     public void RunSearch_ExactSubstringTreatsCSharpGlobalQualifiedNamesAsCanonical()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_csharp_global");
@@ -9310,6 +9323,117 @@ jobs:
             Assert.Equal(string.Empty, qualifiedStderr);
             Assert.Equal(1, qualifiedDocument.RootElement.GetProperty("count").GetInt32());
             Assert.Equal(1, qualifiedDocument.RootElement.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_ExactSubstringTreatsCSharpUnicodeEscapedIdentifiersAsCanonical()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_exact_csharp_unicode_escape");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/escaped.cs",
+                "csharp",
+                "namespace Demo;\n\n"
+                + "public class EscapedIdentifiers\n"
+                + "{\n"
+                + "    public void Match()\n"
+                + "    {\n"
+                + "        var first = \\u0047lobalName;\n"
+                + "        var second = \\U00000047lobalName;\n"
+                + "        var keyword = @\\u0063lass.Member;\n"
+                + "    }\n"
+                + "}\n");
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/plain.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                public class PlainIdentifiers
+                {
+                    public void Match()
+                    {
+                        var first = GlobalName;
+                    }
+                }
+                """);
+
+            var (plainQueryExitCode, plainQueryStdout, plainQueryStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["GlobalName", "--db", dbPath, "--path", "src/escaped.cs", "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+            using var plainQueryDocument = ParseJsonOutput(plainQueryStdout);
+
+            var (escapedQueryExitCode, escapedQueryStdout, escapedQueryStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["\\U00000047lobalName", "--db", dbPath, "--path", "src/plain.cs", "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+            using var escapedQueryDocument = ParseJsonOutput(escapedQueryStdout);
+
+            var (verbatimExitCode, verbatimStdout, verbatimStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["class.Member", "--db", dbPath, "--path", "src/escaped.cs", "--json", "--exact-substring", "--count"],
+                _jsonOptions));
+            using var verbatimDocument = ParseJsonOutput(verbatimStdout);
+
+            Assert.Equal(CommandExitCodes.Success, plainQueryExitCode);
+            Assert.Equal(string.Empty, plainQueryStderr);
+            Assert.Equal(1, plainQueryDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, plainQueryDocument.RootElement.GetProperty("files").GetInt32());
+
+            Assert.Equal(CommandExitCodes.Success, escapedQueryExitCode);
+            Assert.Equal(string.Empty, escapedQueryStderr);
+            Assert.Equal(1, escapedQueryDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, escapedQueryDocument.RootElement.GetProperty("files").GetInt32());
+
+            Assert.Equal(CommandExitCodes.Success, verbatimExitCode);
+            Assert.Equal(string.Empty, verbatimStderr);
+            Assert.Equal(1, verbatimDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(1, verbatimDocument.RootElement.GetProperty("files").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_LiteralSafeSearchKeepsCSharpUnicodeEscapeQueriesRawForFts()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_search_csharp_unicode_escape_fts");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/escaped.cs",
+                "csharp",
+                "namespace Demo;\n\n"
+                + "public class EscapedIdentifiers\n"
+                + "{\n"
+                + "    public void Match()\n"
+                + "    {\n"
+                + "        var first = \\u0047lobalName;\n"
+                + "    }\n"
+                + "}\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["\\u0047lobalName", "--db", dbPath, "--path", "src/escaped.cs", "--lang", "csharp", "--json", "--count"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.Equal(1, json.GetProperty("files").GetInt32());
         }
         finally
         {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12755,6 +12755,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinExtensionPropertyReceivers_CaptureTypeReferences()
+    {
+        // Extension property receivers are declarations too, but the receiver appears before
+        // the property name rather than after a parameter colon.
+        // extension property の receiver も宣言上の依存だが、property 名より前に現れるため
+        // parameter colon 後の型抽出だけでは拾えない。
+        const string content = """
+            class User
+            class Box<T>
+
+            val User.displayName: String get() = ""
+            var Box<User>.selected: User
+                get() = TODO()
+                set(value) {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.True(references.Count(r => r.SymbolName == "User" && r.ReferenceKind == "type_reference") >= 2);
+        Assert.Contains(references, r => r.SymbolName == "Box" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -19644,6 +19644,42 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinSecondaryConstructorDelegation_RewritesThisAndSuperCalls()
+    {
+        const string content = """
+            open class Parent(value: Int) {}
+
+            class Child
+                : Parent {
+                constructor() : this(0) {
+                }
+
+                constructor(value: Int) : super(value) {
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "Child"
+            && r.ReferenceKind == "call"
+            && r.Context.Contains(": this(", StringComparison.Ordinal)
+            && r.ContainerKind == "function"
+            && r.ContainerName == "Child");
+        Assert.Contains(references, r =>
+            r.SymbolName == "Parent"
+            && r.ReferenceKind == "call"
+            && r.Context.Contains(": super(", StringComparison.Ordinal)
+            && r.ContainerKind == "function"
+            && r.ContainerName == "Child");
+        Assert.DoesNotContain(references, r =>
+            r.ReferenceKind == "call"
+            && (r.SymbolName == "constructor" || r.SymbolName == "this" || r.SymbolName == "super"));
+    }
+
+    [Fact]
     public void Extract_KotlinImportAlias_DoesNotEmitTypeReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13091,6 +13091,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinGenericBounds_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            interface Comparable<T>
+            interface Handler<T>
+            class Payload
+            class Box<out T : Comparable<T>>
+
+            fun <reified T> run(input: T): Handler<T> where T : Payload, T : Handler<T> = TODO()
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Comparable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "T" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpWhereConstraintKeywords_DoNotBecomeTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12934,6 +12934,34 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinBacktickAnnotations_NormalizesNames()
+    {
+        // Kotlin annotations can be backticked declarations; metadata references should keep
+        // the canonical annotation symbol name for both no-arg and argument forms.
+        // Kotlin annotation も backtick 付き宣言にできるため、引数なし・引数ありの metadata
+        // reference でも canonical annotation symbol 名を使う。
+        const string content = """
+            annotation class `Fancy Name`(val value: String = "")
+
+            @`Fancy Name`
+            class Demo {
+                @`Fancy Name`("x")
+                fun run(input: @`Fancy Name` Payload) {}
+            }
+
+            class Payload
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(symbols, s => s.Name == "Fancy Name" && s.Kind == "class");
+        Assert.True(references.Count(r => r.SymbolName == "Fancy Name" && r.ReferenceKind == "annotation") >= 3);
+        Assert.DoesNotContain(references, r => r.SymbolName == "`Fancy Name`" && r.ReferenceKind == "annotation");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Fancy Name" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12836,6 +12836,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinBacktickClassLiterals_NormalizesTypeReferenceNames()
+    {
+        // Kotlin class literals can target backticked type names too; keep them aligned with
+        // the declaration's canonical name instead of treating the backticks as a string.
+        // Kotlin の class literal でも backtick 付き型名を対象にできるため、backtick を
+        // 文字列扱いせず、宣言側と同じ canonical 名で参照を発行する。
+        const string content = """
+            class `Display Name`
+
+            class Demo {
+                val token = `Display Name`::class
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(symbols, s => s.Name == "Display Name" && s.Kind == "class");
+        Assert.Contains(references, r => r.SymbolName == "Display Name" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "`Display Name`" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13176,6 +13176,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpGenericSignatures_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            interface IContract<T> {}
+            class Base<T> {}
+
+            class Demo<TValue> : Base<TValue>, IContract<TValue>
+            {
+                public TItem Pick<TItem>(TItem value, IContract<TItem> fallback) => value;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Base" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "IContract" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => (r.SymbolName is "TValue" or "TItem") && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1217,6 +1217,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaGenericHeritage_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            package demo;
+
+            interface Comparable<T> {}
+            class Base<T> {}
+            interface Handler<T> {}
+            class Box<T extends Comparable<T>> extends Base<T> implements Handler<T> {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Comparable" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Base" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "T" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_KotlinCallableReferences_TrackOwnerTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13009,6 +13009,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpWhereConstraintKeywords_DoNotBecomeTypeReferences()
+    {
+        const string content = """
+            interface IContract {}
+            class Demo<TValue, TKey>
+                where TValue : unmanaged, IContract
+                where TKey : notnull
+            {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "IContract" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => (r.SymbolName is "unmanaged" or "notnull") && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12859,6 +12859,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinBacktickMethodReferenceOwners_CaptureTypeReference()
+    {
+        // JVM method references already emit owner type edges for Java/Kotlin; Kotlin backtick
+        // owners need the same canonical name handling as declarations and type positions.
+        // JVM method reference の owner 型 edge は Java/Kotlin で発行しているため、
+        // Kotlin の backtick owner でも宣言・型位置と同じ canonical 名に揃える。
+        const string content = """
+            class `Display Name` {
+                fun render() {}
+            }
+
+            class Demo {
+                val handler = `Display Name`::render
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(symbols, s => s.Name == "Display Name" && s.Kind == "class");
+        Assert.Contains(references, r => r.SymbolName == "Display Name" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "render" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "`Display Name`" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13253,6 +13253,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpGenericTypeKeywords_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            class User {}
+
+            class Demo {
+                public static object TypeOf<T>() => typeof(T);
+                public static string NameOf<T>() => nameof(T);
+                public static object UserType() => typeof(User);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "T" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1147,6 +1147,53 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaGenericOwnerMethodReferences_NormalizesOwnerType()
+    {
+        const string content = """
+            package demo;
+
+            import java.util.function.Function;
+            import java.util.function.Supplier;
+
+            public class Box<T> {
+                public String open() {
+                    return "";
+                }
+            }
+
+            public class Factory {
+                public Supplier<Box<String>> make() {
+                    return Box<String>::new;
+                }
+
+                public Function<Box<String>, String> opener() {
+                    return Box<String>::open;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "Box"
+            && r.ReferenceKind == "instantiate"
+            && r.Context.Contains("Box<String>::new", StringComparison.Ordinal)
+            && r.ContainerName == "make");
+        Assert.Contains(references, r =>
+            r.SymbolName == "open"
+            && r.ReferenceKind == "call"
+            && r.Context.Contains("Box<String>::open", StringComparison.Ordinal)
+            && r.ContainerName == "opener");
+        Assert.Contains(references, r =>
+            r.SymbolName == "Box"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("Box<String>::open", StringComparison.Ordinal)
+            && r.ContainerName == "opener");
+        Assert.DoesNotContain(references, r => r.SymbolName.Contains("<", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_KotlinCallableReferences_TrackOwnerTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -19680,6 +19680,44 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinClassLiterals_CaptureTypeReferences()
+    {
+        const string content = """
+            class User {}
+            class Profile {}
+
+            class Service {
+                fun inspect(value: Any) {
+                    val kClass = User::class
+                    val javaClass = Profile::class.java
+                    val runtimeClass = value::class
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "User"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("User::class", StringComparison.Ordinal)
+            && r.ContainerName == "inspect");
+        Assert.Contains(references, r =>
+            r.SymbolName == "Profile"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("Profile::class.java", StringComparison.Ordinal)
+            && r.ContainerName == "inspect");
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "value"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("value::class", StringComparison.Ordinal));
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "class"
+            && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_KotlinImportAlias_DoesNotEmitTypeReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12911,6 +12911,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinBacktickConstructorCalls_NormalizesInstantiateNames()
+    {
+        // Backticked Kotlin class names should behave like ordinary constructor calls: the
+        // instantiate edge uses the canonical class symbol name.
+        // backtick 付き Kotlin class 名の constructor call も通常の constructor call と同様に、
+        // canonical class symbol 名で instantiate edge を発行する。
+        const string content = """
+            class `Display Name`
+
+            class Demo {
+                val value = `Display Name`()
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(symbols, s => s.Name == "Display Name" && s.Kind == "class");
+        Assert.Contains(references, r => r.SymbolName == "Display Name" && r.ReferenceKind == "instantiate");
+        Assert.DoesNotContain(references, r => r.SymbolName == "`Display Name`" && r.ReferenceKind == "instantiate");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13116,9 +13116,10 @@ public class ReferenceExtractorTests
     {
         const string content = """
             interface IContract {}
-            class Demo<TValue, TKey>
+            class Demo<TValue, TKey, TBuffer>
                 where TValue : unmanaged, IContract
                 where TKey : notnull
+                where TBuffer : IContract, allows ref struct
             {
             }
             """;
@@ -13127,7 +13128,7 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "IContract" && r.ReferenceKind == "type_reference");
-        Assert.DoesNotContain(references, r => (r.SymbolName is "unmanaged" or "notnull") && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => (r.SymbolName is "allows" or "ref" or "unmanaged" or "notnull") && r.ReferenceKind == "type_reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6551,6 +6551,48 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinKnownClassConstructorCalls_AreInstantiate()
+    {
+        // Kotlin has no `new` keyword, so same-file class constructor calls such as
+        // `User(1)` should mirror C# / Java constructor search by emitting `instantiate`.
+        // PascalCase functions and annotations must remain `call` / `annotation`.
+        // Kotlin には `new` がないため、同一ファイル class の `User(1)` のような
+        // constructor 呼び出しを C# / Java と同じく `instantiate` として検索可能にする。
+        // PascalCase function と annotation は `call` / `annotation` のままにする。
+        const string content = """
+            class User(val id: Int)
+            data class Profile(val name: String)
+            annotation class Marker
+
+            fun Build(): User = User(1)
+
+            @Marker()
+            fun decorated() {}
+
+            class Service {
+                fun run() {
+                    val a = User(1)
+                    val b = Profile("p")
+                    Build()
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "instantiate" && r.Line == 5);
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "instantiate" && r.Line == 12);
+        Assert.Contains(references, r => r.SymbolName == "Profile" && r.ReferenceKind == "instantiate" && r.Line == 13);
+        Assert.DoesNotContain(references, r => r.SymbolName == "User" && r.ReferenceKind == "instantiate" && r.Line == 1);
+        Assert.DoesNotContain(references, r => r.SymbolName == "User" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "Build" && r.ReferenceKind == "call" && r.Line == 14);
+        Assert.DoesNotContain(references, r => r.SymbolName == "Build" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Marker" && r.ReferenceKind == "annotation" && r.Line == 7);
+        Assert.DoesNotContain(references, r => r.SymbolName == "Marker" && r.ReferenceKind == "instantiate");
+    }
+
+    [Fact]
     public void Extract_JavaInvalidNestedGenericParenlessInitializer_DoesNotEmitInstantiate()
     {
         // Java does not have collection/object initializer syntax, so the C#-only nested

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10941,6 +10941,45 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaDocLinks_CaptureTypeReferences()
+    {
+        const string content = """
+            package demo;
+
+            class User {
+                void save() {}
+            }
+
+            class Helper {}
+            class Hidden {}
+
+            class Service {
+                /**
+                 * Uses {@link User#save()} and {@linkplain java.util.List<User>}.
+                 * @see Helper
+                 * @see <a href="https://example.invalid">external</a>
+                 */
+                void run() {}
+
+                void other() {
+                    /** {@link Hidden} */
+                    int local = 0;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference" && r.ContainerName == "run");
+        Assert.Contains(references, r => r.SymbolName == "save" && r.ReferenceKind == "type_reference" && r.ContainerName == "run");
+        Assert.Contains(references, r => r.SymbolName == "List" && r.ReferenceKind == "type_reference" && r.ContainerName == "run");
+        Assert.Contains(references, r => r.SymbolName == "Helper" && r.ReferenceKind == "type_reference" && r.ContainerName == "run");
+        Assert.DoesNotContain(references, r => r.SymbolName == "href" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Hidden" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpTypePositions_CaptureTypeReferences()
     {
         // issue #256: base lists, declaration types, generic constraints, type tests,
@@ -19849,6 +19888,40 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r =>
             r.SymbolName == "class"
             && r.ReferenceKind == "call");
+    }
+
+    [Fact]
+    public void Extract_KotlinKDocLinks_CaptureTypeReferences()
+    {
+        const string content = """
+            class User
+            class Helper
+            class Hidden
+
+            class Service {
+                /**
+                 * Loads [User] and [User.name].
+                 * See [docs](https://example.invalid) and [alias][User].
+                 * @see Helper
+                 */
+                fun load() {}
+
+                fun other() {
+                    /** [Hidden] */
+                    val local = 0
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference" && r.ContainerName == "load");
+        Assert.Contains(references, r => r.SymbolName == "name" && r.ReferenceKind == "type_reference" && r.ContainerName == "load");
+        Assert.Contains(references, r => r.SymbolName == "Helper" && r.ReferenceKind == "type_reference" && r.ContainerName == "load");
+        Assert.DoesNotContain(references, r => r.SymbolName == "docs" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "alias" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Hidden" && r.ReferenceKind == "type_reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -19718,6 +19718,88 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharpJavaKotlinCatchClauses_CaptureExceptionTypeReferences()
+    {
+        const string csharp = """
+            class Service {
+                void Run() {
+                    try { Work(); }
+                    catch (System.IO.IOException ex) when (ex != null) { }
+                    catch (CustomException) { }
+                    catch (System.Exception @caught) { }
+                }
+            }
+            """;
+
+        var csharpSymbols = SymbolExtractor.Extract(1, "csharp", csharp);
+        var csharpReferences = ReferenceExtractor.Extract(1, "csharp", csharp, csharpSymbols);
+
+        Assert.Contains(csharpReferences, r =>
+            r.SymbolName == "IOException"
+            && r.ReferenceKind == "type_reference"
+            && r.ContainerName == "Run");
+        Assert.Contains(csharpReferences, r =>
+            r.SymbolName == "CustomException"
+            && r.ReferenceKind == "type_reference"
+            && r.ContainerName == "Run");
+        Assert.DoesNotContain(csharpReferences, r =>
+            r.SymbolName == "ex"
+            && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(csharpReferences, r =>
+            r.SymbolName == "caught"
+            && r.ReferenceKind == "type_reference");
+
+        const string java = """
+            class Service {
+                void run() {
+                    try { work(); }
+                    catch (final java.io.IOException | CustomException ex) { }
+                }
+            }
+            """;
+
+        var javaSymbols = SymbolExtractor.Extract(1, "java", java);
+        var javaReferences = ReferenceExtractor.Extract(1, "java", java, javaSymbols);
+
+        Assert.Contains(javaReferences, r =>
+            r.SymbolName == "IOException"
+            && r.ReferenceKind == "type_reference"
+            && r.ContainerName == "run");
+        Assert.Contains(javaReferences, r =>
+            r.SymbolName == "CustomException"
+            && r.ReferenceKind == "type_reference"
+            && r.ContainerName == "run");
+        Assert.DoesNotContain(javaReferences, r =>
+            r.SymbolName == "ex"
+            && r.ReferenceKind == "type_reference");
+
+        const string kotlin = """
+            class Service {
+                fun run() {
+                    try { work() }
+                    catch (ex: java.io.IOException) { }
+                    catch (_: CustomException) { }
+                }
+            }
+            """;
+
+        var kotlinSymbols = SymbolExtractor.Extract(1, "kotlin", kotlin);
+        var kotlinReferences = ReferenceExtractor.Extract(1, "kotlin", kotlin, kotlinSymbols);
+
+        Assert.Contains(kotlinReferences, r =>
+            r.SymbolName == "IOException"
+            && r.ReferenceKind == "type_reference"
+            && r.ContainerName == "run");
+        Assert.Contains(kotlinReferences, r =>
+            r.SymbolName == "CustomException"
+            && r.ReferenceKind == "type_reference"
+            && r.ContainerName == "run");
+        Assert.DoesNotContain(kotlinReferences, r =>
+            r.SymbolName == "ex"
+            && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_KotlinImportAlias_DoesNotEmitTypeReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1069,6 +1069,10 @@ public class ReferenceExtractorTests
                 public Supplier<J> make() {
                     return J::new;
                 }
+
+                public Supplier<java.util.Iterator<Integer>> iterator(List<Integer> xs) {
+                    return xs::iterator;
+                }
             }
             """;
 
@@ -1080,13 +1084,72 @@ public class ReferenceExtractorTests
             && r.ReferenceKind == "call"
             && r.ContainerName == "sum");
         Assert.Contains(references, r =>
+            r.SymbolName == "Integer"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("Integer::intValue", StringComparison.Ordinal)
+            && r.ContainerName == "sum");
+        Assert.Contains(references, r =>
             r.SymbolName == "toUpperCase"
             && r.ReferenceKind == "call"
+            && r.ContainerName == "names");
+        Assert.Contains(references, r =>
+            r.SymbolName == "String"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("String::toUpperCase", StringComparison.Ordinal)
             && r.ContainerName == "names");
         Assert.Contains(references, r =>
             r.SymbolName == "J"
             && r.ReferenceKind == "instantiate"
             && r.ContainerName == "make");
+        Assert.Contains(references, r =>
+            r.SymbolName == "iterator"
+            && r.ReferenceKind == "call"
+            && r.ContainerName == "iterator");
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "xs"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("xs::iterator", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_KotlinCallableReferences_TrackOwnerTypeReferences()
+    {
+        const string content = """
+            class User {
+                fun name(): String = "u"
+            }
+
+            class Worker {
+                fun wire(users: List<User>) {
+                    val names = users.map(User::name)
+                    val user = User()
+                    val bound = user::name
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "name"
+            && r.ReferenceKind == "call"
+            && r.Context.Contains("User::name", StringComparison.Ordinal)
+            && r.ContainerName == "wire");
+        Assert.Contains(references, r =>
+            r.SymbolName == "User"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("User::name", StringComparison.Ordinal)
+            && r.ContainerName == "wire");
+        Assert.Contains(references, r =>
+            r.SymbolName == "name"
+            && r.ReferenceKind == "call"
+            && r.Context.Contains("user::name", StringComparison.Ordinal)
+            && r.ContainerName == "wire");
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "user"
+            && r.ReferenceKind == "type_reference"
+            && r.Context.Contains("user::name", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12708,6 +12708,33 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaAnnotatedFinalInstanceof_CapturesTypeReference()
+    {
+        // Java pattern instanceof can put modifiers and type-use annotations before the tested
+        // type; those prefixes should not hide the real dependency or become type references.
+        // Java の pattern instanceof では型の前に modifier / type-use annotation が置けるため、
+        // prefix で実型の依存を落としたり注釈名を型参照化したりしてはならない。
+        const string content = """
+            @interface NonNull {}
+            class Payload {}
+
+            class Demo {
+                boolean run(Object value) {
+                    return value instanceof final @NonNull Payload payload;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "NonNull" && r.ReferenceKind == "annotation");
+        Assert.DoesNotContain(references, r => r.SymbolName == "NonNull" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "final" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_KotlinTypeUseAnnotations_DoNotBecomeTypeReferences()
     {
         // Kotlin type-use annotations should mirror Java type expressions: the annotation

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10791,18 +10791,22 @@ public class ReferenceExtractorTests
     [Fact]
     public void Extract_CsharpTypeof_HandlesGenericAndArrayArguments()
     {
-        // typeof(List<int>) should capture `List`; the lexer skips `<int>` because `int` is a
-        // built-in C# alias that must never appear as a type_reference row.
-        // typeof(List<int>) は `List` を拾い、`<int>` 内の C# built-in alias はスキップする。
+        // typeof(List<Payload>) should capture both `List` and the nested generic argument.
+        // C# built-in aliases inside generic arguments still must never appear as rows.
+        // typeof(List<Payload>) は `List` と nested generic argument の両方を拾う。
+        // generic 引数内の C# built-in alias は引き続きスキップする。
         const string content = """
             using System.Collections.Generic;
+
+            public class Payload {}
 
             public class Caller
             {
                 public void Work()
                 {
-                    var t1 = typeof(List<int>);
-                    var t2 = typeof(System.Collections.Generic.Dictionary<string, int>);
+                    var t1 = typeof(List<Payload>);
+                    var t2 = typeof(System.Collections.Generic.Dictionary<string, Payload[]>);
+                    var t3 = typeof(Dictionary<string, List<Payload>>);
                 }
             }
             """;
@@ -10811,6 +10815,7 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "List" && r.ReferenceKind == "type_reference");
+        Assert.True(references.Count(r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference") >= 3);
         // For dotted args, each segment gets its own row — preserves rename safety.
         // ドット付き引数は segment ごとに行を出す — rename 追跡のため。
         Assert.Contains(references, r => r.SymbolName == "System" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1238,6 +1238,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaGenericThrows_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            package demo;
+
+            class Failure extends Exception {}
+            class Demo {
+                public <E extends Failure> void run() throws E {}
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Failure" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "E" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_KotlinCallableReferences_TrackOwnerTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12962,6 +12962,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinUseSiteTypeAnnotations_DoNotBecomeTypeReferences()
+    {
+        // Kotlin use-site targets are prefixes on annotations, not part of the annotated type.
+        // The annotation should stay metadata and the following type should remain the dependency.
+        const string content = """
+            annotation class Fancy
+            class Payload
+
+            class Demo {
+                val value: @field:Fancy Payload = Payload()
+                fun run(input: @receiver:Fancy Payload): @param:Fancy Payload = input
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.True(references.Count(r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference") >= 3);
+        Assert.True(references.Count(r => r.SymbolName == "Fancy" && r.ReferenceKind == "annotation") >= 3);
+        Assert.DoesNotContain(references, r => r.SymbolName == "Fancy" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => (r.SymbolName is "field" or "receiver" or "param") && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12733,6 +12733,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinExtensionFunctionReceivers_CaptureTypeReferences()
+    {
+        // Kotlin extension receivers are type-position dependencies just like parameters and
+        // return types; `fun User.render()` should make `references User` find the extension.
+        // Kotlin の extension receiver は parameter / return type と同じ型位置の依存であり、
+        // `fun User.render()` でも `references User` から拡張関数へ辿れる必要がある。
+        const string content = """
+            class User
+            class Box<T>
+
+            fun User.render() {}
+            fun Box<User>.unwrap() {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.True(references.Count(r => r.SymbolName == "User" && r.ReferenceKind == "type_reference") >= 2);
+        Assert.Contains(references, r => r.SymbolName == "Box" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12708,6 +12708,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinTypeUseAnnotations_DoNotBecomeTypeReferences()
+    {
+        // Kotlin type-use annotations should mirror Java type expressions: the annotation
+        // itself is metadata, while the annotated type remains the dependency edge.
+        // Kotlin の type-use annotation も Java と同様に metadata として扱い、
+        // 注釈名を type_reference にせず、注釈された型だけを依存として残す。
+        const string content = """
+            annotation class Fancy
+            class Payload
+
+            class Demo {
+                val value: @Fancy Payload = Payload()
+                fun run(input: @Fancy Payload): @Fancy Payload = input
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.True(references.Count(r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference") >= 3);
+        Assert.Contains(references, r => r.SymbolName == "Fancy" && r.ReferenceKind == "annotation");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Fancy" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13192,6 +13192,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinGenericClassLiterals_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            class User
+
+            inline fun <reified T> genericKClass() = T::class
+            fun userKClass() = User::class
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "T" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpWhereConstraintKeywords_DoNotBecomeTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1112,6 +1112,41 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaArrayConstructorMethodReferences_NormalizesOwnerType()
+    {
+        const string content = """
+            package demo;
+
+            public class Widget {}
+
+            public class Factory {
+                public Object make() {
+                    return Widget[]::new;
+                }
+
+                public Object makeNested() {
+                    return demo.Widget[][]::new;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "Widget"
+            && r.ReferenceKind == "instantiate"
+            && r.Context.Contains("Widget[]::new", StringComparison.Ordinal)
+            && r.ContainerName == "make");
+        Assert.Contains(references, r =>
+            r.SymbolName == "demo.Widget"
+            && r.ReferenceKind == "instantiate"
+            && r.Context.Contains("demo.Widget[][]::new", StringComparison.Ordinal)
+            && r.ContainerName == "makeNested");
+        Assert.DoesNotContain(references, r => r.SymbolName.Contains("[]", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_KotlinCallableReferences_TrackOwnerTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12885,6 +12885,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinBacktickMethodReferenceNames_NormalizesCallNames()
+    {
+        // Backticked Kotlin callable names are source syntax; method-reference call edges should
+        // use the same canonical name as the callable declaration.
+        // Kotlin callable 名の backtick は source syntax なので、method reference の call edge も
+        // 宣言側と同じ canonical 名で発行する。
+        const string content = """
+            class User {
+                fun `render name`() {}
+            }
+
+            class Demo {
+                val handler = User::`render name`
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(symbols, s => s.Name == "render name" && s.Kind == "function");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "render name" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "`render name`" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13175,6 +13175,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinGenericTypeOperators_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            class User
+
+            inline fun <reified T> accepts(value: Any): Boolean = value is T
+            fun parse(value: Any): User = value as User
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "T" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpWhereConstraintKeywords_DoNotBecomeTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13233,6 +13233,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpGenericTypeOperators_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            class User {}
+
+            class Demo {
+                public static bool Is<T>(object value) => value is T;
+                public static bool IsEither<T>(object value) => value is T or User;
+                public static User Cast(object value) => value as User;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "T" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12806,6 +12806,36 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinBacktickTypeReferences_NormalizesNames()
+    {
+        // Kotlin declaration names already strip source-only backticks; type-position
+        // references need the same canonical name so dependency search joins them.
+        // Kotlin の宣言名は source-only な backtick を外しているため、型位置参照も同じ
+        // canonical 名で発行し、依存検索で宣言と結合できるようにする。
+        const string content = """
+            class `Display Name`
+            class Holder<T>
+
+            class Demo {
+                val first: `Display Name` = TODO()
+                val second: Holder<`Display Name`> = TODO()
+                val third: `Display Name`? = null
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(symbols, s => s.Name == "Display Name" && s.Kind == "class");
+        var displayNameTypeReferenceCount = references.Count(r => r.SymbolName == "Display Name" && r.ReferenceKind == "type_reference");
+        Assert.True(
+            displayNameTypeReferenceCount >= 3,
+            $"Expected at least 3 Display Name type references, got {displayNameTypeReferenceCount}.");
+        Assert.Contains(references, r => r.SymbolName == "Holder" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "`Display Name`" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -6522,6 +6522,41 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpGenericInvocationTypeArguments_AreTypeReferences()
+    {
+        const string content = """
+            using System.Collections.Generic;
+
+            namespace Demo;
+
+            public sealed class Payload { }
+            public sealed class Result { }
+
+            public static class Helper
+            {
+                public static void DoWork<T>() { }
+            }
+
+            public class Builder
+            {
+                public void Build()
+                {
+                    var a = new List<Payload>();
+                    Helper.DoWork<List<Result>>();
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference" && r.Line == 17);
+        Assert.Contains(references, r => r.SymbolName == "List" && r.ReferenceKind == "type_reference" && r.Line == 18);
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference" && r.Line == 18);
+        Assert.DoesNotContain(references, r => r.SymbolName == "T" && r.ReferenceKind == "type_reference" && r.Line == 10);
+    }
+
+    [Fact]
     public void Extract_JavaNestedGenericConstructors_AreInstantiate()
     {
         // Regression (issue #263): Java constructor calls with nested generic type args
@@ -6548,6 +6583,37 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "ArrayList" && r.ReferenceKind == "instantiate" && r.Line == 8);
         Assert.DoesNotContain(references, r => r.SymbolName == "HashMap" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "ArrayList" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
+    public void Extract_JavaGenericInvocationTypeArguments_AreTypeReferences()
+    {
+        const string content = """
+            import java.util.Collections;
+            import java.util.HashMap;
+            import java.util.List;
+
+            class Payload {}
+            class Result {}
+
+            class Worker {
+                <T> T read() { return null; }
+
+                void run() {
+                    var a = new HashMap<String, List<Payload>>();
+                    var b = Collections.<Result>emptyList();
+                    var c = this.<Payload>read();
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference" && r.Line == 12);
+        Assert.Contains(references, r => r.SymbolName == "List" && r.ReferenceKind == "type_reference" && r.Line == 12);
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference" && r.Line == 13);
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference" && r.Line == 14);
     }
 
     [Fact]
@@ -6590,6 +6656,32 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "Build" && r.ReferenceKind == "instantiate");
         Assert.Contains(references, r => r.SymbolName == "Marker" && r.ReferenceKind == "annotation" && r.Line == 7);
         Assert.DoesNotContain(references, r => r.SymbolName == "Marker" && r.ReferenceKind == "instantiate");
+    }
+
+    [Fact]
+    public void Extract_KotlinGenericInvocationTypeArguments_AreTypeReferences()
+    {
+        const string content = """
+            class Payload
+            class Result
+            class Box<T>
+
+            fun <T> read(): T = TODO()
+
+            class Worker {
+                fun run() {
+                    val box = Box<Payload>()
+                    val result = read<Result>()
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Box" && r.ReferenceKind == "instantiate" && r.Line == 9);
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference" && r.Line == 9);
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference" && r.Line == 10);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12986,6 +12986,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinVarianceTypeArguments_DoNotBecomeTypeReferences()
+    {
+        const string content = """
+            interface Producer<T>
+            interface Consumer<T>
+            class Payload
+
+            class Demo {
+                val produced: Producer<out Payload>? = null
+                val consumed: Consumer<in Payload>? = null
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Producer" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Consumer" && r.ReferenceKind == "type_reference");
+        Assert.True(references.Count(r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference") >= 2);
+        Assert.DoesNotContain(references, r => (r.SymbolName is "in" or "out") && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpShortAndTStyleTypeNames_CaptureTypeReferences()
     {
         // Regression for issue #644: real type names like `X` and `TResult` must not be

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1194,6 +1194,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_JavaGenericCallableSignatures_DoNotEmitTypeParameterReferences()
+    {
+        const string content = """
+            package demo;
+
+            interface Comparable<T> {}
+            class Payload {}
+
+            class Demo {
+                public <T extends Comparable<T>> T pick(T input, Comparable<T> fallback) {
+                    return input;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        var references = ReferenceExtractor.Extract(1, "java", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Comparable" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "T" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_KotlinCallableReferences_TrackOwnerTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12571,6 +12571,42 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Kotlin_NormalizesBacktickedSymbolNames()
+    {
+        var content = """
+            class `when` {
+                fun `is`(): Int = 1
+                val `value-name`: Int = 2
+            }
+
+            typealias `Alias Name` = `when`
+
+            enum class `enum` {
+                `mixed-case`
+            }
+
+            class Holder {
+                companion object `Factory Name` {
+                    fun `top level`(): String = "ok"
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "when");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "is" && s.ContainerName == "when");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "value-name" && s.ContainerName == "when");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Alias Name");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "enum");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "mixed-case" && s.ContainerName == "enum");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Holder");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Factory Name");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "top level" && s.ContainerName == "Factory Name");
+        Assert.DoesNotContain(symbols, s => s.Name.Contains('`'));
+    }
+
+    [Fact]
     public void Extract_Kotlin_DetectsTypealiasDeclarations()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -5209,6 +5209,32 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_NormalizesUnicodeEscapedIdentifierNames()
+    {
+        const string content = "namespace Demo.\\u004eames;\n\n"
+            + "public class \\u0046oo\n"
+            + "{\n"
+            + "    public int @\\u0063lass { get; set; }\n"
+            + "    public void \\u0042ar() { }\n"
+            + "}\n\n"
+            + "public enum \\u0043olor\n"
+            + "{\n"
+            + "    \\u0052ed,\n"
+            + "}\n";
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "Demo.Names");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Foo");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "class" && s.ContainerName == "Foo");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Bar" && s.ContainerName == "Foo");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Color");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Red" && s.ContainerName == "Color");
+        Assert.DoesNotContain(symbols, s => s.Name.Contains('\\'));
+        Assert.DoesNotContain(symbols, s => s.Name.Contains('@'));
+    }
+
+    [Fact]
     public void Extract_CSharp_NormalizesVerbatimQualifiedNamespaceAndImportNames()
     {
         var content = """
@@ -11735,6 +11761,25 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "UserService");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "getUser");
+    }
+
+    [Fact]
+    public void Extract_Java_NormalizesUnicodeEscapedIdentifierNames()
+    {
+        const string content = "package demo.\\u0061pp;\n\n"
+            + "public class \\u0046oo {\n"
+            + "    public void \\u0062ar() { }\n"
+            + "}\n\n"
+            + "public interface \\uuuu0041pi {\n"
+            + "}\n";
+
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "demo.app");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Foo");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "bar" && s.ContainerName == "Foo");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Api");
+        Assert.DoesNotContain(symbols, s => s.Name.Contains('\\'));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Suppress generic type-parameter self references across C#, Java, and Kotlin type-reference extraction.
- Add targeted coverage for C# generic signatures, type operators, and type keywords; Java callable, heritage, and throws clauses; Kotlin bounds, type operators, and class literals.
- Scope Kotlin generic parameter suppression to declaration generic clauses so normal type arguments such as `Box<User>` remain searchable.

## Validation
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release --no-build` (3768 passed, 3 skipped)
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check origin/main..HEAD`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Review
No blocking/actionable issues found.