### PR TITLE
[codex] Improve T-SQL reference indexing coverage

### DIFF
--- a/changelog.d/unreleased/+sql-alter-assembly-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-assembly-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER ASSEMBLY targets are indexed as references** — exact SQL reference search can now find assemblies mentioned by `ALTER ASSEMBLY`.
+
+## 日本語
+
+- **SQL ALTER ASSEMBLY の target を reference として索引するようになりました** — `ALTER ASSEMBLY` で指定される assembly も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-authorization-bare-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-authorization-bare-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL bare ALTER AUTHORIZATION object targets are indexed as references** — exact SQL reference search can now find objects mentioned by `ALTER AUTHORIZATION ON schema.object`.
+
+## 日本語
+
+- **SQL bare ALTER AUTHORIZATION の object target を reference として索引するようになりました** — `ALTER AUTHORIZATION ON schema.object` で指定される object も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-authorization-object-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-authorization-object-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER AUTHORIZATION object targets are indexed as references** — exact SQL reference search can now find objects mentioned by `ALTER AUTHORIZATION ON OBJECT::...`.
+
+## 日本語
+
+- **SQL ALTER AUTHORIZATION の object target を reference として索引するようになりました** — `ALTER AUTHORIZATION ON OBJECT::...` で指定される object も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-fulltext-catalog-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-fulltext-catalog-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER FULLTEXT CATALOG targets are indexed as references** — exact SQL reference search can now find full-text catalogs mentioned by `ALTER FULLTEXT CATALOG`.
+
+## 日本語
+
+- **SQL ALTER FULLTEXT CATALOG の target を reference として索引するようになりました** — `ALTER FULLTEXT CATALOG` で指定される full-text catalog も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-fulltext-index-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-fulltext-index-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER FULLTEXT INDEX table targets are indexed as references** — exact SQL reference search can now find tables mentioned after `ALTER FULLTEXT INDEX ON`.
+
+## 日本語
+
+- **SQL ALTER FULLTEXT INDEX の table target を reference として索引するようになりました** — `ALTER FULLTEXT INDEX ON` の後に指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-function-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-function-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER FUNCTION targets are indexed as references** — exact SQL reference search can now find functions mentioned by `ALTER FUNCTION`.
+
+## 日本語
+
+- **SQL ALTER FUNCTION の target を reference として索引するようになりました** — `ALTER FUNCTION` で指定される function も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-index-table-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-index-table-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **T-SQL `ALTER INDEX ... ON` table targets are indexed as references** — exact SQL reference search can now find tables touched only by index rebuild or reorganize maintenance scripts.
+
+## 日本語
+
+- **T-SQL の `ALTER INDEX ... ON` table target を reference として索引するようになりました** — index rebuild / reorganize の maintenance script だけで触られる table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-partition-function-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-partition-function-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER PARTITION FUNCTION targets are indexed as references** — exact SQL reference search can now find partition functions mentioned by `ALTER PARTITION FUNCTION`.
+
+## 日本語
+
+- **SQL ALTER PARTITION FUNCTION の target を reference として索引するようになりました** — `ALTER PARTITION FUNCTION` で指定される partition function も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-partition-scheme-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-partition-scheme-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER PARTITION SCHEME targets are indexed as references** — exact SQL reference search can now find partition schemes mentioned by `ALTER PARTITION SCHEME`.
+
+## 日本語
+
+- **SQL ALTER PARTITION SCHEME の target を reference として索引するようになりました** — `ALTER PARTITION SCHEME` で指定される partition scheme も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-procedure-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-procedure-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER PROCEDURE targets are indexed as references** — exact SQL reference search can now find procedures mentioned by `ALTER PROCEDURE` or `ALTER PROC`.
+
+## 日本語
+
+- **SQL ALTER PROCEDURE の target を reference として索引するようになりました** — `ALTER PROCEDURE` / `ALTER PROC` で指定される procedure も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-schema-transfer-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-schema-transfer-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER SCHEMA transfer targets are indexed as references** — exact SQL reference search can now find objects moved by `ALTER SCHEMA ... TRANSFER`.
+
+## 日本語
+
+- **SQL ALTER SCHEMA の transfer target を reference として索引するようになりました** — `ALTER SCHEMA ... TRANSFER` で移動される object も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-security-policy-name-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-security-policy-name-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER SECURITY POLICY names are indexed as references** — exact SQL reference search can now find security policies mentioned by `ALTER SECURITY POLICY`.
+
+## 日本語
+
+- **SQL ALTER SECURITY POLICY の policy name を reference として索引するようになりました** — `ALTER SECURITY POLICY` で指定される security policy も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-security-policy-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-security-policy-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER SECURITY POLICY predicate tables are indexed as references** — exact SQL reference search can now find tables added to row-level security policies.
+
+## 日本語
+
+- **SQL ALTER SECURITY POLICY の predicate table を reference として索引するようになりました** — row-level security policy に追加される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-sequence-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-sequence-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER SEQUENCE targets are indexed as references** — exact SQL reference search can now find sequences mentioned by `ALTER SEQUENCE`.
+
+## 日本語
+
+- **SQL ALTER SEQUENCE の target を reference として索引するようになりました** — `ALTER SEQUENCE` で指定される sequence も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-table-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-table-references.fixed.md
@@ -8,8 +8,8 @@ affected:
 
 ## English
 
-- **SQL `ALTER TABLE` statements now surface table references** — `references`, callers/search-adjacent graph readers, and exact SQL name matching can now find tables that are only touched by T-SQL schema migrations.
+- **SQL `ALTER TABLE` statements now surface table references** — `references` and exact SQL name matching can now find tables that are only touched by T-SQL schema migrations.
 
 ## 日本語
 
-- **SQL の `ALTER TABLE` が table reference として出るようになりました** — T-SQL の schema migration だけで触られる table も、`references` や関連 graph reader、SQL exact name matching で見つけられるようになりました。
+- **SQL の `ALTER TABLE` が table reference として出るようになりました** — T-SQL の schema migration だけで触られる table も、`references` や SQL exact name matching で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-table-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-table-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL `ALTER TABLE` statements now surface table references** — `references`, callers/search-adjacent graph readers, and exact SQL name matching can now find tables that are only touched by T-SQL schema migrations.
+
+## 日本語
+
+- **SQL の `ALTER TABLE` が table reference として出るようになりました** — T-SQL の schema migration だけで触られる table も、`references` や関連 graph reader、SQL exact name matching で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-table-switch-targets.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-table-switch-targets.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER TABLE SWITCH targets are indexed as references** — exact SQL reference search can now find destination tables mentioned after `SWITCH TO`.
+
+## 日本語
+
+- **SQL ALTER TABLE SWITCH の destination table を reference として索引するようになりました** — `SWITCH TO` の後に指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-trigger-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-trigger-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER TRIGGER targets are indexed as references** — exact SQL reference search can now find triggers mentioned by `ALTER TRIGGER`.
+
+## 日本語
+
+- **SQL ALTER TRIGGER の target を reference として索引するようになりました** — `ALTER TRIGGER` で指定される trigger も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-view-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-view-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER VIEW targets are indexed as references** — exact SQL reference search can now find views mentioned by `ALTER VIEW`.
+
+## 日本語
+
+- **SQL ALTER VIEW の target を reference として索引するようになりました** — `ALTER VIEW` で指定される view も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-alter-xml-schema-collection-references.fixed.md
+++ b/changelog.d/unreleased/+sql-alter-xml-schema-collection-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL ALTER XML SCHEMA COLLECTION targets are indexed as references** — exact SQL reference search can now find XML schema collections mentioned by `ALTER XML SCHEMA COLLECTION`.
+
+## 日本語
+
+- **SQL ALTER XML SCHEMA COLLECTION の target を reference として索引するようになりました** — `ALTER XML SCHEMA COLLECTION` で指定される XML schema collection も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-bare-object-permission-references.fixed.md
+++ b/changelog.d/unreleased/+sql-bare-object-permission-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL bare object permission targets are indexed as references** — exact SQL reference search can now find objects mentioned by `GRANT`, `DENY`, and `REVOKE` statements that use `ON schema.object`.
+
+## 日本語
+
+- **SQL bare object permission の target を reference として索引するようになりました** — `ON schema.object` を使う `GRANT`、`DENY`、`REVOKE` statement の対象 object も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-bulk-insert-references.fixed.md
+++ b/changelog.d/unreleased/+sql-bulk-insert-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **T-SQL `BULK INSERT` destinations are indexed as table references** — exact SQL reference search can now find tables loaded through `BULK INSERT dbo.Table FROM ...`.
+
+## 日本語
+
+- **T-SQL の `BULK INSERT` destination を table reference として索引するようになりました** — `BULK INSERT dbo.Table FROM ...` でロードされる table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-create-clustered-columnstore-index-references.fixed.md
+++ b/changelog.d/unreleased/+sql-create-clustered-columnstore-index-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL CREATE CLUSTERED COLUMNSTORE INDEX table targets are indexed as references** — exact SQL reference search can now find tables mentioned by clustered columnstore index creation.
+
+## 日本語
+
+- **SQL CREATE CLUSTERED COLUMNSTORE INDEX の table target を reference として索引するようになりました** — clustered columnstore index 作成で指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-create-fulltext-index-references.fixed.md
+++ b/changelog.d/unreleased/+sql-create-fulltext-index-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL CREATE FULLTEXT INDEX table targets are indexed as references** — exact SQL reference search can now find tables mentioned after `CREATE FULLTEXT INDEX ON`.
+
+## 日本語
+
+- **SQL CREATE FULLTEXT INDEX の table target を reference として索引するようになりました** — `CREATE FULLTEXT INDEX ON` の後に指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-create-hash-index-references.fixed.md
+++ b/changelog.d/unreleased/+sql-create-hash-index-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL CREATE NONCLUSTERED HASH INDEX table targets are indexed as references** — exact SQL reference search can now find tables mentioned by memory-optimized hash index creation.
+
+## 日本語
+
+- **SQL CREATE NONCLUSTERED HASH INDEX の table target を reference として索引するようになりました** — memory-optimized hash index 作成で指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-create-index-table-references.fixed.md
+++ b/changelog.d/unreleased/+sql-create-index-table-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL `CREATE INDEX ... ON` table targets are indexed as references** — exact SQL reference search can now find tables used only by index definitions while continuing to suppress access-method names such as `btree`.
+
+## 日本語
+
+- **SQL の `CREATE INDEX ... ON` table target を reference として索引するようになりました** — `btree` のような access method 名は抑止したまま、index 定義だけで触られる table も SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-create-security-policy-references.fixed.md
+++ b/changelog.d/unreleased/+sql-create-security-policy-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL CREATE SECURITY POLICY predicate tables are indexed as references** — exact SQL reference search can now find tables mentioned after row-level security predicates.
+
+## 日本語
+
+- **SQL CREATE SECURITY POLICY の predicate table を reference として索引するようになりました** — row-level security predicate の後に指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-create-special-xml-index-references.fixed.md
+++ b/changelog.d/unreleased/+sql-create-special-xml-index-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL CREATE PRIMARY/SELECTIVE XML INDEX table targets are indexed as references** — exact SQL reference search can now find tables mentioned after special XML index creation.
+
+## 日本語
+
+- **SQL CREATE PRIMARY/SELECTIVE XML INDEX の table target を reference として索引するようになりました** — special XML index 作成で指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-create-statistics-references.fixed.md
+++ b/changelog.d/unreleased/+sql-create-statistics-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL CREATE STATISTICS table targets are indexed as references** — exact SQL reference search can now find tables mentioned after `CREATE STATISTICS ... ON`.
+
+## 日本語
+
+- **SQL CREATE STATISTICS の table target を reference として索引するようになりました** — `CREATE STATISTICS ... ON` の後に指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-create-trigger-table-references.fixed.md
+++ b/changelog.d/unreleased/+sql-create-trigger-table-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL `CREATE TRIGGER ... ON` table targets are indexed as references** — exact SQL reference search can now find tables that are only touched by trigger definitions.
+
+## 日本語
+
+- **SQL の `CREATE TRIGGER ... ON` table target を reference として索引するようになりました** — trigger 定義だけで触られる table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-delete-without-from-references.fixed.md
+++ b/changelog.d/unreleased/+sql-delete-without-from-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DELETE targets without FROM are indexed as references** — exact SQL reference search can now find qualified tables mentioned by `DELETE schema.table`.
+
+## 日本語
+
+- **SQL DELETE の FROM なし target を reference として索引するようになりました** — `DELETE schema.table` で指定される qualified table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-aggregate-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-aggregate-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP AGGREGATE targets are indexed as references** — exact SQL reference search can now find aggregates mentioned by `DROP AGGREGATE`.
+
+## 日本語
+
+- **SQL DROP AGGREGATE の target を reference として索引するようになりました** — `DROP AGGREGATE` で指定される aggregate も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-assembly-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-assembly-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP ASSEMBLY targets are indexed as references** — exact SQL reference search can now find assemblies mentioned by `DROP ASSEMBLY`.
+
+## 日本語
+
+- **SQL DROP ASSEMBLY の target を reference として索引するようになりました** — `DROP ASSEMBLY` で指定される assembly も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-default-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-default-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP DEFAULT targets are indexed as references** — exact SQL reference search can now find defaults mentioned by `DROP DEFAULT`.
+
+## 日本語
+
+- **SQL DROP DEFAULT の target を reference として索引するようになりました** — `DROP DEFAULT` で指定される default も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-fulltext-catalog-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-fulltext-catalog-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP FULLTEXT CATALOG targets are indexed as references** — exact SQL reference search can now find full-text catalogs mentioned by `DROP FULLTEXT CATALOG`.
+
+## 日本語
+
+- **SQL DROP FULLTEXT CATALOG の target を reference として索引するようになりました** — `DROP FULLTEXT CATALOG` で指定される full-text catalog も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-fulltext-index-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-fulltext-index-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP FULLTEXT INDEX table targets are indexed as references** — exact SQL reference search can now find tables mentioned after `DROP FULLTEXT INDEX ON`.
+
+## 日本語
+
+- **SQL DROP FULLTEXT INDEX の table target を reference として索引するようになりました** — `DROP FULLTEXT INDEX ON` の後に指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-function-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-function-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP FUNCTION targets are indexed as references** — exact SQL reference search can now find functions mentioned by `DROP FUNCTION`.
+
+## 日本語
+
+- **SQL DROP FUNCTION の target を reference として索引するようになりました** — `DROP FUNCTION` で指定される function も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-index-legacy-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-index-legacy-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL legacy DROP INDEX owning tables are indexed as references** — exact SQL reference search can now find tables mentioned by `DROP INDEX table.index`.
+
+## 日本語
+
+- **SQL legacy DROP INDEX の owning table を reference として索引するようになりました** — `DROP INDEX table.index` で指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-index-table-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-index-table-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **T-SQL `DROP INDEX ... ON` table targets are indexed as references** — exact SQL reference search can now find tables touched only by SQL Server index cleanup scripts.
+
+## 日本語
+
+- **T-SQL の `DROP INDEX ... ON` table target を reference として索引するようになりました** — SQL Server の index cleanup script だけで触られる table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-partition-function-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-partition-function-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP PARTITION FUNCTION targets are indexed as references** — exact SQL reference search can now find partition functions mentioned by `DROP PARTITION FUNCTION`.
+
+## 日本語
+
+- **SQL DROP PARTITION FUNCTION の target を reference として索引するようになりました** — `DROP PARTITION FUNCTION` で指定される partition function も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-partition-scheme-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-partition-scheme-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP PARTITION SCHEME targets are indexed as references** — exact SQL reference search can now find partition schemes mentioned by `DROP PARTITION SCHEME`.
+
+## 日本語
+
+- **SQL DROP PARTITION SCHEME の target を reference として索引するようになりました** — `DROP PARTITION SCHEME` で指定される partition scheme も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-procedure-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-procedure-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP PROCEDURE targets are indexed as references** — exact SQL reference search can now find procedures mentioned by `DROP PROCEDURE` or `DROP PROC`.
+
+## 日本語
+
+- **SQL DROP PROCEDURE の target を reference として索引するようになりました** — `DROP PROCEDURE` / `DROP PROC` で指定される procedure も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-rule-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-rule-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP RULE targets are indexed as references** — exact SQL reference search can now find rules mentioned by `DROP RULE`.
+
+## 日本語
+
+- **SQL DROP RULE の target を reference として索引するようになりました** — `DROP RULE` で指定される rule も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-security-policy-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-security-policy-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP SECURITY POLICY targets are indexed as references** — exact SQL reference search can now find security policies mentioned by `DROP SECURITY POLICY`.
+
+## 日本語
+
+- **SQL DROP SECURITY POLICY の target を reference として索引するようになりました** — `DROP SECURITY POLICY` で指定される security policy も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-sequence-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-sequence-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP SEQUENCE targets are indexed as references** — exact SQL reference search can now find sequences mentioned by `DROP SEQUENCE`.
+
+## 日本語
+
+- **SQL DROP SEQUENCE の target を reference として索引するようになりました** — `DROP SEQUENCE` で指定される sequence も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-statistics-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-statistics-references.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/SqlNameResolver.cs
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP STATISTICS owning tables are indexed as references** — exact SQL reference search can now find tables mentioned by `DROP STATISTICS table.statistic`.
+
+## 日本語
+
+- **SQL DROP STATISTICS の owning table を reference として索引するようになりました** — `DROP STATISTICS table.statistic` で指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-synonym-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-synonym-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP SYNONYM targets are indexed as references** — exact SQL reference search can now find synonyms mentioned by `DROP SYNONYM`.
+
+## 日本語
+
+- **SQL DROP SYNONYM の target を reference として索引するようになりました** — `DROP SYNONYM` で指定される synonym も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-table-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-table-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL `DROP TABLE` statements now surface table references** — exact SQL reference search can now find teardown migrations that drop one or more T-SQL tables, including `IF EXISTS` forms.
+
+## 日本語
+
+- **SQL の `DROP TABLE` が table reference として出るようになりました** — `IF EXISTS` を含む T-SQL の単一または複数 table 削除 migration も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-trigger-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-trigger-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP TRIGGER targets are indexed as references** — exact SQL reference search can now find triggers mentioned by `DROP TRIGGER`.
+
+## 日本語
+
+- **SQL DROP TRIGGER の target を reference として索引するようになりました** — `DROP TRIGGER` で指定される trigger も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-type-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP TYPE targets are indexed as references** — exact SQL reference search can now find user-defined types mentioned by `DROP TYPE`.
+
+## 日本語
+
+- **SQL DROP TYPE の target を reference として索引するようになりました** — `DROP TYPE` で指定される user-defined type も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-view-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-view-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP VIEW targets are indexed as references** — exact SQL reference search can now find views mentioned by `DROP VIEW`.
+
+## 日本語
+
+- **SQL DROP VIEW の target を reference として索引するようになりました** — `DROP VIEW` で指定される view も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-drop-xml-schema-collection-references.fixed.md
+++ b/changelog.d/unreleased/+sql-drop-xml-schema-collection-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL DROP XML SCHEMA COLLECTION targets are indexed as references** — exact SQL reference search can now find XML schema collections mentioned by `DROP XML SCHEMA COLLECTION`.
+
+## 日本語
+
+- **SQL DROP XML SCHEMA COLLECTION の target を reference として索引するようになりました** — `DROP XML SCHEMA COLLECTION` で指定される XML schema collection も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-foreign-key-reference-targets.fixed.md
+++ b/changelog.d/unreleased/+sql-foreign-key-reference-targets.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL foreign-key `REFERENCES` targets are indexed as table references** — exact SQL reference search can now find tables that are only mentioned as foreign-key targets.
+
+## 日本語
+
+- **SQL foreign key の `REFERENCES` target を table reference として索引するようになりました** — foreign key の参照先としてだけ現れる table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-insert-without-into-references.fixed.md
+++ b/changelog.d/unreleased/+sql-insert-without-into-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **T-SQL `INSERT` targets are indexed when `INTO` is omitted** — exact SQL reference search can now find write targets in SQL Server-style `INSERT dbo.Table (...)` statements.
+
+## 日本語
+
+- **`INTO` を省略した T-SQL `INSERT` の target を索引するようになりました** — SQL Server 形式の `INSERT dbo.Table (...)` に出る write target も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-object-permission-references.fixed.md
+++ b/changelog.d/unreleased/+sql-object-permission-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL object permission targets are indexed as references** — exact SQL reference search can now find objects mentioned by `GRANT`, `DENY`, and `REVOKE` statements that use `ON OBJECT::...`.
+
+## 日本語
+
+- **SQL object permission の target を reference として索引するようになりました** — `ON OBJECT::...` を使う `GRANT`、`DENY`、`REVOKE` statement の対象 object も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-output-into-references.fixed.md
+++ b/changelog.d/unreleased/+sql-output-into-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL OUTPUT INTO targets are indexed as references** — exact SQL reference search can now find audit or capture tables mentioned by DML `OUTPUT ... INTO`.
+
+## 日本語
+
+- **SQL OUTPUT INTO の target を reference として索引するようになりました** — DML の `OUTPUT ... INTO` で指定される audit/capture table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-select-into-references.fixed.md
+++ b/changelog.d/unreleased/+sql-select-into-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **T-SQL `SELECT ... INTO` table targets are indexed beyond temp tables** — exact SQL reference search can now find non-temp tables created or written through `SELECT ... INTO dbo.Table`.
+
+## 日本語
+
+- **T-SQL の `SELECT ... INTO` table target を temp table 以外でも索引するようになりました** — `SELECT ... INTO dbo.Table` で作成または書き込まれる非 temp table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-synonym-base-references.fixed.md
+++ b/changelog.d/unreleased/+sql-synonym-base-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL synonym base objects are indexed as references** — exact SQL reference search can now find objects that are only mentioned after `CREATE SYNONYM ... FOR`.
+
+## 日本語
+
+- **SQL synonym の base object を reference として索引するようになりました** — `CREATE SYNONYM ... FOR` の後にだけ現れる object も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-system-versioning-history-references.fixed.md
+++ b/changelog.d/unreleased/+sql-system-versioning-history-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL system-versioning history tables are indexed as references** — exact SQL reference search can now find tables mentioned by `HISTORY_TABLE = ...`.
+
+## 日本語
+
+- **SQL system-versioning の history table を reference として索引するようになりました** — `HISTORY_TABLE = ...` で指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-toggle-trigger-table-references.fixed.md
+++ b/changelog.d/unreleased/+sql-toggle-trigger-table-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **T-SQL trigger enable/disable statements now index their table targets** — exact SQL reference search can find tables touched only by `ENABLE TRIGGER ... ON` or `DISABLE TRIGGER ... ON` maintenance scripts.
+
+## 日本語
+
+- **T-SQL の trigger enable/disable 文で table target を索引するようになりました** — `ENABLE TRIGGER ... ON` / `DISABLE TRIGGER ... ON` の maintenance script だけで触られる table も、SQL の exact reference search で見つけられるようになりました。

--- a/changelog.d/unreleased/+sql-update-statistics-references.fixed.md
+++ b/changelog.d/unreleased/+sql-update-statistics-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **SQL UPDATE STATISTICS targets are indexed as references** — exact SQL reference search can now find tables mentioned by `UPDATE STATISTICS`.
+
+## 日本語
+
+- **SQL UPDATE STATISTICS の target を reference として索引するようになりました** — `UPDATE STATISTICS` で指定される table も、SQL の exact reference search で見つけられるようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -114,6 +114,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateClusteredColumnstoreIndexOnTargetRegex = new(
         $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?\s+CLUSTERED\s+COLUMNSTORE\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateHashIndexOnTargetRegex = new(
+        $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?\s+NONCLUSTERED\s+HASH\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CreateFullTextIndexOnTargetRegex = new(
         $@"(?<![\w$])CREATE\s+FULLTEXT\s+INDEX\b\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -622,6 +625,21 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateClusteredColumnstoreIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName,
+            suppressedCallIndices);
+
+        EmitMultiTargetReferences(
+            CreateHashIndexOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -213,6 +213,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterFullTextCatalogTargetRegex = new(
         $@"(?<![\w$])ALTER\s+FULLTEXT\s+CATALOG\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterPartitionFunctionTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+PARTITION\s+FUNCTION\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -1067,6 +1070,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterFullTextCatalogTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterPartitionFunctionTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -177,6 +177,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropSecurityPolicyTargetRegex = new(
         $@"(?<![\w$])DROP\s+SECURITY\s+POLICY\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropFullTextCatalogTargetRegex = new(
+        $@"(?<![\w$])DROP\s+FULLTEXT\s+CATALOG\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -863,6 +866,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropSecurityPolicyTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropFullTextCatalogTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -32,6 +32,8 @@ internal static class SqlReferenceExtractor
         @"(?:(?:" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")\s*\.\s*)*(?:" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")";
     private const string QualifiedIdentifierPattern =
         @"(?:(?:" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")\s*\.\s*)*(?<name>" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")";
+    private const string QualifiedIdentifierWithQualifierPattern =
+        @"(?:(?:" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")\s*\.\s*)+(?<name>" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")";
     private const string SourceAliasTailPattern =
         @"(?:\s+(?:AS\s+)?(?!JOIN\b|ON\b|USING\b|WHERE\b|GROUP\b|HAVING\b|ORDER\b|LIMIT\b|OFFSET\b|FETCH\b|UNION\b|EXCEPT\b|INTERSECT\b|RETURNING\b|FOR\b|WINDOW\b)(?:" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + "))?";
     private const string SourceTableHintTailPattern =
@@ -69,6 +71,9 @@ internal static class SqlReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex DeleteUsingSourceRegex = new(
         $@"(?<![\w$])DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierNoCapturePattern}(?:\s+(?:AS\s+)?(?!USING\b|WHERE\b|RETURNING\b)(?:{QuotedIdentifierPattern}|{BareIdentifierPattern}))?\s+USING\b\s+(?:(?:ONLY|LATERAL)\b\s+)?{QualifiedIdentifierPattern}(?:\s+(?:AS\s+)?(?!WHERE\b|RETURNING\b|ON\b|USING\b)(?:{QuotedIdentifierPattern}|{BareIdentifierPattern}))?(?:\s*,\s*(?:(?:ONLY|LATERAL)\b\s+)?{QualifiedIdentifierPattern}(?:\s+(?:AS\s+)?(?!WHERE\b|RETURNING\b|ON\b|USING\b)(?:{QuotedIdentifierPattern}|{BareIdentifierPattern}))?)*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DeleteTargetWithoutFromRegex = new(
+        $@"(?<![\w$])DELETE\b(?:\s+{TopTargetModifierPattern})?\s+(?!FROM\b){QualifiedIdentifierWithQualifierPattern}(?=\s*(?:;|$)|\s+(?:FROM|WHERE|OUTPUT|OPTION|RETURNING)\b)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex DeleteUsingPrefixRegex = new(
         $@"(?<![\w$])DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierNoCapturePattern}(?:\s+(?:AS\s+)?(?!USING\b|WHERE\b|RETURNING\b)(?:{QuotedIdentifierPattern}|{BareIdentifierPattern}))?\s*$",
@@ -435,6 +440,20 @@ internal static class SqlReferenceExtractor
             fileId,
             establishedTempObjectNames,
             suppressedCallIndices,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DeleteTargetWithoutFromRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
             resolveContainerForCall,
             shouldIgnoreName);
 

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -122,6 +122,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex UpdateStatisticsTargetRegex = new(
         $@"(?<![\w$])UPDATE\s+STATISTICS\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateStatisticsOnTargetRegex = new(
+        $@"(?<![\w$])CREATE\s+STATISTICS\b\s+{QualifiedIdentifierNoCapturePattern}\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -549,6 +552,21 @@ internal static class SqlReferenceExtractor
             fileId,
             resolveContainerForCall,
             shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            CreateStatisticsOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName,
+            suppressedCallIndices);
 
         EmitTargetReferences(
             statement,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -156,6 +156,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropFunctionTargetRegex = new(
         $@"(?<![\w$])DROP\s+FUNCTION\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropTriggerTargetRegex = new(
+        $@"(?<![\w$])DROP\s+TRIGGER\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -744,6 +747,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropFunctionTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropTriggerTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -104,6 +104,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropIndexOnTargetRegex = new(
         $@"(?<![\w$])DROP\s+INDEX\b\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierNoCapturePattern}\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateTriggerOnTargetRegex = new(
+        $@"(?<![\w$])CREATE\s+(?:OR\s+ALTER\s+)?TRIGGER\b\s+{QualifiedIdentifierNoCapturePattern}[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -435,6 +438,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            CreateTriggerOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -78,10 +78,10 @@ internal static class SqlReferenceExtractor
         @"(?<![\w$])FROM\b[\s\S]*,\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TargetReferencePrefixRegex = new(
-        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?|UPDATE\b(?:\s+(?:{TopTargetModifierPattern}|ONLY\b))*|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?|TRUNCATE\s+TABLE(?:\s+ONLY\b)?|CREATE(?:\s+(?:TEMP|TEMPORARY))?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|ALTER\s+TABLE|DROP\s+TABLE(?:\s+IF\s+EXISTS)?)\s*$",
+        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?|BULK\s+INSERT|UPDATE\b(?:\s+(?:{TopTargetModifierPattern}|ONLY\b))*|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?|TRUNCATE\s+TABLE(?:\s+ONLY\b)?|CREATE(?:\s+(?:TEMP|TEMPORARY))?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|ALTER\s+TABLE|DROP\s+TABLE(?:\s+IF\s+EXISTS)?)\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TargetReferenceRegex = new(
-        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+(?:INTO\s+|(?!OR\b|IGNORE\b|OVERWRITE\b|LOW_PRIORITY\b|DELAYED\b|HIGH_PRIORITY\b)){QualifiedIdentifierPattern}|UPDATE\b(?:\s+{TopTargetModifierPattern})\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+ONLY\b)*\s+{QualifiedIdentifierPattern}|MERGE\b(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?\s+{QualifiedIdentifierPattern}|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierPattern}|ALTER\s+TABLE\s+{QualifiedIdentifierPattern})",
+        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+(?:INTO\s+|(?!OR\b|IGNORE\b|OVERWRITE\b|LOW_PRIORITY\b|DELAYED\b|HIGH_PRIORITY\b)){QualifiedIdentifierPattern}|BULK\s+INSERT\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+{TopTargetModifierPattern})\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+ONLY\b)*\s+{QualifiedIdentifierPattern}|MERGE\b(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?\s+{QualifiedIdentifierPattern}|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierPattern}|ALTER\s+TABLE\s+{QualifiedIdentifierPattern})",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
     private static readonly Regex TruncateTargetRegex = new(
         $@"(?<![\w$])TRUNCATE\s+TABLE\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern})*",

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -195,6 +195,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterViewTargetRegex = new(
         $@"(?<![\w$])ALTER\s+VIEW\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterProcedureTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+(?:PROCEDURE|PROC)\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -965,6 +968,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterViewTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterProcedureTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -216,6 +216,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterPartitionFunctionTargetRegex = new(
         $@"(?<![\w$])ALTER\s+PARTITION\s+FUNCTION\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterPartitionSchemeTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+PARTITION\s+SCHEME\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -1084,6 +1087,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterPartitionFunctionTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterPartitionSchemeTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -121,6 +121,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterTableSwitchTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+TABLE\s+{QualifiedIdentifierNoCapturePattern}\s+SWITCH\b[\s\S]*?\bTO\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex UpdateStatisticsTargetRegex = new(
         $@"(?<![\w$])UPDATE\s+STATISTICS\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -532,6 +535,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterSchemaTransferTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterTableSwitchTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -98,6 +98,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateIndexOnTargetRegex = new(
         $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?(?:\s+(?:NONCLUSTERED\s+COLUMNSTORE|CLUSTERED|NONCLUSTERED|COLUMNSTORE|XML|SPATIAL))?\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterIndexOnTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+INDEX\b\s+(?:ALL|{QualifiedIdentifierNoCapturePattern})\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -412,6 +415,20 @@ internal static class SqlReferenceExtractor
             resolveContainerForCall,
             shouldIgnoreName,
             suppressedCallIndices);
+
+        EmitMultiTargetReferences(
+            AlterIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
 
         EmitTargetReferences(
             statement,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -222,6 +222,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterXmlSchemaCollectionTargetRegex = new(
         $@"(?<![\w$])ALTER\s+XML\s+SCHEMA\s+COLLECTION\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterAssemblyTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+ASSEMBLY\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -1118,6 +1121,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterXmlSchemaCollectionTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterAssemblyTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -189,6 +189,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropXmlSchemaCollectionTargetRegex = new(
         $@"(?<![\w$])DROP\s+XML\s+SCHEMA\s+COLLECTION\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropAssemblyTargetRegex = new(
+        $@"(?<![\w$])DROP\s+ASSEMBLY\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -931,6 +934,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropXmlSchemaCollectionTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropAssemblyTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -180,6 +180,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropFullTextCatalogTargetRegex = new(
         $@"(?<![\w$])DROP\s+FULLTEXT\s+CATALOG\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropPartitionSchemeTargetRegex = new(
+        $@"(?<![\w$])DROP\s+PARTITION\s+SCHEME\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -880,6 +883,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropFullTextCatalogTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropPartitionSchemeTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -113,6 +113,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex ForeignKeyReferencesTargetRegex = new(
         $@"(?<![\w$])REFERENCES\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateSynonymForTargetRegex = new(
+        $@"(?<![\w$])CREATE\s+(?:OR\s+REPLACE\s+)?(?:PUBLIC\s+)?SYNONYM\b\s+{QualifiedIdentifierNoCapturePattern}\s+FOR\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -498,6 +501,20 @@ internal static class SqlReferenceExtractor
             resolveContainerForCall,
             shouldIgnoreName,
             suppressedCallIndices);
+
+        EmitMultiTargetReferences(
+            CreateSynonymForTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
 
         EmitTargetReferences(
             statement,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -219,6 +219,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterPartitionSchemeTargetRegex = new(
         $@"(?<![\w$])ALTER\s+PARTITION\s+SCHEME\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterXmlSchemaCollectionTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+XML\s+SCHEMA\s+COLLECTION\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -1101,6 +1104,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterPartitionSchemeTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterXmlSchemaCollectionTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -201,6 +201,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterFunctionTargetRegex = new(
         $@"(?<![\w$])ALTER\s+FUNCTION\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterTriggerTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+TRIGGER\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -999,6 +1002,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterFunctionTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterTriggerTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -124,6 +124,12 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterTableSwitchTargetRegex = new(
         $@"(?<![\w$])ALTER\s+TABLE\s+{QualifiedIdentifierNoCapturePattern}\s+SWITCH\b[\s\S]*?\bTO\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex ObjectPermissionTargetRegex = new(
+        $@"(?<![\w$])(?:GRANT|DENY|REVOKE)\b[\s\S]*?\bON\s+OBJECT\s*::\s*{QualifiedIdentifierPattern}\s+(?:TO|FROM)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex RevokeObjectPermissionStatementRegex = new(
+        $@"(?<![\w$])REVOKE\b[\s\S]*?\bON\s+OBJECT\s*::\s*{QualifiedIdentifierNoCapturePattern}\s+FROM\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex UpdateStatisticsTargetRegex = new(
         $@"(?<![\w$])UPDATE\s+STATISTICS\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -562,6 +568,20 @@ internal static class SqlReferenceExtractor
             shouldIgnoreName);
 
         EmitMultiTargetReferences(
+            ObjectPermissionTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
             UpdateStatisticsTargetRegex.Matches(statement),
             statement,
             statementStart,
@@ -702,6 +722,9 @@ internal static class SqlReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForCall,
         Func<string, bool> shouldIgnoreName)
     {
+        if (RevokeObjectPermissionStatementRegex.IsMatch(statement))
+            return;
+
         foreach (Match match in matches)
         {
             if (IsInsideDoubleQuotedRegion(statement, match.Index))

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -159,6 +159,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropTriggerTargetRegex = new(
         $@"(?<![\w$])DROP\s+TRIGGER\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropSequenceTargetRegex = new(
+        $@"(?<![\w$])DROP\s+SEQUENCE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -761,6 +764,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropTriggerTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropSequenceTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -210,6 +210,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterSecurityPolicyTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SECURITY\s+POLICY\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterFullTextCatalogTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+FULLTEXT\s+CATALOG\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -1050,6 +1053,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterSecurityPolicyTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterFullTextCatalogTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -78,10 +78,10 @@ internal static class SqlReferenceExtractor
         @"(?<![\w$])FROM\b[\s\S]*,\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TargetReferencePrefixRegex = new(
-        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO|UPDATE\b(?:\s+(?:{TopTargetModifierPattern}|ONLY\b))*|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?|TRUNCATE\s+TABLE(?:\s+ONLY\b)?|CREATE(?:\s+(?:TEMP|TEMPORARY))?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?)\s*$",
+        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO|UPDATE\b(?:\s+(?:{TopTargetModifierPattern}|ONLY\b))*|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?|TRUNCATE\s+TABLE(?:\s+ONLY\b)?|CREATE(?:\s+(?:TEMP|TEMPORARY))?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|ALTER\s+TABLE)\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TargetReferenceRegex = new(
-        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+{TopTargetModifierPattern})\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+ONLY\b)*\s+{QualifiedIdentifierPattern}|MERGE\b(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?\s+{QualifiedIdentifierPattern}|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierPattern})",
+        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+{TopTargetModifierPattern})\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+ONLY\b)*\s+{QualifiedIdentifierPattern}|MERGE\b(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?\s+{QualifiedIdentifierPattern}|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierPattern}|ALTER\s+TABLE\s+{QualifiedIdentifierPattern})",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
     private static readonly Regex TruncateTargetRegex = new(
         $@"(?<![\w$])TRUNCATE\s+TABLE\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern})*",

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -165,6 +165,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropTypeTargetRegex = new(
         $@"(?<![\w$])DROP\s+TYPE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropRuleTargetRegex = new(
+        $@"(?<![\w$])DROP\s+RULE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -795,6 +798,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropTypeTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropRuleTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -106,6 +106,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterIndexOnTargetRegex = new(
         $@"(?<![\w$])ALTER\s+INDEX\b\s+(?:ALL|{QualifiedIdentifierNoCapturePattern})\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterFullTextIndexOnTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+FULLTEXT\s+INDEX\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex DropIndexOnTargetRegex = new(
         $@"(?<![\w$])DROP\s+INDEX\b\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierNoCapturePattern}\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -474,6 +477,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterFullTextIndexOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -204,6 +204,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterTriggerTargetRegex = new(
         $@"(?<![\w$])ALTER\s+TRIGGER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterSequenceTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+SEQUENCE\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -1016,6 +1019,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterTriggerTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterSequenceTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -119,6 +119,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex UpdateStatisticsTargetRegex = new(
+        $@"(?<![\w$])UPDATE\s+STATISTICS\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -533,6 +536,20 @@ internal static class SqlReferenceExtractor
             resolveContainerForCall,
             shouldIgnoreName);
 
+        EmitMultiTargetReferences(
+            UpdateStatisticsTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
         EmitTargetReferences(
             statement,
             statementStart,
@@ -795,6 +812,10 @@ internal static class SqlReferenceExtractor
                 continue;
             if (!wasQuoted
                 && string.Equals(resolvedName, "SET", StringComparison.OrdinalIgnoreCase)
+                && match.Value.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (!wasQuoted
+                && string.Equals(resolvedName, "STATISTICS", StringComparison.OrdinalIgnoreCase)
                 && match.Value.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase))
                 continue;
 

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -75,6 +75,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DeleteTargetWithoutFromRegex = new(
         $@"(?<![\w$])DELETE\b(?:\s+{TopTargetModifierPattern})?\s+(?!FROM\b){QualifiedIdentifierWithQualifierPattern}(?=\s*(?:;|$)|\s+(?:FROM|WHERE|OUTPUT|OPTION|RETURNING)\b)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex OutputIntoTargetRegex = new(
+        $@"(?<![\w$])OUTPUT\b[\s\S]*?\bINTO\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex DeleteUsingPrefixRegex = new(
         $@"(?<![\w$])DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierNoCapturePattern}(?:\s+(?:AS\s+)?(?!USING\b|WHERE\b|RETURNING\b)(?:{QuotedIdentifierPattern}|{BareIdentifierPattern}))?\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -456,6 +459,21 @@ internal static class SqlReferenceExtractor
             fileId,
             resolveContainerForCall,
             shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            OutputIntoTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName,
+            suppressedCallIndices);
 
         EmitSelectIntoTargetReferences(
             statement,
@@ -987,7 +1005,7 @@ internal static class SqlReferenceExtractor
             var container = resolveContainerForCall(nameGroup.Index);
             ReferenceExtractor.AddReference(references, seen, fileId, resolvedName, nameColumn, "reference", context, lineNumber, container);
             if (IsFollowedByOpenParen(statement, nameGroup.Index + nameGroup.Length))
-                suppressedCallIndices.Add(GetCallLikeSuppressionIndex(statement, nameGroup.Index) + statementStart - lineOffset);
+                AddCallLikeSuppressionIndices(suppressedCallIndices, statement, nameGroup.Index, statementStart, lineOffset);
         }
     }
 
@@ -1023,7 +1041,7 @@ internal static class SqlReferenceExtractor
                 var container = resolveContainerForCall(capture.Index);
                 ReferenceExtractor.AddReference(references, seen, fileId, resolvedName, nameColumn, "reference", context, lineNumber, container);
                 if (suppressedCallIndices != null && IsFollowedByOpenParen(statement, capture.Index + capture.Length))
-                    suppressedCallIndices.Add(GetCallLikeSuppressionIndex(statement, capture.Index) + statementStart - lineOffset);
+                    AddCallLikeSuppressionIndices(suppressedCallIndices, statement, capture.Index, statementStart, lineOffset);
             }
         }
     }
@@ -1070,6 +1088,87 @@ internal static class SqlReferenceExtractor
 
         return index;
     }
+
+    private static void AddCallLikeSuppressionIndices(
+        HashSet<int> suppressedCallIndices,
+        string line,
+        int leafIndex,
+        int statementStart,
+        int lineOffset)
+    {
+        var leafSuppressionIndex = GetCallLikeSuppressionIndex(line, leafIndex) + statementStart - lineOffset;
+        suppressedCallIndices.Add(leafSuppressionIndex);
+
+        var qualifiedStart = FindQualifiedIdentifierStart(line, leafIndex);
+        if (qualifiedStart == leafIndex)
+            return;
+
+        suppressedCallIndices.Add(GetCallLikeSuppressionIndex(line, qualifiedStart) + statementStart - lineOffset);
+    }
+
+    private static int FindQualifiedIdentifierStart(string line, int leafIndex)
+    {
+        var start = leafIndex;
+        while (start > 0)
+        {
+            var scan = start - 1;
+            while (scan >= 0 && char.IsWhiteSpace(line[scan]))
+                scan--;
+            if (scan < 0 || line[scan] != '.')
+                break;
+
+            scan--;
+            while (scan >= 0 && char.IsWhiteSpace(line[scan]))
+                scan--;
+            if (scan < 0)
+                break;
+
+            start = ScanIdentifierSegmentStart(line, scan);
+        }
+
+        return start;
+    }
+
+    private static int ScanIdentifierSegmentStart(string line, int index)
+    {
+        if (line[index] == ']')
+        {
+            index--;
+            while (index >= 0)
+            {
+                if (line[index] == '[')
+                    return index;
+                index--;
+            }
+
+            return 0;
+        }
+
+        if (line[index] is '"' or '`')
+        {
+            var quote = line[index--];
+            while (index >= 0)
+            {
+                if (line[index] == quote)
+                    return index;
+                index--;
+            }
+
+            return 0;
+        }
+
+        while (index >= 0 && IsIdentifierContinuationForReverseScan(line[index]))
+            index--;
+
+        return index + 1;
+    }
+
+    private static bool IsIdentifierContinuationForReverseScan(char ch)
+        => ch is '_' or '$' or '#'
+           || char.IsLetterOrDigit(ch)
+           || char.GetUnicodeCategory(ch) is System.Globalization.UnicodeCategory.NonSpacingMark
+               or System.Globalization.UnicodeCategory.SpacingCombiningMark
+               or System.Globalization.UnicodeCategory.ConnectorPunctuation;
 
     private static string CombineStatementPrefix(string prefix, string line, out int lineOffset)
     {

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -101,6 +101,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterIndexOnTargetRegex = new(
         $@"(?<![\w$])ALTER\s+INDEX\b\s+(?:ALL|{QualifiedIdentifierNoCapturePattern})\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropIndexOnTargetRegex = new(
+        $@"(?<![\w$])DROP\s+INDEX\b\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierNoCapturePattern}\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -418,6 +421,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropIndexOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -112,6 +112,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropIndexOnTargetRegex = new(
         $@"(?<![\w$])DROP\s+INDEX\b\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierNoCapturePattern}\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropFullTextIndexOnTargetRegex = new(
+        $@"(?<![\w$])DROP\s+FULLTEXT\s+INDEX\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CreateTriggerOnTargetRegex = new(
         $@"(?<![\w$])CREATE\s+(?:OR\s+ALTER\s+)?TRIGGER\b\s+{QualifiedIdentifierNoCapturePattern}[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -505,6 +508,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropFullTextIndexOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -150,6 +150,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex RevokePermissionStatementRegex = new(
         $@"(?<![\w$])REVOKE\b[\s\S]*?\bON\s+(?:OBJECT\s*::\s*)?(?![A-Z_]+\s*::){QualifiedIdentifierNoCapturePattern}\s+FROM\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterAuthorizationObjectTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+AUTHORIZATION\s+ON\s+OBJECT\s*::\s*{QualifiedIdentifierPattern}\s+TO\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex UpdateStatisticsTargetRegex = new(
         $@"(?<![\w$])UPDATE\s+STATISTICS\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -675,6 +678,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             ObjectPermissionTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterAuthorizationObjectTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -171,6 +171,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropDefaultTargetRegex = new(
         $@"(?<![\w$])DROP\s+DEFAULT\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropAggregateTargetRegex = new(
+        $@"(?<![\w$])DROP\s+AGGREGATE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -829,6 +832,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropDefaultTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropAggregateTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -78,10 +78,10 @@ internal static class SqlReferenceExtractor
         @"(?<![\w$])FROM\b[\s\S]*,\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TargetReferencePrefixRegex = new(
-        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO|UPDATE\b(?:\s+(?:{TopTargetModifierPattern}|ONLY\b))*|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?|TRUNCATE\s+TABLE(?:\s+ONLY\b)?|CREATE(?:\s+(?:TEMP|TEMPORARY))?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|ALTER\s+TABLE|DROP\s+TABLE(?:\s+IF\s+EXISTS)?)\s*$",
+        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?|UPDATE\b(?:\s+(?:{TopTargetModifierPattern}|ONLY\b))*|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?|TRUNCATE\s+TABLE(?:\s+ONLY\b)?|CREATE(?:\s+(?:TEMP|TEMPORARY))?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|ALTER\s+TABLE|DROP\s+TABLE(?:\s+IF\s+EXISTS)?)\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TargetReferenceRegex = new(
-        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+{TopTargetModifierPattern})\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+ONLY\b)*\s+{QualifiedIdentifierPattern}|MERGE\b(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?\s+{QualifiedIdentifierPattern}|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierPattern}|ALTER\s+TABLE\s+{QualifiedIdentifierPattern})",
+        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+(?:INTO\s+|(?!OR\b|IGNORE\b|OVERWRITE\b|LOW_PRIORITY\b|DELAYED\b|HIGH_PRIORITY\b)){QualifiedIdentifierPattern}|UPDATE\b(?:\s+{TopTargetModifierPattern})\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+ONLY\b)*\s+{QualifiedIdentifierPattern}|MERGE\b(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?\s+{QualifiedIdentifierPattern}|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierPattern}|ALTER\s+TABLE\s+{QualifiedIdentifierPattern})",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
     private static readonly Regex TruncateTargetRegex = new(
         $@"(?<![\w$])TRUNCATE\s+TABLE\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern})*",

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -183,6 +183,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropPartitionSchemeTargetRegex = new(
         $@"(?<![\w$])DROP\s+PARTITION\s+SCHEME\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropPartitionFunctionTargetRegex = new(
+        $@"(?<![\w$])DROP\s+PARTITION\s+FUNCTION\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -897,6 +900,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropPartitionSchemeTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropPartitionFunctionTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -207,6 +207,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterSequenceTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SEQUENCE\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterSecurityPolicyTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+SECURITY\s+POLICY\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -1033,6 +1036,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterSequenceTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterSecurityPolicyTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -153,6 +153,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropProcedureTargetRegex = new(
         $@"(?<![\w$])DROP\s+(?:PROCEDURE|PROC)\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropFunctionTargetRegex = new(
+        $@"(?<![\w$])DROP\s+FUNCTION\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -727,6 +730,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropProcedureTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropFunctionTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -192,6 +192,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropAssemblyTargetRegex = new(
         $@"(?<![\w$])DROP\s+ASSEMBLY\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterViewTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+VIEW\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -948,6 +951,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropAssemblyTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterViewTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -100,6 +100,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateIndexOnTargetRegex = new(
         $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?(?:\s+(?:NONCLUSTERED\s+COLUMNSTORE|CLUSTERED|NONCLUSTERED|COLUMNSTORE|XML|SPATIAL))?\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateFullTextIndexOnTargetRegex = new(
+        $@"(?<![\w$])CREATE\s+FULLTEXT\s+INDEX\b\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterIndexOnTargetRegex = new(
         $@"(?<![\w$])ALTER\s+INDEX\b\s+(?:ALL|{QualifiedIdentifierNoCapturePattern})\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -441,6 +444,21 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName,
+            suppressedCallIndices);
+
+        EmitMultiTargetReferences(
+            CreateFullTextIndexOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -186,6 +186,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropPartitionFunctionTargetRegex = new(
         $@"(?<![\w$])DROP\s+PARTITION\s+FUNCTION\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropXmlSchemaCollectionTargetRegex = new(
+        $@"(?<![\w$])DROP\s+XML\s+SCHEMA\s+COLLECTION\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -914,6 +917,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropPartitionFunctionTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropXmlSchemaCollectionTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -112,6 +112,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropIndexOnTargetRegex = new(
         $@"(?<![\w$])DROP\s+INDEX\b\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierNoCapturePattern}\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropIndexLegacyTargetRegex = new(
+        $@"(?<![\w$])DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?{DropStatisticsItemPattern}(?:\s*,\s*{DropStatisticsItemPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex DropFullTextIndexOnTargetRegex = new(
         $@"(?<![\w$])DROP\s+FULLTEXT\s+INDEX\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -508,6 +511,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropIndexLegacyTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -150,6 +150,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterTableSwitchTargetRegex = new(
         $@"(?<![\w$])ALTER\s+TABLE\s+{QualifiedIdentifierNoCapturePattern}\s+SWITCH\b[\s\S]*?\bTO\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterTableSystemVersioningHistoryTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+TABLE\s+{QualifiedIdentifierNoCapturePattern}[\s\S]*?\bSYSTEM_VERSIONING\s*=\s*ON\b[\s\S]*?\bHISTORY_TABLE\s*=\s*{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex ObjectPermissionTargetRegex = new(
         $@"(?<![\w$])(?:GRANT|DENY|REVOKE)\b[\s\S]*?\bON\s+(?:OBJECT\s*::\s*)?(?![A-Z_]+\s*::){QualifiedIdentifierPattern}\s+(?:TO|FROM)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -701,6 +704,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterTableSwitchTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterTableSystemVersioningHistoryTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -110,6 +110,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex ToggleTriggerOnTargetRegex = new(
         $@"(?<![\w$])(?:ENABLE|DISABLE)\s+TRIGGER\b\s+(?:ALL|{QualifiedIdentifierNoCapturePattern})\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex ForeignKeyReferencesTargetRegex = new(
+        $@"(?<![\w$])REFERENCES\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -480,6 +483,21 @@ internal static class SqlReferenceExtractor
             fileId,
             resolveContainerForCall,
             shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            ForeignKeyReferencesTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName,
+            suppressedCallIndices);
 
         EmitTargetReferences(
             statement,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -153,6 +153,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterAuthorizationObjectTargetRegex = new(
         $@"(?<![\w$])ALTER\s+AUTHORIZATION\s+ON\s+OBJECT\s*::\s*{QualifiedIdentifierPattern}\s+TO\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterAuthorizationBareTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+AUTHORIZATION\s+ON\s+(?![A-Z_]+\s*::){QualifiedIdentifierPattern}\s+TO\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex UpdateStatisticsTargetRegex = new(
         $@"(?<![\w$])UPDATE\s+STATISTICS\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -692,6 +695,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterAuthorizationObjectTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterAuthorizationBareTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -168,6 +168,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropRuleTargetRegex = new(
         $@"(?<![\w$])DROP\s+RULE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropDefaultTargetRegex = new(
+        $@"(?<![\w$])DROP\s+DEFAULT\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -812,6 +815,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropRuleTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropDefaultTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -78,13 +78,16 @@ internal static class SqlReferenceExtractor
         @"(?<![\w$])FROM\b[\s\S]*,\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TargetReferencePrefixRegex = new(
-        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO|UPDATE\b(?:\s+(?:{TopTargetModifierPattern}|ONLY\b))*|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?|TRUNCATE\s+TABLE(?:\s+ONLY\b)?|CREATE(?:\s+(?:TEMP|TEMPORARY))?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|ALTER\s+TABLE)\s*$",
+        $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO|UPDATE\b(?:\s+(?:{TopTargetModifierPattern}|ONLY\b))*|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?|TRUNCATE\s+TABLE(?:\s+ONLY\b)?|CREATE(?:\s+(?:TEMP|TEMPORARY))?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|ALTER\s+TABLE|DROP\s+TABLE(?:\s+IF\s+EXISTS)?)\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TargetReferenceRegex = new(
         $@"(?<![\w$])(?:INSERT(?:\s+{TopTargetModifierPattern})?\s+INTO\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+{TopTargetModifierPattern})\s+{QualifiedIdentifierPattern}|UPDATE\b(?:\s+ONLY\b)*\s+{QualifiedIdentifierPattern}|MERGE\b(?:\s+{TopTargetModifierPattern})?(?:\s+INTO)?\s+{QualifiedIdentifierPattern}|DELETE\b(?:\s+{TopTargetModifierPattern})?\s+FROM(?:\s+ONLY\b)?\s+{QualifiedIdentifierPattern}|ALTER\s+TABLE\s+{QualifiedIdentifierPattern})",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
     private static readonly Regex TruncateTargetRegex = new(
         $@"(?<![\w$])TRUNCATE\s+TABLE\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropTableTargetRegex = new(
+        $@"(?<![\w$])DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TopCallSuppressionRegex = new(
         @"(?<![\w$])(?:SELECT|INSERT|UPDATE|MERGE|DELETE)\b\s+(?<name>TOP)\s*\(",
@@ -406,7 +409,22 @@ internal static class SqlReferenceExtractor
             resolveContainerForCall,
             shouldIgnoreName);
 
-        EmitTruncateTargetReferences(
+        EmitMultiTargetReferences(
+            DropTableTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            TruncateTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,
@@ -648,7 +666,8 @@ internal static class SqlReferenceExtractor
         }
     }
 
-    private static void EmitTruncateTargetReferences(
+    private static void EmitMultiTargetReferences(
+        MatchCollection matches,
         string statement,
         int statementStart,
         int statementLineOffset,
@@ -661,7 +680,7 @@ internal static class SqlReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForCall,
         Func<string, bool> shouldIgnoreName)
     {
-        foreach (Match match in TruncateTargetRegex.Matches(statement))
+        foreach (Match match in matches)
         {
             if (IsInsideDoubleQuotedRegion(statement, match.Index))
                 continue;

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -108,6 +108,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateIndexOnTargetRegex = new(
         $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?(?:\s+(?:NONCLUSTERED\s+COLUMNSTORE|CLUSTERED|NONCLUSTERED|COLUMNSTORE|XML|SPATIAL))?\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateSpecialXmlIndexOnTargetRegex = new(
+        $@"(?<![\w$])CREATE\s+(?:PRIMARY\s+XML|SELECTIVE\s+XML)\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CreateFullTextIndexOnTargetRegex = new(
         $@"(?<![\w$])CREATE\s+FULLTEXT\s+INDEX\b\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -586,6 +589,21 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName,
+            suppressedCallIndices);
+
+        EmitMultiTargetReferences(
+            CreateSpecialXmlIndexOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -49,6 +49,8 @@ internal static class SqlReferenceExtractor
         @"TOP\s*\([^)\r\n]*\)(?:\s+PERCENT)?(?:\s+WITH\s+TIES)?";
     private const string MergeTargetHintPattern =
         @"WITH\s*\((?:[^()]|\([^()]*\))*\)";
+    private const string DropStatisticsItemPattern =
+        @"(?:(?:" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")\s*\.\s*)*(?<name>" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")\s*\.\s*(?:" + QuotedIdentifierPattern + "|" + BareIdentifierPattern + @")";
 
     private static readonly Regex ProcCallRegex = new(
         @"(?<![\w$])(?:EXEC|EXECUTE|CALL)\b\s+(?:@\w+\s*=\s*)?" + ProcCallQualifierPattern + @"(?<name>" + ProcCallIdentifierPattern + @")",
@@ -124,6 +126,9 @@ internal static class SqlReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CreateStatisticsOnTargetRegex = new(
         $@"(?<![\w$])CREATE\s+STATISTICS\b\s+{QualifiedIdentifierNoCapturePattern}\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropStatisticsTargetRegex = new(
+        $@"(?<![\w$])DROP\s+STATISTICS\s+{DropStatisticsItemPattern}(?:\s*,\s*{DropStatisticsItemPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
@@ -567,6 +572,20 @@ internal static class SqlReferenceExtractor
             resolveContainerForCall,
             shouldIgnoreName,
             suppressedCallIndices);
+
+        EmitMultiTargetReferences(
+            DropStatisticsTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
 
         EmitTargetReferences(
             statement,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -147,6 +147,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropSynonymTargetRegex = new(
         $@"(?<![\w$])DROP\s+(?:PUBLIC\s+)?SYNONYM\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropViewTargetRegex = new(
+        $@"(?<![\w$])DROP\s+(?:MATERIALIZED\s+)?VIEW\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -693,6 +696,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropSynonymTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropViewTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -125,10 +125,10 @@ internal static class SqlReferenceExtractor
         $@"(?<![\w$])ALTER\s+TABLE\s+{QualifiedIdentifierNoCapturePattern}\s+SWITCH\b[\s\S]*?\bTO\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex ObjectPermissionTargetRegex = new(
-        $@"(?<![\w$])(?:GRANT|DENY|REVOKE)\b[\s\S]*?\bON\s+OBJECT\s*::\s*{QualifiedIdentifierPattern}\s+(?:TO|FROM)\b",
+        $@"(?<![\w$])(?:GRANT|DENY|REVOKE)\b[\s\S]*?\bON\s+(?:OBJECT\s*::\s*)?(?![A-Z_]+\s*::){QualifiedIdentifierPattern}\s+(?:TO|FROM)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static readonly Regex RevokeObjectPermissionStatementRegex = new(
-        $@"(?<![\w$])REVOKE\b[\s\S]*?\bON\s+OBJECT\s*::\s*{QualifiedIdentifierNoCapturePattern}\s+FROM\b",
+    private static readonly Regex RevokePermissionStatementRegex = new(
+        $@"(?<![\w$])REVOKE\b[\s\S]*?\bON\s+(?:OBJECT\s*::\s*)?(?![A-Z_]+\s*::){QualifiedIdentifierNoCapturePattern}\s+FROM\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex UpdateStatisticsTargetRegex = new(
         $@"(?<![\w$])UPDATE\s+STATISTICS\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
@@ -722,7 +722,7 @@ internal static class SqlReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForCall,
         Func<string, bool> shouldIgnoreName)
     {
-        if (RevokeObjectPermissionStatementRegex.IsMatch(statement))
+        if (RevokePermissionStatementRegex.IsMatch(statement))
             return;
 
         foreach (Match match in matches)

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -162,6 +162,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropSequenceTargetRegex = new(
         $@"(?<![\w$])DROP\s+SEQUENCE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropTypeTargetRegex = new(
+        $@"(?<![\w$])DROP\s+TYPE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -778,6 +781,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropSequenceTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropTypeTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -129,6 +129,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateTriggerOnTargetRegex = new(
         $@"(?<![\w$])CREATE\s+(?:OR\s+ALTER\s+)?TRIGGER\b\s+{QualifiedIdentifierNoCapturePattern}[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateSecurityPolicyPredicateTargetRegex = new(
+        $@"(?<![\w$])CREATE\s+SECURITY\s+POLICY\b[\s\S]*?\b(?:FILTER|BLOCK)\s+PREDICATE\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}(?:[\s\S]*?\b(?:FILTER|BLOCK)\s+PREDICATE\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex ToggleTriggerOnTargetRegex = new(
         $@"(?<![\w$])(?:ENABLE|DISABLE)\s+TRIGGER\b\s+(?:ALL|{QualifiedIdentifierNoCapturePattern})\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -596,6 +599,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateTriggerOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            CreateSecurityPolicyPredicateTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -144,6 +144,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateSynonymForTargetRegex = new(
         $@"(?<![\w$])CREATE\s+(?:OR\s+REPLACE\s+)?(?:PUBLIC\s+)?SYNONYM\b\s+{QualifiedIdentifierNoCapturePattern}\s+FOR\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropSynonymTargetRegex = new(
+        $@"(?<![\w$])DROP\s+(?:PUBLIC\s+)?SYNONYM\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -676,6 +679,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateSynonymForTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropSynonymTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -95,6 +95,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AccessMethodCallSuppressionRegex = new(
         $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?\s+INDEX\b[\s\S]*?\bUSING\b\s+(?<name>{QuotedIdentifierPattern}|{BareIdentifierPattern})(?=\s*\()",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateIndexOnTargetRegex = new(
+        $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?(?:\s+(?:NONCLUSTERED\s+COLUMNSTORE|CLUSTERED|NONCLUSTERED|COLUMNSTORE|XML|SPATIAL))?\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -395,6 +398,21 @@ internal static class SqlReferenceExtractor
             resolveContainerForCall,
             shouldIgnoreName);
 
+        EmitMultiTargetReferences(
+            CreateIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName,
+            suppressedCallIndices);
+
         EmitTargetReferences(
             statement,
             statementStart,
@@ -610,7 +628,8 @@ internal static class SqlReferenceExtractor
         HashSet<string> seen,
         long fileId,
         Func<int, SymbolRecord?> resolveContainerForCall,
-        Func<string, bool> shouldIgnoreName)
+        Func<string, bool> shouldIgnoreName,
+        HashSet<int>? suppressedCallIndices = null)
     {
         foreach (Match match in SelectIntoTargetStatementRegex.Matches(statement))
         {
@@ -678,7 +697,8 @@ internal static class SqlReferenceExtractor
         HashSet<string> seen,
         long fileId,
         Func<int, SymbolRecord?> resolveContainerForCall,
-        Func<string, bool> shouldIgnoreName)
+        Func<string, bool> shouldIgnoreName,
+        HashSet<int>? suppressedCallIndices = null)
     {
         foreach (Match match in matches)
         {
@@ -696,6 +716,8 @@ internal static class SqlReferenceExtractor
 
                 var container = resolveContainerForCall(capture.Index);
                 ReferenceExtractor.AddReference(references, seen, fileId, resolvedName, nameColumn, "reference", context, lineNumber, container);
+                if (suppressedCallIndices != null && IsFollowedByOpenParen(statement, capture.Index + capture.Length))
+                    suppressedCallIndices.Add(GetCallLikeSuppressionIndex(statement, capture.Index) + statementStart - lineOffset);
             }
         }
     }

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -174,6 +174,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropAggregateTargetRegex = new(
         $@"(?<![\w$])DROP\s+AGGREGATE\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropSecurityPolicyTargetRegex = new(
+        $@"(?<![\w$])DROP\s+SECURITY\s+POLICY\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -846,6 +849,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropAggregateTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropSecurityPolicyTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -132,6 +132,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateSecurityPolicyPredicateTargetRegex = new(
         $@"(?<![\w$])CREATE\s+SECURITY\s+POLICY\b[\s\S]*?\b(?:FILTER|BLOCK)\s+PREDICATE\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}(?:[\s\S]*?\b(?:FILTER|BLOCK)\s+PREDICATE\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterSecurityPolicyPredicateTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+SECURITY\s+POLICY\b[\s\S]*?\b(?:FILTER|BLOCK)\s+PREDICATE\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}(?:[\s\S]*?\b(?:FILTER|BLOCK)\s+PREDICATE\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex ToggleTriggerOnTargetRegex = new(
         $@"(?<![\w$])(?:ENABLE|DISABLE)\s+TRIGGER\b\s+(?:ALL|{QualifiedIdentifierNoCapturePattern})\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -613,6 +616,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateSecurityPolicyPredicateTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterSecurityPolicyPredicateTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -95,10 +95,10 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AccessMethodCallSuppressionRegex = new(
         $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?\s+INDEX\b[\s\S]*?\bUSING\b\s+(?<name>{QuotedIdentifierPattern}|{BareIdentifierPattern})(?=\s*\()",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static readonly Regex SelectIntoTempTargetStatementRegex = new(
-        $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?<name>{TempIdentifierPattern})",
+    private static readonly Regex SelectIntoTargetStatementRegex = new(
+        $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
-    private static readonly Regex SelectIntoTempPrefixRegex = new(
+    private static readonly Regex SelectIntoTargetPrefixRegex = new(
         @"(?<![\w$])SELECT\b.*?\bINTO\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CreateTempTableRegex = new(
@@ -382,7 +382,7 @@ internal static class SqlReferenceExtractor
             resolveContainerForCall,
             shouldIgnoreName);
 
-        EmitSelectIntoTempReferences(
+        EmitSelectIntoTargetReferences(
             statement,
             statementStart,
             statementLineOffset,
@@ -599,7 +599,7 @@ internal static class SqlReferenceExtractor
         ReferenceExtractor.AddReference(references, seen, fileId, resolvedName, nameColumn, "reference", context, lineNumber, referenceContainer);
     }
 
-    private static void EmitSelectIntoTempReferences(
+    private static void EmitSelectIntoTargetReferences(
         string statement,
         int statementStart,
         int statementLineOffset,
@@ -612,7 +612,7 @@ internal static class SqlReferenceExtractor
         Func<int, SymbolRecord?> resolveContainerForCall,
         Func<string, bool> shouldIgnoreName)
     {
-        foreach (Match match in SelectIntoTempTargetStatementRegex.Matches(statement))
+        foreach (Match match in SelectIntoTargetStatementRegex.Matches(statement))
         {
             if (IsInsideDoubleQuotedRegion(statement, match.Index))
                 continue;
@@ -786,7 +786,7 @@ internal static class SqlReferenceExtractor
 
         return TargetReferenceRegex.IsMatch(statement)
             || TruncateTargetRegex.IsMatch(statement)
-            || SelectIntoTempTargetStatementRegex.IsMatch(statement)
+            || SelectIntoTargetStatementRegex.IsMatch(statement)
             || CreateTempTableRegex.IsMatch(statement)
             || CreateTempRoutineRegex.IsMatch(statement);
     }
@@ -799,7 +799,7 @@ internal static class SqlReferenceExtractor
         return CanStatementEstablishTempObject(statement)
             || TargetReferencePrefixRegex.IsMatch(statement)
             || FromListContinuationPrefixRegex.IsMatch(statement)
-            || SelectIntoTempPrefixRegex.IsMatch(statement)
+            || SelectIntoTargetPrefixRegex.IsMatch(statement)
             || DeleteUsingPrefixRegex.IsMatch(statement)
             || DeleteUsingListContinuationPrefixRegex.IsMatch(statement)
             || MergeUsingPrefixRegex.IsMatch(statement)
@@ -992,7 +992,7 @@ internal static class SqlReferenceExtractor
     {
         CollectTempObjectNamesFromMatches(TargetReferenceRegex.Matches(statement), statement, names);
         CollectTempObjectNamesFromMatches(TruncateTargetRegex.Matches(statement), statement, names);
-        CollectTempObjectNamesFromMatches(SelectIntoTempTargetStatementRegex.Matches(statement), statement, names);
+        CollectTempObjectNamesFromMatches(SelectIntoTargetStatementRegex.Matches(statement), statement, names);
         CollectTempObjectNamesFromMatches(CreateTempTableRegex.Matches(statement), statement, names);
         CollectTempObjectNamesFromMatches(CreateTempRoutineRegex.Matches(statement), statement, names);
     }

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -111,6 +111,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateSpecialXmlIndexOnTargetRegex = new(
         $@"(?<![\w$])CREATE\s+(?:PRIMARY\s+XML|SELECTIVE\s+XML)\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CreateClusteredColumnstoreIndexOnTargetRegex = new(
+        $@"(?<![\w$])CREATE\b(?:\s+UNIQUE\b)?\s+CLUSTERED\s+COLUMNSTORE\s+INDEX\b[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CreateFullTextIndexOnTargetRegex = new(
         $@"(?<![\w$])CREATE\s+FULLTEXT\s+INDEX\b\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -604,6 +607,21 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateSpecialXmlIndexOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName,
+            suppressedCallIndices);
+
+        EmitMultiTargetReferences(
+            CreateClusteredColumnstoreIndexOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -116,6 +116,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateSynonymForTargetRegex = new(
         $@"(?<![\w$])CREATE\s+(?:OR\s+REPLACE\s+)?(?:PUBLIC\s+)?SYNONYM\b\s+{QualifiedIdentifierNoCapturePattern}\s+FOR\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterSchemaTransferTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -504,6 +507,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateSynonymForTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterSchemaTransferTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -150,6 +150,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex DropViewTargetRegex = new(
         $@"(?<![\w$])DROP\s+(?:MATERIALIZED\s+)?VIEW\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex DropProcedureTargetRegex = new(
+        $@"(?<![\w$])DROP\s+(?:PROCEDURE|PROC)\s+(?:IF\s+EXISTS\s+)?{QualifiedIdentifierPattern}(?:\s*,\s*{QualifiedIdentifierPattern})*",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -710,6 +713,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             DropViewTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            DropProcedureTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -107,6 +107,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex CreateTriggerOnTargetRegex = new(
         $@"(?<![\w$])CREATE\s+(?:OR\s+ALTER\s+)?TRIGGER\b\s+{QualifiedIdentifierNoCapturePattern}[\s\S]*?\bON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex ToggleTriggerOnTargetRegex = new(
+        $@"(?<![\w$])(?:ENABLE|DISABLE)\s+TRIGGER\b\s+(?:ALL|{QualifiedIdentifierNoCapturePattern})\s+ON\s+(?:(?:ONLY)\b\s+)?{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex SelectIntoTargetStatementRegex = new(
         $@"(?<![\w$])SELECT\b.*?\bINTO\s+(?!OUTFILE\b|DUMPFILE\b){QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -452,6 +455,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             CreateTriggerOnTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            ToggleTriggerOnTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -198,6 +198,9 @@ internal static class SqlReferenceExtractor
     private static readonly Regex AlterProcedureTargetRegex = new(
         $@"(?<![\w$])ALTER\s+(?:PROCEDURE|PROC)\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex AlterFunctionTargetRegex = new(
+        $@"(?<![\w$])ALTER\s+FUNCTION\s+{QualifiedIdentifierPattern}",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex AlterSchemaTransferTargetRegex = new(
         $@"(?<![\w$])ALTER\s+SCHEMA\b\s+{QualifiedIdentifierNoCapturePattern}\s+TRANSFER\s+{QualifiedIdentifierPattern}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -982,6 +985,20 @@ internal static class SqlReferenceExtractor
 
         EmitMultiTargetReferences(
             AlterProcedureTargetRegex.Matches(statement),
+            statement,
+            statementStart,
+            statementLineOffset,
+            lineOffset,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            resolveContainerForCall,
+            shouldIgnoreName);
+
+        EmitMultiTargetReferences(
+            AlterFunctionTargetRegex.Matches(statement),
             statement,
             statementStart,
             statementLineOffset,

--- a/src/CodeIndex/Indexer/References/Support/SqlNameResolver.cs
+++ b/src/CodeIndex/Indexer/References/Support/SqlNameResolver.cs
@@ -251,6 +251,13 @@ internal static class SqlNameResolver
                 match = candidate;
                 return true;
             }
+
+            if (zeroBasedColumn >= candidate.StartIndex
+                && zeroBasedColumn < candidate.EndIndexExclusive
+                && TryReadQualifiedNamePrefixAtColumn(context, candidate.StartIndex, zeroBasedColumn, out match))
+            {
+                return true;
+            }
         }
 
         return false;
@@ -512,6 +519,59 @@ internal static class SqlNameResolver
 
         segment = current.ToString().Trim();
         return segment.Length > 0;
+    }
+
+    private static bool TryReadQualifiedNamePrefixAtColumn(
+        string text,
+        int startIndex,
+        int zeroBasedColumn,
+        out QualifiedNameMatch match)
+    {
+        match = default;
+        var segments = new List<(string Name, int StartIndex, int EndIndexExclusive)>();
+        var index = startIndex;
+        while (true)
+        {
+            var segmentStartIndex = index;
+            if (!TryReadQualifiedNameSegment(text, ref index, out var segment))
+                return false;
+
+            segments.Add((segment, segmentStartIndex, index));
+            var scan = index;
+            while (scan < text.Length && char.IsWhiteSpace(text[scan]))
+                scan++;
+
+            if (scan >= text.Length || text[scan] != '.')
+                break;
+
+            scan++;
+            while (scan < text.Length && char.IsWhiteSpace(text[scan]))
+                scan++;
+
+            if (scan >= text.Length || !IsSqlIdentifierStartChar(text[scan]))
+                break;
+
+            index = scan;
+        }
+
+        for (var i = 1; i < segments.Count; i++)
+        {
+            var segment = segments[i];
+            if (zeroBasedColumn < segment.StartIndex || zeroBasedColumn >= segment.EndIndexExclusive)
+                continue;
+
+            var normalizedName = string.Join(".", segments.Take(i + 1).Select(part => part.Name));
+            match = new QualifiedNameMatch(
+                normalizedName,
+                i + 1,
+                startIndex,
+                segment.EndIndexExclusive,
+                segment.StartIndex,
+                segment.EndIndexExclusive);
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsSqlIdentifierStartChar(char ch)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5427,6 +5427,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropAggregateReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_aggregate_target.sql", "sql",
+            """
+            CREATE AGGREGATE dbo.TotalAmount(@value int)
+            RETURNS int
+            EXTERNAL NAME SalesAssembly.TotalAmount;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_aggregate_cleanup.sql", "sql",
+            """
+            DROP AGGREGATE dbo.TotalAmount;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.TotalAmount", lang: "sql", exact: true, pathPatterns: ["sql_drop_aggregate"]));
+        Assert.Equal("src/sql_drop_aggregate_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.TotalAmount", lang: "sql", exact: true, pathPatterns: ["sql_drop_aggregate"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.TotalAmount", lang: "sql", exact: true, pathPatterns: ["sql_drop_aggregate"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5055,6 +5055,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DeleteWithoutFromReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_delete_without_from_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_delete_without_from_cleanup.sql", "sql",
+            """
+            DELETE dbo.Orders WHERE Id = 1;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_delete_without_from"]));
+        Assert.Equal("src/sql_delete_without_from_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_delete_without_from"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_delete_without_from"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5356,6 +5356,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropTypeReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_type_target.sql", "sql",
+            """
+            CREATE TYPE dbo.CustomerKey
+                FROM int NOT NULL;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_type_cleanup.sql", "sql",
+            """
+            DROP TYPE dbo.CustomerKey;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.CustomerKey", lang: "sql", exact: true, pathPatterns: ["sql_drop_type"]));
+        Assert.Equal("src/sql_drop_type_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.CustomerKey", lang: "sql", exact: true, pathPatterns: ["sql_drop_type"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.CustomerKey", lang: "sql", exact: true, pathPatterns: ["sql_drop_type"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5033,6 +5033,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropIndexLegacyReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_index_legacy_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int, CreatedAt datetime2);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_index_legacy_cleanup.sql", "sql",
+            """
+            DROP INDEX dbo.Orders.IX_Orders_Date;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_index_legacy"]));
+        Assert.Equal("src/sql_drop_index_legacy_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_index_legacy"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_index_legacy"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5379,6 +5379,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropRuleReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_rule_target.sql", "sql",
+            """
+            CREATE RULE dbo.PositiveAmount
+            AS
+            @amount >= 0;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_rule_cleanup.sql", "sql",
+            """
+            DROP RULE dbo.PositiveAmount;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.PositiveAmount", lang: "sql", exact: true, pathPatterns: ["sql_drop_rule"]));
+        Assert.Equal("src/sql_drop_rule_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.PositiveAmount", lang: "sql", exact: true, pathPatterns: ["sql_drop_rule"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.PositiveAmount", lang: "sql", exact: true, pathPatterns: ["sql_drop_rule"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4989,6 +4989,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterFullTextIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_fulltext_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Documents (Id int, Title nvarchar(200));
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_fulltext_index_maintenance.sql", "sql",
+            """
+            ALTER FULLTEXT INDEX ON dbo.Documents START FULL POPULATION;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_alter_fulltext_index"]));
+        Assert.Equal("src/sql_alter_fulltext_index_maintenance.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_alter_fulltext_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_alter_fulltext_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5543,6 +5543,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropXmlSchemaCollectionReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_xml_schema_collection_target.sql", "sql",
+            """
+            CREATE XML SCHEMA COLLECTION dbo.InvoiceSchema AS '<schema/>';
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_xml_schema_collection_cleanup.sql", "sql",
+            """
+            DROP XML SCHEMA COLLECTION dbo.InvoiceSchema;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.InvoiceSchema", lang: "sql", exact: true, pathPatterns: ["sql_drop_xml_schema_collection"]));
+        Assert.Equal("src/sql_drop_xml_schema_collection_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.InvoiceSchema", lang: "sql", exact: true, pathPatterns: ["sql_drop_xml_schema_collection"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.InvoiceSchema", lang: "sql", exact: true, pathPatterns: ["sql_drop_xml_schema_collection"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5333,6 +5333,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropSequenceReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_sequence_target.sql", "sql",
+            """
+            CREATE SEQUENCE dbo.OrderNumbers
+                START WITH 1;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_sequence_cleanup.sql", "sql",
+            """
+            DROP SEQUENCE dbo.OrderNumbers;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.OrderNumbers", lang: "sql", exact: true, pathPatterns: ["sql_drop_sequence"]));
+        Assert.Equal("src/sql_drop_sequence_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.OrderNumbers", lang: "sql", exact: true, pathPatterns: ["sql_drop_sequence"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.OrderNumbers", lang: "sql", exact: true, pathPatterns: ["sql_drop_sequence"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5077,6 +5077,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_OutputIntoReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_output_into_target.sql", "sql",
+            """
+            CREATE TABLE audit.OrderAudit (OrderId int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_output_into_update.sql", "sql",
+            """
+            UPDATE dbo.Orders SET Status = 'Closed' OUTPUT inserted.Id INTO audit.OrderAudit (OrderId) WHERE Id = 1;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("audit.OrderAudit", lang: "sql", exact: true, pathPatterns: ["sql_output_into"]));
+        Assert.Equal("src/sql_output_into_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("audit.OrderAudit", lang: "sql", exact: true, pathPatterns: ["sql_output_into"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("audit.OrderAudit", lang: "sql", exact: true, pathPatterns: ["sql_output_into"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4636,6 +4636,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_BulkInsertReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_bulk_insert_target.sql", "sql",
+            """
+            CREATE TABLE dbo.ImportQueue (Payload nvarchar(max));
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_bulk_insert_writer.sql", "sql",
+            """
+            BULK INSERT dbo.ImportQueue FROM 'queue.csv';
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.ImportQueue", lang: "sql", exact: true, pathPatterns: ["sql_bulk_insert"]));
+        Assert.Equal("src/sql_bulk_insert_writer.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.ImportQueue", lang: "sql", exact: true, pathPatterns: ["sql_bulk_insert"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.ImportQueue", lang: "sql", exact: true, pathPatterns: ["sql_bulk_insert"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4834,6 +4834,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_UpdateStatisticsReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_update_statistics_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_update_statistics_refresh.sql", "sql",
+            """
+            UPDATE STATISTICS dbo.Orders WITH FULLSCAN;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_update_statistics"]));
+        Assert.Equal("src/sql_update_statistics_refresh.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_update_statistics"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_update_statistics"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4568,6 +4568,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropTableReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_table_reference_targets.sql", "sql",
+            """
+            CREATE TABLE dbo.OldOrders (Id int);
+            GO
+            CREATE TABLE sales.OldInvoices (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_table_reference_migration.sql", "sql",
+            """
+            DROP TABLE IF EXISTS dbo.OldOrders, sales.OldInvoices;
+            GO
+            """);
+
+        var references = _reader.SearchReferences("sales.OldInvoices", lang: "sql", exact: true, pathPatterns: ["sql_drop_table_reference"]);
+        var reference = Assert.Single(references);
+        Assert.Equal("src/sql_drop_table_reference_migration.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("sales.OldInvoices", lang: "sql", exact: true, pathPatterns: ["sql_drop_table_reference"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("sales.OldInvoices", lang: "sql", exact: true, pathPatterns: ["sql_drop_table_reference"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5307,6 +5307,32 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropTriggerReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_trigger_target.sql", "sql",
+            """
+            CREATE TRIGGER audit.OrdersAudit
+            ON dbo.Orders
+            AFTER INSERT
+            AS
+            SELECT 1;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_trigger_cleanup.sql", "sql",
+            """
+            DROP TRIGGER audit.OrdersAudit;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("audit.OrdersAudit", lang: "sql", exact: true, pathPatterns: ["sql_drop_trigger"]));
+        Assert.Equal("src/sql_drop_trigger_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("audit.OrdersAudit", lang: "sql", exact: true, pathPatterns: ["sql_drop_trigger"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("audit.OrdersAudit", lang: "sql", exact: true, pathPatterns: ["sql_drop_trigger"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5474,6 +5474,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropFullTextCatalogReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_fulltext_catalog_target.sql", "sql",
+            """
+            CREATE FULLTEXT CATALOG ftOrders;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_fulltext_catalog_cleanup.sql", "sql",
+            """
+            DROP FULLTEXT CATALOG ftOrders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("ftOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_fulltext_catalog"]));
+        Assert.Equal("src/sql_drop_fulltext_catalog_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("ftOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_fulltext_catalog"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("ftOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_fulltext_catalog"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4680,6 +4680,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int, CreatedAt datetime2);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_index_maintenance.sql", "sql",
+            """
+            ALTER INDEX IX_Orders_CreatedAt ON dbo.Orders REBUILD;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_index"]));
+        Assert.Equal("src/sql_alter_index_maintenance.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5143,6 +5143,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateSecurityPolicyReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_create_security_policy_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int, TenantId int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_create_security_policy_definition.sql", "sql",
+            """
+            CREATE SECURITY POLICY sec.OrderPolicy
+                ADD FILTER PREDICATE sec.fn_tenant(TenantId) ON dbo.Orders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_security_policy"]));
+        Assert.Equal("src/sql_create_security_policy_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_security_policy"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_security_policy"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5744,6 +5744,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterFullTextCatalogReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_fulltext_catalog_target.sql", "sql",
+            """
+            CREATE FULLTEXT CATALOG ftOrders;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_fulltext_catalog_update.sql", "sql",
+            """
+            ALTER FULLTEXT CATALOG ftOrders REBUILD;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("ftOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_fulltext_catalog"]));
+        Assert.Equal("src/sql_alter_fulltext_catalog_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("ftOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_fulltext_catalog"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("ftOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_fulltext_catalog"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4989,6 +4989,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateSpecialXmlIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_create_special_xml_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Documents (Id int, Payload xml);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_create_special_xml_index_definition.sql", "sql",
+            """
+            CREATE PRIMARY XML INDEX IX_Documents_Xml ON dbo.Documents (Payload);
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_create_special_xml_index"]));
+        Assert.Equal("src/sql_create_special_xml_index_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_create_special_xml_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_create_special_xml_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_AlterFullTextIndexReferencesResolveThroughSearch()
     {
         InsertIndexedFile("src/sql_alter_fulltext_index_target.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4790,6 +4790,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateSynonymReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_synonym_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Customers (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_synonym_definition.sql", "sql",
+            """
+            CREATE SYNONYM dbo.CustomerAlias FOR dbo.Customers;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Customers", lang: "sql", exact: true, pathPatterns: ["sql_synonym"]));
+        Assert.Equal("src/sql_synonym_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Customers", lang: "sql", exact: true, pathPatterns: ["sql_synonym"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Customers", lang: "sql", exact: true, pathPatterns: ["sql_synonym"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5189,6 +5189,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterTableSystemVersioningReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_table_system_versioning_target.sql", "sql",
+            """
+            CREATE TABLE history.OrdersHistory (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_table_system_versioning_enable.sql", "sql",
+            """
+            ALTER TABLE dbo.Orders
+                SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = history.OrdersHistory));
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("history.OrdersHistory", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_system_versioning"]));
+        Assert.Equal("src/sql_alter_table_system_versioning_enable.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("history.OrdersHistory", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_system_versioning"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("history.OrdersHistory", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_system_versioning"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5121,6 +5121,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterAuthorizationBareObjectReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_authorization_bare_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_authorization_bare_owner.sql", "sql",
+            """
+            ALTER AUTHORIZATION ON dbo.Orders TO app_owner;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_authorization_bare"]));
+        Assert.Equal("src/sql_alter_authorization_bare_owner.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_authorization_bare"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_authorization_bare"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5234,6 +5234,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropViewReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_view_target.sql", "sql",
+            """
+            CREATE VIEW dbo.OrderSummary AS SELECT 1 AS Id;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_view_cleanup.sql", "sql",
+            """
+            DROP VIEW dbo.OrderSummary;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.OrderSummary", lang: "sql", exact: true, pathPatterns: ["sql_drop_view"]));
+        Assert.Equal("src/sql_drop_view_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.OrderSummary", lang: "sql", exact: true, pathPatterns: ["sql_drop_view"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.OrderSummary", lang: "sql", exact: true, pathPatterns: ["sql_drop_view"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5520,6 +5520,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropPartitionFunctionReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_partition_function_target.sql", "sql",
+            """
+            CREATE PARTITION FUNCTION pfOrders(int)
+            AS RANGE LEFT FOR VALUES (100);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_partition_function_cleanup.sql", "sql",
+            """
+            DROP PARTITION FUNCTION pfOrders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("pfOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_partition_function"]));
+        Assert.Equal("src/sql_drop_partition_function_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("pfOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_partition_function"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("pfOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_partition_function"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5256,6 +5256,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropProcedureReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_procedure_target.sql", "sql",
+            """
+            CREATE PROCEDURE dbo.RebuildOrders
+            AS
+            SELECT 1;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_procedure_cleanup.sql", "sql",
+            """
+            DROP PROCEDURE dbo.RebuildOrders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.RebuildOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_procedure"]));
+        Assert.Equal("src/sql_drop_procedure_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.RebuildOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_procedure"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.RebuildOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_procedure"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5280,6 +5280,33 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropFunctionReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_function_target.sql", "sql",
+            """
+            CREATE FUNCTION dbo.CalculateTax()
+            RETURNS int
+            AS
+            BEGIN
+                RETURN 1;
+            END;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_function_cleanup.sql", "sql",
+            """
+            DROP FUNCTION dbo.CalculateTax;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.CalculateTax", lang: "sql", exact: true, pathPatterns: ["sql_drop_function"]));
+        Assert.Equal("src/sql_drop_function_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.CalculateTax", lang: "sql", exact: true, pathPatterns: ["sql_drop_function"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.CalculateTax", lang: "sql", exact: true, pathPatterns: ["sql_drop_function"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5789,6 +5789,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterPartitionSchemeReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_partition_scheme_target.sql", "sql",
+            """
+            CREATE PARTITION SCHEME psOrders
+            AS PARTITION pfOrders
+            ALL TO ([PRIMARY]);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_partition_scheme_update.sql", "sql",
+            """
+            ALTER PARTITION SCHEME psOrders NEXT USED [PRIMARY];
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("psOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_partition_scheme"]));
+        Assert.Equal("src/sql_alter_partition_scheme_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("psOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_partition_scheme"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("psOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_partition_scheme"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4658,6 +4658,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_create_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int, CreatedAt datetime2);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_create_index_definition.sql", "sql",
+            """
+            CREATE INDEX IX_Orders_CreatedAt ON dbo.Orders (CreatedAt);
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_index"]));
+        Assert.Equal("src/sql_create_index_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5099,6 +5099,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterAuthorizationObjectReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_authorization_object_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_authorization_object_owner.sql", "sql",
+            """
+            ALTER AUTHORIZATION ON OBJECT::dbo.Orders TO app_owner;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_authorization_object"]));
+        Assert.Equal("src/sql_alter_authorization_object_owner.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_authorization_object"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_authorization_object"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5033,6 +5033,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateHashIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_create_hash_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.OrderCache (Id int NOT NULL);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_create_hash_index_definition.sql", "sql",
+            """
+            CREATE NONCLUSTERED HASH INDEX IX_OrderCache_Id
+            ON dbo.OrderCache (Id)
+            WITH (BUCKET_COUNT = 1024);
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.OrderCache", lang: "sql", exact: true, pathPatterns: ["sql_create_hash_index"]));
+        Assert.Equal("src/sql_create_hash_index_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.OrderCache", lang: "sql", exact: true, pathPatterns: ["sql_create_hash_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.OrderCache", lang: "sql", exact: true, pathPatterns: ["sql_create_hash_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_AlterFullTextIndexReferencesResolveThroughSearch()
     {
         InsertIndexedFile("src/sql_alter_fulltext_index_target.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5835,6 +5835,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterAssemblyReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_assembly_target.sql", "sql",
+            """
+            CREATE ASSEMBLY SalesAssembly
+            FROM 0x4D5A;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_assembly_update.sql", "sql",
+            """
+            ALTER ASSEMBLY SalesAssembly
+            FROM 0x4D5A;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("SalesAssembly", lang: "sql", exact: true, pathPatterns: ["sql_alter_assembly"]));
+        Assert.Equal("src/sql_alter_assembly_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("SalesAssembly", lang: "sql", exact: true, pathPatterns: ["sql_alter_assembly"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("SalesAssembly", lang: "sql", exact: true, pathPatterns: ["sql_alter_assembly"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5451,6 +5451,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropSecurityPolicyReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_security_policy_target.sql", "sql",
+            """
+            CREATE SECURITY POLICY dbo.CustomerFilter
+            ADD FILTER PREDICATE dbo.fn_filter(CustomerId) ON dbo.Customers;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_security_policy_cleanup.sql", "sql",
+            """
+            DROP SECURITY POLICY dbo.CustomerFilter;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.CustomerFilter", lang: "sql", exact: true, pathPatterns: ["sql_drop_security_policy"]));
+        Assert.Equal("src/sql_drop_security_policy_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.CustomerFilter", lang: "sql", exact: true, pathPatterns: ["sql_drop_security_policy"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.CustomerFilter", lang: "sql", exact: true, pathPatterns: ["sql_drop_security_policy"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5813,6 +5813,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterXmlSchemaCollectionReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_xml_schema_collection_target.sql", "sql",
+            """
+            CREATE XML SCHEMA COLLECTION dbo.InvoiceSchema AS '<schema/>';
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_xml_schema_collection_update.sql", "sql",
+            """
+            ALTER XML SCHEMA COLLECTION dbo.InvoiceSchema ADD '<schema/>';
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.InvoiceSchema", lang: "sql", exact: true, pathPatterns: ["sql_alter_xml_schema_collection"]));
+        Assert.Equal("src/sql_alter_xml_schema_collection_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.InvoiceSchema", lang: "sql", exact: true, pathPatterns: ["sql_alter_xml_schema_collection"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.InvoiceSchema", lang: "sql", exact: true, pathPatterns: ["sql_alter_xml_schema_collection"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4923,6 +4923,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_ObjectPermissionReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_object_permission_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_object_permission_grant.sql", "sql",
+            """
+            GRANT SELECT ON OBJECT::dbo.Orders TO ReportingRole;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_object_permission"]));
+        Assert.Equal("src/sql_object_permission_grant.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_object_permission"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_object_permission"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4812,6 +4812,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterSchemaTransferReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_schema_transfer_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_schema_transfer_move.sql", "sql",
+            """
+            ALTER SCHEMA archive TRANSFER dbo.Orders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_schema_transfer"]));
+        Assert.Equal("src/sql_alter_schema_transfer_move.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_schema_transfer"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_schema_transfer"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5168,7 +5168,7 @@ public class DbReaderTests : IDisposable
     [Fact]
     public void SqlQualifiedNames_AlterSecurityPolicyReferencesResolveThroughSearch()
     {
-        InsertIndexedFile("src/sql_alter_security_policy_target.sql", "sql",
+        InsertIndexedFile("src/sql_alter_security_policy_name_target.sql", "sql",
             """
             CREATE TABLE dbo.Orders (Id int, TenantId int);
             GO
@@ -5718,6 +5718,29 @@ public class DbReaderTests : IDisposable
         Assert.Equal("src/sql_alter_sequence_update.sql", reference.Path);
         Assert.Equal(1, _reader.CountSearchReferences("dbo.OrderNumbers", lang: "sql", exact: true, pathPatterns: ["sql_alter_sequence"]));
         Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.OrderNumbers", lang: "sql", exact: true, pathPatterns: ["sql_alter_sequence"]));
+    }
+
+    [Fact]
+    public void SqlQualifiedNames_AlterSecurityPolicyNameReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_security_policy_target.sql", "sql",
+            """
+            CREATE SECURITY POLICY dbo.CustomerFilter
+            ADD FILTER PREDICATE dbo.fn_filter(CustomerId) ON dbo.Customers;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_security_policy_name_update.sql", "sql",
+            """
+            ALTER SECURITY POLICY dbo.CustomerFilter WITH (STATE = OFF);
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.CustomerFilter", lang: "sql", exact: true, pathPatterns: ["sql_alter_security_policy_name"]));
+        Assert.Equal("src/sql_alter_security_policy_name_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.CustomerFilter", lang: "sql", exact: true, pathPatterns: ["sql_alter_security_policy_name"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.CustomerFilter", lang: "sql", exact: true, pathPatterns: ["sql_alter_security_policy_name"]));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5588,6 +5588,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterViewReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_view_target.sql", "sql",
+            """
+            CREATE VIEW dbo.OrderSummary AS SELECT 1 AS Id;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_view_update.sql", "sql",
+            """
+            ALTER VIEW dbo.OrderSummary AS SELECT 2 AS Id;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.OrderSummary", lang: "sql", exact: true, pathPatterns: ["sql_alter_view"]));
+        Assert.Equal("src/sql_alter_view_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.OrderSummary", lang: "sql", exact: true, pathPatterns: ["sql_alter_view"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.OrderSummary", lang: "sql", exact: true, pathPatterns: ["sql_alter_view"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4856,6 +4856,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateStatisticsReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_create_statistics_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_create_statistics_definition.sql", "sql",
+            """
+            CREATE STATISTICS st_OrderDate ON dbo.Orders (OrderDate);
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_statistics"]));
+        Assert.Equal("src/sql_create_statistics_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_statistics"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_statistics"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4614,6 +4614,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_SelectIntoReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_select_into_target.sql", "sql",
+            """
+            CREATE TABLE dbo.OrderArchive (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_select_into_writer.sql", "sql",
+            """
+            SELECT Id INTO dbo.OrderArchive FROM dbo.Orders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.OrderArchive", lang: "sql", exact: true, pathPatterns: ["sql_select_into"]));
+        Assert.Equal("src/sql_select_into_writer.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.OrderArchive", lang: "sql", exact: true, pathPatterns: ["sql_select_into"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.OrderArchive", lang: "sql", exact: true, pathPatterns: ["sql_select_into"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5011,6 +5011,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropFullTextIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_fulltext_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Documents (Id int, Title nvarchar(200));
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_fulltext_index_cleanup.sql", "sql",
+            """
+            DROP FULLTEXT INDEX ON dbo.Documents;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_drop_fulltext_index"]));
+        Assert.Equal("src/sql_drop_fulltext_index_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_drop_fulltext_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_drop_fulltext_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5668,6 +5668,36 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterTriggerReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_trigger_target.sql", "sql",
+            """
+            CREATE TRIGGER audit.OrdersAudit
+            ON dbo.Orders
+            AFTER INSERT
+            AS
+            SELECT 1;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_trigger_update.sql", "sql",
+            """
+            ALTER TRIGGER audit.OrdersAudit
+            ON dbo.Orders
+            AFTER INSERT
+            AS
+            SELECT 2;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("audit.OrdersAudit", lang: "sql", exact: true, pathPatterns: ["sql_alter_trigger"]));
+        Assert.Equal("src/sql_alter_trigger_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("audit.OrdersAudit", lang: "sql", exact: true, pathPatterns: ["sql_alter_trigger"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("audit.OrdersAudit", lang: "sql", exact: true, pathPatterns: ["sql_alter_trigger"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4945,6 +4945,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_BareObjectPermissionReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_bare_object_permission_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_bare_object_permission_grant.sql", "sql",
+            """
+            GRANT SELECT ON dbo.Orders TO ReportingRole;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_bare_object_permission"]));
+        Assert.Equal("src/sql_bare_object_permission_grant.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_bare_object_permission"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_bare_object_permission"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5698,6 +5698,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterSequenceReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_sequence_target.sql", "sql",
+            """
+            CREATE SEQUENCE dbo.OrderNumbers
+                START WITH 1;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_sequence_update.sql", "sql",
+            """
+            ALTER SEQUENCE dbo.OrderNumbers RESTART WITH 10;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.OrderNumbers", lang: "sql", exact: true, pathPatterns: ["sql_alter_sequence"]));
+        Assert.Equal("src/sql_alter_sequence_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.OrderNumbers", lang: "sql", exact: true, pathPatterns: ["sql_alter_sequence"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.OrderNumbers", lang: "sql", exact: true, pathPatterns: ["sql_alter_sequence"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5168,7 +5168,7 @@ public class DbReaderTests : IDisposable
     [Fact]
     public void SqlQualifiedNames_AlterSecurityPolicyReferencesResolveThroughSearch()
     {
-        InsertIndexedFile("src/sql_alter_security_policy_name_target.sql", "sql",
+        InsertIndexedFile("src/sql_alter_security_policy_target.sql", "sql",
             """
             CREATE TABLE dbo.Orders (Id int, TenantId int);
             GO
@@ -5723,7 +5723,7 @@ public class DbReaderTests : IDisposable
     [Fact]
     public void SqlQualifiedNames_AlterSecurityPolicyNameReferencesResolveThroughSearch()
     {
-        InsertIndexedFile("src/sql_alter_security_policy_target.sql", "sql",
+        InsertIndexedFile("src/sql_alter_security_policy_name_target.sql", "sql",
             """
             CREATE SECURITY POLICY dbo.CustomerFilter
             ADD FILTER PREDICATE dbo.fn_filter(CustomerId) ON dbo.Customers;

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5496,6 +5496,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropPartitionSchemeReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_partition_scheme_target.sql", "sql",
+            """
+            CREATE PARTITION SCHEME psOrders
+            AS PARTITION pfOrders
+            ALL TO ([PRIMARY]);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_partition_scheme_cleanup.sql", "sql",
+            """
+            DROP PARTITION SCHEME psOrders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("psOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_partition_scheme"]));
+        Assert.Equal("src/sql_drop_partition_scheme_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("psOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_partition_scheme"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("psOrders", lang: "sql", exact: true, pathPatterns: ["sql_drop_partition_scheme"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5212,6 +5212,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropSynonymReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_synonym_target.sql", "sql",
+            """
+            CREATE SYNONYM dbo.CustomerAlias FOR dbo.Customers;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_synonym_cleanup.sql", "sql",
+            """
+            DROP SYNONYM dbo.CustomerAlias;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.CustomerAlias", lang: "sql", exact: true, pathPatterns: ["sql_drop_synonym"]));
+        Assert.Equal("src/sql_drop_synonym_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.CustomerAlias", lang: "sql", exact: true, pathPatterns: ["sql_drop_synonym"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.CustomerAlias", lang: "sql", exact: true, pathPatterns: ["sql_drop_synonym"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4546,6 +4546,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterTableReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_table_reference_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_table_reference_migration.sql", "sql",
+            """
+            ALTER TABLE dbo.Orders ADD UpdatedAt datetime2 NULL;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_reference"]));
+        Assert.Equal("src/sql_alter_table_reference_migration.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_reference"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_reference"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5610,6 +5610,32 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterProcedureReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_procedure_target.sql", "sql",
+            """
+            CREATE PROCEDURE dbo.RebuildOrders
+            AS
+            SELECT 1;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_procedure_update.sql", "sql",
+            """
+            ALTER PROCEDURE dbo.RebuildOrders
+            AS
+            SELECT 2;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.RebuildOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_procedure"]));
+        Assert.Equal("src/sql_alter_procedure_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.RebuildOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_procedure"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.RebuildOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_procedure"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5636,6 +5636,38 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterFunctionReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_function_target.sql", "sql",
+            """
+            CREATE FUNCTION dbo.CalculateTax()
+            RETURNS int
+            AS
+            BEGIN
+                RETURN 1;
+            END;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_function_update.sql", "sql",
+            """
+            ALTER FUNCTION dbo.CalculateTax()
+            RETURNS int
+            AS
+            BEGIN
+                RETURN 2;
+            END;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.CalculateTax", lang: "sql", exact: true, pathPatterns: ["sql_alter_function"]));
+        Assert.Equal("src/sql_alter_function_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.CalculateTax", lang: "sql", exact: true, pathPatterns: ["sql_alter_function"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.CalculateTax", lang: "sql", exact: true, pathPatterns: ["sql_alter_function"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4878,6 +4878,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropStatisticsReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_statistics_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_statistics_cleanup.sql", "sql",
+            """
+            DROP STATISTICS dbo.Orders.st_OrderDate;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_statistics"]));
+        Assert.Equal("src/sql_drop_statistics_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_statistics"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_statistics"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4746,6 +4746,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DisableTriggerReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_disable_trigger_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_disable_trigger_maintenance.sql", "sql",
+            """
+            DISABLE TRIGGER dbo.trg_Orders_Audit ON dbo.Orders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_disable_trigger"]));
+        Assert.Equal("src/sql_disable_trigger_maintenance.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_disable_trigger"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_disable_trigger"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4702,6 +4702,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int, CreatedAt datetime2);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_index_cleanup.sql", "sql",
+            """
+            DROP INDEX IX_Orders_CreatedAt ON dbo.Orders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_index"]));
+        Assert.Equal("src/sql_drop_index_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_drop_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4592,6 +4592,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_InsertWithoutIntoReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_insert_without_into_target.sql", "sql",
+            """
+            CREATE TABLE dbo.AuditLog (Action nvarchar(100));
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_insert_without_into_writer.sql", "sql",
+            """
+            INSERT dbo.AuditLog (Action) VALUES ('login');
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.AuditLog", lang: "sql", exact: true, pathPatterns: ["sql_insert_without_into"]));
+        Assert.Equal("src/sql_insert_without_into_writer.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.AuditLog", lang: "sql", exact: true, pathPatterns: ["sql_insert_without_into"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.AuditLog", lang: "sql", exact: true, pathPatterns: ["sql_insert_without_into"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4768,6 +4768,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_ForeignKeyReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_foreign_key_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Customers (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_foreign_key_source.sql", "sql",
+            """
+            ALTER TABLE dbo.Orders ADD CONSTRAINT FK_Orders_Customers FOREIGN KEY (CustomerId) REFERENCES dbo.Customers (Id);
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Customers", lang: "sql", exact: true, pathPatterns: ["sql_foreign_key"]));
+        Assert.Equal("src/sql_foreign_key_source.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Customers", lang: "sql", exact: true, pathPatterns: ["sql_foreign_key"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Customers", lang: "sql", exact: true, pathPatterns: ["sql_foreign_key"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4967,6 +4967,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateFullTextIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_create_fulltext_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Documents (Id int, Title nvarchar(200));
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_create_fulltext_index_definition.sql", "sql",
+            """
+            CREATE FULLTEXT INDEX ON dbo.Documents (Title) KEY INDEX PK_Documents;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_create_fulltext_index"]));
+        Assert.Equal("src/sql_create_fulltext_index_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_create_fulltext_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Documents", lang: "sql", exact: true, pathPatterns: ["sql_create_fulltext_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5011,6 +5011,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateClusteredColumnstoreIndexReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_create_clustered_columnstore_index_target.sql", "sql",
+            """
+            CREATE TABLE dbo.FactSales (Id int, Amount money);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_create_clustered_columnstore_index_definition.sql", "sql",
+            """
+            CREATE CLUSTERED COLUMNSTORE INDEX CCI_FactSales ON dbo.FactSales;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.FactSales", lang: "sql", exact: true, pathPatterns: ["sql_create_clustered_columnstore_index"]));
+        Assert.Equal("src/sql_create_clustered_columnstore_index_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.FactSales", lang: "sql", exact: true, pathPatterns: ["sql_create_clustered_columnstore_index"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.FactSales", lang: "sql", exact: true, pathPatterns: ["sql_create_clustered_columnstore_index"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_AlterFullTextIndexReferencesResolveThroughSearch()
     {
         InsertIndexedFile("src/sql_alter_fulltext_index_target.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5403,6 +5403,30 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropDefaultReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_default_target.sql", "sql",
+            """
+            CREATE DEFAULT dbo.ZeroDefault
+            AS
+            0;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_default_cleanup.sql", "sql",
+            """
+            DROP DEFAULT dbo.ZeroDefault;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.ZeroDefault", lang: "sql", exact: true, pathPatterns: ["sql_drop_default"]));
+        Assert.Equal("src/sql_drop_default_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.ZeroDefault", lang: "sql", exact: true, pathPatterns: ["sql_drop_default"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.ZeroDefault", lang: "sql", exact: true, pathPatterns: ["sql_drop_default"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5166,6 +5166,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterSecurityPolicyReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_security_policy_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int, TenantId int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_security_policy_definition.sql", "sql",
+            """
+            ALTER SECURITY POLICY sec.OrderPolicy
+                ADD FILTER PREDICATE sec.fn_tenant(TenantId) ON dbo.Orders;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_security_policy"]));
+        Assert.Equal("src/sql_alter_security_policy_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_security_policy"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_alter_security_policy"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4724,6 +4724,28 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_CreateTriggerReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_create_trigger_target.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_create_trigger_definition.sql", "sql",
+            """
+            CREATE TRIGGER dbo.trg_Orders_Audit ON dbo.Orders AFTER INSERT AS SELECT 1;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_trigger"]));
+        Assert.Equal("src/sql_create_trigger_definition.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_trigger"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("dbo.Orders", lang: "sql", exact: true, pathPatterns: ["sql_create_trigger"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -4900,6 +4900,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterTableSwitchTargetReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_table_switch_targets.sql", "sql",
+            """
+            CREATE TABLE dbo.Orders (Id int);
+            CREATE TABLE archive.OrdersArchive (Id int);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_table_switch_move.sql", "sql",
+            """
+            ALTER TABLE dbo.Orders SWITCH TO archive.OrdersArchive;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("archive.OrdersArchive", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_switch"]));
+        Assert.Equal("src/sql_alter_table_switch_move.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("archive.OrdersArchive", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_switch"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("archive.OrdersArchive", lang: "sql", exact: true, pathPatterns: ["sql_alter_table_switch"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5565,6 +5565,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_DropAssemblyReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_drop_assembly_target.sql", "sql",
+            """
+            CREATE ASSEMBLY SalesAssembly
+            FROM 0x4D5A;
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_drop_assembly_cleanup.sql", "sql",
+            """
+            DROP ASSEMBLY SalesAssembly;
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("SalesAssembly", lang: "sql", exact: true, pathPatterns: ["sql_drop_assembly"]));
+        Assert.Equal("src/sql_drop_assembly_cleanup.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("SalesAssembly", lang: "sql", exact: true, pathPatterns: ["sql_drop_assembly"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("SalesAssembly", lang: "sql", exact: true, pathPatterns: ["sql_drop_assembly"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -5766,6 +5766,29 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SqlQualifiedNames_AlterPartitionFunctionReferencesResolveThroughSearch()
+    {
+        InsertIndexedFile("src/sql_alter_partition_function_target.sql", "sql",
+            """
+            CREATE PARTITION FUNCTION pfOrders(int)
+            AS RANGE LEFT FOR VALUES (100);
+            GO
+            """);
+
+        InsertIndexedFile("src/sql_alter_partition_function_update.sql", "sql",
+            """
+            ALTER PARTITION FUNCTION pfOrders() SPLIT RANGE (200);
+            GO
+            """);
+
+        var reference = Assert.Single(
+            _reader.SearchReferences("pfOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_partition_function"]));
+        Assert.Equal("src/sql_alter_partition_function_update.sql", reference.Path);
+        Assert.Equal(1, _reader.CountSearchReferences("pfOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_partition_function"]));
+        Assert.Equal(new QueryCountResult(1, 1, IncludesSql: true), _reader.CountSearchReferencesTotal("pfOrders", lang: "sql", exact: true, pathPatterns: ["sql_alter_partition_function"]));
+    }
+
+    [Fact]
     public void SqlQualifiedNames_QuotedUnicodeExactDefinitionsStayAlignedWithGraphReaders()
     {
         InsertIndexedFile("src/sql_quoted_unicode_exact_definition.sql", "sql",

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11722,6 +11722,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterFullTextIndexCapturesTableReference()
+    {
+        const string content = """
+            ALTER FULLTEXT INDEX ON dbo.Documents ENABLE;
+            ALTER FULLTEXT INDEX ON [content].[Articles] START FULL POPULATION;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Documents" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Articles" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12137,6 +12137,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterViewCapturesTargetReference()
+    {
+        const string content = """
+            ALTER VIEW dbo.OrderSummary AS SELECT 1 AS Id;
+            ALTER VIEW [sales].[InvoiceSummary] AS SELECT 1 AS Id;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrderSummary" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceSummary" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11423,6 +11423,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_BulkInsertCapturesTargetReference()
+    {
+        // T-SQL `BULK INSERT` names the destination table before the file path; that table should
+        // be indexed as a write target.
+        // T-SQL の `BULK INSERT` は file path の前に destination table を置く。この table は
+        // write target として索引する。
+        const string content = """
+            BULK INSERT dbo.ImportQueue FROM 'queue.csv';
+            BULK INSERT [sales].[InvoiceImport] FROM 'invoices.csv';
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "ImportQueue" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceImport" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11950,6 +11950,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropTriggerCapturesTargetReference()
+    {
+        const string content = """
+            DROP TRIGGER audit.OrdersAudit;
+            DROP TRIGGER IF EXISTS [audit].[InvoicesAudit], ddl_sync ON DATABASE;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrdersAudit" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoicesAudit" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "ddl_sync" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11670,6 +11670,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_ObjectPermissionsCaptureTargetReference()
+    {
+        const string content = """
+            GRANT SELECT ON OBJECT::dbo.Orders TO ReportingRole;
+            DENY UPDATE ON OBJECT::[sales].[Invoices] TO ReportingRole;
+            REVOKE DELETE ON OBJECT::archive.Customers FROM ReportingRole;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "Customers" && r.ReferenceKind == "reference" && r.Line == 3);
+        Assert.DoesNotContain(references, r => r.SymbolName == "ReportingRole" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11887,6 +11887,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropSynonymCapturesTargetReference()
+    {
+        const string content = """
+            DROP SYNONYM dbo.CustomerAlias;
+            DROP PUBLIC SYNONYM [sales].[InvoiceAlias];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "CustomerAlias" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceAlias" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12197,6 +12197,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterSequenceCapturesTargetReference()
+    {
+        const string content = """
+            ALTER SEQUENCE dbo.OrderNumbers RESTART WITH 1;
+            ALTER SEQUENCE [billing].[InvoiceNumbers] INCREMENT BY 10;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrderNumbers" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceNumbers" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12014,6 +12014,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropDefaultCapturesTargetReference()
+    {
+        const string content = """
+            DROP DEFAULT dbo.ZeroDefault;
+            DROP DEFAULT IF EXISTS [billing].[InvoiceDefault], archive.LegacyCustomerDefault;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "ZeroDefault" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceDefault" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "LegacyCustomerDefault" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11706,6 +11706,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateFullTextIndexCapturesTableReference()
+    {
+        const string content = """
+            CREATE FULLTEXT INDEX ON dbo.Documents (Title) KEY INDEX PK_Documents;
+            CREATE FULLTEXT INDEX ON [content].[Articles] ([Body]) KEY INDEX [PK_Articles];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Documents" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Articles" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "Documents" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11982,6 +11982,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropTypeCapturesTargetReference()
+    {
+        const string content = """
+            DROP TYPE dbo.CustomerKey;
+            DROP TYPE IF EXISTS [billing].[InvoiceTableType], archive.LegacyCustomerType;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "CustomerKey" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceTableType" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "LegacyCustomerType" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12106,6 +12106,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropXmlSchemaCollectionCapturesTargetReference()
+    {
+        const string content = """
+            DROP XML SCHEMA COLLECTION dbo.InvoiceSchema;
+            DROP XML SCHEMA COLLECTION [archive].[CustomerSchema];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "InvoiceSchema" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "CustomerSchema" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11910,7 +11910,7 @@ public class ReferenceExtractorTests
 
         Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference");
-        Assert.DoesNotContain(references, r => r.SymbolName == "OrderPolicy" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "OrderPolicy" && r.ReferenceKind == "reference" && r.Line == 1);
     }
 
     [Fact]
@@ -12743,10 +12743,10 @@ public class ReferenceExtractorTests
     {
         // issue #638 / #639 / #648 / #649: temp tables should stay on the SQL reference path,
         // including `##global` names and `SELECT ... INTO #temp`, while procedural
-        // `SELECT ... INTO variable` still must not leak into the object graph.
+        // `SELECT ... INTO @variable` still must not leak into the object graph.
         // issue #638 / #639 / #648 / #649: temp table は SQL reference 経路に残し、
         // `##global` 名と `SELECT ... INTO #temp` も拾いつつ、手続き系の
-        // `SELECT ... INTO variable` は object graph に混ぜない。
+        // `SELECT ... INTO @variable` は object graph に混ぜない。
         const string content = """
             INSERT INTO #audit_log (action) VALUES ('login');
             UPDATE #audit_log SET action = 'logout';
@@ -12758,7 +12758,7 @@ public class ReferenceExtractorTests
 
             SELECT id INTO #selected_users FROM users;
             SELECT id INTO ##selected_global_users FROM users;
-            SELECT id INTO target_var FROM users;
+            SELECT id INTO @target_var FROM users;
             SELECT * FROM users # comment with ##ignored_temp;
 
             INSERT TOP (10) INTO #audit_log (action) VALUES ('merge-ready');

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12272,6 +12272,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterXmlSchemaCollectionCapturesTargetReference()
+    {
+        const string content = """
+            ALTER XML SCHEMA COLLECTION dbo.InvoiceSchema ADD '<schema/>';
+            ALTER XML SCHEMA COLLECTION [archive].[CustomerSchema] ADD '<schema/>';
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "InvoiceSchema" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "CustomerSchema" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11998,6 +11998,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropRuleCapturesTargetReference()
+    {
+        const string content = """
+            DROP RULE dbo.PositiveAmount;
+            DROP RULE IF EXISTS [billing].[InvoiceRule], archive.LegacyCustomerRule;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "PositiveAmount" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceRule" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "LegacyCustomerRule" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11358,6 +11358,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropTableCapturesAllTargetReferences()
+    {
+        // T-SQL teardown migrations should still be searchable by the table names they touch,
+        // including SQL Server's `IF EXISTS` form and comma-separated drop lists.
+        // T-SQL の teardown migration も触った table 名で検索できるべき。SQL Server の
+        // `IF EXISTS` と comma-separated drop list も保持する。
+        const string content = """
+            DROP TABLE IF EXISTS dbo.OldOrders, [sales].[OldInvoices];
+            DROP TABLE archive.LegacyOrders;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OldOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "OldInvoices" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "LegacyOrders" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "IF" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "EXISTS" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11504,6 +11504,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateTriggerCapturesOnTableReference()
+    {
+        // Trigger definitions name the table after `ON`; that table should be visible to
+        // reference search independently of the trigger symbol itself.
+        // trigger 定義は `ON` 後に table を置く。trigger symbol とは別に、その table を
+        // reference search へ出す。
+        const string content = """
+            CREATE TRIGGER dbo.trg_Orders_Audit ON dbo.Orders AFTER INSERT AS SELECT 1;
+            CREATE OR ALTER TRIGGER [sales].[trg_Invoices_Audit] ON [sales].[Invoices] AFTER UPDATE AS SELECT 1;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "trg_Orders_Audit" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11545,6 +11545,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_ForeignKeyReferencesCapturesTargetTableReference()
+    {
+        // Foreign-key clauses name the referenced table after `REFERENCES`; keep that table visible
+        // and suppress the phantom call that would otherwise come from the following column list.
+        // foreign key 節は `REFERENCES` 後に参照先 table を置く。後続の column list による
+        // phantom call を抑止しつつ table reference として残す。
+        const string content = """
+            ALTER TABLE dbo.Orders ADD CONSTRAINT FK_Orders_Customers FOREIGN KEY (CustomerId) REFERENCES dbo.Customers (Id);
+            CREATE TABLE sales.Invoices (CustomerId int REFERENCES [sales].[Customers](Id));
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Customers" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Customers" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "Customers" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11442,6 +11442,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateIndexCapturesOnTableReference()
+    {
+        // `CREATE INDEX ... ON table` is a table usage. The access method after `USING` must stay
+        // suppressed while the indexed table becomes searchable.
+        // `CREATE INDEX ... ON table` は table 使用箇所。`USING` 後の access method は抑止しつつ、
+        // index 対象 table は検索可能にする。
+        const string content = """
+            CREATE INDEX IX_Orders_CreatedAt ON dbo.Orders (CreatedAt);
+            CREATE UNIQUE NONCLUSTERED INDEX IX_Invoices ON [sales].[Invoices] (Id);
+            CREATE INDEX idx_users_name ON users USING btree (name);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "users" && r.ReferenceKind == "reference" && r.Line == 3);
+        Assert.DoesNotContain(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "btree");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12287,6 +12287,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterAssemblyCapturesTargetReference()
+    {
+        const string content = """
+            ALTER ASSEMBLY SalesAssembly FROM 0x4D5A;
+            ALTER ASSEMBLY [InvoiceAssembly] WITH PERMISSION_SET = SAFE;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "SalesAssembly" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceAssembly" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11380,6 +11380,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_InsertWithoutIntoCapturesTargetReference()
+    {
+        // T-SQL permits `INSERT table ...` without `INTO`; the table is still the write target
+        // and should be searchable as a reference.
+        // T-SQL は `INTO` なしの `INSERT table ...` を許す。table は write target なので
+        // reference として検索できるべき。
+        const string content = """
+            INSERT dbo.AuditLog (Action) VALUES ('login');
+            INSERT TOP (10) [sales].[Orders] (Id) SELECT Id FROM staging.Orders;
+            INSERT OR REPLACE INTO sqlite_users (id) VALUES (1);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "AuditLog" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "OR" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "REPLACE" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12227,6 +12227,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterFullTextCatalogCapturesTargetReference()
+    {
+        const string content = """
+            ALTER FULLTEXT CATALOG ftOrders REBUILD;
+            ALTER FULLTEXT CATALOG [ftInvoices] REORGANIZE;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "ftOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "ftInvoices" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11835,6 +11835,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateSecurityPolicyCapturesPredicateTableReferences()
+    {
+        const string content = """
+            CREATE SECURITY POLICY sec.OrderPolicy
+                ADD FILTER PREDICATE sec.fn_tenant(TenantId) ON dbo.Orders,
+                ADD BLOCK PREDICATE sec.fn_tenant(TenantId) ON [sales].[Invoices] AFTER INSERT;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "OrderPolicy" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11688,6 +11688,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_BareObjectPermissionsCaptureTargetReference()
+    {
+        const string content = """
+            GRANT SELECT ON dbo.Orders TO ReportingRole;
+            REVOKE DELETE ON archive.Customers FROM ReportingRole;
+            GRANT CONTROL ON SCHEMA::sales TO ReportingRole;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Customers" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "ReportingRole" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "sales" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11801,6 +11801,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterAuthorizationObjectCapturesTargetReference()
+    {
+        const string content = """
+            ALTER AUTHORIZATION ON OBJECT::dbo.Orders TO app_owner;
+            ALTER AUTHORIZATION ON OBJECT::[sales].[Invoices] TO app_owner;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "app_owner" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11737,6 +11737,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropFullTextIndexCapturesTableReference()
+    {
+        const string content = """
+            DROP FULLTEXT INDEX ON dbo.Documents;
+            DROP FULLTEXT INDEX ON [content].[Articles];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Documents" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Articles" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11637,6 +11637,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropStatisticsCapturesOwningTableReference()
+    {
+        const string content = """
+            DROP STATISTICS dbo.Orders.st_OrderDate;
+            DROP STATISTICS [sales].[Invoices].[st_InvoiceDate], archive.Customers.st_CustomerName;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "Customers" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "st_OrderDate" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11654,6 +11654,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterTableSwitchCapturesTargetTableReference()
+    {
+        const string content = """
+            ALTER TABLE dbo.Orders SWITCH TO archive.OrdersArchive;
+            ALTER TABLE [sales].[Invoices] SWITCH PARTITION 2 TO [history].[InvoicesArchive] PARTITION 1;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "OrdersArchive" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoicesArchive" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12257,6 +12257,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterPartitionSchemeCapturesTargetReference()
+    {
+        const string content = """
+            ALTER PARTITION SCHEME psOrders NEXT USED [PRIMARY];
+            ALTER PARTITION SCHEME [psInvoices] NEXT USED [PRIMARY];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "psOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "psInvoices" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12030,6 +12030,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropAggregateCapturesTargetReference()
+    {
+        const string content = """
+            DROP AGGREGATE dbo.TotalAmount;
+            DROP AGGREGATE IF EXISTS [billing].[InvoiceTotal], archive.LegacyCustomerTotal;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "TotalAmount" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceTotal" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "LegacyCustomerTotal" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11466,6 +11466,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterIndexCapturesOnTableReference()
+    {
+        // T-SQL index maintenance names the table after `ON`; search should surface that table
+        // even when the index name itself is `ALL`.
+        // T-SQL の index maintenance は `ON` 後に table を置く。index 名が `ALL` の場合でも
+        // その table を検索対象にする。
+        const string content = """
+            ALTER INDEX IX_Orders_CreatedAt ON dbo.Orders REBUILD;
+            ALTER INDEX ALL ON [sales].[Invoices] REORGANIZE;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "ALL" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11966,6 +11966,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropSequenceCapturesTargetReference()
+    {
+        const string content = """
+            DROP SEQUENCE dbo.OrderNumbers;
+            DROP SEQUENCE IF EXISTS [billing].[InvoiceNumbers], archive.CustomerNumbers;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrderNumbers" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceNumbers" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "CustomerNumbers" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11752,6 +11752,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropIndexLegacyCapturesOwningTableReference()
+    {
+        const string content = """
+            DROP INDEX dbo.Orders.IX_Orders_Date;
+            DROP INDEX [sales].[Invoices].[IX_Invoices_Date], archive.Customers.IX_Customers_Name;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "Customers" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "IX_Orders_Date" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11402,6 +11402,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_SelectIntoCapturesNonTempTargetReference()
+    {
+        // T-SQL `SELECT ... INTO schema.Table` creates/writes a table. Non-temp targets should
+        // be searchable just like the existing temp-table path.
+        // T-SQL の `SELECT ... INTO schema.Table` は table 作成/書き込み。temp 以外の target も
+        // 既存の temp-table 経路と同様に検索できるべき。
+        const string content = """
+            SELECT Id, Total INTO dbo.OrderArchive FROM dbo.Orders;
+            SELECT * INTO [sales].[InvoiceArchive] FROM sales.Invoices;
+            SELECT * INTO OUTFILE 'orders.csv' FROM dbo.Orders;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrderArchive" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceArchive" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "OUTFILE" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11565,6 +11565,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateSynonymCapturesBaseObjectReference()
+    {
+        // T-SQL/Oracle synonym definitions should point reference search at the base object after `FOR`,
+        // not at the synonym name being defined.
+        // T-SQL/Oracle の synonym 定義では、定義される synonym 名ではなく `FOR` 後の base object を
+        // reference search に出す。
+        const string content = """
+            CREATE SYNONYM dbo.CustomerAlias FOR dbo.Customers;
+            CREATE OR REPLACE PUBLIC SYNONYM InvoiceAlias FOR [sales].[Invoices];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Customers" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "CustomerAlias" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11337,6 +11337,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterTableCapturesTargetReference()
+    {
+        // T-SQL schema changes are table usages too. Without an `ALTER TABLE` target edge,
+        // references/search miss migration-only changes to a table.
+        // T-SQL の schema 変更も table 使用箇所。`ALTER TABLE` target edge がないと、
+        // migration だけで触られる table を references/search が見落とす。
+        const string content = """
+            ALTER TABLE dbo.Orders ADD UpdatedAt datetime2 NULL;
+            ALTER TABLE [sales].[Invoices] NOCHECK CONSTRAINT FK_Invoices_Customers;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "dbo" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "sales" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11737,6 +11737,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateClusteredColumnstoreIndexCapturesTableReference()
+    {
+        const string content = """
+            CREATE CLUSTERED COLUMNSTORE INDEX CCI_FactSales ON dbo.FactSales;
+            CREATE CLUSTERED COLUMNSTORE INDEX [CCI_InvoiceFacts] ON [warehouse].[InvoiceFacts];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "FactSales" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceFacts" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_AlterFullTextIndexCapturesTableReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12152,6 +12152,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterProcedureCapturesTargetReference()
+    {
+        const string content = """
+            ALTER PROCEDURE dbo.RebuildOrders AS SELECT 1;
+            ALTER PROC [jobs].[SyncInvoices] AS SELECT 1;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "RebuildOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "SyncInvoices" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11817,6 +11817,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterAuthorizationBareObjectCapturesTargetReference()
+    {
+        const string content = """
+            ALTER AUTHORIZATION ON dbo.Orders TO app_owner;
+            ALTER AUTHORIZATION ON [sales].[Invoices] TO app_owner;
+            ALTER AUTHORIZATION ON SCHEMA::sales TO app_owner;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "sales" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "app_owner" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12046,6 +12046,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropSecurityPolicyCapturesTargetReference()
+    {
+        const string content = """
+            DROP SECURITY POLICY dbo.CustomerFilter;
+            DROP SECURITY POLICY IF EXISTS [security].[InvoiceFilter];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "CustomerFilter" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceFilter" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11869,6 +11869,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterTableSystemVersioningCapturesHistoryTableReference()
+    {
+        const string content = """
+            ALTER TABLE dbo.Orders
+                SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = history.OrdersHistory));
+            ALTER TABLE [sales].[Invoices]
+                SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [history].[InvoicesHistory]));
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "OrdersHistory" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "InvoicesHistory" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11852,6 +11852,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterSecurityPolicyCapturesPredicateTableReferences()
+    {
+        const string content = """
+            ALTER SECURITY POLICY sec.OrderPolicy
+                ADD FILTER PREDICATE sec.fn_tenant(TenantId) ON dbo.Orders,
+                ADD BLOCK PREDICATE sec.fn_tenant(TenantId) ON [sales].[Invoices] AFTER UPDATE;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "OrderPolicy" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12167,6 +12167,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterFunctionCapturesTargetReference()
+    {
+        const string content = """
+            ALTER FUNCTION dbo.CalculateTax() RETURNS int AS BEGIN RETURN 1; END;
+            ALTER FUNCTION [reporting].[FormatInvoice]() RETURNS int AS BEGIN RETURN 1; END;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "CalculateTax" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "FormatInvoice" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12182,6 +12182,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterTriggerCapturesTargetReference()
+    {
+        const string content = """
+            ALTER TRIGGER audit.OrdersAudit ON dbo.Orders AFTER INSERT AS SELECT 1;
+            ALTER TRIGGER [audit].[InvoicesAudit] ON dbo.Invoices AFTER UPDATE AS SELECT 1;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrdersAudit" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoicesAudit" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11585,6 +11585,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterSchemaTransferCapturesMovedObjectReference()
+    {
+        // T-SQL `ALTER SCHEMA ... TRANSFER object` should surface the object being moved, not only
+        // the destination schema.
+        // T-SQL の `ALTER SCHEMA ... TRANSFER object` は destination schema だけでなく、
+        // 移動される object を reference として出す。
+        const string content = """
+            ALTER SCHEMA archive TRANSFER dbo.Orders;
+            ALTER SCHEMA [history] TRANSFER [sales].[Invoices];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "archive" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11752,6 +11752,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateHashIndexCapturesTableReference()
+    {
+        const string content = """
+            CREATE NONCLUSTERED HASH INDEX IX_OrderCache_Id ON dbo.OrderCache (Id) WITH (BUCKET_COUNT = 1024);
+            CREATE UNIQUE NONCLUSTERED HASH INDEX [IX_InvoiceCache_Id] ON [memory].[InvoiceCache] ([Id]) WITH (BUCKET_COUNT = 2048);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrderCache" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceCache" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_AlterFullTextIndexCapturesTableReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12212,6 +12212,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterSecurityPolicyCapturesTargetReference()
+    {
+        const string content = """
+            ALTER SECURITY POLICY dbo.CustomerFilter WITH (STATE = ON);
+            ALTER SECURITY POLICY [security].[InvoiceFilter] WITH (STATE = OFF);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "CustomerFilter" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceFilter" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12121,6 +12121,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropAssemblyCapturesTargetReference()
+    {
+        const string content = """
+            DROP ASSEMBLY SalesAssembly;
+            DROP ASSEMBLY IF EXISTS [InvoiceAssembly], archive.CustomerAssembly;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "SalesAssembly" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceAssembly" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "CustomerAssembly" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11934,6 +11934,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropFunctionCapturesTargetReference()
+    {
+        const string content = """
+            DROP FUNCTION dbo.CalculateTax;
+            DROP FUNCTION IF EXISTS [reporting].[FormatInvoice], archive.TrimCustomerName;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "CalculateTax" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "FormatInvoice" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "TrimCustomerName" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12076,6 +12076,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropPartitionSchemeCapturesTargetReference()
+    {
+        const string content = """
+            DROP PARTITION SCHEME psOrders;
+            DROP PARTITION SCHEME [psInvoices];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "psOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "psInvoices" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11722,6 +11722,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateSpecialXmlIndexCapturesTableReference()
+    {
+        const string content = """
+            CREATE PRIMARY XML INDEX IX_Documents_Xml ON dbo.Documents (Payload);
+            CREATE SELECTIVE XML INDEX IX_Articles_Xml ON [content].[Articles] ([Body]);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Documents" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Articles" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_AlterFullTextIndexCapturesTableReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11621,6 +11621,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_CreateStatisticsCapturesTableReference()
+    {
+        const string content = """
+            CREATE STATISTICS st_OrderDate ON dbo.Orders (OrderDate);
+            CREATE STATISTICS [st_InvoiceDate] ON [sales].[Invoices] ([InvoiceDate]);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12061,6 +12061,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropFullTextCatalogCapturesTargetReference()
+    {
+        const string content = """
+            DROP FULLTEXT CATALOG ftOrders;
+            DROP FULLTEXT CATALOG [ftInvoices];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "ftOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "ftInvoices" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11918,6 +11918,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropProcedureCapturesTargetReference()
+    {
+        const string content = """
+            DROP PROCEDURE dbo.RebuildOrders;
+            DROP PROC IF EXISTS [jobs].[SyncInvoices], archive.CleanupCustomers;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "RebuildOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "SyncInvoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "CleanupCustomers" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12091,6 +12091,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropPartitionFunctionCapturesTargetReference()
+    {
+        const string content = """
+            DROP PARTITION FUNCTION pfOrders;
+            DROP PARTITION FUNCTION [pfInvoices];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "pfOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "pfInvoices" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11486,6 +11486,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropIndexCapturesOnTableReference()
+    {
+        // SQL Server `DROP INDEX name ON table` should make the affected table searchable.
+        // SQL Server の `DROP INDEX name ON table` でも対象 table を検索可能にする。
+        const string content = """
+            DROP INDEX IX_Orders_CreatedAt ON dbo.Orders;
+            DROP INDEX IF EXISTS IX_Invoices ON [sales].[Invoices];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "IX_Orders_CreatedAt" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11605,6 +11605,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_UpdateStatisticsCapturesTableReference()
+    {
+        const string content = """
+            UPDATE STATISTICS dbo.Orders WITH FULLSCAN;
+            UPDATE STATISTICS [sales].[Invoices] ([IX_Invoices]);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "STATISTICS" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11524,6 +11524,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_EnableDisableTriggerCapturesOnTableReference()
+    {
+        // T-SQL trigger toggles also name the owning table after `ON`; the trigger name itself
+        // should not be mistaken for the table reference.
+        // T-SQL の trigger toggle も `ON` 後に所有 table を置く。trigger 名自体を
+        // table reference と誤認しない。
+        const string content = """
+            DISABLE TRIGGER dbo.trg_Orders_Audit ON dbo.Orders;
+            ENABLE TRIGGER ALL ON [sales].[Invoices];
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "trg_Orders_Audit" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "ALL" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11785,6 +11785,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_OutputIntoCapturesTargetTableReference()
+    {
+        const string content = """
+            UPDATE dbo.Orders SET Status = 'Closed' OUTPUT inserted.Id INTO audit.OrderAudit (OrderId) WHERE Id = 1;
+            DELETE FROM [sales].[Invoices] OUTPUT deleted.Id INTO [audit].[InvoiceAudit] ([InvoiceId]);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrderAudit" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceAudit" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "OrderAudit" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11902,6 +11902,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DropViewCapturesTargetReference()
+    {
+        const string content = """
+            DROP VIEW dbo.OrderSummary;
+            DROP VIEW IF EXISTS [sales].[InvoiceSummary], archive.CustomerSummary;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "OrderSummary" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "InvoiceSummary" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "CustomerSummary" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11769,6 +11769,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_DeleteWithoutFromCapturesQualifiedTargetReference()
+    {
+        const string content = """
+            DELETE dbo.Orders WHERE Id = 1;
+            DELETE TOP (10) [sales].[Invoices] OUTPUT deleted.Id WHERE InvoiceDate < @cutoff;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Orders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "Invoices" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.DoesNotContain(references, r => r.SymbolName == "deleted" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12242,6 +12242,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterPartitionFunctionCapturesTargetReference()
+    {
+        const string content = """
+            ALTER PARTITION FUNCTION pfOrders() SPLIT RANGE (100);
+            ALTER PARTITION FUNCTION [pfInvoices]() MERGE RANGE (200);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "pfOrders" && r.ReferenceKind == "reference" && r.Line == 1);
+        Assert.Contains(references, r => r.SymbolName == "pfInvoices" && r.ReferenceKind == "reference" && r.Line == 2);
+    }
+
+    [Fact]
     public void Extract_SQL_DeleteUsingCapturesSourceReferences()
     {
         // issue #712: PostgreSQL `DELETE ... USING` keeps the target on `DELETE FROM`, but the


### PR DESCRIPTION
## Summary

This PR broadens T-SQL reference extraction and search coverage across DDL, DML, permission, statistics, index, security policy, partition, full-text, XML schema collection, assembly, synonym, and system-versioning syntax.

Key changes:

- Index additional T-SQL object targets and references in `SqlReferenceExtractor`.
- Extend SQL name resolution support for newly indexed constructs.
- Add focused extractor tests and exact-reference database search tests for each covered syntax form.
- Add changelog fragments for the user-visible search improvements.

## Validation

Per commit during the implementation loop:

- Ran the matching `ReferenceExtractorTests` case.
- Ran the matching `DbReaderTests` exact-reference search case.
- Ran `dotnet run --project tools/CodeIndex.Changelog -- check`.
- Ran `git diff --check` and staged diff checks.
- Ran `dotnet build` after each commit.
- Ran `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json` after each commit.
- Performed Codex adversarial review for each commit; one review follow-up tightened SQL ALTER SECURITY POLICY name fixture coverage.

Full test suite was not run.

## Documentation And Changelog

Added changelog fragments under `changelog.d/unreleased/`:

<details>
<summary>Changelog fragments</summary>

- `changelog.d/unreleased/+sql-alter-assembly-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-authorization-bare-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-authorization-object-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-fulltext-catalog-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-fulltext-index-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-function-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-index-table-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-partition-function-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-partition-scheme-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-procedure-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-schema-transfer-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-security-policy-name-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-security-policy-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-sequence-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-table-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-table-switch-targets.fixed.md`
- `changelog.d/unreleased/+sql-alter-trigger-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-view-references.fixed.md`
- `changelog.d/unreleased/+sql-alter-xml-schema-collection-references.fixed.md`
- `changelog.d/unreleased/+sql-bare-object-permission-references.fixed.md`
- `changelog.d/unreleased/+sql-bulk-insert-references.fixed.md`
- `changelog.d/unreleased/+sql-create-clustered-columnstore-index-references.fixed.md`
- `changelog.d/unreleased/+sql-create-fulltext-index-references.fixed.md`
- `changelog.d/unreleased/+sql-create-hash-index-references.fixed.md`
- `changelog.d/unreleased/+sql-create-index-table-references.fixed.md`
- `changelog.d/unreleased/+sql-create-security-policy-references.fixed.md`
- `changelog.d/unreleased/+sql-create-special-xml-index-references.fixed.md`
- `changelog.d/unreleased/+sql-create-statistics-references.fixed.md`
- `changelog.d/unreleased/+sql-create-trigger-table-references.fixed.md`
- `changelog.d/unreleased/+sql-delete-without-from-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-aggregate-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-assembly-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-default-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-fulltext-catalog-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-fulltext-index-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-function-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-index-legacy-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-index-table-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-partition-function-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-partition-scheme-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-procedure-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-rule-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-security-policy-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-sequence-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-statistics-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-synonym-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-table-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-trigger-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-type-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-view-references.fixed.md`
- `changelog.d/unreleased/+sql-drop-xml-schema-collection-references.fixed.md`
- `changelog.d/unreleased/+sql-foreign-key-reference-targets.fixed.md`
- `changelog.d/unreleased/+sql-insert-without-into-references.fixed.md`
- `changelog.d/unreleased/+sql-object-permission-references.fixed.md`
- `changelog.d/unreleased/+sql-output-into-references.fixed.md`
- `changelog.d/unreleased/+sql-select-into-references.fixed.md`
- `changelog.d/unreleased/+sql-synonym-base-references.fixed.md`
- `changelog.d/unreleased/+sql-system-versioning-history-references.fixed.md`
- `changelog.d/unreleased/+sql-toggle-trigger-table-references.fixed.md`
- `changelog.d/unreleased/+sql-update-statistics-references.fixed.md`

</details>

## Issues

No auto-closing issues.

## Follow-Up Candidates

- Run the full test suite before marking ready if CI does not cover the same breadth.
