### PR TITLE
[codex] Improve Python search extraction coverage

### DIFF
--- a/changelog.d/unreleased/+python-abstract-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-abstract-property-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python abstract properties are indexed as properties** — legacy `@abstractproperty` and qualified `@abc.abstractproperty` decorators now classify decorated methods as property symbols.
+
+## 日本語
+
+- **Python の abstract property を property として index するようにしました** — legacy の `@abstractproperty` と修飾付き `@abc.abstractproperty` decorator が付いた method を property symbol として分類するようにしました。

--- a/changelog.d/unreleased/+python-all-append-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-all-append-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `__all__.append` exports are indexed** — package `__init__.py` files that append literal names to `__all__` now expose those names as import symbols for exact symbol search.
+
+## 日本語
+
+- **Python の `__all__.append` export を index するようにしました** — package の `__init__.py` が literal 名を `__all__` に append する場合も、exact symbol search 用の import symbol として公開名を index するようになりました。

--- a/changelog.d/unreleased/+python-all-extend-next-line-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-all-extend-next-line-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `__all__.extend` handles next-line values** — `__all__.extend(` followed by a literal list or tuple on the next line now indexes those exported names for exact symbol search.
+
+## 日本語
+
+- **Python の `__all__.extend` が次行開始の値にも対応しました** — `__all__.extend(` の次行に literal list や tuple を置く形式でも、export 名を exact symbol search 用に index するようになりました。

--- a/changelog.d/unreleased/+python-all-extend-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-all-extend-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `__all__.extend` exports are indexed** — package `__init__.py` files that extend `__all__` with literal names now expose those names as import symbols for exact symbol search.
+
+## 日本語
+
+- **Python の `__all__.extend` export を index するようにしました** — package の `__init__.py` が literal 名で `__all__` を extend する場合も、exact symbol search 用の import symbol として公開名を index するようになりました。

--- a/changelog.d/unreleased/+python-annotated-class-attributes.fixed.md
+++ b/changelog.d/unreleased/+python-annotated-class-attributes.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python annotated class attributes are indexed as properties** — class-body declarations such as `name: str` now appear in symbol search while method-local annotations stay excluded.
+
+## 日本語
+
+- **Python の型注釈付き class attribute を property として index するようにしました** — `name: str` のような class body 宣言が symbol search に出るようになり、method-local annotation は除外されたままです。

--- a/changelog.d/unreleased/+python-annotations-dictionary-properties.fixed.md
+++ b/changelog.d/unreleased/+python-annotations-dictionary-properties.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python class `__annotations__` dictionary keys are indexed as properties** — literal keys in class-body `__annotations__` assignments now appear in symbol search.
+
+## 日本語
+
+- **Python class の `__annotations__` 辞書 key を property として index するようにしました** — class body の `__annotations__` 代入に含まれる literal key が symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-assert-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-assert-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `assert_type` calls emit expected type references** — `assert_type(value, models.User)` now records the expected type for reference search.
+
+## 日本語
+
+- **Python の `assert_type` 呼び出しが期待型参照を出すようになりました** — `assert_type(value, models.User)` が期待型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-assigned-class-attributes.fixed.md
+++ b/changelog.d/unreleased/+python-assigned-class-attributes.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python assigned class attributes are indexed as properties** — class-body assignments such as `DEFAULT_TIMEOUT = 30` now appear in symbol search while method-local assignments stay excluded.
+
+## 日本語
+
+- **Python の代入形式 class attribute を property として index するようにしました** — `DEFAULT_TIMEOUT = 30` のような class body の代入が symbol search に出るようになり、method-local assignment は除外されたままです。

--- a/changelog.d/unreleased/+python-attrs-fields-references.fixed.md
+++ b/changelog.d/unreleased/+python-attrs-fields-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `attrs.fields` calls emit target type references** — `attrs.fields(models.User)` and `attr.fields(models.User)` now record the inspected attrs model type for reference search.
+
+## 日本語
+
+- **Python の `attrs.fields` 呼び出しが対象型参照を出すようになりました** — `attrs.fields(models.User)` と `attr.fields(models.User)` が検査対象の attrs モデル型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-augmented-slots-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-augmented-slots-property-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python augmented `__slots__` fields are indexed as properties** — slot names added with `__slots__ += (...)` now appear as property symbols.
+
+## 日本語
+
+- **Python の augmented `__slots__` field を property として index するようにしました** — `__slots__ += (...)` で追加される slot 名も property symbol として出るようになりました。

--- a/changelog.d/unreleased/+python-bare-raise-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-bare-raise-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python bare `raise` statements emit type references** — `raise CustomError` now records `CustomError` as a `type_reference` so exception usage is searchable even without call parentheses.
+
+## 日本語
+
+- **Python の括弧なし `raise` が型参照を出すようになりました** — `raise CustomError` が `CustomError` を `type_reference` として記録し、呼び出し括弧がない例外利用も検索できるようになりました。

--- a/changelog.d/unreleased/+python-cached-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-cached-property-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python cached properties are indexed as properties** — `@cached_property` and qualified cached property decorators now classify the decorated `def` as a property symbol instead of a function.
+
+## 日本語
+
+- **Python の cached property を property として index するようにしました** — `@cached_property` と修飾付き cached property decorator が付いた `def` を function ではなく property symbol として分類するようにしました。

--- a/changelog.d/unreleased/+python-call-decorator-references.fixed.md
+++ b/changelog.d/unreleased/+python-call-decorator-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python call-style decorators emit decorator references** — decorators such as `@parametrized(...)` now produce a `decorator` reference in addition to the ordinary call edge.
+
+## 日本語
+
+- **Python の呼び出し形 decorator が decorator reference を出すようになりました** — `@parametrized(...)` のような decorator が通常の call edge に加えて `decorator` reference も生成するようになりました。

--- a/changelog.d/unreleased/+python-cast-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-cast-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `cast` calls emit target type references** — `cast(models.User, value)` now records `User` as a `type_reference` so type-narrowing casts are searchable from the target type.
+
+## 日本語
+
+- **Python の `cast` 呼び出しが対象型参照を出すようになりました** — `cast(models.User, value)` が `User` を `type_reference` として記録し、型ナローイング用の cast を対象型から検索できるようになりました。

--- a/changelog.d/unreleased/+python-class-base-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-class-base-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python class bases emit type references** — `class UserView(views.BaseView):` now records `BaseView` as a `type_reference` so base-class usage is searchable from the base type.
+
+## 日本語
+
+- **Python の基底クラスが型参照を出すようになりました** — `class UserView(views.BaseView):` が `BaseView` を `type_reference` として記録し、基底型側から利用箇所を検索できるようになりました。

--- a/changelog.d/unreleased/+python-contextlib-suppress-references.fixed.md
+++ b/changelog.d/unreleased/+python-contextlib-suppress-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `contextlib.suppress` calls emit exception type references** — `contextlib.suppress(errors.NotFoundError)` now records the suppressed exception type for reference search.
+
+## 日本語
+
+- **Python の `contextlib.suppress` 呼び出しが例外型参照を出すようになりました** — `contextlib.suppress(errors.NotFoundError)` が握りつぶす例外型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-create-model-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-create-model-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `create_model` assignments are indexed as classes** — dynamic model declarations such as `RuntimeUser = create_model(...)` now appear in symbol search.
+
+## 日本語
+
+- **Python の `create_model` 代入を class として index するようにしました** — `RuntimeUser = create_model(...)` のような動的 model 宣言が symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-current-package-from-import-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-current-package-from-import-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python current-package re-exports gain qualified import symbols** — `from . import helper` inside `__init__.py` now indexes both `helper` and the package-qualified module name for exact symbol search.
+
+## 日本語
+
+- **Python の current-package re-export に修飾済み import symbol を追加しました** — `__init__.py` 内の `from . import helper` が `helper` と package-qualified module name の両方を index するようになり、exact symbol search で見つけやすくなりました。

--- a/changelog.d/unreleased/+python-current-package-module-import-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-current-package-module-import-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python current-package module imports gain package-qualified symbols** — `from .tools import build` inside `__init__.py` now indexes `package.subpkg.tools.build` for exact symbol search.
+
+## 日本語
+
+- **Python の current-package module import に package-qualified symbol を追加しました** — `__init__.py` 内の `from .tools import build` が exact symbol search 用に `package.subpkg.tools.build` を index するようになりました。

--- a/changelog.d/unreleased/+python-dataclasses-fields-references.fixed.md
+++ b/changelog.d/unreleased/+python-dataclasses-fields-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `dataclasses.fields` calls emit target type references** — `dataclasses.fields(models.User)` now records the inspected dataclass type for reference search.
+
+## 日本語
+
+- **Python の `dataclasses.fields` 呼び出しが対象型参照を出すようになりました** — `dataclasses.fields(models.User)` が検査対象の dataclass 型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-except-tuple-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-except-tuple-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python tuple `except` clauses emit type references** — handlers such as `except (TimeoutError, network.NetworkError):` now record each exception type for reference search.
+
+## 日本語
+
+- **Python の tuple 形式 `except` 節が型参照を出すようになりました** — `except (TimeoutError, network.NetworkError):` のような複数例外ハンドラが各例外型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-except-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-except-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `except` clauses emit type references** — `except CustomError as exc:` now records `CustomError` as a `type_reference`, making exception handlers discoverable from the exception class.
+
+## 日本語
+
+- **Python の `except` 節が型参照を出すようになりました** — `except CustomError as exc:` が `CustomError` を `type_reference` として記録し、例外クラスから捕捉箇所を探せるようになりました。

--- a/changelog.d/unreleased/+python-final-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-final-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `Final` declarations are indexed** — module constants such as `DEFAULT_TIMEOUT: Final[int] = 30` now appear as property symbols in symbol search.
+
+## 日本語
+
+- **Python の `Final` 宣言を index するようにしました** — `DEFAULT_TIMEOUT: Final[int] = 30` のような module constant が property symbol として symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-functional-enum-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-functional-enum-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python functional enum declarations are indexed as classes** — assignments such as `Color = Enum(...)` and `Status = enum.Enum(...)` now appear in symbol search.
+
+## 日本語
+
+- **Python の functional enum 宣言を class として index するようにしました** — `Color = Enum(...)` や `Status = enum.Enum(...)` のような代入が symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-functional-enum-variants.fixed.md
+++ b/changelog.d/unreleased/+python-functional-enum-variants.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python functional enum variants are indexed as classes** — `IntEnum`, `Flag`, `IntFlag`, and `StrEnum` factory assignments now appear in symbol search.
+
+## 日本語
+
+- **Python の functional enum variant を class として index するようにしました** — `IntEnum`、`Flag`、`IntFlag`、`StrEnum` の factory 代入が symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-generic-parameter-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-generic-parameter-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python generic parameter annotations emit nested type references** — `def save(users: Sequence[models.User]):` now records `User` from inside the parameter annotation.
+
+## 日本語
+
+- **Python の generic 引数型注釈が内側の型参照を出すようになりました** — `def save(users: Sequence[models.User]):` が引数注釈内の `User` を記録するようになりました。

--- a/changelog.d/unreleased/+python-generic-return-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-generic-return-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python generic return annotations emit nested type references** — `def load_many() -> list[models.User]:` now records `User` from inside the return annotation.
+
+## 日本語
+
+- **Python の generic 戻り値型注釈が内側の型参照を出すようになりました** — `def load_many() -> list[models.User]:` が戻り値注釈内の `User` を記録するようになりました。

--- a/changelog.d/unreleased/+python-generic-variable-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-generic-variable-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python generic variable annotations emit nested type references** — `users: Sequence[models.User] = []` now records `User` from inside the variable annotation.
+
+## 日本語
+
+- **Python の generic 変数型注釈が内側の型参照を出すようになりました** — `users: Sequence[models.User] = []` が変数注釈内の `User` を記録するようになりました。

--- a/changelog.d/unreleased/+python-get-type-hints-references.fixed.md
+++ b/changelog.d/unreleased/+python-get-type-hints-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `get_type_hints` calls emit target type references** — `get_type_hints(models.User)` now records the inspected target for reference search.
+
+## 日本語
+
+- **Python の `get_type_hints` 呼び出しが対象型参照を出すようになりました** — `get_type_hints(models.User)` が検査対象を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-isinstance-tuple-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-isinstance-tuple-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python tuple `isinstance` checks emit type references** — `isinstance(value, (models.User, api.Admin))` now records each checked type for reference search.
+
+## 日本語
+
+- **Python の tuple 形式 `isinstance` が型参照を出すようになりました** — `isinstance(value, (models.User, api.Admin))` が確認対象の各型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-isinstance-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-isinstance-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `isinstance` checks emit type references** — `isinstance(value, models.User)` now records the checked type so runtime type checks are searchable from the class.
+
+## 日本語
+
+- **Python の `isinstance` チェックが型参照を出すようになりました** — `isinstance(value, models.User)` が確認対象の型を記録し、実行時型チェックをクラス側から検索できるようになりました。

--- a/changelog.d/unreleased/+python-issubclass-tuple-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-issubclass-tuple-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python tuple `issubclass` checks emit type references** — `issubclass(cls, (services.Plugin, mixins.Audited))` now records each checked base type for reference search.
+
+## 日本語
+
+- **Python の tuple 形式 `issubclass` が型参照を出すようになりました** — `issubclass(cls, (services.Plugin, mixins.Audited))` が確認対象の各基底型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-issubclass-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-issubclass-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `issubclass` checks emit type references** — `issubclass(cls, services.Plugin)` now records the checked base type for reference search.
+
+## 日本語
+
+- **Python の `issubclass` チェックが型参照を出すようになりました** — `issubclass(cls, services.Plugin)` が確認対象の基底型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-make-dataclass-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-make-dataclass-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `make_dataclass` assignments are indexed as classes** — dynamic dataclass factories such as `DynamicUser = make_dataclass(...)` now appear as class symbols.
+
+## 日本語
+
+- **Python の `make_dataclass` 代入を class として index するようにしました** — `DynamicUser = make_dataclass(...)` のような動的 dataclass factory が class symbol として出るようになりました。

--- a/changelog.d/unreleased/+python-match-args-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-match-args-property-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `__match_args__` fields are indexed as properties** — literal names in class-body `__match_args__` assignments now appear as property symbols for symbol search.
+
+## 日本語
+
+- **Python の `__match_args__` field を property として index するようにしました** — class body の `__match_args__` 代入に含まれる literal 名が symbol search 用の property symbol として出るようになりました。

--- a/changelog.d/unreleased/+python-metaclass-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-metaclass-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python class metaclasses emit type references** — `class Model(metaclass=orm.ModelMeta):` now records the metaclass so metaclass usage is searchable.
+
+## 日本語
+
+- **Python の metaclass 指定が型参照を出すようになりました** — `class Model(metaclass=orm.ModelMeta):` が metaclass を記録し、メタクラスの利用箇所を検索できるようになりました。

--- a/changelog.d/unreleased/+python-multiple-class-base-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-multiple-class-base-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python multiple class bases emit type references** — `class UserView(views.BaseView, mixins.AuditedMixin):` now records each base class for reference search.
+
+## 日本語
+
+- **Python の複数基底クラスが型参照を出すようになりました** — `class UserView(views.BaseView, mixins.AuditedMixin):` が各基底クラスを参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-namedtuple-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-namedtuple-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python functional named tuples are indexed as classes** — assignments such as `Point = NamedTuple(...)` and `Coordinate = collections.namedtuple(...)` now appear as class symbols.
+
+## 日本語
+
+- **Python の functional named tuple を class として index するようにしました** — `Point = NamedTuple(...)` や `Coordinate = collections.namedtuple(...)` のような代入が class symbol として出るようになりました。

--- a/changelog.d/unreleased/+python-newtype-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-newtype-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `NewType` aliases are indexed** — aliases such as `UserId = NewType("UserId", int)` and `OrderId = typing.NewType(...)` now appear in symbol search.
+
+## 日本語
+
+- **Python の `NewType` alias を index するようにしました** — `UserId = NewType("UserId", int)` や `OrderId = typing.NewType(...)` のような alias が symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-newtype-underlying-references.fixed.md
+++ b/changelog.d/unreleased/+python-newtype-underlying-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `NewType` calls emit underlying type references** — `NewType("UserId", models.User)` now records the wrapped type for reference search.
+
+## 日本語
+
+- **Python の `NewType` 呼び出しが元型参照を出すようになりました** — `NewType("UserId", models.User)` がラップ元の型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-parameter-annotation-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-parameter-annotation-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python parameter annotations emit type references** — `def save(user: models.User):` now records the parameter type for reference search.
+
+## 日本語
+
+- **Python の引数型注釈が型参照を出すようになりました** — `def save(user: models.User):` が引数型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-parent-relative-import-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-parent-relative-import-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python parent-relative imports gain package-qualified symbols** — `from ..shared import helper` inside package `__init__.py` now indexes the resolved package path, such as `package.shared.helper`, for exact symbol search.
+
+## 日本語
+
+- **Python の parent-relative import に package-qualified symbol を追加しました** — package の `__init__.py` 内の `from ..shared import helper` が、`package.shared.helper` のような解決後の package path を exact symbol search 用に index するようになりました。

--- a/changelog.d/unreleased/+python-property-accessor-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-property-accessor-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python property accessors are indexed as properties** — `@name.setter` and `@name.deleter` methods now appear as property symbols instead of function symbols.
+
+## 日本語
+
+- **Python の property accessor を property として index するようにしました** — `@name.setter` と `@name.deleter` の method が function ではなく property symbol として出るようになりました。

--- a/changelog.d/unreleased/+python-pydantic-type-adapter-references.fixed.md
+++ b/changelog.d/unreleased/+python-pydantic-type-adapter-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `pydantic.TypeAdapter` calls emit target type references** — `pydantic.TypeAdapter(models.User)` now records the adapted model type for reference search.
+
+## 日本語
+
+- **Python の `pydantic.TypeAdapter` 呼び出しが対象型参照を出すようになりました** — `pydantic.TypeAdapter(models.User)` がアダプタ対象のモデル型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-pytest-raises-references.fixed.md
+++ b/changelog.d/unreleased/+python-pytest-raises-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `pytest.raises` calls emit exception type references** — `pytest.raises(errors.ValidationError)` now records the expected exception type for reference search.
+
+## 日本語
+
+- **Python の `pytest.raises` 呼び出しが例外型参照を出すようになりました** — `pytest.raises(errors.ValidationError)` が期待される例外型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-qualified-assert-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-qualified-assert-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python qualified `typing.assert_type` calls emit expected type references** — `typing.assert_type(value, models.User)` now records the expected type for reference search.
+
+## 日本語
+
+- **Python の qualified `typing.assert_type` 呼び出しが期待型参照を出すようになりました** — `typing.assert_type(value, models.User)` が期待型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-qualified-call-decorator-references.fixed.md
+++ b/changelog.d/unreleased/+python-qualified-call-decorator-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python qualified call decorators keep their full decorator reference** — dotted decorators such as `@pytest.mark.parametrize(...)` now emit `pytest.mark.parametrize` as a `decorator` reference.
+
+## 日本語
+
+- **Python の修飾付き呼び出し形 decorator が完全名の decorator reference を保持するようになりました** — `@pytest.mark.parametrize(...)` のような dotted decorator が `pytest.mark.parametrize` を `decorator` reference として出すようになりました。

--- a/changelog.d/unreleased/+python-qualified-cast-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-qualified-cast-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python qualified `typing.cast` calls emit target type references** — `typing.cast(models.User, value)` now records the cast target type for reference search.
+
+## 日本語
+
+- **Python の qualified `typing.cast` 呼び出しが対象型参照を出すようになりました** — `typing.cast(models.User, value)` が cast 対象の型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-qualified-get-type-hints-references.fixed.md
+++ b/changelog.d/unreleased/+python-qualified-get-type-hints-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python qualified `typing.get_type_hints` calls emit target type references** — `typing.get_type_hints(models.User)` now records the inspected target for reference search.
+
+## 日本語
+
+- **Python の qualified `typing.get_type_hints` 呼び出しが対象型参照を出すようになりました** — `typing.get_type_hints(models.User)` が検査対象を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-raise-from-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-raise-from-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `raise ... from ...` emits exception type references** — `raise package.CustomError from exc` now records the raised exception type even when exception chaining is present.
+
+## 日本語
+
+- **Python の `raise ... from ...` が例外型参照を出すようになりました** — `raise package.CustomError from exc` のような例外連鎖でも、送出する例外型を記録するようになりました。

--- a/changelog.d/unreleased/+python-relative-module-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-relative-module-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python relative import modules gain qualified symbols** — relative `from .tools import build` statements now index the resolved module name, such as `package.subpkg.tools`, in addition to imported members.
+
+## 日本語
+
+- **Python の relative import module に修飾済み symbol を追加しました** — `from .tools import build` のような relative import が、import された member に加えて `package.subpkg.tools` のような解決後の module 名も index するようになりました。

--- a/changelog.d/unreleased/+python-return-annotation-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-return-annotation-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python return annotations emit type references** — `def load() -> models.User:` now records the return type for reference search.
+
+## 日本語
+
+- **Python の戻り値型注釈が型参照を出すようになりました** — `def load() -> models.User:` が戻り値型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-slots-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-slots-property-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `__slots__` fields are indexed as properties** — literal slot names in class-body `__slots__` assignments now appear as property symbols instead of only indexing `__slots__` itself.
+
+## 日本語
+
+- **Python の `__slots__` field を property として index するようにしました** — class body の `__slots__` 代入に含まれる literal slot 名を property symbol として出し、`__slots__` 自体だけが index される状態を避けるようにしました。

--- a/changelog.d/unreleased/+python-type-alias-target-references.fixed.md
+++ b/changelog.d/unreleased/+python-type-alias-target-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python type aliases emit target type references** — `UserAlias: TypeAlias = models.User` now records the aliased target type for reference search.
+
+## 日本語
+
+- **Python の型エイリアスが対象型参照を出すようになりました** — `UserAlias: TypeAlias = models.User` がエイリアス先の型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-type-parameter-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-type-parameter-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python type-parameter aliases are indexed** — `TypeVar`, `ParamSpec`, and `TypeVarTuple` assignments now appear in symbol search.
+
+## 日本語
+
+- **Python の型パラメータ alias を index するようにしました** — `TypeVar`、`ParamSpec`、`TypeVarTuple` の代入が symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-typealias-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-typealias-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python `TypeAlias` declarations are indexed** — legacy aliases such as `JsonValue: TypeAlias = ...` and `Handler: typing.TypeAlias = ...` now appear in symbol search.
+
+## 日本語
+
+- **Python の `TypeAlias` 宣言を index するようにしました** — `JsonValue: TypeAlias = ...` や `Handler: typing.TypeAlias = ...` のような legacy alias が symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-typeddict-symbols.fixed.md
+++ b/changelog.d/unreleased/+python-typeddict-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Python functional `TypedDict` declarations are indexed as classes** — assignments such as `UserPayload = TypedDict(...)` and `OrderPayload = typing.TypedDict(...)` now appear in symbol search.
+
+## 日本語
+
+- **Python の functional `TypedDict` 宣言を class として index するようにしました** — `UserPayload = TypedDict(...)` や `OrderPayload = typing.TypedDict(...)` のような代入が symbol search に出るようになりました。

--- a/changelog.d/unreleased/+python-typevar-bound-references.fixed.md
+++ b/changelog.d/unreleased/+python-typevar-bound-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `TypeVar` bounds emit type references** — `TypeVar("TUser", bound=models.User)` now records the bound type for reference search.
+
+## 日本語
+
+- **Python の `TypeVar` bound が型参照を出すようになりました** — `TypeVar("TUser", bound=models.User)` がbound型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-typevar-constraint-references.fixed.md
+++ b/changelog.d/unreleased/+python-typevar-constraint-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python `TypeVar` constraints emit type references** — `TypeVar("TAccount", models.User, models.Admin)` now records each constraint type for reference search.
+
+## 日本語
+
+- **Python の `TypeVar` 制約が型参照を出すようになりました** — `TypeVar("TAccount", models.User, models.Admin)` が各制約型を参照検索に記録するようになりました。

--- a/changelog.d/unreleased/+python-variable-annotation-type-references.fixed.md
+++ b/changelog.d/unreleased/+python-variable-annotation-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python variable annotations emit type references** — `user: models.User = load_user()` now records the annotated type for reference search.
+
+## 日本語
+
+- **Python の変数型注釈が型参照を出すようになりました** — `user: models.User = load_user()` が注釈された型を参照検索に記録するようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -69,6 +69,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex DirectAnnotationTypeRegex = new(
         @":\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)(?=\s*(?:=|,|$))",
         RegexOptions.Compiled);
+    private static readonly Regex VariableAnnotationTypeRegex = new(
+        @"^\s*(?:self\.)?\w+\s*:\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)(?=\s*(?:=|#|$))",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -515,6 +518,35 @@ internal static class PythonReferenceExtractor
                     resolveContainerForReference(nameIndex) ?? container,
                     "python");
             }
+        }
+    }
+
+    public static void EmitVariableAnnotationReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in VariableAnnotationTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
         }
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -102,6 +102,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex DataclassesFieldsTargetRegex = new(
         @"\bdataclasses\.fields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex AttrsFieldsTargetRegex = new(
+        @"\b(?:attr|attrs)\.fields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -831,6 +834,35 @@ internal static class PythonReferenceExtractor
         Func<string, bool> isIgnoredName)
     {
         foreach (Match match in DataclassesFieldsTargetRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitAttrsFieldsReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in AttrsFieldsTargetRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -63,6 +63,12 @@ internal static class PythonReferenceExtractor
     private static readonly Regex FunctionReturnTypeRegex = new(
         @"^\s*(?:async\s+)?def\s+\w+\s*\([^)]*\)\s*->\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*:",
         RegexOptions.Compiled);
+    private static readonly Regex FunctionParameterListRegex = new(
+        @"^\s*(?:async\s+)?def\s+\w+\s*\((?<params>[^)]*)\)",
+        RegexOptions.Compiled);
+    private static readonly Regex DirectAnnotationTypeRegex = new(
+        @":\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)(?=\s*(?:=|,|$))",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -474,6 +480,41 @@ internal static class PythonReferenceExtractor
                 lineNumber,
                 resolveContainerForReference(nameIndex) ?? container,
                 "python");
+        }
+    }
+
+    public static void EmitFunctionParameterReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<int, SymbolRecord?> resolveContainerForReference,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match functionMatch in FunctionParameterListRegex.Matches(preparedLine))
+        {
+            var paramsGroup = functionMatch.Groups["params"];
+            foreach (Match annotationMatch in DirectAnnotationTypeRegex.Matches(paramsGroup.Value))
+            {
+                var name = annotationMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                var nameIndex = paramsGroup.Index + annotationMatch.Groups["name"].Index;
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    nameIndex,
+                    context,
+                    lineNumber,
+                    resolveContainerForReference(nameIndex) ?? container,
+                    "python");
+            }
         }
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -33,6 +33,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex IsInstanceTupleTypeRegex = new(
         @"\bisinstance\s*\(\s*[^,\n]+,\s*\((?<types>[^)]*)\)\s*\)",
         RegexOptions.Compiled);
+    private static readonly Regex IsSubclassTypeRegex = new(
+        @"\bissubclass\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -181,6 +184,35 @@ internal static class PythonReferenceExtractor
         }
 
         foreach (Match match in IsInstanceTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitIsSubclassReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in IsSubclassTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -12,6 +12,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex DecoratorRegex = new(
         @"^\s*@(?<name>[_\p{L}]\w*(?:\.[_\p{L}]\w*)*)\s*(?:#.*)?$",
         RegexOptions.Compiled);
+    private static readonly Regex DecoratorCallRegex = new(
+        @"^\s*@(?<name>[_\p{L}]\w*)\s*\(",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -24,6 +27,17 @@ internal static class PythonReferenceExtractor
         HashSet<string>? definitionNames,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in DecoratorCallRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+            if (definitionNames != null && definitionNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(references, seen, fileId, match, "decorator", context, lineNumber, container);
+        }
+
         foreach (Match match in DecoratorRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -111,6 +111,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex PytestRaisesTypeRegex = new(
         @"\bpytest\.raises\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex ContextlibSuppressTypeRegex = new(
+        @"\bcontextlib\.suppress\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -927,6 +930,35 @@ internal static class PythonReferenceExtractor
         Func<string, bool> isIgnoredName)
     {
         foreach (Match match in PytestRaisesTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitContextlibSuppressReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in ContextlibSuppressTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -72,6 +72,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex DirectAnnotationTypeRegex = new(
         @":\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)(?=\s*(?:=|,|$))",
         RegexOptions.Compiled);
+    private static readonly Regex AnnotationExpressionTypeRegex = new(
+        @":\s*(?<type>[^=,]+)(?=\s*(?:=|,|$))",
+        RegexOptions.Compiled);
     private static readonly Regex VariableAnnotationTypeRegex = new(
         @"^\s*(?:self\.)?\w+\s*:\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)(?=\s*(?:=|#|$))",
         RegexOptions.Compiled);
@@ -526,6 +529,29 @@ internal static class PythonReferenceExtractor
         foreach (Match functionMatch in FunctionParameterListRegex.Matches(preparedLine))
         {
             var paramsGroup = functionMatch.Groups["params"];
+            foreach (Match annotationMatch in AnnotationExpressionTypeRegex.Matches(paramsGroup.Value))
+            {
+                var typeGroup = annotationMatch.Groups["type"];
+                foreach (Match typeMatch in TypeNameRegex.Matches(typeGroup.Value))
+                {
+                    var name = typeMatch.Groups["name"].Value;
+                    if (isIgnoredName(name))
+                        continue;
+
+                    var nameIndex = paramsGroup.Index + typeGroup.Index + typeMatch.Groups["name"].Index;
+                    ReferenceExtractor.AddTypeReferenceSegments(
+                        references,
+                        seen,
+                        fileId,
+                        name,
+                        nameIndex,
+                        context,
+                        lineNumber,
+                        resolveContainerForReference(nameIndex) ?? container,
+                        "python");
+                }
+            }
+
             foreach (Match annotationMatch in DirectAnnotationTypeRegex.Matches(paramsGroup.Value))
             {
                 var name = annotationMatch.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -90,6 +90,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex TypeVarBoundTypeRegex = new(
         @"\b(?:(?:typing|typing_extensions)\.)?TypeVar\s*\([^)]*\bbound\s*=\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex TypeVarConstraintTypesRegex = new(
+        @"\b(?:(?:typing|typing_extensions)\.)?TypeVar\s*\(\s*[^,\n]+,\s*(?<types>[^)=]*,[^)=]*)\)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -725,6 +728,39 @@ internal static class PythonReferenceExtractor
                 lineNumber,
                 container,
                 "python");
+        }
+    }
+
+    public static void EmitTypeVarConstraintReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in TypeVarConstraintTypesRegex.Matches(preparedLine))
+        {
+            var typesGroup = match.Groups["types"];
+            foreach (Match typeMatch in TypeNameRegex.Matches(typesGroup.Value))
+            {
+                var name = typeMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    typesGroup.Index + typeMatch.Groups["name"].Index,
+                    context,
+                    lineNumber,
+                    container,
+                    "python");
+            }
         }
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -99,6 +99,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex QualifiedGetTypeHintsTargetRegex = new(
         @"\b(?:typing|typing_extensions)\.get_type_hints\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex DataclassesFieldsTargetRegex = new(
+        @"\bdataclasses\.fields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -799,6 +802,35 @@ internal static class PythonReferenceExtractor
         }
 
         foreach (Match match in GetTypeHintsTargetRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitDataclassesFieldsReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in DataclassesFieldsTargetRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -45,6 +45,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex QualifiedCastTypeRegex = new(
         @"\b(?:typing|typing_extensions)\.cast\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*,",
         RegexOptions.Compiled);
+    private static readonly Regex AssertTypeRegex = new(
+        @"(?<!\.)\bassert_type\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -291,6 +294,35 @@ internal static class PythonReferenceExtractor
         }
 
         foreach (Match match in CastTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitAssertTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in AssertTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -54,6 +54,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex SingleClassBaseTypeRegex = new(
         @"^\s*class\s+\w+\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)\s*:",
         RegexOptions.Compiled);
+    private static readonly Regex MultipleClassBaseTypesRegex = new(
+        @"^\s*class\s+\w+\s*\((?<types>[^=)]*,[^=)]*)\)\s*:",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -376,6 +379,29 @@ internal static class PythonReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForReference,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in MultipleClassBaseTypesRegex.Matches(preparedLine))
+        {
+            var typesGroup = match.Groups["types"];
+            foreach (Match typeMatch in TypeNameRegex.Matches(typesGroup.Value))
+            {
+                var name = typeMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                var nameIndex = typesGroup.Index + typeMatch.Groups["name"].Index;
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    nameIndex,
+                    context,
+                    lineNumber,
+                    resolveContainerForReference(nameIndex) ?? container,
+                    "python");
+            }
+        }
+
         foreach (Match match in SingleClassBaseTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -63,6 +63,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex FunctionReturnTypeRegex = new(
         @"^\s*(?:async\s+)?def\s+\w+\s*\([^)]*\)\s*->\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*:",
         RegexOptions.Compiled);
+    private static readonly Regex FunctionReturnAnnotationExpressionRegex = new(
+        @"^\s*(?:async\s+)?def\s+\w+\s*\([^)]*\)\s*->\s*(?<type>[^:]+)\s*:",
+        RegexOptions.Compiled);
     private static readonly Regex FunctionParameterListRegex = new(
         @"^\s*(?:async\s+)?def\s+\w+\s*\((?<params>[^)]*)\)",
         RegexOptions.Compiled);
@@ -466,6 +469,29 @@ internal static class PythonReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForReference,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in FunctionReturnAnnotationExpressionRegex.Matches(preparedLine))
+        {
+            var typeGroup = match.Groups["type"];
+            foreach (Match typeMatch in TypeNameRegex.Matches(typeGroup.Value))
+            {
+                var name = typeMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                var nameIndex = typeGroup.Index + typeMatch.Groups["name"].Index;
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    nameIndex,
+                    context,
+                    lineNumber,
+                    resolveContainerForReference(nameIndex) ?? container,
+                    "python");
+            }
+        }
+
         foreach (Match match in FunctionReturnTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -105,6 +105,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex AttrsFieldsTargetRegex = new(
         @"\b(?:attr|attrs)\.fields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex PydanticTypeAdapterTargetRegex = new(
+        @"\bpydantic\.TypeAdapter\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -863,6 +866,35 @@ internal static class PythonReferenceExtractor
         Func<string, bool> isIgnoredName)
     {
         foreach (Match match in AttrsFieldsTargetRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitPydanticTypeAdapterReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in PydanticTypeAdapterTargetRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -39,6 +39,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex IsSubclassTupleTypeRegex = new(
         @"\bissubclass\s*\(\s*[^,\n]+,\s*\((?<types>[^)]*)\)\s*\)",
         RegexOptions.Compiled);
+    private static readonly Regex CastTypeRegex = new(
+        @"(?<!\.)\bcast\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*,",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -238,6 +241,35 @@ internal static class PythonReferenceExtractor
         }
 
         foreach (Match match in IsSubclassTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitCastReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in CastTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -60,6 +60,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex ClassMetaclassTypeRegex = new(
         @"^\s*class\s+\w+\s*\([^)]*\bmetaclass\s*=\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex FunctionReturnTypeRegex = new(
+        @"^\s*(?:async\s+)?def\s+\w+\s*\([^)]*\)\s*->\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*:",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -439,6 +442,37 @@ internal static class PythonReferenceExtractor
                 context,
                 lineNumber,
                 resolveContainerForReference(match.Groups["name"].Index) ?? container,
+                "python");
+        }
+    }
+
+    public static void EmitFunctionReturnReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<int, SymbolRecord?> resolveContainerForReference,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in FunctionReturnTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            var nameIndex = match.Groups["name"].Index;
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                nameIndex,
+                context,
+                lineNumber,
+                resolveContainerForReference(nameIndex) ?? container,
                 "python");
         }
     }

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -84,6 +84,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex TypeAliasRhsExpressionRegex = new(
         @"^\s*(?:type\s+\w+(?:\[[^\]]*\])?\s*=|\w+\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=)\s*(?<type>.+)$",
         RegexOptions.Compiled);
+    private static readonly Regex NewTypeUnderlyingTypeRegex = new(
+        @"\b(?:(?:typing|typing_extensions)\.)?NewType\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -661,6 +664,35 @@ internal static class PythonReferenceExtractor
                     container,
                     "python");
             }
+        }
+    }
+
+    public static void EmitNewTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in NewTypeUnderlyingTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
         }
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -108,6 +108,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex PydanticTypeAdapterTargetRegex = new(
         @"\bpydantic\.TypeAdapter\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex PytestRaisesTypeRegex = new(
+        @"\bpytest\.raises\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -895,6 +898,35 @@ internal static class PythonReferenceExtractor
         Func<string, bool> isIgnoredName)
     {
         foreach (Match match in PydanticTypeAdapterTargetRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitPytestRaisesReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in PytestRaisesTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -16,7 +16,7 @@ internal static class PythonReferenceExtractor
         @"^\s*@(?<name>[_\p{L}]\w*(?:\.[_\p{L}]\w*)*)\s*\(",
         RegexOptions.Compiled);
     private static readonly Regex BareRaiseTypeRegex = new(
-        @"^\s*raise\s+(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*(?:#.*)?$",
+        @"^\s*raise\s+(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)(?:\s+from\s+[_\p{L}]\w*)?\s*(?:#.*)?$",
         RegexOptions.Compiled);
     private static readonly Regex ExceptTypeRegex = new(
         @"^\s*except\s+(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*(?:as\s+\w+)?\s*:",

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -48,6 +48,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex AssertTypeRegex = new(
         @"(?<!\.)\bassert_type\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)",
         RegexOptions.Compiled);
+    private static readonly Regex QualifiedAssertTypeRegex = new(
+        @"\b(?:typing|typing_extensions)\.assert_type\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -322,6 +325,24 @@ internal static class PythonReferenceExtractor
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in QualifiedAssertTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+
         foreach (Match match in AssertTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -27,6 +27,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex TypeNameRegex = new(
         @"(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex IsInstanceTypeRegex = new(
+        @"\bisinstance\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -124,6 +127,35 @@ internal static class PythonReferenceExtractor
         }
 
         foreach (Match match in ExceptTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitIsInstanceReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in IsInstanceTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -81,6 +81,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex VariableAnnotationExpressionRegex = new(
         @"^\s*(?:self\.)?\w+\s*:\s*(?<type>[^=#]+)(?=\s*(?:=|#|$))",
         RegexOptions.Compiled);
+    private static readonly Regex TypeAliasRhsExpressionRegex = new(
+        @"^\s*(?:type\s+\w+(?:\[[^\]]*\])?\s*=|\w+\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=)\s*(?<type>.+)$",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -625,6 +628,39 @@ internal static class PythonReferenceExtractor
                 lineNumber,
                 container,
                 "python");
+        }
+    }
+
+    public static void EmitTypeAliasReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in TypeAliasRhsExpressionRegex.Matches(preparedLine))
+        {
+            var typeGroup = match.Groups["type"];
+            foreach (Match typeMatch in TypeNameRegex.Matches(typeGroup.Value))
+            {
+                var name = typeMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    typeGroup.Index + typeMatch.Groups["name"].Index,
+                    context,
+                    lineNumber,
+                    container,
+                    "python");
+            }
         }
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -57,6 +57,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex MultipleClassBaseTypesRegex = new(
         @"^\s*class\s+\w+\s*\((?<types>[^=)]*,[^=)]*)\)\s*:",
         RegexOptions.Compiled);
+    private static readonly Regex ClassMetaclassTypeRegex = new(
+        @"^\s*class\s+\w+\s*\([^)]*\bmetaclass\s*=\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -379,6 +382,25 @@ internal static class PythonReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForReference,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in ClassMetaclassTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            var nameIndex = match.Groups["name"].Index;
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                nameIndex,
+                context,
+                lineNumber,
+                resolveContainerForReference(nameIndex) ?? container,
+                "python");
+        }
+
         foreach (Match match in MultipleClassBaseTypesRegex.Matches(preparedLine))
         {
             var typesGroup = match.Groups["types"];

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -96,6 +96,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex GetTypeHintsTargetRegex = new(
         @"(?<!\.)\bget_type_hints\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex QualifiedGetTypeHintsTargetRegex = new(
+        @"\b(?:typing|typing_extensions)\.get_type_hints\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -777,6 +780,24 @@ internal static class PythonReferenceExtractor
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in QualifiedGetTypeHintsTargetRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+
         foreach (Match match in GetTypeHintsTargetRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -36,6 +36,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex IsSubclassTypeRegex = new(
         @"\bissubclass\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)",
         RegexOptions.Compiled);
+    private static readonly Regex IsSubclassTupleTypeRegex = new(
+        @"\bissubclass\s*\(\s*[^,\n]+,\s*\((?<types>[^)]*)\)\s*\)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -212,6 +215,28 @@ internal static class PythonReferenceExtractor
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in IsSubclassTupleTypeRegex.Matches(preparedLine))
+        {
+            var typesGroup = match.Groups["types"];
+            foreach (Match typeMatch in TypeNameRegex.Matches(typesGroup.Value))
+            {
+                var name = typeMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    typesGroup.Index + typeMatch.Groups["name"].Index,
+                    context,
+                    lineNumber,
+                    container,
+                    "python");
+            }
+        }
+
         foreach (Match match in IsSubclassTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -18,6 +18,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex BareRaiseTypeRegex = new(
         @"^\s*raise\s+(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*(?:#.*)?$",
         RegexOptions.Compiled);
+    private static readonly Regex ExceptTypeRegex = new(
+        @"^\s*except\s+(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*(?:as\s+\w+)?\s*:",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -64,6 +67,35 @@ internal static class PythonReferenceExtractor
         Func<string, bool> isIgnoredName)
     {
         foreach (Match match in BareRaiseTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitExceptReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in ExceptTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -30,6 +30,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex IsInstanceTypeRegex = new(
         @"\bisinstance\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)",
         RegexOptions.Compiled);
+    private static readonly Regex IsInstanceTupleTypeRegex = new(
+        @"\bisinstance\s*\(\s*[^,\n]+,\s*\((?<types>[^)]*)\)\s*\)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -155,6 +158,28 @@ internal static class PythonReferenceExtractor
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in IsInstanceTupleTypeRegex.Matches(preparedLine))
+        {
+            var typesGroup = match.Groups["types"];
+            foreach (Match typeMatch in TypeNameRegex.Matches(typesGroup.Value))
+            {
+                var name = typeMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    typesGroup.Index + typeMatch.Groups["name"].Index,
+                    context,
+                    lineNumber,
+                    container,
+                    "python");
+            }
+        }
+
         foreach (Match match in IsInstanceTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -51,6 +51,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex QualifiedAssertTypeRegex = new(
         @"\b(?:typing|typing_extensions)\.assert_type\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)",
         RegexOptions.Compiled);
+    private static readonly Regex SingleClassBaseTypeRegex = new(
+        @"^\s*class\s+\w+\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)\s*:",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -358,6 +361,36 @@ internal static class PythonReferenceExtractor
                 context,
                 lineNumber,
                 container,
+                "python");
+        }
+    }
+
+    public static void EmitClassBaseReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<int, SymbolRecord?> resolveContainerForReference,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in SingleClassBaseTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                resolveContainerForReference(match.Groups["name"].Index) ?? container,
                 "python");
         }
     }

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -13,7 +13,7 @@ internal static class PythonReferenceExtractor
         @"^\s*@(?<name>[_\p{L}]\w*(?:\.[_\p{L}]\w*)*)\s*(?:#.*)?$",
         RegexOptions.Compiled);
     private static readonly Regex DecoratorCallRegex = new(
-        @"^\s*@(?<name>[_\p{L}]\w*)\s*\(",
+        @"^\s*@(?<name>[_\p{L}]\w*(?:\.[_\p{L}]\w*)*)\s*\(",
         RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -93,6 +93,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex TypeVarConstraintTypesRegex = new(
         @"\b(?:(?:typing|typing_extensions)\.)?TypeVar\s*\(\s*[^,\n]+,\s*(?<types>[^)=]*,[^)=]*)\)",
         RegexOptions.Compiled);
+    private static readonly Regex GetTypeHintsTargetRegex = new(
+        @"(?<!\.)\bget_type_hints\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -761,6 +764,35 @@ internal static class PythonReferenceExtractor
                     container,
                     "python");
             }
+        }
+    }
+
+    public static void EmitGetTypeHintsReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in GetTypeHintsTargetRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
         }
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -42,6 +42,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex CastTypeRegex = new(
         @"(?<!\.)\bcast\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*,",
         RegexOptions.Compiled);
+    private static readonly Regex QualifiedCastTypeRegex = new(
+        @"\b(?:typing|typing_extensions)\.cast\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*,",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -269,6 +272,24 @@ internal static class PythonReferenceExtractor
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in QualifiedCastTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+
         foreach (Match match in CastTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -78,6 +78,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex VariableAnnotationTypeRegex = new(
         @"^\s*(?:self\.)?\w+\s*:\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)(?=\s*(?:=|#|$))",
         RegexOptions.Compiled);
+    private static readonly Regex VariableAnnotationExpressionRegex = new(
+        @"^\s*(?:self\.)?\w+\s*:\s*(?<type>[^=#]+)(?=\s*(?:=|#|$))",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -583,6 +586,29 @@ internal static class PythonReferenceExtractor
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in VariableAnnotationExpressionRegex.Matches(preparedLine))
+        {
+            var typeGroup = match.Groups["type"];
+            foreach (Match typeMatch in TypeNameRegex.Matches(typeGroup.Value))
+            {
+                var name = typeMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                var nameIndex = typeGroup.Index + typeMatch.Groups["name"].Index;
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    nameIndex,
+                    context,
+                    lineNumber,
+                    container,
+                    "python");
+            }
+        }
+
         foreach (Match match in VariableAnnotationTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -87,6 +87,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex NewTypeUnderlyingTypeRegex = new(
         @"\b(?:(?:typing|typing_extensions)\.)?NewType\s*\(\s*[^,\n]+,\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex TypeVarBoundTypeRegex = new(
+        @"\b(?:(?:typing|typing_extensions)\.)?TypeVar\s*\([^)]*\bbound\s*=\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -678,6 +681,35 @@ internal static class PythonReferenceExtractor
         Func<string, bool> isIgnoredName)
     {
         foreach (Match match in NewTypeUnderlyingTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitTypeVarBoundReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in TypeVarBoundTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (isIgnoredName(name))

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -21,6 +21,12 @@ internal static class PythonReferenceExtractor
     private static readonly Regex ExceptTypeRegex = new(
         @"^\s*except\s+(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*(?:as\s+\w+)?\s*:",
         RegexOptions.Compiled);
+    private static readonly Regex ExceptTupleTypeRegex = new(
+        @"^\s*except\s*\((?<types>[^)]*)\)\s*(?:as\s+\w+)?\s*:",
+        RegexOptions.Compiled);
+    private static readonly Regex TypeNameRegex = new(
+        @"(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -95,6 +101,28 @@ internal static class PythonReferenceExtractor
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
+        foreach (Match match in ExceptTupleTypeRegex.Matches(preparedLine))
+        {
+            var typesGroup = match.Groups["types"];
+            foreach (Match typeMatch in TypeNameRegex.Matches(typesGroup.Value))
+            {
+                var name = typeMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                ReferenceExtractor.AddTypeReferenceSegments(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    typesGroup.Index + typeMatch.Groups["name"].Index,
+                    context,
+                    lineNumber,
+                    container,
+                    "python");
+            }
+        }
+
         foreach (Match match in ExceptTypeRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -15,6 +15,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex DecoratorCallRegex = new(
         @"^\s*@(?<name>[_\p{L}]\w*(?:\.[_\p{L}]\w*)*)\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex BareRaiseTypeRegex = new(
+        @"^\s*raise\s+(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*(?:#.*)?$",
+        RegexOptions.Compiled);
 
     public static void EmitDecoratorReferences(
         string preparedLine,
@@ -47,6 +50,35 @@ internal static class PythonReferenceExtractor
                 continue;
 
             ReferenceExtractor.AddReference(references, seen, fileId, match, "decorator", context, lineNumber, container);
+        }
+    }
+
+    public static void EmitRaiseReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        foreach (Match match in BareRaiseTypeRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddTypeReferenceSegments(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
         }
     }
 }

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2490,6 +2490,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitContextlibSuppressReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2334,6 +2334,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitIsSubclassReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2325,6 +2325,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitIsInstanceReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2343,6 +2343,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitCastReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2387,6 +2387,19 @@ public static partial class ReferenceExtractor
                             symbol.Line == lineNumber
                             && string.Equals(symbol.Kind, "function", StringComparison.Ordinal)),
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitFunctionParameterReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    index => ResolveContainerForCall(index)
+                        ?? symbols.FirstOrDefault(symbol =>
+                            symbol.Line == lineNumber
+                            && string.Equals(symbol.Kind, "function", StringComparison.Ordinal)),
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2481,6 +2481,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitPytestRaisesReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2374,6 +2374,19 @@ public static partial class ReferenceExtractor
                             symbol.Line == lineNumber
                             && string.Equals(symbol.Kind, "class", StringComparison.Ordinal)),
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitFunctionReturnReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    index => ResolveContainerForCall(index)
+                        ?? symbols.FirstOrDefault(symbol =>
+                            symbol.Line == lineNumber
+                            && string.Equals(symbol.Kind, "function", StringComparison.Ordinal)),
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2418,6 +2418,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitNewTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2445,6 +2445,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitGetTypeHintsReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2436,6 +2436,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitTypeVarConstraintReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2409,6 +2409,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitTypeAliasReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2472,6 +2472,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitPydanticTypeAdapterReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2400,6 +2400,15 @@ public static partial class ReferenceExtractor
                             symbol.Line == lineNumber
                             && string.Equals(symbol.Kind, "function", StringComparison.Ordinal)),
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitVariableAnnotationReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2454,6 +2454,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitDataclassesFieldsReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2307,6 +2307,15 @@ public static partial class ReferenceExtractor
                     container,
                     definitionNames,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitRaiseReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2427,6 +2427,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitTypeVarBoundReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2352,6 +2352,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitAssertTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2361,6 +2361,19 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitClassBaseReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    index => ResolveContainerForCall(index)
+                        ?? symbols.FirstOrDefault(symbol =>
+                            symbol.Line == lineNumber
+                            && string.Equals(symbol.Kind, "class", StringComparison.Ordinal)),
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2316,6 +2316,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitExceptReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2463,6 +2463,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitAttrsFieldsReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
             }
 
             if (language == "r")

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -13,6 +13,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAssignmentRegex = new(@"^\s*__all__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAppendRegex = new(@"^\s*__all__\.append\(\s*(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*\)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {
@@ -190,11 +191,23 @@ public static partial class SymbolExtractor
             ];
         }
 
+        var extendMatch = PythonAllExtendRegex.Match(line);
+        if (extendMatch.Success)
+            return TryExpandPythonAllExportSymbolsFromValues(lines, lineIndex, extendMatch.Groups["values"].Index);
+
         var match = PythonAllAssignmentRegex.Match(line);
         if (!match.Success)
             return null;
 
-        var valuesStartColumn = match.Groups["values"].Index;
+        return TryExpandPythonAllExportSymbolsFromValues(lines, lineIndex, match.Groups["values"].Index);
+    }
+
+    private static List<PythonExportSymbolEntry>? TryExpandPythonAllExportSymbolsFromValues(
+        string[] lines,
+        int lineIndex,
+        int valuesStartColumn)
+    {
+        var line = lines[lineIndex];
         if (valuesStartColumn < 0 || valuesStartColumn >= line.Length)
             return null;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -16,7 +16,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAnnotatedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*:\s*[^=].*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAssignedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*=(?!=).*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex PythonClassSlotsAssignmentRegex = new(@"^\s*__slots__\s*=\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonClassSlotsAssignmentRegex = new(@"^\s*__slots__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -18,6 +18,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonClassAssignedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*=(?!=).*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassSlotsAssignmentRegex = new(@"^\s*__slots__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassMatchArgsAssignmentRegex = new(@"^\s*__match_args__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonClassAnnotationsAssignmentRegex = new(@"^\s*__annotations__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {
@@ -242,6 +243,27 @@ public static partial class SymbolExtractor
                     continue;
                 }
 
+                var annotationsMatch = PythonClassAnnotationsAssignmentRegex.Match(line);
+                if (annotationsMatch.Success)
+                {
+                    var annotationKeys = TryExpandPythonStringDictionaryKeys(lines, i, annotationsMatch.Groups["values"].Index);
+                    if (annotationKeys != null)
+                    {
+                        foreach (var key in annotationKeys)
+                        {
+                            AddPythonClassPropertySymbol(
+                                fileId,
+                                lines,
+                                symbols,
+                                key.Name,
+                                key.LineIndex,
+                                key.StartColumn);
+                        }
+                    }
+
+                    continue;
+                }
+
                 var match = PythonClassAnnotatedAttributeRegex.Match(line);
                 if (!match.Success)
                     match = PythonClassAssignedAttributeRegex.Match(line);
@@ -283,6 +305,101 @@ public static partial class SymbolExtractor
                 Signature = lines[lineIndex].Trim(),
             },
             lines[lineIndex]);
+    }
+
+    private static List<PythonExportSymbolEntry>? TryExpandPythonStringDictionaryKeys(
+        string[] lines,
+        int lineIndex,
+        int valuesStartColumn)
+    {
+        var entries = new List<PythonExportSymbolEntry>();
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+        var currentLineIndex = lineIndex;
+        var currentColumn = valuesStartColumn;
+        var depth = 0;
+        var inString = false;
+        var quoteChar = '\0';
+        var stringStartColumn = -1;
+
+        while (currentLineIndex < lines.Length)
+        {
+            var currentLine = lines[currentLineIndex];
+            if (currentColumn >= currentLine.Length)
+            {
+                if (depth <= 0 && !inString)
+                    break;
+
+                currentLineIndex++;
+                currentColumn = 0;
+                continue;
+            }
+
+            var ch = currentLine[currentColumn];
+            if (inString)
+            {
+                if (ch == '\\' && currentColumn + 1 < currentLine.Length)
+                {
+                    currentColumn += 2;
+                    continue;
+                }
+
+                if (ch == quoteChar)
+                {
+                    var afterStringColumn = currentColumn + 1;
+                    while (afterStringColumn < currentLine.Length && char.IsWhiteSpace(currentLine[afterStringColumn]))
+                        afterStringColumn++;
+
+                    if (afterStringColumn < currentLine.Length && currentLine[afterStringColumn] == ':')
+                    {
+                        var name = currentLine[stringStartColumn..currentColumn].Trim();
+                        if (name.Length > 0 && seenNames.Add(name))
+                            entries.Add(new PythonExportSymbolEntry(name, currentLineIndex, stringStartColumn));
+                    }
+
+                    inString = false;
+                    quoteChar = '\0';
+                    stringStartColumn = -1;
+                    currentColumn++;
+                    continue;
+                }
+
+                currentColumn++;
+                continue;
+            }
+
+            if (ch == '#')
+                break;
+
+            if (ch == '\'' || ch == '"')
+            {
+                inString = true;
+                quoteChar = ch;
+                stringStartColumn = currentColumn + 1;
+                currentColumn++;
+                continue;
+            }
+
+            if (ch is '{' or '[' or '(')
+            {
+                depth++;
+                currentColumn++;
+                continue;
+            }
+
+            if (ch is '}' or ']' or ')')
+            {
+                if (depth > 0)
+                    depth--;
+                currentColumn++;
+                if (depth <= 0)
+                    break;
+                continue;
+            }
+
+            currentColumn++;
+        }
+
+        return entries.Count > 0 ? entries : null;
     }
 
     private static List<PythonExportSymbolEntry>? TryExpandPythonAllExportSymbols(string[] lines, int lineIndex)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -13,6 +13,36 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAssignmentRegex = new(@"^\s*__all__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
+    {
+        for (var i = defLineIndex - 1; i >= 0; i--)
+        {
+            var trimmed = lines[i].Trim();
+            if (!trimmed.StartsWith('@'))
+                return false;
+
+            if (IsPythonPropertyDecorator(trimmed))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsPythonPropertyDecorator(string trimmedDecorator)
+    {
+        var decorator = trimmedDecorator[1..];
+        var commentIndex = decorator.IndexOf('#');
+        if (commentIndex >= 0)
+            decorator = decorator[..commentIndex];
+        var parenIndex = decorator.IndexOf('(');
+        if (parenIndex >= 0)
+            decorator = decorator[..parenIndex];
+
+        decorator = decorator.Trim();
+        return decorator is "property" or "cached_property"
+            || decorator.EndsWith(".cached_property", StringComparison.Ordinal);
+    }
+
     private static List<PythonImportSymbolEntry>? TryExpandPythonImportSymbols(
         string[] lines,
         int lineIndex,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -40,7 +40,9 @@ public static partial class SymbolExtractor
 
         decorator = decorator.Trim();
         return decorator is "property" or "cached_property"
-            || decorator.EndsWith(".cached_property", StringComparison.Ordinal);
+            || decorator.EndsWith(".cached_property", StringComparison.Ordinal)
+            || decorator.EndsWith(".setter", StringComparison.Ordinal)
+            || decorator.EndsWith(".deleter", StringComparison.Ordinal);
     }
 
     private static List<PythonImportSymbolEntry>? TryExpandPythonImportSymbols(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -14,6 +14,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonAllAssignmentRegex = new(@"^\s*__all__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAppendRegex = new(@"^\s*__all__\.append\(\s*(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*\)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonClassAnnotatedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*:\s*[^=].*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {
@@ -172,6 +173,70 @@ public static partial class SymbolExtractor
                         },
                         lines[export.LineIndex]);
                 }
+            }
+        }
+    }
+
+    private static void ExtractPythonClassAttributeSymbols(
+        long fileId,
+        string[] lines,
+        List<SymbolRecord> symbols)
+    {
+        var classSymbols = symbols
+            .Where(static symbol => symbol.Kind == "class" && symbol.BodyStartLine.HasValue)
+            .ToList();
+
+        foreach (var classSymbol in classSymbols)
+        {
+            var classLineIndex = Math.Max(0, classSymbol.Line - 1);
+            var classIndent = CountIndent(lines[classLineIndex]);
+            int? memberIndent = null;
+            var bodyStartIndex = Math.Max(classSymbol.BodyStartLine!.Value - 1, classLineIndex + 1);
+            var bodyEndIndex = Math.Min(classSymbol.EndLine, lines.Length);
+
+            for (var i = bodyStartIndex; i < bodyEndIndex; i++)
+            {
+                var line = lines[i];
+                var trimmed = line.Trim();
+                if (trimmed.Length == 0 || trimmed.StartsWith('@'))
+                    continue;
+
+                var indent = CountIndent(line);
+                if (indent <= classIndent)
+                    break;
+                memberIndent ??= indent;
+                if (indent != memberIndent.Value)
+                    continue;
+
+                if (trimmed.StartsWith("def ", StringComparison.Ordinal)
+                    || trimmed.StartsWith("async def ", StringComparison.Ordinal)
+                    || trimmed.StartsWith("class ", StringComparison.Ordinal)
+                    || trimmed.StartsWith("type ", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var match = PythonClassAnnotatedAttributeRegex.Match(line);
+                if (!match.Success)
+                    continue;
+
+                var name = match.Groups["name"].Value;
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    i + 1,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "property",
+                        Name = name,
+                        Line = i + 1,
+                        StartLine = i + 1,
+                        StartColumn = match.Groups["name"].Index,
+                        EndLine = i + 1,
+                        Signature = trimmed,
+                    },
+                    line);
             }
         }
     }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -377,6 +377,10 @@ public static partial class SymbolExtractor
         var normalizedModulePart = treatAsFromImport
             ? modulePart?.Trim().TrimStart('.').TrimEnd('.')
             : null;
+        var isCurrentPackageRelativeImport = treatAsFromImport
+            && !string.IsNullOrEmpty(pythonModulePrefix)
+            && !string.IsNullOrEmpty(modulePart)
+            && modulePart.All(static ch => ch == '.');
         foreach (var rawSpec in importedNames.Split(','))
         {
             var spec = rawSpec.Trim();
@@ -424,6 +428,17 @@ public static partial class SymbolExtractor
                         line,
                         absoluteStartColumn,
                         $"{normalizedModulePart}.{importedName}",
+                        entries,
+                        seenNames,
+                        ref searchStartColumn);
+                }
+
+                if (isCurrentPackageRelativeImport)
+                {
+                    AddPythonImportEntry(
+                        line,
+                        absoluteStartColumn,
+                        $"{pythonModulePrefix}.{importedName}",
                         entries,
                         seenNames,
                         ref searchStartColumn);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -16,6 +16,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAnnotatedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*:\s*[^=].*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAssignedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*=(?!=).*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonClassSlotsAssignmentRegex = new(@"^\s*__slots__\s*=\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {
@@ -217,31 +218,68 @@ public static partial class SymbolExtractor
                     continue;
                 }
 
+                var slotsMatch = PythonClassSlotsAssignmentRegex.Match(line);
+                if (slotsMatch.Success)
+                {
+                    var slots = TryExpandPythonAllExportSymbolsFromValues(lines, i, slotsMatch.Groups["values"].Index);
+                    if (slots != null)
+                    {
+                        foreach (var slot in slots)
+                        {
+                            AddPythonClassPropertySymbol(
+                                fileId,
+                                lines,
+                                symbols,
+                                slot.Name,
+                                slot.LineIndex,
+                                slot.StartColumn);
+                        }
+                    }
+
+                    continue;
+                }
+
                 var match = PythonClassAnnotatedAttributeRegex.Match(line);
                 if (!match.Success)
                     match = PythonClassAssignedAttributeRegex.Match(line);
                 if (!match.Success)
                     continue;
 
-                var name = match.Groups["name"].Value;
-                AddSymbolRecord(
+                AddPythonClassPropertySymbol(
+                    fileId,
+                    lines,
                     symbols,
-                    cssSeenSymbols: null,
-                    i + 1,
-                    new SymbolRecord
-                    {
-                        FileId = fileId,
-                        Kind = "property",
-                        Name = name,
-                        Line = i + 1,
-                        StartLine = i + 1,
-                        StartColumn = match.Groups["name"].Index,
-                        EndLine = i + 1,
-                        Signature = trimmed,
-                    },
-                    line);
+                    match.Groups["name"].Value,
+                    i,
+                    match.Groups["name"].Index);
             }
         }
+    }
+
+    private static void AddPythonClassPropertySymbol(
+        long fileId,
+        string[] lines,
+        List<SymbolRecord> symbols,
+        string name,
+        int lineIndex,
+        int startColumn)
+    {
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineIndex + 1,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "property",
+                Name = name,
+                Line = lineIndex + 1,
+                StartLine = lineIndex + 1,
+                StartColumn = startColumn,
+                EndLine = lineIndex + 1,
+                Signature = lines[lineIndex].Trim(),
+            },
+            lines[lineIndex]);
     }
 
     private static List<PythonExportSymbolEntry>? TryExpandPythonAllExportSymbols(string[] lines, int lineIndex)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -17,6 +17,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonClassAnnotatedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*:\s*[^=].*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAssignedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*=(?!=).*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassSlotsAssignmentRegex = new(@"^\s*__slots__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonClassMatchArgsAssignmentRegex = new(@"^\s*__match_args__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {
@@ -219,6 +220,8 @@ public static partial class SymbolExtractor
                 }
 
                 var slotsMatch = PythonClassSlotsAssignmentRegex.Match(line);
+                if (!slotsMatch.Success)
+                    slotsMatch = PythonClassMatchArgsAssignmentRegex.Match(line);
                 if (slotsMatch.Success)
                 {
                     var slots = TryExpandPythonAllExportSymbolsFromValues(lines, i, slotsMatch.Groups["values"].Index);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -377,16 +377,9 @@ public static partial class SymbolExtractor
         var normalizedModulePart = treatAsFromImport
             ? modulePart?.Trim().TrimStart('.').TrimEnd('.')
             : null;
-        var isCurrentPackageRelativeImport = treatAsFromImport
-            && !string.IsNullOrEmpty(pythonModulePrefix)
-            && !string.IsNullOrEmpty(modulePart)
-            && modulePart.All(static ch => ch == '.');
-        var currentPackageRelativeModulePart = treatAsFromImport
-            && !string.IsNullOrEmpty(pythonModulePrefix)
-            && modulePart?.StartsWith(".", StringComparison.Ordinal) == true
-            && !modulePart.StartsWith("..", StringComparison.Ordinal)
-                ? modulePart.TrimStart('.').TrimEnd('.')
-                : null;
+        var relativeQualifiedModulePart = treatAsFromImport
+            ? ResolvePythonRelativeFromImportModuleName(modulePart, pythonModulePrefix)
+            : null;
         foreach (var rawSpec in importedNames.Split(','))
         {
             var spec = rawSpec.Trim();
@@ -439,23 +432,12 @@ public static partial class SymbolExtractor
                         ref searchStartColumn);
                 }
 
-                if (isCurrentPackageRelativeImport)
+                if (!string.IsNullOrEmpty(relativeQualifiedModulePart))
                 {
                     AddPythonImportEntry(
                         line,
                         absoluteStartColumn,
-                        $"{pythonModulePrefix}.{importedName}",
-                        entries,
-                        seenNames,
-                        ref searchStartColumn);
-                }
-
-                if (!string.IsNullOrEmpty(currentPackageRelativeModulePart))
-                {
-                    AddPythonImportEntry(
-                        line,
-                        absoluteStartColumn,
-                        $"{pythonModulePrefix}.{currentPackageRelativeModulePart}.{importedName}",
+                        $"{relativeQualifiedModulePart}.{importedName}",
                         entries,
                         seenNames,
                         ref searchStartColumn);
@@ -482,6 +464,32 @@ public static partial class SymbolExtractor
                     ref searchStartColumn);
             }
         }
+    }
+
+    private static string? ResolvePythonRelativeFromImportModuleName(string? modulePart, string? pythonModulePrefix)
+    {
+        if (string.IsNullOrEmpty(modulePart)
+            || string.IsNullOrEmpty(pythonModulePrefix)
+            || !modulePart.StartsWith(".", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var leadingDots = 0;
+        while (leadingDots < modulePart.Length && modulePart[leadingDots] == '.')
+            leadingDots++;
+
+        var levelsToDrop = leadingDots - 1;
+        var packageParts = pythonModulePrefix.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        if (levelsToDrop >= packageParts.Length)
+            return null;
+
+        var basePartCount = packageParts.Length - levelsToDrop;
+        var resolved = string.Join('.', packageParts.Take(basePartCount));
+        var suffix = modulePart[leadingDots..].Trim('.');
+        return suffix.Length == 0
+            ? resolved
+            : $"{resolved}.{suffix}";
     }
 
     private static void AddPythonImportModuleEntry(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -39,8 +39,9 @@ public static partial class SymbolExtractor
             decorator = decorator[..parenIndex];
 
         decorator = decorator.Trim();
-        return decorator is "property" or "cached_property"
+        return decorator is "property" or "cached_property" or "abstractproperty"
             || decorator.EndsWith(".cached_property", StringComparison.Ordinal)
+            || decorator.EndsWith(".abstractproperty", StringComparison.Ordinal)
             || decorator.EndsWith(".setter", StringComparison.Ordinal)
             || decorator.EndsWith(".deleter", StringComparison.Ordinal);
     }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -381,6 +381,12 @@ public static partial class SymbolExtractor
             && !string.IsNullOrEmpty(pythonModulePrefix)
             && !string.IsNullOrEmpty(modulePart)
             && modulePart.All(static ch => ch == '.');
+        var currentPackageRelativeModulePart = treatAsFromImport
+            && !string.IsNullOrEmpty(pythonModulePrefix)
+            && modulePart?.StartsWith(".", StringComparison.Ordinal) == true
+            && !modulePart.StartsWith("..", StringComparison.Ordinal)
+                ? modulePart.TrimStart('.').TrimEnd('.')
+                : null;
         foreach (var rawSpec in importedNames.Split(','))
         {
             var spec = rawSpec.Trim();
@@ -439,6 +445,17 @@ public static partial class SymbolExtractor
                         line,
                         absoluteStartColumn,
                         $"{pythonModulePrefix}.{importedName}",
+                        entries,
+                        seenNames,
+                        ref searchStartColumn);
+                }
+
+                if (!string.IsNullOrEmpty(currentPackageRelativeModulePart))
+                {
+                    AddPythonImportEntry(
+                        line,
+                        absoluteStartColumn,
+                        $"{pythonModulePrefix}.{currentPackageRelativeModulePart}.{importedName}",
                         entries,
                         seenNames,
                         ref searchStartColumn);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -12,6 +12,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonDirectImportRegex = new(@"^import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAssignmentRegex = new(@"^\s*__all__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonAllAppendRegex = new(@"^\s*__all__\.append\(\s*(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*\)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {
@@ -177,6 +178,18 @@ public static partial class SymbolExtractor
     private static List<PythonExportSymbolEntry>? TryExpandPythonAllExportSymbols(string[] lines, int lineIndex)
     {
         var line = lines[lineIndex];
+        var appendMatch = PythonAllAppendRegex.Match(line);
+        if (appendMatch.Success)
+        {
+            return
+            [
+                new PythonExportSymbolEntry(
+                    appendMatch.Groups["name"].Value,
+                    lineIndex,
+                    appendMatch.Groups["name"].Index),
+            ];
+        }
+
         var match = PythonAllAssignmentRegex.Match(line);
         if (!match.Success)
             return null;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -92,7 +92,7 @@ public static partial class SymbolExtractor
 
         var modulePart = fromImportMatch.Groups["module"].Value;
         var fromImportSpecs = fromImportMatch.Groups["imports"].Value;
-        AddPythonImportModuleEntry(line, absoluteStartColumn, modulePart, entries, seenNames);
+        AddPythonImportModuleEntry(line, absoluteStartColumn, modulePart, entries, seenNames, pythonModulePrefix);
         if (TryExpandPythonMultilineParenthesizedImportBlock(
                 lines,
                 lineIndex,
@@ -497,24 +497,37 @@ public static partial class SymbolExtractor
         int absoluteStartColumn,
         string modulePart,
         List<PythonImportSymbolEntry> entries,
-        HashSet<string> seenNames)
+        HashSet<string> seenNames,
+        string? pythonModulePrefix)
     {
         modulePart = modulePart.Trim();
         if (modulePart.Length == 0)
             return;
 
-        var normalizedModule = modulePart.TrimStart('.');
-        if (normalizedModule.Length == 0)
-            return;
-
         var searchStartColumn = absoluteStartColumn;
-        AddPythonImportEntry(line, absoluteStartColumn, normalizedModule, entries, seenNames, ref searchStartColumn);
-        if (normalizedModule.Contains('.'))
+        var normalizedModule = modulePart.TrimStart('.');
+        if (normalizedModule.Length > 0)
         {
-            AddPythonImportDottedPrefixEntries(
+            AddPythonImportEntry(line, absoluteStartColumn, normalizedModule, entries, seenNames, ref searchStartColumn);
+            if (normalizedModule.Contains('.'))
+            {
+                AddPythonImportDottedPrefixEntries(
+                    line,
+                    absoluteStartColumn,
+                    normalizedModule,
+                    entries,
+                    seenNames,
+                    ref searchStartColumn);
+            }
+        }
+
+        var relativeQualifiedModule = ResolvePythonRelativeFromImportModuleName(modulePart, pythonModulePrefix);
+        if (!string.IsNullOrEmpty(relativeQualifiedModule))
+        {
+            AddPythonImportEntry(
                 line,
                 absoluteStartColumn,
-                normalizedModule,
+                relativeQualifiedModule,
                 entries,
                 seenNames,
                 ref searchStartColumn);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -13,7 +13,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAssignmentRegex = new(@"^\s*__all__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAppendRegex = new(@"^\s*__all__\.append\(\s*(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*\)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {
@@ -193,13 +193,26 @@ public static partial class SymbolExtractor
 
         var extendMatch = PythonAllExtendRegex.Match(line);
         if (extendMatch.Success)
-            return TryExpandPythonAllExportSymbolsFromValues(lines, lineIndex, extendMatch.Groups["values"].Index);
+            return TryExpandPythonAllExportSymbolsFromCallValues(lines, lineIndex, extendMatch.Groups["values"].Index);
 
         var match = PythonAllAssignmentRegex.Match(line);
         if (!match.Success)
             return null;
 
         return TryExpandPythonAllExportSymbolsFromValues(lines, lineIndex, match.Groups["values"].Index);
+    }
+
+    private static List<PythonExportSymbolEntry>? TryExpandPythonAllExportSymbolsFromCallValues(
+        string[] lines,
+        int lineIndex,
+        int valuesStartColumn)
+    {
+        if (valuesStartColumn < lines[lineIndex].Length)
+            return TryExpandPythonAllExportSymbolsFromValues(lines, lineIndex, valuesStartColumn);
+
+        return lineIndex + 1 < lines.Length
+            ? TryExpandPythonAllExportSymbolsFromValues(lines, lineIndex + 1, 0)
+            : null;
     }
 
     private static List<PythonExportSymbolEntry>? TryExpandPythonAllExportSymbolsFromValues(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -15,6 +15,7 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonAllAppendRegex = new(@"^\s*__all__\.append\(\s*(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*\)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAnnotatedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*:\s*[^=].*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonClassAssignedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*=(?!=).*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static bool HasPythonPropertyDecorator(string[] lines, int defLineIndex)
     {
@@ -217,6 +218,8 @@ public static partial class SymbolExtractor
                 }
 
                 var match = PythonClassAnnotatedAttributeRegex.Match(line);
+                if (!match.Success)
+                    match = PythonClassAssignedAttributeRegex.Match(line);
                 if (!match.Success)
                     continue;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -713,7 +713,7 @@ public static partial class SymbolExtractor
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|collections)\.)?(?:NamedTuple|namedtuple)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:dataclasses\.)?make_dataclass\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?TypedDict\s*\(", RegexOptions.Compiled), BodyStyle.None),
-            new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:enum\.)?Enum\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:enum\.)?(?:Enum|IntEnum|Flag|IntFlag|StrEnum)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:pydantic\.)?create_model\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -711,6 +711,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:async\s+)?def\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*\(", RegexOptions.Compiled), BodyStyle.Indent),
             new("class",    new Regex(@"^\s*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Indent),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:from\s+(?<name>(?:\.+[\w.]*|[\w.]+))\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cobol"] =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -715,6 +715,7 @@ public static partial class SymbolExtractor
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?NewType\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?Final(?:\[[^\]]+\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:from\s+(?<name>(?:\.+[\w.]*|[\w.]+))\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cobol"] =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -718,6 +718,7 @@ public static partial class SymbolExtractor
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?NewType\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?(?:TypeVar|ParamSpec|TypeVarTuple)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?Final(?:\[[^\]]+\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:from\s+(?<name>(?:\.+[\w.]*|[\w.]+))\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -713,6 +713,7 @@ public static partial class SymbolExtractor
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|collections)\.)?(?:NamedTuple|namedtuple)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:dataclasses\.)?make_dataclass\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?TypedDict\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:enum\.)?Enum\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?NewType\s*\(", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -714,6 +714,7 @@ public static partial class SymbolExtractor
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:dataclasses\.)?make_dataclass\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?TypedDict\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:enum\.)?Enum\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:pydantic\.)?create_model\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?NewType\s*\(", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -712,6 +712,7 @@ public static partial class SymbolExtractor
             new("class",    new Regex(@"^\s*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Indent),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?NewType\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:from\s+(?<name>(?:\.+[\w.]*|[\w.]+))\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cobol"] =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2546,7 +2546,7 @@ public static partial class SymbolExtractor
                     // Python @property decorator: reclassify the def as property
                     // Python @property デコレータ: def を property に再分類
                     var kind = pattern.Kind;
-                    if (kind == "function" && lang == "python" && i > 0 && lines[i - 1].TrimStart().StartsWith("@property"))
+                    if (kind == "function" && lang == "python" && HasPythonPropertyDecorator(lines, i))
                         kind = "property";
 
                     if (lang == "css")

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3559,6 +3559,8 @@ public static partial class SymbolExtractor
             ExtractCppSameLineClassBodyMembers(fileId, lines, symbols);
         if (lang == "python")
             ExtractPythonAllExportSymbols(fileId, lines, symbols, pythonModulePrefix);
+        if (lang == "python")
+            ExtractPythonClassAttributeSymbols(fileId, lines, symbols);
         if (lang == "perl")
             ExtractPerlHashConstantSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -711,6 +711,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:async\s+)?def\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*\(", RegexOptions.Compiled), BodyStyle.Indent),
             new("class",    new Regex(@"^\s*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Indent),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|collections)\.)?(?:NamedTuple|namedtuple)\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:dataclasses\.)?make_dataclass\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?NewType\s*\(", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -712,6 +712,7 @@ public static partial class SymbolExtractor
             new("class",    new Regex(@"^\s*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Indent),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|collections)\.)?(?:NamedTuple|namedtuple)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:dataclasses\.)?make_dataclass\s*\(", RegexOptions.Compiled), BodyStyle.None),
+            new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?TypedDict\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?NewType\s*\(", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -710,6 +710,7 @@ public static partial class SymbolExtractor
         [
             new("function", new Regex(@"^\s*(?:async\s+)?def\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*\(", RegexOptions.Compiled), BodyStyle.Indent),
             new("class",    new Regex(@"^\s*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Indent),
+            new("class",    new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|collections)\.)?(?:NamedTuple|namedtuple)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*(?:\[[^\]]*\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?TypeAlias\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?NewType\s*\(", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -278,6 +278,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonCast_CapturesTargetTypeReference()
+    {
+        const string content = """
+            def load(value):
+                return cast(models.User, value)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "load");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -503,6 +503,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonTypeAlias_CapturesAliasedTypeReference()
+    {
+        const string content = """
+            UserAlias: TypeAlias = models.User
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -346,6 +346,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonClassBase_CapturesBaseTypeReference()
+    {
+        const string content = """
+            class UserView(views.BaseView):
+                pass
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "BaseView"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "UserView");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -652,6 +652,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonPytestRaises_CapturesExceptionTypeReference()
+    {
+        const string content = """
+            def test_invalid():
+                with pytest.raises(errors.ValidationError):
+                    validate({})
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "ValidationError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "test_invalid");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -670,6 +670,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonContextlibSuppress_CapturesExceptionTypeReference()
+    {
+        const string content = """
+            def cleanup():
+                with contextlib.suppress(errors.NotFoundError):
+                    remove()
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "NotFoundError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "cleanup");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -240,6 +240,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonIsSubclass_CapturesCheckedTypeReference()
+    {
+        const string content = """
+            def accepts(cls):
+                return issubclass(cls, services.Plugin)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Plugin"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "accepts");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -295,6 +295,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonQualifiedCast_CapturesTargetTypeReference()
+    {
+        const string content = """
+            def load(value):
+                return typing.cast(models.User, value)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "load");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -121,6 +121,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonBareRaise_CapturesExceptionTypeReference()
+    {
+        const string content = """
+            def fail():
+                raise CustomError
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "CustomError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "fail");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -617,6 +617,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonAttrsFields_CapturesTargetTypeReference()
+    {
+        const string content = """
+            def inspect():
+                return attrs.fields(models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "inspect");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -566,6 +566,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonGetTypeHints_CapturesTargetTypeReference()
+    {
+        const string content = """
+            def inspect():
+                return get_type_hints(models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "inspect");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -418,6 +418,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonFunctionParameterAnnotation_CapturesParameterTypeReference()
+    {
+        const string content = """
+            def save(user: models.User):
+                persist(user)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "save");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -202,6 +202,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonIsInstance_CapturesCheckedTypeReference()
+    {
+        const string content = """
+            def accepts(value):
+                return isinstance(value, models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "accepts");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -363,6 +363,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonClassMultipleBases_CapturesEachBaseTypeReference()
+    {
+        const string content = """
+            class UserView(views.BaseView, mixins.AuditedMixin):
+                pass
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "BaseView"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "UserView");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "AuditedMixin"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "UserView");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -384,6 +384,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonClassMetaclass_CapturesMetaclassTypeReference()
+    {
+        const string content = """
+            class Model(metaclass=orm.ModelMeta):
+                pass
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "ModelMeta"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Model");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -486,6 +486,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonGenericVariableAnnotation_CapturesNestedTypeReference()
+    {
+        const string content = """
+            def save():
+                users: Sequence[models.User] = []
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "save");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -418,6 +418,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonGenericReturnAnnotation_CapturesNestedTypeReference()
+    {
+        const string content = """
+            def load_many() -> list[models.User]:
+                return []
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "load_many");
+    }
+
+    [Fact]
     public void Extract_PythonFunctionParameterAnnotation_CapturesParameterTypeReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -138,6 +138,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonExcept_CapturesExceptionTypeReference()
+    {
+        const string content = """
+            def recover():
+                try:
+                    run()
+                except CustomError as exc:
+                    return exc
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "CustomError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "recover");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -329,6 +329,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonQualifiedAssertType_CapturesExpectedTypeReference()
+    {
+        const string content = """
+            def test_user(value):
+                typing.assert_type(value, models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "test_user");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -548,6 +548,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonTypeVarConstraints_CapturesConstraintTypeReferences()
+    {
+        const string content = """
+            TAccount = TypeVar("TAccount", models.User, models.Admin)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Admin"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -138,6 +138,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonRaiseFrom_CapturesExceptionTypeReference()
+    {
+        const string content = """
+            def fail():
+                raise package.CustomError from exc
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "CustomError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "fail");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "exc"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_PythonExcept_CapturesExceptionTypeReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -518,6 +518,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonNewType_CapturesUnderlyingTypeReference()
+    {
+        const string content = """
+            UserId = NewType("UserId", models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -312,6 +312,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonAssertType_CapturesExpectedTypeReference()
+    {
+        const string content = """
+            def test_user(value):
+                assert_type(value, models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "test_user");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -583,6 +583,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonQualifiedGetTypeHints_CapturesTargetTypeReference()
+    {
+        const string content = """
+            def inspect():
+                return typing.get_type_hints(models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "inspect");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -219,6 +219,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonIsInstanceTuple_CapturesEachCheckedTypeReference()
+    {
+        const string content = """
+            def accepts(value):
+                return isinstance(value, (models.User, api.Admin))
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "accepts");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Admin"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "accepts");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -452,6 +452,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonGenericParameterAnnotation_CapturesNestedTypeReference()
+    {
+        const string content = """
+            def save(users: Sequence[models.User]):
+                persist(users)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "save");
+    }
+
+    [Fact]
     public void Extract_PythonVariableAnnotation_CapturesVariableTypeReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -634,6 +634,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonPydanticTypeAdapter_CapturesTargetTypeReference()
+    {
+        const string content = """
+            def validate(value):
+                adapter = pydantic.TypeAdapter(models.User)
+                return adapter.validate_python(value)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "validate");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -600,6 +600,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonDataclassesFields_CapturesTargetTypeReference()
+    {
+        const string content = """
+            def inspect():
+                return dataclasses.fields(models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "inspect");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -435,6 +435,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonVariableAnnotation_CapturesVariableTypeReference()
+    {
+        const string content = """
+            def save():
+                user: models.User = load_user()
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "save");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -95,9 +95,12 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "python", content);
         var references = ReferenceExtractor.Extract(1, "python", content, symbols);
 
-        Assert.Equal(3, references.Count(reference => reference.ReferenceKind == "decorator"));
+        Assert.Equal(4, references.Count(reference => reference.ReferenceKind == "decorator"));
         Assert.Contains(references, reference =>
             reference.SymbolName == "bare_decorator"
+            && reference.ReferenceKind == "decorator");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "parametrized"
             && reference.ReferenceKind == "decorator");
         Assert.Contains(references, reference =>
             reference.SymbolName == "staticmethod"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -158,6 +158,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonExceptTuple_CapturesEachExceptionTypeReference()
+    {
+        const string content = """
+            def recover():
+                try:
+                    run()
+                except (TimeoutError, network.NetworkError) as exc:
+                    return exc
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "TimeoutError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "recover");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "NetworkError"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "recover");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -90,12 +90,16 @@ public class ReferenceExtractorTests
             @pytest.fixture
             def fixture():
                 pass
+
+            @pytest.mark.parametrize("value", [1])
+            def parametrized_fixture(value):
+                pass
             """;
 
         var symbols = SymbolExtractor.Extract(1, "python", content);
         var references = ReferenceExtractor.Extract(1, "python", content, symbols);
 
-        Assert.Equal(4, references.Count(reference => reference.ReferenceKind == "decorator"));
+        Assert.Equal(5, references.Count(reference => reference.ReferenceKind == "decorator"));
         Assert.Contains(references, reference =>
             reference.SymbolName == "bare_decorator"
             && reference.ReferenceKind == "decorator");
@@ -107,6 +111,9 @@ public class ReferenceExtractorTests
             && reference.ReferenceKind == "decorator");
         Assert.Contains(references, reference =>
             reference.SymbolName == "pytest.fixture"
+            && reference.ReferenceKind == "decorator");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "pytest.mark.parametrize"
             && reference.ReferenceKind == "decorator");
         Assert.Contains(references, reference =>
             reference.SymbolName == "parametrized"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -533,6 +533,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonTypeVarBound_CapturesBoundTypeReference()
+    {
+        const string content = """
+            TUser = TypeVar("TUser", bound=models.User)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -257,6 +257,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonIsSubclassTuple_CapturesEachCheckedTypeReference()
+    {
+        const string content = """
+            def accepts(cls):
+                return issubclass(cls, (services.Plugin, mixins.Audited))
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Plugin"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "accepts");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Audited"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "accepts");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -401,6 +401,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonFunctionReturnAnnotation_CapturesReturnTypeReference()
+    {
+        const string content = """
+            def load() -> models.User:
+                return get_user()
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "User"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "load");
+    }
+
+    [Fact]
     public void Extract_RustMacroCalls_CaptureDelimitedFormsWithoutMacroRulesDeclaration()
     {
         // issue #258: Rust macro invocations need to surface as call-like references so

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -51,6 +51,8 @@ public class SymbolExtractorTests
             OrderPayload = typing.TypedDict("OrderPayload", {"id": int})
             Color = Enum("Color", "RED BLUE")
             Status = enum.Enum("Status", "OPEN CLOSED")
+            RuntimeUser = create_model("RuntimeUser", name=(str, ...))
+            RuntimeOrder = pydantic.create_model("RuntimeOrder", id=(int, ...))
             DEFAULT_TIMEOUT: Final[int] = 30
             API_HOST: typing.Final = "example.invalid"
 
@@ -90,6 +92,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "OrderPayload");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Color");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Status");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "RuntimeUser");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "RuntimeOrder");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DEFAULT_TIMEOUT");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "API_HOST");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Theme" && s.ContainerName == "Config");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -82,6 +82,30 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_CachedPropertyDecoratorsAreProperties()
+    {
+        var content = """
+            import functools
+            from functools import cached_property
+
+            class Metrics:
+                @cached_property
+                def total(self) -> int:
+                    return 1
+
+                @functools.cached_property
+                def count(self) -> int:
+                    return 2
+            """;
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "total");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "count");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "total");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "count");
+    }
+
+    [Fact]
     public void Extract_Python_ExpandsImportAliasesAndImportedNames()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -106,6 +106,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_PropertyAccessorDecoratorsAreProperties()
+    {
+        var content = """
+            class User:
+                @property
+                def name(self) -> str:
+                    return self._name
+
+                @name.setter
+                def name(self, value: str) -> None:
+                    self._name = value
+
+                @name.deleter
+                def name(self) -> None:
+                    del self._name
+            """;
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Equal(3, symbols.Count(s => s.Kind == "property" && s.Name == "name"));
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "name");
+    }
+
+    [Fact]
     public void Extract_Python_ExpandsImportAliasesAndImportedNames()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -273,6 +273,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesAllExtendExportsFromInitModules()
+    {
+        var content = """
+            __all__ = []
+            __all__.extend([
+                "first_api",
+                "second_api",
+            ])
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content, "package/subpkg/__init__.py");
+        var exports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("first_api", exports);
+        Assert.Contains("package.subpkg.first_api", exports);
+        Assert.Contains("second_api", exports);
+        Assert.Contains("package.subpkg.second_api", exports);
+    }
+
+    [Fact]
     public void Extract_Python_IndexesQualifiedModuleAliasesFromInitModules()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -258,6 +258,21 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesAllAppendExportsFromInitModules()
+    {
+        var content = """
+            __all__ = []
+            __all__.append("dynamic_api")
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content, "package/subpkg/__init__.py");
+        var exports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("dynamic_api", exports);
+        Assert.Contains("package.subpkg.dynamic_api", exports);
+    }
+
+    [Fact]
     public void Extract_Python_IndexesQualifiedModuleAliasesFromInitModules()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -297,6 +297,20 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesCurrentPackageRelativeModuleImports()
+    {
+        var content = """
+            from .tools import build
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content, "package/subpkg/__init__.py");
+        var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("tools.build", imports);
+        Assert.Contains("package.subpkg.tools.build", imports);
+    }
+
+    [Fact]
     public void Extract_Python_HandlesUnclosedMultilineImportBlocksWithoutPhantomSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -129,6 +129,30 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_AbstractPropertyDecoratorsAreProperties()
+    {
+        var content = """
+            import abc
+            from abc import abstractproperty
+
+            class Base:
+                @abstractproperty
+                def name(self) -> str:
+                    raise NotImplementedError
+
+                @abc.abstractproperty
+                def value(self) -> int:
+                    raise NotImplementedError
+            """;
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "value");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "name");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "value");
+    }
+
+    [Fact]
     public void Extract_Python_ExpandsImportAliasesAndImportedNames()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -69,6 +69,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_DetectsAnnotatedClassAttributesAsProperties()
+    {
+        var content = """
+            class User:
+                name: str
+                age: int = 0
+
+                def hydrate(self) -> None:
+                    local_value: str = "ignored"
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "age" && s.ContainerName == "User");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local_value");
+    }
+
+    [Fact]
     public void Extract_Python_DetectsDecoratedAndDunderMethods()
     {
         var content = "@dataclass\nclass User:\n    name: str\n    age: int\n\n    def __init__(self, name: str, age: int) -> None:\n        self.name = name\n\n    @property\n    def display_name(self) -> str:\n        return self.name\n\n    def __str__(self) -> str:\n        return self.name\n\n    @staticmethod\n    def create(name: str) -> 'User':\n        return User(name, 0)";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -125,6 +125,21 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_ExpandsAugmentedSlotsAsClassProperties()
+    {
+        var content = """
+            class User:
+                __slots__ = ("name",)
+                __slots__ += ("email",)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "email" && s.ContainerName == "User");
+    }
+
+    [Fact]
     public void Extract_Python_DetectsDecoratedAndDunderMethods()
     {
         var content = "@dataclass\nclass User:\n    name: str\n    age: int\n\n    def __init__(self, name: str, age: int) -> None:\n        self.name = name\n\n    @property\n    def display_name(self) -> str:\n        return self.name\n\n    def __str__(self) -> str:\n        return self.name\n\n    @staticmethod\n    def create(name: str) -> 'User':\n        return User(name, 0)";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -293,6 +293,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesAllExtendExportsWhenValuesStartOnNextLine()
+    {
+        var content = """
+            __all__ = []
+            __all__.extend(
+                [
+                    "split_api",
+                ]
+            )
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content, "package/subpkg/__init__.py");
+        var exports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("split_api", exports);
+        Assert.Contains("package.subpkg.split_api", exports);
+    }
+
+    [Fact]
     public void Extract_Python_IndexesQualifiedModuleAliasesFromInitModules()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -43,6 +43,8 @@ public class SymbolExtractorTests
             Handler: typing.TypeAlias = Callable[..., None]
             UserId = NewType("UserId", int)
             OrderId = typing.NewType("OrderId", int)
+            Point = NamedTuple("Point", [("x", int), ("y", int)])
+            Coordinate = collections.namedtuple("Coordinate", "lat lon")
 
             def first[T](items: list[T]) -> T:
                 return items[0]
@@ -72,6 +74,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Handler");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "OrderId");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Point");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Coordinate");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Theme" && s.ContainerName == "Config");
         Assert.DoesNotContain(symbols, s => s.Name == "type");
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -43,6 +43,9 @@ public class SymbolExtractorTests
             Handler: typing.TypeAlias = Callable[..., None]
             UserId = NewType("UserId", int)
             OrderId = typing.NewType("OrderId", int)
+            T = TypeVar("T")
+            P = typing.ParamSpec("P")
+            Ts = typing_extensions.TypeVarTuple("Ts")
             Point = NamedTuple("Point", [("x", int), ("y", int)])
             Coordinate = collections.namedtuple("Coordinate", "lat lon")
             DynamicUser = make_dataclass("DynamicUser", [("name", str)])
@@ -84,6 +87,9 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Handler");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "UserId");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "OrderId");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "T");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "P");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Ts");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Point");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Coordinate");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DynamicUser");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -283,6 +283,20 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesCurrentPackageRelativeFromImports()
+    {
+        var content = """
+            from . import helper
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content, "package/subpkg/__init__.py");
+        var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("helper", imports);
+        Assert.Contains("package.subpkg.helper", imports);
+    }
+
+    [Fact]
     public void Extract_Python_HandlesUnclosedMultilineImportBlocksWithoutPhantomSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -47,6 +47,8 @@ public class SymbolExtractorTests
             Coordinate = collections.namedtuple("Coordinate", "lat lon")
             DynamicUser = make_dataclass("DynamicUser", [("name", str)])
             DynamicOrder = dataclasses.make_dataclass("DynamicOrder", [("id", int)])
+            DEFAULT_TIMEOUT: Final[int] = 30
+            API_HOST: typing.Final = "example.invalid"
 
             def first[T](items: list[T]) -> T:
                 return items[0]
@@ -80,6 +82,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Coordinate");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DynamicUser");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DynamicOrder");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DEFAULT_TIMEOUT");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "API_HOST");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Theme" && s.ContainerName == "Config");
         Assert.DoesNotContain(symbols, s => s.Name == "type");
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -47,6 +47,8 @@ public class SymbolExtractorTests
             Coordinate = collections.namedtuple("Coordinate", "lat lon")
             DynamicUser = make_dataclass("DynamicUser", [("name", str)])
             DynamicOrder = dataclasses.make_dataclass("DynamicOrder", [("id", int)])
+            UserPayload = TypedDict("UserPayload", {"name": str})
+            OrderPayload = typing.TypedDict("OrderPayload", {"id": int})
             DEFAULT_TIMEOUT: Final[int] = 30
             API_HOST: typing.Final = "example.invalid"
 
@@ -82,6 +84,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Coordinate");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DynamicUser");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DynamicOrder");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "UserPayload");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "OrderPayload");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DEFAULT_TIMEOUT");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "API_HOST");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Theme" && s.ContainerName == "Config");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -182,6 +182,21 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_ExpandsMatchArgsAsClassProperties()
+    {
+        var content = """
+            class Point:
+                __match_args__ = ("x", "y")
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "x" && s.ContainerName == "Point");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "y" && s.ContainerName == "Point");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "__match_args__");
+    }
+
+    [Fact]
     public void Extract_Python_DetectsDecoratedAndDunderMethods()
     {
         var content = "@dataclass\nclass User:\n    name: str\n    age: int\n\n    def __init__(self, name: str, age: int) -> None:\n        self.name = name\n\n    @property\n    def display_name(self) -> str:\n        return self.name\n\n    def __str__(self) -> str:\n        return self.name\n\n    @staticmethod\n    def create(name: str) -> 'User':\n        return User(name, 0)";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -311,6 +311,20 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesParentPackageRelativeModuleImports()
+    {
+        var content = """
+            from ..shared import helper
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content, "package/subpkg/__init__.py");
+        var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("shared.helper", imports);
+        Assert.Contains("package.shared.helper", imports);
+    }
+
+    [Fact]
     public void Extract_Python_HandlesUnclosedMultilineImportBlocksWithoutPhantomSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -107,6 +107,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_ExpandsSlotsAsClassProperties()
+    {
+        var content = """
+            class User:
+                __slots__ = (
+                    "name",
+                    "age",
+                )
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "age" && s.ContainerName == "User");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "__slots__");
+    }
+
+    [Fact]
     public void Extract_Python_DetectsDecoratedAndDunderMethods()
     {
         var content = "@dataclass\nclass User:\n    name: str\n    age: int\n\n    def __init__(self, name: str, age: int) -> None:\n        self.name = name\n\n    @property\n    def display_name(self) -> str:\n        return self.name\n\n    def __str__(self) -> str:\n        return self.name\n\n    @staticmethod\n    def create(name: str) -> 'User':\n        return User(name, 0)";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -88,6 +88,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_DetectsAssignedClassAttributesAsProperties()
+    {
+        var content = """
+            class Settings:
+                DEFAULT_TIMEOUT = 30
+                endpoint = "https://example.invalid"
+
+                def configure(self) -> None:
+                    local_value = 1
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DEFAULT_TIMEOUT" && s.ContainerName == "Settings");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "endpoint" && s.ContainerName == "Settings");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local_value");
+    }
+
+    [Fact]
     public void Extract_Python_DetectsDecoratedAndDunderMethods()
     {
         var content = "@dataclass\nclass User:\n    name: str\n    age: int\n\n    def __init__(self, name: str, age: int) -> None:\n        self.name = name\n\n    @property\n    def display_name(self) -> str:\n        return self.name\n\n    def __str__(self) -> str:\n        return self.name\n\n    @staticmethod\n    def create(name: str) -> 'User':\n        return User(name, 0)";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -45,6 +45,8 @@ public class SymbolExtractorTests
             OrderId = typing.NewType("OrderId", int)
             Point = NamedTuple("Point", [("x", int), ("y", int)])
             Coordinate = collections.namedtuple("Coordinate", "lat lon")
+            DynamicUser = make_dataclass("DynamicUser", [("name", str)])
+            DynamicOrder = dataclasses.make_dataclass("DynamicOrder", [("id", int)])
 
             def first[T](items: list[T]) -> T:
                 return items[0]
@@ -76,6 +78,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "OrderId");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Point");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Coordinate");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DynamicUser");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DynamicOrder");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Theme" && s.ContainerName == "Config");
         Assert.DoesNotContain(symbols, s => s.Name == "type");
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -39,6 +39,8 @@ public class SymbolExtractorTests
         var content = """
             type Vector = list[float]
             type Connection = str | int
+            JsonValue: TypeAlias = dict[str, object]
+            Handler: typing.TypeAlias = Callable[..., None]
 
             def first[T](items: list[T]) -> T:
                 return items[0]
@@ -64,6 +66,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Config");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Vector");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Connection");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "JsonValue");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Handler");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Theme" && s.ContainerName == "Config");
         Assert.DoesNotContain(symbols, s => s.Name == "type");
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -41,6 +41,8 @@ public class SymbolExtractorTests
             type Connection = str | int
             JsonValue: TypeAlias = dict[str, object]
             Handler: typing.TypeAlias = Callable[..., None]
+            UserId = NewType("UserId", int)
+            OrderId = typing.NewType("OrderId", int)
 
             def first[T](items: list[T]) -> T:
                 return items[0]
@@ -68,6 +70,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Connection");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "JsonValue");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Handler");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "UserId");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "OrderId");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Theme" && s.ContainerName == "Config");
         Assert.DoesNotContain(symbols, s => s.Name == "type");
     }

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -54,6 +54,8 @@ public class SymbolExtractorTests
             OrderPayload = typing.TypedDict("OrderPayload", {"id": int})
             Color = Enum("Color", "RED BLUE")
             Status = enum.Enum("Status", "OPEN CLOSED")
+            ErrorCode = IntEnum("ErrorCode", "NOT_FOUND INVALID")
+            Permission = enum.IntFlag("Permission", "READ WRITE")
             RuntimeUser = create_model("RuntimeUser", name=(str, ...))
             RuntimeOrder = pydantic.create_model("RuntimeOrder", id=(int, ...))
             DEFAULT_TIMEOUT: Final[int] = 30
@@ -98,6 +100,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "OrderPayload");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Color");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Status");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ErrorCode");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Permission");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "RuntimeUser");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "RuntimeOrder");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DEFAULT_TIMEOUT");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -197,6 +197,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_ExpandsAnnotationsDictionaryAsClassProperties()
+    {
+        var content = """
+            class User:
+                __annotations__ = {
+                    "name": str,
+                    "age": int,
+                }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "age" && s.ContainerName == "User");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "__annotations__");
+    }
+
+    [Fact]
     public void Extract_Python_DetectsDecoratedAndDunderMethods()
     {
         var content = "@dataclass\nclass User:\n    name: str\n    age: int\n\n    def __init__(self, name: str, age: int) -> None:\n        self.name = name\n\n    @property\n    def display_name(self) -> str:\n        return self.name\n\n    def __str__(self) -> str:\n        return self.name\n\n    @staticmethod\n    def create(name: str) -> 'User':\n        return User(name, 0)";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -307,6 +307,7 @@ public class SymbolExtractorTests
         var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
 
         Assert.Contains("tools.build", imports);
+        Assert.Contains("package.subpkg.tools", imports);
         Assert.Contains("package.subpkg.tools.build", imports);
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -49,6 +49,8 @@ public class SymbolExtractorTests
             DynamicOrder = dataclasses.make_dataclass("DynamicOrder", [("id", int)])
             UserPayload = TypedDict("UserPayload", {"name": str})
             OrderPayload = typing.TypedDict("OrderPayload", {"id": int})
+            Color = Enum("Color", "RED BLUE")
+            Status = enum.Enum("Status", "OPEN CLOSED")
             DEFAULT_TIMEOUT: Final[int] = 30
             API_HOST: typing.Final = "example.invalid"
 
@@ -86,6 +88,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "DynamicOrder");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "UserPayload");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "OrderPayload");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Color");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Status");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DEFAULT_TIMEOUT");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "API_HOST");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Theme" && s.ContainerName == "Config");


### PR DESCRIPTION
## Summary

- Expand Python symbol extraction for common dynamic declarations and class metadata patterns.
- Add Python reference extraction for class bases, metaclasses, annotations, type aliases, TypeVar/NewType usage, runtime type helpers, introspection helpers, and exception-testing/suppression helpers.
- Add focused regression tests and bilingual changelog fragments for each behavior change.

## Impact

Python search results now surface many type and framework usage sites that previously did not appear because they are not ordinary call syntax. This improves reference search for inheritance, typing annotations, Pydantic/dataclasses/attrs usage, pytest exception assertions, and exception suppression.

## Validation

- Targeted tests were run for each commit.
- Changelog validation was run for each commit.
- `dotnet build` passed after each commit.
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json` passed after each commit.
- Final `dotnet test` passed: 4037 passed, 3 skipped, 0 failed.