### PR TITLE
[codex] Improve C reference extraction coverage

### DIFF
--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -35,6 +35,7 @@ affected:
 - **C references now capture `_t` `_Generic` associations** — `_Generic(value, widget_t: ...)` now references typedef association types.
 - **C references now capture tagged `_Generic` associations** — `_Generic(value, struct node *: ...)` now references tag association types.
 - **C references now capture `_t` `_Atomic` type specifiers** — `_Atomic(widget_t)` now references the typedef type.
+- **C references now capture tagged `_Atomic` type specifiers** — `_Atomic(struct node *)` now references the tag type.
 
 ## 日本語
 
@@ -63,3 +64,4 @@ affected:
 - **C の参照抽出が `_t` の `_Generic` association を捕捉するようになりました** — `_Generic(value, widget_t: ...)` から typedef association 型への参照を生成します。
 - **C の参照抽出が tag 付き `_Generic` association を捕捉するようになりました** — `_Generic(value, struct node *: ...)` から tag association 型への参照を生成します。
 - **C の参照抽出が `_t` の `_Atomic` type specifier を捕捉するようになりました** — `_Atomic(widget_t)` から typedef 型への参照を生成します。
+- **C の参照抽出が tag 付き `_Atomic` type specifier を捕捉するようになりました** — `_Atomic(struct node *)` から tag 型への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -51,6 +51,7 @@ affected:
 - **C references now capture `_t` `va_arg` operands** — `va_arg(args, widget_t)` now references the requested typedef.
 - **C references now capture tagged `va_arg` operands** — `va_arg(args, struct node *)` now references the requested tag.
 - **C references now capture tagged `sizeof` operands** — `sizeof(struct node *)` now references the measured tag.
+- **C references now capture pointer-qualified `_t` `sizeof` operands** — `sizeof(widget_t * const)` now references the measured typedef.
 
 ## 日本語
 
@@ -95,3 +96,4 @@ affected:
 - **C の参照抽出が `_t` `va_arg` operand を捕捉するようになりました** — `va_arg(args, widget_t)` から要求 typedef への参照を生成します。
 - **C の参照抽出が tag 付き `va_arg` operand を捕捉するようになりました** — `va_arg(args, struct node *)` から要求 tag への参照を生成します。
 - **C の参照抽出が tag 付き `sizeof` operand を捕捉するようになりました** — `sizeof(struct node *)` から測定 tag への参照を生成します。
+- **C の参照抽出が pointer-qualified `_t` `sizeof` operand を捕捉するようになりました** — `sizeof(widget_t * const)` から測定 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -40,6 +40,7 @@ affected:
 - **C references now capture tagged `_Alignas` specifiers** — `_Alignas(struct node)` and `alignas(union value *)` now reference tag types.
 - **C references now capture `_t` function-pointer typedef returns** — `typedef widget_t (*factory_t)(void);` now references the return typedef.
 - **C references now capture tagged function-pointer typedef returns** — `typedef struct node *(*factory_t)(void);` now references the returned tag.
+- **C references now capture `_t` function-pointer declaration returns** — `widget_t (*factory)(void);` now references the return typedef.
 
 ## 日本語
 
@@ -73,3 +74,4 @@ affected:
 - **C の参照抽出が tag 付き `_Alignas` specifier を捕捉するようになりました** — `_Alignas(struct node)` と `alignas(union value *)` から tag 型への参照を生成します。
 - **C の参照抽出が `_t` function-pointer typedef の戻り型を捕捉するようになりました** — `typedef widget_t (*factory_t)(void);` から戻り値 typedef への参照を生成します。
 - **C の参照抽出が tag 付き function-pointer typedef の戻り型を捕捉するようになりました** — `typedef struct node *(*factory_t)(void);` から戻り値 tag への参照を生成します。
+- **C の参照抽出が `_t` function-pointer 宣言の戻り型を捕捉するようになりました** — `widget_t (*factory)(void);` から戻り値 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -59,6 +59,7 @@ affected:
 - **C references now capture `_t` `typeof_unqual` operands** — `typeof_unqual(widget_t *)` now references the operand typedef.
 - **C references now capture tagged `typeof_unqual` operands** — `typeof_unqual(struct node *)` now references the operand tag.
 - **C references now capture `_t` `__builtin_types_compatible_p` operands** — both typedef type arguments now produce references.
+- **C references now capture tagged `__builtin_types_compatible_p` operands** — both tag type arguments now produce references.
 
 ## 日本語
 
@@ -111,3 +112,4 @@ affected:
 - **C の参照抽出が `_t` `typeof_unqual` operand を捕捉するようになりました** — `typeof_unqual(widget_t *)` から operand typedef への参照を生成します。
 - **C の参照抽出が tag 付き `typeof_unqual` operand を捕捉するようになりました** — `typeof_unqual(struct node *)` から operand tag への参照を生成します。
 - **C の参照抽出が `_t` `__builtin_types_compatible_p` operand を捕捉するようになりました** — 2つの typedef 型引数から参照を生成します。
+- **C の参照抽出が tag 付き `__builtin_types_compatible_p` operand を捕捉するようになりました** — 2つの tag 型引数から参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -31,6 +31,7 @@ affected:
 - **C references now capture `_t` compound literals** — literals such as `(widget_t){0}` now reference the typedef type.
 - **C references now capture tagged compound literals** — literals such as `(struct node){0}` now reference the tag name.
 - **C references now capture `_t` `typeof` operands** — `typeof(widget_t)` and `__typeof__(message_t *)` now reference typedef names.
+- **C references now capture tagged `typeof` operands** — `typeof(struct node *)` now references the tag name.
 
 ## 日本語
 
@@ -55,3 +56,4 @@ affected:
 - **C の参照抽出が `_t` compound literal を捕捉するようになりました** — `(widget_t){0}` のような literal から typedef 型への参照を生成します。
 - **C の参照抽出が tag 付き compound literal を捕捉するようになりました** — `(struct node){0}` のような literal から tag 名への参照を生成します。
 - **C の参照抽出が `_t` の `typeof` operand を捕捉するようになりました** — `typeof(widget_t)` と `__typeof__(message_t *)` から typedef 名への参照を生成します。
+- **C の参照抽出が tag 付き `typeof` operand を捕捉するようになりました** — `typeof(struct node *)` から tag 名への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -66,6 +66,7 @@ affected:
 - **C references now capture tagged `__builtin_va_arg` operands** — `__builtin_va_arg(args, struct node *)` now references the requested tag.
 - **C references now capture pointer-qualified `_t` return types** — `widget_t * const make_widget(void)` now references the returned typedef.
 - **C references now capture pointer-qualified tagged return types** — `struct node * const make_node(void)` now references the returned tag.
+- **C references now capture pointer-qualified `_t` parameter types** — `widget_t * restrict widget` now references the parameter typedef.
 
 ## 日本語
 
@@ -125,3 +126,4 @@ affected:
 - **C の参照抽出が tag 付き `__builtin_va_arg` operand を捕捉するようになりました** — `__builtin_va_arg(args, struct node *)` から要求 tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` 戻り値型を捕捉するようになりました** — `widget_t * const make_widget(void)` から戻り値 typedef への参照を生成します。
 - **C の参照抽出が pointer-qualified tag 付き戻り値型を捕捉するようになりました** — `struct node * const make_node(void)` から戻り値 tag への参照を生成します。
+- **C の参照抽出が pointer-qualified `_t` parameter 型を捕捉するようになりました** — `widget_t * restrict widget` から parameter typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -16,6 +16,7 @@ affected:
 - **C search now indexes union declarations** — named `union` definitions now produce `union` symbols alongside structs and enums.
 - **C search now indexes union typedef aliases** — forward `typedef union Name Alias;` declarations now provide searchable `union` symbols for alias names.
 - **C search now indexes bracket-attributed functions** — C23-style `[[nodiscard]] int f(...)` declarations now surface by function name.
+- **C references now capture `#include_next` headers** — next-header directives now appear in reference-oriented queries, not only symbol search.
 
 ## 日本語
 
@@ -25,3 +26,4 @@ affected:
 - **C 検索が union 宣言をインデックスするようになりました** — 名前付き `union` 定義も struct / enum と同じように `union` シンボルを生成します。
 - **C 検索が union typedef エイリアスをインデックスするようになりました** — forward `typedef union Name Alias;` 宣言でも alias 名の検索可能な `union` シンボルを生成します。
 - **C 検索が角括弧属性付き関数をインデックスするようになりました** — C23 形式の `[[nodiscard]] int f(...)` 宣言も関数名で表面化します。
+- **C の参照抽出が `#include_next` ヘッダーを捕捉するようになりました** — next-header ディレクティブが symbol search だけでなく参照系クエリにも出るようになりました。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -14,6 +14,7 @@ affected:
 - **C search now indexes `#include_next` targets** — GNU-style next-header directives now produce import symbols alongside ordinary `#include` rows.
 - **C search now indexes `#import` headers** — import-style header directives now surface as import symbols for header navigation.
 - **C search now indexes union declarations** — named `union` definitions now produce `union` symbols alongside structs and enums.
+- **C search now indexes union typedef aliases** — forward `typedef union Name Alias;` declarations now provide searchable `union` symbols for alias names.
 
 ## 日本語
 
@@ -21,3 +22,4 @@ affected:
 - **C 検索が `#include_next` の参照先をインデックスするようになりました** — GNU 風の next-header ディレクティブも通常の `#include` と同じように import シンボルを生成します。
 - **C 検索が `#import` ヘッダーをインデックスするようになりました** — import 形式のヘッダーディレクティブも import シンボルとして表面化し、ヘッダー移動に使えるようになりました。
 - **C 検索が union 宣言をインデックスするようになりました** — 名前付き `union` 定義も struct / enum と同じように `union` シンボルを生成します。
+- **C 検索が union typedef エイリアスをインデックスするようになりました** — forward `typedef union Name Alias;` 宣言でも alias 名の検索可能な `union` シンボルを生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -65,6 +65,7 @@ affected:
 - **C references now capture `_t` `__builtin_va_arg` operands** — `__builtin_va_arg(args, widget_t)` now references the requested typedef.
 - **C references now capture tagged `__builtin_va_arg` operands** — `__builtin_va_arg(args, struct node *)` now references the requested tag.
 - **C references now capture pointer-qualified `_t` return types** — `widget_t * const make_widget(void)` now references the returned typedef.
+- **C references now capture pointer-qualified tagged return types** — `struct node * const make_node(void)` now references the returned tag.
 
 ## 日本語
 
@@ -123,3 +124,4 @@ affected:
 - **C の参照抽出が `_t` `__builtin_va_arg` operand を捕捉するようになりました** — `__builtin_va_arg(args, widget_t)` から要求 typedef への参照を生成します。
 - **C の参照抽出が tag 付き `__builtin_va_arg` operand を捕捉するようになりました** — `__builtin_va_arg(args, struct node *)` から要求 tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` 戻り値型を捕捉するようになりました** — `widget_t * const make_widget(void)` から戻り値 typedef への参照を生成します。
+- **C の参照抽出が pointer-qualified tag 付き戻り値型を捕捉するようになりました** — `struct node * const make_node(void)` から戻り値 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -15,6 +15,7 @@ affected:
 - **C search now indexes `#import` headers** — import-style header directives now surface as import symbols for header navigation.
 - **C search now indexes union declarations** — named `union` definitions now produce `union` symbols alongside structs and enums.
 - **C search now indexes union typedef aliases** — forward `typedef union Name Alias;` declarations now provide searchable `union` symbols for alias names.
+- **C search now indexes bracket-attributed functions** — C23-style `[[nodiscard]] int f(...)` declarations now surface by function name.
 
 ## 日本語
 
@@ -23,3 +24,4 @@ affected:
 - **C 検索が `#import` ヘッダーをインデックスするようになりました** — import 形式のヘッダーディレクティブも import シンボルとして表面化し、ヘッダー移動に使えるようになりました。
 - **C 検索が union 宣言をインデックスするようになりました** — 名前付き `union` 定義も struct / enum と同じように `union` シンボルを生成します。
 - **C 検索が union typedef エイリアスをインデックスするようになりました** — forward `typedef union Name Alias;` 宣言でも alias 名の検索可能な `union` シンボルを生成します。
+- **C 検索が角括弧属性付き関数をインデックスするようになりました** — C23 形式の `[[nodiscard]] int f(...)` 宣言も関数名で表面化します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -29,6 +29,7 @@ affected:
 - **C references now capture `_t` parameter types** — function parameters such as `widget_t *widget` now point back to typedef names.
 - **C references now capture tagged parameter types** — parameters such as `struct node *node` now produce type references for tag names.
 - **C references now capture `_t` compound literals** — literals such as `(widget_t){0}` now reference the typedef type.
+- **C references now capture tagged compound literals** — literals such as `(struct node){0}` now reference the tag name.
 
 ## 日本語
 
@@ -51,3 +52,4 @@ affected:
 - **C の参照抽出が `_t` parameter 型を捕捉するようになりました** — `widget_t *widget` のような関数 parameter から typedef 名へ戻れるようになりました。
 - **C の参照抽出が tag 付き parameter 型を捕捉するようになりました** — `struct node *node` のような parameter から tag 名の type reference を生成します。
 - **C の参照抽出が `_t` compound literal を捕捉するようになりました** — `(widget_t){0}` のような literal から typedef 型への参照を生成します。
+- **C の参照抽出が tag 付き compound literal を捕捉するようになりました** — `(struct node){0}` のような literal から tag 名への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -55,6 +55,7 @@ affected:
 - **C references now capture pointer-qualified tagged `sizeof` operands** — `sizeof(struct node * const)` now references the measured tag.
 - **C references now capture tagged alignment operands** — `_Alignof(struct node *)` and `alignof(union value)` now reference measured tags.
 - **C references now capture `_t` GNU alignment operands** — `__alignof__(widget_t *)` now references the measured typedef.
+- **C references now capture tagged GNU alignment operands** — `__alignof__(struct node *)` now references the measured tag.
 
 ## 日本語
 
@@ -103,3 +104,4 @@ affected:
 - **C の参照抽出が pointer-qualified tag 付き `sizeof` operand を捕捉するようになりました** — `sizeof(struct node * const)` から測定 tag への参照を生成します。
 - **C の参照抽出が tag 付き alignment operand を捕捉するようになりました** — `_Alignof(struct node *)` と `alignof(union value)` から測定 tag への参照を生成します。
 - **C の参照抽出が `_t` GNU alignment operand を捕捉するようになりました** — `__alignof__(widget_t *)` から測定 typedef への参照を生成します。
+- **C の参照抽出が tag 付き GNU alignment operand を捕捉するようになりました** — `__alignof__(struct node *)` から測定 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -53,6 +53,7 @@ affected:
 - **C references now capture tagged `sizeof` operands** — `sizeof(struct node *)` now references the measured tag.
 - **C references now capture pointer-qualified `_t` `sizeof` operands** — `sizeof(widget_t * const)` now references the measured typedef.
 - **C references now capture pointer-qualified tagged `sizeof` operands** — `sizeof(struct node * const)` now references the measured tag.
+- **C references now capture tagged alignment operands** — `_Alignof(struct node *)` and `alignof(union value)` now reference measured tags.
 
 ## 日本語
 
@@ -99,3 +100,4 @@ affected:
 - **C の参照抽出が tag 付き `sizeof` operand を捕捉するようになりました** — `sizeof(struct node *)` から測定 tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` `sizeof` operand を捕捉するようになりました** — `sizeof(widget_t * const)` から測定 typedef への参照を生成します。
 - **C の参照抽出が pointer-qualified tag 付き `sizeof` operand を捕捉するようになりました** — `sizeof(struct node * const)` から測定 tag への参照を生成します。
+- **C の参照抽出が tag 付き alignment operand を捕捉するようになりました** — `_Alignof(struct node *)` と `alignof(union value)` から測定 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -60,6 +60,7 @@ affected:
 - **C references now capture tagged `typeof_unqual` operands** — `typeof_unqual(struct node *)` now references the operand tag.
 - **C references now capture `_t` `__builtin_types_compatible_p` operands** — both typedef type arguments now produce references.
 - **C references now capture tagged `__builtin_types_compatible_p` operands** — both tag type arguments now produce references.
+- **C references now capture `_t` `__builtin_offsetof` operands** — `__builtin_offsetof(widget_t, field)` now references the operand typedef.
 
 ## 日本語
 
@@ -113,3 +114,4 @@ affected:
 - **C の参照抽出が tag 付き `typeof_unqual` operand を捕捉するようになりました** — `typeof_unqual(struct node *)` から operand tag への参照を生成します。
 - **C の参照抽出が `_t` `__builtin_types_compatible_p` operand を捕捉するようになりました** — 2つの typedef 型引数から参照を生成します。
 - **C の参照抽出が tag 付き `__builtin_types_compatible_p` operand を捕捉するようになりました** — 2つの tag 型引数から参照を生成します。
+- **C の参照抽出が `_t` `__builtin_offsetof` operand を捕捉するようになりました** — `__builtin_offsetof(widget_t, field)` から operand typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -33,6 +33,7 @@ affected:
 - **C references now capture `_t` `typeof` operands** — `typeof(widget_t)` and `__typeof__(message_t *)` now reference typedef names.
 - **C references now capture tagged `typeof` operands** — `typeof(struct node *)` now references the tag name.
 - **C references now capture `_t` `_Generic` associations** — `_Generic(value, widget_t: ...)` now references typedef association types.
+- **C references now capture tagged `_Generic` associations** — `_Generic(value, struct node *: ...)` now references tag association types.
 
 ## 日本語
 
@@ -59,3 +60,4 @@ affected:
 - **C の参照抽出が `_t` の `typeof` operand を捕捉するようになりました** — `typeof(widget_t)` と `__typeof__(message_t *)` から typedef 名への参照を生成します。
 - **C の参照抽出が tag 付き `typeof` operand を捕捉するようになりました** — `typeof(struct node *)` から tag 名への参照を生成します。
 - **C の参照抽出が `_t` の `_Generic` association を捕捉するようになりました** — `_Generic(value, widget_t: ...)` から typedef association 型への参照を生成します。
+- **C の参照抽出が tag 付き `_Generic` association を捕捉するようになりました** — `_Generic(value, struct node *: ...)` から tag association 型への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -11,7 +11,9 @@ affected:
 ## English
 
 - **C search now indexes spaced include directives** — `# include <header.h>` forms now produce import symbols, so symbol/search navigation sees headers written with preprocessor whitespace.
+- **C search now indexes `#include_next` targets** — GNU-style next-header directives now produce import symbols alongside ordinary `#include` rows.
 
 ## 日本語
 
 - **C 検索が空白付き include ディレクティブをインデックスするようになりました** — `# include <header.h>` 形式でも import シンボルを生成し、preprocessor 空白を使ったヘッダーも symbol/search navigation で見つかるようになりました。
+- **C 検索が `#include_next` の参照先をインデックスするようになりました** — GNU 風の next-header ディレクティブも通常の `#include` と同じように import シンボルを生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -41,6 +41,7 @@ affected:
 - **C references now capture `_t` function-pointer typedef returns** — `typedef widget_t (*factory_t)(void);` now references the return typedef.
 - **C references now capture tagged function-pointer typedef returns** — `typedef struct node *(*factory_t)(void);` now references the returned tag.
 - **C references now capture `_t` function-pointer declaration returns** — `widget_t (*factory)(void);` now references the return typedef.
+- **C references now capture tagged function-pointer declaration returns** — `struct node *(*factory)(void);` now references the returned tag.
 
 ## 日本語
 
@@ -75,3 +76,4 @@ affected:
 - **C の参照抽出が `_t` function-pointer typedef の戻り型を捕捉するようになりました** — `typedef widget_t (*factory_t)(void);` から戻り値 typedef への参照を生成します。
 - **C の参照抽出が tag 付き function-pointer typedef の戻り型を捕捉するようになりました** — `typedef struct node *(*factory_t)(void);` から戻り値 tag への参照を生成します。
 - **C の参照抽出が `_t` function-pointer 宣言の戻り型を捕捉するようになりました** — `widget_t (*factory)(void);` から戻り値 typedef への参照を生成します。
+- **C の参照抽出が tag 付き function-pointer 宣言の戻り型を捕捉するようになりました** — `struct node *(*factory)(void);` から戻り値 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -63,6 +63,7 @@ affected:
 - **C references now capture `_t` `__builtin_offsetof` operands** — `__builtin_offsetof(widget_t, field)` now references the operand typedef.
 - **C references now capture tagged `__builtin_offsetof` operands** — `__builtin_offsetof(struct node, next)` now references the operand tag.
 - **C references now capture `_t` `__builtin_va_arg` operands** — `__builtin_va_arg(args, widget_t)` now references the requested typedef.
+- **C references now capture tagged `__builtin_va_arg` operands** — `__builtin_va_arg(args, struct node *)` now references the requested tag.
 
 ## 日本語
 
@@ -119,3 +120,4 @@ affected:
 - **C の参照抽出が `_t` `__builtin_offsetof` operand を捕捉するようになりました** — `__builtin_offsetof(widget_t, field)` から operand typedef への参照を生成します。
 - **C の参照抽出が tag 付き `__builtin_offsetof` operand を捕捉するようになりました** — `__builtin_offsetof(struct node, next)` から operand tag への参照を生成します。
 - **C の参照抽出が `_t` `__builtin_va_arg` operand を捕捉するようになりました** — `__builtin_va_arg(args, widget_t)` から要求 typedef への参照を生成します。
+- **C の参照抽出が tag 付き `__builtin_va_arg` operand を捕捉するようになりました** — `__builtin_va_arg(args, struct node *)` から要求 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -54,6 +54,7 @@ affected:
 - **C references now capture pointer-qualified `_t` `sizeof` operands** — `sizeof(widget_t * const)` now references the measured typedef.
 - **C references now capture pointer-qualified tagged `sizeof` operands** — `sizeof(struct node * const)` now references the measured tag.
 - **C references now capture tagged alignment operands** — `_Alignof(struct node *)` and `alignof(union value)` now reference measured tags.
+- **C references now capture `_t` GNU alignment operands** — `__alignof__(widget_t *)` now references the measured typedef.
 
 ## 日本語
 
@@ -101,3 +102,4 @@ affected:
 - **C の参照抽出が pointer-qualified `_t` `sizeof` operand を捕捉するようになりました** — `sizeof(widget_t * const)` から測定 typedef への参照を生成します。
 - **C の参照抽出が pointer-qualified tag 付き `sizeof` operand を捕捉するようになりました** — `sizeof(struct node * const)` から測定 tag への参照を生成します。
 - **C の参照抽出が tag 付き alignment operand を捕捉するようになりました** — `_Alignof(struct node *)` と `alignof(union value)` から測定 tag への参照を生成します。
+- **C の参照抽出が `_t` GNU alignment operand を捕捉するようになりました** — `__alignof__(widget_t *)` から測定 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -20,6 +20,7 @@ affected:
 - **C references now capture macro include targets** — `#include PROJECT_HEADER` now produces a header reference for macro-based include wiring.
 - **C references now suppress type-keyword noise** — `struct`, `enum`, `union`, and qualifiers are filtered out of C type-reference rows so typedef edges point at real tag names.
 - **C references now capture `_t` cast types** — lowercase typedef casts such as `(widget_t *)raw` now produce type-reference rows.
+- **C references now capture `_t` `sizeof` operands** — `sizeof(widget_t)` now produces a type-reference row for typedef-based size checks.
 
 ## 日本語
 
@@ -33,3 +34,4 @@ affected:
 - **C の参照抽出が macro include の参照先を捕捉するようになりました** — `#include PROJECT_HEADER` でも macro ベースの include 配線をヘッダー参照として生成します。
 - **C の参照抽出が型キーワード由来のノイズを抑えるようになりました** — `struct` / `enum` / `union` や修飾子を C の type-reference 行から除外し、typedef edge が実際の tag 名を指すようにしました。
 - **C の参照抽出が `_t` cast 型を捕捉するようになりました** — `(widget_t *)raw` のような lowercase typedef cast でも type-reference 行を生成します。
+- **C の参照抽出が `_t` の `sizeof` operand を捕捉するようになりました** — `sizeof(widget_t)` でも typedef ベースの size check に対する type-reference 行を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -28,6 +28,7 @@ affected:
 - **C references now capture tagged return types** — functions returning `struct node *` now produce type references for the returned tag.
 - **C references now capture `_t` parameter types** — function parameters such as `widget_t *widget` now point back to typedef names.
 - **C references now capture tagged parameter types** — parameters such as `struct node *node` now produce type references for tag names.
+- **C references now capture `_t` compound literals** — literals such as `(widget_t){0}` now reference the typedef type.
 
 ## 日本語
 
@@ -49,3 +50,4 @@ affected:
 - **C の参照抽出が tag 付き戻り値型を捕捉するようになりました** — `struct node *` を返す関数から戻り値 tag の type reference を生成します。
 - **C の参照抽出が `_t` parameter 型を捕捉するようになりました** — `widget_t *widget` のような関数 parameter から typedef 名へ戻れるようになりました。
 - **C の参照抽出が tag 付き parameter 型を捕捉するようになりました** — `struct node *node` のような parameter から tag 名の type reference を生成します。
+- **C の参照抽出が `_t` compound literal を捕捉するようになりました** — `(widget_t){0}` のような literal から typedef 型への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -43,6 +43,7 @@ affected:
 - **C references now capture `_t` function-pointer declaration returns** — `widget_t (*factory)(void);` now references the return typedef.
 - **C references now capture tagged function-pointer declaration returns** — `struct node *(*factory)(void);` now references the returned tag.
 - **C references now capture pointer-qualified `_t` declarations** — `widget_t * restrict current;` now references the declared typedef.
+- **C references now capture pointer-qualified tagged declarations** — `struct node * const next;` now references the declared tag.
 
 ## 日本語
 
@@ -79,3 +80,4 @@ affected:
 - **C の参照抽出が `_t` function-pointer 宣言の戻り型を捕捉するようになりました** — `widget_t (*factory)(void);` から戻り値 typedef への参照を生成します。
 - **C の参照抽出が tag 付き function-pointer 宣言の戻り型を捕捉するようになりました** — `struct node *(*factory)(void);` から戻り値 tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` 宣言を捕捉するようになりました** — `widget_t * restrict current;` から宣言 typedef への参照を生成します。
+- **C の参照抽出が pointer-qualified tag 付き宣言を捕捉するようになりました** — `struct node * const next;` から宣言 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -69,6 +69,7 @@ affected:
 - **C references now capture pointer-qualified `_t` parameter types** — `widget_t * restrict widget` now references the parameter typedef.
 - **C references now capture pointer-qualified tagged parameter types** — `struct node * const node` now references the parameter tag.
 - **C references now capture pointer-qualified `_t` `_Generic` associations** — `widget_t * const:` now references the association typedef.
+- **C references now capture pointer-qualified tagged `_Generic` associations** — `struct node * const:` now references the association tag.
 
 ## 日本語
 
@@ -131,3 +132,4 @@ affected:
 - **C の参照抽出が pointer-qualified `_t` parameter 型を捕捉するようになりました** — `widget_t * restrict widget` から parameter typedef への参照を生成します。
 - **C の参照抽出が pointer-qualified tag 付き parameter 型を捕捉するようになりました** — `struct node * const node` から parameter tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` `_Generic` association を捕捉するようになりました** — `widget_t * const:` から association typedef への参照を生成します。
+- **C の参照抽出が pointer-qualified tag 付き `_Generic` association を捕捉するようになりました** — `struct node * const:` から association tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -24,6 +24,7 @@ affected:
 - **C references now capture `_t` alignment operands** — `_Alignof(widget_t)` and `alignof(config_t)` now surface typedef operands as type references.
 - **C references now capture `_t` declaration types** — local declarations such as `widget_t *current;` now point search results back to typedef names.
 - **C references now capture tagged declaration types** — declarations such as `struct node *next;` now produce type references for the tag name.
+- **C references now capture `_t` return types** — functions returning typedefs such as `widget_t *make_widget(void)` now reference the typedef name.
 
 ## 日本語
 
@@ -41,3 +42,4 @@ affected:
 - **C の参照抽出が `_t` の alignment operand を捕捉するようになりました** — `_Alignof(widget_t)` と `alignof(config_t)` でも typedef operand を type reference として表面化します。
 - **C の参照抽出が `_t` 宣言型を捕捉するようになりました** — `widget_t *current;` のような local declaration から typedef 名へ search result が戻れるようになりました。
 - **C の参照抽出が tag 付き宣言型を捕捉するようになりました** — `struct node *next;` のような宣言から tag 名の type reference を生成します。
+- **C の参照抽出が `_t` 戻り値型を捕捉するようになりました** — `widget_t *make_widget(void)` のように typedef を返す関数から typedef 名への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -42,6 +42,7 @@ affected:
 - **C references now capture tagged function-pointer typedef returns** — `typedef struct node *(*factory_t)(void);` now references the returned tag.
 - **C references now capture `_t` function-pointer declaration returns** — `widget_t (*factory)(void);` now references the return typedef.
 - **C references now capture tagged function-pointer declaration returns** — `struct node *(*factory)(void);` now references the returned tag.
+- **C references now capture pointer-qualified `_t` declarations** — `widget_t * restrict current;` now references the declared typedef.
 
 ## 日本語
 
@@ -77,3 +78,4 @@ affected:
 - **C の参照抽出が tag 付き function-pointer typedef の戻り型を捕捉するようになりました** — `typedef struct node *(*factory_t)(void);` から戻り値 tag への参照を生成します。
 - **C の参照抽出が `_t` function-pointer 宣言の戻り型を捕捉するようになりました** — `widget_t (*factory)(void);` から戻り値 typedef への参照を生成します。
 - **C の参照抽出が tag 付き function-pointer 宣言の戻り型を捕捉するようになりました** — `struct node *(*factory)(void);` から戻り値 tag への参照を生成します。
+- **C の参照抽出が pointer-qualified `_t` 宣言を捕捉するようになりました** — `widget_t * restrict current;` から宣言 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -32,6 +32,7 @@ affected:
 - **C references now capture tagged compound literals** — literals such as `(struct node){0}` now reference the tag name.
 - **C references now capture `_t` `typeof` operands** — `typeof(widget_t)` and `__typeof__(message_t *)` now reference typedef names.
 - **C references now capture tagged `typeof` operands** — `typeof(struct node *)` now references the tag name.
+- **C references now capture `_t` `_Generic` associations** — `_Generic(value, widget_t: ...)` now references typedef association types.
 
 ## 日本語
 
@@ -57,3 +58,4 @@ affected:
 - **C の参照抽出が tag 付き compound literal を捕捉するようになりました** — `(struct node){0}` のような literal から tag 名への参照を生成します。
 - **C の参照抽出が `_t` の `typeof` operand を捕捉するようになりました** — `typeof(widget_t)` と `__typeof__(message_t *)` から typedef 名への参照を生成します。
 - **C の参照抽出が tag 付き `typeof` operand を捕捉するようになりました** — `typeof(struct node *)` から tag 名への参照を生成します。
+- **C の参照抽出が `_t` の `_Generic` association を捕捉するようになりました** — `_Generic(value, widget_t: ...)` から typedef association 型への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -27,6 +27,7 @@ affected:
 - **C references now capture `_t` return types** — functions returning typedefs such as `widget_t *make_widget(void)` now reference the typedef name.
 - **C references now capture tagged return types** — functions returning `struct node *` now produce type references for the returned tag.
 - **C references now capture `_t` parameter types** — function parameters such as `widget_t *widget` now point back to typedef names.
+- **C references now capture tagged parameter types** — parameters such as `struct node *node` now produce type references for tag names.
 
 ## 日本語
 
@@ -47,3 +48,4 @@ affected:
 - **C の参照抽出が `_t` 戻り値型を捕捉するようになりました** — `widget_t *make_widget(void)` のように typedef を返す関数から typedef 名への参照を生成します。
 - **C の参照抽出が tag 付き戻り値型を捕捉するようになりました** — `struct node *` を返す関数から戻り値 tag の type reference を生成します。
 - **C の参照抽出が `_t` parameter 型を捕捉するようになりました** — `widget_t *widget` のような関数 parameter から typedef 名へ戻れるようになりました。
+- **C の参照抽出が tag 付き parameter 型を捕捉するようになりました** — `struct node *node` のような parameter から tag 名の type reference を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -56,6 +56,7 @@ affected:
 - **C references now capture tagged alignment operands** — `_Alignof(struct node *)` and `alignof(union value)` now reference measured tags.
 - **C references now capture `_t` GNU alignment operands** — `__alignof__(widget_t *)` now references the measured typedef.
 - **C references now capture tagged GNU alignment operands** — `__alignof__(struct node *)` now references the measured tag.
+- **C references now capture `_t` `typeof_unqual` operands** — `typeof_unqual(widget_t *)` now references the operand typedef.
 
 ## 日本語
 
@@ -105,3 +106,4 @@ affected:
 - **C の参照抽出が tag 付き alignment operand を捕捉するようになりました** — `_Alignof(struct node *)` と `alignof(union value)` から測定 tag への参照を生成します。
 - **C の参照抽出が `_t` GNU alignment operand を捕捉するようになりました** — `__alignof__(widget_t *)` から測定 typedef への参照を生成します。
 - **C の参照抽出が tag 付き GNU alignment operand を捕捉するようになりました** — `__alignof__(struct node *)` から測定 tag への参照を生成します。
+- **C の参照抽出が `_t` `typeof_unqual` operand を捕捉するようになりました** — `typeof_unqual(widget_t *)` から operand typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -36,6 +36,7 @@ affected:
 - **C references now capture tagged `_Generic` associations** — `_Generic(value, struct node *: ...)` now references tag association types.
 - **C references now capture `_t` `_Atomic` type specifiers** — `_Atomic(widget_t)` now references the typedef type.
 - **C references now capture tagged `_Atomic` type specifiers** — `_Atomic(struct node *)` now references the tag type.
+- **C references now capture `_t` `_Alignas` specifiers** — `_Alignas(widget_t)` and `alignas(message_t *)` now reference typedef types.
 
 ## 日本語
 
@@ -65,3 +66,4 @@ affected:
 - **C の参照抽出が tag 付き `_Generic` association を捕捉するようになりました** — `_Generic(value, struct node *: ...)` から tag association 型への参照を生成します。
 - **C の参照抽出が `_t` の `_Atomic` type specifier を捕捉するようになりました** — `_Atomic(widget_t)` から typedef 型への参照を生成します。
 - **C の参照抽出が tag 付き `_Atomic` type specifier を捕捉するようになりました** — `_Atomic(struct node *)` から tag 型への参照を生成します。
+- **C の参照抽出が `_t` の `_Alignas` specifier を捕捉するようになりました** — `_Alignas(widget_t)` と `alignas(message_t *)` から typedef 型への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -47,6 +47,7 @@ affected:
 - **C references now capture `_t` pointer-to-array declarations** — `widget_t (*items)[4];` now references the array element typedef.
 - **C references now capture tagged pointer-to-array declarations** — `struct node (*items)[4];` now references the array element tag.
 - **C references now capture `_t` `offsetof` operands** — `offsetof(widget_t, field)` now references the operand typedef.
+- **C references now capture tagged `offsetof` operands** — `offsetof(struct node, next)` now references the operand tag.
 
 ## 日本語
 
@@ -87,3 +88,4 @@ affected:
 - **C の参照抽出が `_t` pointer-to-array 宣言を捕捉するようになりました** — `widget_t (*items)[4];` から配列要素 typedef への参照を生成します。
 - **C の参照抽出が tag 付き pointer-to-array 宣言を捕捉するようになりました** — `struct node (*items)[4];` から配列要素 tag への参照を生成します。
 - **C の参照抽出が `_t` `offsetof` operand を捕捉するようになりました** — `offsetof(widget_t, field)` から operand typedef への参照を生成します。
+- **C の参照抽出が tag 付き `offsetof` operand を捕捉するようになりました** — `offsetof(struct node, next)` から operand tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -64,6 +64,7 @@ affected:
 - **C references now capture tagged `__builtin_offsetof` operands** — `__builtin_offsetof(struct node, next)` now references the operand tag.
 - **C references now capture `_t` `__builtin_va_arg` operands** — `__builtin_va_arg(args, widget_t)` now references the requested typedef.
 - **C references now capture tagged `__builtin_va_arg` operands** — `__builtin_va_arg(args, struct node *)` now references the requested tag.
+- **C references now capture pointer-qualified `_t` return types** — `widget_t * const make_widget(void)` now references the returned typedef.
 
 ## 日本語
 
@@ -121,3 +122,4 @@ affected:
 - **C の参照抽出が tag 付き `__builtin_offsetof` operand を捕捉するようになりました** — `__builtin_offsetof(struct node, next)` から operand tag への参照を生成します。
 - **C の参照抽出が `_t` `__builtin_va_arg` operand を捕捉するようになりました** — `__builtin_va_arg(args, widget_t)` から要求 typedef への参照を生成します。
 - **C の参照抽出が tag 付き `__builtin_va_arg` operand を捕捉するようになりました** — `__builtin_va_arg(args, struct node *)` から要求 tag への参照を生成します。
+- **C の参照抽出が pointer-qualified `_t` 戻り値型を捕捉するようになりました** — `widget_t * const make_widget(void)` から戻り値 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -19,6 +19,7 @@ affected:
 - **C references now capture `#include_next` headers** — next-header directives now appear in reference-oriented queries, not only symbol search.
 - **C references now capture macro include targets** — `#include PROJECT_HEADER` now produces a header reference for macro-based include wiring.
 - **C references now suppress type-keyword noise** — `struct`, `enum`, `union`, and qualifiers are filtered out of C type-reference rows so typedef edges point at real tag names.
+- **C references now capture `_t` cast types** — lowercase typedef casts such as `(widget_t *)raw` now produce type-reference rows.
 
 ## 日本語
 
@@ -31,3 +32,4 @@ affected:
 - **C の参照抽出が `#include_next` ヘッダーを捕捉するようになりました** — next-header ディレクティブが symbol search だけでなく参照系クエリにも出るようになりました。
 - **C の参照抽出が macro include の参照先を捕捉するようになりました** — `#include PROJECT_HEADER` でも macro ベースの include 配線をヘッダー参照として生成します。
 - **C の参照抽出が型キーワード由来のノイズを抑えるようになりました** — `struct` / `enum` / `union` や修飾子を C の type-reference 行から除外し、typedef edge が実際の tag 名を指すようにしました。
+- **C の参照抽出が `_t` cast 型を捕捉するようになりました** — `(widget_t *)raw` のような lowercase typedef cast でも type-reference 行を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -37,6 +37,7 @@ affected:
 - **C references now capture `_t` `_Atomic` type specifiers** — `_Atomic(widget_t)` now references the typedef type.
 - **C references now capture tagged `_Atomic` type specifiers** — `_Atomic(struct node *)` now references the tag type.
 - **C references now capture `_t` `_Alignas` specifiers** — `_Alignas(widget_t)` and `alignas(message_t *)` now reference typedef types.
+- **C references now capture tagged `_Alignas` specifiers** — `_Alignas(struct node)` and `alignas(union value *)` now reference tag types.
 
 ## 日本語
 
@@ -67,3 +68,4 @@ affected:
 - **C の参照抽出が `_t` の `_Atomic` type specifier を捕捉するようになりました** — `_Atomic(widget_t)` から typedef 型への参照を生成します。
 - **C の参照抽出が tag 付き `_Atomic` type specifier を捕捉するようになりました** — `_Atomic(struct node *)` から tag 型への参照を生成します。
 - **C の参照抽出が `_t` の `_Alignas` specifier を捕捉するようになりました** — `_Alignas(widget_t)` と `alignas(message_t *)` から typedef 型への参照を生成します。
+- **C の参照抽出が tag 付き `_Alignas` specifier を捕捉するようになりました** — `_Alignas(struct node)` と `alignas(union value *)` から tag 型への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -45,6 +45,7 @@ affected:
 - **C references now capture pointer-qualified `_t` declarations** — `widget_t * restrict current;` now references the declared typedef.
 - **C references now capture pointer-qualified tagged declarations** — `struct node * const next;` now references the declared tag.
 - **C references now capture `_t` pointer-to-array declarations** — `widget_t (*items)[4];` now references the array element typedef.
+- **C references now capture tagged pointer-to-array declarations** — `struct node (*items)[4];` now references the array element tag.
 
 ## 日本語
 
@@ -83,3 +84,4 @@ affected:
 - **C の参照抽出が pointer-qualified `_t` 宣言を捕捉するようになりました** — `widget_t * restrict current;` から宣言 typedef への参照を生成します。
 - **C の参照抽出が pointer-qualified tag 付き宣言を捕捉するようになりました** — `struct node * const next;` から宣言 tag への参照を生成します。
 - **C の参照抽出が `_t` pointer-to-array 宣言を捕捉するようになりました** — `widget_t (*items)[4];` から配列要素 typedef への参照を生成します。
+- **C の参照抽出が tag 付き pointer-to-array 宣言を捕捉するようになりました** — `struct node (*items)[4];` から配列要素 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -39,6 +39,7 @@ affected:
 - **C references now capture `_t` `_Alignas` specifiers** — `_Alignas(widget_t)` and `alignas(message_t *)` now reference typedef types.
 - **C references now capture tagged `_Alignas` specifiers** — `_Alignas(struct node)` and `alignas(union value *)` now reference tag types.
 - **C references now capture `_t` function-pointer typedef returns** — `typedef widget_t (*factory_t)(void);` now references the return typedef.
+- **C references now capture tagged function-pointer typedef returns** — `typedef struct node *(*factory_t)(void);` now references the returned tag.
 
 ## 日本語
 
@@ -71,3 +72,4 @@ affected:
 - **C の参照抽出が `_t` の `_Alignas` specifier を捕捉するようになりました** — `_Alignas(widget_t)` と `alignas(message_t *)` から typedef 型への参照を生成します。
 - **C の参照抽出が tag 付き `_Alignas` specifier を捕捉するようになりました** — `_Alignas(struct node)` と `alignas(union value *)` から tag 型への参照を生成します。
 - **C の参照抽出が `_t` function-pointer typedef の戻り型を捕捉するようになりました** — `typedef widget_t (*factory_t)(void);` から戻り値 typedef への参照を生成します。
+- **C の参照抽出が tag 付き function-pointer typedef の戻り型を捕捉するようになりました** — `typedef struct node *(*factory_t)(void);` から戻り値 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -67,6 +67,7 @@ affected:
 - **C references now capture pointer-qualified `_t` return types** — `widget_t * const make_widget(void)` now references the returned typedef.
 - **C references now capture pointer-qualified tagged return types** — `struct node * const make_node(void)` now references the returned tag.
 - **C references now capture pointer-qualified `_t` parameter types** — `widget_t * restrict widget` now references the parameter typedef.
+- **C references now capture pointer-qualified tagged parameter types** — `struct node * const node` now references the parameter tag.
 
 ## 日本語
 
@@ -127,3 +128,4 @@ affected:
 - **C の参照抽出が pointer-qualified `_t` 戻り値型を捕捉するようになりました** — `widget_t * const make_widget(void)` から戻り値 typedef への参照を生成します。
 - **C の参照抽出が pointer-qualified tag 付き戻り値型を捕捉するようになりました** — `struct node * const make_node(void)` から戻り値 tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` parameter 型を捕捉するようになりました** — `widget_t * restrict widget` から parameter typedef への参照を生成します。
+- **C の参照抽出が pointer-qualified tag 付き parameter 型を捕捉するようになりました** — `struct node * const node` から parameter tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -12,8 +12,10 @@ affected:
 
 - **C search now indexes spaced include directives** — `# include <header.h>` forms now produce import symbols, so symbol/search navigation sees headers written with preprocessor whitespace.
 - **C search now indexes `#include_next` targets** — GNU-style next-header directives now produce import symbols alongside ordinary `#include` rows.
+- **C search now indexes `#import` headers** — import-style header directives now surface as import symbols for header navigation.
 
 ## 日本語
 
 - **C 検索が空白付き include ディレクティブをインデックスするようになりました** — `# include <header.h>` 形式でも import シンボルを生成し、preprocessor 空白を使ったヘッダーも symbol/search navigation で見つかるようになりました。
 - **C 検索が `#include_next` の参照先をインデックスするようになりました** — GNU 風の next-header ディレクティブも通常の `#include` と同じように import シンボルを生成します。
+- **C 検索が `#import` ヘッダーをインデックスするようになりました** — import 形式のヘッダーディレクティブも import シンボルとして表面化し、ヘッダー移動に使えるようになりました。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -21,6 +21,7 @@ affected:
 - **C references now suppress type-keyword noise** — `struct`, `enum`, `union`, and qualifiers are filtered out of C type-reference rows so typedef edges point at real tag names.
 - **C references now capture `_t` cast types** — lowercase typedef casts such as `(widget_t *)raw` now produce type-reference rows.
 - **C references now capture `_t` `sizeof` operands** — `sizeof(widget_t)` now produces a type-reference row for typedef-based size checks.
+- **C references now capture `_t` alignment operands** — `_Alignof(widget_t)` and `alignof(config_t)` now surface typedef operands as type references.
 
 ## 日本語
 
@@ -35,3 +36,4 @@ affected:
 - **C の参照抽出が型キーワード由来のノイズを抑えるようになりました** — `struct` / `enum` / `union` や修飾子を C の type-reference 行から除外し、typedef edge が実際の tag 名を指すようにしました。
 - **C の参照抽出が `_t` cast 型を捕捉するようになりました** — `(widget_t *)raw` のような lowercase typedef cast でも type-reference 行を生成します。
 - **C の参照抽出が `_t` の `sizeof` operand を捕捉するようになりました** — `sizeof(widget_t)` でも typedef ベースの size check に対する type-reference 行を生成します。
+- **C の参照抽出が `_t` の alignment operand を捕捉するようになりました** — `_Alignof(widget_t)` と `alignof(config_t)` でも typedef operand を type reference として表面化します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -22,6 +22,7 @@ affected:
 - **C references now capture `_t` cast types** — lowercase typedef casts such as `(widget_t *)raw` now produce type-reference rows.
 - **C references now capture `_t` `sizeof` operands** — `sizeof(widget_t)` now produces a type-reference row for typedef-based size checks.
 - **C references now capture `_t` alignment operands** — `_Alignof(widget_t)` and `alignof(config_t)` now surface typedef operands as type references.
+- **C references now capture `_t` declaration types** — local declarations such as `widget_t *current;` now point search results back to typedef names.
 
 ## 日本語
 
@@ -37,3 +38,4 @@ affected:
 - **C の参照抽出が `_t` cast 型を捕捉するようになりました** — `(widget_t *)raw` のような lowercase typedef cast でも type-reference 行を生成します。
 - **C の参照抽出が `_t` の `sizeof` operand を捕捉するようになりました** — `sizeof(widget_t)` でも typedef ベースの size check に対する type-reference 行を生成します。
 - **C の参照抽出が `_t` の alignment operand を捕捉するようになりました** — `_Alignof(widget_t)` と `alignof(config_t)` でも typedef operand を type reference として表面化します。
+- **C の参照抽出が `_t` 宣言型を捕捉するようになりました** — `widget_t *current;` のような local declaration から typedef 名へ search result が戻れるようになりました。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -46,6 +46,7 @@ affected:
 - **C references now capture pointer-qualified tagged declarations** — `struct node * const next;` now references the declared tag.
 - **C references now capture `_t` pointer-to-array declarations** — `widget_t (*items)[4];` now references the array element typedef.
 - **C references now capture tagged pointer-to-array declarations** — `struct node (*items)[4];` now references the array element tag.
+- **C references now capture `_t` `offsetof` operands** — `offsetof(widget_t, field)` now references the operand typedef.
 
 ## 日本語
 
@@ -85,3 +86,4 @@ affected:
 - **C の参照抽出が pointer-qualified tag 付き宣言を捕捉するようになりました** — `struct node * const next;` から宣言 tag への参照を生成します。
 - **C の参照抽出が `_t` pointer-to-array 宣言を捕捉するようになりました** — `widget_t (*items)[4];` から配列要素 typedef への参照を生成します。
 - **C の参照抽出が tag 付き pointer-to-array 宣言を捕捉するようになりました** — `struct node (*items)[4];` から配列要素 tag への参照を生成します。
+- **C の参照抽出が `_t` `offsetof` operand を捕捉するようになりました** — `offsetof(widget_t, field)` から operand typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -25,6 +25,7 @@ affected:
 - **C references now capture `_t` declaration types** — local declarations such as `widget_t *current;` now point search results back to typedef names.
 - **C references now capture tagged declaration types** — declarations such as `struct node *next;` now produce type references for the tag name.
 - **C references now capture `_t` return types** — functions returning typedefs such as `widget_t *make_widget(void)` now reference the typedef name.
+- **C references now capture tagged return types** — functions returning `struct node *` now produce type references for the returned tag.
 
 ## 日本語
 
@@ -43,3 +44,4 @@ affected:
 - **C の参照抽出が `_t` 宣言型を捕捉するようになりました** — `widget_t *current;` のような local declaration から typedef 名へ search result が戻れるようになりました。
 - **C の参照抽出が tag 付き宣言型を捕捉するようになりました** — `struct node *next;` のような宣言から tag 名の type reference を生成します。
 - **C の参照抽出が `_t` 戻り値型を捕捉するようになりました** — `widget_t *make_widget(void)` のように typedef を返す関数から typedef 名への参照を生成します。
+- **C の参照抽出が tag 付き戻り値型を捕捉するようになりました** — `struct node *` を返す関数から戻り値 tag の type reference を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -1,0 +1,17 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C search now indexes spaced include directives** — `# include <header.h>` forms now produce import symbols, so symbol/search navigation sees headers written with preprocessor whitespace.
+
+## 日本語
+
+- **C 検索が空白付き include ディレクティブをインデックスするようになりました** — `# include <header.h>` 形式でも import シンボルを生成し、preprocessor 空白を使ったヘッダーも symbol/search navigation で見つかるようになりました。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -61,6 +61,7 @@ affected:
 - **C references now capture `_t` `__builtin_types_compatible_p` operands** — both typedef type arguments now produce references.
 - **C references now capture tagged `__builtin_types_compatible_p` operands** — both tag type arguments now produce references.
 - **C references now capture `_t` `__builtin_offsetof` operands** — `__builtin_offsetof(widget_t, field)` now references the operand typedef.
+- **C references now capture tagged `__builtin_offsetof` operands** — `__builtin_offsetof(struct node, next)` now references the operand tag.
 
 ## 日本語
 
@@ -115,3 +116,4 @@ affected:
 - **C の参照抽出が `_t` `__builtin_types_compatible_p` operand を捕捉するようになりました** — 2つの typedef 型引数から参照を生成します。
 - **C の参照抽出が tag 付き `__builtin_types_compatible_p` operand を捕捉するようになりました** — 2つの tag 型引数から参照を生成します。
 - **C の参照抽出が `_t` `__builtin_offsetof` operand を捕捉するようになりました** — `__builtin_offsetof(widget_t, field)` から operand typedef への参照を生成します。
+- **C の参照抽出が tag 付き `__builtin_offsetof` operand を捕捉するようになりました** — `__builtin_offsetof(struct node, next)` から operand tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -50,6 +50,7 @@ affected:
 - **C references now capture tagged `offsetof` operands** — `offsetof(struct node, next)` now references the operand tag.
 - **C references now capture `_t` `va_arg` operands** — `va_arg(args, widget_t)` now references the requested typedef.
 - **C references now capture tagged `va_arg` operands** — `va_arg(args, struct node *)` now references the requested tag.
+- **C references now capture tagged `sizeof` operands** — `sizeof(struct node *)` now references the measured tag.
 
 ## 日本語
 
@@ -93,3 +94,4 @@ affected:
 - **C の参照抽出が tag 付き `offsetof` operand を捕捉するようになりました** — `offsetof(struct node, next)` から operand tag への参照を生成します。
 - **C の参照抽出が `_t` `va_arg` operand を捕捉するようになりました** — `va_arg(args, widget_t)` から要求 typedef への参照を生成します。
 - **C の参照抽出が tag 付き `va_arg` operand を捕捉するようになりました** — `va_arg(args, struct node *)` から要求 tag への参照を生成します。
+- **C の参照抽出が tag 付き `sizeof` operand を捕捉するようになりました** — `sizeof(struct node *)` から測定 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -44,6 +44,7 @@ affected:
 - **C references now capture tagged function-pointer declaration returns** — `struct node *(*factory)(void);` now references the returned tag.
 - **C references now capture pointer-qualified `_t` declarations** — `widget_t * restrict current;` now references the declared typedef.
 - **C references now capture pointer-qualified tagged declarations** — `struct node * const next;` now references the declared tag.
+- **C references now capture `_t` pointer-to-array declarations** — `widget_t (*items)[4];` now references the array element typedef.
 
 ## 日本語
 
@@ -81,3 +82,4 @@ affected:
 - **C の参照抽出が tag 付き function-pointer 宣言の戻り型を捕捉するようになりました** — `struct node *(*factory)(void);` から戻り値 tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` 宣言を捕捉するようになりました** — `widget_t * restrict current;` から宣言 typedef への参照を生成します。
 - **C の参照抽出が pointer-qualified tag 付き宣言を捕捉するようになりました** — `struct node * const next;` から宣言 tag への参照を生成します。
+- **C の参照抽出が `_t` pointer-to-array 宣言を捕捉するようになりました** — `widget_t (*items)[4];` から配列要素 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -58,6 +58,7 @@ affected:
 - **C references now capture tagged GNU alignment operands** — `__alignof__(struct node *)` now references the measured tag.
 - **C references now capture `_t` `typeof_unqual` operands** — `typeof_unqual(widget_t *)` now references the operand typedef.
 - **C references now capture tagged `typeof_unqual` operands** — `typeof_unqual(struct node *)` now references the operand tag.
+- **C references now capture `_t` `__builtin_types_compatible_p` operands** — both typedef type arguments now produce references.
 
 ## 日本語
 
@@ -109,3 +110,4 @@ affected:
 - **C の参照抽出が tag 付き GNU alignment operand を捕捉するようになりました** — `__alignof__(struct node *)` から測定 tag への参照を生成します。
 - **C の参照抽出が `_t` `typeof_unqual` operand を捕捉するようになりました** — `typeof_unqual(widget_t *)` から operand typedef への参照を生成します。
 - **C の参照抽出が tag 付き `typeof_unqual` operand を捕捉するようになりました** — `typeof_unqual(struct node *)` から operand tag への参照を生成します。
+- **C の参照抽出が `_t` `__builtin_types_compatible_p` operand を捕捉するようになりました** — 2つの typedef 型引数から参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -30,6 +30,7 @@ affected:
 - **C references now capture tagged parameter types** — parameters such as `struct node *node` now produce type references for tag names.
 - **C references now capture `_t` compound literals** — literals such as `(widget_t){0}` now reference the typedef type.
 - **C references now capture tagged compound literals** — literals such as `(struct node){0}` now reference the tag name.
+- **C references now capture `_t` `typeof` operands** — `typeof(widget_t)` and `__typeof__(message_t *)` now reference typedef names.
 
 ## 日本語
 
@@ -53,3 +54,4 @@ affected:
 - **C の参照抽出が tag 付き parameter 型を捕捉するようになりました** — `struct node *node` のような parameter から tag 名の type reference を生成します。
 - **C の参照抽出が `_t` compound literal を捕捉するようになりました** — `(widget_t){0}` のような literal から typedef 型への参照を生成します。
 - **C の参照抽出が tag 付き compound literal を捕捉するようになりました** — `(struct node){0}` のような literal から tag 名への参照を生成します。
+- **C の参照抽出が `_t` の `typeof` operand を捕捉するようになりました** — `typeof(widget_t)` と `__typeof__(message_t *)` から typedef 名への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -26,6 +26,7 @@ affected:
 - **C references now capture tagged declaration types** — declarations such as `struct node *next;` now produce type references for the tag name.
 - **C references now capture `_t` return types** — functions returning typedefs such as `widget_t *make_widget(void)` now reference the typedef name.
 - **C references now capture tagged return types** — functions returning `struct node *` now produce type references for the returned tag.
+- **C references now capture `_t` parameter types** — function parameters such as `widget_t *widget` now point back to typedef names.
 
 ## 日本語
 
@@ -45,3 +46,4 @@ affected:
 - **C の参照抽出が tag 付き宣言型を捕捉するようになりました** — `struct node *next;` のような宣言から tag 名の type reference を生成します。
 - **C の参照抽出が `_t` 戻り値型を捕捉するようになりました** — `widget_t *make_widget(void)` のように typedef を返す関数から typedef 名への参照を生成します。
 - **C の参照抽出が tag 付き戻り値型を捕捉するようになりました** — `struct node *` を返す関数から戻り値 tag の type reference を生成します。
+- **C の参照抽出が `_t` parameter 型を捕捉するようになりました** — `widget_t *widget` のような関数 parameter から typedef 名へ戻れるようになりました。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -49,6 +49,7 @@ affected:
 - **C references now capture `_t` `offsetof` operands** — `offsetof(widget_t, field)` now references the operand typedef.
 - **C references now capture tagged `offsetof` operands** — `offsetof(struct node, next)` now references the operand tag.
 - **C references now capture `_t` `va_arg` operands** — `va_arg(args, widget_t)` now references the requested typedef.
+- **C references now capture tagged `va_arg` operands** — `va_arg(args, struct node *)` now references the requested tag.
 
 ## 日本語
 
@@ -91,3 +92,4 @@ affected:
 - **C の参照抽出が `_t` `offsetof` operand を捕捉するようになりました** — `offsetof(widget_t, field)` から operand typedef への参照を生成します。
 - **C の参照抽出が tag 付き `offsetof` operand を捕捉するようになりました** — `offsetof(struct node, next)` から operand tag への参照を生成します。
 - **C の参照抽出が `_t` `va_arg` operand を捕捉するようになりました** — `va_arg(args, widget_t)` から要求 typedef への参照を生成します。
+- **C の参照抽出が tag 付き `va_arg` operand を捕捉するようになりました** — `va_arg(args, struct node *)` から要求 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -52,6 +52,7 @@ affected:
 - **C references now capture tagged `va_arg` operands** — `va_arg(args, struct node *)` now references the requested tag.
 - **C references now capture tagged `sizeof` operands** — `sizeof(struct node *)` now references the measured tag.
 - **C references now capture pointer-qualified `_t` `sizeof` operands** — `sizeof(widget_t * const)` now references the measured typedef.
+- **C references now capture pointer-qualified tagged `sizeof` operands** — `sizeof(struct node * const)` now references the measured tag.
 
 ## 日本語
 
@@ -97,3 +98,4 @@ affected:
 - **C の参照抽出が tag 付き `va_arg` operand を捕捉するようになりました** — `va_arg(args, struct node *)` から要求 tag への参照を生成します。
 - **C の参照抽出が tag 付き `sizeof` operand を捕捉するようになりました** — `sizeof(struct node *)` から測定 tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` `sizeof` operand を捕捉するようになりました** — `sizeof(widget_t * const)` から測定 typedef への参照を生成します。
+- **C の参照抽出が pointer-qualified tag 付き `sizeof` operand を捕捉するようになりました** — `sizeof(struct node * const)` から測定 tag への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -38,6 +38,7 @@ affected:
 - **C references now capture tagged `_Atomic` type specifiers** — `_Atomic(struct node *)` now references the tag type.
 - **C references now capture `_t` `_Alignas` specifiers** — `_Alignas(widget_t)` and `alignas(message_t *)` now reference typedef types.
 - **C references now capture tagged `_Alignas` specifiers** — `_Alignas(struct node)` and `alignas(union value *)` now reference tag types.
+- **C references now capture `_t` function-pointer typedef returns** — `typedef widget_t (*factory_t)(void);` now references the return typedef.
 
 ## 日本語
 
@@ -69,3 +70,4 @@ affected:
 - **C の参照抽出が tag 付き `_Atomic` type specifier を捕捉するようになりました** — `_Atomic(struct node *)` から tag 型への参照を生成します。
 - **C の参照抽出が `_t` の `_Alignas` specifier を捕捉するようになりました** — `_Alignas(widget_t)` と `alignas(message_t *)` から typedef 型への参照を生成します。
 - **C の参照抽出が tag 付き `_Alignas` specifier を捕捉するようになりました** — `_Alignas(struct node)` と `alignas(union value *)` から tag 型への参照を生成します。
+- **C の参照抽出が `_t` function-pointer typedef の戻り型を捕捉するようになりました** — `typedef widget_t (*factory_t)(void);` から戻り値 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -18,6 +18,7 @@ affected:
 - **C search now indexes bracket-attributed functions** — C23-style `[[nodiscard]] int f(...)` declarations now surface by function name.
 - **C references now capture `#include_next` headers** — next-header directives now appear in reference-oriented queries, not only symbol search.
 - **C references now capture macro include targets** — `#include PROJECT_HEADER` now produces a header reference for macro-based include wiring.
+- **C references now suppress type-keyword noise** — `struct`, `enum`, `union`, and qualifiers are filtered out of C type-reference rows so typedef edges point at real tag names.
 
 ## 日本語
 
@@ -29,3 +30,4 @@ affected:
 - **C 検索が角括弧属性付き関数をインデックスするようになりました** — C23 形式の `[[nodiscard]] int f(...)` 宣言も関数名で表面化します。
 - **C の参照抽出が `#include_next` ヘッダーを捕捉するようになりました** — next-header ディレクティブが symbol search だけでなく参照系クエリにも出るようになりました。
 - **C の参照抽出が macro include の参照先を捕捉するようになりました** — `#include PROJECT_HEADER` でも macro ベースの include 配線をヘッダー参照として生成します。
+- **C の参照抽出が型キーワード由来のノイズを抑えるようになりました** — `struct` / `enum` / `union` や修飾子を C の type-reference 行から除外し、typedef edge が実際の tag 名を指すようにしました。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -34,6 +34,7 @@ affected:
 - **C references now capture tagged `typeof` operands** — `typeof(struct node *)` now references the tag name.
 - **C references now capture `_t` `_Generic` associations** — `_Generic(value, widget_t: ...)` now references typedef association types.
 - **C references now capture tagged `_Generic` associations** — `_Generic(value, struct node *: ...)` now references tag association types.
+- **C references now capture `_t` `_Atomic` type specifiers** — `_Atomic(widget_t)` now references the typedef type.
 
 ## 日本語
 
@@ -61,3 +62,4 @@ affected:
 - **C の参照抽出が tag 付き `typeof` operand を捕捉するようになりました** — `typeof(struct node *)` から tag 名への参照を生成します。
 - **C の参照抽出が `_t` の `_Generic` association を捕捉するようになりました** — `_Generic(value, widget_t: ...)` から typedef association 型への参照を生成します。
 - **C の参照抽出が tag 付き `_Generic` association を捕捉するようになりました** — `_Generic(value, struct node *: ...)` から tag association 型への参照を生成します。
+- **C の参照抽出が `_t` の `_Atomic` type specifier を捕捉するようになりました** — `_Atomic(widget_t)` から typedef 型への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -23,6 +23,7 @@ affected:
 - **C references now capture `_t` `sizeof` operands** — `sizeof(widget_t)` now produces a type-reference row for typedef-based size checks.
 - **C references now capture `_t` alignment operands** — `_Alignof(widget_t)` and `alignof(config_t)` now surface typedef operands as type references.
 - **C references now capture `_t` declaration types** — local declarations such as `widget_t *current;` now point search results back to typedef names.
+- **C references now capture tagged declaration types** — declarations such as `struct node *next;` now produce type references for the tag name.
 
 ## 日本語
 
@@ -39,3 +40,4 @@ affected:
 - **C の参照抽出が `_t` の `sizeof` operand を捕捉するようになりました** — `sizeof(widget_t)` でも typedef ベースの size check に対する type-reference 行を生成します。
 - **C の参照抽出が `_t` の alignment operand を捕捉するようになりました** — `_Alignof(widget_t)` と `alignof(config_t)` でも typedef operand を type reference として表面化します。
 - **C の参照抽出が `_t` 宣言型を捕捉するようになりました** — `widget_t *current;` のような local declaration から typedef 名へ search result が戻れるようになりました。
+- **C の参照抽出が tag 付き宣言型を捕捉するようになりました** — `struct node *next;` のような宣言から tag 名の type reference を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -62,6 +62,7 @@ affected:
 - **C references now capture tagged `__builtin_types_compatible_p` operands** — both tag type arguments now produce references.
 - **C references now capture `_t` `__builtin_offsetof` operands** — `__builtin_offsetof(widget_t, field)` now references the operand typedef.
 - **C references now capture tagged `__builtin_offsetof` operands** — `__builtin_offsetof(struct node, next)` now references the operand tag.
+- **C references now capture `_t` `__builtin_va_arg` operands** — `__builtin_va_arg(args, widget_t)` now references the requested typedef.
 
 ## 日本語
 
@@ -117,3 +118,4 @@ affected:
 - **C の参照抽出が tag 付き `__builtin_types_compatible_p` operand を捕捉するようになりました** — 2つの tag 型引数から参照を生成します。
 - **C の参照抽出が `_t` `__builtin_offsetof` operand を捕捉するようになりました** — `__builtin_offsetof(widget_t, field)` から operand typedef への参照を生成します。
 - **C の参照抽出が tag 付き `__builtin_offsetof` operand を捕捉するようになりました** — `__builtin_offsetof(struct node, next)` から operand tag への参照を生成します。
+- **C の参照抽出が `_t` `__builtin_va_arg` operand を捕捉するようになりました** — `__builtin_va_arg(args, widget_t)` から要求 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -17,6 +17,7 @@ affected:
 - **C search now indexes union typedef aliases** — forward `typedef union Name Alias;` declarations now provide searchable `union` symbols for alias names.
 - **C search now indexes bracket-attributed functions** — C23-style `[[nodiscard]] int f(...)` declarations now surface by function name.
 - **C references now capture `#include_next` headers** — next-header directives now appear in reference-oriented queries, not only symbol search.
+- **C references now capture macro include targets** — `#include PROJECT_HEADER` now produces a header reference for macro-based include wiring.
 
 ## 日本語
 
@@ -27,3 +28,4 @@ affected:
 - **C 検索が union typedef エイリアスをインデックスするようになりました** — forward `typedef union Name Alias;` 宣言でも alias 名の検索可能な `union` シンボルを生成します。
 - **C 検索が角括弧属性付き関数をインデックスするようになりました** — C23 形式の `[[nodiscard]] int f(...)` 宣言も関数名で表面化します。
 - **C の参照抽出が `#include_next` ヘッダーを捕捉するようになりました** — next-header ディレクティブが symbol search だけでなく参照系クエリにも出るようになりました。
+- **C の参照抽出が macro include の参照先を捕捉するようになりました** — `#include PROJECT_HEADER` でも macro ベースの include 配線をヘッダー参照として生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -68,6 +68,7 @@ affected:
 - **C references now capture pointer-qualified tagged return types** — `struct node * const make_node(void)` now references the returned tag.
 - **C references now capture pointer-qualified `_t` parameter types** — `widget_t * restrict widget` now references the parameter typedef.
 - **C references now capture pointer-qualified tagged parameter types** — `struct node * const node` now references the parameter tag.
+- **C references now capture pointer-qualified `_t` `_Generic` associations** — `widget_t * const:` now references the association typedef.
 
 ## 日本語
 
@@ -129,3 +130,4 @@ affected:
 - **C の参照抽出が pointer-qualified tag 付き戻り値型を捕捉するようになりました** — `struct node * const make_node(void)` から戻り値 tag への参照を生成します。
 - **C の参照抽出が pointer-qualified `_t` parameter 型を捕捉するようになりました** — `widget_t * restrict widget` から parameter typedef への参照を生成します。
 - **C の参照抽出が pointer-qualified tag 付き parameter 型を捕捉するようになりました** — `struct node * const node` から parameter tag への参照を生成します。
+- **C の参照抽出が pointer-qualified `_t` `_Generic` association を捕捉するようになりました** — `widget_t * const:` から association typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -13,9 +13,11 @@ affected:
 - **C search now indexes spaced include directives** — `# include <header.h>` forms now produce import symbols, so symbol/search navigation sees headers written with preprocessor whitespace.
 - **C search now indexes `#include_next` targets** — GNU-style next-header directives now produce import symbols alongside ordinary `#include` rows.
 - **C search now indexes `#import` headers** — import-style header directives now surface as import symbols for header navigation.
+- **C search now indexes union declarations** — named `union` definitions now produce `union` symbols alongside structs and enums.
 
 ## 日本語
 
 - **C 検索が空白付き include ディレクティブをインデックスするようになりました** — `# include <header.h>` 形式でも import シンボルを生成し、preprocessor 空白を使ったヘッダーも symbol/search navigation で見つかるようになりました。
 - **C 検索が `#include_next` の参照先をインデックスするようになりました** — GNU 風の next-header ディレクティブも通常の `#include` と同じように import シンボルを生成します。
 - **C 検索が `#import` ヘッダーをインデックスするようになりました** — import 形式のヘッダーディレクティブも import シンボルとして表面化し、ヘッダー移動に使えるようになりました。
+- **C 検索が union 宣言をインデックスするようになりました** — 名前付き `union` 定義も struct / enum と同じように `union` シンボルを生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -48,6 +48,7 @@ affected:
 - **C references now capture tagged pointer-to-array declarations** — `struct node (*items)[4];` now references the array element tag.
 - **C references now capture `_t` `offsetof` operands** — `offsetof(widget_t, field)` now references the operand typedef.
 - **C references now capture tagged `offsetof` operands** — `offsetof(struct node, next)` now references the operand tag.
+- **C references now capture `_t` `va_arg` operands** — `va_arg(args, widget_t)` now references the requested typedef.
 
 ## 日本語
 
@@ -89,3 +90,4 @@ affected:
 - **C の参照抽出が tag 付き pointer-to-array 宣言を捕捉するようになりました** — `struct node (*items)[4];` から配列要素 tag への参照を生成します。
 - **C の参照抽出が `_t` `offsetof` operand を捕捉するようになりました** — `offsetof(widget_t, field)` から operand typedef への参照を生成します。
 - **C の参照抽出が tag 付き `offsetof` operand を捕捉するようになりました** — `offsetof(struct node, next)` から operand tag への参照を生成します。
+- **C の参照抽出が `_t` `va_arg` operand を捕捉するようになりました** — `va_arg(args, widget_t)` から要求 typedef への参照を生成します。

--- a/changelog.d/unreleased/+c-search-enhancements.changed.md
+++ b/changelog.d/unreleased/+c-search-enhancements.changed.md
@@ -57,6 +57,7 @@ affected:
 - **C references now capture `_t` GNU alignment operands** — `__alignof__(widget_t *)` now references the measured typedef.
 - **C references now capture tagged GNU alignment operands** — `__alignof__(struct node *)` now references the measured tag.
 - **C references now capture `_t` `typeof_unqual` operands** — `typeof_unqual(widget_t *)` now references the operand typedef.
+- **C references now capture tagged `typeof_unqual` operands** — `typeof_unqual(struct node *)` now references the operand tag.
 
 ## 日本語
 
@@ -107,3 +108,4 @@ affected:
 - **C の参照抽出が `_t` GNU alignment operand を捕捉するようになりました** — `__alignof__(widget_t *)` から測定 typedef への参照を生成します。
 - **C の参照抽出が tag 付き GNU alignment operand を捕捉するようになりました** — `__alignof__(struct node *)` から測定 tag への参照を生成します。
 - **C の参照抽出が `_t` `typeof_unqual` operand を捕捉するようになりました** — `typeof_unqual(widget_t *)` から operand typedef への参照を生成します。
+- **C の参照抽出が tag 付き `typeof_unqual` operand を捕捉するようになりました** — `typeof_unqual(struct node *)` から operand tag への参照を生成します。

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -626,8 +626,9 @@ public static partial class ReferenceExtractor
         },
         ["c"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "bool", "char", "double", "float", "int", "long", "short", "signed", "size_t",
-            "ssize_t", "uint8_t", "uint16_t", "uint32_t", "uint64_t", "unsigned", "void",
+            "_Atomic", "bool", "char", "const", "double", "enum", "float", "int", "long",
+            "restrict", "short", "signed", "size_t", "ssize_t", "struct", "uint8_t",
+            "uint16_t", "uint32_t", "uint64_t", "union", "unsigned", "void", "volatile",
         },
         ["cpp"] = new HashSet<string>(StringComparer.Ordinal)
         {

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -48,7 +48,7 @@ internal static class LanguageReferenceExtractionSupport
         @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefParameterTypeRegex = new(
-        @"(?:\(|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*",
+        @"(?:\(|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedParameterTypeRegex = new(
         @"(?:\(|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -51,7 +51,7 @@ internal static class LanguageReferenceExtractionSupport
         @"(?:\(|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedParameterTypeRegex = new(
-        @"(?:\(|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*",
+        @"(?:\(|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefCompoundLiteralTypeRegex = new(
         @"\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)\s*\{",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -101,6 +101,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedOffsetofTypeRegex = new(
         @"\boffsetof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?,",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefVaArgTypeRegex = new(
+        @"\bva_arg\s*\(\s*[^,;{}]+,\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1241,6 +1244,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedOffsetofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefVaArgTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -38,6 +38,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefFunctionReturnTypeRegex = new(
         @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedFunctionReturnTypeRegex = new(
+        @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1052,6 +1055,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefFunctionReturnTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedFunctionReturnTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -68,6 +68,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefAtomicTypeRegex = new(
         @"\b_Atomic\s*\(\s*(?<type>(?:(?:const|volatile|restrict)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedAtomicTypeRegex = new(
+        @"\b_Atomic\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1142,6 +1145,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefAtomicTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedAtomicTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -65,6 +65,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedGenericAssociationTypeRegex = new(
         @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefAtomicTypeRegex = new(
+        @"\b_Atomic\s*\(\s*(?<type>(?:(?:const|volatile|restrict)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1133,6 +1136,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedGenericAssociationTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefAtomicTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -126,7 +126,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\b(?:offsetof|__builtin_offsetof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?,",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefVaArgTypeRegex = new(
-        @"\bva_arg\s*\(\s*[^,;{}]+,\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
+        @"\b(?:va_arg|__builtin_va_arg)\s*\(\s*[^,;{}]+,\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedVaArgTypeRegex = new(
         @"\bva_arg\s*\(\s*[^,;{}]+,\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -56,6 +56,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefTypeofTypeRegex = new(
         @"\b(?:typeof|__typeof__|__typeof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedTypeofTypeRegex = new(
+        @"\b(?:typeof|__typeof__|__typeof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1106,6 +1109,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefTypeofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedTypeofTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -80,6 +80,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefFunctionPointerAliasTypeRegex = new(
         @"\btypedef\s+(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedFunctionPointerAliasTypeRegex = new(
+        @"\btypedef\s+(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1178,6 +1181,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefFunctionPointerAliasTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedFunctionPointerAliasTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -42,7 +42,7 @@ internal static class LanguageReferenceExtractionSupport
         @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*(?=[=,;\[])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefFunctionReturnTypeRegex = new(
-        @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*\s*\(",
+        @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedFunctionReturnTypeRegex = new(
         @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*\s*\(",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -86,6 +86,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefFunctionPointerDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedFunctionPointerDeclarationTypeRegex = new(
+        @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1196,6 +1199,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefFunctionPointerDeclarationTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedFunctionPointerDeclarationTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -32,6 +32,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*\s*(?=[=,;\[])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedDeclarationTypeRegex = new(
+        @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*\s*(?=[=,;\[])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1034,6 +1037,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefDeclarationTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedDeclarationTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -6,7 +6,7 @@ namespace CodeIndex.Indexer;
 internal static class LanguageReferenceExtractionSupport
 {
     private static readonly Regex CppIncludeRegex = new(
-        @"^(?:\s*#\s*(?:include|import)\s*(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)"")|\s*(?:export\s+)?import\s+(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>:?[A-Za-z_]\w*(?:[.:][A-Za-z_]\w*)*))\s*;)",
+        @"^(?:\s*#\s*(?:include(?:_next)?|import)\s*(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)"")|\s*(?:export\s+)?import\s+(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>:?[A-Za-z_]\w*(?:[.:][A-Za-z_]\w*)*))\s*;)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppBaseListRegex = new(
         @"^\s*(?:export\s+)?(?:(?:template|requires)\b[^{;]*\s+)*(?:class|struct)\s+[A-Za-z_]\w*(?:\s*final)?\s*:\s*(?<bases>[^{;]+)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -30,7 +30,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefDeclarationTypeRegex = new(
-        @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*\s*(?=[=,;\[])",
+        @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*(?=[=,;\[])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*\s*(?=[=,;\[])",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -77,6 +77,12 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefBuiltinTypesCompatibleSecondTypeRegex = new(
         @"\b__builtin_types_compatible_p\s*\([^,;{}]+,\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedBuiltinTypesCompatibleFirstTypeRegex = new(
+        @"\b__builtin_types_compatible_p\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?,",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedBuiltinTypesCompatibleSecondTypeRegex = new(
+        @"\b__builtin_types_compatible_p\s*\([^,;{}]+,\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefGenericAssociationTypeRegex = new(
         @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1217,6 +1223,18 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefBuiltinTypesCompatibleSecondTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedBuiltinTypesCompatibleFirstTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedBuiltinTypesCompatibleSecondTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -84,7 +84,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\b__builtin_types_compatible_p\s*\([^,;{}]+,\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefGenericAssociationTypeRegex = new(
-        @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*:",
+        @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*(?:\s*(?:const|volatile|restrict|_Atomic))?)*\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedGenericAssociationTypeRegex = new(
         @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?:",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -92,6 +92,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefPointerArrayDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\[",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedPointerArrayDeclarationTypeRegex = new(
+        @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\[",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1214,6 +1217,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefPointerArrayDeclarationTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedPointerArrayDeclarationTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -87,7 +87,7 @@ internal static class LanguageReferenceExtractionSupport
         @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*(?:\s*(?:const|volatile|restrict|_Atomic))?)*\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedGenericAssociationTypeRegex = new(
-        @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?:",
+        @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\s*\*(?:\s*(?:const|volatile|restrict|_Atomic))?)*\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefAtomicTypeRegex = new(
         @"\b_Atomic\s*\(\s*(?<type>(?:(?:const|volatile|restrict)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -29,6 +29,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefAlignofTypeRegex = new(
         @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefDeclarationTypeRegex = new(
+        @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*\s*(?=[=,;\[])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1025,6 +1028,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefAlignofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefDeclarationTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -41,6 +41,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedFunctionReturnTypeRegex = new(
         @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefParameterTypeRegex = new(
+        @"(?:\(|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1061,6 +1064,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedFunctionReturnTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefParameterTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -33,7 +33,7 @@ internal static class LanguageReferenceExtractionSupport
         @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*(?=[=,;\[])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedDeclarationTypeRegex = new(
-        @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*\s*(?=[=,;\[])",
+        @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*(?=[=,;\[])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefFunctionReturnTypeRegex = new(
         @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*\s*\(",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -71,6 +71,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedAtomicTypeRegex = new(
         @"\b_Atomic\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefAlignasTypeRegex = new(
+        @"\b(?:_Alignas|alignas)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1151,6 +1154,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedAtomicTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefAlignasTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -123,7 +123,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\b(?:offsetof|__builtin_offsetof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*,",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedOffsetofTypeRegex = new(
-        @"\boffsetof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?,",
+        @"\b(?:offsetof|__builtin_offsetof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?,",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefVaArgTypeRegex = new(
         @"\bva_arg\s*\(\s*[^,;{}]+,\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -83,6 +83,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedFunctionPointerAliasTypeRegex = new(
         @"\btypedef\s+(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefFunctionPointerDeclarationTypeRegex = new(
+        @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1187,6 +1190,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedFunctionPointerAliasTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefFunctionPointerDeclarationTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -53,6 +53,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedCompoundLiteralTypeRegex = new(
         @"\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)\s*\{",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefTypeofTypeRegex = new(
+        @"\b(?:typeof|__typeof__|__typeof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1097,6 +1100,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedCompoundLiteralTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefTypeofTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -23,6 +23,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefCastTypeRegex = new(
         @"(?<![\w])\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)\s*(?:[A-Za-z_]\w*|\*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefSizeofTypeRegex = new(
+        @"\bsizeof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1007,6 +1010,12 @@ internal static class LanguageReferenceExtractionSupport
         if (language == "c")
         {
             foreach (Match match in CTypedefCastTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefSizeofTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -59,6 +59,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedTypeofTypeRegex = new(
         @"\b(?:typeof|__typeof__|__typeof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefGenericAssociationTypeRegex = new(
+        @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*:",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1115,6 +1118,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedTypeofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefGenericAssociationTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -104,6 +104,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefVaArgTypeRegex = new(
         @"\bva_arg\s*\(\s*[^,;{}]+,\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedVaArgTypeRegex = new(
+        @"\bva_arg\s*\(\s*[^,;{}]+,\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1250,6 +1253,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefVaArgTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedVaArgTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -77,6 +77,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedAlignasTypeRegex = new(
         @"\b(?:_Alignas|alignas)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefFunctionPointerAliasTypeRegex = new(
+        @"\btypedef\s+(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1169,6 +1172,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedAlignasTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefFunctionPointerAliasTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -6,7 +6,7 @@ namespace CodeIndex.Indexer;
 internal static class LanguageReferenceExtractionSupport
 {
     private static readonly Regex CppIncludeRegex = new(
-        @"^(?:\s*#\s*(?:include(?:_next)?|import)\s*(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)"")|\s*(?:export\s+)?import\s+(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>:?[A-Za-z_]\w*(?:[.:][A-Za-z_]\w*)*))\s*;)",
+        @"^(?:\s*#\s*(?:include(?:_next)?|import)\s*(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>[^\s]+))|\s*(?:export\s+)?import\s+(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>:?[A-Za-z_]\w*(?:[.:][A-Za-z_]\w*)*))\s*;)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppBaseListRegex = new(
         @"^\s*(?:export\s+)?(?:(?:template|requires)\b[^{;]*\s+)*(?:class|struct)\s+[A-Za-z_]\w*(?:\s*final)?\s*:\s*(?<bases>[^{;]+)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -20,6 +20,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CppCStyleCastTypeRegex = new(
         @"(?<![\w])\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}()]+>)?(?:\s*[*&])*)\s*\)\s*(?:[A-Za-z_]\w*|\*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefCastTypeRegex = new(
+        @"(?<![\w])\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)\s*(?:[A-Za-z_]\w*|\*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -999,6 +1002,15 @@ internal static class LanguageReferenceExtractionSupport
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+        }
+
+        if (language == "c")
+        {
+            foreach (Match match in CTypedefCastTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
         }
 
         foreach (Match match in CppTypeOperandOperatorRegex.Matches(preparedLine))

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -32,6 +32,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefAlignofTypeRegex = new(
         @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedAlignofTypeRegex = new(
+        @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*(?=[=,;\[])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1112,6 +1115,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefAlignofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedAlignofTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -44,6 +44,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefParameterTypeRegex = new(
         @"(?:\(|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedParameterTypeRegex = new(
+        @"(?:\(|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1070,6 +1073,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefParameterTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedParameterTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -50,6 +50,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefCompoundLiteralTypeRegex = new(
         @"\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)\s*\{",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedCompoundLiteralTypeRegex = new(
+        @"\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)\s*\{",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1088,6 +1091,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefCompoundLiteralTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedCompoundLiteralTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -26,6 +26,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefSizeofTypeRegex = new(
         @"\bsizeof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedSizeofTypeRegex = new(
+        @"\bsizeof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefAlignofTypeRegex = new(
         @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1097,6 +1100,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefSizeofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedSizeofTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -26,6 +26,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefSizeofTypeRegex = new(
         @"\bsizeof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefAlignofTypeRegex = new(
+        @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1016,6 +1019,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefSizeofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefAlignofTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -120,7 +120,7 @@ internal static class LanguageReferenceExtractionSupport
         @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\[",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefOffsetofTypeRegex = new(
-        @"\boffsetof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*,",
+        @"\b(?:offsetof|__builtin_offsetof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*,",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedOffsetofTypeRegex = new(
         @"\boffsetof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?,",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -30,7 +30,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\bsizeof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\s*\*(?:\s*(?:const|volatile|restrict|_Atomic))?)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefAlignofTypeRegex = new(
-        @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
+        @"\b(?:_Alignof|alignof|__alignof__|__alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedAlignofTypeRegex = new(
         @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -62,6 +62,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefGenericAssociationTypeRegex = new(
         @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedGenericAssociationTypeRegex = new(
+        @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?:",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1124,6 +1127,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefGenericAssociationTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedGenericAssociationTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -45,7 +45,7 @@ internal static class LanguageReferenceExtractionSupport
         @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedFunctionReturnTypeRegex = new(
-        @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*\s*\(",
+        @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefParameterTypeRegex = new(
         @"(?:\(|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -68,6 +68,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefTypeofUnqualTypeRegex = new(
         @"\b(?:typeof_unqual|__typeof_unqual__|__typeof_unqual)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedTypeofUnqualTypeRegex = new(
+        @"\b(?:typeof_unqual|__typeof_unqual__|__typeof_unqual)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefGenericAssociationTypeRegex = new(
         @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1190,6 +1193,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefTypeofUnqualTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedTypeofUnqualTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -129,7 +129,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\b(?:va_arg|__builtin_va_arg)\s*\(\s*[^,;{}]+,\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedVaArgTypeRegex = new(
-        @"\bva_arg\s*\(\s*[^,;{}]+,\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        @"\b(?:va_arg|__builtin_va_arg)\s*\(\s*[^,;{}]+,\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -65,6 +65,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedTypeofTypeRegex = new(
         @"\b(?:typeof|__typeof__|__typeof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefTypeofUnqualTypeRegex = new(
+        @"\b(?:typeof_unqual|__typeof_unqual__|__typeof_unqual)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefGenericAssociationTypeRegex = new(
         @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1181,6 +1184,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedTypeofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefTypeofUnqualTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -89,6 +89,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedFunctionPointerDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefPointerArrayDeclarationTypeRegex = new(
+        @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\[",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1205,6 +1208,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedFunctionPointerDeclarationTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefPointerArrayDeclarationTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -98,6 +98,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefOffsetofTypeRegex = new(
         @"\boffsetof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*,",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedOffsetofTypeRegex = new(
+        @"\boffsetof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?,",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1232,6 +1235,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefOffsetofTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedOffsetofTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -71,6 +71,12 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedTypeofUnqualTypeRegex = new(
         @"\b(?:typeof_unqual|__typeof_unqual__|__typeof_unqual)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefBuiltinTypesCompatibleFirstTypeRegex = new(
+        @"\b__builtin_types_compatible_p\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*,",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefBuiltinTypesCompatibleSecondTypeRegex = new(
+        @"\b__builtin_types_compatible_p\s*\([^,;{}]+,\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefGenericAssociationTypeRegex = new(
         @"(?:_Generic\s*\([^,;{}]*,|,)\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1199,6 +1205,18 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedTypeofUnqualTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefBuiltinTypesCompatibleFirstTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefBuiltinTypesCompatibleSecondTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -33,7 +33,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\b(?:_Alignof|alignof|__alignof__|__alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedAlignofTypeRegex = new(
-        @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        @"\b(?:_Alignof|alignof|__alignof__|__alignof)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*\s*(?=[=,;\[])",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -24,7 +24,7 @@ internal static class LanguageReferenceExtractionSupport
         @"(?<![\w])\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)\s*(?:[A-Za-z_]\w*|\*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefSizeofTypeRegex = new(
-        @"\bsizeof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",
+        @"\bsizeof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*(?:\s*(?:const|volatile|restrict|_Atomic))?)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedSizeofTypeRegex = new(
         @"\bsizeof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -35,6 +35,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*\s*(?=[=,;\[])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefFunctionReturnTypeRegex = new(
+        @"^\s*(?:(?:static|extern|inline|const|volatile|restrict|_Atomic)\s+)*(?<type>[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*[A-Za-z_]\w*\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1043,6 +1046,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedDeclarationTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefFunctionReturnTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -27,7 +27,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\bsizeof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*(?:\s*(?:const|volatile|restrict|_Atomic))?)*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTaggedSizeofTypeRegex = new(
-        @"\bsizeof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        @"\bsizeof\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\s*\*(?:\s*(?:const|volatile|restrict|_Atomic))?)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CTypedefAlignofTypeRegex = new(
         @"\b(?:_Alignof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t(?:\s*\*)*)\s*\)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -47,6 +47,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedParameterTypeRegex = new(
         @"(?:\(|,)\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefCompoundLiteralTypeRegex = new(
+        @"\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)\s*\{",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1079,6 +1082,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedParameterTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefCompoundLiteralTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -74,6 +74,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTypedefAlignasTypeRegex = new(
         @"\b(?:_Alignas|alignas)\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTaggedAlignasTypeRegex = new(
+        @"\b(?:_Alignas|alignas)\s*\(\s*(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1160,6 +1163,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTypedefAlignasTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTaggedAlignasTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -95,6 +95,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CTaggedPointerArrayDeclarationTypeRegex = new(
         @"(?<![\w])(?<type>(?:struct|enum|union)\s+[A-Za-z_]\w*)\s*(?:\*+\s*)?\(\s*\*\s*[A-Za-z_]\w*\s*\)\s*\[",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CTypedefOffsetofTypeRegex = new(
+        @"\boffsetof\s*\(\s*(?<type>(?:(?:const|volatile|restrict|_Atomic)\s+)*[A-Za-z_]\w*_t\b)(?:\s*\*)*\s*,",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTypeOperandOperatorRegex = new(
         @"\b(?:sizeof|alignof)\s*\(\s*(?<type>(?:(?:const|volatile|typename|class|struct|enum)\s+)*(?:[A-Z_]\w*|[A-Za-z_]\w*\s*::\s*[A-Za-z_]\w*)(?:\s*<[^;{}]+>)?(?:\s*[*&])*)\s*\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1223,6 +1226,12 @@ internal static class LanguageReferenceExtractionSupport
             }
 
             foreach (Match match in CTaggedPointerArrayDeclarationTypeRegex.Matches(preparedLine))
+            {
+                var group = match.Groups["type"];
+                ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+            }
+
+            foreach (Match match in CTypedefOffsetofTypeRegex.Matches(preparedLine))
             {
                 var group = match.Groups["type"];
                 ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1373,7 +1373,7 @@ public static partial class SymbolExtractor
             new("struct",   new Regex(@"^\s*(?:typedef\s+)?struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*typedef\s+enum\s+(?:\w+\s+)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*(?:typedef\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("import",   new Regex(@"^\s*#\s*include(?:_next)?\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*#\s*(?:include(?:_next)?|import)\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cpp"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -96,7 +96,7 @@ public static partial class SymbolExtractor
     // GCC/Clang/MSVC の attribute specifier は戻り値型の前や、戻り値型トークンの途中に現れる。
     // それらを戻り値型マッチャーに含めて、よくある注釈付き C 関数も `symbols` / `search` に出るようにする。
     private const string CAttributeSpecifierTokenPattern =
-        @"(?:__attribute__\s*\(\((?:(?>[^()]+)|\((?<CAttributeDepth>)|\)(?<-CAttributeDepth>))*(?(CAttributeDepth)(?!))\)\)\s*|__declspec\s*\((?:(?>[^()]+)|\((?<CAttributeDepth>)|\)(?<-CAttributeDepth>))*(?(CAttributeDepth)(?!))\)\s*|_Noreturn\s+)";
+        @"(?:\[\[[^\r\n]*?\]\]\s*|__attribute__\s*\(\((?:(?>[^()]+)|\((?<CAttributeDepth>)|\)(?<-CAttributeDepth>))*(?(CAttributeDepth)(?!))\)\)\s*|__declspec\s*\((?:(?>[^()]+)|\((?<CAttributeDepth>)|\)(?<-CAttributeDepth>))*(?(CAttributeDepth)(?!))\)\s*|_Noreturn\s+)";
     private const string CFunctionReturnTypePattern =
         @"(?<returnType>(?:(?:\w+[\s*]+)|" + CAttributeSpecifierTokenPattern + @")+)";
     private const string CSharpTypeSegmentPattern =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1371,6 +1371,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*#\s*define\s+(?<name>[A-Za-z_]\w*)(?=\s|$)", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*typedef\s+struct\s+(?:\w+\s*)?(?:\*+\s*)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*(?:typedef\s+)?struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("union",    new Regex(@"^\s*typedef\s+union\s+(?:\w+\s*)?(?:\*+\s*)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("union",    new Regex(@"^\s*(?:typedef\s+)?union\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*typedef\s+enum\s+(?:\w+\s+)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*(?:typedef\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1373,7 +1373,7 @@ public static partial class SymbolExtractor
             new("struct",   new Regex(@"^\s*(?:typedef\s+)?struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*typedef\s+enum\s+(?:\w+\s+)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*(?:typedef\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("import",   new Regex(@"^\s*#\s*include\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*#\s*include(?:_next)?\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cpp"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1373,7 +1373,7 @@ public static partial class SymbolExtractor
             new("struct",   new Regex(@"^\s*(?:typedef\s+)?struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*typedef\s+enum\s+(?:\w+\s+)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*(?:typedef\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("import",   new Regex(@"^\s*#include\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*#\s*include\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cpp"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1371,6 +1371,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*#\s*define\s+(?<name>[A-Za-z_]\w*)(?=\s|$)", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*typedef\s+struct\s+(?:\w+\s*)?(?:\*+\s*)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("struct",   new Regex(@"^\s*(?:typedef\s+)?struct\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("union",    new Regex(@"^\s*(?:typedef\s+)?union\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("enum",     new Regex(@"^\s*typedef\s+enum\s+(?:\w+\s+)?(?<name>\w+)\s*;", RegexOptions.Compiled), BodyStyle.None),
             new("enum",     new Regex(@"^\s*(?:typedef\s+)?enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("import",   new Regex(@"^\s*#\s*(?:include(?:_next)?|import)\s+(?:<(?<name>[^>]+)>|""(?<name>[^""]+)""|(?<name>[^\s]+))", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2308,6 +2308,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefGnuAlignofOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long align = __alignof__(widget_t *);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2243,6 +2243,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedSizeofOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long size = sizeof(struct node *);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2181,6 +2181,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedPointerArrayDeclarations_CapturesTagElementTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                struct node (*items)[4];
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1771,6 +1771,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefCasts_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void convert(void *raw) {
+                widget_t *widget = (widget_t *)raw;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2290,6 +2290,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedAlignofOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long nodeAlign = _Alignof(struct node *);
+                unsigned long valueAlign = alignof(union value);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName is "struct" or "union");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1835,6 +1835,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedDeclarations_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                struct node *next;
+                enum mode mode;
+                union value value;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "mode" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName is "struct" or "enum" or "union");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2354,6 +2354,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedTypeofUnqualOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                typeof_unqual(struct node *) current;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1886,6 +1886,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTypedefReturnTypes_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            widget_t * const make_widget(void) {
+                return 0;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTypedefParameters_CapturesLowercaseTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1963,6 +1963,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTaggedParameters_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void visit(struct node * const node) {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTypedefCompoundLiterals_CapturesLowercaseTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2090,6 +2090,20 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedFunctionPointerAliases_CapturesTagReturnTypeReferences()
+    {
+        const string content = """
+            typedef struct node *(*node_factory_t)(void);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1786,6 +1786,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefSizeof_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void measure(void) {
+                unsigned long bytes = sizeof(widget_t);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2434,6 +2434,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefBuiltinVaArgOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                consume(__builtin_va_arg(args, widget_t));
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1998,6 +1998,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedGenericAssociations_CapturesTagTypeReferences()
+    {
+        const string content = """
+            int choose(int value) {
+                return _Generic(value, struct node *: 1, enum mode: 2, default: 0);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "mode" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName is "struct" or "enum");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2046,6 +2046,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefAlignasSpecifiers_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            _Alignas(widget_t) unsigned char widgetStorage[64];
+            alignas(message_t *) unsigned char messageStorage[64];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "message_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2339,6 +2339,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefTypeofUnqualOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                typeof_unqual(widget_t *) current;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2090,6 +2090,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTaggedGenericAssociations_CapturesTagTypeReferences()
+    {
+        const string content = """
+            int choose(int value) {
+                return _Generic(value, struct node * const: 1, default: 0);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTypedefAtomicTypeSpecifiers_CapturesLowercaseTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2104,6 +2104,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefFunctionPointerDeclarations_CapturesLowercaseReturnTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                widget_t (*factory)(void);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2243,6 +2243,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                consume(va_arg(args, struct node *));
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1901,6 +1901,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTaggedReturnTypes_CapturesTagTypeReferences()
+    {
+        const string content = """
+            struct node * const make_node(void) {
+                return 0;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTypedefParameters_CapturesLowercaseTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2150,6 +2150,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTaggedDeclarations_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                struct node * const next;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1818,6 +1818,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefDeclarations_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                widget_t *current;
+                const message_t message = {};
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "message_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1742,12 +1742,14 @@ public class ReferenceExtractorTests
     {
         const string content = """
             #include_next <limits.h>
+            #include PROJECT_HEADER
             """;
 
         var symbols = SymbolExtractor.Extract(1, "c", content);
         var references = ReferenceExtractor.Extract(1, "c", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "limits.h" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "PROJECT_HEADER" && r.ReferenceKind == "type_reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2370,6 +2370,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefBuiltinTypesCompatibleOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            int same(void) {
+                return __builtin_types_compatible_p(widget_t *, message_t);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "message_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1855,6 +1855,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefFunctionReturns_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            static widget_t *make_widget(void) {
+                return 0;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2259,6 +2259,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTypedefSizeofOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long size = sizeof(widget_t * const);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1801,6 +1801,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefAlignof_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void measure(void) {
+                unsigned long widgetAlign = _Alignof(widget_t);
+                unsigned long configAlign = alignof(config_t);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "config_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2166,6 +2166,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefPointerArrayDeclarations_CapturesLowercaseElementTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                widget_t (*items)[4];
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1966,6 +1966,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedTypeofOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void copy(void) {
+                void (*sink)(typeof(struct node *));
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2058,6 +2058,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTypedefGenericAssociations_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            int choose(int value) {
+                return _Generic(value, widget_t * const: 1, default: 0);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTaggedGenericAssociations_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1933,6 +1933,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedCompoundLiterals_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void init(void) {
+                use((struct node){0});
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1870,6 +1870,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedFunctionReturns_CapturesTagTypeReferences()
+    {
+        const string content = """
+            static struct node *make_node(void) {
+                return 0;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2418,6 +2418,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedBuiltinOffsetofOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long offset = __builtin_offsetof(struct node, next);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2015,6 +2015,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefAtomicTypeSpecifiers_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void init(void) {
+                _Atomic(widget_t) current;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2386,6 +2386,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedBuiltinTypesCompatibleOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            int same(void) {
+                return __builtin_types_compatible_p(struct node *, union value);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName is "struct" or "union");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2212,6 +2212,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedOffsetofOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long offset = offsetof(struct node, next);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2403,6 +2403,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefBuiltinOffsetofOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long offset = __builtin_offsetof(widget_t, field);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2197,6 +2197,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefOffsetofOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long offset = offsetof(widget_t, field);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2449,6 +2449,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedBuiltinVaArgOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                consume(__builtin_va_arg(args, struct node *));
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1918,6 +1918,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefCompoundLiterals_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void init(void) {
+                use((widget_t){0});
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1932,6 +1932,20 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTypedefParameters_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void visit(widget_t * restrict widget) {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CTaggedParameters_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2135,6 +2135,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTypedefDeclarations_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                widget_t * restrict current;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2030,6 +2030,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedAtomicTypeSpecifiers_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void init(void) {
+                _Atomic(struct node *) current;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1982,6 +1982,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefGenericAssociations_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            int choose(int value) {
+                return _Generic(value, widget_t: 1, message_t *: 2, default: 0);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "message_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1886,6 +1886,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefParameters_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void visit(widget_t *widget, const message_t *message) {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "message_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1753,6 +1753,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefTags_SkipsTypeKeywords()
+    {
+        const string content = """
+            typedef struct node node_t;
+            typedef enum mode mode_t;
+            typedef union value value_t;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "mode" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName is "struct" or "enum" or "union");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1949,6 +1949,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefTypeofOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void copy(widget_t value) {
+                typeof(widget_t) next = value;
+                __typeof__(message_t *) message = 0;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "message_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2119,6 +2119,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedFunctionPointerDeclarations_CapturesTagReturnTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                struct node *(*factory)(void);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1901,6 +1901,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedParameters_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void visit(struct node *node, enum mode mode, union value *value) {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "mode" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName is "struct" or "enum" or "union");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2274,6 +2274,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CPointerQualifiedTaggedSizeofOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long size = sizeof(struct node * const);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2323,6 +2323,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedGnuAlignofOperands_CapturesTagTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                unsigned long align = __alignof__(struct node *);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "struct");
+    }
+
+    [Fact]
     public void Extract_CTaggedVaArgOperands_CapturesTagTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2228,6 +2228,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefVaArgOperands_CapturesLowercaseTypeReferences()
+    {
+        const string content = """
+            void configure(void) {
+                consume(va_arg(args, widget_t));
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2077,6 +2077,19 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTypedefFunctionPointerAliases_CapturesLowercaseReturnTypeReferences()
+    {
+        const string content = """
+            typedef widget_t (*widget_factory_t)(void);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "widget_t" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1738,6 +1738,19 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CIncludeNext_CapturesHeaderReference()
+    {
+        const string content = """
+            #include_next <limits.h>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "limits.h" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2061,6 +2061,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CTaggedAlignasSpecifiers_CapturesTagTypeReferences()
+    {
+        const string content = """
+            _Alignas(struct node) unsigned char nodeStorage[64];
+            alignas(union value *) unsigned char valueStorage[64];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "c", content);
+        var references = ReferenceExtractor.Extract(1, "c", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "node" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "value" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName is "struct" or "union");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringFixture_DoesNotBecomeReference()
     {
         const string content = """"

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14555,6 +14555,7 @@ public class SymbolExtractorTests
             #include <stdio.h>
             # include <stdlib.h>
             #include_next <limits.h>
+            #import "legacy.h"
             #include "project/foo.h"
             #include HEADER_NAME
             """;
@@ -14564,6 +14565,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stdio.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stdlib.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "limits.h");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "legacy.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "project/foo.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "HEADER_NAME");
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14428,10 +14428,15 @@ public class SymbolExtractorTests
         var content = """
             typedef struct Node Node_t;
             typedef struct Payload* PayloadRef;
+            typedef union Value Value_t;
             typedef enum Mode Mode_t;
 
             struct Node {
                 int value;
+            };
+
+            union Value {
+                int number;
             };
 
             enum Mode {
@@ -14443,6 +14448,8 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Node_t");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "PayloadRef");
+        Assert.Contains(symbols, s => s.Kind == "union" && s.Name == "Value_t");
+        Assert.Contains(symbols, s => s.Kind == "union" && s.Name == "Value");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Mode_t");
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Node");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Mode");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14553,6 +14553,7 @@ public class SymbolExtractorTests
         // C: include targets should be searchable by header name / C: include 先はヘッダー名で検索できるべき
         var content = """
             #include <stdio.h>
+            # include <stdlib.h>
             #include "project/foo.h"
             #include HEADER_NAME
             """;
@@ -14560,6 +14561,7 @@ public class SymbolExtractorTests
         var symbols = SymbolExtractor.Extract(1, "c", content);
 
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stdio.h");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stdlib.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "project/foo.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "HEADER_NAME");
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14554,6 +14554,7 @@ public class SymbolExtractorTests
         var content = """
             #include <stdio.h>
             # include <stdlib.h>
+            #include_next <limits.h>
             #include "project/foo.h"
             #include HEADER_NAME
             """;
@@ -14562,6 +14563,7 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stdio.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stdlib.h");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "limits.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "project/foo.h");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "HEADER_NAME");
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14414,10 +14414,11 @@ public class SymbolExtractorTests
     public void Extract_C_DetectsFunctionsAndStructs()
     {
         // C: functions, struct / C: 関数、構造体
-        var content = "typedef struct Config {\n    int value;\n};\nint main(int argc) {\n}";
+        var content = "typedef struct Config {\n    int value;\n};\nunion Packet {\n    int tag;\n};\nint main(int argc) {\n}";
         var symbols = SymbolExtractor.Extract(1, "c", content);
 
         Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Config");
+        Assert.Contains(symbols, s => s.Kind == "union" && s.Name == "Packet");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "main");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14469,6 +14469,10 @@ public class SymbolExtractorTests
             __declspec(dllexport) int exported(void) {
                 return 0;
             }
+
+            [[nodiscard]] int compute(void) {
+                return 1;
+            }
             """;
 
         var symbols = SymbolExtractor.Extract(1, "c", content);
@@ -14476,6 +14480,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "die");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "add");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "exported");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "compute");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

This PR improves C reference extraction coverage across 60 small commits on `codex/c-search-enhancements-20`.

The changes make C type-reference search find more real-world C constructs, including include variants, union forms, lowercase `_t` typedef uses, tagged type operands, GNU/C23 type operators, builtin operands, function-pointer return types, pointer-qualified declarations, return types, parameters, and `_Generic` associations.

## Impact

C code search now returns more complete type-reference results for common typedef and tagged-type syntax. This should improve symbol/reference navigation for C projects that use `_t` typedefs, `struct`/`enum`/`union` tags, GNU builtins, C23 spellings, and pointer-qualified declarations.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` — 4043 passed, 3 skipped
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Per-commit adversarial review was performed after each commit in the latest 20-commit round, with no blocking/actionable issues found.