### PR TITLE
[codex] Improve Rust reference extraction coverage

### DIFF
--- a/changelog.d/unreleased/+rust-as-cast-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-as-cast-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust `as` casts now index target types** — casts such as `value as User` and pointer casts record the real target type references for search and impact queries.
+
+## 日本語
+
+- **Rust の `as` cast が変換先型を index するようになりました** — `value as User` や pointer cast で、検索・影響調査に使える実型参照を記録します。

--- a/changelog.d/unreleased/+rust-associated-call-receiver-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-associated-call-receiver-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust associated-call receivers now emit type references** — calls such as `User::new()` and `Vec::<User>::new()` now keep the receiver type visible to reference search.
+
+## 日本語
+
+- **Rust の associated call receiver が type reference を出すようになりました** — `User::new()` や `Vec::<User>::new()` の receiver 型を参照検索で見つけられます。

--- a/changelog.d/unreleased/+rust-associated-type-binding-key-noise.fixed.md
+++ b/changelog.d/unreleased/+rust-associated-type-binding-key-noise.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust associated type binding keys no longer appear as type references** — `Future<Output = User>` keeps the real `Future`/`User` dependencies without indexing `Output` as a target type.
+
+## 日本語
+
+- **Rust associated type binding の key が type reference として出なくなりました** — `Future<Output = User>` では実依存の `Future`/`User` を残し、`Output` は対象型として索引しません。

--- a/changelog.d/unreleased/+rust-associated-type-bound-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-associated-type-bound-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust associated type bounds are now indexed** — declarations such as `type Item: Display + Debug` now expose their bound types as references alongside any default target type.
+
+## 日本語
+
+- **Rust の associated type bounds をインデックスするようになりました** — `type Item: Display + Debug` のような宣言で、default target 型に加えて bound 型も参照として辿れます。

--- a/changelog.d/unreleased/+rust-associated-value-receiver-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-associated-value-receiver-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust associated values now emit receiver type references** — non-call paths such as `User::DEFAULT` and `Result::<User, Error>::Ok` index the receiver and turbofish types without treating the value name as a type.
+
+## 日本語
+
+- **Rust associated value が receiver の type reference を出すようになりました** — `User::DEFAULT` や `Result::<User, Error>::Ok` で receiver と turbofish 型を索引し、値名自体は型として扱いません。

--- a/changelog.d/unreleased/+rust-attribute-annotation-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-attribute-annotation-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust attributes now surface as annotation references** — attribute heads such as `#[tokio::test]` and `#[serde(...)]` are now searchable without treating `derive(...)` as a runtime call.
+
+## 日本語
+
+- **Rust attribute を annotation reference として出すようになりました** — `#[tokio::test]` や `#[serde(...)]` のような attribute head を、`derive(...)` を runtime call と誤認せずに検索できます。

--- a/changelog.d/unreleased/+rust-cfg-attr-derive-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-cfg-attr-derive-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust `cfg_attr(..., derive(...))` traits are now indexed** — conditional derives now contribute the same trait type references as direct `derive` attributes.
+
+## 日本語
+
+- **Rust の `cfg_attr(..., derive(...))` trait を index するようになりました** — 条件付き derive でも、直接の `derive` 属性と同じ trait 型参照を記録します。

--- a/changelog.d/unreleased/+rust-closure-signature-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-closure-signature-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust closure signatures now emit type references** — typed closure parameters and explicit closure return types are indexed so closure-local dependencies participate in search and impact analysis.
+
+## 日本語
+
+- **Rust closure signature が type reference を出すようになりました** — 型付き closure 引数と明示的な戻り値型を索引し、closure 内の依存も検索と影響分析に反映します。

--- a/changelog.d/unreleased/+rust-const-static-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-const-static-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust `const` and `static` item types are now indexed as type references** — declarations such as `const GLOBAL: Arc<User>` and `static mut STATE: Option<State>` now contribute their annotated types to reference search and inspection workflows.
+
+## 日本語
+
+- **Rust の `const` / `static` item の型を type reference としてインデックスするようになりました** — `const GLOBAL: Arc<User>` や `static mut STATE: Option<State>` のような宣言で、注釈された型を参照検索や inspect ワークフローから辿れます。

--- a/changelog.d/unreleased/+rust-derive-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-derive-type-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust derive traits are now indexed as type references** — `#[derive(Debug, Clone, serde::Serialize)]` now exposes the derived trait names to reference search and inspection.
+
+## 日本語
+
+- **Rust derive trait を type reference としてインデックスするようになりました** — `#[derive(Debug, Clone, serde::Serialize)]` の derive 対象 trait 名を reference search や inspect から辿れます。

--- a/changelog.d/unreleased/+rust-enum-variant-payload-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-enum-variant-payload-type-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust enum variant payload types are now indexed** — tuple and struct-style variants such as `Created(User)` and `Moved { from: Point }` now expose their payload types as references attached to the enum.
+
+## 日本語
+
+- **Rust enum variant の payload 型をインデックスするようになりました** — `Created(User)` や `Moved { from: Point }` のような tuple / struct 形式の variant で、payload 型を enum に紐づく参照として辿れます。

--- a/changelog.d/unreleased/+rust-extern-crate-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-extern-crate-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust `extern crate` declarations now emit references** — crate names from `extern crate` items are recorded for reference search without treating aliases as types.
+
+## 日本語
+
+- **Rust の `extern crate` 宣言が reference を出すようになりました** — `extern crate` item の crate 名を参照検索に記録し、alias は型として扱いません。

--- a/changelog.d/unreleased/+rust-function-trait-bound-return-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-function-trait-bound-return-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust function-trait bound return types are now indexed** — `F: FnOnce() -> Result<User, Error>` and matching `where` clauses keep the `Result`/payload return dependencies visible.
+
+## 日本語
+
+- **Rust function-trait bound の戻り値型が索引されるようになりました** — `F: FnOnce() -> Result<User, Error>` や同等の `where` 句で `Result` と payload の戻り値依存を保持します。

--- a/changelog.d/unreleased/+rust-generic-default-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-generic-default-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust generic default types are now indexed** — default type arguments such as `T = User` in generic parameter lists now emit type references.
+
+## 日本語
+
+- **Rust generic default 型を index するようになりました** — generic parameter list の `T = User` のような default 型を type reference として記録します。

--- a/changelog.d/unreleased/+rust-glob-import-parent-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-glob-import-parent-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust glob imports now reference their parent module** — `use crate::prelude::*;` records `prelude` instead of dropping the import target at `*`.
+
+## 日本語
+
+- **Rust glob import が親 module を reference として出すようになりました** — `use crate::prelude::*;` で `*` に到達して捨てず、`prelude` を記録します。

--- a/changelog.d/unreleased/+rust-hrtb-for-noise.fixed.md
+++ b/changelog.d/unreleased/+rust-hrtb-for-noise.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust higher-ranked trait bounds keep their real bound types visible** — lifetime binders such as `for<'a>` are masked without erasing `Fn`/payload types or emitting `for` as a type reference.
+
+## 日本語
+
+- **Rust の higher-ranked trait bound で実際の bound 型が残るようになりました** — `for<'a>` のような lifetime binder で `Fn` や payload 型を消さず、`for` も type reference として出さないようにしました。

--- a/changelog.d/unreleased/+rust-lifetime-type-ref-noise.fixed.md
+++ b/changelog.d/unreleased/+rust-lifetime-type-ref-noise.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust lifetime names no longer appear as type references** — lifetime markers such as `'a` are skipped while preserving the surrounding real types.
+
+## 日本語
+
+- **Rust lifetime 名が type reference として出ないようになりました** — `'a` などの lifetime marker を除外しつつ、周辺の実型は保持します。

--- a/changelog.d/unreleased/+rust-mod-declaration-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-mod-declaration-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust external module declarations now emit references** — semicolon-style `mod users;` declarations are searchable as module references.
+
+## 日本語
+
+- **Rust の外部 module 宣言が reference を出すようになりました** — `mod users;` のような semicolon 付き宣言を module 参照として検索できます。

--- a/changelog.d/unreleased/+rust-path-qualified-impl-symbols.fixed.md
+++ b/changelog.d/unreleased/+rust-path-qualified-impl-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Rust path-qualified `impl` blocks now attach to the implementing type** — `impl crate::models::Widget {}` and trait impls for qualified targets now surface `Widget` instead of a path prefix as the searchable impl symbol.
+
+## 日本語
+
+- **Rust の path-qualified な `impl` block を実装対象の型へ紐づけるようになりました** — `impl crate::models::Widget {}` や修飾付き target の trait impl で、検索対象の impl シンボルが path prefix ではなく `Widget` になります。

--- a/changelog.d/unreleased/+rust-qualified-associated-call-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-qualified-associated-call-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust fully-qualified associated calls now emit receiver and trait type references** — `<User as Service>::handle()` indexes both `User` and `Service`.
+
+## 日本語
+
+- **Rust fully-qualified associated call が receiver と trait の type reference を出すようになりました** — `<User as Service>::handle()` で `User` と `Service` の両方を索引します。

--- a/changelog.d/unreleased/+rust-raw-identifier-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-raw-identifier-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust raw identifiers now normalize in type references** — type-position references such as `r#type` and `crate::r#type` are indexed under the usable symbol name instead of leaking a phantom `r` segment.
+
+## 日本語
+
+- **Rust raw identifier を型参照でも正規化するようになりました** — `r#type` や `crate::r#type` のような型位置の参照を、phantom な `r` ではなく実際に検索できるシンボル名でインデックスします。

--- a/changelog.d/unreleased/+rust-self-associated-noise.fixed.md
+++ b/changelog.d/unreleased/+rust-self-associated-noise.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust `Self` associated calls no longer create self type edges** — `Self::new()` and `Self { ... }` stop emitting `Self` as an external type reference or instantiation while concrete receivers remain indexed.
+
+## 日本語
+
+- **Rust の `Self` associated call が自己 type edge を出さなくなりました** — `Self::new()` や `Self { ... }` は `Self` を外部 type reference / instantiate として出さず、具体型 receiver は従来通り索引します。

--- a/changelog.d/unreleased/+rust-struct-literal-instantiates.fixed.md
+++ b/changelog.d/unreleased/+rust-struct-literal-instantiates.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust struct literals now emit instantiation references** — `User { ... }` and path-qualified struct literals are visible to reference and impact queries.
+
+## 日本語
+
+- **Rust の struct literal が instantiate reference を出すようになりました** — `User { ... }` や path-qualified struct literal を参照・影響調査で見つけられます。

--- a/changelog.d/unreleased/+rust-trait-alias-type-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-trait-alias-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust trait alias targets now emit type references** — dependencies in `trait Alias = Bound + Other;` declarations are indexed.
+
+## 日本語
+
+- **Rust trait alias の右辺が type reference を出すようになりました** — `trait Alias = Bound + Other;` 宣言内の依存型を索引します。

--- a/changelog.d/unreleased/+rust-trait-super-bound-return-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-trait-super-bound-return-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust trait superbound function returns are now indexed** — `trait Handler: FnOnce() -> User` keeps `User` visible as a type reference.
+
+## 日本語
+
+- **Rust trait superbound の function 戻り値型が索引されるようになりました** — `trait Handler: FnOnce() -> User` で `User` を type reference として保持します。

--- a/changelog.d/unreleased/+rust-tuple-constructor-instantiates.fixed.md
+++ b/changelog.d/unreleased/+rust-tuple-constructor-instantiates.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust tuple-style constructors now emit instantiation references** — `User(...)`, `Some(...)`, and `Ok(...)` are classified as construction edges instead of ordinary calls.
+
+## 日本語
+
+- **Rust の tuple-style constructor が instantiate reference を出すようになりました** — `User(...)`、`Some(...)`、`Ok(...)` を通常 call ではなく構築エッジとして分類します。

--- a/changelog.d/unreleased/+rust-type-alias-target-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-type-alias-target-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust type aliases now index their target types** — aliases such as `type UserMap = HashMap<Key, User>` now expose the right-hand-side types as references for search, inspect, and dependency workflows.
+
+## 日本語
+
+- **Rust の type alias が target 型をインデックスするようになりました** — `type UserMap = HashMap<Key, User>` のような alias で、右辺の型を search / inspect / dependency ワークフローから参照できます。

--- a/changelog.d/unreleased/+rust-type-modifier-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-type-modifier-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust type modifiers no longer appear as type references** — keywords such as `impl`, `dyn`, `const`, `mut`, and the `'static` lifetime are filtered from type-reference results while preserving the real surrounding types.
+
+## 日本語
+
+- **Rust の型 modifier が type reference として出ないようになりました** — `impl`、`dyn`、`const`、`mut`、`'static` lifetime などのキーワードを型参照結果から除外しつつ、周辺の実型は保持します。

--- a/changelog.d/unreleased/+rust-use-reference-refs.fixed.md
+++ b/changelog.d/unreleased/+rust-use-reference-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust `use` imports now emit references** — imported target names from simple and grouped `use` statements are recorded as references without indexing aliases as types.
+
+## 日本語
+
+- **Rust の `use` import が reference を出すようになりました** — simple/grouped `use` の import target 名を参照として記録し、alias は型として扱いません。

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -1362,6 +1362,15 @@ internal static class RustReferenceExtractor
                 context,
                 lineNumber,
                 resolveContainerForColumn);
+            EmitGenericFunctionTraitReturnTypeReferences(
+                preparedLine,
+                genericOpenIndex,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
         }
 
         TypedLanguageReferenceExtractor.EmitWhereClauseTypeReferences(
@@ -1373,6 +1382,108 @@ internal static class RustReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+        EmitWhereClauseFunctionTraitReturnTypeReferences(
+            preparedLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
+
+    private static void EmitGenericFunctionTraitReturnTypeReferences(
+        string preparedLine,
+        int genericOpenIndex,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var genericCloseIndex = FindRustGenericClose(preparedLine, genericOpenIndex);
+        if (genericCloseIndex <= genericOpenIndex)
+            return;
+
+        var clause = preparedLine.Substring(genericOpenIndex + 1, genericCloseIndex - genericOpenIndex - 1);
+        EmitFunctionTraitReturnTypesFromBoundClause(
+            clause,
+            genericOpenIndex + 1,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn);
+    }
+
+    private static void EmitWhereClauseFunctionTraitReturnTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var whereIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "where"))
+        {
+            var clauseStart = whereIndex + "where".Length;
+            var clauseEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, clauseStart, stopAtComma: false, stopAtArrow: false);
+            if (clauseEnd <= clauseStart)
+                clauseEnd = preparedLine.Length;
+
+            EmitFunctionTraitReturnTypesFromBoundClause(
+                preparedLine.Substring(clauseStart, clauseEnd - clauseStart),
+                clauseStart,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+        }
+    }
+
+    private static void EmitFunctionTraitReturnTypesFromBoundClause(
+        string clause,
+        int clauseStart,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(clause))
+        {
+            var fragment = clause.Substring(segmentStart, segmentLength);
+            var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(fragment, ':');
+            if (colonIndex < 0)
+                continue;
+
+            var arrowIndex = TypedLanguageReferenceExtractor.FindTopLevelSequence(fragment, "->", colonIndex + 1);
+            if (arrowIndex < 0)
+                continue;
+
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, arrowIndex + 2);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart, stopAtArrow: false);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteStart = clauseStart + segmentStart + typeStart;
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                absoluteStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(absoluteStart));
+        }
     }
 
     private static void EmitGenericDefaultTypeReferences(
@@ -1385,7 +1496,7 @@ internal static class RustReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
     {
-        var genericCloseIndex = ReferenceExtractor.FindMatchingChar(preparedLine, genericOpenIndex, '<', '>');
+        var genericCloseIndex = FindRustGenericClose(preparedLine, genericOpenIndex);
         if (genericCloseIndex <= genericOpenIndex)
             return;
 
@@ -1414,6 +1525,34 @@ internal static class RustReferenceExtractor
                 lineNumber,
                 resolveContainerForColumn(absoluteStart));
         }
+    }
+
+    private static int FindRustGenericClose(string text, int openIndex)
+    {
+        var depth = 0;
+        for (var index = openIndex; index < text.Length; index++)
+        {
+            if (text[index] == '-' && index + 1 < text.Length && text[index + 1] == '>')
+            {
+                index++;
+                continue;
+            }
+
+            if (text[index] == '<')
+            {
+                depth++;
+                continue;
+            }
+
+            if (text[index] != '>')
+                continue;
+
+            depth--;
+            if (depth == 0)
+                return index;
+        }
+
+        return -1;
     }
 
     public static string NormalizeIdentifier(string identifier)

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -1125,6 +1125,33 @@ internal static class RustReferenceExtractor
         return index >= 0 && line[index] == '#';
     }
 
+    public static bool IsLikelyInstantiationCallName(string originalName, string normalizedName, string line, int callIndex)
+    {
+        var normalizedLeaf = LastPathSegment(normalizedName);
+        var originalLeaf = LastPathSegment(originalName);
+        if (!IsLikelyRustTypePathLeaf(originalLeaf) && !IsLikelyRustTypePathLeaf(normalizedLeaf))
+            return false;
+
+        var afterName = callIndex + originalName.Length;
+        while (afterName < line.Length && char.IsWhiteSpace(line[afterName]))
+            afterName++;
+
+        if (afterName >= line.Length)
+            return false;
+
+        if (line[afterName] == '!')
+            return false;
+
+        return line[afterName] is '(' or '<'
+               || (afterName + 1 < line.Length && line[afterName] == ':' && line[afterName + 1] == ':');
+    }
+
+    private static string LastPathSegment(string name)
+    {
+        var leafStart = name.LastIndexOf("::", StringComparison.Ordinal);
+        return leafStart >= 0 ? name[(leafStart + 2)..] : name;
+    }
+
     public static bool IsRawIdentifierPrefix(string line, int callIndex) =>
         callIndex >= 2
         && line[callIndex - 2] == 'r'

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -10,6 +10,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex DeriveAttributeRegex = new(
         @"#\s*!?\s*\[\s*derive\s*\((?<types>[^\)]*)\)",
         RegexOptions.Compiled);
+    private static readonly Regex AttributeHeadRegex = new(
+        $@"#\s*!?\s*\[\s*(?<name>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)",
+        RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -74,6 +77,16 @@ internal static class RustReferenceExtractor
                     lineNumber,
                     container);
             }
+        }
+
+        foreach (Match match in AttributeHeadRegex.Matches(preparedLine))
+        {
+            var nameGroup = match.Groups["name"];
+            var name = NormalizeIdentifier(nameGroup.Value);
+            if (string.Equals(name, "derive", StringComparison.Ordinal))
+                continue;
+
+            ReferenceExtractor.AddReference(references, seen, fileId, name, nameGroup.Index, "annotation", context, lineNumber, container);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -22,6 +22,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex ModuleDeclarationRegex = new(
         $@"^\s*(?:pub(?:\s*\([^\)]*\))?\s+)?mod\s+(?<name>{RustIdentifierPattern})\s*;",
         RegexOptions.Compiled);
+    private static readonly Regex UseStatementRegex = new(
+        @"^\s*(?:pub(?:\s*\([^\)]*\))?\s+)?use\s+(?<body>.+);",
+        RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -126,6 +129,7 @@ internal static class RustReferenceExtractor
         SymbolRecord? container,
         SymbolRecord? enumContainer)
     {
+        EmitUseReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitExternCrateReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitModuleDeclarationReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -139,6 +143,114 @@ internal static class RustReferenceExtractor
         EmitAsCastTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitUseReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = UseStatementRegex.Match(preparedLine);
+        if (!match.Success)
+            return;
+
+        var bodyGroup = match.Groups["body"];
+        EmitUseBodyReferences(bodyGroup.Value, bodyGroup.Index, references, seen, fileId, context, lineNumber, container, prefix: null);
+    }
+
+    private static void EmitUseBodyReferences(
+        string body,
+        int bodyStart,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        string? prefix)
+    {
+        var text = body.Trim();
+        if (text.Length == 0)
+            return;
+
+        var textStart = bodyStart + body.IndexOf(text, StringComparison.Ordinal);
+        var openBrace = text.IndexOf('{');
+        if (openBrace >= 0)
+        {
+            var closeBrace = text.LastIndexOf('}');
+            if (closeBrace > openBrace)
+            {
+                var groupedPrefix = CombineUsePath(prefix, text[..openBrace].Trim());
+                var inner = text.Substring(openBrace + 1, closeBrace - openBrace - 1);
+                foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(inner))
+                {
+                    EmitUseBodyReferences(
+                        inner.Substring(segmentStart, segmentLength),
+                        textStart + openBrace + 1 + segmentStart,
+                        references,
+                        seen,
+                        fileId,
+                        context,
+                        lineNumber,
+                        container,
+                        groupedPrefix);
+                }
+
+                return;
+            }
+        }
+
+        var aliasIndex = FindTopLevelUseAliasIndex(text);
+        var target = aliasIndex >= 0 ? text[..aliasIndex].Trim() : text;
+        if (target.Length == 0 || target is "crate" or "super" or "*")
+            return;
+
+        if (target == "self" && !string.IsNullOrWhiteSpace(prefix))
+            target = prefix;
+        else if (target == "self")
+            return;
+        else if (!string.IsNullOrWhiteSpace(prefix))
+            target = CombineUsePath(prefix, target);
+
+        var leafStart = target.LastIndexOf("::", StringComparison.Ordinal);
+        var leaf = leafStart >= 0 ? target[(leafStart + 2)..].Trim() : target.Trim();
+        if (leaf.Length == 0 || leaf is "crate" or "self" or "super" or "*")
+            return;
+
+        var leafIndex = text.IndexOf(leaf, StringComparison.Ordinal);
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            NormalizeIdentifier(leaf),
+            textStart + Math.Max(0, leafIndex),
+            "reference",
+            context,
+            lineNumber,
+            container);
+    }
+
+    private static int FindTopLevelUseAliasIndex(string text)
+    {
+        foreach (var asIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(text, "as"))
+            return asIndex;
+
+        return -1;
+    }
+
+    private static string CombineUsePath(string? prefix, string name)
+    {
+        var cleanedPrefix = prefix?.Trim().TrimEnd(':');
+        var cleanedName = name.Trim().TrimEnd(':');
+        if (string.IsNullOrWhiteSpace(cleanedPrefix))
+            return cleanedName;
+        if (string.IsNullOrWhiteSpace(cleanedName))
+            return cleanedPrefix;
+        return $"{cleanedPrefix}::{cleanedName}";
     }
 
     private static void EmitExternCrateReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -54,6 +54,7 @@ internal static class RustReferenceExtractor
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitConstStaticTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTypeAliasTargetReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitAssociatedTypeBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTupleStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -244,6 +245,45 @@ internal static class RustReferenceExtractor
                 context,
                 lineNumber,
                 resolveContainerForColumn(typeStart));
+        }
+    }
+
+    private static void EmitAssociatedTypeBoundReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var typeIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "type"))
+        {
+            var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':', typeIndex + "type".Length);
+            if (colonIndex < 0)
+                continue;
+
+            var assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=', typeIndex + "type".Length);
+            if (assignmentIndex >= 0 && assignmentIndex < colonIndex)
+                continue;
+
+            var boundsStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+            var boundsEnd = assignmentIndex > colonIndex
+                ? assignmentIndex
+                : TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, boundsStart);
+            if (boundsEnd <= boundsStart)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                preparedLine.Substring(boundsStart, boundsEnd - boundsStart),
+                boundsStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(boundsStart));
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -25,6 +25,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex UseStatementRegex = new(
         @"^\s*(?:pub(?:\s*\([^\)]*\))?\s+)?use\s+(?<body>.+);",
         RegexOptions.Compiled);
+    private static readonly Regex AssociatedCallReceiverRegex = new(
+        $@"(?<![\w$])(?<receiver>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:::\s*<(?<args>[^>\n]+)>)?::\s*{RustIdentifierPattern}(?:<[^>\n]+>)?\s*\(",
+        RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -141,6 +144,7 @@ internal static class RustReferenceExtractor
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitEnumVariantTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, enumContainer);
         EmitAsCastTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitAssociatedCallReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
@@ -823,6 +827,61 @@ internal static class RustReferenceExtractor
                 lineNumber,
                 resolveContainerForColumn(typeStart));
         }
+    }
+
+    private static void EmitAssociatedCallReceiverTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (Match match in AssociatedCallReceiverRegex.Matches(preparedLine))
+        {
+            var receiverGroup = match.Groups["receiver"];
+            var receiver = receiverGroup.Value;
+            var leafStart = receiver.LastIndexOf("::", StringComparison.Ordinal);
+            var leaf = leafStart >= 0 ? receiver[(leafStart + 2)..] : receiver;
+            var leafOffset = leafStart >= 0 ? leafStart + 2 : 0;
+            if (!IsLikelyRustTypePathLeaf(leaf))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                NormalizeIdentifier(leaf),
+                receiverGroup.Index + leafOffset,
+                "type_reference",
+                context,
+                lineNumber,
+                resolveContainerForColumn(receiverGroup.Index));
+
+            var argsGroup = match.Groups["args"];
+            if (!argsGroup.Success)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                argsGroup.Value,
+                argsGroup.Index,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(argsGroup.Index));
+        }
+    }
+
+    private static bool IsLikelyRustTypePathLeaf(string leaf)
+    {
+        if (leaf.StartsWith("r#", StringComparison.Ordinal))
+            return leaf.Length > 2 && IsRustIdentifierPart(leaf[2]);
+
+        return leaf.Length > 0 && char.IsUpper(leaf[0]);
     }
 
     private static void EmitImplAndTraitTypeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -959,14 +959,15 @@ internal static class RustReferenceExtractor
             var leafStart = receiver.LastIndexOf("::", StringComparison.Ordinal);
             var leaf = leafStart >= 0 ? receiver[(leafStart + 2)..] : receiver;
             var leafOffset = leafStart >= 0 ? leafStart + 2 : 0;
-            if (!IsLikelyRustTypePathLeaf(leaf))
+            var normalizedLeaf = NormalizeIdentifier(leaf);
+            if (normalizedLeaf == "Self" || !IsLikelyRustTypePathLeaf(leaf))
                 continue;
 
             ReferenceExtractor.AddReference(
                 references,
                 seen,
                 fileId,
-                NormalizeIdentifier(leaf),
+                normalizedLeaf,
                 receiverGroup.Index + leafOffset,
                 "type_reference",
                 context,
@@ -1018,14 +1019,15 @@ internal static class RustReferenceExtractor
             var leafStart = name.LastIndexOf("::", StringComparison.Ordinal);
             var leaf = leafStart >= 0 ? name[(leafStart + 2)..] : name;
             var leafOffset = leafStart >= 0 ? leafStart + 2 : 0;
-            if (!IsLikelyRustTypePathLeaf(leaf))
+            var normalizedLeaf = NormalizeIdentifier(leaf);
+            if (normalizedLeaf == "Self" || !IsLikelyRustTypePathLeaf(leaf))
                 continue;
 
             ReferenceExtractor.AddReference(
                 references,
                 seen,
                 fileId,
-                NormalizeIdentifier(leaf),
+                normalizedLeaf,
                 nameGroup.Index + leafOffset,
                 "instantiate",
                 context,

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -7,6 +7,9 @@ internal static class RustReferenceExtractor
 {
     private const string RustIdentifierPattern = @"(?:r#)?[_\p{L}][\w$]*";
     private static readonly string[] ConstStaticKeywords = ["const", "static"];
+    private static readonly Regex DeriveAttributeRegex = new(
+        @"#\s*!?\s*\[\s*derive\s*\((?<types>[^\)]*)\)",
+        RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -37,6 +40,40 @@ internal static class RustReferenceExtractor
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;
             addCallLikeReference(name, callIndex);
+        }
+    }
+
+    public static void EmitAttributeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in DeriveAttributeRegex.Matches(preparedLine))
+        {
+            var typesGroup = match.Groups["types"];
+            foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typesGroup.Value))
+            {
+                var fragment = typesGroup.Value.Substring(segmentStart, segmentLength);
+                var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, 0);
+                var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
+                if (typeEnd <= typeStart)
+                    continue;
+
+                TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                    fragment.Substring(typeStart, typeEnd - typeStart),
+                    typesGroup.Index + segmentStart + typeStart,
+                    "rust",
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+            }
         }
     }
 
@@ -680,6 +717,32 @@ internal static class RustReferenceExtractor
 
         var prefix = line[..callIndex].TrimEnd();
         return prefix.EndsWith("fn", StringComparison.Ordinal);
+    }
+
+    public static bool IsDeriveAttributeCallSite(string line, string name, int callIndex)
+    {
+        if (!string.Equals(name, "derive", StringComparison.Ordinal) || callIndex <= 0)
+            return false;
+
+        var index = callIndex - 1;
+        while (index >= 0 && char.IsWhiteSpace(line[index]))
+            index--;
+
+        if (index < 0 || line[index] != '[')
+            return false;
+
+        index--;
+        while (index >= 0 && char.IsWhiteSpace(line[index]))
+            index--;
+
+        if (index >= 0 && line[index] == '!')
+        {
+            index--;
+            while (index >= 0 && char.IsWhiteSpace(line[index]))
+                index--;
+        }
+
+        return index >= 0 && line[index] == '#';
     }
 
     public static bool IsRawIdentifierPrefix(string line, int callIndex) =>

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -109,6 +109,7 @@ internal static class RustReferenceExtractor
         EmitTupleStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitEnumVariantTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, enumContainer);
+        EmitAsCastTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
@@ -593,6 +594,43 @@ internal static class RustReferenceExtractor
             && line[startIndex] == 'r'
             && line[startIndex + 1] == '#'
             && IsRustIdentifierPart(line[startIndex + 2]);
+    }
+
+    private static void EmitAsCastTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var trimmed = preparedLine.TrimStart();
+        if (trimmed.StartsWith("use ", StringComparison.Ordinal)
+            || trimmed.StartsWith("pub use ", StringComparison.Ordinal)
+            || trimmed.StartsWith("extern crate ", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        foreach (var asIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "as"))
+        {
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, asIndex + "as".Length);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                preparedLine.Substring(typeStart, typeEnd - typeStart),
+                typeStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(typeStart));
+        }
     }
 
     private static void EmitImplAndTraitTypeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -19,6 +19,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex ExternCrateRegex = new(
         $@"^\s*(?:pub\s+)?extern\s+crate\s+(?<name>{RustIdentifierPattern})(?:\s+as\s+{RustIdentifierPattern})?\s*;",
         RegexOptions.Compiled);
+    private static readonly Regex ModuleDeclarationRegex = new(
+        $@"^\s*(?:pub(?:\s*\([^\)]*\))?\s+)?mod\s+(?<name>{RustIdentifierPattern})\s*;",
+        RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -124,6 +127,7 @@ internal static class RustReferenceExtractor
         SymbolRecord? enumContainer)
     {
         EmitExternCrateReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
+        EmitModuleDeclarationReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitConstStaticTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -147,6 +151,32 @@ internal static class RustReferenceExtractor
         SymbolRecord? container)
     {
         var match = ExternCrateRegex.Match(preparedLine);
+        if (!match.Success)
+            return;
+
+        var nameGroup = match.Groups["name"];
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            NormalizeIdentifier(nameGroup.Value),
+            nameGroup.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
+    }
+
+    private static void EmitModuleDeclarationReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = ModuleDeclarationRegex.Match(preparedLine);
         if (!match.Success)
             return;
 

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -139,6 +139,7 @@ internal static class RustReferenceExtractor
         EmitExternCrateReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitModuleDeclarationReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitClosureSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitConstStaticTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTypeAliasTargetReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -365,6 +366,81 @@ internal static class RustReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn(typeStart));
+    }
+
+    private static void EmitClosureSignatureTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchIndex = 0;
+        while (searchIndex < preparedLine.Length)
+        {
+            var openPipe = preparedLine.IndexOf('|', searchIndex);
+            if (openPipe < 0)
+                return;
+
+            var closePipe = preparedLine.IndexOf('|', openPipe + 1);
+            if (closePipe < 0)
+                return;
+
+            searchIndex = closePipe + 1;
+            var parameterList = preparedLine.Substring(openPipe + 1, closePipe - openPipe - 1);
+            var hasParameterTypes = TypedLanguageReferenceExtractor.FindTopLevelChar(parameterList, ':') >= 0;
+            var arrowIndex = TypedLanguageReferenceExtractor.FindTopLevelSequence(preparedLine, "->", closePipe + 1);
+            var hasImmediateReturnType = arrowIndex >= 0 && HasOnlyWhitespace(preparedLine, closePipe + 1, arrowIndex);
+            if (!hasParameterTypes && !hasImmediateReturnType)
+                continue;
+
+            if (hasParameterTypes)
+            {
+                TypedLanguageReferenceExtractor.EmitColonParameterTypeReferences(
+                    preparedLine,
+                    openPipe + 1,
+                    closePipe,
+                    "rust",
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn);
+            }
+
+            if (!hasImmediateReturnType)
+                continue;
+
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, arrowIndex + 2);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                preparedLine.Substring(typeStart, typeEnd - typeStart),
+                typeStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(typeStart));
+        }
+    }
+
+    private static bool HasOnlyWhitespace(string text, int startIndex, int endIndex)
+    {
+        for (var index = Math.Max(0, startIndex); index < endIndex && index < text.Length; index++)
+        {
+            if (!char.IsWhiteSpace(text[index]))
+                return false;
+        }
+
+        return true;
     }
 
     private static void EmitLetTypeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -48,7 +48,8 @@ internal static class RustReferenceExtractor
         string context,
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn,
-        SymbolRecord? container)
+        SymbolRecord? container,
+        SymbolRecord? enumContainer)
     {
         EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -57,6 +58,7 @@ internal static class RustReferenceExtractor
         EmitAssociatedTypeBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTupleStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
+        EmitEnumVariantTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, enumContainer);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
@@ -413,6 +415,135 @@ internal static class RustReferenceExtractor
 
     private static bool IsRustIdentifierPart(char ch) =>
         ch == '_' || ch == '$' || char.IsLetterOrDigit(ch);
+
+    private static void EmitEnumVariantTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? enumContainer)
+    {
+        if (enumContainer?.Kind != "enum")
+            return;
+
+        var variantStart = FirstNonWhitespaceIndex(preparedLine);
+        if (variantStart >= preparedLine.Length
+            || preparedLine[variantStart] is '}' or '#'
+            || !IsLikelyRustEnumVariantStart(preparedLine, variantStart))
+        {
+            return;
+        }
+
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(', variantStart);
+        var openBrace = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '{', variantStart);
+        if (openParen >= 0 && (openBrace < 0 || openParen < openBrace))
+        {
+            EmitEnumTupleVariantTypeReferences(preparedLine, openParen, references, seen, fileId, context, lineNumber, enumContainer);
+        }
+
+        if (openBrace >= 0)
+            EmitEnumStructVariantTypeReferences(preparedLine, openBrace, references, seen, fileId, context, lineNumber, enumContainer);
+    }
+
+    private static void EmitEnumTupleVariantTypeReferences(
+        string preparedLine,
+        int openParen,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord enumContainer)
+    {
+        var closeParen = ReferenceExtractor.FindMatchingChar(preparedLine, openParen, '(', ')');
+        if (closeParen <= openParen)
+            return;
+
+        var fieldList = preparedLine.Substring(openParen + 1, closeParen - openParen - 1);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(fieldList))
+        {
+            var fragment = fieldList.Substring(segmentStart, segmentLength);
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, 0);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteStart = openParen + 1 + segmentStart + typeStart;
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                absoluteStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                enumContainer);
+        }
+    }
+
+    private static void EmitEnumStructVariantTypeReferences(
+        string preparedLine,
+        int openBrace,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord enumContainer)
+    {
+        var closeBrace = ReferenceExtractor.FindMatchingChar(preparedLine, openBrace, '{', '}');
+        if (closeBrace <= openBrace)
+            return;
+
+        var fieldList = preparedLine.Substring(openBrace + 1, closeBrace - openBrace - 1);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(fieldList))
+        {
+            var fragment = fieldList.Substring(segmentStart, segmentLength);
+            var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(fragment, ':');
+            if (colonIndex < 0)
+                continue;
+
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, colonIndex + 1);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteStart = openBrace + 1 + segmentStart + typeStart;
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                absoluteStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                enumContainer);
+        }
+    }
+
+    private static int FirstNonWhitespaceIndex(string text)
+    {
+        var index = 0;
+        while (index < text.Length && char.IsWhiteSpace(text[index]))
+            index++;
+
+        return index;
+    }
+
+    private static bool IsLikelyRustEnumVariantStart(string line, int startIndex)
+    {
+        if (startIndex < line.Length && char.IsUpper(line[startIndex]))
+            return true;
+
+        return startIndex + 2 < line.Length
+            && line[startIndex] == 'r'
+            && line[startIndex + 1] == '#'
+            && IsRustIdentifierPart(line[startIndex + 2]);
+    }
 
     private static void EmitImplAndTraitTypeReferences(
         string preparedLine,

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -53,6 +53,7 @@ internal static class RustReferenceExtractor
         EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitConstStaticTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitTypeAliasTargetReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTupleStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -211,6 +212,39 @@ internal static class RustReferenceExtractor
             return startIndex;
 
         return afterMut;
+    }
+
+    private static void EmitTypeAliasTargetReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var typeIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "type"))
+        {
+            var assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=', typeIndex + "type".Length);
+            if (assignmentIndex < 0)
+                continue;
+
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, assignmentIndex + 1);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                preparedLine.Substring(typeStart, typeEnd - typeStart),
+                typeStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(typeStart));
+        }
     }
 
     private static void EmitTupleStructFieldTypeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -143,6 +143,7 @@ internal static class RustReferenceExtractor
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitConstStaticTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTypeAliasTargetReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitTraitAliasTargetReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitAssociatedTypeBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTupleStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
@@ -555,6 +556,39 @@ internal static class RustReferenceExtractor
         foreach (var typeIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "type"))
         {
             var assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=', typeIndex + "type".Length);
+            if (assignmentIndex < 0)
+                continue;
+
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, assignmentIndex + 1);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                preparedLine.Substring(typeStart, typeEnd - typeStart),
+                typeStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(typeStart));
+        }
+    }
+
+    private static void EmitTraitAliasTargetReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var traitIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "trait"))
+        {
+            var assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=', traitIndex + "trait".Length);
             if (assignmentIndex < 0)
                 continue;
 

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -221,8 +221,12 @@ internal static class RustReferenceExtractor
 
         var aliasIndex = FindTopLevelUseAliasIndex(text);
         var target = aliasIndex >= 0 ? text[..aliasIndex].Trim() : text;
-        if (target.Length == 0 || target is "crate" or "super" or "*")
+        if (target.Length == 0
+            || target is "crate" or "super"
+            || target == "*" && string.IsNullOrWhiteSpace(prefix))
+        {
             return;
+        }
 
         if (target == "self" && !string.IsNullOrWhiteSpace(prefix))
             target = prefix;
@@ -233,6 +237,16 @@ internal static class RustReferenceExtractor
 
         var leafStart = target.LastIndexOf("::", StringComparison.Ordinal);
         var leaf = leafStart >= 0 ? target[(leafStart + 2)..].Trim() : target.Trim();
+        if (leaf == "*")
+        {
+            if (leafStart < 0)
+                return;
+
+            var globParent = target[..leafStart].Trim();
+            var globParentLeafStart = globParent.LastIndexOf("::", StringComparison.Ordinal);
+            leaf = globParentLeafStart >= 0 ? globParent[(globParentLeafStart + 2)..].Trim() : globParent;
+        }
+
         if (leaf.Length == 0 || leaf is "crate" or "self" or "super" or "*")
             return;
 

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -6,6 +6,7 @@ namespace CodeIndex.Indexer;
 internal static class RustReferenceExtractor
 {
     private const string RustIdentifierPattern = @"(?:r#)?[_\p{L}][\w$]*";
+    private static readonly string[] ConstStaticKeywords = ["const", "static"];
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -51,6 +52,7 @@ internal static class RustReferenceExtractor
     {
         EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitConstStaticTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTupleStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -146,6 +148,69 @@ internal static class RustReferenceExtractor
                 lineNumber,
                 resolveContainerForColumn(typeStart));
         }
+    }
+
+    private static void EmitConstStaticTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (var keyword in ConstStaticKeywords)
+        {
+            foreach (var keywordIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, keyword))
+            {
+                var declarationStart = keywordIndex + keyword.Length;
+                if (keyword == "static")
+                    declarationStart = SkipOptionalRustMut(preparedLine, declarationStart);
+
+                var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':', declarationStart);
+                if (colonIndex < 0)
+                    continue;
+
+                var assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=', declarationStart);
+                if (assignmentIndex >= 0 && assignmentIndex < colonIndex)
+                    continue;
+
+                var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+                var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+                if (typeEnd <= typeStart)
+                    continue;
+
+                TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                    preparedLine.Substring(typeStart, typeEnd - typeStart),
+                    typeStart,
+                    "rust",
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(typeStart));
+            }
+        }
+    }
+
+    private static int SkipOptionalRustMut(string line, int startIndex)
+    {
+        var index = startIndex;
+        while (index < line.Length && char.IsWhiteSpace(line[index]))
+            index++;
+
+        if (index + "mut".Length > line.Length
+            || string.CompareOrdinal(line, index, "mut", 0, "mut".Length) != 0)
+        {
+            return startIndex;
+        }
+
+        var afterMut = index + "mut".Length;
+        if (afterMut < line.Length && IsRustIdentifierPart(line[afterMut]))
+            return startIndex;
+
+        return afterMut;
     }
 
     private static void EmitTupleStructFieldTypeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -10,6 +10,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex DeriveAttributeRegex = new(
         @"#\s*!?\s*\[\s*derive\s*\((?<types>[^\)]*)\)",
         RegexOptions.Compiled);
+    private static readonly Regex CfgAttrDeriveAttributeRegex = new(
+        @"#\s*!?\s*\[\s*cfg_attr\s*\(.*?\bderive\s*\((?<types>[^\)]*)\)",
+        RegexOptions.Compiled);
     private static readonly Regex AttributeHeadRegex = new(
         $@"#\s*!?\s*\[\s*(?<name>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)",
         RegexOptions.Compiled);
@@ -57,26 +60,12 @@ internal static class RustReferenceExtractor
     {
         foreach (Match match in DeriveAttributeRegex.Matches(preparedLine))
         {
-            var typesGroup = match.Groups["types"];
-            foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typesGroup.Value))
-            {
-                var fragment = typesGroup.Value.Substring(segmentStart, segmentLength);
-                var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, 0);
-                var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
-                if (typeEnd <= typeStart)
-                    continue;
+            EmitDeriveTypeList(match.Groups["types"], references, seen, fileId, context, lineNumber, container);
+        }
 
-                TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
-                    fragment.Substring(typeStart, typeEnd - typeStart),
-                    typesGroup.Index + segmentStart + typeStart,
-                    "rust",
-                    references,
-                    seen,
-                    fileId,
-                    context,
-                    lineNumber,
-                    container);
-            }
+        foreach (Match match in CfgAttrDeriveAttributeRegex.Matches(preparedLine))
+        {
+            EmitDeriveTypeList(match.Groups["types"], references, seen, fileId, context, lineNumber, container);
         }
 
         foreach (Match match in AttributeHeadRegex.Matches(preparedLine))
@@ -87,6 +76,36 @@ internal static class RustReferenceExtractor
                 continue;
 
             ReferenceExtractor.AddReference(references, seen, fileId, name, nameGroup.Index, "annotation", context, lineNumber, container);
+        }
+    }
+
+    private static void EmitDeriveTypeList(
+        Group typesGroup,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typesGroup.Value))
+        {
+            var fragment = typesGroup.Value.Substring(segmentStart, segmentLength);
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, 0);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                typesGroup.Index + segmentStart + typeStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -1061,6 +1061,15 @@ internal static class RustReferenceExtractor
                 context,
                 lineNumber,
                 resolveContainerForColumn);
+            EmitGenericDefaultTypeReferences(
+                preparedLine,
+                genericOpenIndex,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
         }
 
         TypedLanguageReferenceExtractor.EmitWhereClauseTypeReferences(
@@ -1072,6 +1081,47 @@ internal static class RustReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+    }
+
+    private static void EmitGenericDefaultTypeReferences(
+        string preparedLine,
+        int genericOpenIndex,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var genericCloseIndex = ReferenceExtractor.FindMatchingChar(preparedLine, genericOpenIndex, '<', '>');
+        if (genericCloseIndex <= genericOpenIndex)
+            return;
+
+        var clause = preparedLine.Substring(genericOpenIndex + 1, genericCloseIndex - genericOpenIndex - 1);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(clause))
+        {
+            var fragment = clause.Substring(segmentStart, segmentLength);
+            var assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(fragment, '=');
+            if (assignmentIndex < 0)
+                continue;
+
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, assignmentIndex + 1);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteStart = genericOpenIndex + 1 + segmentStart + typeStart;
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                absoluteStart,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(absoluteStart));
+        }
     }
 
     public static string NormalizeIdentifier(string identifier)

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -28,6 +28,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex AssociatedCallReceiverRegex = new(
         $@"(?<![\w$])(?<receiver>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:::\s*<(?<args>[^>\n]+)>)?::\s*{RustIdentifierPattern}(?:<[^>\n]+>)?\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex AssociatedValueReceiverRegex = new(
+        $@"(?<![\w$])(?<receiver>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:::\s*<(?<args>[^>\n]+)>)?::\s*{RustIdentifierPattern}(?!\s*::\s*<)(?!\s*[\(<])",
+        RegexOptions.Compiled);
     private static readonly Regex StructLiteralRegex = new(
         $@"(?<![\w$])(?<name>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:::\s*<(?<args>[^>\n]+)>)?\s*\{{",
         RegexOptions.Compiled);
@@ -151,6 +154,7 @@ internal static class RustReferenceExtractor
         EmitAsCastTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitQualifiedAssociatedCallReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitAssociatedCallReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitAssociatedValueReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitStructLiteralInstantiationReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, enumContainer);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -965,6 +969,54 @@ internal static class RustReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForColumn)
     {
         foreach (Match match in AssociatedCallReceiverRegex.Matches(preparedLine))
+        {
+            var receiverGroup = match.Groups["receiver"];
+            var receiver = receiverGroup.Value;
+            var leafStart = receiver.LastIndexOf("::", StringComparison.Ordinal);
+            var leaf = leafStart >= 0 ? receiver[(leafStart + 2)..] : receiver;
+            var leafOffset = leafStart >= 0 ? leafStart + 2 : 0;
+            var normalizedLeaf = NormalizeIdentifier(leaf);
+            if (normalizedLeaf == "Self" || !IsLikelyRustTypePathLeaf(leaf))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                normalizedLeaf,
+                receiverGroup.Index + leafOffset,
+                "type_reference",
+                context,
+                lineNumber,
+                resolveContainerForColumn(receiverGroup.Index));
+
+            var argsGroup = match.Groups["args"];
+            if (!argsGroup.Success)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                argsGroup.Value,
+                argsGroup.Index,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(argsGroup.Index));
+        }
+    }
+
+    private static void EmitAssociatedValueReceiverTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (Match match in AssociatedValueReceiverRegex.Matches(preparedLine))
         {
             var receiverGroup = match.Groups["receiver"];
             var receiver = receiverGroup.Value;

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -1329,6 +1329,20 @@ internal static class RustReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn(boundsStart));
+
+        var fullBoundsEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, boundsStart, stopAtArrow: false);
+        if (fullBoundsEnd > boundsStart)
+        {
+            EmitFunctionTraitReturnTypeFromExpression(
+                preparedLine.Substring(boundsStart, fullBoundsEnd - boundsStart),
+                boundsStart,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn);
+        }
     }
 
     private static void EmitGenericBoundReferences(
@@ -1484,6 +1498,38 @@ internal static class RustReferenceExtractor
                 lineNumber,
                 resolveContainerForColumn(absoluteStart));
         }
+    }
+
+    private static void EmitFunctionTraitReturnTypeFromExpression(
+        string expression,
+        int expressionStart,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var arrowIndex = TypedLanguageReferenceExtractor.FindTopLevelSequence(expression, "->");
+        if (arrowIndex < 0)
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(expression, arrowIndex + 2);
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(expression, typeStart, stopAtArrow: false);
+        if (typeEnd <= typeStart)
+            return;
+
+        var absoluteStart = expressionStart + typeStart;
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            expression.Substring(typeStart, typeEnd - typeStart),
+            absoluteStart,
+            "rust",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(absoluteStart));
     }
 
     private static void EmitGenericDefaultTypeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -149,6 +149,7 @@ internal static class RustReferenceExtractor
         EmitStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitEnumVariantTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, enumContainer);
         EmitAsCastTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitQualifiedAssociatedCallReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitAssociatedCallReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitStructLiteralInstantiationReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, enumContainer);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -776,6 +777,17 @@ internal static class RustReferenceExtractor
     private static bool IsRustIdentifierPart(char ch) =>
         ch == '_' || ch == '$' || char.IsLetterOrDigit(ch);
 
+    private static bool IsRustIdentifierStart(char ch) =>
+        ch == '_' || char.IsLetter(ch);
+
+    private static int SkipWhitespace(string text, int index)
+    {
+        while (index < text.Length && char.IsWhiteSpace(text[index]))
+            index++;
+
+        return index;
+    }
+
     private static void EmitEnumVariantTypeReferences(
         string preparedLine,
         List<ReferenceRecord> references,
@@ -989,6 +1001,108 @@ internal static class RustReferenceExtractor
                 lineNumber,
                 resolveContainerForColumn(argsGroup.Index));
         }
+    }
+
+    private static void EmitQualifiedAssociatedCallReceiverTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchIndex = 0;
+        while (searchIndex < preparedLine.Length)
+        {
+            var openAngle = preparedLine.IndexOf('<', searchIndex);
+            if (openAngle < 0)
+                return;
+
+            searchIndex = openAngle + 1;
+            var closeAngle = ReferenceExtractor.FindMatchingChar(preparedLine, openAngle, '<', '>');
+            if (closeAngle <= openAngle)
+                continue;
+
+            var afterClose = SkipWhitespace(preparedLine, closeAngle + 1);
+            if (afterClose + 2 > preparedLine.Length
+                || preparedLine[afterClose] != ':'
+                || preparedLine[afterClose + 1] != ':')
+            {
+                continue;
+            }
+
+            var methodStart = SkipWhitespace(preparedLine, afterClose + 2);
+            if (methodStart >= preparedLine.Length || !IsRustIdentifierStart(preparedLine[methodStart]))
+                continue;
+
+            var methodEnd = methodStart + 1;
+            while (methodEnd < preparedLine.Length && IsRustIdentifierPart(preparedLine[methodEnd]))
+                methodEnd++;
+
+            var callOpen = SkipWhitespace(preparedLine, methodEnd);
+            if (callOpen >= preparedLine.Length || preparedLine[callOpen] != '(')
+                continue;
+
+            var qualified = preparedLine.Substring(openAngle + 1, closeAngle - openAngle - 1);
+            foreach (var asIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(qualified, "as"))
+            {
+                EmitQualifiedAssociatedCallTypePart(
+                    qualified,
+                    openAngle + 1,
+                    0,
+                    asIndex,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn);
+                EmitQualifiedAssociatedCallTypePart(
+                    qualified,
+                    openAngle + 1,
+                    asIndex + "as".Length,
+                    qualified.Length,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn);
+                break;
+            }
+        }
+    }
+
+    private static void EmitQualifiedAssociatedCallTypePart(
+        string qualified,
+        int qualifiedStart,
+        int partStart,
+        int partEnd,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(qualified, partStart);
+        while (partEnd > typeStart && char.IsWhiteSpace(qualified[partEnd - 1]))
+            partEnd--;
+        if (partEnd <= typeStart)
+            return;
+
+        var absoluteStart = qualifiedStart + typeStart;
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            qualified.Substring(typeStart, partEnd - typeStart),
+            absoluteStart,
+            "rust",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(absoluteStart));
     }
 
     private static bool IsLikelyRustTypePathLeaf(string leaf)

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -16,6 +16,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex AttributeHeadRegex = new(
         $@"#\s*!?\s*\[\s*(?<name>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)",
         RegexOptions.Compiled);
+    private static readonly Regex ExternCrateRegex = new(
+        $@"^\s*(?:pub\s+)?extern\s+crate\s+(?<name>{RustIdentifierPattern})(?:\s+as\s+{RustIdentifierPattern})?\s*;",
+        RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -120,6 +123,7 @@ internal static class RustReferenceExtractor
         SymbolRecord? container,
         SymbolRecord? enumContainer)
     {
+        EmitExternCrateReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
         EmitFunctionSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitLetTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitConstStaticTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -131,6 +135,32 @@ internal static class RustReferenceExtractor
         EmitAsCastTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitExternCrateReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = ExternCrateRegex.Match(preparedLine);
+        if (!match.Success)
+            return;
+
+        var nameGroup = match.Groups["name"];
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            NormalizeIdentifier(nameGroup.Value),
+            nameGroup.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
     }
 
     private static void EmitFunctionSignatureTypeReferences(
@@ -627,7 +657,8 @@ internal static class RustReferenceExtractor
         var trimmed = preparedLine.TrimStart();
         if (trimmed.StartsWith("use ", StringComparison.Ordinal)
             || trimmed.StartsWith("pub use ", StringComparison.Ordinal)
-            || trimmed.StartsWith("extern crate ", StringComparison.Ordinal))
+            || trimmed.StartsWith("extern crate ", StringComparison.Ordinal)
+            || trimmed.StartsWith("pub extern crate ", StringComparison.Ordinal))
         {
             return;
         }

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -28,6 +28,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex AssociatedCallReceiverRegex = new(
         $@"(?<![\w$])(?<receiver>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:::\s*<(?<args>[^>\n]+)>)?::\s*{RustIdentifierPattern}(?:<[^>\n]+>)?\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex StructLiteralRegex = new(
+        $@"(?<![\w$])(?<name>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:::\s*<(?<args>[^>\n]+)>)?\s*\{{",
+        RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -145,6 +148,7 @@ internal static class RustReferenceExtractor
         EmitEnumVariantTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, enumContainer);
         EmitAsCastTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitAssociatedCallReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitStructLiteralInstantiationReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, enumContainer);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
@@ -882,6 +886,80 @@ internal static class RustReferenceExtractor
             return leaf.Length > 2 && IsRustIdentifierPart(leaf[2]);
 
         return leaf.Length > 0 && char.IsUpper(leaf[0]);
+    }
+
+    private static void EmitStructLiteralInstantiationReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        SymbolRecord? enumContainer)
+    {
+        if (enumContainer != null || IsRustTypeDeclarationLine(preparedLine))
+            return;
+
+        foreach (Match match in StructLiteralRegex.Matches(preparedLine))
+        {
+            var nameGroup = match.Groups["name"];
+            var name = nameGroup.Value;
+            var leafStart = name.LastIndexOf("::", StringComparison.Ordinal);
+            var leaf = leafStart >= 0 ? name[(leafStart + 2)..] : name;
+            var leafOffset = leafStart >= 0 ? leafStart + 2 : 0;
+            if (!IsLikelyRustTypePathLeaf(leaf))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                NormalizeIdentifier(leaf),
+                nameGroup.Index + leafOffset,
+                "instantiate",
+                context,
+                lineNumber,
+                resolveContainerForColumn(nameGroup.Index));
+
+            var argsGroup = match.Groups["args"];
+            if (!argsGroup.Success)
+                continue;
+
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                argsGroup.Value,
+                argsGroup.Index,
+                "rust",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(argsGroup.Index));
+        }
+    }
+
+    private static bool IsRustTypeDeclarationLine(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("pub", StringComparison.Ordinal))
+        {
+            var afterPub = "pub".Length;
+            if (afterPub < trimmed.Length && trimmed[afterPub] == '(')
+            {
+                var closeParen = ReferenceExtractor.FindMatchingChar(trimmed, afterPub, '(', ')');
+                if (closeParen > afterPub)
+                    trimmed = trimmed[(closeParen + 1)..].TrimStart();
+            }
+            else if (afterPub < trimmed.Length && char.IsWhiteSpace(trimmed[afterPub]))
+            {
+                trimmed = trimmed[afterPub..].TrimStart();
+            }
+        }
+
+        return trimmed.StartsWith("struct ", StringComparison.Ordinal)
+               || trimmed.StartsWith("enum ", StringComparison.Ordinal)
+               || trimmed.StartsWith("union ", StringComparison.Ordinal);
     }
 
     private static void EmitImplAndTraitTypeReferences(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1666,6 +1666,31 @@ public static partial class ReferenceExtractor
         for (int i = 0; i < expression.Length; i++)
         {
             char c = expression[i];
+            if (language == "rust"
+                && c == 'r'
+                && i + 2 < expression.Length
+                && expression[i + 1] == '#'
+                && IsJavaIdentifierStart(expression[i + 2]))
+            {
+                var rustSegmentStart = i;
+                i += 2;
+                var rawNameStart = i;
+                i++;
+                while (i < expression.Length && IsJavaIdentifierPart(expression[i]))
+                    i++;
+
+                var rustSegment = expression.Substring(rawNameStart, i - rawNameStart);
+                if (i + 1 < expression.Length && expression[i] == ':' && expression[i + 1] == ':')
+                {
+                    i++;
+                    continue;
+                }
+
+                AddTypeReferenceSegment(references, seen, fileId, rustSegment, expressionStartInLine + rustSegmentStart, context, lineNumber, container, language, ignoredSegments: ignoredSegments);
+                i--;
+                continue;
+            }
+
             if (language is "java" or "kotlin" && c == '@')
             {
                 i = SkipJavaAnnotation(expression, i);

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1728,6 +1728,12 @@ public static partial class ReferenceExtractor
             while (i < expression.Length && IsTypeExpressionIdentifierPart(language, expression[i]))
                 i++;
 
+            if (language == "rust" && segmentStart > 0 && expression[segmentStart - 1] == '\'')
+            {
+                i--;
+                continue;
+            }
+
             var rawSegment = expression.Substring(segmentStart, i - segmentStart);
             var isEscapedCSharpIdentifier = language == "csharp" && rawSegment.Length > 0 && rawSegment[0] == '@';
             var segment = rawSegment;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1686,7 +1686,7 @@ public static partial class ReferenceExtractor
                     continue;
                 }
 
-                AddTypeReferenceSegment(references, seen, fileId, rustSegment, expressionStartInLine + rustSegmentStart, context, lineNumber, container, language, ignoredSegments: ignoredSegments);
+                AddReference(references, seen, fileId, rustSegment, expressionStartInLine + rustSegmentStart, "type_reference", context, lineNumber, container);
                 i--;
                 continue;
             }

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1746,6 +1746,12 @@ public static partial class ReferenceExtractor
                 continue;
             }
 
+            if (language == "rust" && IsRustAssociatedTypeBindingKey(expression, i))
+            {
+                i--;
+                continue;
+            }
+
             if (i + 1 < expression.Length && expression[i] == ':' && expression[i + 1] == ':')
             {
                 i++;
@@ -1755,6 +1761,15 @@ public static partial class ReferenceExtractor
             AddTypeReferenceSegment(references, seen, fileId, segment, expressionStartInLine + segmentStart, context, lineNumber, container, language, isEscapedCSharpIdentifier, ignoredSegments);
             i--;
         }
+    }
+
+    private static bool IsRustAssociatedTypeBindingKey(string expression, int segmentEnd)
+    {
+        var index = segmentEnd;
+        while (index < expression.Length && char.IsWhiteSpace(expression[index]))
+            index++;
+
+        return index < expression.Length && expression[index] == '=';
     }
 
     private static void AddTypeScriptTypeExpressionSegments(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -1848,6 +1848,8 @@ public static partial class ReferenceExtractor
         var result = lang == "python"
             ? MaskPythonSingleLineFStrings(line)
             : line;
+        if (lang == "rust")
+            result = MaskRustLifetimeTokens(result);
         if (lang != "cobol")
         {
             var stringLiteralRegex = lang == "kotlin"
@@ -1905,6 +1907,38 @@ public static partial class ReferenceExtractor
         }
 
         return result;
+    }
+
+    private static string MaskRustLifetimeTokens(string line)
+    {
+        var quoteIndex = line.IndexOf('\'');
+        if (quoteIndex < 0)
+            return line;
+
+        var chars = line.ToCharArray();
+        for (var index = quoteIndex; index + 1 < chars.Length; index++)
+        {
+            if (chars[index] != '\'')
+                continue;
+
+            var next = chars[index + 1];
+            if (next != '_' && !char.IsLetter(next))
+                continue;
+
+            var end = index + 2;
+            while (end < chars.Length && IsJavaIdentifierPart(chars[end]))
+                end++;
+
+            if (end == index + 2 && end < chars.Length && chars[end] == '\'')
+                continue;
+
+            for (var maskIndex = index; maskIndex < end; maskIndex++)
+                chars[maskIndex] = ' ';
+
+            index = end - 1;
+        }
+
+        return new string(chars);
     }
 
     private static string[] MaskPascalBlockCommentLines(IReadOnlyList<string> lines)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1861,6 +1861,12 @@ public static partial class ReferenceExtractor
                     AddReference(references, seen, fileId, normalizedName, callIndex, "instantiate", context, lineNumber, callContainer);
                     return true;
                 }
+                if (language == "rust"
+                    && RustReferenceExtractor.IsLikelyInstantiationCallName(name, normalizedName, preparedLine, callIndex))
+                {
+                    AddReference(references, seen, fileId, normalizedName, callIndex, "instantiate", context, lineNumber, callContainer);
+                    return true;
+                }
                 if (IsIgnoredCallName(language, name))
                 {
                     if (!(language == "scala" && string.Equals(name, "foreach", StringComparison.Ordinal)))

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -615,7 +615,7 @@ public static partial class ReferenceExtractor
         },
         ["rust"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "Self", "bool", "char", "const", "dyn", "f32", "f64", "i8", "i16", "i32", "i64", "i128",
+            "Self", "bool", "char", "const", "dyn", "f32", "f64", "for", "i8", "i16", "i32", "i64", "i128",
             "impl", "isize", "mut", "ref", "static", "str", "u8", "u16", "u32", "u64", "u128", "usize",
         },
         ["c"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1828,6 +1828,8 @@ public static partial class ReferenceExtractor
 
                 if (language == "rust" && RustReferenceExtractor.IsFunctionDeclarationCallSite(preparedLine, callIndex))
                     return false;
+                if (language == "rust" && RustReferenceExtractor.IsDeriveAttributeCallSite(preparedLine, normalizedName, callIndex))
+                    return false;
 
                 // Suppress the same-line Java ctor declarator's self-call. CallRegex matches
                 // `CtorName(` at the declarator once per same-line ctor, but it is a declaration
@@ -2090,6 +2092,7 @@ public static partial class ReferenceExtractor
             if (language == "rust")
             {
                 RustReferenceExtractor.EmitAdditionalCallReferences(preparedLine, AddCallLikeReference);
+                RustReferenceExtractor.EmitAttributeReferences(preparedLine, references, seen, fileId, context, lineNumber, container);
             }
 
             if (language == "csharp")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -615,8 +615,8 @@ public static partial class ReferenceExtractor
         },
         ["rust"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "Self", "bool", "char", "f32", "f64", "i8", "i16", "i32", "i64", "i128", "isize",
-            "str", "u8", "u16", "u32", "u64", "u128", "usize",
+            "Self", "bool", "char", "const", "dyn", "f32", "f64", "i8", "i16", "i32", "i64", "i128",
+            "impl", "isize", "mut", "ref", "static", "str", "u8", "u16", "u32", "u64", "u128", "usize",
         },
         ["c"] = new HashSet<string>(StringComparer.Ordinal)
         {

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -998,6 +998,12 @@ public static partial class ReferenceExtractor
                              (symbol.Kind == "class" || symbol.Kind == "struct" || symbol.Kind == "interface" || symbol.Kind == "enum"))
             .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
             .ToList();
+        var rustEnumCandidates = language == "rust"
+            ? symbols
+                .Where(symbol => symbol.Kind == "enum" && symbol.BodyStartLine != null && symbol.BodyEndLine != null)
+                .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
+                .ToList()
+            : null;
 
         // Synthetic function-kind container for C# primary-ctor declarations with a base
         // primary-ctor call such as `record Child(int x) : Parent(x)` or C# 12 `class Child(int x) : Parent(x)`.
@@ -1532,6 +1538,9 @@ public static partial class ReferenceExtractor
             }
             else if (language == "rust")
             {
+                var rustEnumContainer = rustEnumCandidates != null
+                    ? FindInnermostContainer(rustEnumCandidates, lineNumber)
+                    : null;
                 RustReferenceExtractor.EmitTypePositionReferences(
                     preparedLine,
                     references,
@@ -1540,7 +1549,8 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     ResolveContainerForCall,
-                    container);
+                    container,
+                    rustEnumContainer);
             }
             else if (language == "c")
                 CReferenceExtractor.EmitTypePositionReferences(preparedLine, originalLine, references, seen, fileId, context, lineNumber, ResolveContainerForCall);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1254,8 +1254,8 @@ public static partial class SymbolExtractor
             new("interface", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?trait\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // impl Trait for Type / `unsafe impl Trait for Type` should attach to the type being extended.
             // `impl Trait for Type` / `unsafe impl Trait for Type` は、拡張先の型に紐づける。
-            new("class",    new Regex(@"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+.+?\s+for\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("class",    new Regex(@"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+(?<name>(?:r#)?\w+)(?!\s+for\b)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+.+?\s+for\s+(?:(?:r#)?\w+::)*(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+(?:(?:r#)?\w+::)*(?<name>(?:r#)?\w+)(?!\s+for\b)", RegexOptions.Compiled), BodyStyle.Brace),
             // mod / モジュール
             new("namespace", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?mod\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // type alias / 型エイリアス

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20944,6 +20944,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustLifetimes_DoNotBecomeTypeReferences()
+    {
+        const string content = """
+            struct Holder<'a> {
+                value: &'a User,
+                fallback: &'static User,
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "a" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "static" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21223,6 +21223,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustSelfAssociatedCalls_DoNotEmitSelfTypeReference()
+    {
+        const string content = """
+            struct User;
+
+            impl User {
+                fn make() -> Self {
+                    Self::new();
+                    User::new();
+                    Self {}
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Self" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Self" && r.ReferenceKind == "instantiate");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20894,6 +20894,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustCfgAttrDeriveAttributes_CaptureTraitTypeReferences()
+    {
+        const string content = """
+            #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+            struct User;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Serialize" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Deserialize" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "cfg_attr" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustAttributes_CaptureAnnotationReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21080,6 +21080,37 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustStructLiterals_CaptureInstantiationReferences()
+    {
+        const string content = """
+            struct Config {
+                enabled: bool,
+            }
+
+            pub(crate) struct Local {
+                enabled: bool,
+            }
+
+            fn build() {
+                let user = User { id: 1 };
+                let store = crate::models::Store { ready: true };
+                let wrapped = Wrapper::<User> { value: user };
+                let helper = crate::helpers::state { ready: true };
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Store" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Wrapper" && r.ReferenceKind == "instantiate");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Config" && r.ReferenceKind == "instantiate");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Local" && r.ReferenceKind == "instantiate");
+        Assert.DoesNotContain(references, r => r.SymbolName == "state" && r.ReferenceKind == "instantiate");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20856,6 +20856,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustEnumVariantPayloads_CaptureTypeReferences()
+    {
+        const string content = """
+            enum Event {
+                Created(User),
+                Moved { from: Point, to: Point },
+                Failed(crate::errors::Error),
+                Empty,
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference" && r.ContainerName == "Event");
+        Assert.Contains(references, r => r.SymbolName == "Point" && r.ReferenceKind == "type_reference" && r.ContainerName == "Event");
+        Assert.Contains(references, r => r.SymbolName == "Error" && r.ReferenceKind == "type_reference" && r.ContainerName == "Event");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21314,6 +21314,20 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustTraitSuperFunctionBounds_CapturesReturnTypes()
+    {
+        const string content = """
+            trait Handler: FnOnce() -> User {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "FnOnce" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21059,6 +21059,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustAssociatedCalls_CaptureReceiverTypeReferences()
+    {
+        const string content = """
+            fn build() {
+                let user = User::new();
+                let store = crate::models::Store::open();
+                let users = Vec::<User>::new();
+                let helper = crate::helpers::build();
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Store" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Vec" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "helpers" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21037,6 +21037,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustUseStatements_CaptureImportTargetReferences()
+    {
+        const string content = """
+            use crate::models::User;
+            use crate::services::{Repository, Store as StoreAlias};
+            use crate::prelude::{self, Widget};
+            pub use r#async::Handler;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "Store" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "prelude" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "Widget" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "StoreAlias" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21206,6 +21206,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustAssociatedTypeBinding_SkipsBindingKey()
+    {
+        const string content = """
+            fn make() -> impl Future<Output = User> {
+                todo!()
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Future" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Output" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20912,6 +20912,38 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustTypeModifiers_DoNotBecomeTypeReferences()
+    {
+        const string content = """
+            fn make() -> impl Future<Output = User> {
+                todo!()
+            }
+
+            struct Service {
+                handler: Box<dyn Handler + Send>,
+                raw: *const Marker,
+                mutable: *mut State,
+                text: &'static str,
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Future" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Box" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Send" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Marker" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "State" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(
+            references,
+            r => r.ReferenceKind == "type_reference"
+                && r.SymbolName is "impl" or "dyn" or "const" or "mut" or "ref" or "static");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20773,6 +20773,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustConstStaticItems_CaptureTypeReferences()
+    {
+        const string content = """
+            const GLOBAL: Arc<User> = Arc::new(User);
+            static mut STATE: Option<State> = None;
+            pub static CACHE: crate::cache::Cache = crate::cache::Cache::new();
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Arc" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Option" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "State" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Cache" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustStructFieldTypes_CaptureStructContainerReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20811,6 +20811,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustAssociatedTypes_CaptureBoundTypeReferences()
+    {
+        const string content = """
+            trait Stream {
+                type Item: Display + Debug;
+                type Error: Into<AppError> = IoError;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Display" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Debug" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Into" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "AppError" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "IoError" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustStructFieldTypes_CaptureStructContainerReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21002,6 +21002,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustExternCrate_CapturesCrateReferences()
+    {
+        const string content = """
+            extern crate serde;
+            pub extern crate r#async as async_crate;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "serde" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "async" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "async_crate" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21133,6 +21133,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustGenericDefaults_CaptureDefaultTypeReferences()
+    {
+        const string content = """
+            struct Cache<T = User, E: Error = IoError> {
+                value: T,
+                error: E,
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Error" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "IoError" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21190,6 +21190,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustTraitAliasTargetTypes_CapturesAliasedBounds()
+    {
+        const string content = """
+            trait Service = Send + Sync + Handler<User>;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Send" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Sync" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20894,6 +20894,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustAttributes_CaptureAnnotationReferences()
+    {
+        const string content = """
+            #[tokio::test]
+            async fn verifies_user() {}
+
+            #[serde(rename = "id")]
+            struct User;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "tokio::test" && r.ReferenceKind == "annotation");
+        Assert.Contains(references, r => r.SymbolName == "serde" && r.ReferenceKind == "annotation");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21296,6 +21296,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustFunctionTraitBounds_CapturesReturnTypes()
+    {
+        const string content = """
+            fn call<F: FnOnce() -> Result<User, Error>>(f: F) {}
+            fn where_call<F>(f: F) where F: FnOnce() -> Response {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "FnOnce" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Error" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21111,6 +21111,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustTupleConstructors_CaptureInstantiationReferences()
+    {
+        const string content = """
+            fn build(value: Value) {
+                let user = User(value);
+                let maybe = Some(user);
+                let result = Ok(maybe);
+                helper(result);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Some" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Ok" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "helper" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "User" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20755,6 +20755,7 @@ public class ReferenceExtractorTests
             struct Wrapper {
                 value: crate::r#type,
                 next: Option<r#async>,
+                keyword: r#struct,
             }
 
             fn build(input: r#type) -> r#async {
@@ -20767,6 +20768,7 @@ public class ReferenceExtractorTests
 
         Assert.Contains(references, r => r.SymbolName == "type" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "async" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "struct" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "r" && r.ReferenceKind == "type_reference");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20792,6 +20792,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustTypeAliases_CaptureTargetTypeReferences()
+    {
+        const string content = """
+            type UserMap<K: Key> = std::collections::HashMap<K, User>;
+            pub type Callback = Handler<Request, Response>;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "HashMap" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustStructFieldTypes_CaptureStructContainerReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21262,6 +21262,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustAssociatedValues_CapturesReceiverAndTurbofishTypes()
+    {
+        const string content = """
+            fn defaults() {
+                let _ = User::DEFAULT;
+                let _ = Result::<User, Error>::Ok;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Error" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "DEFAULT" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Ok" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21169,6 +21169,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustClosureSignatureTypes_CapturesParameterAndReturnTypes()
+    {
+        const string content = """
+            fn configure() {
+                let handler = |input: User, ctx: &Context| -> Result<Response, Error> {
+                    build(input, ctx)
+                };
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Context" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Error" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21151,6 +21151,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustHigherRankedTraitBounds_PreserveBoundTypes()
+    {
+        const string content = """
+            trait Handler<F: for<'a> Fn(&'a User)> {
+                fn handle(&self, f: F);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Fn" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "for" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "a" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21282,6 +21282,20 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustGlobImports_CaptureParentModuleReference()
+    {
+        const string content = """
+            use crate::prelude::*;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "prelude" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "*" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20962,6 +20962,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustAsCasts_CaptureTargetTypeReferences()
+    {
+        const string content = """
+            use crate::models::User as UserAlias;
+
+            fn convert(raw: *const u8, input: Value) {
+                let user = input as User;
+                let marker = raw as *const Marker;
+                let handler = input as Box<dyn Handler>;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Marker" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Box" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "as" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "UserAlias" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20746,6 +20746,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustRawIdentifierTypeReferences_NormalizesNames()
+    {
+        const string content = """
+            struct r#type;
+            struct r#async;
+
+            struct Wrapper {
+                value: crate::r#type,
+                next: Option<r#async>,
+            }
+
+            fn build(input: r#type) -> r#async {
+                todo!()
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "type" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "async" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "r" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustStructFieldTypes_CaptureStructContainerReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21246,6 +21246,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustQualifiedAssociatedCalls_CapturesReceiverAndTraitTypes()
+    {
+        const string content = """
+            fn run() {
+                <User as Service>::handle();
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Service" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -21018,6 +21018,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustModDeclarations_CaptureModuleReferences()
+    {
+        const string content = """
+            mod users;
+            pub(crate) mod r#async;
+            mod inline {
+                fn helper() {}
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "users" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "async" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "inline" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20876,6 +20876,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustDeriveAttributes_CaptureTraitTypeReferences()
+    {
+        const string content = """
+            #[derive(Debug, Clone, serde::Serialize)]
+            struct User;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Debug" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Clone" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Serialize" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "derive" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "derive" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeQuery_DynamicImportTypeMapsToImportSymbol()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12184,6 +12184,10 @@ public class SymbolExtractorTests
             impl Debug for Widget {}
             impl<T> Future for Task<T> {}
             unsafe impl<T> Send for Empty<T> {}
+            impl crate::models::Widget {}
+            impl<T> crate::tasks::Task<T> {}
+            impl Debug for crate::models::Widget {}
+            unsafe impl<T> Send for crate::tasks::Task<T> {}
             """;
         var symbols = SymbolExtractor.Extract(1, "rust", content);
 
@@ -12196,6 +12200,9 @@ public class SymbolExtractorTests
         Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "Debug");
         Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "Future");
         Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "Send");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "crate");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "models");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "tasks");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

This PR improves Rust reference extraction coverage for search, dependency, and impact workflows. It includes several focused fixes around Rust type-position references, associated paths, imports, and function-trait bounds.

## Changes

- Preserve Rust higher-ranked trait bound types such as `for<'a> Fn(&'a User)` without emitting lifetime or `for` noise.
- Index Rust closure signature parameter and return types.
- Index Rust trait alias targets and glob import parent modules.
- Suppress noisy Rust `Self` receiver edges and associated type binding keys such as `Output = ...`.
- Index Rust associated call/value receivers, fully qualified associated calls, and function-trait return types in generic, where, and trait superbound positions.

## Why

These patterns are rename-sensitive Rust dependencies, but several were either invisible to `references` / `impact` or produced noisy edges. The changes make Rust search results more complete while keeping call graph noise down.

## Validation

- `dotnet build`
- `dotnet test` (`3875` passed, `3` skipped)
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`