### PR TITLE
Improve F# search indexing coverage

### DIFF
--- a/changelog.d/unreleased/+fsharp-abstract-shorthand-members.fixed.md
+++ b/changelog.d/unreleased/+fsharp-abstract-shorthand-members.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# abstract member shorthand is now searchable** — declarations such as `abstract Reset : unit -> unit` are indexed as function symbols even when the `member` keyword is omitted.
+
+## 日本語
+
+- **F# の abstract member 省略形が検索できるようになりました** — `member` を省いた `abstract Reset : unit -> unit` のような宣言を function symbol として索引します。

--- a/changelog.d/unreleased/+fsharp-and-function-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-and-function-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# mutually recursive functions are now searchable** — `and isOdd n = ...` is indexed as a function symbol alongside the leading `let rec` definition.
+
+## 日本語
+
+- **F# の相互再帰関数が検索できるようになりました** — `and isOdd n = ...` を先頭の `let rec` 定義と同じく function symbol として索引します。

--- a/changelog.d/unreleased/+fsharp-assert-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-assert-application-calls.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# assertion predicate calls are now indexed** — `assert validate user` records `validate` as a call while suppressing the `assert` keyword itself.
+
+## 日本語
+
+- **F# assertion の述語呼び出しを索引するようになりました** — `assert validate user` で `validate` を call として記録し、`assert` キーワード自体は抑止します。

--- a/changelog.d/unreleased/+fsharp-attributed-union-cases.fixed.md
+++ b/changelog.d/unreleased/+fsharp-attributed-union-cases.fixed.md
@@ -1,1 +1,14 @@
-Improved F# symbol extraction so union cases with attributes are indexed by the case name.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.FSharp.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# attributed union cases are now searchable** — union cases such as `| [<Obsolete>] Amber` are indexed by the case name.
+
+## 日本語
+
+- **F# の属性付き union case を検索できるようになりました** — `| [<Obsolete>] Amber` のようなケースを case 名で索引します。

--- a/changelog.d/unreleased/+fsharp-attributed-union-cases.fixed.md
+++ b/changelog.d/unreleased/+fsharp-attributed-union-cases.fixed.md
@@ -1,0 +1,1 @@
+Improved F# symbol extraction so union cases with attributes are indexed by the case name.

--- a/changelog.d/unreleased/+fsharp-backtick-member-names.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backtick-member-names.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# backticked member names are now searchable** — members such as `member this.``display name`` = ...` are normalized and indexed instead of being skipped by the member pattern.
+
+## 日本語
+
+- **F# の backtick 付き member 名が検索できるようになりました** — `member this.``display name`` = ...` のようなmemberを正規化して索引します。

--- a/changelog.d/unreleased/+fsharp-backtick-module-names.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backtick-module-names.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# backticked module names are now searchable** — module declarations whose names are escaped with F# backticks are normalized and indexed as namespace symbols.
+
+## 日本語
+
+- **F# の backtick 付き module 名が検索できるようになりました** — F# backtick でエスケープされた module 宣言名を正規化し、namespace symbol として索引します。

--- a/changelog.d/unreleased/+fsharp-backtick-type-names.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backtick-type-names.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# backticked type names are now searchable across more type forms** — escaped record, union, class, interface, struct, and delegate names are normalized before indexing.
+
+## 日本語
+
+- **F# の backtick 付き type 名がより多くの型形式で検索できるようになりました** — エスケープされたrecord / union / class / interface / struct / delegate名を正規化して索引します。

--- a/changelog.d/unreleased/+fsharp-backticked-module-alias-targets.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backticked-module-alias-targets.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **F# module abbreviations can now index backticked targets** — `module Helpers = ``Legacy Helpers``` records the normalized target module name.
+- **F# module abbreviations can now index backticked targets** — module abbreviations targeting backticked modules record the normalized target module name.
 
 ## 日本語
 
-- **F# の module abbreviation で backtick 付き target を索引するようになりました** — `module Helpers = ``Legacy Helpers``` で正規化した target module 名を記録します。
+- **F# の module abbreviation で backtick 付き target を索引するようになりました** — backtick 付き module を対象にする module abbreviation で、正規化した target module 名を記録します。

--- a/changelog.d/unreleased/+fsharp-backticked-module-alias-targets.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backticked-module-alias-targets.fixed.md
@@ -1,0 +1,1 @@
+Improved F# symbol extraction so module abbreviations targeting backticked modules are indexed by the normalized target name.

--- a/changelog.d/unreleased/+fsharp-backticked-module-alias-targets.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backticked-module-alias-targets.fixed.md
@@ -1,1 +1,14 @@
-Improved F# symbol extraction so module abbreviations targeting backticked modules are indexed by the normalized target name.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# module abbreviations can now index backticked targets** — `module Helpers = ``Legacy Helpers``` records the normalized target module name.
+
+## 日本語
+
+- **F# の module abbreviation で backtick 付き target を索引するようになりました** — `module Helpers = ``Legacy Helpers``` で正規化した target module 名を記録します。

--- a/changelog.d/unreleased/+fsharp-backticked-open-imports.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backticked-open-imports.fixed.md
@@ -1,1 +1,14 @@
-Improved F# symbol extraction so open statements targeting backticked modules are indexed by the normalized module name.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# backticked open targets are now searchable** — `open ``Domain Helpers``` is indexed by the normalized module name.
+
+## 日本語
+
+- **F# の backtick 付き open target を検索できるようになりました** — `open ``Domain Helpers``` を正規化した module 名で索引します。

--- a/changelog.d/unreleased/+fsharp-backticked-open-imports.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backticked-open-imports.fixed.md
@@ -1,0 +1,1 @@
+Improved F# symbol extraction so open statements targeting backticked modules are indexed by the normalized module name.

--- a/changelog.d/unreleased/+fsharp-backticked-open-imports.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backticked-open-imports.fixed.md
@@ -7,8 +7,8 @@ affected:
 
 ## English
 
-- **F# backticked open targets are now searchable** — `open ``Domain Helpers``` is indexed by the normalized module name.
+- **F# backticked open targets are now searchable** — open statements targeting backticked modules are indexed by the normalized module name.
 
 ## 日本語
 
-- **F# の backtick 付き open target を検索できるようになりました** — `open ``Domain Helpers``` を正規化した module 名で索引します。
+- **F# の backtick 付き open target を検索できるようになりました** — backtick 付き module を対象にする open statement を、正規化した module 名で索引します。

--- a/changelog.d/unreleased/+fsharp-backward-pipeline-argument-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backward-pipeline-argument-calls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# backward pipeline argument calls are now indexed** — `printfn <| render user` now exposes `render` as a call reference in addition to the left-hand pipeline callee.
+
+## 日本語
+
+- **F# の backward pipeline 右辺の関数適用も索引するようになりました** — `printfn <| render user` で左辺の呼び出し先に加えて `render` も call reference として取得できます。

--- a/changelog.d/unreleased/+fsharp-backward-pipeline-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-backward-pipeline-calls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# backward pipeline callees are now indexed** — calls such as `printfn <| value` and `<||` variants now expose the left-hand function as a call reference.
+
+## 日本語
+
+- **F# の backward pipeline の呼び出し先を索引するようになりました** — `printfn <| value` や `<||` 系の左辺関数を call reference として取得できます。

--- a/changelog.d/unreleased/+fsharp-block-boundary-call-false-positives.fixed.md
+++ b/changelog.d/unreleased/+fsharp-block-boundary-call-false-positives.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# block-boundary values no longer look like calls** — bare values before `do` or `else`, such as `for item in items do` and `then readyValue else`, are no longer indexed as call references.
+
+## 日本語
+
+- **F# block 境界の単独値を call と誤認しなくなりました** — `for item in items do` や `then readyValue else` のように `do` / `else` の前にある単独値を call 参照として索引しません。

--- a/changelog.d/unreleased/+fsharp-cast-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-cast-application-calls.fixed.md
@@ -1,1 +1,15 @@
-Improved F# reference extraction so call-like expressions immediately wrapped by upcast or downcast are indexed by the inner function name instead of the cast keyword.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# cast expression calls are now indexed by the inner function** — `upcast createWidget user` records `createWidget` as a call while suppressing the `upcast` and `downcast` keywords.
+
+## 日本語
+
+- **F# cast expression の呼び出しを内側の関数名で索引するようになりました** — `upcast createWidget user` で `createWidget` を call として記録し、`upcast` / `downcast` キーワードは抑止します。

--- a/changelog.d/unreleased/+fsharp-cast-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-cast-application-calls.fixed.md
@@ -1,0 +1,1 @@
+Improved F# reference extraction so call-like expressions immediately wrapped by upcast or downcast are indexed by the inner function name instead of the cast keyword.

--- a/changelog.d/unreleased/+fsharp-chained-composition-operands.fixed.md
+++ b/changelog.d/unreleased/+fsharp-chained-composition-operands.fixed.md
@@ -1,1 +1,14 @@
-Improved F# reference extraction so chained function composition expressions index each composed function operand.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# chained function composition now indexes every operand** — expressions such as `validate >> normalize >> persist` record all composed functions.
+
+## 日本語
+
+- **F# の連鎖した関数合成で全operandを索引するようになりました** — `validate >> normalize >> persist` のような式で、合成対象の全関数を記録します。

--- a/changelog.d/unreleased/+fsharp-chained-composition-operands.fixed.md
+++ b/changelog.d/unreleased/+fsharp-chained-composition-operands.fixed.md
@@ -1,0 +1,1 @@
+Improved F# reference extraction so chained function composition expressions index each composed function operand.

--- a/changelog.d/unreleased/+fsharp-composition-operand-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-composition-operand-calls.fixed.md
@@ -1,0 +1,1 @@
+Improved F# reference extraction so function composition operands around >> and << are indexed as call-like references.

--- a/changelog.d/unreleased/+fsharp-composition-operand-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-composition-operand-calls.fixed.md
@@ -1,1 +1,14 @@
-Improved F# reference extraction so function composition operands around >> and << are indexed as call-like references.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# function composition operands are now indexed** — composed functions around `>>` and `<<` are recorded as call-like references.
+
+## 日本語
+
+- **F# の関数合成 operand を索引するようになりました** — `>>` と `<<` の前後にある合成対象の関数を call-like reference として記録します。

--- a/changelog.d/unreleased/+fsharp-computation-expression-bang-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-computation-expression-bang-calls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# computation expression bang calls are now indexed** — parenless calls after `do!`, `return!`, and `yield!` now appear as call references.
+
+## 日本語
+
+- **F# computation expression の bang call を索引するようになりました** — `do!`、`return!`、`yield!` の後にある括弧なし呼び出しを call reference として取得できます。

--- a/changelog.d/unreleased/+fsharp-condition-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-condition-application-calls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# condition application calls are now indexed** — parenless calls at the start of `if`, `elif`, and `while` conditions now appear as call references.
+
+## 日本語
+
+- **F# 条件式先頭の関数適用を索引するようになりました** — `if`、`elif`、`while` 条件の先頭にある括弧なし呼び出しを call reference として取得できます。

--- a/changelog.d/unreleased/+fsharp-condition-boolean-false-positives.fixed.md
+++ b/changelog.d/unreleased/+fsharp-condition-boolean-false-positives.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# condition extraction avoids bare boolean values** — `if isReady then ...` no longer records `isReady` as a call while `if validate user then ...` remains indexed.
+
+## 日本語
+
+- **F# 条件抽出で単独の boolean 値を call と誤認しないようになりました** — `if isReady then ...` では `isReady` を call として記録せず、`if validate user then ...` は引き続き索引します。

--- a/changelog.d/unreleased/+fsharp-constrained-constructor-classes.fixed.md
+++ b/changelog.d/unreleased/+fsharp-constrained-constructor-classes.fixed.md
@@ -1,0 +1,1 @@
+Improved F# symbol extraction so generic constructor-style type declarations with when constraints are indexed as classes.

--- a/changelog.d/unreleased/+fsharp-constrained-constructor-classes.fixed.md
+++ b/changelog.d/unreleased/+fsharp-constrained-constructor-classes.fixed.md
@@ -1,1 +1,14 @@
-Improved F# symbol extraction so generic constructor-style type declarations with when constraints are indexed as classes.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# constrained constructor-style classes are now indexed** — declarations such as `type Factory<'T when 'T : not struct>(value: 'T) = class end` remain searchable by class name.
+
+## 日本語
+
+- **F# の制約付き constructor-style class を索引するようになりました** — `type Factory<'T when 'T : not struct>(value: 'T) = class end` のような宣言を class 名で検索できます。

--- a/changelog.d/unreleased/+fsharp-constrained-generic-classes.fixed.md
+++ b/changelog.d/unreleased/+fsharp-constrained-generic-classes.fixed.md
@@ -1,0 +1,1 @@
+Improved F# symbol extraction so generic class declarations with when constraints are indexed as classes.

--- a/changelog.d/unreleased/+fsharp-constrained-generic-classes.fixed.md
+++ b/changelog.d/unreleased/+fsharp-constrained-generic-classes.fixed.md
@@ -1,1 +1,14 @@
-Improved F# symbol extraction so generic class declarations with when constraints are indexed as classes.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# constrained generic classes are now indexed as classes** — declarations such as `type Box<'T when 'T : not struct> = class end` remain searchable by class name.
+
+## 日本語
+
+- **F# の制約付き generic class を class として索引するようになりました** — `type Box<'T when 'T : not struct> = class end` のような宣言を class 名で検索できます。

--- a/changelog.d/unreleased/+fsharp-delegate-type-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-delegate-type-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# delegate type declarations are now indexed as delegates** — `type Handler = delegate of ...` is searchable by the declared delegate name instead of being treated as an alias/import fallback.
+
+## 日本語
+
+- **F# の delegate type declaration が delegate として索引されるようになりました** — `type Handler = delegate of ...` を alias/import の fallback ではなく、宣言された delegate 名で検索できます。

--- a/changelog.d/unreleased/+fsharp-for-range-boundary-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-for-range-boundary-calls.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# `for` range boundary calls are now indexed** — `to endIndex user` and `downto lowerBound user` record their boundary functions while suppressing the range keywords.
+
+## 日本語
+
+- **F# `for` range 境界の呼び出しを索引するようになりました** — `to endIndex user` や `downto lowerBound user` の境界関数を記録し、rangeキーワード自体は抑止します。

--- a/changelog.d/unreleased/+fsharp-generic-class-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-generic-class-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# generic class declarations are now searchable** — declarations such as `type Box<'T> = class end` and generic constructor forms are indexed as class symbols.
+
+## 日本語
+
+- **F# の generic class 宣言が検索できるようになりました** — `type Box<'T> = class end` や generic constructor 形式を class symbol として索引します。

--- a/changelog.d/unreleased/+fsharp-interface-type-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-interface-type-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# inline interface declarations are now indexed as interfaces** — `type IFoo = interface ...` declarations are no longer surfaced as type aliases.
+
+## 日本語
+
+- **F# の inline interface declaration が interface として索引されるようになりました** — `type IFoo = interface ...` 形式の declaration を typealias として出さないようにしました。

--- a/changelog.d/unreleased/+fsharp-lazy-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-lazy-application-calls.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# lazy expression calls are now indexed** — `lazy compute user` records `compute` as a call while suppressing the `lazy` keyword and bare lazy values.
+
+## 日本語
+
+- **F# lazy expression の呼び出しを索引するようになりました** — `lazy compute user` で `compute` を call として記録し、`lazy` キーワードと単独のlazy値は抑止します。

--- a/changelog.d/unreleased/+fsharp-let-bang-bindings.fixed.md
+++ b/changelog.d/unreleased/+fsharp-let-bang-bindings.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# `let!` bindings are now searchable** — computation expression bindings such as `let! loadedUser = ...` are indexed with the same lightweight symbol coverage as ordinary `let` bindings.
+
+## 日本語
+
+- **F# の `let!` binding が検索できるようになりました** — `let! loadedUser = ...` のような computation expression binding を通常の `let` binding と同じ軽量symbolとして索引します。

--- a/changelog.d/unreleased/+fsharp-match-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-match-application-calls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# match input application calls are now indexed** — `match parse value with` records `parse` as a call while plain `match status with` remains ignored.
+
+## 日本語
+
+- **F# match 入力側の関数適用を索引するようになりました** — `match parse value with` では `parse` を call として記録し、単独値の `match status with` は無視します。

--- a/changelog.d/unreleased/+fsharp-match-bang-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-match-bang-application-calls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# `match!` input calls are now indexed** — computation expression inputs such as `match! fetch value with` record `fetch` as a call.
+
+## 日本語
+
+- **F# の `match!` 入力側呼び出しを索引するようになりました** — computation expression の `match! fetch value with` で `fetch` を call として記録します。

--- a/changelog.d/unreleased/+fsharp-member-val-properties.fixed.md
+++ b/changelog.d/unreleased/+fsharp-member-val-properties.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# auto-properties are now searchable** — `member val DisplayName = ...` is indexed as a `property` symbol instead of being skipped by the regular member extractor.
+
+## 日本語
+
+- **F# auto-property が検索できるようになりました** — `member val DisplayName = ...` を通常member抽出で除外したまま、`property` シンボルとして索引します。

--- a/changelog.d/unreleased/+fsharp-module-alias-imports.fixed.md
+++ b/changelog.d/unreleased/+fsharp-module-alias-imports.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# module abbreviations now expose their target namespace** — `module Json = System.Text.Json` keeps `Json` searchable while also indexing `System.Text.Json` as an import.
+
+## 日本語
+
+- **F# の module abbreviation が右辺の namespace も公開するようになりました** — `module Json = System.Text.Json` は `Json` を検索可能に保ちながら、`System.Text.Json` も import として索引します。

--- a/changelog.d/unreleased/+fsharp-new-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-new-application-calls.fixed.md
@@ -1,0 +1,1 @@
+Improved F# reference extraction for constructor applications written as new Type value so the constructed type is indexed as an instantiation target.

--- a/changelog.d/unreleased/+fsharp-new-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-new-application-calls.fixed.md
@@ -1,1 +1,14 @@
-Improved F# reference extraction for constructor applications written as new Type value so the constructed type is indexed as an instantiation target.
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# constructor applications without parentheses are now indexed** — `new Customer user` records `Customer` as an instantiation target.
+
+## 日本語
+
+- **F# の括弧なし constructor application を索引するようになりました** — `new Customer user` で `Customer` を instantiation target として記録します。

--- a/changelog.d/unreleased/+fsharp-open-type-imports.fixed.md
+++ b/changelog.d/unreleased/+fsharp-open-type-imports.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# `open type` imports now index the opened type** — `open type System.Math` is searchable as an import for `System.Math` instead of stopping at the contextual keyword.
+
+## 日本語
+
+- **F# の `open type` import が開いた型名で索引されるようになりました** — `open type System.Math` は文脈キーワードで止まらず、`System.Math` の import として検索できます。

--- a/changelog.d/unreleased/+fsharp-public-type-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-public-type-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# public type declarations are now searchable** — `type public PublicId = ...` and public union declarations are indexed by their declared type names.
+
+## 日本語
+
+- **F# の public type declaration が検索可能になりました** — `type public PublicId = ...` や public union declaration を宣言された型名で索引します。

--- a/changelog.d/unreleased/+fsharp-raise-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-raise-application-calls.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# raise expression calls are now indexed** — `raise buildError user` records `buildError` as a call while suppressing the `raise` keyword and bare exception values.
+
+## 日本語
+
+- **F# raise expression の呼び出しを索引するようになりました** — `raise buildError user` で `buildError` を call として記録し、`raise` キーワードと単独の例外値は抑止します。

--- a/changelog.d/unreleased/+fsharp-recursive-type-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-recursive-type-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# recursive type declarations are now searchable by type name** — `type rec Tree<'T> = ...` is indexed as a type symbol instead of being skipped by the top-level F# patterns.
+
+## 日本語
+
+- **F# の recursive type declaration が型名で検索できるようになりました** — `type rec Tree<'T> = ...` が上位の F# pattern でスキップされず、型シンボルとして索引されます。

--- a/changelog.d/unreleased/+fsharp-struct-keyword-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-struct-keyword-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# keyword struct declarations are now indexed as structs** — `type Coordinates = struct ...` is searchable as a `struct` symbol instead of falling through generic type patterns.
+
+## 日本語
+
+- **F# の keyword struct declaration が struct として索引されるようになりました** — `type Coordinates = struct ...` を汎用 type pattern に落とさず、`struct` シンボルとして検索できます。

--- a/changelog.d/unreleased/+fsharp-try-finally-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-try-finally-calls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# `try`/`finally` application calls are now indexed** — parenless calls after `try` and `finally` now appear in call-reference results.
+
+## 日本語
+
+- **F# の `try` / `finally` 後の関数適用を索引するようになりました** — `try` や `finally` の直後にある括弧なし呼び出しを call reference として取得できます。

--- a/changelog.d/unreleased/+fsharp-use-bindings.fixed.md
+++ b/changelog.d/unreleased/+fsharp-use-bindings.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# `use` bindings are now searchable** — resource bindings such as `use client = ...` and `use! lease = ...` are indexed as lightweight symbols.
+
+## 日本語
+
+- **F# の `use` binding が検索できるようになりました** — `use client = ...` や `use! lease = ...` のようなresource bindingを軽量symbolとして索引します。

--- a/changelog.d/unreleased/+fsharp-val-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+fsharp-val-property-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **F# `val` declarations are now searchable** — signature declarations such as `val Id : string` and `val mutable Count : int` are indexed as property symbols.
+
+## 日本語
+
+- **F# の `val` 宣言が検索できるようになりました** — `val Id : string` や `val mutable Count : int` のようなsignature宣言を property symbol として索引します。

--- a/changelog.d/unreleased/+fsharp-when-guard-application-calls.fixed.md
+++ b/changelog.d/unreleased/+fsharp-when-guard-application-calls.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **F# pattern guard calls are now indexed** — `when validate user ->` records `validate` as a call while bare guard values remain ignored.
+
+## 日本語
+
+- **F# pattern guard の関数呼び出しを索引するようになりました** — `when validate user ->` では `validate` を call として記録し、単独のguard値は無視します。

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -29,6 +29,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?!(?:then|do)\b)(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex MatchApplicationCallRegex = new(
+        $@"^\s*match\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?!with\b)(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -83,6 +88,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in ConditionApplicationCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in MatchApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -49,6 +49,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex RaiseApplicationCallRegex = new(
+        $@"\braise\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|to|downto|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -131,6 +136,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in LazyApplicationCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in RaiseApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -39,6 +39,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?!->\b)(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex AssertApplicationCallRegex = new(
+        $@"^\s*assert\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -107,6 +112,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in WhenGuardApplicationCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in AssertApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -54,6 +54,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex CastApplicationCallRegex = new(
+        $@"\b(?:upcast|downcast)\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|to|downto|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -143,6 +148,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in RaiseApplicationCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in CastApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -10,6 +10,10 @@ internal static class FSharpReferenceExtractor
         $@"(?<![\w$])(?:\|{{1,3}}>)\s*(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b",
         RegexOptions.Compiled);
 
+    private static readonly Regex BackwardPipelineCallRegex = new(
+        $@"(?<![\w$])(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\s*<\|{{1,3}}",
+        RegexOptions.Compiled);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do|else|in)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -36,6 +40,13 @@ internal static class FSharpReferenceExtractor
         Action<string, int> addCallLikeReference)
     {
         foreach (Match match in PipelineCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in BackwardPipelineCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -48,7 +48,7 @@ internal static class FSharpReferenceExtractor
         $@"(?:\b(?:then|do!?|else|in|to|downto|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
             (?<name>{IdentifierPattern})\b
-            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+            (?=\s+(?!(?:do|else)\b)(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
     private static readonly Regex OperatorCallRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -65,7 +65,7 @@ internal static class FSharpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
     private static readonly Regex CompositionOperandCallRegex = new(
-        $@"(?<![\w$])(?:(?:{IdentifierPattern})\s*\.\s*)*(?<left>{IdentifierPattern})\b\s*(?:>>|<<)\s*(?:(?:{IdentifierPattern})\s*\.\s*)*(?<right>{IdentifierPattern})\b",
+        $@"(?=(?<![\w$])(?:(?:{IdentifierPattern})\s*\.\s*)*(?<left>{IdentifierPattern})\b\s*(?:>>|<<)\s*(?:(?:{IdentifierPattern})\s*\.\s*)*(?<right>{IdentifierPattern})\b)",
         RegexOptions.Compiled);
 
     private static readonly Regex SpaceApplicationCallRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -30,7 +30,7 @@ internal static class FSharpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
     private static readonly Regex MatchApplicationCallRegex = new(
-        $@"^\s*match\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+        $@"^\s*match!?\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
             (?=\s+(?!with\b)(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -64,6 +64,10 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex CompositionOperandCallRegex = new(
+        $@"(?<![\w$])(?:(?:{IdentifierPattern})\s*\.\s*)*(?<left>{IdentifierPattern})\b\s*(?:>>|<<)\s*(?:(?:{IdentifierPattern})\s*\.\s*)*(?<right>{IdentifierPattern})\b",
+        RegexOptions.Compiled);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|to|downto|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -171,6 +175,12 @@ internal static class FSharpReferenceExtractor
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;
             addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in CompositionOperandCallRegex.Matches(preparedLine))
+        {
+            addCallLikeReference(match.Groups["left"].Value, match.Groups["left"].Index);
+            addCallLikeReference(match.Groups["right"].Value, match.Groups["right"].Index);
         }
 
         foreach (Match match in SpaceApplicationCallRegex.Matches(preparedLine))

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -44,6 +44,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex LazyApplicationCallRegex = new(
+        $@"\blazy\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|to|downto|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -119,6 +124,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in AssertApplicationCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in LazyApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -24,6 +24,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex ConditionApplicationCallRegex = new(
+        $@"^\s*(?:if|elif|while)\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -71,6 +76,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in TryFinallyApplicationCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in ConditionApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -19,6 +19,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex TryFinallyApplicationCallRegex = new(
+        $@"^\s*(?:try|finally)\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -59,6 +64,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in BackwardPipelineArgumentCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in TryFinallyApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -14,6 +14,11 @@ internal static class FSharpReferenceExtractor
         $@"(?<![\w$])(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\s*<\|{{1,3}}",
         RegexOptions.Compiled);
 
+    private static readonly Regex BackwardPipelineArgumentCallRegex = new(
+        $@"<\|{{1,3}}\s*(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do|else|in)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -47,6 +52,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in BackwardPipelineCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in BackwardPipelineArgumentCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -45,7 +45,7 @@ internal static class FSharpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
     private static readonly Regex SpaceApplicationCallRegex = new(
-        $@"(?:\b(?:then|do!?|else|in|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
+        $@"(?:\b(?:then|do!?|else|in|to|downto|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
             (?<name>{IdentifierPattern})\b
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -20,7 +20,7 @@ internal static class FSharpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
     private static readonly Regex SpaceApplicationCallRegex = new(
-        $@"(?:\b(?:then|do|else|in)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
+        $@"(?:\b(?:then|do!?|else|in|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
             (?<name>{IdentifierPattern})\b
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -26,7 +26,7 @@ internal static class FSharpReferenceExtractor
 
     private static readonly Regex ConditionApplicationCallRegex = new(
         $@"^\s*(?:if|elif|while)\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
-            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+            (?=\s+(?!(?:then|do)\b)(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
     private static readonly Regex SpaceApplicationCallRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -59,6 +59,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex NewApplicationCallRegex = new(
+        $@"\bnew\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|to|downto|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -155,6 +160,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in CastApplicationCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in NewApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -34,6 +34,11 @@ internal static class FSharpReferenceExtractor
             (?=\s+(?!with\b)(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
         RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
+    private static readonly Regex WhenGuardApplicationCallRegex = new(
+        $@"\bwhen\s+(?:(?:{IdentifierPattern})\s*\.\s*)*(?<name>{IdentifierPattern})\b
+            (?=\s+(?!->\b)(?:{IdentifierPattern}|""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|\(|\[|\{{|\d))",
+        RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
     private static readonly Regex SpaceApplicationCallRegex = new(
         $@"(?:\b(?:then|do!?|else|in|return!?|yield!?)\s+|->\s+|[=(,\[\{{;]\s*|^\s*)
             (?:(?:{IdentifierPattern})\s*\.\s*)*
@@ -95,6 +100,13 @@ internal static class FSharpReferenceExtractor
         }
 
         foreach (Match match in MatchApplicationCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            var callIndex = match.Groups["name"].Index;
+            addCallLikeReference(name, callIndex);
+        }
+
+        foreach (Match match in WhenGuardApplicationCallRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             var callIndex = match.Groups["name"].Index;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -192,7 +192,7 @@ public static partial class ReferenceExtractor
             "match", "with", "member", "override", "abstract", "mutable", "rec", "fun", "open",
             "module", "type", "of", "then", "elif", "done", "begin", "end",
             "let", "use", "if", "else", "do", "try", "finally", "in", "for", "while", "return", "yield",
-            "assert",
+            "assert", "to", "downto",
         },
         // PHP include/require constructs / PHP の include/require 構文
         ["php"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -192,7 +192,7 @@ public static partial class ReferenceExtractor
             "match", "with", "member", "override", "abstract", "mutable", "rec", "fun", "open",
             "module", "type", "of", "then", "elif", "done", "begin", "end",
             "let", "use", "if", "else", "do", "try", "finally", "in", "for", "while", "return", "yield",
-            "assert", "to", "downto",
+            "assert", "to", "downto", "lazy",
         },
         // PHP include/require constructs / PHP の include/require 構文
         ["php"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -192,6 +192,7 @@ public static partial class ReferenceExtractor
             "match", "with", "member", "override", "abstract", "mutable", "rec", "fun", "open",
             "module", "type", "of", "then", "elif", "done", "begin", "end",
             "let", "use", "if", "else", "do", "try", "finally", "in", "for", "while", "return", "yield",
+            "assert",
         },
         // PHP include/require constructs / PHP の include/require 構文
         ["php"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -192,7 +192,7 @@ public static partial class ReferenceExtractor
             "match", "with", "member", "override", "abstract", "mutable", "rec", "fun", "open",
             "module", "type", "of", "then", "elif", "done", "begin", "end",
             "let", "use", "if", "else", "do", "try", "finally", "in", "for", "while", "return", "yield",
-            "assert", "to", "downto", "lazy", "raise",
+            "assert", "to", "downto", "lazy", "raise", "upcast", "downcast",
         },
         // PHP include/require constructs / PHP の include/require 構文
         ["php"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -192,7 +192,7 @@ public static partial class ReferenceExtractor
             "match", "with", "member", "override", "abstract", "mutable", "rec", "fun", "open",
             "module", "type", "of", "then", "elif", "done", "begin", "end",
             "let", "use", "if", "else", "do", "try", "finally", "in", "for", "while", "return", "yield",
-            "assert", "to", "downto", "lazy",
+            "assert", "to", "downto", "lazy", "raise",
         },
         // PHP include/require constructs / PHP の include/require 構文
         ["php"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.FSharp.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.FSharp.cs
@@ -23,7 +23,7 @@ public static partial class SymbolExtractor
 
     private static readonly Regex FSharpTypeDeclarationRegex = new(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)*(?<name>(?:``[^`]+``|[_\p{L}][\w']*))(?:\s*<[^>]+>)?\s*=\s*(?<rest>.*)$", RegexOptions.Compiled);
     private static readonly Regex FSharpRecordFieldRegex = new(@"^(?:\[\<[^>]+\>\]\s*)*(?:mutable\s+)?(?<name>(?:``[^`]+``|[_\p{L}][\w']*))\s*:\s*.+$", RegexOptions.Compiled);
-    private static readonly Regex FSharpUnionCaseRegex = new(@"^\|?\s*(?<name>(?:``[^`]+``|[_\p{L}][\w']*))(?:\s+of\b.*)?$", RegexOptions.Compiled);
+    private static readonly Regex FSharpUnionCaseRegex = new(@"^\|?\s*(?:\[\<[^>]+\>\]\s*)*(?<name>(?:``[^`]+``|[_\p{L}][\w']*))(?:\s+of\b.*)?$", RegexOptions.Compiled);
     private static readonly Regex FSharpActivePatternDefinitionRegex = new(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*\(\|(?<cases>.+?)\|\)", RegexOptions.Compiled);
     private static readonly Regex FSharpActivePatternNameRegex = new(@"^(?:``[^`]+``|[_\p{L}][\w']*)$", RegexOptions.Compiled);
     private static readonly Regex FSharpOperatorDefinitionRegex = new(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>\((?!\|)[^)\s]+\))(?:\s+(?:\w+|\())?", RegexOptions.Compiled);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1465,6 +1465,7 @@ public static partial class SymbolExtractor
         [
             new("function", new Regex(@"^\s*let!?\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*use!?\s+(?<name>(?:``[^`]+``|\w+))\s*(?:=|:)", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*and\s+(?<name>(?:``[^`]+``|\w+))\s+(?:``[^`]+``|\w+|\()", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1488,6 +1488,7 @@ public static partial class SymbolExtractor
             new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>\w+)\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?val\s+(?<name>(?:``[^`]+``|\w+))\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?(?:(?:inline)\s+)?(?:(?:this|_|\w+)\.)?(?!val\b)(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*open\s+(?:type\s+)?(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1490,6 +1490,7 @@ public static partial class SymbolExtractor
             new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>(?:``[^`]+``|\w+))\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?abstract\s+(?!member\b)(?<name>(?:``[^`]+``|\w+))\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?val\s+(?<name>(?:``[^`]+``|\w+))(?=\s|\(|=|:|$)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?(?:(?:inline)\s+)?(?:(?:this|_|\w+)\.)?(?!val\b)(?<name>(?:``[^`]+``|\w+))(?=\s|\(|=|:|$)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*open\s+(?:type\s+)?(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1464,23 +1464,23 @@ public static partial class SymbolExtractor
         ["fsharp"] =
         [
             new("function", new Regex(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
-            new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
             // mistaken for union cases just because the right-hand side starts with a capitalized
             // type name.
             // `type Result<'T> = Choice<'T, string>` のような generic abbreviation は、
             // 右辺が大文字始まりの型名でも union case と誤認しない。
-            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*<[^=]+?>\s*(?:when\b[^=]+)?\s*=\s*(?![^\r\n]*\|)(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
-            new("enum", new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*<[^=]+?>\s*(?:when\b[^=]+)?\s*=\s*(?![^\r\n]*\|)(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
+            new("enum", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
             // Simple aliases without generic parameters stay searchable as `typealias`.
             // generic 引数なしの単純な alias も `typealias` として検索可能にする。
-            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?![^\r\n]*\|)(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
-            new("struct",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
-            new("enum",     new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?![^\r\n]*\|)(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
+            new("struct",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
+            new("enum",     new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1481,7 +1481,7 @@ public static partial class SymbolExtractor
             // Simple aliases without generic parameters stay searchable as `typealias`.
             // generic 引数なしの単純な alias も `typealias` として検索可能にする。
             new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?![^\r\n]*\|)(?!(?:class|delegate|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?(?:\s+when\b[^=]+)?\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1487,7 +1487,7 @@ public static partial class SymbolExtractor
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!delegate\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>(?:``[^`]+``|[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>(?:``[^`]+``|[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>(?:``[^`]+``|\w+))\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?abstract\s+(?!member\b)(?<name>(?:``[^`]+``|\w+))\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1491,6 +1491,7 @@ public static partial class SymbolExtractor
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>(?:``[^`]+``|\w+))\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?abstract\s+(?!member\b)(?<name>(?:``[^`]+``|\w+))\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:static\s+)?val\s+(?:mutable\s+)?(?<name>(?:``[^`]+``|\w+))\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?val\s+(?<name>(?:``[^`]+``|\w+))(?=\s|\(|=|:|$)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?(?:(?:inline)\s+)?(?:(?:this|_|\w+)\.)?(?!val\b)(?<name>(?:``[^`]+``|\w+))(?=\s|\(|=|:|$)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*open\s+(?:type\s+)?(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1465,6 +1465,7 @@ public static partial class SymbolExtractor
         [
             new("function", new Regex(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
             // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
             // mistaken for union cases just because the right-hand side starts with a capitalized
             // type name.

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1464,6 +1464,7 @@ public static partial class SymbolExtractor
         ["fsharp"] =
         [
             new("function", new Regex(@"^\s*let!?\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*use!?\s+(?<name>(?:``[^`]+``|\w+))\s*(?:=|:)", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1488,7 +1488,7 @@ public static partial class SymbolExtractor
             new("import",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!delegate\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
-            new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
+            new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>(?:``[^`]+``|[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>(?:``[^`]+``|\w+))\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?abstract\s+(?!member\b)(?<name>(?:``[^`]+``|\w+))\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:static\s+)?val\s+(?:mutable\s+)?(?<name>(?:``[^`]+``|\w+))\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1482,6 +1482,7 @@ public static partial class SymbolExtractor
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>\w+)\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?(?:(?:inline)\s+)?(?:(?:this|_|\w+)\.)?(?!val\b)(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1464,23 +1464,23 @@ public static partial class SymbolExtractor
         ["fsharp"] =
         [
             new("function", new Regex(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
-            new("struct", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
             // mistaken for union cases just because the right-hand side starts with a capitalized
             // type name.
             // `type Result<'T> = Choice<'T, string>` のような generic abbreviation は、
             // 右辺が大文字始まりの型名でも union case と誤認しない。
-            new("typealias", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*<[^=]+?>\s*(?:when\b[^=]+)?\s*=\s*(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
-            new("enum", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*<[^=]+?>\s*(?:when\b[^=]+)?\s*=\s*(?![^\r\n]*\|)(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
+            new("enum", new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
             // Simple aliases without generic parameters stay searchable as `typealias`.
             // generic 引数なしの単純な alias も `typealias` として検索可能にする。
-            new("typealias", new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
-            new("struct",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
-            new("enum",     new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>\w+)\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?![^\r\n]*\|)(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
+            new("struct",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
+            new("enum",     new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>\w+)\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*type\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1470,7 +1470,7 @@ public static partial class SymbolExtractor
             new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),
             new("delegate", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*delegate\b", RegexOptions.Compiled), BodyStyle.None),
-            new("class", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^=]+?>)?\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
+            new("class", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^=]+?>)?(?:\s+when\b[^=]+)?\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
             // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
             // mistaken for union cases just because the right-hand side starts with a capitalized
             // type name.

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1467,22 +1467,23 @@ public static partial class SymbolExtractor
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),
+            new("delegate", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*delegate\b", RegexOptions.Compiled), BodyStyle.None),
             // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
             // mistaken for union cases just because the right-hand side starts with a capitalized
             // type name.
             // `type Result<'T> = Choice<'T, string>` のような generic abbreviation は、
             // 右辺が大文字始まりの型名でも union case と誤認しない。
-            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*<[^=]+?>\s*(?:when\b[^=]+)?\s*=\s*(?![^\r\n]*\|)(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*<[^=]+?>\s*(?:when\b[^=]+)?\s*=\s*(?![^\r\n]*\|)(?!(?:class|delegate|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
             new("enum", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
             // Simple aliases without generic parameters stay searchable as `typealias`.
             // generic 引数なしの単純な alias も `typealias` として検索可能にする。
-            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?![^\r\n]*\|)(?!(?:class|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
+            new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?![^\r\n]*\|)(?!(?:class|delegate|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!delegate\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1463,7 +1463,7 @@ public static partial class SymbolExtractor
         ],
         ["fsharp"] =
         [
-            new("function", new Regex(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*let!?\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1466,24 +1466,24 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*let!?\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*use!?\s+(?<name>(?:``[^`]+``|\w+))\s*(?:=|:)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*and\s+(?<name>(?:``[^`]+``|\w+))\s+(?:``[^`]+``|\w+|\()", RegexOptions.Compiled), BodyStyle.None),
-            new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
-            new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
-            new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),
-            new("delegate", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*delegate\b", RegexOptions.Compiled), BodyStyle.None),
+            new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
+            new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),
+            new("delegate", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*delegate\b", RegexOptions.Compiled), BodyStyle.None),
             // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
             // mistaken for union cases just because the right-hand side starts with a capitalized
             // type name.
             // `type Result<'T> = Choice<'T, string>` のような generic abbreviation は、
             // 右辺が大文字始まりの型名でも union case と誤認しない。
             new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*<[^=]+?>\s*(?:when\b[^=]+)?\s*=\s*(?![^\r\n]*\|)(?!(?:class|delegate|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
-            new("enum", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("enum", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*(?:\|?\s*[A-Z][\w']*\b(?:\s*\|[^=].*)?)", RegexOptions.Compiled), BodyStyle.Brace),
             // Simple aliases without generic parameters stay searchable as `typealias`.
             // generic 引数なしの単純な alias も `typealias` として検索可能にする。
             new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?![^\r\n]*\|)(?!(?:class|delegate|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
-            new("struct",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
-            new("enum",     new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
+            new("struct",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
+            new("enum",     new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?!\{)(?!\|)(?!class\b)(?!delegate\b)(?!struct\b)(?!interface\b)(?!enum\b).+", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1466,6 +1466,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*let\s+(?:(?:rec|mutable|inline|private|internal|public)\s+)*(?<name>(?:``[^`]+``|\w+))(?:\s+(?:\w+|\())?", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
+            new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>\w+)(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),
             // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
             // mistaken for union cases just because the right-hand side starts with a capitalized
             // type name.

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1487,9 +1487,9 @@ public static partial class SymbolExtractor
             new("namespace", new Regex(@"^\s*namespace\s+(?:(?:rec|global)\s+)*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?:``[^`]+``|[\w.]+)\s*=\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>\w+)\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?val\s+(?<name>(?:``[^`]+``|\w+))\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?(?:(?:inline)\s+)?(?:(?:this|_|\w+)\.)?(?!val\b)(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>(?:``[^`]+``|\w+))\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?val\s+(?<name>(?:``[^`]+``|\w+))(?=\s|\(|=|:|$)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?(?:(?:inline)\s+)?(?:(?:this|_|\w+)\.)?(?!val\b)(?<name>(?:``[^`]+``|\w+))(?=\s|\(|=|:|$)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*open\s+(?:type\s+)?(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["vb"] =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1470,6 +1470,7 @@ public static partial class SymbolExtractor
             new("interface", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*interface\b", RegexOptions.Compiled), BodyStyle.None),
             new("struct", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*struct\b", RegexOptions.Compiled), BodyStyle.None),
             new("delegate", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*=\s*delegate\b", RegexOptions.Compiled), BodyStyle.None),
+            new("class", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^=]+?>)?\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
             // Generic abbreviations such as `type Result<'T> = Choice<'T, string>` should not be
             // mistaken for union cases just because the right-hand side starts with a capitalized
             // type name.
@@ -1480,8 +1481,7 @@ public static partial class SymbolExtractor
             // Simple aliases without generic parameters stay searchable as `typealias`.
             // generic 引数なしの単純な alias も `typealias` として検索可能にする。
             new("typealias", new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?![^\r\n]*\|)(?!(?:class|delegate|interface|struct|enum|exception)\b)(?!\{)(?!\|)(?!\()", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*class\b", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))(?:\s*<[^>]+>)?\s*(?:\([^)]*\))\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*\{", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*type\s+(?:(?:rec|private|internal|public)\s+)?(?<name>(?:``[^`]+``|\w+))\s*=\s*(?:\|\s*)?\w+(?:\s*\|\s*\w+)+", RegexOptions.Compiled), BodyStyle.None),
             new("exception", new Regex(@"^\s*exception\s+(?:(?:private|internal)\s+)?(?<name>(?:``[^`]+``|\w+))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1485,7 +1485,7 @@ public static partial class SymbolExtractor
             new("namespace", new Regex(@"^\s*module\s+(?:(?:(?:private|internal)\s+|rec\s+))*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?override\s+(?:(?:this|_|\w+)\.)?(?<name>\w+)\s*(?:\(|=|:)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?(?:(?:inline)\s+)?(?:(?:this|_|\w+)\.)?(?!val\b)(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("import",   new Regex(@"^\s*open\s+(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*open\s+(?:type\s+)?(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["vb"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1494,7 +1494,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:static\s+)?val\s+(?:mutable\s+)?(?<name>(?:``[^`]+``|\w+))\s*:", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("property", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?val\s+(?<name>(?:``[^`]+``|\w+))(?=\s|\(|=|:|$)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("function", new Regex(@"^\s*(?:(?<visibility>private|internal|public)\s+)?(?:(?:static|abstract|override|default)\s+)*member\s+(?:(?:private|internal)\s+)?(?:(?:inline)\s+)?(?:(?:this|_|\w+)\.)?(?!val\b)(?<name>(?:``[^`]+``|\w+))(?=\s|\(|=|:|$)", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("import",   new Regex(@"^\s*open\s+(?:type\s+)?(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*open\s+(?:type\s+)?(?<name>(?:``[^`]+``|[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["vb"] =
         [

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10618,6 +10618,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsMatchApplicationCalls()
+    {
+        const string content = """
+            let run value =
+                match parse value with
+                | Some parsed -> parsed
+                | None -> value
+
+            let inspect status =
+                match status with
+                | Ready -> true
+                | _ -> false
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "parse" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "status" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10786,6 +10786,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsCompositionOperandCalls()
+    {
+        const string content = """
+            let workflow =
+                normalize >> persist
+
+            let loader =
+                Views.render << loadModel
+
+            let shifted flags count =
+                flags >>> count
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "normalize" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "persist" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "render" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "loadModel" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "flags" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "count" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10582,6 +10582,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsTryFinallyApplicationCalls()
+    {
+        const string content = """
+            let run value =
+                try load value
+                finally cleanup value
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "load" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "cleanup" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10549,6 +10549,7 @@ public class ReferenceExtractorTests
         const string content = """
             let run user =
                 printfn <| user.Name
+                printfn <| render user
                 log <|| ("user", user.Id)
             """;
 
@@ -10556,6 +10557,7 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "printfn" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "render" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "log" && r.ReferenceKind == "call");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10630,12 +10630,20 @@ public class ReferenceExtractorTests
                 match status with
                 | Ready -> true
                 | _ -> false
+
+            let workflow value =
+                task {
+                    match! fetch value with
+                    | Some parsed -> return parsed
+                    | None -> return value
+                }
             """;
 
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
         var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "parse" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "fetch" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "status" && r.ReferenceKind == "call");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10666,6 +10666,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsAssertApplicationCalls()
+    {
+        const string content = """
+            let run user =
+                assert validate user
+                assert isReady
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "validate" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "assert" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "isReady" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10598,6 +10598,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsConditionApplicationCalls()
+    {
+        const string content = """
+            let run user cursor =
+                if validate user then printfn "valid"
+                elif shouldRetry user then printfn "retry"
+                while hasNext cursor do printfn "next"
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "validate" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "shouldRetry" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "hasNext" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10714,6 +10714,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsLazyApplicationCalls()
+    {
+        const string content = """
+            let run user =
+                let delayed = lazy compute user
+                let cached = lazy readyValue
+                delayed
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "compute" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "lazy" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "readyValue" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10603,6 +10603,7 @@ public class ReferenceExtractorTests
         const string content = """
             let run user cursor =
                 if validate user then printfn "valid"
+                if isReady then printfn "ready"
                 elif shouldRetry user then printfn "retry"
                 while hasNext cursor do printfn "next"
             """;
@@ -10613,6 +10614,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "validate" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "shouldRetry" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "hasNext" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "isReady" && r.ReferenceKind == "call");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10691,6 +10691,13 @@ public class ReferenceExtractorTests
                     printfn "%d" i
                 for i = startIndex user downto lowerBound user do
                     printfn "%d" i
+                for item in items do
+                    printfn "%A" item
+                for i = 1 to maxIndex do
+                    printfn "%d" i
+
+            let inspect isReady =
+                if isReady then readyValue else fallbackValue
             """;
 
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
@@ -10701,6 +10708,9 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "lowerBound" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "to" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "downto" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "items" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "maxIndex" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "readyValue" && r.ReferenceKind == "call");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10544,6 +10544,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsBackwardPipelineCallee()
+    {
+        const string content = """
+            let run user =
+                printfn <| user.Name
+                log <|| ("user", user.Id)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "printfn" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "log" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10749,6 +10749,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsCastApplicationCalls()
+    {
+        const string content = """
+            let run user currentValue =
+                let boxed = upcast createWidget user
+                let typed = downcast currentValue
+                boxed, typed
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "createWidget" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "upcast" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "downcast" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "currentValue" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10683,6 +10683,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsForRangeBoundaryApplicationCalls()
+    {
+        const string content = """
+            let run user =
+                for i = 1 to endIndex user do
+                    printfn "%d" i
+                for i = startIndex user downto lowerBound user do
+                    printfn "%d" i
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "startIndex" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "endIndex" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "lowerBound" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "to" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "downto" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10790,10 +10790,10 @@ public class ReferenceExtractorTests
     {
         const string content = """
             let workflow =
-                normalize >> persist
+                validate >> normalize >> persist
 
             let loader =
-                Views.render << loadModel
+                Views.render << loadModel << hydrate
 
             let shifted flags count =
                 flags >>> count
@@ -10802,10 +10802,12 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
         var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
 
+        Assert.Contains(references, r => r.SymbolName == "validate" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "normalize" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "persist" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "render" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "loadModel" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "hydrate" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "flags" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "count" && r.ReferenceKind == "call");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10768,6 +10768,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsNewApplicationCalls()
+    {
+        const string content = """
+            let run user =
+                let customer = new Customer user
+                let order = new Sales.Order customer
+                customer, order
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Customer" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Order" && r.ReferenceKind == "instantiate");
+        Assert.DoesNotContain(references, r => r.SymbolName == "new" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10732,6 +10732,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsRaiseApplicationCalls()
+    {
+        const string content = """
+            let run user currentError =
+                do raise buildError user
+                raise currentError
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "buildError" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "raise" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "currentError" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10562,6 +10562,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsComputationExpressionBangCalls()
+    {
+        const string content = """
+            let workflow value =
+                task {
+                    do! run value
+                    return! finish value
+                    yield! produce value
+                }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "run" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "finish" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "produce" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10640,6 +10640,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_FSharp_DetectsWhenGuardApplicationCalls()
+    {
+        const string content = """
+            let describe value =
+                match value with
+                | Some user when validate user -> user.Name
+                | Some user when isReady -> user.Name
+                | _ -> "unknown"
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "fsharp", content);
+        var references = ReferenceExtractor.Extract(1, "fsharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "validate" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "isReady" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_FSharp_DetectsMatchArmApplicationCalls()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14684,7 +14684,9 @@ public class SymbolExtractorTests
 
             let workflow user =
                 task {
+                    use client = createClient user
                     let! loadedUser = loadUser user
+                    use! lease = acquireLease loadedUser
                     return loadedUser
                 }
             """;
@@ -14710,7 +14712,9 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ToString");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Visit");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "validate");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "client");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "loadedUser");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "lease");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14668,6 +14668,7 @@ public class SymbolExtractorTests
             type ``Color Choice`` = Red | Blue
             type ``Worker Type``() = class end
             type Box<'T> = class end
+            type ConstrainedBox<'T when 'T : not struct> = class end
             type Factory<'T>(value: 'T) = class end
 
             type Person(name: string) =
@@ -14715,6 +14716,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Worker Type");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Box");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ConstrainedBox");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Factory");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ILogger");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "User Record");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14665,6 +14665,8 @@ public class SymbolExtractorTests
             type ``User Record`` = { Name: string }
             type ``Color Choice`` = Red | Blue
             type ``Worker Type``() = class end
+            type Box<'T> = class end
+            type Factory<'T>(value: 'T) = class end
 
             type Person(name: string) =
                 member this.Name = name
@@ -14708,6 +14710,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "Domain Helpers");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Worker Type");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Box");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Factory");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ILogger");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "User Record");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Color Choice");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14662,6 +14662,9 @@ public class SymbolExtractorTests
 
             type UserId = int
             type OrderId = string
+            type ``User Record`` = { Name: string }
+            type ``Color Choice`` = Red | Blue
+            type ``Worker Type``() = class end
 
             type Person(name: string) =
                 member this.Name = name
@@ -14704,7 +14707,10 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System.Text.Json");
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "Domain Helpers");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Worker Type");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ILogger");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "User Record");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Color Choice");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Coordinates");
         Assert.Contains(symbols, s => s.Kind == "delegate" && s.Name == "Handler");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14681,6 +14681,12 @@ public class SymbolExtractorTests
 
             let validate user =
                 user.Age > 0
+
+            let workflow user =
+                task {
+                    let! loadedUser = loadUser user
+                    return loadedUser
+                }
             """;
 
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
@@ -14704,6 +14710,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ToString");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Visit");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "validate");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "loadedUser");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14664,6 +14664,7 @@ public class SymbolExtractorTests
 
             type Person(name: string) =
                 member this.Name = name
+                member this.``display name`` = name
                 member val DisplayName = name with get, set
                 member _.Age = 0
                 static member Create(name: string) = Person(name)
@@ -14696,6 +14697,7 @@ public class SymbolExtractorTests
         Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Coordinates");
         Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Handler");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Name");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "display name");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DisplayName");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Age");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Create");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14647,6 +14647,7 @@ public class SymbolExtractorTests
         // F#: namespace rec, module private, member forms / F#: namespace rec、module private、member形
         var content = """
             namespace rec MyApp.Domain
+            module Json = System.Text.Json
 
             type UserId = int
             type OrderId = string
@@ -14667,6 +14668,7 @@ public class SymbolExtractorTests
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp.Domain");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System.Text.Json");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "OrderId");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14671,6 +14671,8 @@ public class SymbolExtractorTests
             type IVisitor =
                 abstract member Visit : unit -> unit
 
+            type ILogger = interface end
+
             let validate user =
                 user.Age > 0
             """;
@@ -14680,8 +14682,10 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp.Domain");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System.Text.Json");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ILogger");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "OrderId");
+        Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "ILogger");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Name");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Age");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Create");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14658,6 +14658,7 @@ public class SymbolExtractorTests
         var content = """
             namespace rec MyApp.Domain
             module Json = System.Text.Json
+            module Helpers = ``Legacy Helpers``
             module ``Domain Helpers``
             open ``Domain Helpers``
 
@@ -14708,6 +14709,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp.Domain");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System.Text.Json");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Legacy Helpers");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Domain Helpers");
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "Domain Helpers");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14575,6 +14575,7 @@ public class SymbolExtractorTests
             module MyApp.Domain
 
             open System
+            open type System.Math
 
             type UserId = int
             type User = { Name: string; Age: int }
@@ -14600,6 +14601,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp.Domain");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System.Math");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "User");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Color");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14664,6 +14664,7 @@ public class SymbolExtractorTests
 
             type Person(name: string) =
                 member this.Name = name
+                member val DisplayName = name with get, set
                 member _.Age = 0
                 static member Create(name: string) = Person(name)
                 override this.ToString() = this.Name
@@ -14695,6 +14696,7 @@ public class SymbolExtractorTests
         Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Coordinates");
         Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Handler");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Name");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DisplayName");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Age");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Create");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ToString");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14672,6 +14672,7 @@ public class SymbolExtractorTests
 
             type IVisitor =
                 abstract member Visit : unit -> unit
+                abstract Reset : unit -> unit
 
             type ILogger = interface end
 
@@ -14714,6 +14715,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Create");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ToString");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Visit");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Reset");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "validate");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "isEven");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "isOdd");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14627,20 +14627,24 @@ public class SymbolExtractorTests
             type UserId = int
             type OrderId = string
             type Names = string list
+            type public PublicId = int
             type Result<'T> = Choice<'T, string>
             type Pair<'T, 'U> = 'T * 'U
             type rec Tree<'T> = Leaf | Node of 'T * Tree<'T>
             type rec Workflow = Started | Finished
+            type public Visibility = Public | Internal
             """;
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
 
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "OrderId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Names");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "PublicId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Result");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Pair");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Tree");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Workflow");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Visibility");
         Assert.DoesNotContain(symbols, s => s.Kind == "enum" && s.Name == "Result");
         Assert.DoesNotContain(symbols, s => s.Kind == "enum" && s.Name == "Pair");
         Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Tree");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14658,6 +14658,7 @@ public class SymbolExtractorTests
         var content = """
             namespace rec MyApp.Domain
             module Json = System.Text.Json
+            module ``Domain Helpers``
 
             type UserId = int
             type OrderId = string
@@ -14701,6 +14702,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp.Domain");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System.Text.Json");
+        Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "Domain Helpers");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ILogger");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Coordinates");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14787,6 +14787,7 @@ public class SymbolExtractorTests
 
             type Color =
                 | Red
+                | [<Obsolete>] Amber
                 | Green
                 | Blue
 
@@ -14797,6 +14798,7 @@ public class SymbolExtractorTests
 
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
         Assert.Contains(symbols, s => s.Name == "Red");
+        Assert.Contains(symbols, s => s.Name == "Amber");
         Assert.Contains(symbols, s => s.Name == "Green");
         Assert.Contains(symbols, s => s.Name == "Blue");
         Assert.Contains(symbols, s => s.Name == "Name");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14673,6 +14673,8 @@ public class SymbolExtractorTests
             type IVisitor =
                 abstract member Visit : unit -> unit
                 abstract Reset : unit -> unit
+                val Id : string
+                val mutable Count : int
 
             type ILogger = interface end
 
@@ -14716,6 +14718,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ToString");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Visit");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Reset");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Id");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Count");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "validate");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "isEven");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "isOdd");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14673,6 +14673,8 @@ public class SymbolExtractorTests
 
             type ILogger = interface end
 
+            type Coordinates = struct end
+
             let validate user =
                 user.Age > 0
             """;
@@ -14683,9 +14685,11 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System.Text.Json");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ILogger");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Coordinates");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "OrderId");
         Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "ILogger");
+        Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Coordinates");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Name");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Age");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Create");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14670,6 +14670,7 @@ public class SymbolExtractorTests
             type Box<'T> = class end
             type ConstrainedBox<'T when 'T : not struct> = class end
             type Factory<'T>(value: 'T) = class end
+            type ConstrainedFactory<'T when 'T : not struct>(value: 'T) = class end
 
             type Person(name: string) =
                 member this.Name = name
@@ -14718,6 +14719,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Box");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ConstrainedBox");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Factory");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ConstrainedFactory");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ILogger");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "User Record");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Color Choice");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14675,6 +14675,8 @@ public class SymbolExtractorTests
 
             type Coordinates = struct end
 
+            type Handler = delegate of string -> unit
+
             let validate user =
                 user.Age > 0
             """;
@@ -14686,10 +14688,12 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "ILogger");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Coordinates");
+        Assert.Contains(symbols, s => s.Kind == "delegate" && s.Name == "Handler");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "OrderId");
         Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "ILogger");
         Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Coordinates");
+        Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Handler");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Name");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Age");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Create");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14659,6 +14659,7 @@ public class SymbolExtractorTests
             namespace rec MyApp.Domain
             module Json = System.Text.Json
             module ``Domain Helpers``
+            open ``Domain Helpers``
 
             type UserId = int
             type OrderId = string
@@ -14707,6 +14708,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "MyApp.Domain");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "System.Text.Json");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Domain Helpers");
         Assert.Contains(symbols, s => s.Kind == "namespace" && s.Name == "Domain Helpers");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Person");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Worker Type");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14629,6 +14629,8 @@ public class SymbolExtractorTests
             type Names = string list
             type Result<'T> = Choice<'T, string>
             type Pair<'T, 'U> = 'T * 'U
+            type rec Tree<'T> = Leaf | Node of 'T * Tree<'T>
+            type rec Workflow = Started | Finished
             """;
         var symbols = SymbolExtractor.Extract(1, "fsharp", content);
 
@@ -14637,8 +14639,12 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Names");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Result");
         Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "Pair");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Tree");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Workflow");
         Assert.DoesNotContain(symbols, s => s.Kind == "enum" && s.Name == "Result");
         Assert.DoesNotContain(symbols, s => s.Kind == "enum" && s.Name == "Pair");
+        Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Tree");
+        Assert.DoesNotContain(symbols, s => s.Kind == "typealias" && s.Name == "Workflow");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14682,6 +14682,9 @@ public class SymbolExtractorTests
             let validate user =
                 user.Age > 0
 
+            let rec isEven n = n = 0 || isOdd (n - 1)
+            and isOdd n = n <> 0 && isEven (n - 1)
+
             let workflow user =
                 task {
                     use client = createClient user
@@ -14712,6 +14715,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "ToString");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Visit");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "validate");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "isEven");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "isOdd");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "client");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "loadedUser");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "lease");


### PR DESCRIPTION
## Summary

- Expands F# reference extraction for functional application forms including condition guards, try/finally expressions, pipelines, match/match!, assert/range boundaries, lazy/raise/cast/new expressions, and function composition.
- Improves F# symbol extraction for recursive/public types, inline interfaces, struct/delegate declarations, backticked modules/types/members/import targets, generic and constrained classes, member val/val/abstract/use/let!/and bindings, and attributed union cases.
- Adds changelog fragments for the F# search improvements and fixes fragment metadata/Markdown formatting found during validation.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test CodeIndex.sln` (3953 passed, 3 skipped)
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` (index fresh)
- Focused extractor tests were run for each incremental change before committing.
- Each implementation commit received a codex adversarial review.

## Changelog

Fragments added under `changelog.d/unreleased/`:

- `+fsharp-abstract-shorthand-members.fixed.md`
- `+fsharp-and-function-symbols.fixed.md`
- `+fsharp-assert-application-calls.fixed.md`
- `+fsharp-attributed-union-cases.fixed.md`
- `+fsharp-backtick-member-names.fixed.md`
- `+fsharp-backtick-module-names.fixed.md`
- `+fsharp-backtick-type-names.fixed.md`
- `+fsharp-backticked-module-alias-targets.fixed.md`
- `+fsharp-backticked-open-imports.fixed.md`
- `+fsharp-backward-pipeline-argument-calls.fixed.md`
- `+fsharp-backward-pipeline-calls.fixed.md`
- `+fsharp-block-boundary-call-false-positives.fixed.md`
- `+fsharp-cast-application-calls.fixed.md`
- `+fsharp-chained-composition-operands.fixed.md`
- `+fsharp-composition-operand-calls.fixed.md`
- `+fsharp-computation-expression-bang-calls.fixed.md`
- `+fsharp-condition-application-calls.fixed.md`
- `+fsharp-condition-boolean-false-positives.fixed.md`
- `+fsharp-constrained-constructor-classes.fixed.md`
- `+fsharp-constrained-generic-classes.fixed.md`
- `+fsharp-delegate-type-symbols.fixed.md`
- `+fsharp-for-range-boundary-calls.fixed.md`
- `+fsharp-generic-class-symbols.fixed.md`
- `+fsharp-interface-type-symbols.fixed.md`
- `+fsharp-lazy-application-calls.fixed.md`
- `+fsharp-let-bang-bindings.fixed.md`
- `+fsharp-match-application-calls.fixed.md`
- `+fsharp-match-bang-application-calls.fixed.md`
- `+fsharp-member-val-properties.fixed.md`
- `+fsharp-module-alias-imports.fixed.md`
- `+fsharp-new-application-calls.fixed.md`
- `+fsharp-open-type-imports.fixed.md`
- `+fsharp-public-type-symbols.fixed.md`
- `+fsharp-raise-application-calls.fixed.md`
- `+fsharp-recursive-type-symbols.fixed.md`
- `+fsharp-struct-keyword-symbols.fixed.md`
- `+fsharp-try-finally-calls.fixed.md`
- `+fsharp-use-bindings.fixed.md`
- `+fsharp-val-property-symbols.fixed.md`
- `+fsharp-when-guard-application-calls.fixed.md`

## Issues

No linked issue.

## Follow-up candidates

None identified.