### PR TITLE
[codex] Improve Go search indexing and references

### DIFF
--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -35,6 +35,7 @@ affected:
 - **Go slice and array composite literals expose element types** — literals such as `[]User{}`, `[3]*Widget{}`, and `[...]model.Event{}` now link their element types.
 - **Go composite type conversions are indexed as type references** — conversions such as `[]User(raw)`, `map[Key]Value(raw)`, and `chan Event(raw)` now link their target types.
 - **Go inline struct fields expose field types** — anonymous forms such as `struct{ ID UserID; Owner *User }{}` now link `UserID` and `User` without indexing field names.
+- **Go inline interface members expose signature types** — anonymous forms such as `interface{ Handle(Context) Result; io.Reader }` now link method parameter, return, and embedded interface types.
 
 ## 日本語
 
@@ -62,3 +63,4 @@ affected:
 - **Go slice / array composite literal の要素型を参照として出すようになりました** — `[]User{}`、`[3]*Widget{}`、`[...]model.Event{}` のような literal から要素型を辿れるようになりました。
 - **Go composite type conversion を型参照として索引するようになりました** — `[]User(raw)`、`map[Key]Value(raw)`、`chan Event(raw)` のような conversion から変換対象型を辿れるようになりました。
 - **Go inline struct field の型を参照として出すようになりました** — `struct{ ID UserID; Owner *User }{}` のような anonymous form から field 名ではなく `UserID` と `User` を辿れるようになりました。
+- **Go inline interface member の signature 型を参照として出すようになりました** — `interface{ Handle(Context) Result; io.Reader }` のような anonymous form から method 引数、戻り値、embedded interface 型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -3,6 +3,7 @@ category: changed
 affected:
   - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
   - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
   - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
   - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -29,6 +30,7 @@ affected:
 - **Go generic instantiations without calls expose type arguments** — function values such as `Decode[User]` and `stream.Map[model.Event, Result]` now link their concrete type arguments.
 - **Go interface type sets expose union term types** — constraint terms such as `~CustomID | External` and `model.Token | ~Alias` now link custom type-set members.
 - **Go labels are indexed as navigation symbols** — labels such as `Retry:` now appear in symbol search and definition-oriented workflows.
+- **Go branch statements link to label symbols** — `goto Retry`, `break Retry`, and `continue Retry` now emit label references for graph workflows.
 
 ## 日本語
 
@@ -51,3 +53,4 @@ affected:
 - **Go の call しない generic instantiation でも型引数を参照として出すようになりました** — `Decode[User]` や `stream.Map[model.Event, Result]` のような関数値から具体型引数を辿れるようになりました。
 - **Go interface type set の union term 型を参照として出すようになりました** — `~CustomID | External` や `model.Token | ~Alias` のような constraint term から custom type-set member を辿れるようになりました。
 - **Go label を navigation symbol として索引するようになりました** — `Retry:` のような label が symbol search や definition 系 workflow に現れるようになりました。
+- **Go branch statement から label symbol へ参照を張るようになりました** — `goto Retry`、`break Retry`、`continue Retry` が graph workflow 用の label reference を出すようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -44,6 +44,7 @@ affected:
 - **Go multi-name struct fields expose their shared type** — fields such as `Primary, Secondary *Client` now link the shared field type without indexing field names.
 - **Go struct fields with spaced generic types expose all type segments** — fields such as `Owner Repository[Key, Value]` now link the generic type and each concrete argument.
 - **Go var/const declarations with spaced generic types expose all type segments** — declarations such as `var repo Repository[Key, Value]` now link the explicit generic type.
+- **Go type specs with spaced generic targets expose all type segments** — declarations such as `type Repo Repository[Key, Value]` now link the target type and arguments.
 
 ## 日本語
 
@@ -80,3 +81,4 @@ affected:
 - **Go の複数名 struct field で共有される型を参照として出すようになりました** — `Primary, Secondary *Client` のような field から field 名を索引せずに共有型を辿れるようになりました。
 - **Go struct field のスペース入り generic 型を参照として出すようになりました** — `Owner Repository[Key, Value]` のような field から generic 型と各具体型引数を辿れるようになりました。
 - **Go var/const 宣言のスペース入り generic 型を参照として出すようになりました** — `var repo Repository[Key, Value]` のような宣言から明示された generic 型を辿れるようになりました。
+- **Go type spec のスペース入り generic target を参照として出すようになりました** — `type Repo Repository[Key, Value]` のような宣言から target 型と型引数を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -20,6 +20,7 @@ affected:
 - **Go function type declarations expose parameter and return types** — declarations such as `type Handler func(Request) Response` and `Callback func(Context) Result` now link their signature types.
 - **Go channel type declarations expose element types** — directional channel declarations such as `<-chan Event` and `chan<- Command` now link `Event` and `Command`.
 - **Go generic composite literals are indexed with their type arguments** — literals such as `Cache[Entry]{}` and `model.Set[Key, Value]{}` now link the instantiated type and concrete type arguments.
+- **Go map composite literals expose key and value types** — literals such as `map[Key]Value{}` and `map[model.Tenant]*Entry{}` now link both sides of the map type.
 
 ## 日本語
 
@@ -36,3 +37,4 @@ affected:
 - **Go function type 宣言の引数型と戻り値型を参照として出すようになりました** — `type Handler func(Request) Response` や `Callback func(Context) Result` のような宣言から signature 内の型を辿れるようになりました。
 - **Go channel type 宣言の要素型を参照として出すようになりました** — `<-chan Event` や `chan<- Command` のような方向付き channel 宣言から `Event` と `Command` を辿れるようになりました。
 - **Go generic composite literal を型引数付きで索引するようになりました** — `Cache[Entry]{}` や `model.Set[Key, Value]{}` のような literal から生成型と具体型引数を辿れるようになりました。
+- **Go map composite literal の key/value 型を参照として出すようになりました** — `map[Key]Value{}` や `map[model.Tenant]*Entry{}` のような literal から map 型の両側を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -24,6 +24,7 @@ affected:
 - **Go parenthesized type conversions are indexed as type references** — idioms such as `(*Concrete)(nil)` and `(model.ID)(raw)` now link the converted type.
 - **Go method expressions expose receiver types** — expressions such as `Handler.Serve`, `(*Worker).Run`, and `model.User.String` now link the receiver type.
 - **Go generic instantiations without calls expose type arguments** — function values such as `Decode[User]` and `stream.Map[model.Event, Result]` now link their concrete type arguments.
+- **Go interface type sets expose union term types** — constraint terms such as `~CustomID | External` and `model.Token | ~Alias` now link custom type-set members.
 
 ## 日本語
 
@@ -44,3 +45,4 @@ affected:
 - **Go の parenthesized type conversion を型参照として索引するようになりました** — `(*Concrete)(nil)` や `(model.ID)(raw)` のような idiom から変換対象型を辿れるようになりました。
 - **Go method expression の receiver 型を参照として出すようになりました** — `Handler.Serve`、`(*Worker).Run`、`model.User.String` のような expression から receiver 型を辿れるようになりました。
 - **Go の call しない generic instantiation でも型引数を参照として出すようになりました** — `Decode[User]` や `stream.Map[model.Event, Result]` のような関数値から具体型引数を辿れるようになりました。
+- **Go interface type set の union term 型を参照として出すようになりました** — `~CustomID | External` や `model.Token | ~Alias` のような constraint term から custom type-set member を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -1,8 +1,11 @@
 ---
 category: changed
 affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
   - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
   - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
 ---
 
 ## English
@@ -25,6 +28,7 @@ affected:
 - **Go method expressions expose receiver types** — expressions such as `Handler.Serve`, `(*Worker).Run`, and `model.User.String` now link the receiver type.
 - **Go generic instantiations without calls expose type arguments** — function values such as `Decode[User]` and `stream.Map[model.Event, Result]` now link their concrete type arguments.
 - **Go interface type sets expose union term types** — constraint terms such as `~CustomID | External` and `model.Token | ~Alias` now link custom type-set members.
+- **Go labels are indexed as navigation symbols** — labels such as `Retry:` now appear in symbol search and definition-oriented workflows.
 
 ## 日本語
 
@@ -46,3 +50,4 @@ affected:
 - **Go method expression の receiver 型を参照として出すようになりました** — `Handler.Serve`、`(*Worker).Run`、`model.User.String` のような expression から receiver 型を辿れるようになりました。
 - **Go の call しない generic instantiation でも型引数を参照として出すようになりました** — `Decode[User]` や `stream.Map[model.Event, Result]` のような関数値から具体型引数を辿れるようになりました。
 - **Go interface type set の union term 型を参照として出すようになりました** — `~CustomID | External` や `model.Token | ~Alias` のような constraint term から custom type-set member を辿れるようになりました。
+- **Go label を navigation symbol として索引するようになりました** — `Retry:` のような label が symbol search や definition 系 workflow に現れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -34,6 +34,7 @@ affected:
 - **Go type switch cases expose pointer and composite case types** — `case *Admin`, `case []Guest`, and `case map[Key]Value` now link their type case entries without indexing value-switch constants.
 - **Go slice and array composite literals expose element types** — literals such as `[]User{}`, `[3]*Widget{}`, and `[...]model.Event{}` now link their element types.
 - **Go composite type conversions are indexed as type references** — conversions such as `[]User(raw)`, `map[Key]Value(raw)`, and `chan Event(raw)` now link their target types.
+- **Go inline struct fields expose field types** — anonymous forms such as `struct{ ID UserID; Owner *User }{}` now link `UserID` and `User` without indexing field names.
 
 ## 日本語
 
@@ -60,3 +61,4 @@ affected:
 - **Go type switch case の pointer / composite 型を参照として出すようになりました** — `case *Admin`、`case []Guest`、`case map[Key]Value` が value switch の定数 case を索引せずに型 case entry を辿れるようになりました。
 - **Go slice / array composite literal の要素型を参照として出すようになりました** — `[]User{}`、`[3]*Widget{}`、`[...]model.Event{}` のような literal から要素型を辿れるようになりました。
 - **Go composite type conversion を型参照として索引するようになりました** — `[]User(raw)`、`map[Key]Value(raw)`、`chan Event(raw)` のような conversion から変換対象型を辿れるようになりました。
+- **Go inline struct field の型を参照として出すようになりました** — `struct{ ID UserID; Owner *User }{}` のような anonymous form から field 名ではなく `UserID` と `User` を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -49,6 +49,7 @@ affected:
 - **Go top-level multi-name const declarations index every property symbol** — `const PrimaryStatus, SecondaryStatus = 1, 2` now exposes both names to symbol search and definition workflows.
 - **Go method symbols are attributed to receiver type containers** — `func (h *Handler) ServeHTTP(...)` now appears under `Handler` in symbol-oriented workflows.
 - **Go generic receiver method containers tolerate spaced type parameters** — `func (s *Store[T, U]) Save(...)` now stays attributed to `Store`.
+- **Go unnamed generic receiver methods keep their type container** — `func (Store[T, U]) Snapshot()` now stays attributed to `Store`.
 
 ## 日本語
 
@@ -90,3 +91,4 @@ affected:
 - **Go top-level の複数名 const 宣言で全 property symbol を索引するようになりました** — `const PrimaryStatus, SecondaryStatus = 1, 2` から両方の名前を symbol search と definition workflow で辿れるようになりました。
 - **Go method symbol を receiver 型 container に帰属させるようになりました** — `func (h *Handler) ServeHTTP(...)` が symbol 系 workflow で `Handler` 配下に現れるようになりました。
 - **Go generic receiver method の container がスペース入り型パラメータに対応しました** — `func (s *Store[T, U]) Save(...)` が `Store` 配下に帰属し続けるようになりました。
+- **Go unnamed generic receiver method が型 container を維持するようになりました** — `func (Store[T, U]) Snapshot()` が `Store` 配下に帰属し続けるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -50,6 +50,7 @@ affected:
 - **Go method symbols are attributed to receiver type containers** — `func (h *Handler) ServeHTTP(...)` now appears under `Handler` in symbol-oriented workflows.
 - **Go generic receiver method containers tolerate spaced type parameters** — `func (s *Store[T, U]) Save(...)` now stays attributed to `Store`.
 - **Go unnamed generic receiver methods keep their type container** — `func (Store[T, U]) Snapshot()` now stays attributed to `Store`.
+- **Go local grouped value declarations no longer pollute package symbols** — function-local `var (...)` and `const (...)` blocks are not indexed as top-level properties.
 
 ## 日本語
 
@@ -92,3 +93,4 @@ affected:
 - **Go method symbol を receiver 型 container に帰属させるようになりました** — `func (h *Handler) ServeHTTP(...)` が symbol 系 workflow で `Handler` 配下に現れるようになりました。
 - **Go generic receiver method の container がスペース入り型パラメータに対応しました** — `func (s *Store[T, U]) Save(...)` が `Store` 配下に帰属し続けるようになりました。
 - **Go unnamed generic receiver method が型 container を維持するようになりました** — `func (Store[T, U]) Snapshot()` が `Store` 配下に帰属し続けるようになりました。
+- **Go local grouped value 宣言が package symbol を汚さないようになりました** — 関数内の `var (...)` / `const (...)` block を top-level property として索引しないようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -45,6 +45,7 @@ affected:
 - **Go struct fields with spaced generic types expose all type segments** — fields such as `Owner Repository[Key, Value]` now link the generic type and each concrete argument.
 - **Go var/const declarations with spaced generic types expose all type segments** — declarations such as `var repo Repository[Key, Value]` now link the explicit generic type.
 - **Go type specs with spaced generic targets expose all type segments** — declarations such as `type Repo Repository[Key, Value]` now link the target type and arguments.
+- **Go top-level multi-name var declarations index every property symbol** — `var Primary, Secondary *Config` now exposes both names to symbol search and definition workflows.
 
 ## 日本語
 
@@ -82,3 +83,4 @@ affected:
 - **Go struct field のスペース入り generic 型を参照として出すようになりました** — `Owner Repository[Key, Value]` のような field から generic 型と各具体型引数を辿れるようになりました。
 - **Go var/const 宣言のスペース入り generic 型を参照として出すようになりました** — `var repo Repository[Key, Value]` のような宣言から明示された generic 型を辿れるようになりました。
 - **Go type spec のスペース入り generic target を参照として出すようになりました** — `type Repo Repository[Key, Value]` のような宣言から target 型と型引数を辿れるようになりました。
+- **Go top-level の複数名 var 宣言で全 property symbol を索引するようになりました** — `var Primary, Secondary *Config` から両方の名前を symbol search と definition workflow で辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -16,6 +16,7 @@ affected:
 - **Go builtin allocation type arguments are indexed as type references** — `make([]User, 0)` and `new(Client)` now link `User` and `Client` without turning `make` or `new` into calls.
 - **Go type assertions are indexed as type references** — `value.(User)` and `value.(*Admin)` now link the asserted types while ignoring the `.(type)` sentinel.
 - **Go function literal signatures expose parameter and return types** — callbacks such as `func(ctx Context) Result` now link `Context` and `Result`.
+- **Go generic call type arguments are indexed as type references** — call sites such as `Decode[User]()` and `Map[model.Event, Result]()` now link their concrete type arguments.
 
 ## 日本語
 
@@ -28,3 +29,4 @@ affected:
 - **Go builtin allocation の型引数を型参照として索引するようになりました** — `make([]User, 0)` や `new(Client)` から `make` / `new` を call にせず `User` と `Client` を辿れるようになりました。
 - **Go type assertion を型参照として索引するようになりました** — `value.(User)` や `value.(*Admin)` から assertion 対象型を辿れるようにしつつ、`.(type)` sentinel は無視します。
 - **Go function literal signature の引数型と戻り値型を参照として出すようになりました** — `func(ctx Context) Result` のような callback から `Context` と `Result` を辿れるようになりました。
+- **Go generic call の型引数を型参照として索引するようになりました** — `Decode[User]()` や `Map[model.Event, Result]()` のような call site から具体型引数を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -42,6 +42,7 @@ affected:
 - **Go standalone type-set terms expose approximation types** — constraint terms such as `~[]Element` and `~map[Key]Value` now link their element, key, and value types.
 - **Go package declarations are indexed as namespace symbols** — `package demo` now appears in symbol search, outline, and definition-oriented workflows.
 - **Go multi-name struct fields expose their shared type** — fields such as `Primary, Secondary *Client` now link the shared field type without indexing field names.
+- **Go struct fields with spaced generic types expose all type segments** — fields such as `Owner Repository[Key, Value]` now link the generic type and each concrete argument.
 
 ## 日本語
 
@@ -76,3 +77,4 @@ affected:
 - **Go standalone type-set term の approximation 型を参照として出すようになりました** — `~[]Element` や `~map[Key]Value` のような constraint term から element、key、value 型を辿れるようになりました。
 - **Go package 宣言を namespace symbol として索引するようになりました** — `package demo` が symbol search、outline、definition 系 workflow に現れるようになりました。
 - **Go の複数名 struct field で共有される型を参照として出すようになりました** — `Primary, Secondary *Client` のような field から field 名を索引せずに共有型を辿れるようになりました。
+- **Go struct field のスペース入り generic 型を参照として出すようになりました** — `Owner Repository[Key, Value]` のような field から generic 型と各具体型引数を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -37,6 +37,7 @@ affected:
 - **Go inline struct fields expose field types** — anonymous forms such as `struct{ ID UserID; Owner *User }{}` now link `UserID` and `User` without indexing field names.
 - **Go inline interface members expose signature types** — anonymous forms such as `interface{ Handle(Context) Result; io.Reader }` now link method parameter, return, and embedded interface types.
 - **Go multi-pointer parenthesized conversions expose converted types** — conversions such as `(**Node)(nil)` now link the underlying pointed-to type.
+- **Go parenthesized composite conversions expose converted types** — conversions such as `([]User)(raw)` and `(map[Key]Value)(raw)` now link their target types.
 
 ## 日本語
 
@@ -66,3 +67,4 @@ affected:
 - **Go inline struct field の型を参照として出すようになりました** — `struct{ ID UserID; Owner *User }{}` のような anonymous form から field 名ではなく `UserID` と `User` を辿れるようになりました。
 - **Go inline interface member の signature 型を参照として出すようになりました** — `interface{ Handle(Context) Result; io.Reader }` のような anonymous form から method 引数、戻り値、embedded interface 型を辿れるようになりました。
 - **Go の multi-pointer parenthesized conversion で変換対象型を参照として出すようになりました** — `(**Node)(nil)` のような conversion から pointer の先の型を辿れるようになりました。
+- **Go の parenthesized composite conversion で変換対象型を参照として出すようになりました** — `([]User)(raw)` や `(map[Key]Value)(raw)` のような conversion から変換対象型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -12,6 +12,7 @@ affected:
 - **Go method receiver types are indexed as type references** — `func (h *Handler) Serve(...)` now links `Handler` from reference search and inspect output.
 - **Go interface method signatures expose parameter and return types** — interface members such as `Handle(ctx Context) Response` now link `Context` and `Response`.
 - **Go multi-name value declarations expose their shared type** — declarations such as `var primary, secondary *Client` now link `Client`.
+- **Go embedded field types are indexed as type references** — embedded fields such as `*BaseStore` and `audit.Logger` now show up in reference search.
 
 ## 日本語
 
@@ -20,3 +21,4 @@ affected:
 - **Go method receiver の型を型参照として索引するようになりました** — `func (h *Handler) Serve(...)` から `Handler` が reference search と inspect 出力で辿れるようになりました。
 - **Go interface method signature の引数型と戻り値型を参照として出すようになりました** — `Handle(ctx Context) Response` のような interface member から `Context` と `Response` を辿れるようになりました。
 - **Go の複数名 value 宣言で共有される型を参照として出すようになりました** — `var primary, secondary *Client` のような宣言から `Client` を辿れるようになりました。
+- **Go の embedded field 型を型参照として索引するようになりました** — `*BaseStore` や `audit.Logger` のような embedded field が reference search に現れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -22,6 +22,7 @@ affected:
 - **Go generic composite literals are indexed with their type arguments** — literals such as `Cache[Entry]{}` and `model.Set[Key, Value]{}` now link the instantiated type and concrete type arguments.
 - **Go map composite literals expose key and value types** — literals such as `map[Key]Value{}` and `map[model.Tenant]*Entry{}` now link both sides of the map type.
 - **Go parenthesized type conversions are indexed as type references** — idioms such as `(*Concrete)(nil)` and `(model.ID)(raw)` now link the converted type.
+- **Go method expressions expose receiver types** — expressions such as `Handler.Serve`, `(*Worker).Run`, and `model.User.String` now link the receiver type.
 
 ## 日本語
 
@@ -40,3 +41,4 @@ affected:
 - **Go generic composite literal を型引数付きで索引するようになりました** — `Cache[Entry]{}` や `model.Set[Key, Value]{}` のような literal から生成型と具体型引数を辿れるようになりました。
 - **Go map composite literal の key/value 型を参照として出すようになりました** — `map[Key]Value{}` や `map[model.Tenant]*Entry{}` のような literal から map 型の両側を辿れるようになりました。
 - **Go の parenthesized type conversion を型参照として索引するようになりました** — `(*Concrete)(nil)` や `(model.ID)(raw)` のような idiom から変換対象型を辿れるようになりました。
+- **Go method expression の receiver 型を参照として出すようになりました** — `Handler.Serve`、`(*Worker).Run`、`model.User.String` のような expression から receiver 型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -31,6 +31,7 @@ affected:
 - **Go interface type sets expose union term types** — constraint terms such as `~CustomID | External` and `model.Token | ~Alias` now link custom type-set members.
 - **Go labels are indexed as navigation symbols** — labels such as `Retry:` now appear in symbol search and definition-oriented workflows.
 - **Go branch statements link to label symbols** — `goto Retry`, `break Retry`, and `continue Retry` now emit label references for graph workflows.
+- **Go type switch cases expose pointer and composite case types** — `case *Admin`, `case []Guest`, and `case map[Key]Value` now link their type case entries without indexing value-switch constants.
 
 ## 日本語
 
@@ -54,3 +55,4 @@ affected:
 - **Go interface type set の union term 型を参照として出すようになりました** — `~CustomID | External` や `model.Token | ~Alias` のような constraint term から custom type-set member を辿れるようになりました。
 - **Go label を navigation symbol として索引するようになりました** — `Retry:` のような label が symbol search や definition 系 workflow に現れるようになりました。
 - **Go branch statement から label symbol へ参照を張るようになりました** — `goto Retry`、`break Retry`、`continue Retry` が graph workflow 用の label reference を出すようになりました。
+- **Go type switch case の pointer / composite 型を参照として出すようになりました** — `case *Admin`、`case []Guest`、`case map[Key]Value` が value switch の定数 case を索引せずに型 case entry を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -43,6 +43,7 @@ affected:
 - **Go package declarations are indexed as namespace symbols** — `package demo` now appears in symbol search, outline, and definition-oriented workflows.
 - **Go multi-name struct fields expose their shared type** — fields such as `Primary, Secondary *Client` now link the shared field type without indexing field names.
 - **Go struct fields with spaced generic types expose all type segments** — fields such as `Owner Repository[Key, Value]` now link the generic type and each concrete argument.
+- **Go var/const declarations with spaced generic types expose all type segments** — declarations such as `var repo Repository[Key, Value]` now link the explicit generic type.
 
 ## 日本語
 
@@ -78,3 +79,4 @@ affected:
 - **Go package 宣言を namespace symbol として索引するようになりました** — `package demo` が symbol search、outline、definition 系 workflow に現れるようになりました。
 - **Go の複数名 struct field で共有される型を参照として出すようになりました** — `Primary, Secondary *Client` のような field から field 名を索引せずに共有型を辿れるようになりました。
 - **Go struct field のスペース入り generic 型を参照として出すようになりました** — `Owner Repository[Key, Value]` のような field から generic 型と各具体型引数を辿れるようになりました。
+- **Go var/const 宣言のスペース入り generic 型を参照として出すようになりました** — `var repo Repository[Key, Value]` のような宣言から明示された generic 型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -14,6 +14,7 @@ affected:
 - **Go multi-name value declarations expose their shared type** — declarations such as `var primary, secondary *Client` now link `Client`.
 - **Go embedded field types are indexed as type references** — embedded fields such as `*BaseStore` and `audit.Logger` now show up in reference search.
 - **Go builtin allocation type arguments are indexed as type references** — `make([]User, 0)` and `new(Client)` now link `User` and `Client` without turning `make` or `new` into calls.
+- **Go type assertions are indexed as type references** — `value.(User)` and `value.(*Admin)` now link the asserted types while ignoring the `.(type)` sentinel.
 
 ## 日本語
 
@@ -24,3 +25,4 @@ affected:
 - **Go の複数名 value 宣言で共有される型を参照として出すようになりました** — `var primary, secondary *Client` のような宣言から `Client` を辿れるようになりました。
 - **Go の embedded field 型を型参照として索引するようになりました** — `*BaseStore` や `audit.Logger` のような embedded field が reference search に現れるようになりました。
 - **Go builtin allocation の型引数を型参照として索引するようになりました** — `make([]User, 0)` や `new(Client)` から `make` / `new` を call にせず `User` と `Client` を辿れるようになりました。
+- **Go type assertion を型参照として索引するようになりました** — `value.(User)` や `value.(*Admin)` から assertion 対象型を辿れるようにしつつ、`.(type)` sentinel は無視します。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -11,6 +11,7 @@ affected:
 - **Go generic type constraints are indexed as type references** — `type Cache[T EntityConstraint] ...` now surfaces `EntityConstraint` in reference search and inspect output.
 - **Go method receiver types are indexed as type references** — `func (h *Handler) Serve(...)` now links `Handler` from reference search and inspect output.
 - **Go interface method signatures expose parameter and return types** — interface members such as `Handle(ctx Context) Response` now link `Context` and `Response`.
+- **Go multi-name value declarations expose their shared type** — declarations such as `var primary, secondary *Client` now link `Client`.
 
 ## 日本語
 
@@ -18,3 +19,4 @@ affected:
 - **Go の generic type 制約を型参照として索引するようになりました** — `type Cache[T EntityConstraint] ...` から `EntityConstraint` が reference search と inspect 出力に現れるようになりました。
 - **Go method receiver の型を型参照として索引するようになりました** — `func (h *Handler) Serve(...)` から `Handler` が reference search と inspect 出力で辿れるようになりました。
 - **Go interface method signature の引数型と戻り値型を参照として出すようになりました** — `Handle(ctx Context) Response` のような interface member から `Context` と `Response` を辿れるようになりました。
+- **Go の複数名 value 宣言で共有される型を参照として出すようになりました** — `var primary, secondary *Client` のような宣言から `Client` を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Go generic function constraints are indexed as type references** — `func Decode[T WireMessage](...)` now surfaces `WireMessage` in reference search and inspect output.
+
+## 日本語
+
+- **Go の generic function 制約を型参照として索引するようになりました** — `func Decode[T WireMessage](...)` から `WireMessage` が reference search と inspect 出力に現れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -39,6 +39,7 @@ affected:
 - **Go multi-pointer parenthesized conversions expose converted types** — conversions such as `(**Node)(nil)` now link the underlying pointed-to type.
 - **Go parenthesized composite conversions expose converted types** — conversions such as `([]User)(raw)` and `(map[Key]Value)(raw)` now link their target types.
 - **Go generic method expressions expose receiver type arguments** — expressions such as `Repository[User].Find` and `(*Store[Entry]).Save` now link both receiver and type argument symbols.
+- **Go standalone type-set terms expose approximation types** — constraint terms such as `~[]Element` and `~map[Key]Value` now link their element, key, and value types.
 
 ## 日本語
 
@@ -70,3 +71,4 @@ affected:
 - **Go の multi-pointer parenthesized conversion で変換対象型を参照として出すようになりました** — `(**Node)(nil)` のような conversion から pointer の先の型を辿れるようになりました。
 - **Go の parenthesized composite conversion で変換対象型を参照として出すようになりました** — `([]User)(raw)` や `(map[Key]Value)(raw)` のような conversion から変換対象型を辿れるようになりました。
 - **Go generic method expression の receiver 型引数を参照として出すようになりました** — `Repository[User].Find` や `(*Store[Entry]).Save` のような expression から receiver と型引数の両方を辿れるようになりました。
+- **Go standalone type-set term の approximation 型を参照として出すようになりました** — `~[]Element` や `~map[Key]Value` のような constraint term から element、key、value 型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -33,6 +33,7 @@ affected:
 - **Go branch statements link to label symbols** — `goto Retry`, `break Retry`, and `continue Retry` now emit label references for graph workflows.
 - **Go type switch cases expose pointer and composite case types** — `case *Admin`, `case []Guest`, and `case map[Key]Value` now link their type case entries without indexing value-switch constants.
 - **Go slice and array composite literals expose element types** — literals such as `[]User{}`, `[3]*Widget{}`, and `[...]model.Event{}` now link their element types.
+- **Go composite type conversions are indexed as type references** — conversions such as `[]User(raw)`, `map[Key]Value(raw)`, and `chan Event(raw)` now link their target types.
 
 ## 日本語
 
@@ -58,3 +59,4 @@ affected:
 - **Go branch statement から label symbol へ参照を張るようになりました** — `goto Retry`、`break Retry`、`continue Retry` が graph workflow 用の label reference を出すようになりました。
 - **Go type switch case の pointer / composite 型を参照として出すようになりました** — `case *Admin`、`case []Guest`、`case map[Key]Value` が value switch の定数 case を索引せずに型 case entry を辿れるようになりました。
 - **Go slice / array composite literal の要素型を参照として出すようになりました** — `[]User{}`、`[3]*Widget{}`、`[...]model.Event{}` のような literal から要素型を辿れるようになりました。
+- **Go composite type conversion を型参照として索引するようになりました** — `[]User(raw)`、`map[Key]Value(raw)`、`chan Event(raw)` のような conversion から変換対象型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -23,6 +23,7 @@ affected:
 - **Go map composite literals expose key and value types** — literals such as `map[Key]Value{}` and `map[model.Tenant]*Entry{}` now link both sides of the map type.
 - **Go parenthesized type conversions are indexed as type references** — idioms such as `(*Concrete)(nil)` and `(model.ID)(raw)` now link the converted type.
 - **Go method expressions expose receiver types** — expressions such as `Handler.Serve`, `(*Worker).Run`, and `model.User.String` now link the receiver type.
+- **Go generic instantiations without calls expose type arguments** — function values such as `Decode[User]` and `stream.Map[model.Event, Result]` now link their concrete type arguments.
 
 ## 日本語
 
@@ -42,3 +43,4 @@ affected:
 - **Go map composite literal の key/value 型を参照として出すようになりました** — `map[Key]Value{}` や `map[model.Tenant]*Entry{}` のような literal から map 型の両側を辿れるようになりました。
 - **Go の parenthesized type conversion を型参照として索引するようになりました** — `(*Concrete)(nil)` や `(model.ID)(raw)` のような idiom から変換対象型を辿れるようになりました。
 - **Go method expression の receiver 型を参照として出すようになりました** — `Handler.Serve`、`(*Worker).Run`、`model.User.String` のような expression から receiver 型を辿れるようになりました。
+- **Go の call しない generic instantiation でも型引数を参照として出すようになりました** — `Decode[User]` や `stream.Map[model.Event, Result]` のような関数値から具体型引数を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -40,6 +40,7 @@ affected:
 - **Go parenthesized composite conversions expose converted types** — conversions such as `([]User)(raw)` and `(map[Key]Value)(raw)` now link their target types.
 - **Go generic method expressions expose receiver type arguments** — expressions such as `Repository[User].Find` and `(*Store[Entry]).Save` now link both receiver and type argument symbols.
 - **Go standalone type-set terms expose approximation types** — constraint terms such as `~[]Element` and `~map[Key]Value` now link their element, key, and value types.
+- **Go package declarations are indexed as namespace symbols** — `package demo` now appears in symbol search, outline, and definition-oriented workflows.
 
 ## 日本語
 
@@ -72,3 +73,4 @@ affected:
 - **Go の parenthesized composite conversion で変換対象型を参照として出すようになりました** — `([]User)(raw)` や `(map[Key]Value)(raw)` のような conversion から変換対象型を辿れるようになりました。
 - **Go generic method expression の receiver 型引数を参照として出すようになりました** — `Repository[User].Find` や `(*Store[Entry]).Save` のような expression から receiver と型引数の両方を辿れるようになりました。
 - **Go standalone type-set term の approximation 型を参照として出すようになりました** — `~[]Element` や `~map[Key]Value` のような constraint term から element、key、value 型を辿れるようになりました。
+- **Go package 宣言を namespace symbol として索引するようになりました** — `package demo` が symbol search、outline、definition 系 workflow に現れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -21,6 +21,7 @@ affected:
 - **Go channel type declarations expose element types** — directional channel declarations such as `<-chan Event` and `chan<- Command` now link `Event` and `Command`.
 - **Go generic composite literals are indexed with their type arguments** — literals such as `Cache[Entry]{}` and `model.Set[Key, Value]{}` now link the instantiated type and concrete type arguments.
 - **Go map composite literals expose key and value types** — literals such as `map[Key]Value{}` and `map[model.Tenant]*Entry{}` now link both sides of the map type.
+- **Go parenthesized type conversions are indexed as type references** — idioms such as `(*Concrete)(nil)` and `(model.ID)(raw)` now link the converted type.
 
 ## 日本語
 
@@ -38,3 +39,4 @@ affected:
 - **Go channel type 宣言の要素型を参照として出すようになりました** — `<-chan Event` や `chan<- Command` のような方向付き channel 宣言から `Event` と `Command` を辿れるようになりました。
 - **Go generic composite literal を型引数付きで索引するようになりました** — `Cache[Entry]{}` や `model.Set[Key, Value]{}` のような literal から生成型と具体型引数を辿れるようになりました。
 - **Go map composite literal の key/value 型を参照として出すようになりました** — `map[Key]Value{}` や `map[model.Tenant]*Entry{}` のような literal から map 型の両側を辿れるようになりました。
+- **Go の parenthesized type conversion を型参照として索引するようになりました** — `(*Concrete)(nil)` や `(model.ID)(raw)` のような idiom から変換対象型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -15,6 +15,7 @@ affected:
 - **Go embedded field types are indexed as type references** — embedded fields such as `*BaseStore` and `audit.Logger` now show up in reference search.
 - **Go builtin allocation type arguments are indexed as type references** — `make([]User, 0)` and `new(Client)` now link `User` and `Client` without turning `make` or `new` into calls.
 - **Go type assertions are indexed as type references** — `value.(User)` and `value.(*Admin)` now link the asserted types while ignoring the `.(type)` sentinel.
+- **Go function literal signatures expose parameter and return types** — callbacks such as `func(ctx Context) Result` now link `Context` and `Result`.
 
 ## 日本語
 
@@ -26,3 +27,4 @@ affected:
 - **Go の embedded field 型を型参照として索引するようになりました** — `*BaseStore` や `audit.Logger` のような embedded field が reference search に現れるようになりました。
 - **Go builtin allocation の型引数を型参照として索引するようになりました** — `make([]User, 0)` や `new(Client)` から `make` / `new` を call にせず `User` と `Client` を辿れるようになりました。
 - **Go type assertion を型参照として索引するようになりました** — `value.(User)` や `value.(*Admin)` から assertion 対象型を辿れるようにしつつ、`.(type)` sentinel は無視します。
+- **Go function literal signature の引数型と戻り値型を参照として出すようになりました** — `func(ctx Context) Result` のような callback から `Context` と `Result` を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -9,8 +9,10 @@ affected:
 
 - **Go generic function constraints are indexed as type references** — `func Decode[T WireMessage](...)` now surfaces `WireMessage` in reference search and inspect output.
 - **Go generic type constraints are indexed as type references** — `type Cache[T EntityConstraint] ...` now surfaces `EntityConstraint` in reference search and inspect output.
+- **Go method receiver types are indexed as type references** — `func (h *Handler) Serve(...)` now links `Handler` from reference search and inspect output.
 
 ## 日本語
 
 - **Go の generic function 制約を型参照として索引するようになりました** — `func Decode[T WireMessage](...)` から `WireMessage` が reference search と inspect 出力に現れるようになりました。
 - **Go の generic type 制約を型参照として索引するようになりました** — `type Cache[T EntityConstraint] ...` から `EntityConstraint` が reference search と inspect 出力に現れるようになりました。
+- **Go method receiver の型を型参照として索引するようになりました** — `func (h *Handler) Serve(...)` から `Handler` が reference search と inspect 出力で辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -32,6 +32,7 @@ affected:
 - **Go labels are indexed as navigation symbols** — labels such as `Retry:` now appear in symbol search and definition-oriented workflows.
 - **Go branch statements link to label symbols** — `goto Retry`, `break Retry`, and `continue Retry` now emit label references for graph workflows.
 - **Go type switch cases expose pointer and composite case types** — `case *Admin`, `case []Guest`, and `case map[Key]Value` now link their type case entries without indexing value-switch constants.
+- **Go slice and array composite literals expose element types** — literals such as `[]User{}`, `[3]*Widget{}`, and `[...]model.Event{}` now link their element types.
 
 ## 日本語
 
@@ -56,3 +57,4 @@ affected:
 - **Go label を navigation symbol として索引するようになりました** — `Retry:` のような label が symbol search や definition 系 workflow に現れるようになりました。
 - **Go branch statement から label symbol へ参照を張るようになりました** — `goto Retry`、`break Retry`、`continue Retry` が graph workflow 用の label reference を出すようになりました。
 - **Go type switch case の pointer / composite 型を参照として出すようになりました** — `case *Admin`、`case []Guest`、`case map[Key]Value` が value switch の定数 case を索引せずに型 case entry を辿れるようになりました。
+- **Go slice / array composite literal の要素型を参照として出すようになりました** — `[]User{}`、`[3]*Widget{}`、`[...]model.Event{}` のような literal から要素型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -46,6 +46,7 @@ affected:
 - **Go var/const declarations with spaced generic types expose all type segments** — declarations such as `var repo Repository[Key, Value]` now link the explicit generic type.
 - **Go type specs with spaced generic targets expose all type segments** — declarations such as `type Repo Repository[Key, Value]` now link the target type and arguments.
 - **Go top-level multi-name var declarations index every property symbol** — `var Primary, Secondary *Config` now exposes both names to symbol search and definition workflows.
+- **Go top-level multi-name const declarations index every property symbol** — `const PrimaryStatus, SecondaryStatus = 1, 2` now exposes both names to symbol search and definition workflows.
 
 ## 日本語
 
@@ -84,3 +85,4 @@ affected:
 - **Go var/const 宣言のスペース入り generic 型を参照として出すようになりました** — `var repo Repository[Key, Value]` のような宣言から明示された generic 型を辿れるようになりました。
 - **Go type spec のスペース入り generic target を参照として出すようになりました** — `type Repo Repository[Key, Value]` のような宣言から target 型と型引数を辿れるようになりました。
 - **Go top-level の複数名 var 宣言で全 property symbol を索引するようになりました** — `var Primary, Secondary *Config` から両方の名前を symbol search と definition workflow で辿れるようになりました。
+- **Go top-level の複数名 const 宣言で全 property symbol を索引するようになりました** — `const PrimaryStatus, SecondaryStatus = 1, 2` から両方の名前を symbol search と definition workflow で辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -13,6 +13,7 @@ affected:
 - **Go interface method signatures expose parameter and return types** — interface members such as `Handle(ctx Context) Response` now link `Context` and `Response`.
 - **Go multi-name value declarations expose their shared type** — declarations such as `var primary, secondary *Client` now link `Client`.
 - **Go embedded field types are indexed as type references** — embedded fields such as `*BaseStore` and `audit.Logger` now show up in reference search.
+- **Go builtin allocation type arguments are indexed as type references** — `make([]User, 0)` and `new(Client)` now link `User` and `Client` without turning `make` or `new` into calls.
 
 ## 日本語
 
@@ -22,3 +23,4 @@ affected:
 - **Go interface method signature の引数型と戻り値型を参照として出すようになりました** — `Handle(ctx Context) Response` のような interface member から `Context` と `Response` を辿れるようになりました。
 - **Go の複数名 value 宣言で共有される型を参照として出すようになりました** — `var primary, secondary *Client` のような宣言から `Client` を辿れるようになりました。
 - **Go の embedded field 型を型参照として索引するようになりました** — `*BaseStore` や `audit.Logger` のような embedded field が reference search に現れるようになりました。
+- **Go builtin allocation の型引数を型参照として索引するようになりました** — `make([]User, 0)` や `new(Client)` から `make` / `new` を call にせず `User` と `Client` を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -47,6 +47,7 @@ affected:
 - **Go type specs with spaced generic targets expose all type segments** — declarations such as `type Repo Repository[Key, Value]` now link the target type and arguments.
 - **Go top-level multi-name var declarations index every property symbol** — `var Primary, Secondary *Config` now exposes both names to symbol search and definition workflows.
 - **Go top-level multi-name const declarations index every property symbol** — `const PrimaryStatus, SecondaryStatus = 1, 2` now exposes both names to symbol search and definition workflows.
+- **Go method symbols are attributed to receiver type containers** — `func (h *Handler) ServeHTTP(...)` now appears under `Handler` in symbol-oriented workflows.
 
 ## 日本語
 
@@ -86,3 +87,4 @@ affected:
 - **Go type spec のスペース入り generic target を参照として出すようになりました** — `type Repo Repository[Key, Value]` のような宣言から target 型と型引数を辿れるようになりました。
 - **Go top-level の複数名 var 宣言で全 property symbol を索引するようになりました** — `var Primary, Secondary *Config` から両方の名前を symbol search と definition workflow で辿れるようになりました。
 - **Go top-level の複数名 const 宣言で全 property symbol を索引するようになりました** — `const PrimaryStatus, SecondaryStatus = 1, 2` から両方の名前を symbol search と definition workflow で辿れるようになりました。
+- **Go method symbol を receiver 型 container に帰属させるようになりました** — `func (h *Handler) ServeHTTP(...)` が symbol 系 workflow で `Handler` 配下に現れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -19,6 +19,7 @@ affected:
 - **Go generic call type arguments are indexed as type references** — call sites such as `Decode[User]()` and `Map[model.Event, Result]()` now link their concrete type arguments.
 - **Go function type declarations expose parameter and return types** — declarations such as `type Handler func(Request) Response` and `Callback func(Context) Result` now link their signature types.
 - **Go channel type declarations expose element types** — directional channel declarations such as `<-chan Event` and `chan<- Command` now link `Event` and `Command`.
+- **Go generic composite literals are indexed with their type arguments** — literals such as `Cache[Entry]{}` and `model.Set[Key, Value]{}` now link the instantiated type and concrete type arguments.
 
 ## 日本語
 
@@ -34,3 +35,4 @@ affected:
 - **Go generic call の型引数を型参照として索引するようになりました** — `Decode[User]()` や `Map[model.Event, Result]()` のような call site から具体型引数を辿れるようになりました。
 - **Go function type 宣言の引数型と戻り値型を参照として出すようになりました** — `type Handler func(Request) Response` や `Callback func(Context) Result` のような宣言から signature 内の型を辿れるようになりました。
 - **Go channel type 宣言の要素型を参照として出すようになりました** — `<-chan Event` や `chan<- Command` のような方向付き channel 宣言から `Event` と `Command` を辿れるようになりました。
+- **Go generic composite literal を型引数付きで索引するようになりました** — `Cache[Entry]{}` や `model.Set[Key, Value]{}` のような literal から生成型と具体型引数を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -36,6 +36,7 @@ affected:
 - **Go composite type conversions are indexed as type references** — conversions such as `[]User(raw)`, `map[Key]Value(raw)`, and `chan Event(raw)` now link their target types.
 - **Go inline struct fields expose field types** — anonymous forms such as `struct{ ID UserID; Owner *User }{}` now link `UserID` and `User` without indexing field names.
 - **Go inline interface members expose signature types** — anonymous forms such as `interface{ Handle(Context) Result; io.Reader }` now link method parameter, return, and embedded interface types.
+- **Go multi-pointer parenthesized conversions expose converted types** — conversions such as `(**Node)(nil)` now link the underlying pointed-to type.
 
 ## 日本語
 
@@ -64,3 +65,4 @@ affected:
 - **Go composite type conversion を型参照として索引するようになりました** — `[]User(raw)`、`map[Key]Value(raw)`、`chan Event(raw)` のような conversion から変換対象型を辿れるようになりました。
 - **Go inline struct field の型を参照として出すようになりました** — `struct{ ID UserID; Owner *User }{}` のような anonymous form から field 名ではなく `UserID` と `User` を辿れるようになりました。
 - **Go inline interface member の signature 型を参照として出すようになりました** — `interface{ Handle(Context) Result; io.Reader }` のような anonymous form から method 引数、戻り値、embedded interface 型を辿れるようになりました。
+- **Go の multi-pointer parenthesized conversion で変換対象型を参照として出すようになりました** — `(**Node)(nil)` のような conversion から pointer の先の型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -10,9 +10,11 @@ affected:
 - **Go generic function constraints are indexed as type references** — `func Decode[T WireMessage](...)` now surfaces `WireMessage` in reference search and inspect output.
 - **Go generic type constraints are indexed as type references** — `type Cache[T EntityConstraint] ...` now surfaces `EntityConstraint` in reference search and inspect output.
 - **Go method receiver types are indexed as type references** — `func (h *Handler) Serve(...)` now links `Handler` from reference search and inspect output.
+- **Go interface method signatures expose parameter and return types** — interface members such as `Handle(ctx Context) Response` now link `Context` and `Response`.
 
 ## 日本語
 
 - **Go の generic function 制約を型参照として索引するようになりました** — `func Decode[T WireMessage](...)` から `WireMessage` が reference search と inspect 出力に現れるようになりました。
 - **Go の generic type 制約を型参照として索引するようになりました** — `type Cache[T EntityConstraint] ...` から `EntityConstraint` が reference search と inspect 出力に現れるようになりました。
 - **Go method receiver の型を型参照として索引するようになりました** — `func (h *Handler) Serve(...)` から `Handler` が reference search と inspect 出力で辿れるようになりました。
+- **Go interface method signature の引数型と戻り値型を参照として出すようになりました** — `Handle(ctx Context) Response` のような interface member から `Context` と `Response` を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -38,6 +38,7 @@ affected:
 - **Go inline interface members expose signature types** — anonymous forms such as `interface{ Handle(Context) Result; io.Reader }` now link method parameter, return, and embedded interface types.
 - **Go multi-pointer parenthesized conversions expose converted types** — conversions such as `(**Node)(nil)` now link the underlying pointed-to type.
 - **Go parenthesized composite conversions expose converted types** — conversions such as `([]User)(raw)` and `(map[Key]Value)(raw)` now link their target types.
+- **Go generic method expressions expose receiver type arguments** — expressions such as `Repository[User].Find` and `(*Store[Entry]).Save` now link both receiver and type argument symbols.
 
 ## 日本語
 
@@ -68,3 +69,4 @@ affected:
 - **Go inline interface member の signature 型を参照として出すようになりました** — `interface{ Handle(Context) Result; io.Reader }` のような anonymous form から method 引数、戻り値、embedded interface 型を辿れるようになりました。
 - **Go の multi-pointer parenthesized conversion で変換対象型を参照として出すようになりました** — `(**Node)(nil)` のような conversion から pointer の先の型を辿れるようになりました。
 - **Go の parenthesized composite conversion で変換対象型を参照として出すようになりました** — `([]User)(raw)` や `(map[Key]Value)(raw)` のような conversion から変換対象型を辿れるようになりました。
+- **Go generic method expression の receiver 型引数を参照として出すようになりました** — `Repository[User].Find` や `(*Store[Entry]).Save` のような expression から receiver と型引数の両方を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -8,7 +8,9 @@ affected:
 ## English
 
 - **Go generic function constraints are indexed as type references** — `func Decode[T WireMessage](...)` now surfaces `WireMessage` in reference search and inspect output.
+- **Go generic type constraints are indexed as type references** — `type Cache[T EntityConstraint] ...` now surfaces `EntityConstraint` in reference search and inspect output.
 
 ## 日本語
 
 - **Go の generic function 制約を型参照として索引するようになりました** — `func Decode[T WireMessage](...)` から `WireMessage` が reference search と inspect 出力に現れるようになりました。
+- **Go の generic type 制約を型参照として索引するようになりました** — `type Cache[T EntityConstraint] ...` から `EntityConstraint` が reference search と inspect 出力に現れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -17,6 +17,7 @@ affected:
 - **Go type assertions are indexed as type references** — `value.(User)` and `value.(*Admin)` now link the asserted types while ignoring the `.(type)` sentinel.
 - **Go function literal signatures expose parameter and return types** — callbacks such as `func(ctx Context) Result` now link `Context` and `Result`.
 - **Go generic call type arguments are indexed as type references** — call sites such as `Decode[User]()` and `Map[model.Event, Result]()` now link their concrete type arguments.
+- **Go function type declarations expose parameter and return types** — declarations such as `type Handler func(Request) Response` and `Callback func(Context) Result` now link their signature types.
 
 ## 日本語
 
@@ -30,3 +31,4 @@ affected:
 - **Go type assertion を型参照として索引するようになりました** — `value.(User)` や `value.(*Admin)` から assertion 対象型を辿れるようにしつつ、`.(type)` sentinel は無視します。
 - **Go function literal signature の引数型と戻り値型を参照として出すようになりました** — `func(ctx Context) Result` のような callback から `Context` と `Result` を辿れるようになりました。
 - **Go generic call の型引数を型参照として索引するようになりました** — `Decode[User]()` や `Map[model.Event, Result]()` のような call site から具体型引数を辿れるようになりました。
+- **Go function type 宣言の引数型と戻り値型を参照として出すようになりました** — `type Handler func(Request) Response` や `Callback func(Context) Result` のような宣言から signature 内の型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -41,6 +41,7 @@ affected:
 - **Go generic method expressions expose receiver type arguments** — expressions such as `Repository[User].Find` and `(*Store[Entry]).Save` now link both receiver and type argument symbols.
 - **Go standalone type-set terms expose approximation types** — constraint terms such as `~[]Element` and `~map[Key]Value` now link their element, key, and value types.
 - **Go package declarations are indexed as namespace symbols** — `package demo` now appears in symbol search, outline, and definition-oriented workflows.
+- **Go multi-name struct fields expose their shared type** — fields such as `Primary, Secondary *Client` now link the shared field type without indexing field names.
 
 ## 日本語
 
@@ -74,3 +75,4 @@ affected:
 - **Go generic method expression の receiver 型引数を参照として出すようになりました** — `Repository[User].Find` や `(*Store[Entry]).Save` のような expression から receiver と型引数の両方を辿れるようになりました。
 - **Go standalone type-set term の approximation 型を参照として出すようになりました** — `~[]Element` や `~map[Key]Value` のような constraint term から element、key、value 型を辿れるようになりました。
 - **Go package 宣言を namespace symbol として索引するようになりました** — `package demo` が symbol search、outline、definition 系 workflow に現れるようになりました。
+- **Go の複数名 struct field で共有される型を参照として出すようになりました** — `Primary, Secondary *Client` のような field から field 名を索引せずに共有型を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -18,6 +18,7 @@ affected:
 - **Go function literal signatures expose parameter and return types** — callbacks such as `func(ctx Context) Result` now link `Context` and `Result`.
 - **Go generic call type arguments are indexed as type references** — call sites such as `Decode[User]()` and `Map[model.Event, Result]()` now link their concrete type arguments.
 - **Go function type declarations expose parameter and return types** — declarations such as `type Handler func(Request) Response` and `Callback func(Context) Result` now link their signature types.
+- **Go channel type declarations expose element types** — directional channel declarations such as `<-chan Event` and `chan<- Command` now link `Event` and `Command`.
 
 ## 日本語
 
@@ -32,3 +33,4 @@ affected:
 - **Go function literal signature の引数型と戻り値型を参照として出すようになりました** — `func(ctx Context) Result` のような callback から `Context` と `Result` を辿れるようになりました。
 - **Go generic call の型引数を型参照として索引するようになりました** — `Decode[User]()` や `Map[model.Event, Result]()` のような call site から具体型引数を辿れるようになりました。
 - **Go function type 宣言の引数型と戻り値型を参照として出すようになりました** — `type Handler func(Request) Response` や `Callback func(Context) Result` のような宣言から signature 内の型を辿れるようになりました。
+- **Go channel type 宣言の要素型を参照として出すようになりました** — `<-chan Event` や `chan<- Command` のような方向付き channel 宣言から `Event` と `Command` を辿れるようになりました。

--- a/changelog.d/unreleased/+go-search-improvements.changed.md
+++ b/changelog.d/unreleased/+go-search-improvements.changed.md
@@ -48,6 +48,7 @@ affected:
 - **Go top-level multi-name var declarations index every property symbol** — `var Primary, Secondary *Config` now exposes both names to symbol search and definition workflows.
 - **Go top-level multi-name const declarations index every property symbol** — `const PrimaryStatus, SecondaryStatus = 1, 2` now exposes both names to symbol search and definition workflows.
 - **Go method symbols are attributed to receiver type containers** — `func (h *Handler) ServeHTTP(...)` now appears under `Handler` in symbol-oriented workflows.
+- **Go generic receiver method containers tolerate spaced type parameters** — `func (s *Store[T, U]) Save(...)` now stays attributed to `Store`.
 
 ## 日本語
 
@@ -88,3 +89,4 @@ affected:
 - **Go top-level の複数名 var 宣言で全 property symbol を索引するようになりました** — `var Primary, Secondary *Config` から両方の名前を symbol search と definition workflow で辿れるようになりました。
 - **Go top-level の複数名 const 宣言で全 property symbol を索引するようになりました** — `const PrimaryStatus, SecondaryStatus = 1, 2` から両方の名前を symbol search と definition workflow で辿れるようになりました。
 - **Go method symbol を receiver 型 container に帰属させるようになりました** — `func (h *Handler) ServeHTTP(...)` が symbol 系 workflow で `Handler` 配下に現れるようになりました。
+- **Go generic receiver method の container がスペース入り型パラメータに対応しました** — `func (s *Store[T, U]) Save(...)` が `Store` 配下に帰属し続けるようになりました。

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2026,6 +2026,9 @@ public static partial class ReferenceExtractor
                         AddCallLikeReference);
                 }
 
+                if (language == "go")
+                    LanguageReferenceExtractionSupport.EmitGoBranchLabelReferences(preparedLine, AddCallLikeReference);
+
                 if (language == "swift")
                     SwiftReferenceExtractor.EmitTrailingClosureReferences(preparedLine, AddCallLikeReference);
                 else if (language == "kotlin")

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -48,6 +48,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex GoTypeAssertionRegex = new(
         @"\.\s*\(\s*(?<type>[^()\r\n]+?)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoFunctionLiteralRegex = new(
+        @"\bfunc\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex DartCtorRegex = new(
         @"\b(?:new|const)\s+(?<name>[A-Z]\w*(?:\.[A-Za-z_]\w*)?)\s*(?:<[^>]+>)?\s*\(",
@@ -960,6 +963,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoTypeAssertionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
         {
@@ -1189,6 +1193,30 @@ internal static class LanguageReferenceExtractionSupport
 
             var trimStart = group.Value.IndexOf(expression, StringComparison.Ordinal);
             EmitGoTypeExpression(expression, group.Index + Math.Max(0, trimStart), references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static void EmitGoFunctionLiteralSignatureTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (Match match in GoFunctionLiteralRegex.Matches(line))
+        {
+            var open = line.IndexOf('(', match.Index);
+            if (open < 0)
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '(', ')');
+            if (close < 0)
+                continue;
+
+            EmitGoParameterListTypes(line, open + 1, close, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            EmitGoSignatureReturnTypes(line, close + 1, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -975,6 +975,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoInlineStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoInlineInterfaceMemberTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoArraySliceCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMapCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1648,6 +1649,136 @@ internal static class LanguageReferenceExtractionSupport
 
         var expression = typeStart == 0 ? field : field[typeStart..];
         EmitGoTypeExpression(expression, absoluteFieldStart + typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoInlineInterfaceMemberTypeReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var interfaceIndex = line.IndexOf("interface", searchStart, StringComparison.Ordinal);
+            if (interfaceIndex < 0)
+                return;
+
+            searchStart = interfaceIndex + "interface".Length;
+            if (!IsIdentifierAt(line, interfaceIndex, "interface"))
+                continue;
+
+            var open = SkipWhitespace(line, searchStart);
+            if (open >= line.Length || line[open] != '{')
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '{', '}');
+            if (close <= open + 1)
+                continue;
+
+            var body = line[(open + 1)..close];
+            var bodyStart = open + 1;
+            foreach (var (memberStart, memberLength) in SplitGoInlineStructFieldSpans(body))
+                EmitGoInlineInterfaceMemberTypes(line, bodyStart + memberStart, bodyStart + memberStart + memberLength, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static void EmitGoInlineInterfaceMemberTypes(
+        string line,
+        int memberStart,
+        int memberEnd,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var cursor = SkipWhitespace(line, memberStart);
+        if (cursor >= memberEnd)
+            return;
+
+        if (!IsIdentifierStart(line[cursor]))
+        {
+            EmitGoInlineInterfaceEmbeddedType(line, cursor, memberEnd, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            return;
+        }
+
+        var nameStart = cursor;
+        cursor++;
+        while (cursor < memberEnd && IsSimpleIdentifierPart(line[cursor]))
+            cursor++;
+
+        var name = line[nameStart..cursor];
+        if (IsGoStatementKeyword(name))
+            return;
+
+        var open = SkipWhitespace(line, cursor);
+        if (open < memberEnd && line[open] == '(')
+        {
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '(', ')');
+            if (close > open && close <= memberEnd)
+            {
+                EmitGoParameterListTypes(line, open + 1, close, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+                EmitGoSignatureReturnTypesInRange(line, close + 1, memberEnd, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            }
+
+            return;
+        }
+
+        EmitGoInlineInterfaceEmbeddedType(line, nameStart, memberEnd, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoInlineInterfaceEmbeddedType(
+        string line,
+        int start,
+        int end,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var typeStart = SkipWhitespace(line, start);
+        if (typeStart >= end)
+            return;
+
+        var expression = line[typeStart..end].Trim();
+        if (expression.Length == 0)
+            return;
+
+        EmitGoTypeExpression(expression, typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoSignatureReturnTypesInRange(
+        string line,
+        int start,
+        int end,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var returnStart = SkipWhitespace(line, start);
+        if (returnStart >= end || line[returnStart] == '{')
+            return;
+
+        if (line[returnStart] == '(')
+        {
+            var returnClose = ReferenceExtractor.FindMatchingChar(line, returnStart, '(', ')');
+            if (returnClose > returnStart && returnClose <= end)
+                EmitGoParameterListTypes(line, returnStart + 1, returnClose, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            return;
+        }
+
+        var expression = line[returnStart..end].TrimEnd();
+        EmitGoTypeExpression(expression, returnStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
 
     private static void EmitGoMapCompositeLiteralTypeReferences(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -964,6 +964,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoTypeAssertionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCallTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
@@ -1264,6 +1265,39 @@ internal static class LanguageReferenceExtractionSupport
                 var absoluteStart = open + 1 + segmentStart + Math.Max(0, trimStart);
                 EmitGoTypeExpression(expression, absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
             }
+        }
+    }
+
+    private static void EmitGoFunctionTypeSignatureTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var funcIndex = line.IndexOf("func", searchStart, StringComparison.Ordinal);
+            if (funcIndex < 0)
+                return;
+
+            searchStart = funcIndex + "func".Length;
+            if (!IsIdentifierAt(line, funcIndex, "func"))
+                continue;
+
+            var open = SkipWhitespace(line, searchStart);
+            if (open >= line.Length || line[open] != '(')
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '(', ')');
+            if (close < 0)
+                continue;
+
+            EmitGoParameterListTypes(line, open + 1, close, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            EmitGoSignatureReturnTypes(line, close + 1, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -969,6 +969,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMapCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoParenthesizedTypeConversionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoMethodExpressionReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCallTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
@@ -1510,6 +1511,123 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         return isPointerConversion || expression.Contains('.');
+    }
+
+    private static void EmitGoMethodExpressionReceiverTypeReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        EmitGoParenthesizedMethodExpressionReceiverTypes(line, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoBareMethodExpressionReceiverTypes(line, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoParenthesizedMethodExpressionReceiverTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var open = line.IndexOf('(', searchStart);
+            if (open < 0)
+                return;
+
+            searchStart = open + 1;
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '(', ')');
+            if (close <= open + 1)
+                continue;
+
+            var dot = SkipWhitespace(line, close + 1);
+            if (dot >= line.Length || line[dot] != '.')
+                continue;
+
+            var methodStart = dot + 1;
+            if (methodStart >= line.Length || !IsIdentifierStart(line[methodStart]))
+                continue;
+
+            var rawExpression = line[(open + 1)..close];
+            var expression = rawExpression.Trim();
+            if (!IsLikelyGoMethodExpressionReceiverType(expression))
+                continue;
+
+            var trimStart = rawExpression.IndexOf(expression, StringComparison.Ordinal);
+            EmitGoTypeExpression(expression, open + 1 + Math.Max(0, trimStart), references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static void EmitGoBareMethodExpressionReceiverTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        for (var dot = 1; dot < line.Length - 1; dot++)
+        {
+            if (line[dot] != '.')
+                continue;
+            if (!IsSimpleIdentifierPart(line[dot - 1]) || !IsIdentifierStart(line[dot + 1]))
+                continue;
+
+            var receiverStart = dot - 1;
+            while (receiverStart >= 0 && IsSimpleIdentifierPart(line[receiverStart]))
+                receiverStart--;
+            receiverStart++;
+
+            var receiverName = line[receiverStart..dot];
+            if (receiverName.Length == 0 || !char.IsUpper(receiverName[0]))
+                continue;
+
+            ReferenceExtractor.AddReference(references, seen, fileId, receiverName, receiverStart, "type_reference", context, lineNumber, resolveContainerForColumn(receiverStart));
+        }
+    }
+
+    private static bool IsLikelyGoMethodExpressionReceiverType(string expression)
+    {
+        if (expression.Length == 0 || expression.Contains(','))
+            return false;
+
+        var cursor = 0;
+        while (cursor < expression.Length && char.IsWhiteSpace(expression[cursor]))
+            cursor++;
+        if (cursor < expression.Length && expression[cursor] == '*')
+            cursor = SkipWhitespace(expression, cursor + 1);
+
+        if (cursor >= expression.Length || !IsIdentifierStart(expression[cursor]))
+            return false;
+
+        var lastSegmentStart = cursor;
+        while (cursor < expression.Length)
+        {
+            if (IsSimpleIdentifierPart(expression[cursor]))
+            {
+                cursor++;
+                continue;
+            }
+
+            if (expression[cursor] != '.')
+                return false;
+
+            cursor++;
+            if (cursor >= expression.Length || !IsIdentifierStart(expression[cursor]))
+                return false;
+            lastSegmentStart = cursor;
+            cursor++;
+        }
+
+        return expression.Contains('.') || char.IsUpper(expression[lastSegmentStart]);
     }
 
     private static bool HasGoIdentifierBeforeBracket(string line, int openBracket)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -1535,6 +1535,7 @@ internal static class LanguageReferenceExtractionSupport
             return;
 
         var parameterOpen = firstParen;
+        var functionHeaderStart = GoFuncRegex.Match(preparedLine).Length;
         var receiverClose = ReferenceExtractor.FindMatchingChar(preparedLine, firstParen, '(', ')');
         if (receiverClose >= 0)
         {
@@ -1545,7 +1546,10 @@ internal static class LanguageReferenceExtractionSupport
             {
                 var nextParen = preparedLine.IndexOf('(', afterReceiver);
                 if (nextParen > afterReceiver)
+                {
                     parameterOpen = nextParen;
+                    functionHeaderStart = afterReceiver;
+                }
             }
         }
 
@@ -1553,6 +1557,7 @@ internal static class LanguageReferenceExtractionSupport
         if (parameterClose < 0)
             return;
 
+        EmitGoTypeParameterConstraints(preparedLine, functionHeaderStart, parameterOpen, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoParameterListTypes(preparedLine, parameterOpen + 1, parameterClose, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         var returnStart = parameterClose + 1;
@@ -1573,6 +1578,65 @@ internal static class LanguageReferenceExtractionSupport
         while (returnEnd < preparedLine.Length && !char.IsWhiteSpace(preparedLine[returnEnd]) && preparedLine[returnEnd] != '{')
             returnEnd++;
         EmitGoTypeExpression(preparedLine[returnStart..returnEnd], returnStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoTypeParameterConstraints(
+        string line,
+        int searchStart,
+        int searchEnd,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (searchStart < 0 || searchStart >= searchEnd || searchEnd > line.Length)
+            return;
+
+        var open = line.IndexOf('[', searchStart, searchEnd - searchStart);
+        if (open < 0)
+            return;
+
+        var close = ReferenceExtractor.FindMatchingChar(line, open, '[', ']');
+        if (close < 0 || close > searchEnd)
+            return;
+
+        var list = line[(open + 1)..close];
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(list))
+        {
+            var rawSegment = list.Substring(segmentStart, segmentLength);
+            var fragment = rawSegment.Trim();
+            if (fragment.Length == 0)
+                continue;
+
+            var constraintStart = FirstGoTypeParameterConstraintStart(fragment);
+            if (constraintStart < 0)
+                continue;
+
+            var fragmentTrimStart = rawSegment.IndexOf(fragment, StringComparison.Ordinal);
+            var absoluteStart = open + 1 + segmentStart + Math.Max(0, fragmentTrimStart) + constraintStart;
+            EmitGoTypeExpression(fragment[constraintStart..], absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static int FirstGoTypeParameterConstraintStart(string fragment)
+    {
+        var cursor = 0;
+        while (cursor < fragment.Length && char.IsWhiteSpace(fragment[cursor]))
+            cursor++;
+        if (cursor >= fragment.Length || !IsIdentifierStart(fragment[cursor]))
+            return -1;
+
+        cursor++;
+        while (cursor < fragment.Length && IsSimpleIdentifierPart(fragment[cursor]))
+            cursor++;
+
+        var constraintStart = cursor;
+        while (constraintStart < fragment.Length && char.IsWhiteSpace(fragment[constraintStart]))
+            constraintStart++;
+
+        return constraintStart < fragment.Length ? constraintStart : -1;
     }
 
     private static void EmitGoParameterListTypes(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -962,6 +962,8 @@ internal static class LanguageReferenceExtractionSupport
 
         if (GoFuncRegex.IsMatch(preparedLine))
             EmitGoFunctionSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        else
+            EmitGoInterfaceMethodSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (Match match in GoCompositeLiteralRegex.Matches(preparedLine))
         {
@@ -1644,9 +1646,90 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         var returnEnd = returnStart;
-        while (returnEnd < preparedLine.Length && !char.IsWhiteSpace(preparedLine[returnEnd]) && preparedLine[returnEnd] != '{')
+        while (returnEnd < preparedLine.Length && preparedLine[returnEnd] != '{')
             returnEnd++;
-        EmitGoTypeExpression(preparedLine[returnStart..returnEnd], returnStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+
+        var expression = preparedLine[returnStart..returnEnd].TrimEnd();
+        EmitGoTypeExpression(expression, returnStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoInterfaceMethodSignatureTypes(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var nameStart = SkipWhitespace(preparedLine, 0);
+        if (nameStart >= preparedLine.Length || !IsIdentifierStart(preparedLine[nameStart]))
+            return;
+
+        var nameEnd = nameStart + 1;
+        while (nameEnd < preparedLine.Length && IsSimpleIdentifierPart(preparedLine[nameEnd]))
+            nameEnd++;
+
+        if (IsGoStatementKeyword(preparedLine[nameStart..nameEnd]))
+            return;
+
+        var open = SkipWhitespace(preparedLine, nameEnd);
+        if (open >= preparedLine.Length || preparedLine[open] != '(')
+            return;
+
+        var close = ReferenceExtractor.FindMatchingChar(preparedLine, open, '(', ')');
+        if (close < 0)
+            return;
+
+        var returnStart = SkipWhitespace(preparedLine, close + 1);
+        if (!IsGoSignatureReturnStart(preparedLine, returnStart))
+            return;
+
+        EmitGoParameterListTypes(preparedLine, open + 1, close, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoSignatureReturnTypes(preparedLine, close + 1, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static bool IsGoStatementKeyword(string value)
+        => value is "case" or "const" or "default" or "defer" or "else" or "for" or "func"
+            or "go" or "if" or "import" or "package" or "return" or "select" or "switch"
+            or "type" or "var";
+
+    private static bool IsGoSignatureReturnStart(string line, int index)
+    {
+        if (index >= line.Length)
+            return false;
+
+        return line[index] is '(' or '*' or '[' or '<' || IsIdentifierStart(line[index]);
+    }
+
+    private static void EmitGoSignatureReturnTypes(
+        string preparedLine,
+        int start,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var returnStart = SkipWhitespace(preparedLine, start);
+        if (returnStart >= preparedLine.Length || preparedLine[returnStart] == '{')
+            return;
+
+        if (preparedLine[returnStart] == '(')
+        {
+            var returnClose = ReferenceExtractor.FindMatchingChar(preparedLine, returnStart, '(', ')');
+            if (returnClose > returnStart)
+                EmitGoParameterListTypes(preparedLine, returnStart + 1, returnClose, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            return;
+        }
+
+        var returnEnd = returnStart;
+        while (returnEnd < preparedLine.Length && preparedLine[returnEnd] != '{')
+            returnEnd++;
+
+        var expression = preparedLine[returnStart..returnEnd].TrimEnd();
+        EmitGoTypeExpression(expression, returnStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
 
     private static void EmitGoTypeParameterConstraints(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -975,6 +975,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoArraySliceCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMapCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoParenthesizedTypeConversionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMethodExpressionReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1591,6 +1592,43 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             EmitGoTypeExpression(line[valueStart..valueEnd], valueStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static void EmitGoArraySliceCompositeLiteralTypeReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var open = line.IndexOf('[', searchStart);
+            if (open < 0)
+                return;
+
+            searchStart = open + 1;
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '[', ']');
+            if (close < 0)
+                continue;
+
+            var elementStart = SkipWhitespace(line, close + 1);
+            if (elementStart >= line.Length || !IsGoTypeExpressionStart(line, elementStart))
+                continue;
+
+            var elementEnd = FindGoInlineTypeExpressionEnd(line, elementStart);
+            var literalOpen = SkipWhitespace(line, elementEnd);
+            if (literalOpen >= line.Length || line[literalOpen] != '{')
+                continue;
+
+            if (!IsGoCompositeLiteralContext(line, open, elementEnd - open))
+                continue;
+
+            EmitGoTypeExpression(line[elementStart..elementEnd], elementStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -2003,7 +2003,7 @@ internal static class LanguageReferenceExtractionSupport
         while (cursor < expression.Length && char.IsWhiteSpace(expression[cursor]))
             cursor++;
         var isPointerConversion = cursor < expression.Length && expression[cursor] == '*';
-        if (cursor < expression.Length && expression[cursor] == '*')
+        while (cursor < expression.Length && expression[cursor] == '*')
             cursor = SkipWhitespace(expression, cursor + 1);
 
         if (cursor >= expression.Length || !IsIdentifierStart(expression[cursor]))

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -2050,6 +2050,7 @@ internal static class LanguageReferenceExtractionSupport
     {
         EmitGoParenthesizedMethodExpressionReceiverTypes(line, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoBareMethodExpressionReceiverTypes(line, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoGenericMethodExpressionReceiverTypes(line, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
 
     private static void EmitGoParenthesizedMethodExpressionReceiverTypes(
@@ -2134,6 +2135,9 @@ internal static class LanguageReferenceExtractionSupport
         if (cursor >= expression.Length || !IsIdentifierStart(expression[cursor]))
             return false;
 
+        if (IsLikelyGoGenericReceiverTypeExpression(expression, cursor))
+            return true;
+
         var lastSegmentStart = cursor;
         while (cursor < expression.Length)
         {
@@ -2154,6 +2158,64 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         return expression.Contains('.') || char.IsUpper(expression[lastSegmentStart]);
+    }
+
+    private static void EmitGoGenericMethodExpressionReceiverTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var open = line.IndexOf('[', searchStart);
+            if (open < 0)
+                return;
+
+            searchStart = open + 1;
+            if (!TryGetGoIdentifierBeforeBracket(line, open, out var nameStart, out var nameLength))
+                continue;
+            if (nameLength == 0 || !char.IsUpper(line[nameStart]))
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '[', ']');
+            if (close < 0)
+                continue;
+
+            var dot = SkipWhitespace(line, close + 1);
+            if (dot >= line.Length || line[dot] != '.')
+                continue;
+
+            var methodStart = dot + 1;
+            if (methodStart >= line.Length || !IsIdentifierStart(line[methodStart]))
+                continue;
+
+            EmitGoTypeExpression(line[nameStart..(close + 1)], nameStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static bool IsLikelyGoGenericReceiverTypeExpression(string expression, int receiverStart)
+    {
+        var open = expression.IndexOf('[', receiverStart);
+        if (open < 0 || !ContainsLikelyGoTypeArgument(expression[open..]))
+            return false;
+
+        var firstSegmentStart = receiverStart;
+        var firstSegmentEnd = firstSegmentStart;
+        while (firstSegmentEnd < expression.Length && IsSimpleIdentifierPart(expression[firstSegmentEnd]))
+            firstSegmentEnd++;
+
+        if (firstSegmentEnd <= firstSegmentStart)
+            return false;
+        if (char.IsUpper(expression[firstSegmentStart]))
+            return true;
+
+        var afterFirst = SkipWhitespace(expression, firstSegmentEnd);
+        return afterFirst < expression.Length && expression[afterFirst] == '.';
     }
 
     private static void EmitGoGenericInstantiationTypeArgumentReferences(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -951,6 +951,7 @@ internal static class LanguageReferenceExtractionSupport
 
         EmitGoTypeDeclarationParameterConstraints(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
         {
@@ -1070,6 +1071,61 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         return requireComma ? count > 1 : count > 0;
+    }
+
+    private static void EmitGoEmbeddedFieldType(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var cursor = SkipWhitespace(line, 0);
+        if (cursor >= line.Length)
+            return;
+
+        if (line[cursor] == '*')
+            cursor = SkipWhitespace(line, cursor + 1);
+
+        if (cursor >= line.Length || !IsIdentifierStart(line[cursor]))
+            return;
+
+        var nameStart = cursor;
+        cursor++;
+        while (cursor < line.Length && IsSimpleIdentifierPart(line[cursor]))
+            cursor++;
+
+        if (IsGoStatementKeyword(line[nameStart..cursor]))
+            return;
+
+        if (cursor < line.Length && line[cursor] == '.')
+        {
+            cursor++;
+            if (cursor >= line.Length || !IsIdentifierStart(line[cursor]))
+                return;
+            cursor++;
+            while (cursor < line.Length && IsSimpleIdentifierPart(line[cursor]))
+                cursor++;
+        }
+
+        if (cursor < line.Length && line[cursor] == '[')
+        {
+            var close = ReferenceExtractor.FindMatchingChar(line, cursor, '[', ']');
+            if (close < 0)
+                return;
+            cursor = close + 1;
+        }
+
+        var afterType = SkipWhitespace(line, cursor);
+        if (afterType < line.Length && line[afterType] != '`')
+            return;
+
+        var typeStart = line.IndexOf('*') >= 0 && line.IndexOf('*') < nameStart
+            ? line.IndexOf('*')
+            : nameStart;
+        EmitGoTypeExpression(line[typeStart..cursor], typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
 
     private static bool StartsWithKeyword(string line, int index, string keyword)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -969,6 +969,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoStandaloneTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameFieldDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoSingleNameFieldDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoChannelElementTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1118,6 +1119,57 @@ internal static class LanguageReferenceExtractionSupport
             return;
 
         EmitGoTypeExpression(line[typeStart..typeEnd], typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoSingleNameFieldDeclarationTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var cursor = SkipWhitespace(line, 0);
+        if (cursor >= line.Length || !IsIdentifierStart(line[cursor]))
+            return;
+
+        var nameStart = cursor;
+        cursor++;
+        while (cursor < line.Length && IsSimpleIdentifierPart(line[cursor]))
+            cursor++;
+
+        if (IsGoStatementKeyword(line[nameStart..cursor]))
+            return;
+
+        var typeStart = SkipWhitespace(line, cursor);
+        if (typeStart >= line.Length || line[typeStart] is ':' or '=' or '(' || !IsGoTypeExpressionStart(line, typeStart))
+            return;
+        if (!IsLikelyGoFieldDeclarationTypeStart(line, typeStart))
+            return;
+
+        var typeEnd = FindGoInlineTypeExpressionEnd(line, typeStart);
+        if (typeEnd <= typeStart)
+            return;
+
+        var afterType = SkipWhitespace(line, typeEnd);
+        if (afterType < line.Length && line[afterType] != '`')
+            return;
+
+        EmitGoTypeExpression(line[typeStart..typeEnd], typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static bool IsLikelyGoFieldDeclarationTypeStart(string line, int typeStart)
+    {
+        if (typeStart >= line.Length || line[typeStart] != '[')
+            return true;
+
+        var close = ReferenceExtractor.FindMatchingChar(line, typeStart, '[', ']');
+        if (close < 0)
+            return false;
+
+        var elementStart = SkipWhitespace(line, close + 1);
+        return elementStart < line.Length && IsGoTypeExpressionStart(line, elementStart);
     }
 
     private static void EmitGoInterfaceTypeSetTermReferences(
@@ -3077,8 +3129,9 @@ internal static class LanguageReferenceExtractionSupport
     }
 
     private static bool IsGoStatementKeyword(string value)
-        => value is "case" or "const" or "default" or "defer" or "else" or "for" or "func"
-            or "go" or "if" or "import" or "package" or "return" or "select" or "switch"
+        => value is "break" or "case" or "const" or "continue" or "default" or "defer"
+            or "else" or "fallthrough" or "for" or "func" or "go" or "goto" or "if"
+            or "import" or "package" or "range" or "return" or "select" or "switch"
             or "type" or "var";
 
     private static bool IsGoSignatureReturnStart(string line, int index)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -48,6 +48,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex GoTypeAssertionRegex = new(
         @"\.\s*\(\s*(?<type>[^()\r\n]+?)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoTypeSwitchCaseRegex = new(
+        @"^\s*case\s+(?<types>.+?)\s*:",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex GoFunctionLiteralRegex = new(
         @"\bfunc\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -968,6 +971,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoChannelElementTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoTypeAssertionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoTypeSwitchCaseReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1290,6 +1294,66 @@ internal static class LanguageReferenceExtractionSupport
             var trimStart = group.Value.IndexOf(expression, StringComparison.Ordinal);
             EmitGoTypeExpression(expression, group.Index + Math.Max(0, trimStart), references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
+    }
+
+    private static void EmitGoTypeSwitchCaseReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var match = GoTypeSwitchCaseRegex.Match(line);
+        if (!match.Success)
+            return;
+
+        var group = match.Groups["types"];
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(group.Value))
+        {
+            var rawType = group.Value.Substring(segmentStart, segmentLength);
+            var expression = rawType.Trim();
+            if (expression.Length == 0
+                || expression is "nil" or "default"
+                || !IsLikelyGoTypeSwitchCaseType(expression))
+            {
+                continue;
+            }
+
+            var trimStart = rawType.IndexOf(expression, StringComparison.Ordinal);
+            EmitGoTypeExpression(expression, group.Index + segmentStart + Math.Max(0, trimStart), references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static bool IsLikelyGoTypeSwitchCaseType(string expression)
+    {
+        var cursor = 0;
+        var hasPointerPrefix = false;
+        while (cursor < expression.Length)
+        {
+            cursor = SkipWhitespace(expression, cursor);
+            if (cursor >= expression.Length || expression[cursor] != '*')
+                break;
+
+            hasPointerPrefix = true;
+            cursor++;
+        }
+
+        if (cursor >= expression.Length)
+            return false;
+        if (expression[cursor] == '[')
+            return true;
+        if (hasPointerPrefix && char.IsUpper(expression[cursor]))
+            return true;
+        if (hasPointerPrefix && expression.IndexOf('.', cursor) >= 0)
+            return true;
+
+        return StartsWithKeyword(expression, cursor, "map")
+            || StartsWithKeyword(expression, cursor, "chan")
+            || StartsWithKeyword(expression, cursor, "func")
+            || StartsWithKeyword(expression, cursor, "interface")
+            || StartsWithKeyword(expression, cursor, "struct");
     }
 
     private static void EmitGoChannelElementTypeReferences(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -31,7 +31,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\b(?:var|const)\s+[A-Za-z_]\w*\s+(?<type>[\*\[\]\w.]+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex GoFieldTypeRegex = new(
-        @"^\s*(?!(?:package|import|func|type|var|const|return|defer|go|if|for|switch|select|case|default|else)\b)[A-Za-z_]\w*\s+(?<type>[\*\[\]\w.]+)(?:\s|`|$)",
+        @"^\s*(?!(?:package|import|func|type|var|const|return|defer|go|break|continue|goto|if|for|switch|select|case|default|else)\b)[A-Za-z_]\w*\s+(?<type>[\*\[\]\w.]+)(?:\s|`|$)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex GoTypeAliasRegex = new(
         @"^\s*type\s+[A-Za-z_]\w*(?:\[[^\]]+\])?\s+=?\s*(?<type>[\*\[\]\w.]+)",
@@ -50,6 +50,9 @@ internal static class LanguageReferenceExtractionSupport
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex GoFunctionLiteralRegex = new(
         @"\bfunc\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoBranchLabelRegex = new(
+        @"\b(?:goto|break|continue)\s+(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex DartCtorRegex = new(
@@ -2229,6 +2232,12 @@ internal static class LanguageReferenceExtractionSupport
 
     private static bool IsSimpleIdentifierPart(char ch) =>
         ch == '_' || char.IsLetterOrDigit(ch);
+
+    internal static void EmitGoBranchLabelReferences(string preparedLine, Action<string, int> addCallLikeReference)
+    {
+        foreach (Match match in GoBranchLabelRegex.Matches(preparedLine))
+            addCallLikeReference(match.Groups["name"].Value, match.Groups["name"].Index);
+    }
 
     private static void EmitFortranCallReferences(string preparedLine, Action<string, int> addCallLikeReference)
     {

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -45,6 +45,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex GoBuiltinTypeArgumentRegex = new(
         @"\b(?:make|new)\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoTypeAssertionRegex = new(
+        @"\.\s*\(\s*(?<type>[^()\r\n]+?)\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex DartCtorRegex = new(
         @"\b(?:new|const)\s+(?<name>[A-Z]\w*(?:\.[A-Za-z_]\w*)?)\s*(?:<[^>]+>)?\s*\(",
@@ -956,6 +959,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoTypeAssertionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
         {
@@ -1164,6 +1168,27 @@ internal static class LanguageReferenceExtractionSupport
             var trimStart = rawType.IndexOf(expression, StringComparison.Ordinal);
             var absoluteStart = open + 1 + firstArgument.Start + Math.Max(0, trimStart);
             EmitGoTypeExpression(expression, absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static void EmitGoTypeAssertionReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (Match match in GoTypeAssertionRegex.Matches(line))
+        {
+            var group = match.Groups["type"];
+            var expression = group.Value.Trim();
+            if (expression.Length == 0 || string.Equals(expression, "type", StringComparison.Ordinal))
+                continue;
+
+            var trimStart = group.Value.IndexOf(expression, StringComparison.Ordinal);
+            EmitGoTypeExpression(expression, group.Index + Math.Max(0, trimStart), references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -966,6 +966,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoTypeAssertionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCallTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
@@ -1337,17 +1338,77 @@ internal static class LanguageReferenceExtractionSupport
         }
     }
 
-    private static bool HasGoIdentifierBeforeBracket(string line, int openBracket)
+    private static void EmitGoGenericCompositeLiteralReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
     {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var open = line.IndexOf('[', searchStart);
+            if (open < 0)
+                return;
+
+            searchStart = open + 1;
+            if (!TryGetGoIdentifierBeforeBracket(line, open, out var nameStart, out var nameLength))
+                continue;
+
+            var typeName = line.Substring(nameStart, nameLength);
+            if (typeName.Length == 0 || !char.IsUpper(typeName[0]))
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '[', ']');
+            if (close < 0)
+                continue;
+
+            var afterClose = SkipWhitespace(line, close + 1);
+            if (afterClose >= line.Length || line[afterClose] != '{')
+                continue;
+
+            if (!IsGoCompositeLiteralContext(line, nameStart, nameLength))
+                continue;
+
+            ReferenceExtractor.AddReference(references, seen, fileId, typeName, nameStart, "instantiate", context, lineNumber, resolveContainerForColumn(nameStart));
+
+            var typeArguments = line[(open + 1)..close];
+            foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typeArguments))
+            {
+                var rawArgument = typeArguments.Substring(segmentStart, segmentLength);
+                var expression = rawArgument.Trim();
+                if (expression.Length == 0 || !ContainsLikelyGoTypeArgument(expression))
+                    continue;
+
+                var trimStart = rawArgument.IndexOf(expression, StringComparison.Ordinal);
+                var absoluteStart = open + 1 + segmentStart + Math.Max(0, trimStart);
+                EmitGoTypeExpression(expression, absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            }
+        }
+    }
+
+    private static bool HasGoIdentifierBeforeBracket(string line, int openBracket)
+        => TryGetGoIdentifierBeforeBracket(line, openBracket, out _, out _);
+
+    private static bool TryGetGoIdentifierBeforeBracket(string line, int openBracket, out int start, out int length)
+    {
+        start = -1;
+        length = 0;
         var cursor = openBracket - 1;
         while (cursor >= 0 && char.IsWhiteSpace(line[cursor]))
             cursor--;
         if (cursor < 0 || !IsSimpleIdentifierPart(line[cursor]))
             return false;
 
+        var end = cursor + 1;
         while (cursor >= 0 && IsSimpleIdentifierPart(line[cursor]))
             cursor--;
 
+        start = cursor + 1;
+        length = end - start;
         return true;
     }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -977,6 +977,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoArraySliceCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMapCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoCompositeTypeConversionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoParenthesizedTypeConversionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMethodExpressionReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericInstantiationTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1665,6 +1666,99 @@ internal static class LanguageReferenceExtractionSupport
             var trimStart = rawExpression.IndexOf(expression, StringComparison.Ordinal);
             EmitGoTypeExpression(expression, open + 1 + Math.Max(0, trimStart), references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
+    }
+
+    private static void EmitGoCompositeTypeConversionReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var typeStart = NextGoCompositeConversionTypeStart(line, searchStart);
+            if (typeStart < 0)
+                return;
+
+            searchStart = typeStart + 1;
+            if (!IsGoTypeExpressionValueContext(line, typeStart))
+                continue;
+
+            var typeEnd = FindGoConversionTypeExpressionEnd(line, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var open = SkipWhitespace(line, typeEnd);
+            if (open >= line.Length || line[open] != '(')
+                continue;
+            if (ReferenceExtractor.FindMatchingChar(line, open, '(', ')') < 0)
+                continue;
+
+            EmitGoTypeExpression(line[typeStart..typeEnd], typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static int NextGoCompositeConversionTypeStart(string line, int searchStart)
+    {
+        for (var cursor = searchStart; cursor < line.Length; cursor++)
+        {
+            if (line[cursor] == '[')
+                return cursor;
+            if (IsIdentifierAt(line, cursor, "map") || IsIdentifierAt(line, cursor, "chan"))
+                return cursor;
+        }
+
+        return -1;
+    }
+
+    private static int FindGoConversionTypeExpressionEnd(string line, int start)
+    {
+        var squareDepth = 0;
+        for (var cursor = start; cursor < line.Length; cursor++)
+        {
+            switch (line[cursor])
+            {
+                case '[':
+                    squareDepth++;
+                    break;
+                case ']':
+                    if (squareDepth > 0)
+                        squareDepth--;
+                    break;
+                case '(':
+                case ',':
+                case '{':
+                case '`':
+                case '=':
+                case ';':
+                    if (squareDepth == 0)
+                        return cursor;
+                    break;
+            }
+        }
+
+        return line.Length;
+    }
+
+    private static bool IsGoTypeExpressionValueContext(string line, int start)
+    {
+        var previous = start - 1;
+        while (previous >= 0 && char.IsWhiteSpace(line[previous]))
+            previous--;
+        if (previous < 0)
+            return true;
+        if (line[previous] is '=' or ':' or '(' or '[' or '{' or ',' or '!' or '&' or '*')
+            return true;
+
+        var tokenEnd = previous + 1;
+        while (previous >= 0 && IsSimpleIdentifierPart(line[previous]))
+            previous--;
+        var token = line[(previous + 1)..tokenEnd];
+        return string.Equals(token, "return", StringComparison.Ordinal);
     }
 
     private static bool IsLikelyGoParenthesizedConversionType(string expression)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -968,6 +968,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMapCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoParenthesizedTypeConversionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCallTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
@@ -1437,6 +1438,78 @@ internal static class LanguageReferenceExtractionSupport
 
             EmitGoTypeExpression(line[valueStart..valueEnd], valueStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
+    }
+
+    private static void EmitGoParenthesizedTypeConversionReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var open = line.IndexOf('(', searchStart);
+            if (open < 0)
+                return;
+
+            searchStart = open + 1;
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '(', ')');
+            if (close <= open + 1)
+                continue;
+
+            var afterClose = SkipWhitespace(line, close + 1);
+            if (afterClose >= line.Length || line[afterClose] != '(')
+                continue;
+
+            var rawExpression = line[(open + 1)..close];
+            var expression = rawExpression.Trim();
+            if (!IsLikelyGoParenthesizedConversionType(expression))
+                continue;
+
+            var trimStart = rawExpression.IndexOf(expression, StringComparison.Ordinal);
+            EmitGoTypeExpression(expression, open + 1 + Math.Max(0, trimStart), references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static bool IsLikelyGoParenthesizedConversionType(string expression)
+    {
+        if (expression.Length == 0 || expression.Contains(','))
+            return false;
+
+        var cursor = 0;
+        while (cursor < expression.Length && char.IsWhiteSpace(expression[cursor]))
+            cursor++;
+        var isPointerConversion = cursor < expression.Length && expression[cursor] == '*';
+        if (cursor < expression.Length && expression[cursor] == '*')
+            cursor = SkipWhitespace(expression, cursor + 1);
+
+        if (cursor >= expression.Length || !IsIdentifierStart(expression[cursor]))
+            return false;
+
+        var lastSegmentStart = cursor;
+        while (cursor < expression.Length)
+        {
+            if (IsSimpleIdentifierPart(expression[cursor]))
+            {
+                cursor++;
+                continue;
+            }
+
+            if (expression[cursor] != '.')
+                return false;
+
+            cursor++;
+            if (cursor >= expression.Length || !IsIdentifierStart(expression[cursor]))
+                return false;
+            lastSegmentStart = cursor;
+            cursor++;
+        }
+
+        return isPointerConversion || expression.Contains('.');
     }
 
     private static bool HasGoIdentifierBeforeBracket(string line, int openBracket)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -1615,6 +1615,7 @@ internal static class LanguageReferenceExtractionSupport
                 var nextParen = preparedLine.IndexOf('(', afterReceiver);
                 if (nextParen > afterReceiver)
                 {
+                    EmitGoParameterListTypes(preparedLine, firstParen + 1, receiverClose, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
                     parameterOpen = nextParen;
                     functionHeaderStart = afterReceiver;
                 }

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -965,6 +965,7 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         EmitGoTypeDeclarationParameterConstraints(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoTypeSpecTargetReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoInterfaceTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoStandaloneTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoSingleNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1050,6 +1051,54 @@ internal static class LanguageReferenceExtractionSupport
             return;
 
         EmitGoTypeParameterConstraints(line, cursor, close + 1, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoTypeSpecTargetReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var cursor = SkipWhitespace(line, 0);
+        if (!StartsWithKeyword(line, cursor, "type"))
+            return;
+
+        cursor = SkipWhitespace(line, cursor + "type".Length);
+        if (cursor >= line.Length || !IsIdentifierStart(line[cursor]))
+            return;
+
+        cursor++;
+        while (cursor < line.Length && IsSimpleIdentifierPart(line[cursor]))
+            cursor++;
+
+        cursor = SkipWhitespace(line, cursor);
+        if (cursor < line.Length && line[cursor] == '[')
+        {
+            var close = ReferenceExtractor.FindMatchingChar(line, cursor, '[', ']');
+            if (close < 0)
+                return;
+            cursor = SkipWhitespace(line, close + 1);
+        }
+
+        if (cursor < line.Length && line[cursor] == '=')
+            cursor = SkipWhitespace(line, cursor + 1);
+
+        if (cursor >= line.Length
+            || StartsWithKeyword(line, cursor, "struct")
+            || StartsWithKeyword(line, cursor, "interface")
+            || !IsGoTypeExpressionStart(line, cursor))
+        {
+            return;
+        }
+
+        var typeEnd = FindGoInlineTypeExpressionEnd(line, cursor);
+        if (typeEnd <= cursor)
+            return;
+
+        EmitGoTypeExpression(line[cursor..typeEnd], cursor, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
 
     private static void EmitGoMultiNameValueDeclarationTypes(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -964,6 +964,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoTypeAssertionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoGenericCallTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
         {
@@ -1218,6 +1219,85 @@ internal static class LanguageReferenceExtractionSupport
             EmitGoParameterListTypes(line, open + 1, close, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
             EmitGoSignatureReturnTypes(line, close + 1, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
+    }
+
+    private static void EmitGoGenericCallTypeArgumentReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (GoFuncRegex.IsMatch(line))
+            return;
+
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var open = line.IndexOf('[', searchStart);
+            if (open < 0)
+                return;
+
+            searchStart = open + 1;
+            if (!HasGoIdentifierBeforeBracket(line, open))
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '[', ']');
+            if (close < 0)
+                continue;
+
+            var afterClose = SkipWhitespace(line, close + 1);
+            if (afterClose >= line.Length || line[afterClose] != '(')
+                continue;
+
+            var typeArguments = line[(open + 1)..close];
+            foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typeArguments))
+            {
+                var rawArgument = typeArguments.Substring(segmentStart, segmentLength);
+                var expression = rawArgument.Trim();
+                if (expression.Length == 0 || !ContainsLikelyGoTypeArgument(expression))
+                    continue;
+
+                var trimStart = rawArgument.IndexOf(expression, StringComparison.Ordinal);
+                var absoluteStart = open + 1 + segmentStart + Math.Max(0, trimStart);
+                EmitGoTypeExpression(expression, absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            }
+        }
+    }
+
+    private static bool HasGoIdentifierBeforeBracket(string line, int openBracket)
+    {
+        var cursor = openBracket - 1;
+        while (cursor >= 0 && char.IsWhiteSpace(line[cursor]))
+            cursor--;
+        if (cursor < 0 || !IsSimpleIdentifierPart(line[cursor]))
+            return false;
+
+        while (cursor >= 0 && IsSimpleIdentifierPart(line[cursor]))
+            cursor--;
+
+        return true;
+    }
+
+    private static bool ContainsLikelyGoTypeArgument(string expression)
+    {
+        for (var i = 0; i < expression.Length; i++)
+        {
+            if (!IsIdentifierStart(expression[i]))
+                continue;
+
+            var start = i;
+            i++;
+            while (i < expression.Length && IsSimpleIdentifierPart(expression[i]))
+                i++;
+
+            if (char.IsUpper(expression[start]))
+                return true;
+        }
+
+        return false;
     }
 
     private static bool StartsWithKeyword(string line, int index, string keyword)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -970,6 +970,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoMapCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoParenthesizedTypeConversionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMethodExpressionReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoGenericInstantiationTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCallTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
@@ -1628,6 +1629,73 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         return expression.Contains('.') || char.IsUpper(expression[lastSegmentStart]);
+    }
+
+    private static void EmitGoGenericInstantiationTypeArgumentReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (GoFuncRegex.IsMatch(line))
+            return;
+
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var open = line.IndexOf('[', searchStart);
+            if (open < 0)
+                return;
+
+            searchStart = open + 1;
+            if (!TryGetGoIdentifierBeforeBracket(line, open, out var nameStart, out var nameLength))
+                continue;
+            if (nameLength == 0 || !char.IsUpper(line[nameStart]))
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '[', ']');
+            if (close < 0)
+                continue;
+
+            var afterClose = SkipWhitespace(line, close + 1);
+            if (afterClose < line.Length && line[afterClose] is '(' or '{')
+                continue;
+            if (afterClose < line.Length && !IsGoGenericInstantiationTerminator(line[afterClose]))
+                continue;
+
+            EmitGoGenericTypeArgumentList(line, open, close, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static bool IsGoGenericInstantiationTerminator(char ch)
+        => char.IsWhiteSpace(ch) || ch is ',' or ')' or ']' or '}' or ';';
+
+    private static void EmitGoGenericTypeArgumentList(
+        string line,
+        int open,
+        int close,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var typeArguments = line[(open + 1)..close];
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typeArguments))
+        {
+            var rawArgument = typeArguments.Substring(segmentStart, segmentLength);
+            var expression = rawArgument.Trim();
+            if (expression.Length == 0 || !ContainsLikelyGoTypeArgument(expression))
+                continue;
+
+            var trimStart = rawArgument.IndexOf(expression, StringComparison.Ordinal);
+            var absoluteStart = open + 1 + segmentStart + Math.Max(0, trimStart);
+            EmitGoTypeExpression(expression, absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
     }
 
     private static bool HasGoIdentifierBeforeBracket(string line, int openBracket)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -968,6 +968,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoInterfaceTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoStandaloneTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoMultiNameFieldDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoChannelElementTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1077,6 +1078,46 @@ internal static class LanguageReferenceExtractionSupport
 
         var expression = line[typeStart..typeEnd].TrimEnd();
         EmitGoTypeExpression(expression, typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoMultiNameFieldDeclarationTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var cursor = SkipWhitespace(line, 0);
+        if (cursor >= line.Length || !IsIdentifierStart(line[cursor]))
+            return;
+
+        var nameStart = cursor;
+        cursor++;
+        while (cursor < line.Length && IsSimpleIdentifierPart(line[cursor]))
+            cursor++;
+
+        if (IsGoStatementKeyword(line[nameStart..cursor]))
+            return;
+
+        cursor = nameStart;
+        if (!TryReadGoIdentifierList(line, ref cursor, requireComma: true))
+            return;
+
+        var typeStart = SkipWhitespace(line, cursor);
+        if (typeStart >= line.Length || line[typeStart] is ':' or '=' || !IsGoTypeExpressionStart(line, typeStart))
+            return;
+
+        var typeEnd = FindGoInlineTypeExpressionEnd(line, typeStart);
+        if (typeEnd <= typeStart)
+            return;
+
+        var afterType = SkipWhitespace(line, typeEnd);
+        if (afterType < line.Length && line[afterType] != '`')
+            return;
+
+        EmitGoTypeExpression(line[typeStart..typeEnd], typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
 
     private static void EmitGoInterfaceTypeSetTermReferences(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -950,6 +950,7 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         EmitGoTypeDeclarationParameterConstraints(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
         {
@@ -1012,6 +1013,63 @@ internal static class LanguageReferenceExtractionSupport
             return;
 
         EmitGoTypeParameterConstraints(line, cursor, close + 1, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoMultiNameValueDeclarationTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var cursor = SkipWhitespace(line, 0);
+        if (StartsWithKeyword(line, cursor, "var"))
+            cursor = SkipWhitespace(line, cursor + "var".Length);
+        else if (StartsWithKeyword(line, cursor, "const"))
+            cursor = SkipWhitespace(line, cursor + "const".Length);
+
+        if (!TryReadGoIdentifierList(line, ref cursor, requireComma: true))
+            return;
+
+        var typeStart = SkipWhitespace(line, cursor);
+        if (typeStart >= line.Length || line[typeStart] == '=' || line.AsSpan(typeStart).StartsWith(":=", StringComparison.Ordinal))
+            return;
+
+        var typeEnd = typeStart;
+        while (typeEnd < line.Length && line[typeEnd] != '=' && line[typeEnd] != '{')
+            typeEnd++;
+
+        var expression = line[typeStart..typeEnd].TrimEnd();
+        EmitGoTypeExpression(expression, typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static bool TryReadGoIdentifierList(string line, ref int cursor, bool requireComma)
+    {
+        var count = 0;
+        while (cursor < line.Length)
+        {
+            cursor = SkipWhitespace(line, cursor);
+            if (cursor >= line.Length || !IsIdentifierStart(line[cursor]))
+                break;
+
+            cursor++;
+            while (cursor < line.Length && IsSimpleIdentifierPart(line[cursor]))
+                cursor++;
+
+            count++;
+            var afterName = SkipWhitespace(line, cursor);
+            if (afterName >= line.Length || line[afterName] != ',')
+            {
+                cursor = afterName;
+                break;
+            }
+
+            cursor = afterName + 1;
+        }
+
+        return requireComma ? count > 1 : count > 0;
     }
 
     private static bool StartsWithKeyword(string line, int index, string keyword)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -2007,7 +2007,15 @@ internal static class LanguageReferenceExtractionSupport
             cursor = SkipWhitespace(expression, cursor + 1);
 
         if (cursor >= expression.Length || !IsIdentifierStart(expression[cursor]))
-            return false;
+        {
+            return cursor < expression.Length && expression[cursor] == '[';
+        }
+
+        if (StartsWithKeyword(expression, cursor, "map")
+            || StartsWithKeyword(expression, cursor, "chan"))
+        {
+            return true;
+        }
 
         var lastSegmentStart = cursor;
         while (cursor < expression.Length)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -974,6 +974,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoTypeSwitchCaseReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoInlineStructFieldTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoArraySliceCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMapCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1546,6 +1547,107 @@ internal static class LanguageReferenceExtractionSupport
                 EmitGoTypeExpression(expression, absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
             }
         }
+    }
+
+    private static void EmitGoInlineStructFieldTypeReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var structIndex = line.IndexOf("struct", searchStart, StringComparison.Ordinal);
+            if (structIndex < 0)
+                return;
+
+            searchStart = structIndex + "struct".Length;
+            if (!IsIdentifierAt(line, structIndex, "struct"))
+                continue;
+
+            var open = SkipWhitespace(line, searchStart);
+            if (open >= line.Length || line[open] != '{')
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '{', '}');
+            if (close <= open + 1)
+                continue;
+
+            var body = line[(open + 1)..close];
+            var bodyStart = open + 1;
+            foreach (var (fieldStart, fieldLength) in SplitGoInlineStructFieldSpans(body))
+                EmitGoInlineStructFieldType(body.Substring(fieldStart, fieldLength), bodyStart + fieldStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static List<(int Start, int Length)> SplitGoInlineStructFieldSpans(string body)
+    {
+        var spans = new List<(int Start, int Length)>();
+        var fieldStart = 0;
+        var squareDepth = 0;
+        var parenDepth = 0;
+        for (var cursor = 0; cursor < body.Length; cursor++)
+        {
+            switch (body[cursor])
+            {
+                case '[':
+                    squareDepth++;
+                    break;
+                case ']':
+                    if (squareDepth > 0)
+                        squareDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0)
+                        parenDepth--;
+                    break;
+                case ';':
+                    if (squareDepth == 0 && parenDepth == 0)
+                    {
+                        spans.Add((fieldStart, cursor - fieldStart));
+                        fieldStart = cursor + 1;
+                    }
+                    break;
+            }
+        }
+
+        spans.Add((fieldStart, body.Length - fieldStart));
+        return spans;
+    }
+
+    private static void EmitGoInlineStructFieldType(
+        string rawField,
+        int rawFieldStart,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var tagStart = rawField.IndexOf('`');
+        if (tagStart >= 0)
+            rawField = rawField[..tagStart];
+
+        var field = rawField.Trim();
+        if (field.Length == 0)
+            return;
+
+        var fieldTrimStart = rawField.IndexOf(field, StringComparison.Ordinal);
+        var absoluteFieldStart = rawFieldStart + Math.Max(0, fieldTrimStart);
+        var typeStart = LastWhitespaceSeparatedTokenStart(field);
+        if (typeStart < 0)
+            return;
+
+        var expression = typeStart == 0 ? field : field[typeStart..];
+        EmitGoTypeExpression(expression, absoluteFieldStart + typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
 
     private static void EmitGoMapCompositeLiteralTypeReferences(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -967,6 +967,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoTypeDeclarationParameterConstraints(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoInterfaceTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoStandaloneTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoSingleNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameFieldDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoSingleNameFieldDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1076,6 +1077,48 @@ internal static class LanguageReferenceExtractionSupport
         var typeEnd = typeStart;
         while (typeEnd < line.Length && line[typeEnd] != '=' && line[typeEnd] != '{')
             typeEnd++;
+
+        var expression = line[typeStart..typeEnd].TrimEnd();
+        EmitGoTypeExpression(expression, typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoSingleNameValueDeclarationTypes(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var cursor = SkipWhitespace(line, 0);
+        if (StartsWithKeyword(line, cursor, "var"))
+            cursor = SkipWhitespace(line, cursor + "var".Length);
+        else if (StartsWithKeyword(line, cursor, "const"))
+            cursor = SkipWhitespace(line, cursor + "const".Length);
+        else
+            return;
+
+        if (cursor >= line.Length || !IsIdentifierStart(line[cursor]))
+            return;
+
+        cursor++;
+        while (cursor < line.Length && IsSimpleIdentifierPart(line[cursor]))
+            cursor++;
+
+        var afterName = SkipWhitespace(line, cursor);
+        if (afterName < line.Length && line[afterName] == ',')
+            return;
+
+        var typeStart = afterName;
+        if (typeStart >= line.Length || line[typeStart] == '=' || line.AsSpan(typeStart).StartsWith(":=", StringComparison.Ordinal))
+            return;
+        if (!IsGoTypeExpressionStart(line, typeStart))
+            return;
+
+        var typeEnd = FindGoInlineTypeExpressionEnd(line, typeStart);
+        if (typeEnd <= typeStart)
+            return;
 
         var expression = line[typeStart..typeEnd].TrimEnd();
         EmitGoTypeExpression(expression, typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -962,6 +962,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoChannelElementTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoTypeAssertionReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1195,6 +1196,41 @@ internal static class LanguageReferenceExtractionSupport
 
             var trimStart = group.Value.IndexOf(expression, StringComparison.Ordinal);
             EmitGoTypeExpression(expression, group.Index + Math.Max(0, trimStart), references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static void EmitGoChannelElementTypeReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var chanIndex = line.IndexOf("chan", searchStart, StringComparison.Ordinal);
+            if (chanIndex < 0)
+                return;
+
+            searchStart = chanIndex + "chan".Length;
+            if (!IsIdentifierAt(line, chanIndex, "chan"))
+                continue;
+
+            var elementStart = SkipWhitespace(line, searchStart);
+            if (elementStart + 1 < line.Length && line[elementStart] == '<' && line[elementStart + 1] == '-')
+                elementStart = SkipWhitespace(line, elementStart + 2);
+
+            if (elementStart >= line.Length || !IsGoTypeExpressionStart(line, elementStart))
+                continue;
+
+            var elementEnd = FindGoInlineTypeExpressionEnd(line, elementStart);
+            if (elementEnd <= elementStart)
+                continue;
+
+            EmitGoTypeExpression(line[elementStart..elementEnd], elementStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
     }
 
@@ -2019,7 +2055,52 @@ internal static class LanguageReferenceExtractionSupport
         if (index >= line.Length)
             return false;
 
-        return line[index] is '(' or '*' or '[' or '<' || IsIdentifierStart(line[index]);
+        return line[index] == '(' || IsGoTypeExpressionStart(line, index);
+    }
+
+    private static bool IsGoTypeExpressionStart(string line, int index)
+    {
+        if (index >= line.Length)
+            return false;
+
+        return line[index] is '*' or '[' or '~' or '<' || IsIdentifierStart(line[index]);
+    }
+
+    private static int FindGoInlineTypeExpressionEnd(string line, int start)
+    {
+        var squareDepth = 0;
+        var parenDepth = 0;
+        for (var cursor = start; cursor < line.Length; cursor++)
+        {
+            switch (line[cursor])
+            {
+                case '[':
+                    squareDepth++;
+                    break;
+                case ']':
+                    if (squareDepth > 0)
+                        squareDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth == 0)
+                        return cursor;
+                    parenDepth--;
+                    break;
+                case ',':
+                case '{':
+                case '`':
+                case '=':
+                case ';':
+                    if (squareDepth == 0 && parenDepth == 0)
+                        return cursor;
+                    break;
+            }
+        }
+
+        return line.Length;
     }
 
     private static void EmitGoSignatureReturnTypes(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -966,6 +966,7 @@ internal static class LanguageReferenceExtractionSupport
 
         EmitGoTypeDeclarationParameterConstraints(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoInterfaceTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoStandaloneTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1160,6 +1161,33 @@ internal static class LanguageReferenceExtractionSupport
 
         spans.Add((termStart, line.Length - termStart));
         return spans;
+    }
+
+    private static void EmitGoStandaloneTypeSetTermReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (line.Contains('|'))
+            return;
+
+        var cursor = SkipWhitespace(line, 0);
+        if (cursor >= line.Length || line[cursor] != '~')
+            return;
+
+        var typeStart = SkipWhitespace(line, cursor + 1);
+        if (typeStart >= line.Length || !IsGoTypeExpressionStart(line, typeStart))
+            return;
+
+        var expression = line[typeStart..].TrimEnd();
+        if (expression.Length == 0)
+            return;
+
+        EmitGoTypeExpression(expression, typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
     }
 
     private static bool TryReadGoIdentifierList(string line, ref int cursor, bool requireComma)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -967,6 +967,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoFunctionLiteralSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoFunctionTypeSignatureTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCompositeLiteralReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoMapCompositeLiteralTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoGenericCallTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
@@ -1387,6 +1388,54 @@ internal static class LanguageReferenceExtractionSupport
                 var absoluteStart = open + 1 + segmentStart + Math.Max(0, trimStart);
                 EmitGoTypeExpression(expression, absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
             }
+        }
+    }
+
+    private static void EmitGoMapCompositeLiteralTypeReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var searchStart = 0;
+        while (searchStart < line.Length)
+        {
+            var mapIndex = line.IndexOf("map", searchStart, StringComparison.Ordinal);
+            if (mapIndex < 0)
+                return;
+
+            searchStart = mapIndex + "map".Length;
+            if (!IsIdentifierAt(line, mapIndex, "map"))
+                continue;
+
+            var open = SkipWhitespace(line, searchStart);
+            if (open >= line.Length || line[open] != '[')
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '[', ']');
+            if (close < 0)
+                continue;
+
+            var valueStart = SkipWhitespace(line, close + 1);
+            if (valueStart >= line.Length || !IsGoTypeExpressionStart(line, valueStart))
+                continue;
+
+            var valueEnd = FindGoInlineTypeExpressionEnd(line, valueStart);
+            var literalOpen = SkipWhitespace(line, valueEnd);
+            if (literalOpen >= line.Length || line[literalOpen] != '{')
+                continue;
+
+            var keyExpression = line[(open + 1)..close].Trim();
+            if (keyExpression.Length > 0)
+            {
+                var keyStart = line.IndexOf(keyExpression, open + 1, StringComparison.Ordinal);
+                EmitGoTypeExpression(keyExpression, keyStart >= 0 ? keyStart : open + 1, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+            }
+
+            EmitGoTypeExpression(line[valueStart..valueEnd], valueStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -42,6 +42,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex GoCompositeLiteralRegex = new(
         @"(?<!\btype\s)(?<name>[A-Z]\w*)\s*\{",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoBuiltinTypeArgumentRegex = new(
+        @"\b(?:make|new)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex DartCtorRegex = new(
         @"\b(?:new|const)\s+(?<name>[A-Z]\w*(?:\.[A-Za-z_]\w*)?)\s*(?:<[^>]+>)?\s*\(",
@@ -952,6 +955,7 @@ internal static class LanguageReferenceExtractionSupport
         EmitGoTypeDeclarationParameterConstraints(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
         {
@@ -1126,6 +1130,41 @@ internal static class LanguageReferenceExtractionSupport
             ? line.IndexOf('*')
             : nameStart;
         EmitGoTypeExpression(line[typeStart..cursor], typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoBuiltinTypeArgumentReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (Match match in GoBuiltinTypeArgumentRegex.Matches(line))
+        {
+            var open = line.IndexOf('(', match.Index);
+            if (open < 0)
+                continue;
+
+            var close = ReferenceExtractor.FindMatchingChar(line, open, '(', ')');
+            if (close < 0)
+                continue;
+
+            var argumentList = line[(open + 1)..close];
+            var firstArgument = ReferenceExtractor.SplitTopLevelCommaSpans(argumentList).FirstOrDefault();
+            if (firstArgument.Length <= 0)
+                continue;
+
+            var rawType = argumentList.Substring(firstArgument.Start, firstArgument.Length);
+            var expression = rawType.Trim();
+            if (expression.Length == 0)
+                continue;
+
+            var trimStart = rawType.IndexOf(expression, StringComparison.Ordinal);
+            var absoluteStart = open + 1 + firstArgument.Start + Math.Max(0, trimStart);
+            EmitGoTypeExpression(expression, absoluteStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
     }
 
     private static bool StartsWithKeyword(string line, int index, string keyword)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -959,6 +959,7 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         EmitGoTypeDeclarationParameterConstraints(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitGoInterfaceTypeSetTermReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoMultiNameValueDeclarationTypes(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoEmbeddedFieldType(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGoBuiltinTypeArgumentReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -1064,6 +1065,90 @@ internal static class LanguageReferenceExtractionSupport
 
         var expression = line[typeStart..typeEnd].TrimEnd();
         EmitGoTypeExpression(expression, typeStart, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitGoInterfaceTypeSetTermReferences(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (!line.Contains('|'))
+            return;
+
+        var first = SkipWhitespace(line, 0);
+        if (first >= line.Length || line.Contains(":=", StringComparison.Ordinal) || line.Contains('='))
+            return;
+        if (IsIdentifierStart(line[first]))
+        {
+            var nameEnd = first + 1;
+            while (nameEnd < line.Length && IsSimpleIdentifierPart(line[nameEnd]))
+                nameEnd++;
+            if (IsGoStatementKeyword(line[first..nameEnd]))
+                return;
+        }
+
+        foreach (var (termStart, termLength) in SplitGoTypeSetTermSpans(line))
+        {
+            var rawTerm = line.Substring(termStart, termLength);
+            var term = rawTerm.Trim();
+            if (term.Length == 0)
+                continue;
+
+            var tildeOffset = term[0] == '~' ? 1 : 0;
+            while (tildeOffset < term.Length && char.IsWhiteSpace(term[tildeOffset]))
+                tildeOffset++;
+            if (tildeOffset >= term.Length || !IsGoTypeExpressionStart(term, tildeOffset))
+                continue;
+
+            var expression = term[tildeOffset..];
+            if (!ContainsLikelyGoTypeArgument(expression))
+                continue;
+
+            var termTrimStart = rawTerm.IndexOf(term, StringComparison.Ordinal);
+            EmitGoTypeExpression(expression, termStart + Math.Max(0, termTrimStart) + tildeOffset, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        }
+    }
+
+    private static List<(int Start, int Length)> SplitGoTypeSetTermSpans(string line)
+    {
+        var spans = new List<(int Start, int Length)>();
+        var termStart = 0;
+        var squareDepth = 0;
+        var parenDepth = 0;
+        for (var cursor = 0; cursor < line.Length; cursor++)
+        {
+            switch (line[cursor])
+            {
+                case '[':
+                    squareDepth++;
+                    break;
+                case ']':
+                    if (squareDepth > 0)
+                        squareDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0)
+                        parenDepth--;
+                    break;
+                case '|':
+                    if (squareDepth == 0 && parenDepth == 0)
+                    {
+                        spans.Add((termStart, cursor - termStart));
+                        termStart = cursor + 1;
+                    }
+                    break;
+            }
+        }
+
+        spans.Add((termStart, line.Length - termStart));
+        return spans;
     }
 
     private static bool TryReadGoIdentifierList(string line, ref int cursor, bool requireComma)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -949,6 +949,8 @@ internal static class LanguageReferenceExtractionSupport
             }
         }
 
+        EmitGoTypeDeclarationParameterConstraints(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
         {
             foreach (Match match in regex.Matches(preparedLine))
@@ -969,6 +971,72 @@ internal static class LanguageReferenceExtractionSupport
 
             ReferenceExtractor.AddReference(references, seen, fileId, group.Value, group.Index, "instantiate", context, lineNumber, resolveContainerForColumn(group.Index));
         }
+    }
+
+    private static void EmitGoTypeDeclarationParameterConstraints(
+        string line,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var cursor = SkipWhitespace(line, 0);
+        if (StartsWithKeyword(line, cursor, "type"))
+            cursor = SkipWhitespace(line, cursor + "type".Length);
+
+        if (cursor >= line.Length || !IsIdentifierStart(line[cursor]))
+            return;
+
+        cursor++;
+        while (cursor < line.Length && IsSimpleIdentifierPart(line[cursor]))
+            cursor++;
+
+        cursor = SkipWhitespace(line, cursor);
+        if (cursor >= line.Length || line[cursor] != '[')
+            return;
+
+        var close = ReferenceExtractor.FindMatchingChar(line, cursor, '[', ']');
+        if (close < 0)
+            return;
+
+        var afterClose = SkipWhitespace(line, close + 1);
+        if (afterClose >= line.Length)
+            return;
+        if (line[afterClose] == '=')
+            afterClose = SkipWhitespace(line, afterClose + 1);
+        if (afterClose >= line.Length || !IsGoTypeDeclarationBodyStart(line, afterClose))
+            return;
+
+        EmitGoTypeParameterConstraints(line, cursor, close + 1, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static bool StartsWithKeyword(string line, int index, string keyword)
+    {
+        if (index < 0 || index + keyword.Length > line.Length)
+            return false;
+        if (!line.AsSpan(index, keyword.Length).SequenceEqual(keyword))
+            return false;
+
+        var beforeOk = index == 0 || !IsSimpleIdentifierPart(line[index - 1]);
+        var after = index + keyword.Length;
+        var afterOk = after >= line.Length || !IsSimpleIdentifierPart(line[after]);
+        return beforeOk && afterOk;
+    }
+
+    private static bool IsGoTypeDeclarationBodyStart(string line, int index)
+    {
+        if (StartsWithKeyword(line, index, "struct")
+            || StartsWithKeyword(line, index, "interface")
+            || StartsWithKeyword(line, index, "func")
+            || StartsWithKeyword(line, index, "map")
+            || StartsWithKeyword(line, index, "chan"))
+        {
+            return true;
+        }
+
+        return line[index] is '*' or '[' or '~' || IsIdentifierStart(line[index]);
     }
 
     private static bool IsGoCompositeLiteralContext(string line, int nameIndex, int nameLength)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -530,7 +530,7 @@ public static partial class SymbolExtractor
                 cursor++;
 
             var afterReceiverName = SkipGoSymbolWhitespace(receiver, cursor);
-            if (afterReceiverName < receiver.Length)
+            if (afterReceiverName > cursor && afterReceiverName < receiver.Length)
                 typeText = receiver[afterReceiverName..];
         }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -543,6 +543,12 @@ public static partial class SymbolExtractor
                 continue;
             }
 
+            if (line.Length == trimmed.Length && trimmed.StartsWith("const", StringComparison.Ordinal))
+            {
+                TryAddGoValueSymbol(fileId, line, i, symbols, trimmed["const".Length..].TrimStart());
+                continue;
+            }
+
             if (trimmed.StartsWith("var", StringComparison.Ordinal)
                 && trimmed["var".Length..].TrimStart().StartsWith("(", StringComparison.Ordinal))
             {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -168,6 +168,53 @@ public static partial class SymbolExtractor
         return true;
     }
 
+    private static bool TryAddGoLabelSymbol(
+        long fileId,
+        string rawLine,
+        int lineIndex,
+        List<SymbolRecord> symbols)
+    {
+        var trimmed = rawLine.TrimStart();
+        if (trimmed.StartsWith("//", StringComparison.Ordinal)
+            || trimmed.StartsWith("/*", StringComparison.Ordinal)
+            || trimmed.StartsWith("*", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var match = GoLabelRegex.Match(rawLine);
+        if (!match.Success)
+            return false;
+
+        var name = match.Groups["name"].Value;
+        if (IsGoLabelKeyword(name) || HasGoSymbol(symbols, fileId, lineIndex + 1, "function", name))
+            return false;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineIndex + 1,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = name,
+                Line = lineIndex + 1,
+                StartLine = lineIndex + 1,
+                StartColumn = match.Groups["name"].Index,
+                EndLine = lineIndex + 1,
+                Signature = name,
+            },
+            rawLine);
+        return true;
+    }
+
+    private static bool IsGoLabelKeyword(string name)
+        => name is "break" or "case" or "chan" or "const" or "continue" or "default" or "defer"
+            or "else" or "fallthrough" or "for" or "func" or "go" or "goto" or "if" or "import"
+            or "interface" or "map" or "package" or "range" or "return" or "select" or "struct"
+            or "switch" or "type" or "var";
+
     private static int CountGoBraceDelta(string text)
     {
         var delta = 0;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -550,6 +550,12 @@ public static partial class SymbolExtractor
                 continue;
             }
 
+            if (line.Length == trimmed.Length && trimmed.StartsWith("var", StringComparison.Ordinal))
+            {
+                TryAddGoValueSymbol(fileId, line, i, symbols, trimmed["var".Length..].TrimStart());
+                continue;
+            }
+
             if (trimmed.StartsWith("type", StringComparison.Ordinal))
             {
                 TryAddGoTypeSymbol(fileId, line, i, symbols, trimmed, ref typeBodyDepth);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -229,6 +229,114 @@ public static partial class SymbolExtractor
         return delta;
     }
 
+    private static int CountGoCodeBraceDelta(string text, ref bool inBlockComment, ref bool inRawString)
+    {
+        var delta = 0;
+        var inString = false;
+        var inRune = false;
+        var escaped = false;
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+            var next = i + 1 < text.Length ? text[i + 1] : '\0';
+
+            if (inBlockComment)
+            {
+                if (ch == '*' && next == '/')
+                {
+                    inBlockComment = false;
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (inRawString)
+            {
+                if (ch == '`')
+                    inRawString = false;
+
+                continue;
+            }
+
+            if (inString)
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (ch == '"')
+                    inString = false;
+
+                continue;
+            }
+
+            if (inRune)
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (ch == '\'')
+                    inRune = false;
+
+                continue;
+            }
+
+            if (ch == '/' && next == '/')
+                break;
+
+            if (ch == '/' && next == '*')
+            {
+                inBlockComment = true;
+                i++;
+                continue;
+            }
+
+            if (ch == '`')
+            {
+                inRawString = true;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (ch == '\'')
+            {
+                inRune = true;
+                continue;
+            }
+
+            if (ch == '{')
+                delta++;
+            else if (ch == '}')
+                delta--;
+        }
+
+        return delta;
+    }
+
     private static bool TryAddGoImportSymbol(
         long fileId,
         string rawLine,
@@ -569,6 +677,8 @@ public static partial class SymbolExtractor
         ExtractGoInterfaceMethods(fileId, lines, symbols);
         var typeBodyDepth = 0;
         var goBlockDepth = 0;
+        var goBlockInBlockComment = false;
+        var goBlockInRawString = false;
 
         for (var i = 0; i < lines.Length; i++)
         {
@@ -583,18 +693,18 @@ public static partial class SymbolExtractor
                 continue;
             }
 
+            if (goBlockDepth > 0)
+            {
+                goBlockDepth += CountGoCodeBraceDelta(line, ref goBlockInBlockComment, ref goBlockInRawString);
+                if (goBlockDepth < 0)
+                    goBlockDepth = 0;
+                continue;
+            }
+
             if (trimmed.Length == 0
                 || trimmed.StartsWith("//", StringComparison.Ordinal)
                 || trimmed.StartsWith("/*", StringComparison.Ordinal))
             {
-                continue;
-            }
-
-            if (goBlockDepth > 0)
-            {
-                goBlockDepth += CountGoBraceDelta(line);
-                if (goBlockDepth < 0)
-                    goBlockDepth = 0;
                 continue;
             }
 
@@ -660,7 +770,7 @@ public static partial class SymbolExtractor
                 continue;
             }
 
-            goBlockDepth += CountGoBraceDelta(line);
+            goBlockDepth += CountGoCodeBraceDelta(line, ref goBlockInBlockComment, ref goBlockInRawString);
             if (goBlockDepth < 0)
                 goBlockDepth = 0;
         }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -480,6 +480,65 @@ public static partial class SymbolExtractor
             && symbol.Name == name);
     }
 
+    private static void AssignGoMethodReceiverContainers(List<SymbolRecord> symbols)
+    {
+        var typeKinds = symbols
+            .Where(symbol => symbol.Kind is "struct" or "interface" or "class")
+            .GroupBy(symbol => symbol.Name, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First().Kind, StringComparer.Ordinal);
+
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Kind != "function"
+                || string.IsNullOrWhiteSpace(symbol.Signature)
+                || !TryGetGoMethodReceiverTypeName(symbol.Signature, out var receiverTypeName))
+            {
+                continue;
+            }
+
+            symbol.ContainerName = receiverTypeName;
+            symbol.ContainerKind = typeKinds.TryGetValue(receiverTypeName, out var kind) ? kind : "class";
+        }
+    }
+
+    private static bool TryGetGoMethodReceiverTypeName(string signature, out string receiverTypeName)
+    {
+        receiverTypeName = string.Empty;
+        var funcIndex = signature.IndexOf("func", StringComparison.Ordinal);
+        if (funcIndex < 0)
+            return false;
+
+        var open = funcIndex + "func".Length;
+        while (open < signature.Length && char.IsWhiteSpace(signature[open]))
+            open++;
+        if (open >= signature.Length || signature[open] != '(')
+            return false;
+
+        var close = ReferenceExtractor.FindMatchingChar(signature, open, '(', ')');
+        if (close <= open + 1)
+            return false;
+
+        var receiver = signature[(open + 1)..close].Trim();
+        if (receiver.Length == 0)
+            return false;
+
+        var typeStart = receiver.LastIndexOfAny([' ', '\t']);
+        var typeText = (typeStart >= 0 ? receiver[(typeStart + 1)..] : receiver).Trim();
+        while (typeText.StartsWith("*", StringComparison.Ordinal))
+            typeText = typeText[1..].TrimStart();
+
+        var genericStart = typeText.IndexOf('[');
+        if (genericStart >= 0)
+            typeText = typeText[..genericStart];
+
+        var dot = typeText.LastIndexOf('.');
+        if (dot >= 0 && dot + 1 < typeText.Length)
+            typeText = typeText[(dot + 1)..];
+
+        receiverTypeName = typeText.Trim();
+        return receiverTypeName.Length > 0;
+    }
+
     private static void ExtractGoGroupedDeclarations(long fileId, string[] lines, List<SymbolRecord> symbols)
     {
         string? blockKind = null;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -568,6 +568,7 @@ public static partial class SymbolExtractor
         string? blockKind = null;
         ExtractGoInterfaceMethods(fileId, lines, symbols);
         var typeBodyDepth = 0;
+        var goBlockDepth = 0;
 
         for (var i = 0; i < lines.Length; i++)
         {
@@ -586,6 +587,14 @@ public static partial class SymbolExtractor
                 || trimmed.StartsWith("//", StringComparison.Ordinal)
                 || trimmed.StartsWith("/*", StringComparison.Ordinal))
             {
+                continue;
+            }
+
+            if (goBlockDepth > 0)
+            {
+                goBlockDepth += CountGoBraceDelta(line);
+                if (goBlockDepth < 0)
+                    goBlockDepth = 0;
                 continue;
             }
 
@@ -626,7 +635,7 @@ public static partial class SymbolExtractor
                 continue;
             }
 
-            if (line.Length == trimmed.Length && trimmed.StartsWith("const", StringComparison.Ordinal))
+            if (trimmed.StartsWith("const", StringComparison.Ordinal))
             {
                 TryAddGoValueSymbol(fileId, line, i, symbols, trimmed["const".Length..].TrimStart());
                 continue;
@@ -639,7 +648,7 @@ public static partial class SymbolExtractor
                 continue;
             }
 
-            if (line.Length == trimmed.Length && trimmed.StartsWith("var", StringComparison.Ordinal))
+            if (trimmed.StartsWith("var", StringComparison.Ordinal))
             {
                 TryAddGoValueSymbol(fileId, line, i, symbols, trimmed["var".Length..].TrimStart());
                 continue;
@@ -650,6 +659,10 @@ public static partial class SymbolExtractor
                 TryAddGoTypeSymbol(fileId, line, i, symbols, trimmed, ref typeBodyDepth);
                 continue;
             }
+
+            goBlockDepth += CountGoBraceDelta(line);
+            if (goBlockDepth < 0)
+                goBlockDepth = 0;
         }
     }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -522,8 +522,19 @@ public static partial class SymbolExtractor
         if (receiver.Length == 0)
             return false;
 
-        var typeStart = receiver.LastIndexOfAny([' ', '\t']);
-        var typeText = (typeStart >= 0 ? receiver[(typeStart + 1)..] : receiver).Trim();
+        var typeText = receiver;
+        if (IsGoSymbolIdentifierStart(receiver[0]))
+        {
+            var cursor = 1;
+            while (cursor < receiver.Length && IsGoSymbolIdentifierPart(receiver[cursor]))
+                cursor++;
+
+            var afterReceiverName = SkipGoSymbolWhitespace(receiver, cursor);
+            if (afterReceiverName < receiver.Length)
+                typeText = receiver[afterReceiverName..];
+        }
+
+        typeText = typeText.Trim();
         while (typeText.StartsWith("*", StringComparison.Ordinal))
             typeText = typeText[1..].TrimStart();
 
@@ -538,6 +549,19 @@ public static partial class SymbolExtractor
         receiverTypeName = typeText.Trim();
         return receiverTypeName.Length > 0;
     }
+
+    private static int SkipGoSymbolWhitespace(string text, int start)
+    {
+        while (start < text.Length && char.IsWhiteSpace(text[start]))
+            start++;
+        return start;
+    }
+
+    private static bool IsGoSymbolIdentifierStart(char ch) =>
+        ch == '_' || char.IsLetter(ch);
+
+    private static bool IsGoSymbolIdentifierPart(char ch) =>
+        ch == '_' || char.IsLetterOrDigit(ch);
 
     private static void ExtractGoGroupedDeclarations(long fileId, string[] lines, List<SymbolRecord> symbols)
     {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1212,6 +1212,7 @@ public static partial class SymbolExtractor
         ],
         ["go"] =
         [
+            new("namespace", new Regex(@"^\s*package\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
             new("function", new Regex(@"^func\s+(?:\([^)]+\)\s+)?(?<name>\w+)(?:\[[^\]\r\n]+\])?\s*[\(\[]", RegexOptions.Compiled), BodyStyle.Brace),
             new("struct",   new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+struct\b", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^type\s+(?<name>\w+)(?:\[[^\]]+\])?\s+interface\b", RegexOptions.Compiled), BodyStyle.Brace),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3535,6 +3535,8 @@ public static partial class SymbolExtractor
         if (lang == "perl")
             ExtractPerlHashConstantSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
+        if (lang == "go")
+            AssignGoMethodReceiverContainers(symbols);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
         KotlinSymbolNameNormalizer.NormalizeSecondaryConstructorNames(symbols);
         if (lang == "shell")

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -193,6 +193,9 @@ public static partial class SymbolExtractor
     private static readonly Regex GoValueBlockSpecRegex = new(
         @"^(?<names>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex GoLabelRegex = new(
+        @"^(?<name>[A-Za-z_]\w*)\s*:\s*(?!=)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex RustUseStartRegex = new(
         @"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?use\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -2017,6 +2020,9 @@ public static partial class SymbolExtractor
             {
                 continue;
             }
+            if (lang == "go")
+                TryAddGoLabelSymbol(fileId, line, i, symbols);
+
             var structuralLine = structuralLines[i];
             var cssScannerLine = cssScannerLines?[i];
             var matchLine = structuralLine;

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7492,6 +7492,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericTypeConstraints_CapturesConstraintTypes()
+    {
+        const string content = """
+            package main
+
+            type Cache[T EntityConstraint] struct {
+                value T
+            }
+
+            type Mapper[K KeyConstraint, V ValueConstraint] map[K]V
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "EntityConstraint" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "KeyConstraint" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "ValueConstraint" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -8059,6 +8059,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoStandaloneTypeSetTerms_CapturesApproximationTypes()
+    {
+        const string content = """
+            package main
+
+            type SliceLike interface {
+                ~[]Element
+                ~map[Key]Value
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Element" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "map" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoBranchLabels_CapturesLabelReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7782,6 +7782,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoArraySliceCompositeLiterals_CapturesElementTypes()
+    {
+        const string content = """
+            package main
+
+            func build(values []func()) {
+                users := []User{}
+                widgets := [3]*Widget{}
+                events := [...]model.Event{}
+                nested := [][]Entry{}
+                values[i]()
+                _, _, _, _ = users, widgets, events, nested
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Widget" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Entry" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "i" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoMapCompositeLiterals_CapturesKeyAndValueTypes()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7627,6 +7627,33 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoTypeAssertions_CapturesAssertedTypes()
+    {
+        const string content = """
+            package main
+
+            func classify(value any) {
+                user := value.(User)
+                admin := value.(*Admin)
+                qualified := value.(model.Member)
+                switch value.(type) {
+                case nil:
+                }
+                _, _, _ = user, admin, qualified
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Admin" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Member" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "type" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "nil" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7577,6 +7577,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericValueDeclarations_CapturesSpacedTypeArguments()
+    {
+        const string content = """
+            package main
+
+            var repo Repository[Key, Value]
+            var history []*model.Event
+            const timeout Duration[Seconds, Millis] = 1
+            var inferred = Build[User]()
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Duration" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Seconds" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Millis" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "repo" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "inferred" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoEmbeddedFieldTypes_CapturesEmbeddedStructFields()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7934,6 +7934,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoParenthesizedCompositeTypeConversions_CapturesConvertedTypes()
+    {
+        const string content = """
+            package main
+
+            func convert(callback func(any) any, raw any) {
+                users := ([]User)(raw)
+                lookup := (map[Key]Value)(raw)
+                stream := (chan Event)(raw)
+                value := (callback)(raw)
+                _, _, _, _ = users, lookup, stream, value
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "callback" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoMethodExpressions_CapturesReceiverTypes()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7654,6 +7654,33 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoFunctionLiteralSignatures_CapturesParameterAndReturnTypes()
+    {
+        const string content = """
+            package main
+
+            func configure() {
+                handler := func(ctx Context, req *Request) (Response, error) {
+                    return Response{}, nil
+                }
+                wrapped := with(func(Event) Result {
+                    return Result{}
+                })
+                _, _ = handler, wrapped
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Context" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7931,6 +7931,41 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoTypeSwitchCases_CapturesPointerAndCompositeCaseTypes()
+    {
+        const string content = """
+            package main
+
+            func classify(value any, status Status) {
+                switch value.(type) {
+                case *Admin, *model.Member:
+                    return
+                case []Guest, map[Key]Value:
+                    return
+                case nil:
+                    return
+                }
+
+                switch status {
+                case status.Ready:
+                    return
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Admin" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Member" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Guest" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Ready" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "nil" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7782,6 +7782,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoMapCompositeLiterals_CapturesKeyAndValueTypes()
+    {
+        const string content = """
+            package main
+
+            func build() {
+                lookup := map[Key]Value{}
+                qualified := map[model.Tenant]*Entry{}
+                _ = lookup
+                _ = qualified
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Tenant" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Entry" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "map" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7806,6 +7806,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoParenthesizedTypeConversions_CapturesConvertedTypes()
+    {
+        const string content = """
+            package main
+
+            func convert(callback func(any) any, raw any) {
+                var _ Interface = (*Concrete)(nil)
+                id := (model.ID)(raw)
+                value := (callback)(raw)
+                _, _ = id, value
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Interface" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Concrete" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "ID" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "callback" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7829,6 +7829,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoMethodExpressions_CapturesReceiverTypes()
+    {
+        const string content = """
+            package main
+
+            func bind(handler Handler) {
+                serve := Handler.Serve
+                run := (*Worker).Run
+                stringify := model.User.String
+                method := handler.Serve
+                _, _, _, _ = serve, run, stringify, method
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Worker" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "handler" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7601,6 +7601,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoBuiltinTypeArguments_CapturesAllocatedTypesWithoutBuiltinCalls()
+    {
+        const string content = """
+            package main
+
+            func allocate() {
+                users := make([]User, 0)
+                cache := make(map[string]CacheEntry)
+                events := make(chan Event)
+                client := new(Client)
+                _, _, _, _ = users, cache, events, client
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "CacheEntry" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Client" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "new" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "make" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7853,6 +7853,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericInstantiations_CapturesTypeArgumentsWithoutCalls()
+    {
+        const string content = """
+            package main
+
+            func bind(values []func()) {
+                decoder := Decode[User]
+                mapper := stream.Map[model.Event, Result]
+                index := values[i]
+                _, _, _ = decoder, mapper, index
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "i" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7577,6 +7577,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoEmbeddedFieldTypes_CapturesEmbeddedStructFields()
+    {
+        const string content = """
+            package main
+
+            type Store struct {
+                *BaseStore
+                audit.Logger
+                Cache[Entry]
+                Name string
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "BaseStore" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Logger" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Cache" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Entry" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Name" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7553,6 +7553,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoMultiNameValueDeclarations_CapturesSharedType()
+    {
+        const string content = """
+            package main
+
+            var primary, secondary *Client
+            const first, second NamedConst = 1, 2
+
+            func configure() {
+                var local, cached *Session
+                assigned, other := load()
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Client" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "NamedConst" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Session" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "load" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7757,6 +7757,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericCompositeLiterals_CapturesTypeAndArguments()
+    {
+        const string content = """
+            package main
+
+            func build(values []func()) {
+                cache := Cache[Entry]{}
+                set := model.Set[Key, Value]{}
+                values[i]()
+                _, _ = cache, set
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Cache" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Set" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Entry" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "i" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7732,6 +7732,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoInlineStructFields_CapturesFieldTypes()
+    {
+        const string content = """
+            package main
+
+            func build() {
+                payload := struct{ ID UserID; Owner *User; Details model.Detail; Values []Value }{}
+                _ = payload
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "UserID" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Detail" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "ID" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Owner" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoChannelTypeDeclarations_CapturesElementTypes()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7705,6 +7705,33 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoFunctionTypeDeclarations_CapturesParameterAndReturnTypes()
+    {
+        const string content = """
+            package main
+
+            type Handler func(Request) Response
+
+            type Server struct {
+                Callback func(Context, *Payload) Result
+            }
+
+            var factory func(Config) *Client
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Context" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Config" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Client" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7532,6 +7532,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoInterfaceMethodSignatures_CapturesParameterAndReturnTypes()
+    {
+        const string content = """
+            package main
+
+            type Handler interface {
+                Handle(ctx Context, input Request) (Response, error)
+                Watch() <-chan Event
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Context" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7601,6 +7601,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoMultiNameStructFields_CapturesSharedType()
+    {
+        const string content = """
+            package main
+
+            type Store struct {
+                Primary, Secondary *Client
+                Cache, Backup Repository[Entry]
+                active, stale bool
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Client" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Entry" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Primary" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Secondary" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "active" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoBuiltinTypeArguments_CapturesAllocatedTypesWithoutBuiltinCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7916,6 +7916,7 @@ public class ReferenceExtractorTests
 
             func convert(callback func(any) any, raw any) {
                 var _ Interface = (*Concrete)(nil)
+                var _ = (**Node)(nil)
                 id := (model.ID)(raw)
                 value := (callback)(raw)
                 _, _ = id, value
@@ -7927,6 +7928,7 @@ public class ReferenceExtractorTests
 
         Assert.Contains(references, r => r.SymbolName == "Interface" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Concrete" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Node" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "ID" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "callback" && r.ReferenceKind == "type_reference");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7755,6 +7755,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoInlineInterfaceMembers_CapturesSignatureTypes()
+    {
+        const string content = """
+            package main
+
+            func bind() {
+                handler := interface{ Handle(Context, *Request) (Response, error); io.Reader }
+                transformer := interface{ Transform(Event) Result }
+                _, _ = handler, transformer
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Context" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Reader" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Handle" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Transform" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoChannelTypeDeclarations_CapturesElementTypes()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7904,6 +7904,33 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoBranchLabels_CapturesLabelReferences()
+    {
+        const string content = """
+            package main
+
+            func run(done bool) {
+            Retry:
+                for {
+                    if done {
+                        break Retry
+                    }
+                    continue Retry
+                }
+                goto Retry
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Retry" && r.ReferenceKind == "call" && r.Context.Contains("break Retry", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "Retry" && r.ReferenceKind == "call" && r.Context.Contains("continue Retry", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "Retry" && r.ReferenceKind == "call" && r.Context.Contains("goto Retry", StringComparison.Ordinal));
+        Assert.DoesNotContain(references, r => r.SymbolName == "Retry" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7681,6 +7681,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericCallTypeArguments_CapturesCallSiteTypes()
+    {
+        const string content = """
+            package main
+
+            func use(values []func()) {
+                decoded := Decode[User, *Payload](input)
+                mapped := stream.Map[model.Event, Result](events)
+                values[i]()
+                _, _ = decoded, mapped
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "i" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7832,6 +7832,34 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoCompositeTypeConversions_CapturesConvertedTypes()
+    {
+        const string content = """
+            package main
+
+            func convert(raw any, rawMap any, rawChan any) {
+                users := []User(raw)
+                lookup := map[Key]Value(rawMap)
+                stream := chan Event(rawChan)
+                returned := func() []Result {
+                    return []Result(raw)
+                }
+                _, _, _, _ = users, lookup, stream, returned
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "raw" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoParenthesizedTypeConversions_CapturesConvertedTypes()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7983,6 +7983,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericMethodExpressions_CapturesReceiverTypesAndArguments()
+    {
+        const string content = """
+            package main
+
+            func bind(repositories []Repository[User]) {
+                find := Repository[User].Find
+                save := (*Store[model.Entry]).Save
+                method := repositories[i].Find
+                _, _, _ = find, save, method
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Store" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Entry" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "repositories" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "i" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoGenericInstantiations_CapturesTypeArgumentsWithoutCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7876,6 +7876,34 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoInterfaceTypeSetTerms_CapturesUnionTypes()
+    {
+        const string content = """
+            package main
+
+            type Identifier interface {
+                ~CustomID | External
+                model.Token | ~Alias
+            }
+
+            func flags() {
+                mask := FlagA | FlagB
+                _ = mask
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "CustomID" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "External" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Token" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Alias" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "FlagA" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "FlagB" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7732,6 +7732,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoChannelTypeDeclarations_CapturesElementTypes()
+    {
+        const string content = """
+            package main
+
+            var updates <-chan Event
+            var commands chan<- Command
+            type Stream chan Result
+
+            type Broker struct {
+                Inputs chan<- *Payload
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Command" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "chan" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7513,6 +7513,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoMethodReceiverTypes_CapturesReceiverType()
+    {
+        const string content = """
+            package main
+
+            func (h *Handler) Serve(ctx Context) Result {
+                return Result{}
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Handler" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Context" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7625,6 +7625,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericStructFields_CapturesSpacedTypeArguments()
+    {
+        const string content = """
+            package main
+
+            type Store struct {
+                Owner Repository[Key, Value]
+                History []*model.Event
+                Name string
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Event" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Owner" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Name" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoBuiltinTypeArguments_CapturesAllocatedTypesWithoutBuiltinCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7473,6 +7473,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericFunctionConstraints_CapturesConstraintTypes()
+    {
+        const string content = """
+            package main
+
+            func Decode[T WireMessage, K KeyConstraint](value T) Result {
+                return Result{}
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "WireMessage" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "KeyConstraint" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -7513,6 +7513,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_GoGenericTypeSpecTargets_CapturesSpacedTypeArguments()
+    {
+        const string content = """
+            package main
+
+            type Repo Repository[Key, Value]
+            type Alias = model.Store[Entry, Result]
+            type Wrapped struct {
+                ID string
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        var references = ReferenceExtractor.Extract(1, "go", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Value" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Store" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Entry" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Result" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Repo" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_GoMethodReceiverTypes_CapturesReceiverType()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -507,6 +507,7 @@ public class SymbolExtractorTests
 
             const MaxRetries = 3
             const Timeout int = 30
+            const PrimaryStatus, SecondaryStatus = 1, 2
             const (
                 StatusActive = "active"
             )
@@ -517,6 +518,7 @@ public class SymbolExtractorTests
 
             func build() {
                 var local, cached *Config
+                const localStatus, cachedStatus = 1, 2
                 user := User{Name: "alice"}
                 _ = user
             }
@@ -526,6 +528,8 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "MaxRetries");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Timeout");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "PrimaryStatus");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "SecondaryStatus");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "StatusActive");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "ErrNotFound");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DefaultConfig");
@@ -533,6 +537,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Secondary");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "cached");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "localStatus");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "cachedStatus");
         Assert.DoesNotContain(symbols, s => s.Name == "Name");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -519,6 +519,14 @@ public class SymbolExtractorTests
             func build() {
                 var local, cached *Config
                 const localStatus, cachedStatus = 1, 2
+                var (
+                    localGrouped = 1
+                    cachedGrouped = 2
+                )
+                const (
+                    localGroupedStatus = 1
+                    cachedGroupedStatus = 2
+                )
                 user := User{Name: "alice"}
                 _ = user
             }
@@ -539,6 +547,10 @@ public class SymbolExtractorTests
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "cached");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "localStatus");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "cachedStatus");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "localGrouped");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "cachedGrouped");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "localGroupedStatus");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "cachedGroupedStatus");
         Assert.DoesNotContain(symbols, s => s.Name == "Name");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10737,6 +10737,37 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Go_DetectsLabels()
+    {
+        var content = """
+            package demo
+
+            func run() {
+            Retry:
+                for {
+                    break Retry
+                }
+
+                item := User{
+                    Retry: true,
+                }
+                value := 1
+                _ = item
+                switch value {
+                case 1:
+                default:
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+
+        var label = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "Retry");
+        Assert.Equal(4, label.Line);
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name is "case" or "default");
+    }
+
+    [Fact]
     public void Extract_Fortran_DetectsModulesProgramsSubroutinesAndFunctions()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -513,8 +513,10 @@ public class SymbolExtractorTests
 
             var ErrNotFound = errors.New("not found")
             var DefaultConfig *Config = &Config{}
+            var Primary, Secondary *Config
 
             func build() {
+                var local, cached *Config
                 user := User{Name: "alice"}
                 _ = user
             }
@@ -527,6 +529,10 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "StatusActive");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "ErrNotFound");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DefaultConfig");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Primary");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Secondary");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "cached");
         Assert.DoesNotContain(symbols, s => s.Name == "Name");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10723,16 +10723,19 @@ public class SymbolExtractorTests
     {
         // Should detect both regular and method functions
         // 通常関数とメソッド関数の両方を検出する
-        var content = "type Handler struct {\n}\nfunc NewHandler() *Handler {\n}\nfunc Load(input User) Result {\n}\nfunc (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n}";
+        var content = "type Handler struct {\n}\ntype Store[T, U any] struct {\n}\nfunc NewHandler() *Handler {\n}\nfunc Load(input User) Result {\n}\nfunc (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n}\nfunc (s *Store[T, U]) Save(value T) {\n}";
         var symbols = SymbolExtractor.Extract(1, "go", content);
 
-        Assert.Equal(3, symbols.Count(s => s.Kind == "function"));
+        Assert.Equal(4, symbols.Count(s => s.Kind == "function"));
         Assert.Contains(symbols, s => s.Name == "NewHandler");
         var regularFunction = Assert.Single(symbols, s => s.Name == "Load");
         Assert.Null(regularFunction.ContainerName);
         var method = Assert.Single(symbols, s => s.Name == "ServeHTTP");
         Assert.Equal("struct", method.ContainerKind);
         Assert.Equal("Handler", method.ContainerName);
+        var genericMethod = Assert.Single(symbols, s => s.Name == "Save");
+        Assert.Equal("struct", genericMethod.ContainerKind);
+        Assert.Equal("Store", genericMethod.ContainerName);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -530,6 +530,16 @@ public class SymbolExtractorTests
                 user := User{Name: "alice"}
                 _ = user
             }
+
+            func bracesInText() {
+                _ = "{"
+                _ = `{
+            }`
+                // {
+            }
+
+            const AfterText = 4
+            var AfterTextConfig *Config
             """;
 
         var symbols = SymbolExtractor.Extract(1, "go", content);
@@ -543,6 +553,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DefaultConfig");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Primary");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Secondary");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "AfterText");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "AfterTextConfig");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "cached");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "localStatus");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -487,6 +487,7 @@ public class SymbolExtractorTests
         var imports = symbols.Where(s => s.Kind == "import").ToList();
 
         Assert.Equal(6, imports.Count);
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "demo");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "main");
         Assert.Contains(imports, s => s.Name == "\"bytes\"");
         Assert.Contains(imports, s => s.Name == "alias \"fmt\"");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10723,12 +10723,16 @@ public class SymbolExtractorTests
     {
         // Should detect both regular and method functions
         // 通常関数とメソッド関数の両方を検出する
-        var content = "func NewHandler() *Handler {\n}\nfunc (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n}";
+        var content = "type Handler struct {\n}\nfunc NewHandler() *Handler {\n}\nfunc Load(input User) Result {\n}\nfunc (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n}";
         var symbols = SymbolExtractor.Extract(1, "go", content);
 
-        Assert.Equal(2, symbols.Count);
+        Assert.Equal(3, symbols.Count(s => s.Kind == "function"));
         Assert.Contains(symbols, s => s.Name == "NewHandler");
-        Assert.Contains(symbols, s => s.Name == "ServeHTTP");
+        var regularFunction = Assert.Single(symbols, s => s.Name == "Load");
+        Assert.Null(regularFunction.ContainerName);
+        var method = Assert.Single(symbols, s => s.Name == "ServeHTTP");
+        Assert.Equal("struct", method.ContainerKind);
+        Assert.Equal("Handler", method.ContainerName);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10723,10 +10723,10 @@ public class SymbolExtractorTests
     {
         // Should detect both regular and method functions
         // 通常関数とメソッド関数の両方を検出する
-        var content = "type Handler struct {\n}\ntype Store[T, U any] struct {\n}\nfunc NewHandler() *Handler {\n}\nfunc Load(input User) Result {\n}\nfunc (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n}\nfunc (s *Store[T, U]) Save(value T) {\n}";
+        var content = "type Handler struct {\n}\ntype Store[T, U any] struct {\n}\nfunc NewHandler() *Handler {\n}\nfunc Load(input User) Result {\n}\nfunc (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n}\nfunc (s *Store[T, U]) Save(value T) {\n}\nfunc (Store[T, U]) Snapshot() {\n}";
         var symbols = SymbolExtractor.Extract(1, "go", content);
 
-        Assert.Equal(4, symbols.Count(s => s.Kind == "function"));
+        Assert.Equal(5, symbols.Count(s => s.Kind == "function"));
         Assert.Contains(symbols, s => s.Name == "NewHandler");
         var regularFunction = Assert.Single(symbols, s => s.Name == "Load");
         Assert.Null(regularFunction.ContainerName);
@@ -10736,6 +10736,9 @@ public class SymbolExtractorTests
         var genericMethod = Assert.Single(symbols, s => s.Name == "Save");
         Assert.Equal("struct", genericMethod.ContainerKind);
         Assert.Equal("Store", genericMethod.ContainerName);
+        var unnamedGenericMethod = Assert.Single(symbols, s => s.Name == "Snapshot");
+        Assert.Equal("struct", unnamedGenericMethod.ContainerKind);
+        Assert.Equal("Store", unnamedGenericMethod.ContainerName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Expand Go reference extraction across generic constraints, calls, composite literals, conversions, type assertions, function signatures, interface members, embedded fields, labels, type sets, and grouped declarations.
- Improve Go symbol indexing for labels, grouped const/var declarations, multi-name top-level values, method receiver containers, and generic receiver forms.
- Harden Go package-level value scanning so function-local grouped declarations and braces inside strings/comments do not pollute or break top-level symbol results.

## Validation

- `dotnet test CodeIndex.sln` — passed, 3907 passed / 3 skipped.
- `dotnet build CodeIndex.sln` — passed, 0 warnings / 0 errors.
- `dotnet run --project tools/CodeIndex.Changelog -- check` — passed, 139 fragments validated.
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` — index fresh.
- Each commit was reviewed with a Codex adversarial review pass; actionable findings in later rounds were fixed by follow-up commits.

## Changelog

- `changelog.d/unreleased/+go-search-improvements.changed.md`

## Follow-Up Candidates

- Continue broadening Go parser coverage around rare multiline declarations where regex-based extraction still has natural limits.