### PR TITLE
[codex] Improve Ruby search extraction coverage

### DIFF
--- a/changelog.d/unreleased/+ruby-alias-endpoint-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-alias-endpoint-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby alias declarations now index their endpoints** — `cdidx` records the names in `alias` and `alias_method` declarations so searches can connect alias definitions to the methods they expose.
+
+## 日本語
+
+- **Ruby の alias 宣言が両端の名前を索引するようになりました** — `cdidx` は `alias` / `alias_method` 宣言内の名前を記録するため、alias 定義と公開されるメソッドを検索でつなげやすくなります。

--- a/changelog.d/unreleased/+ruby-association-class-name-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-association-class-name-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby association `class_name` options now link to target classes** — `cdidx` indexes string class names from Rails-style `belongs_to`, `has_one`, and `has_many` declarations so association searches can find the actual model type.
+
+## 日本語
+
+- **Ruby association の `class_name` option が対象クラスへリンクするようになりました** — `cdidx` は Rails 風の `belongs_to` / `has_one` / `has_many` 宣言にある文字列クラス名を索引するため、association 検索で実際のモデル型を見つけやすくなります。

--- a/changelog.d/unreleased/+ruby-attribute-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-attribute-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails `attribute` declarations now index attribute names** — `cdidx` records the first argument from `attribute :timezone` while ignoring type and option values.
+
+## 日本語
+
+- **Ruby Rails の `attribute` 宣言が属性名を索引するようになりました** — `cdidx` は `attribute :timezone` の第一引数を記録し、型やoption値は参照に混ぜません。

--- a/changelog.d/unreleased/+ruby-attribute-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-attribute-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails `attribute` declarations now create property symbols** — `cdidx` indexes `attribute :timezone` as a searchable model property.
+
+## 日本語
+
+- **Ruby Rails の `attribute` 宣言がproperty symbolを作るようになりました** — `cdidx` は `attribute :timezone` を検索可能なmodel propertyとして索引します。

--- a/changelog.d/unreleased/+ruby-autoload-constant-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-autoload-constant-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `autoload` constants are now indexed as references** — `cdidx` records the constant argument from `autoload :Name, "path"` so lazy-loaded Ruby types are easier to find.
+
+## 日本語
+
+- **Ruby の `autoload` 定数を参照として索引するようになりました** — `cdidx` は `autoload :Name, "path"` の定数引数を記録するため、遅延読み込みされる Ruby 型を見つけやすくなります。

--- a/changelog.d/unreleased/+ruby-class-inheritance-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-class-inheritance-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby superclass references are now indexed** — `cdidx` records the parent class in `class Child < Parent`, allowing searches for Ruby types to find inheritance usage.
+
+## 日本語
+
+- **Ruby の親クラス参照を索引するようになりました** — `cdidx` は `class Child < Parent` の親クラスを記録するため、Ruby 型の検索で継承利用箇所を見つけられます。

--- a/changelog.d/unreleased/+ruby-class-new-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-class-new-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby `Class.new` block assignments now create class symbols** — `cdidx` indexes declarations such as `User = Class.new(...) do` as classes so methods defined inside the block are searchable under the dynamic class.
+
+## 日本語
+
+- **Ruby の `Class.new` ブロック代入がclass symbolを作るようになりました** — `cdidx` は `User = Class.new(...) do` のような宣言をclassとして索引し、ブロック内メソッドを動的クラス配下で検索できるようにします。

--- a/changelog.d/unreleased/+ruby-composed-of-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-composed-of-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails `composed_of` declarations now link aggregate and class targets** — `cdidx` records the aggregate name and `class_name` target from `composed_of :address`.
+
+## 日本語
+
+- **Ruby Rails の `composed_of` 宣言がaggregate名とclass targetへリンクするようになりました** — `cdidx` は `composed_of :address` のaggregate名と `class_name` targetを記録します。

--- a/changelog.d/unreleased/+ruby-constant-assignment-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-constant-assignment-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby constant assignments are now indexed as property symbols** — `cdidx` records constants such as `MAX_RETRIES = 3`, making Ruby configuration and domain constants searchable through symbol queries.
+
+## 日本語
+
+- **Ruby の定数代入を property シンボルとして索引するようになりました** — `cdidx` は `MAX_RETRIES = 3` のような定数を記録するため、Ruby の設定値やドメイン定数をシンボル検索で見つけられます。

--- a/changelog.d/unreleased/+ruby-constant-visibility-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-constant-visibility-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby constant visibility declarations now link to constants** — `cdidx` indexes targets from `private_constant` and `public_constant` while suppressing keyword call noise.
+
+## 日本語
+
+- **Ruby の定数 visibility 宣言が定数へリンクするようになりました** — `cdidx` は `private_constant` / `public_constant` の対象を索引し、キーワード自体の call ノイズは抑えます。

--- a/changelog.d/unreleased/+ruby-create-table-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-create-table-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails `create_table` declarations now index table names** — `cdidx` records symbol and string table names passed to `create_table` while suppressing migration option keys.
+
+## 日本語
+
+- **Ruby Rails の `create_table` 宣言がtable名を索引するようになりました** — `cdidx` は `create_table` に渡されたsymbol/stringのtable名を記録し、migration option keyは参照から除外します。

--- a/changelog.d/unreleased/+ruby-dsl-option-key-noise.fixed.md
+++ b/changelog.d/unreleased/+ruby-dsl-option-key-noise.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby DSL option hashes no longer add noisy references** — `cdidx` stops command-target scanning at Ruby keyword options such as `dependent:` or `only:`, keeping Rails-style reference results focused on real targets.
+
+## 日本語
+
+- **Ruby DSL の option hash がノイズ参照を追加しないようになりました** — `cdidx` は `dependent:` や `only:` のような Ruby keyword option で command target の走査を止め、Rails 風 DSL の参照結果を実際の対象に絞ります。

--- a/changelog.d/unreleased/+ruby-enum-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-enum-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails `enum` declarations now create property symbols** — `cdidx` indexes `enum :status` as a searchable model property.
+
+## 日本語
+
+- **Ruby Rails の `enum` 宣言がproperty symbolを作るようになりました** — `cdidx` は `enum :status` を検索可能なmodel propertyとして索引します。

--- a/changelog.d/unreleased/+ruby-factorybot-factory-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-factorybot-factory-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby FactoryBot factories now create searchable symbols** — `cdidx` indexes `factory :user do` definitions as function symbols with Ruby block ranges.
+
+## 日本語
+
+- **Ruby FactoryBot のfactory定義が検索可能なsymbolを作るようになりました** — `cdidx` は `factory :user do` 定義をRubyブロック範囲付きのfunction symbolとして索引します。

--- a/changelog.d/unreleased/+ruby-gem-dependency-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-gem-dependency-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `gem` declarations now index dependency names** — `cdidx` records the first string argument from `gem "name"` so Gemfile dependency searches can find package declarations without keyword noise.
+
+## 日本語
+
+- **Ruby の `gem` 宣言が依存名を索引するようになりました** — `cdidx` は `gem "name"` の最初の文字列引数を記録するため、Gemfile の依存宣言をキーワードノイズなしで検索できます。

--- a/changelog.d/unreleased/+ruby-load-path-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-load-path-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `load` paths are now indexed as references** — `cdidx` records the string path in `load "file.rb"` so dynamically loaded Ruby files are easier to find.
+
+## 日本語
+
+- **Ruby の `load` パスを参照として索引するようになりました** — `cdidx` は `load "file.rb"` の文字列パスを記録するため、動的に読み込まれる Ruby ファイルを見つけやすくなります。

--- a/changelog.d/unreleased/+ruby-module-function-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-module-function-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `module_function` declarations now link to exported methods** — `cdidx` indexes method names passed to `module_function` while suppressing the keyword as call noise.
+
+## 日本語
+
+- **Ruby の `module_function` 宣言が公開メソッドへリンクするようになりました** — `cdidx` は `module_function` に渡されたメソッド名を索引し、キーワード自体の call ノイズは抑えます。

--- a/changelog.d/unreleased/+ruby-nested-attributes-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-nested-attributes-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails nested attribute declarations now index association names** — `cdidx` records associations passed to `accepts_nested_attributes_for` while stopping before option keys.
+
+## 日本語
+
+- **Ruby Rails のnested attribute宣言がassociation名を索引するようになりました** — `cdidx` は `accepts_nested_attributes_for` に渡されたassociationを記録し、option keyの手前で停止します。

--- a/changelog.d/unreleased/+ruby-operator-method-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-operator-method-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby operator method definitions are now indexed as functions** — `cdidx` records definitions such as `def []`, `def []=`, and `def <=>`, improving symbol navigation for Ruby value objects and collection APIs.
+
+## 日本語
+
+- **Ruby の operator method 定義を関数として索引するようになりました** — `cdidx` は `def []`、`def []=`、`def <=>` のような定義を記録し、Ruby の値オブジェクトや collection API のシンボル移動を改善します。

--- a/changelog.d/unreleased/+ruby-prepend-target-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-prepend-target-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `prepend` now links to the mixed-in module** — `cdidx` treats `prepend SomeModule` like `include` and `extend`, indexing the module argument while avoiding a noisy call edge for the keyword.
+
+## 日本語
+
+- **Ruby の `prepend` が mixin 対象モジュールへリンクするようになりました** — `cdidx` は `prepend SomeModule` を `include` / `extend` と同様に扱い、キーワード自体のノイズになる call edge を避けつつモジュール引数を索引します。

--- a/changelog.d/unreleased/+ruby-qualified-class-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-qualified-class-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby qualified class and module names are now indexed fully** — `cdidx` records names such as `Admin::Billing::Invoice` instead of only the first namespace segment.
+
+## 日本語
+
+- **Ruby の修飾付き class / module 名を完全な名前で索引するようになりました** — `cdidx` は `Admin::Billing::Invoice` のような名前を先頭 namespace セグメントだけでなく完全な名前として記録します。

--- a/changelog.d/unreleased/+ruby-rails-enum-attribute-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-rails-enum-attribute-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails `enum` declarations now index attribute names** — `cdidx` records the attribute passed to `enum :status` while leaving enum values and options out of reference search.
+
+## 日本語
+
+- **Ruby Rails の `enum` 宣言が属性名を索引するようになりました** — `cdidx` は `enum :status` の属性名を記録し、enum値やオプションは参照検索に混ぜません。

--- a/changelog.d/unreleased/+ruby-rails-route-resource-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-rails-route-resource-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails route declarations now index resource names** — `cdidx` records names passed to `resources :articles` and `resource :profile` without indexing route option keys as references.
+
+## 日本語
+
+- **Ruby Rails の route 宣言がresource名を索引するようになりました** — `cdidx` は `resources :articles` や `resource :profile` の名前を記録し、routeオプションキーは参照として扱いません。

--- a/changelog.d/unreleased/+ruby-rake-namespace-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-rake-namespace-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rake namespaces now create namespace symbols** — `cdidx` indexes `namespace :db do` blocks and attaches nested tasks to the namespace container.
+
+## 日本語
+
+- **Ruby Rake の namespace がnamespace symbolを作るようになりました** — `cdidx` は `namespace :db do` ブロックを索引し、内側のtaskをnamespace container配下に置きます。

--- a/changelog.d/unreleased/+ruby-rake-task-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-rake-task-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rake task definitions are now indexed as functions** — `cdidx` records `task :build` and `task test: :environment` names, improving entrypoint search in Ruby/Rake projects.
+
+## 日本語
+
+- **Ruby の Rake task 定義を関数として索引するようになりました** — `cdidx` は `task :build` や `task test: :environment` の名前を記録し、Ruby/Rake プロジェクトの入口検索を改善します。

--- a/changelog.d/unreleased/+ruby-refine-target-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-refine-target-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `refine` declarations now link to refined classes** — `cdidx` records targets from `refine String do` while suppressing the refinement keyword as call noise.
+
+## 日本語
+
+- **Ruby の `refine` 宣言が refinement 対象クラスへリンクするようになりました** — `cdidx` は `refine String do` の対象を索引し、キーワード自体の call ノイズは抑えます。

--- a/changelog.d/unreleased/+ruby-require-import-symbol-names.fixed.md
+++ b/changelog.d/unreleased/+ruby-require-import-symbol-names.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby `require` import symbols now omit surrounding quotes** — `cdidx` indexes `require "path"` and `require_relative 'path'` import names as `path`, improving symbol search matches.
+
+## 日本語
+
+- **Ruby の `require` import シンボルが周囲の引用符を除いて索引されるようになりました** — `cdidx` は `require "path"` / `require_relative 'path'` の import 名を `path` として記録し、シンボル検索で一致しやすくします。

--- a/changelog.d/unreleased/+ruby-require-relative-target-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-require-relative-target-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `require_relative` targets are now indexed as references** — `cdidx` now records the relative path argument from `require_relative "..."`, making Ruby local dependency searches more complete.
+
+## 日本語
+
+- **Ruby の `require_relative` 対象を参照として索引するようになりました** — `cdidx` は `require_relative "..."` の相対パス引数を記録するため、Ruby のローカル依存検索がより完全になります。

--- a/changelog.d/unreleased/+ruby-rescue-exception-type-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-rescue-exception-type-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `rescue` clauses now index exception types** — `cdidx` records exception constants in `rescue ErrorType` clauses so searches can find handlers for Ruby error classes.
+
+## 日本語
+
+- **Ruby の `rescue` 節が例外型を索引するようになりました** — `cdidx` は `rescue ErrorType` 節の例外定数を記録するため、Ruby のエラークラスを扱うハンドラを検索で見つけられます。

--- a/changelog.d/unreleased/+ruby-rescue-from-exception-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-rescue-from-exception-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `rescue_from` declarations now index exception classes** — `cdidx` records exception targets from Rails-style `rescue_from` declarations while avoiding option-hash noise.
+
+## 日本語
+
+- **Ruby の `rescue_from` 宣言が例外クラスを索引するようになりました** — `cdidx` は Rails 風 `rescue_from` 宣言の例外対象を記録し、option hash 由来のノイズは避けます。

--- a/changelog.d/unreleased/+ruby-rspec-describe-target-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-rspec-describe-target-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby RSpec `describe` blocks now link subject constants** — `cdidx` records constants passed to `describe User do` and `RSpec.describe User do` while suppressing the DSL keyword as call noise.
+
+## 日本語
+
+- **Ruby RSpec の `describe` ブロックが対象定数へリンクするようになりました** — `cdidx` は `describe User do` や `RSpec.describe User do` の定数引数を記録し、DSLキーワード自体の call ノイズは抑えます。

--- a/changelog.d/unreleased/+ruby-rspec-let-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-rspec-let-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby RSpec `let` helpers now create property symbols** — `cdidx` indexes `let(:user) do` and `let!(:account) do` helper definitions with Ruby block ranges.
+
+## 日本語
+
+- **Ruby RSpec の `let` helper がproperty symbolを作るようになりました** — `cdidx` は `let(:user) do` と `let!(:account) do` のhelper定義をRubyブロック範囲付きで索引します。

--- a/changelog.d/unreleased/+ruby-rspec-shared-examples-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-rspec-shared-examples-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby RSpec shared examples now create function symbols** — `cdidx` indexes `shared_examples "auditable" do` blocks so reusable spec contracts are searchable.
+
+## 日本語
+
+- **Ruby RSpec のshared examplesがfunction symbolを作るようになりました** — `cdidx` は `shared_examples "auditable" do` ブロックを索引し、再利用されるspec契約を検索可能にします。

--- a/changelog.d/unreleased/+ruby-rspec-subject-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-rspec-subject-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby RSpec named subjects now create property symbols** — `cdidx` indexes `subject(:profile) do` helper definitions with Ruby block ranges.
+
+## 日本語
+
+- **Ruby RSpec の名前付きsubjectがproperty symbolを作るようになりました** — `cdidx` は `subject(:profile) do` のhelper定義をRubyブロック範囲付きで索引します。

--- a/changelog.d/unreleased/+ruby-serialize-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-serialize-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails `serialize` declarations now index serialized attribute names** — `cdidx` records `serialize :settings` without indexing serializer option keys or values.
+
+## 日本語
+
+- **Ruby Rails の `serialize` 宣言がserialized属性名を索引するようになりました** — `cdidx` は `serialize :settings` を記録し、serializer option keyや値は参照に混ぜません。

--- a/changelog.d/unreleased/+ruby-singleton-method-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-singleton-method-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby receiver-qualified singleton methods are now indexed by method name** — `cdidx` records `export!` from `def Admin::User.export!` instead of mistaking the receiver for the function symbol.
+
+## 日本語
+
+- **Ruby の receiver 付き singleton method をメソッド名で索引するようになりました** — `cdidx` は `def Admin::User.export!` から receiver ではなく `export!` を関数シンボルとして記録します。

--- a/changelog.d/unreleased/+ruby-store-accessor-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-store-accessor-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby Rails `store_accessor` declarations now create property symbols** — `cdidx` indexes generated accessors such as `theme` and `locale` from `store_accessor :settings, :theme, :locale`.
+
+## 日本語
+
+- **Ruby Rails の `store_accessor` 宣言がproperty symbolを作るようになりました** — `cdidx` は `store_accessor :settings, :theme, :locale` から生成される `theme` や `locale` accessorを索引します。

--- a/changelog.d/unreleased/+ruby-struct-new-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-struct-new-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby `Struct.new` block assignments now create class symbols** — `cdidx` indexes declarations such as `Result = Struct.new(...) do` as classes and keeps methods defined inside the block under that dynamic container.
+
+## 日本語
+
+- **Ruby の `Struct.new` ブロック代入がclass symbolを作るようになりました** — `cdidx` は `Result = Struct.new(...) do` のような宣言をclassとして索引し、ブロック内メソッドを動的container配下に保ちます。

--- a/changelog.d/unreleased/+ruby-using-refinement-refs.fixed.md
+++ b/changelog.d/unreleased/+ruby-using-refinement-refs.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Ruby `using` refinement targets are now indexed as references** — `cdidx` records the refinement module in `using SomeRefinement` without adding a noisy call edge for the keyword.
+
+## 日本語
+
+- **Ruby の `using` refinement 対象を参照として索引するようになりました** — `cdidx` は `using SomeRefinement` の refinement モジュールを記録し、キーワード自体のノイズになる call edge は追加しません。

--- a/changelog.d/unreleased/+ruby-visibility-modified-method-symbols.fixed.md
+++ b/changelog.d/unreleased/+ruby-visibility-modified-method-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Ruby visibility-modified method definitions are now indexed** — `cdidx` recognizes `private def`, `protected def`, and `public def` forms, including singleton methods.
+
+## 日本語
+
+- **Ruby の visibility modifier 付きメソッド定義を索引するようになりました** — `cdidx` は singleton method を含む `private def`、`protected def`、`public def` 形式を認識します。

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -16,6 +16,7 @@ internal static class RubyReferenceExtractor
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
         "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "load", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "private_constant", "public_constant",
         "alias", "alias_method",
         "define_method", "before_action", "after_action", "around_action", "helper_method",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -19,7 +19,7 @@ internal static class RubyReferenceExtractor
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
         "define_method", "describe", "resource", "resources", "create_table", "attribute", "serialize", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
-        "has_many", "has_one", "belongs_to", "composed_of", "scope", "delegate", "validates", "enum",
+        "has_many", "has_one", "belongs_to", "composed_of", "accepts_nested_attributes_for", "scope", "delegate", "validates", "enum",
     };
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -15,7 +15,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
-        "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "load", "gem", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "include", "extend", "prepend", "using", "refine", "autoload", "require", "require_relative", "load", "gem", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
         "define_method", "before_action", "after_action", "around_action", "helper_method", "rescue_from",

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -18,13 +18,13 @@ internal static class RubyReferenceExtractor
         "include", "extend", "prepend", "using", "refine", "autoload", "require", "require_relative", "load", "gem", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
-        "define_method", "describe", "resource", "resources", "create_table", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
+        "define_method", "describe", "resource", "resources", "create_table", "attribute", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates", "enum",
     };
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)
     {
-        "require", "require_relative", "load", "gem", "raise", "define_method", "create_table",
+        "require", "require_relative", "load", "gem", "raise", "define_method", "create_table", "attribute",
     };
 
     private static readonly HashSet<string> ClassNameOptionCommandNames = new(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -18,13 +18,13 @@ internal static class RubyReferenceExtractor
         "include", "extend", "prepend", "using", "refine", "autoload", "require", "require_relative", "load", "gem", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
-        "define_method", "describe", "resource", "resources", "create_table", "attribute", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
+        "define_method", "describe", "resource", "resources", "create_table", "attribute", "serialize", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates", "enum",
     };
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)
     {
-        "require", "require_relative", "load", "gem", "raise", "define_method", "create_table", "attribute",
+        "require", "require_relative", "load", "gem", "raise", "define_method", "create_table", "attribute", "serialize",
     };
 
     private static readonly HashSet<string> ClassNameOptionCommandNames = new(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -26,8 +26,17 @@ internal static class RubyReferenceExtractor
         "require", "require_relative", "raise", "define_method",
     };
 
+    private static readonly HashSet<string> ClassNameOptionCommandNames = new(StringComparer.Ordinal)
+    {
+        "has_many", "has_one", "belongs_to",
+    };
+
     private static readonly Regex CommandTargetTokenRegex = new(
         @"(?<![\w$@])(?<token>:(?:""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|[A-Za-z_]\w*[?!]?)|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*')",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ClassNameOptionRegex = new(
+        @"(?<![\w$@]):?class_name\s*(?::|=>)\s*(?<quote>['""])(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\k<quote>",
         RegexOptions.Compiled);
 
     public static void EmitAdditionalCallReferences(
@@ -100,6 +109,17 @@ internal static class RubyReferenceExtractor
         if (commentIndex >= 0)
             tail = tail[..commentIndex];
 
+        EmitClassNameOptionReferences(
+            name,
+            tail,
+            argsStart,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForCall);
+
         var matchedAny = false;
         foreach (Match match in CommandTargetTokenRegex.Matches(tail))
         {
@@ -162,6 +182,38 @@ internal static class RubyReferenceExtractor
     }
 
     private static bool IsIdentifierStart(char ch) => char.IsLetter(ch) || ch == '_';
+
+    private static void EmitClassNameOptionReferences(
+        string commandName,
+        string tail,
+        int tailStartIndex,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        if (!ClassNameOptionCommandNames.Contains(commandName))
+            return;
+
+        foreach (Match match in ClassNameOptionRegex.Matches(tail))
+        {
+            var name = match.Groups["name"].Value;
+            var tokenIndex = tailStartIndex + match.Groups["name"].Index;
+            var targetContainer = resolveContainerForCall(tokenIndex);
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                tokenIndex,
+                "reference",
+                context,
+                lineNumber,
+                targetContainer);
+        }
+    }
 
     private static bool IsHashOptionKey(string tail, Match match, string rawToken)
     {

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -10,7 +10,7 @@ internal static class RubyReferenceExtractor
         RegexOptions.Compiled);
 
     private static readonly Regex BlockCallRegex = new(
-        @"(?<![\w$@])(?<name>[A-Za-z_]\w*[?!]?)(?:\s*\([^\)\r\n]*\))?\s*(?:\{|do\b)",
+        @"(?<![\w$@:])(?<name>[A-Za-z_]\w*[?!]?)(?:\s*\([^\)\r\n]*\))?\s*(?:\{|do\b)",
         RegexOptions.Compiled);
 
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
@@ -18,13 +18,13 @@ internal static class RubyReferenceExtractor
         "include", "extend", "prepend", "using", "refine", "autoload", "require", "require_relative", "load", "gem", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
-        "define_method", "describe", "resource", "resources", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
+        "define_method", "describe", "resource", "resources", "create_table", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates", "enum",
     };
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)
     {
-        "require", "require_relative", "load", "gem", "raise", "define_method",
+        "require", "require_relative", "load", "gem", "raise", "define_method", "create_table",
     };
 
     private static readonly HashSet<string> ClassNameOptionCommandNames = new(StringComparer.Ordinal)
@@ -185,6 +185,7 @@ internal static class RubyReferenceExtractor
                     && !string.Equals(name, "require_relative", StringComparison.Ordinal)
                     && !string.Equals(name, "load", StringComparison.Ordinal)
                     && !string.Equals(name, "gem", StringComparison.Ordinal)
+                    && !string.Equals(name, "create_table", StringComparison.Ordinal)
                     && !string.Equals(name, "define_method", StringComparison.Ordinal))
                 {
                     continue;

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -15,7 +15,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
-        "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "load", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "alias", "alias_method",
         "define_method", "before_action", "after_action", "around_action", "helper_method",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
@@ -23,7 +23,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)
     {
-        "require", "require_relative", "raise", "define_method",
+        "require", "require_relative", "load", "raise", "define_method",
     };
 
     private static readonly HashSet<string> ClassNameOptionCommandNames = new(StringComparer.Ordinal)
@@ -182,6 +182,7 @@ internal static class RubyReferenceExtractor
             {
                 if (!string.Equals(name, "require", StringComparison.Ordinal)
                     && !string.Equals(name, "require_relative", StringComparison.Ordinal)
+                    && !string.Equals(name, "load", StringComparison.Ordinal)
                     && !string.Equals(name, "define_method", StringComparison.Ordinal))
                 {
                     continue;

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -18,7 +18,7 @@ internal static class RubyReferenceExtractor
         "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "load", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
-        "define_method", "before_action", "after_action", "around_action", "helper_method",
+        "define_method", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
     };
 

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -15,7 +15,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
-        "include", "extend", "prepend", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "include", "extend", "prepend", "autoload", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "define_method", "before_action", "after_action", "around_action", "helper_method",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
     };

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -19,7 +19,7 @@ internal static class RubyReferenceExtractor
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
         "define_method", "describe", "resource", "resources", "create_table", "attribute", "serialize", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
-        "has_many", "has_one", "belongs_to", "scope", "delegate", "validates", "enum",
+        "has_many", "has_one", "belongs_to", "composed_of", "scope", "delegate", "validates", "enum",
     };
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)
@@ -29,7 +29,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> ClassNameOptionCommandNames = new(StringComparer.Ordinal)
     {
-        "has_many", "has_one", "belongs_to",
+        "has_many", "has_one", "belongs_to", "composed_of",
     };
 
     private static readonly Regex CommandTargetTokenRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -16,6 +16,7 @@ internal static class RubyReferenceExtractor
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
         "include", "extend", "prepend", "autoload", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "alias", "alias_method",
         "define_method", "before_action", "after_action", "around_action", "helper_method",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
     };

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -15,14 +15,14 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
-        "include", "extend", "require", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "include", "extend", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "define_method", "before_action", "after_action", "around_action", "helper_method",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
     };
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)
     {
-        "require", "raise", "define_method",
+        "require", "require_relative", "raise", "define_method",
     };
 
     private static readonly Regex CommandTargetTokenRegex = new(
@@ -127,6 +127,7 @@ internal static class RubyReferenceExtractor
             else if (rawToken[0] == '\'' || rawToken[0] == '"')
             {
                 if (!string.Equals(name, "require", StringComparison.Ordinal)
+                    && !string.Equals(name, "require_relative", StringComparison.Ordinal)
                     && !string.Equals(name, "define_method", StringComparison.Ordinal))
                 {
                     continue;

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -18,7 +18,7 @@ internal static class RubyReferenceExtractor
         "include", "extend", "prepend", "using", "refine", "autoload", "require", "require_relative", "load", "gem", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
-        "define_method", "describe", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
+        "define_method", "describe", "resource", "resources", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
     };
 

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -39,6 +39,10 @@ internal static class RubyReferenceExtractor
         @"(?<![\w$@]):?class_name\s*(?::|=>)\s*(?<quote>['""])(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\k<quote>",
         RegexOptions.Compiled);
 
+    private static readonly Regex ClassInheritanceRegex = new(
+        @"^\s*class\s+[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*\s*<\s*(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)",
+        RegexOptions.Compiled);
+
     public static void EmitAdditionalCallReferences(
         string preparedLine,
         string originalLine,
@@ -51,6 +55,15 @@ internal static class RubyReferenceExtractor
         HashSet<int> matchedCallIndices,
         Action<string, int> addCallLikeReference)
     {
+        EmitInheritanceReferences(
+            preparedLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForCall);
+
         foreach (Match match in CommandCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
@@ -182,6 +195,34 @@ internal static class RubyReferenceExtractor
     }
 
     private static bool IsIdentifierStart(char ch) => char.IsLetter(ch) || ch == '_';
+
+    private static void EmitInheritanceReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        var match = ClassInheritanceRegex.Match(preparedLine);
+        if (!match.Success)
+            return;
+
+        var name = match.Groups["name"].Value;
+        var tokenIndex = match.Groups["name"].Index;
+        var targetContainer = resolveContainerForCall(tokenIndex);
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            name,
+            tokenIndex,
+            "type_reference",
+            context,
+            lineNumber,
+            targetContainer);
+    }
 
     private static void EmitClassNameOptionReferences(
         string commandName,

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -43,6 +43,14 @@ internal static class RubyReferenceExtractor
         @"^\s*class\s+[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*\s*<\s*(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)",
         RegexOptions.Compiled);
 
+    private static readonly Regex RescueClauseRegex = new(
+        @"(?<![\w$@])rescue\s+(?<types>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*(?:\s*,\s*[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)*)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex QualifiedConstantRegex = new(
+        @"[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*",
+        RegexOptions.Compiled);
+
     public static void EmitAdditionalCallReferences(
         string preparedLine,
         string originalLine,
@@ -56,6 +64,15 @@ internal static class RubyReferenceExtractor
         Action<string, int> addCallLikeReference)
     {
         EmitInheritanceReferences(
+            preparedLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForCall);
+
+        EmitRescueTypeReferences(
             preparedLine,
             references,
             seen,
@@ -222,6 +239,37 @@ internal static class RubyReferenceExtractor
             context,
             lineNumber,
             targetContainer);
+    }
+
+    private static void EmitRescueTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        foreach (Match rescueMatch in RescueClauseRegex.Matches(preparedLine))
+        {
+            var typesGroup = rescueMatch.Groups["types"];
+            foreach (Match typeMatch in QualifiedConstantRegex.Matches(typesGroup.Value))
+            {
+                var name = typeMatch.Value;
+                var tokenIndex = typesGroup.Index + typeMatch.Index;
+                var targetContainer = resolveContainerForCall(tokenIndex);
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    tokenIndex,
+                    "type_reference",
+                    context,
+                    lineNumber,
+                    targetContainer);
+            }
+        }
     }
 
     private static void EmitClassNameOptionReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -15,7 +15,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
-        "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "load", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "load", "gem", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
         "define_method", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
@@ -24,7 +24,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)
     {
-        "require", "require_relative", "load", "raise", "define_method",
+        "require", "require_relative", "load", "gem", "raise", "define_method",
     };
 
     private static readonly HashSet<string> ClassNameOptionCommandNames = new(StringComparer.Ordinal)
@@ -184,6 +184,7 @@ internal static class RubyReferenceExtractor
                 if (!string.Equals(name, "require", StringComparison.Ordinal)
                     && !string.Equals(name, "require_relative", StringComparison.Ordinal)
                     && !string.Equals(name, "load", StringComparison.Ordinal)
+                    && !string.Equals(name, "gem", StringComparison.Ordinal)
                     && !string.Equals(name, "define_method", StringComparison.Ordinal))
                 {
                     continue;

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -16,7 +16,7 @@ internal static class RubyReferenceExtractor
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
         "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "load", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
-        "private_constant", "public_constant",
+        "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
         "define_method", "before_action", "after_action", "around_action", "helper_method",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -19,7 +19,7 @@ internal static class RubyReferenceExtractor
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
         "define_method", "describe", "resource", "resources", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
-        "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
+        "has_many", "has_one", "belongs_to", "scope", "delegate", "validates", "enum",
     };
 
     private static readonly HashSet<string> CommandTargetSingleTokenNames = new(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -114,6 +114,9 @@ internal static class RubyReferenceExtractor
                 break;
             }
 
+            if (IsHashOptionKey(tail, match, rawToken))
+                break;
+
             if (string.Equals(name, "raise", StringComparison.Ordinal))
             {
                 if (rawToken[0] == ':' || rawToken[0] == '\'' || rawToken[0] == '"')
@@ -159,6 +162,19 @@ internal static class RubyReferenceExtractor
     }
 
     private static bool IsIdentifierStart(char ch) => char.IsLetter(ch) || ch == '_';
+
+    private static bool IsHashOptionKey(string tail, Match match, string rawToken)
+    {
+        var tokenIndex = match.Groups["token"].Index;
+        var nextIndex = tokenIndex + rawToken.Length;
+        while (nextIndex < tail.Length && char.IsWhiteSpace(tail[nextIndex]))
+            nextIndex++;
+
+        if (rawToken[0] == ':')
+            return nextIndex + 1 < tail.Length && tail[nextIndex] == '=' && tail[nextIndex + 1] == '>';
+
+        return nextIndex < tail.Length && tail[nextIndex] == ':';
+    }
 
     private static string NormalizeCommandTargetToken(string token)
     {

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -15,7 +15,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
-        "include", "extend", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "include", "extend", "prepend", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "define_method", "before_action", "after_action", "around_action", "helper_method",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
     };

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -18,7 +18,7 @@ internal static class RubyReferenceExtractor
         "include", "extend", "prepend", "using", "refine", "autoload", "require", "require_relative", "load", "gem", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "private_constant", "public_constant", "module_function",
         "alias", "alias_method",
-        "define_method", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
+        "define_method", "describe", "before_action", "after_action", "around_action", "helper_method", "rescue_from",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",
     };
 

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -15,7 +15,7 @@ internal static class RubyReferenceExtractor
 
     private static readonly HashSet<string> CommandTargetReferenceNames = new(StringComparer.Ordinal)
     {
-        "include", "extend", "prepend", "autoload", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
+        "include", "extend", "prepend", "using", "autoload", "require", "require_relative", "raise", "attr", "attr_accessor", "attr_reader", "attr_writer",
         "alias", "alias_method",
         "define_method", "before_action", "after_action", "around_action", "helper_method",
         "has_many", "has_one", "belongs_to", "scope", "delegate", "validates",

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -176,6 +176,7 @@ public static partial class ReferenceExtractor
             "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method", "describe",
             "resource", "resources", "create_table", "attribute", "serialize",
             "private_constant", "public_constant", "module_function", "rescue_from", "gem", "composed_of",
+            "accepts_nested_attributes_for",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
         ["perl"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -174,7 +174,7 @@ public static partial class ReferenceExtractor
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method", "describe",
-            "resource", "resources", "create_table", "attribute",
+            "resource", "resources", "create_table", "attribute", "serialize",
             "private_constant", "public_constant", "module_function", "rescue_from", "gem",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -174,7 +174,7 @@ public static partial class ReferenceExtractor
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method", "describe",
-            "resource", "resources", "create_table",
+            "resource", "resources", "create_table", "attribute",
             "private_constant", "public_constant", "module_function", "rescue_from", "gem",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -173,7 +173,7 @@ public static partial class ReferenceExtractor
         // Ruby contextual keywords / Ruby の文脈キーワード
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "raise", "yield", "super", "include", "extend", "prepend", "alias", "alias_method",
+            "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method",
             "private_constant", "public_constant", "module_function", "rescue_from", "gem",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -173,7 +173,7 @@ public static partial class ReferenceExtractor
         // Ruby contextual keywords / Ruby の文脈キーワード
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method",
+            "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method", "describe",
             "private_constant", "public_constant", "module_function", "rescue_from", "gem",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -174,7 +174,7 @@ public static partial class ReferenceExtractor
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "raise", "yield", "super", "include", "extend", "prepend", "alias", "alias_method",
-            "private_constant", "public_constant", "module_function",
+            "private_constant", "public_constant", "module_function", "rescue_from",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
         ["perl"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -174,7 +174,7 @@ public static partial class ReferenceExtractor
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "raise", "yield", "super", "include", "extend", "prepend", "alias", "alias_method",
-            "private_constant", "public_constant",
+            "private_constant", "public_constant", "module_function",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
         ["perl"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -175,7 +175,7 @@ public static partial class ReferenceExtractor
         {
             "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method", "describe",
             "resource", "resources", "create_table", "attribute", "serialize",
-            "private_constant", "public_constant", "module_function", "rescue_from", "gem",
+            "private_constant", "public_constant", "module_function", "rescue_from", "gem", "composed_of",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
         ["perl"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -174,7 +174,7 @@ public static partial class ReferenceExtractor
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method", "describe",
-            "resource", "resources",
+            "resource", "resources", "create_table",
             "private_constant", "public_constant", "module_function", "rescue_from", "gem",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -173,7 +173,7 @@ public static partial class ReferenceExtractor
         // Ruby contextual keywords / Ruby の文脈キーワード
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "raise", "yield", "super", "include", "extend",
+            "raise", "yield", "super", "include", "extend", "prepend",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
         ["perl"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -173,7 +173,7 @@ public static partial class ReferenceExtractor
         // Ruby contextual keywords / Ruby の文脈キーワード
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "raise", "yield", "super", "include", "extend", "prepend",
+            "raise", "yield", "super", "include", "extend", "prepend", "alias", "alias_method",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
         ["perl"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -174,6 +174,7 @@ public static partial class ReferenceExtractor
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "raise", "yield", "super", "include", "extend", "prepend", "refine", "alias", "alias_method", "describe",
+            "resource", "resources",
             "private_constant", "public_constant", "module_function", "rescue_from", "gem",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -174,7 +174,7 @@ public static partial class ReferenceExtractor
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "raise", "yield", "super", "include", "extend", "prepend", "alias", "alias_method",
-            "private_constant", "public_constant", "module_function", "rescue_from",
+            "private_constant", "public_constant", "module_function", "rescue_from", "gem",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
         ["perl"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -174,6 +174,7 @@ public static partial class ReferenceExtractor
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "raise", "yield", "super", "include", "extend", "prepend", "alias", "alias_method",
+            "private_constant", "public_constant",
             "unless", "case", "begin", "until", "module", "rescue", "ensure",
         },
         ["perl"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
@@ -302,7 +302,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
     return trimmed == terminator;
 }
 
-    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:class|module|def|if|unless|case|begin|do|while|until|for)\b", RegexOptions.Compiled);
+    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|[A-Z][A-Za-z0-9_]*\s*=\s*Class\.new\b.*\bdo\b)", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
 private enum RubyScanMode
 {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
@@ -302,7 +302,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
     return trimmed == terminator;
 }
 
-    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|(?:namespace|factory)\s+:\w+\b.*\bdo\b|let!?\s*\(\s*:\w+\s*\)\s*do\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
+    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|(?:namespace|factory)\s+:\w+\b.*\bdo\b|(?:subject|let!?)\s*\(\s*:\w+\s*\)\s*do\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
 private enum RubyScanMode
 {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
@@ -302,7 +302,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
     return trimmed == terminator;
 }
 
-    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|(?:namespace|factory)\s+:\w+\b.*\bdo\b|(?:subject|let!?)\s*\(\s*:\w+\s*\)\s*do\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
+    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|(?:namespace|factory)\s+:\w+\b.*\bdo\b|shared_examples(?:_for)?\s+['""].*['""]\s*do\b|(?:subject|let!?)\s*\(\s*:\w+\s*\)\s*do\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
 private enum RubyScanMode
 {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
@@ -302,7 +302,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
     return trimmed == terminator;
 }
 
-    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
+    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|namespace\s+:\w+\b.*\bdo\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
 private enum RubyScanMode
 {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
@@ -302,7 +302,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
     return trimmed == terminator;
 }
 
-    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|namespace\s+:\w+\b.*\bdo\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
+    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|(?:namespace|factory)\s+:\w+\b.*\bdo\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
 private enum RubyScanMode
 {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
@@ -302,7 +302,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
     return trimmed == terminator;
 }
 
-    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|(?:namespace|factory)\s+:\w+\b.*\bdo\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
+    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|(?:namespace|factory)\s+:\w+\b.*\bdo\b|let!?\s*\(\s*:\w+\s*\)\s*do\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
 private enum RubyScanMode
 {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
@@ -302,7 +302,7 @@ private static bool IsRubyHeredocTerminatorLine(string line, string terminator, 
     return trimmed == terminator;
 }
 
-    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|[A-Z][A-Za-z0-9_]*\s*=\s*Class\.new\b.*\bdo\b)", RegexOptions.Compiled);
+    private static readonly Regex RubyBlockStartRegex = new(@"^\s*(?:(?:class|module|def|if|unless|case|begin|do|while|until|for)\b|[A-Z][A-Za-z0-9_]*\s*=\s*(?:Class|Struct)\.new\b.*\bdo\b)", RegexOptions.Compiled);
     private static readonly Regex RubyBlockTokenRegex = new(@"\b(?:class|module|def|if|unless|case|begin|do|while|until|for|end)\b", RegexOptions.Compiled);
 private enum RubyScanMode
 {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1329,6 +1329,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*enum\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*attribute\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
+            new("property", new Regex(@"^\s*store_accessor\s+:\w+\s*,\s*:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*factory\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("property", new Regex(@"^\s*let!?\s*\(\s*:(?<name>\w+)\s*\)\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1327,6 +1327,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*alias\b\s+:?(?<name>\w+[?!=]?)\s+:?\w+[?!=]?", RegexOptions.Compiled), BodyStyle.None),
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*class\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*module\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1327,7 +1327,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*alias\b\s+:?(?<name>\w+[?!=]?)\s+:?\w+[?!=]?", RegexOptions.Compiled), BodyStyle.None),
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(@"^\s*def\s+(?:self\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("function", new Regex(@"^\s*def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*class\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*module\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("import",   new Regex(@"^\s*require(?:_relative)?\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1327,6 +1327,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*alias\b\s+:?(?<name>\w+[?!=]?)\s+:?\w+[?!=]?", RegexOptions.Compiled), BodyStyle.None),
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
+            new("namespace", new Regex(@"^\s*namespace\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*task\s+(?::(?<name>\w+)|(?<name>\w+)\s*:)", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Class\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Struct\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1329,6 +1329,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*task\s+(?::(?<name>\w+)|(?<name>\w+)\s*:)", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Class\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Struct\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("property", new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:private|protected|public)\s+)?def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\[\]=?|\*\*|<<|>>|<=>|===|==|!=|!~|=~|<=|>=|[+\-*/%&|^~<>]=?|[+\-]@|!)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*(?:(?:private|protected|public)\s+)?def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1328,6 +1328,7 @@ public static partial class SymbolExtractor
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\[\]=?|\*\*|<<|>>|<=>|===|==|!=|!~|=~|<=|>=|[+\-*/%&|^~<>]=?|[+\-]@|!)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*class\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*module\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1328,6 +1328,7 @@ public static partial class SymbolExtractor
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("function", new Regex(@"^\s*factory\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*task\s+(?::(?<name>\w+)|(?<name>\w+)\s*:)", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Class\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Struct\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1328,6 +1328,7 @@ public static partial class SymbolExtractor
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*enum\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
+            new("property", new Regex(@"^\s*attribute\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*factory\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("property", new Regex(@"^\s*let!?\s*\(\s*:(?<name>\w+)\s*\)\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1328,6 +1328,7 @@ public static partial class SymbolExtractor
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*task\s+(?::(?<name>\w+)|(?<name>\w+)\s*:)", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Class\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("property", new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:private|protected|public)\s+)?def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\[\]=?|\*\*|<<|>>|<=>|===|==|!=|!~|=~|<=|>=|[+\-*/%&|^~<>]=?|[+\-]@|!)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*(?:(?:private|protected|public)\s+)?def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1332,6 +1332,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*store_accessor\s+:\w+\s*,\s*:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*factory\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("property", new Regex(@"^\s*subject\s*\(\s*:(?<name>\w+)\s*\)\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("property", new Regex(@"^\s*let!?\s*\(\s*:(?<name>\w+)\s*\)\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*task\s+(?::(?<name>\w+)|(?<name>\w+)\s*:)", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Class\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1328,8 +1328,8 @@ public static partial class SymbolExtractor
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(@"^\s*def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\[\]=?|\*\*|<<|>>|<=>|===|==|!=|!~|=~|<=|>=|[+\-*/%&|^~<>]=?|[+\-]@|!)", RegexOptions.Compiled), BodyStyle.RubyEnd),
-            new("function", new Regex(@"^\s*def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("function", new Regex(@"^\s*(?:(?:private|protected|public)\s+)?def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\[\]=?|\*\*|<<|>>|<=>|===|==|!=|!~|=~|<=|>=|[+\-*/%&|^~<>]=?|[+\-]@|!)", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("function", new Regex(@"^\s*(?:(?:private|protected|public)\s+)?def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*class\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*module\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("import",   new Regex(@"^\s*require(?:_relative)?\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1329,6 +1329,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*factory\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("property", new Regex(@"^\s*let!?\s*\(\s*:(?<name>\w+)\s*\)\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*task\s+(?::(?<name>\w+)|(?<name>\w+)\s*:)", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Class\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("class",    new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=\s*Struct\.new\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1327,6 +1327,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*alias\b\s+:?(?<name>\w+[?!=]?)\s+:?\w+[?!=]?", RegexOptions.Compiled), BodyStyle.None),
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*task\s+(?::(?<name>\w+)|(?<name>\w+)\s*:)", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*(?<name>[A-Z][A-Za-z0-9_]*)\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:private|protected|public)\s+)?def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\[\]=?|\*\*|<<|>>|<=>|===|==|!=|!~|=~|<=|>=|[+\-*/%&|^~<>]=?|[+\-]@|!)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*(?:(?:private|protected|public)\s+)?def\s+(?:(?:self|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1327,6 +1327,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*alias\b\s+:?(?<name>\w+[?!=]?)\s+:?\w+[?!=]?", RegexOptions.Compiled), BodyStyle.None),
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
+            new("property", new Regex(@"^\s*enum\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*factory\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("property", new Regex(@"^\s*let!?\s*\(\s*:(?<name>\w+)\s*\)\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1332,6 +1332,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*store_accessor\s+:\w+\s*,\s*:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*factory\s+:(?<name>\w+)\b.*\bdo\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("function", new Regex(@"^\s*shared_examples(?:_for)?\s+(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("property", new Regex(@"^\s*subject\s*\(\s*:(?<name>\w+)\s*\)\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("property", new Regex(@"^\s*let!?\s*\(\s*:(?<name>\w+)\s*\)\s*do\b", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("function", new Regex(@"^\s*task\s+(?::(?<name>\w+)|(?<name>\w+)\s*:)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -7717,12 +7717,29 @@ public static partial class SymbolExtractor
             "fsharp" => FSharpSymbolNameNormalizer.Normalize(name),
             "java" => JavaSymbolNameNormalizer.Normalize(name),
             "kotlin" => KotlinSymbolNameNormalizer.Normalize(name, matchLine),
+            "ruby" => NormalizeRubySymbolName(name, matchLine),
             "rust" => RustSymbolNameNormalizer.Normalize(name),
             "smalltalk" => NormalizeSmalltalkSelectorName(name),
             "swift" => SwiftSymbolNameNormalizer.Normalize(name),
             "sql" => SqlSymbolNameNormalizer.Normalize(name),
             _ => name,
         };
+    }
+
+    private static string NormalizeRubySymbolName(string name, string matchLine)
+    {
+        if (!matchLine.TrimStart().StartsWith("require", StringComparison.Ordinal))
+            return name;
+
+        var trimmed = name.Trim();
+        if (trimmed.Length >= 2
+            && ((trimmed[0] == '\'' && trimmed[^1] == '\'')
+                || (trimmed[0] == '"' && trimmed[^1] == '"')))
+        {
+            return trimmed[1..^1];
+        }
+
+        return trimmed;
     }
 
     private static string NormalizeSmalltalkSelectorName(string name)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1328,8 +1328,8 @@ public static partial class SymbolExtractor
             // scope/has_many/belongs_to (Rails DSL) — extracted as function for navigation
             new("function", new Regex(@"^\s*(?:scope|has_many|has_one|belongs_to)\s+:(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*def\s+(?:self\.)?(?<name>\w+[?!=]?)", RegexOptions.Compiled), BodyStyle.RubyEnd),
-            new("class",    new Regex(@"^\s*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.RubyEnd),
-            new("class",    new Regex(@"^\s*module\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("class",    new Regex(@"^\s*class\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),
+            new("class",    new Regex(@"^\s*module\s+(?<name>[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)", RegexOptions.Compiled), BodyStyle.RubyEnd),
             new("import",   new Regex(@"^\s*require(?:_relative)?\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["perl"] =

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2639,6 +2639,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRescueClause_IndexesExceptionTypes()
+    {
+        const string content = """
+            def load
+              fetch
+            rescue Network::TimeoutError, ParserError => error
+              nil
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Network::TimeoutError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "load");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "ParserError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "load");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "rescue");
+    }
+
+    [Fact]
     public void Extract_RubyRaiseSyntax_IsIgnored()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2552,6 +2552,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyGem_IndexesDependencyName()
+    {
+        const string content = """
+            gem "rails", "~> 8.0"
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "gem");
+        Assert.Contains(references, reference => reference.SymbolName == "rails");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "~> 8.0");
+    }
+
+    [Fact]
     public void Extract_RubyAutoload_IndexesConstantTarget()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2914,6 +2914,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRailsAttribute_IndexesAttributeName()
+    {
+        const string content = """
+            class User < ApplicationRecord
+              attribute :timezone, :string, default: "UTC"
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "attribute");
+        Assert.Contains(references, reference => reference.SymbolName == "timezone" && reference.ContainerName == "User");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "string");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "default");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "UTC");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2620,6 +2620,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyClassInheritance_IndexesSuperclass()
+    {
+        const string content = """
+            class ApplicationJob
+            end
+
+            class CleanupJob < ApplicationJob
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "ApplicationJob"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RubyRaiseSyntax_IsIgnored()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2600,6 +2600,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyAssociationClassNameOption_IndexesClassNameTarget()
+    {
+        const string content = """
+            class Post
+              belongs_to :author, class_name: "User"
+              has_many :line_items, :class_name => 'Orders::LineItem'
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "author" && reference.ContainerName == "Post");
+        Assert.Contains(references, reference => reference.SymbolName == "line_items" && reference.ContainerName == "Post");
+        Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ContainerName == "Post");
+        Assert.Contains(references, reference => reference.SymbolName == "Orders::LineItem" && reference.ContainerName == "Post");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "class_name");
+    }
+
+    [Fact]
     public void Extract_RubyRaiseSyntax_IsIgnored()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2694,6 +2694,7 @@ public class ReferenceExtractorTests
               include Shared
               extend ModName
               prepend AuditTrail
+              using CurrencyFormatting
               before_action :authenticate
               attr_accessor :name
 
@@ -2709,11 +2710,13 @@ public class ReferenceExtractorTests
 
         Assert.DoesNotContain(references, reference => reference.SymbolName == "include");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "prepend");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "using");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "super");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "yield");
         Assert.Contains(references, reference => reference.SymbolName == "Shared" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "ModName" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "AuditTrail" && reference.ContainerName == "Worker");
+        Assert.Contains(references, reference => reference.SymbolName == "CurrencyFormatting" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "authenticate" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "name" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "item" && reference.ContainerName == "run");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2933,6 +2933,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRailsSerialize_IndexesSerializedAttributeName()
+    {
+        const string content = """
+            class User < ApplicationRecord
+              serialize :settings, coder: JSON
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "serialize");
+        Assert.Contains(references, reference => reference.SymbolName == "settings" && reference.ContainerName == "User");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "coder");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "JSON");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2536,6 +2536,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyAutoload_IndexesConstantTarget()
+    {
+        const string content = """
+            module Registry
+              autoload :User, "models/user"
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "autoload" && reference.ContainerName == "Registry");
+        Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ContainerName == "Registry");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "models/user");
+    }
+
+    [Fact]
     public void Extract_RubyRaiseSyntax_IsIgnored()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2520,6 +2520,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRequireRelative_IndexesTargetPath()
+    {
+        const string content = """
+            def load_user
+              require_relative "models/user"
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "require_relative" && reference.ContainerName == "load_user");
+        Assert.Contains(references, reference => reference.SymbolName == "models/user" && reference.ContainerName == "load_user");
+    }
+
+    [Fact]
     public void Extract_RubyRaiseSyntax_IsIgnored()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2850,6 +2850,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRailsRoutes_IndexesResourceNames()
+    {
+        const string content = """
+            Rails.application.routes.draw do
+              resources :articles, only: :show
+              resource :profile
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "resources");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "resource");
+        Assert.Contains(references, reference => reference.SymbolName == "articles");
+        Assert.Contains(references, reference => reference.SymbolName == "profile");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "only");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "show");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2565,6 +2565,7 @@ public class ReferenceExtractorTests
             class Worker
               include Shared
               extend ModName
+              prepend AuditTrail
               before_action :authenticate
               attr_accessor :name
 
@@ -2579,10 +2580,12 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
 
         Assert.DoesNotContain(references, reference => reference.SymbolName == "include");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "prepend");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "super");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "yield");
         Assert.Contains(references, reference => reference.SymbolName == "Shared" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "ModName" && reference.ContainerName == "Worker");
+        Assert.Contains(references, reference => reference.SymbolName == "AuditTrail" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "authenticate" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "name" && reference.ContainerName == "Worker");
         Assert.Contains(references, reference => reference.SymbolName == "item" && reference.ContainerName == "run");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2720,6 +2720,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRescueFrom_IndexesExceptionClassTargets()
+    {
+        const string content = """
+            class ApplicationController
+              rescue_from Payment::Declined, AuthorizationError, with: :render_error
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "rescue_from");
+        Assert.Contains(references, reference => reference.SymbolName == "Payment::Declined" && reference.ContainerName == "ApplicationController");
+        Assert.Contains(references, reference => reference.SymbolName == "AuthorizationError" && reference.ContainerName == "ApplicationController");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "with");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "render_error");
+    }
+
+    [Fact]
     public void Extract_RubyRaiseSyntax_IsIgnored()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2813,6 +2813,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRefine_IndexesRefinedClass()
+    {
+        const string content = """
+            module StringFormatting
+              refine String do
+                def titleize
+                end
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "refine");
+        Assert.Contains(references, reference => reference.SymbolName == "String" && reference.ContainerName == "StringFormatting");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2871,6 +2871,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRailsEnum_IndexesAttributeName()
+    {
+        const string content = """
+            class Conversation
+              enum :status, { active: 0, archived: 1 }, prefix: true
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "enum");
+        Assert.Contains(references, reference => reference.SymbolName == "status" && reference.ContainerName == "Conversation");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "active");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "archived");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "prefix");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2592,6 +2592,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyConstantVisibilityDeclarations_IndexConstants()
+    {
+        const string content = """
+            class Config
+              SecretKey = "x"
+              Token = "t"
+              private_constant :SecretKey
+              public_constant :Token
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "private_constant");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "public_constant");
+        Assert.Contains(references, reference => reference.SymbolName == "SecretKey" && reference.ContainerName == "Config");
+        Assert.Contains(references, reference => reference.SymbolName == "Token" && reference.ContainerName == "Config");
+    }
+
+    [Fact]
     public void Extract_RubyCommandTargets_StopBeforeKeywordOptions()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2536,6 +2536,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyLoad_IndexesLoadedPath()
+    {
+        const string content = """
+            def boot
+              load "config/routes.rb"
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "load" && reference.ContainerName == "boot");
+        Assert.Contains(references, reference => reference.SymbolName == "config/routes.rb" && reference.ContainerName == "boot");
+    }
+
+    [Fact]
     public void Extract_RubyAutoload_IndexesConstantTarget()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2969,6 +2969,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRailsNestedAttributes_IndexesAssociationNames()
+    {
+        const string content = """
+            class Post < ApplicationRecord
+              accepts_nested_attributes_for :comments, :tags, allow_destroy: true
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "accepts_nested_attributes_for");
+        Assert.Contains(references, reference => reference.SymbolName == "comments" && reference.ContainerName == "Post");
+        Assert.Contains(references, reference => reference.SymbolName == "tags" && reference.ContainerName == "Post");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "allow_destroy");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "true");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2553,6 +2553,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyAliasDeclarations_IndexAliasEndpoints()
+    {
+        const string content = """
+            class Person
+              def name
+              end
+
+              alias_method :full_name, :name
+              alias display_name name
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "alias");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "alias_method");
+        Assert.Contains(references, reference => reference.SymbolName == "full_name" && reference.ContainerName == "Person");
+        Assert.Contains(references, reference => reference.SymbolName == "display_name" && reference.ContainerName == "Person");
+        Assert.Equal(2, references.Count(reference => reference.SymbolName == "name" && reference.ContainerName == "Person"));
+    }
+
+    [Fact]
     public void Extract_RubyRaiseSyntax_IsIgnored()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2832,6 +2832,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRSpecDescribe_IndexesSubjectConstant()
+    {
+        const string content = """
+            RSpec.describe User do
+              describe Account do
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "describe");
+        Assert.Contains(references, reference => reference.SymbolName == "User");
+        Assert.Contains(references, reference => reference.SymbolName == "Account");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2576,6 +2576,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyCommandTargets_StopBeforeKeywordOptions()
+    {
+        const string content = """
+            class Article
+              has_many :comments, dependent: :destroy
+              validates :title, presence: true
+              before_action :load_article, only: :show
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "comments" && reference.ContainerName == "Article");
+        Assert.Contains(references, reference => reference.SymbolName == "title" && reference.ContainerName == "Article");
+        Assert.Contains(references, reference => reference.SymbolName == "load_article" && reference.ContainerName == "Article");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "dependent");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "destroy");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "presence");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "only");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "show");
+    }
+
+    [Fact]
     public void Extract_RubyRaiseSyntax_IsIgnored()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2951,6 +2951,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRailsComposedOf_IndexesAggregateAndClassName()
+    {
+        const string content = """
+            class Customer < ApplicationRecord
+              composed_of :address, class_name: "Address"
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "composed_of");
+        Assert.Contains(references, reference => reference.SymbolName == "address" && reference.ContainerName == "Customer");
+        Assert.Contains(references, reference => reference.SymbolName == "Address" && reference.ContainerName == "Customer");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "class_name");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2613,6 +2613,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyModuleFunction_IndexesExportedMethods()
+    {
+        const string content = """
+            module Formatting
+              def normalize
+              end
+
+              module_function :normalize
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "module_function");
+        Assert.Contains(references, reference => reference.SymbolName == "normalize" && reference.ContainerName == "Formatting");
+    }
+
+    [Fact]
     public void Extract_RubyCommandTargets_StopBeforeKeywordOptions()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2890,6 +2890,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RubyRailsCreateTable_IndexesTableName()
+    {
+        const string content = """
+            class CreateUsers < ActiveRecord::Migration[8.0]
+              def change
+                create_table :users, id: :uuid do |t|
+                end
+                create_table "audit_logs" do |t|
+                end
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+        var references = ReferenceExtractor.Extract(1, "ruby", content, symbols);
+
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "create_table");
+        Assert.Contains(references, reference => reference.SymbolName == "users" && reference.ContainerName == "change");
+        Assert.Contains(references, reference => reference.SymbolName == "audit_logs" && reference.ContainerName == "change");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "id");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "uuid");
+    }
+
+    [Fact]
     public void Extract_RubyCommandSyntax_DetectsNoParenCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12366,6 +12366,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsRSpecLetDefinitions()
+    {
+        var content = """
+            RSpec.describe User do
+              let(:user) do
+                build(:user)
+              end
+
+              let!(:account) do
+                create(:account)
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        var user = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "user"));
+        var account = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "account"));
+        Assert.NotNull(user.BodyStartLine);
+        Assert.NotNull(account.BodyEndLine);
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12101,13 +12101,14 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_Ruby_DetectsAttrAndRailsDSL()
     {
-        var content = "class User < ActiveRecord::Base\n  attr_accessor :name\n  attr_reader :email\n  has_many :posts\n  belongs_to :company\n  scope :active\n  enum :status\n\n  def initialize(name)\n    @name = name\n  end\nend";
+        var content = "class User < ActiveRecord::Base\n  attr_accessor :name\n  attr_reader :email\n  has_many :posts\n  belongs_to :company\n  scope :active\n  enum :status\n  attribute :timezone, :string\n\n  def initialize(name)\n    @name = name\n  end\nend";
         var symbols = SymbolExtractor.Extract(1, "ruby", content);
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "User");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "email");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "status");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "timezone");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "posts");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "company");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "active");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12375,6 +12375,10 @@ public class SymbolExtractorTests
     {
         var content = """
             RSpec.describe User do
+              subject(:profile) do
+                build(:profile)
+              end
+
               let(:user) do
                 build(:user)
               end
@@ -12387,8 +12391,10 @@ public class SymbolExtractorTests
 
         var symbols = SymbolExtractor.Extract(1, "ruby", content);
 
+        var profile = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "profile"));
         var user = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "user"));
         var account = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "account"));
+        Assert.NotNull(profile.BodyStartLine);
         Assert.NotNull(user.BodyStartLine);
         Assert.NotNull(account.BodyEndLine);
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12269,6 +12269,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsRakeTaskDefinitions()
+    {
+        var content = """
+            task :build do
+            end
+
+            task test: :environment do
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "test");
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12191,6 +12191,22 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_NormalizesRequireImportNames()
+    {
+        var content = """
+            require "active_support/core_ext/string"
+            require_relative 'models/user'
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "active_support/core_ext/string");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "models/user");
+        Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "\"active_support/core_ext/string\"");
+        Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "'models/user'");
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12171,6 +12171,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsReceiverQualifiedSingletonMethods()
+    {
+        var content = """
+            class Admin::User
+              def self.find
+              end
+
+              def Admin::User.export!
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "find");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "export!");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "Admin");
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12348,6 +12348,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsFactoryBotFactoryDefinitions()
+    {
+        var content = """
+            FactoryBot.define do
+              factory :user do
+                name { "Ada" }
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        var factory = Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "user"));
+        Assert.NotNull(factory.BodyStartLine);
+        Assert.NotNull(factory.BodyEndLine);
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12207,6 +12207,22 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsConstantAssignments()
+    {
+        var content = """
+            class Client
+              MAX_RETRIES = 3
+              DefaultTimeout = 30
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "MAX_RETRIES");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DefaultTimeout");
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12374,6 +12374,11 @@ public class SymbolExtractorTests
     public void Extract_Ruby_DetectsRSpecLetDefinitions()
     {
         var content = """
+            shared_examples "auditable" do
+              it "tracks changes" do
+              end
+            end
+
             RSpec.describe User do
               subject(:profile) do
                 build(:profile)
@@ -12391,9 +12396,11 @@ public class SymbolExtractorTests
 
         var symbols = SymbolExtractor.Extract(1, "ruby", content);
 
+        var sharedExamples = Assert.Single(symbols.Where(s => s.Kind == "function" && s.Name == "auditable"));
         var profile = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "profile"));
         var user = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "user"));
         var account = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "account"));
+        Assert.NotNull(sharedExamples.BodyStartLine);
         Assert.NotNull(profile.BodyStartLine);
         Assert.NotNull(user.BodyStartLine);
         Assert.NotNull(account.BodyEndLine);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12123,6 +12123,7 @@ public class SymbolExtractorTests
               attr_accessor :name, :age, :email
               attr_reader :id, :created_at
               attr_writer :internal_flag, :debug_count
+              store_accessor :settings, :theme, :locale
               attr_accessor :nickname
 
               def greet(greeting = "Hello")
@@ -12146,6 +12147,8 @@ public class SymbolExtractorTests
         Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "created_at"));
         Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "internal_flag"));
         Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "debug_count"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "theme"));
+        Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "locale"));
         Assert.Equal(1, symbols.Count(s => s.Kind == "property" && s.Name == "nickname"));
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "greet");
         Assert.Equal(1, symbols.Count(s => s.Kind == "function" && s.Name == "full_name"));

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12328,6 +12328,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsRakeNamespaces()
+    {
+        var content = """
+            namespace :db do
+              task :migrate do
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "db");
+        Assert.Contains(symbols, s =>
+            s.Kind == "function"
+            && s.Name == "migrate"
+            && s.ContainerKind == "namespace"
+            && s.ContainerName == "db");
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12244,6 +12244,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsStructNewBlockAssignments()
+    {
+        var content = """
+            Result = Struct.new(:ok, :value) do
+              def success?
+                ok
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Result");
+        Assert.Contains(symbols, s =>
+            s.Kind == "function"
+            && s.Name == "success?"
+            && s.ContainerKind == "class"
+            && s.ContainerName == "Result");
+    }
+
+    [Fact]
     public void Extract_Ruby_DetectsOperatorMethodDefinitions()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12223,6 +12223,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsClassNewBlockAssignments()
+    {
+        var content = """
+            User = Class.new(ApplicationRecord) do
+              def active?
+                true
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "User");
+        Assert.Contains(symbols, s =>
+            s.Kind == "function"
+            && s.Name == "active?"
+            && s.ContainerKind == "class"
+            && s.ContainerName == "User");
+    }
+
+    [Fact]
     public void Extract_Ruby_DetectsOperatorMethodDefinitions()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12246,6 +12246,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsVisibilityModifiedMethodDefinitions()
+    {
+        var content = """
+            class Client
+              private def secret
+              end
+
+              protected def token?
+              end
+
+              public def self.build!
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "secret");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "token?");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build!");
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12101,12 +12101,13 @@ public class SymbolExtractorTests
     [Fact]
     public void Extract_Ruby_DetectsAttrAndRailsDSL()
     {
-        var content = "class User < ActiveRecord::Base\n  attr_accessor :name\n  attr_reader :email\n  has_many :posts\n  belongs_to :company\n  scope :active\n\n  def initialize(name)\n    @name = name\n  end\nend";
+        var content = "class User < ActiveRecord::Base\n  attr_accessor :name\n  attr_reader :email\n  has_many :posts\n  belongs_to :company\n  scope :active\n  enum :status\n\n  def initialize(name)\n    @name = name\n  end\nend";
         var symbols = SymbolExtractor.Extract(1, "ruby", content);
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "User");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "email");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "status");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "posts");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "company");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "active");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12223,6 +12223,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsOperatorMethodDefinitions()
+    {
+        var content = """
+            class Collection
+              def [](index)
+              end
+
+              def self.[]=(key, value)
+              end
+
+              def <=>(other)
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "[]");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "[]=");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "<=>");
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12154,6 +12154,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Ruby_DetectsQualifiedClassAndModuleNames()
+    {
+        var content = """
+            module Admin::Billing
+              class Admin::Billing::Invoice
+              end
+            end
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "ruby", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Admin::Billing");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Admin::Billing::Invoice");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "Admin");
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsExpandedFeatures()
     {
         var content = "macro_rules! my_macro {\n    () => {};\n}\n\npub mod utils {\n}\n\nconst MAX_SIZE: usize = 1024;\nstatic COUNTER: AtomicU32 = AtomicU32::new(0);\npub const fn default_value() -> i32 { 42 }\npub unsafe fn raw_ptr() { }\npub extern fn no_abi() { }\npub unsafe extern \"C-unwind\" fn ffi_entry() { }\ndefault async fn trait_default() { }\ntype Result<T> = std::result::Result<T, Error>;\ntrait Iter {\n    type Item;\n    fn next(&mut self) -> Option<Self::Item>;\n}\ntype Callback = fn(i32) -> i32;\npub union MyUnion { f: f32 }";


### PR DESCRIPTION
## Summary

This PR improves Ruby search coverage across reference and symbol extraction. It adds searchable references for common Rails and Ruby DSL forms such as Gemfile `gem`, `refine`, RSpec `describe`, route resources, migrations, model attributes, serialization, composed objects, and nested attributes.

It also adds searchable symbols for Ruby/Rails/RSpec constructs such as dynamic `Class.new` / `Struct.new` blocks, Rake namespaces, FactoryBot factories, RSpec `let` / `subject` / shared examples, Rails enum / attribute / store accessors, and related DSL declarations.

Each behavior change includes focused tests and a bilingual changelog fragment under `changelog.d/unreleased/`.

## Validation

- `dotnet test` passed: 3908 passed / 3 skipped
- `dotnet run --project tools/CodeIndex.Changelog -- check` passed: 178 fragments validated
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` reported a fresh index and workspace match
- `dotnet build` was run after each commit during the loop

## Review

Codex adversarial review was performed commit-by-commit. No blocking/actionable issues were found.