### PR TITLE
[codex] Improve COBOL search coverage

### DIFF
--- a/changelog.d/unreleased/+cobol-cancel-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cancel-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL `CANCEL` program targets are now searchable** — quoted and unquoted `CANCEL` targets now emit references to the external program name.
+
+## 日本語
+
+- **COBOL の `CANCEL` program target を検索可能にしました** — quoted / unquoted の `CANCEL` 対象が外部 program 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-address-commarea-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-address-commarea-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `ADDRESS COMMAREA` data areas are now searchable** — `EXEC CICS ADDRESS COMMAREA(...)` lines now emit references to the COMMAREA data area.
+
+## 日本語
+
+- **COBOL CICS の `ADDRESS COMMAREA` data area を検索可能にしました** — `EXEC CICS ADDRESS COMMAREA(...)` 行が COMMAREA data area への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-assign-applid-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-assign-applid-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `ASSIGN APPLID` data areas are now searchable** — `EXEC CICS ASSIGN APPLID(...)` lines now emit references to the receiving data area.
+
+## 日本語
+
+- **COBOL CICS の `ASSIGN APPLID` data area を検索可能にしました** — `EXEC CICS ASSIGN APPLID(...)` 行が受け取り data area への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-delete-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-delete-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `DELETE FILE` targets are now searchable** — `EXEC CICS DELETE FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `DELETE FILE` target を検索可能にしました** — `EXEC CICS DELETE FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-deleteq-ts-queue-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-deleteq-ts-queue-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `DELETEQ TS QUEUE` targets are now searchable** — `EXEC CICS DELETEQ TS QUEUE(...)` lines now emit references to queue names.
+
+## 日本語
+
+- **COBOL CICS の `DELETEQ TS QUEUE` target を検索可能にしました** — `EXEC CICS DELETEQ TS QUEUE(...)` 行が queue 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-deq-resource-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-deq-resource-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `DEQ RESOURCE` targets are now searchable** — `EXEC CICS DEQ RESOURCE(...)` lines now emit references to resource names.
+
+## 日本語
+
+- **COBOL CICS の `DEQ RESOURCE` target を検索可能にしました** — `EXEC CICS DEQ RESOURCE(...)` 行が resource 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-endbr-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-endbr-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `ENDBR FILE` targets are now searchable** — `EXEC CICS ENDBR FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `ENDBR FILE` target を検索可能にしました** — `EXEC CICS ENDBR FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-enq-resource-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-enq-resource-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `ENQ RESOURCE` targets are now searchable** — `EXEC CICS ENQ RESOURCE(...)` lines now emit references to resource names.
+
+## 日本語
+
+- **COBOL CICS の `ENQ RESOURCE` target を検索可能にしました** — `EXEC CICS ENQ RESOURCE(...)` 行が resource 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-freemain-data-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-freemain-data-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `FREEMAIN DATA` data areas are now searchable** — `EXEC CICS FREEMAIN DATA(...)` lines now emit references to freed data areas.
+
+## 日本語
+
+- **COBOL CICS の `FREEMAIN DATA` data area を検索可能にしました** — `EXEC CICS FREEMAIN DATA(...)` 行が解放対象 data area への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-getmain-set-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-getmain-set-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `GETMAIN SET` data areas are now searchable** — `EXEC CICS GETMAIN SET(...)` lines now emit references to pointer data areas.
+
+## 日本語
+
+- **COBOL CICS の `GETMAIN SET` data area を検索可能にしました** — `EXEC CICS GETMAIN SET(...)` 行が pointer data area への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-handle-condition-call.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-handle-condition-call.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `HANDLE CONDITION` handlers are now searchable** — `EXEC CICS HANDLE CONDITION ...` lines now emit calls to handler paragraphs.
+
+## 日本語
+
+- **COBOL CICS の `HANDLE CONDITION` handler を検索可能にしました** — `EXEC CICS HANDLE CONDITION ...` 行が handler paragraph への call を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-link-program-call.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-link-program-call.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `LINK PROGRAM` calls are now searchable** — `EXEC CICS LINK PROGRAM(...)` lines now emit call references to linked program names.
+
+## 日本語
+
+- **COBOL CICS の `LINK PROGRAM` call を検索可能にしました** — `EXEC CICS LINK PROGRAM(...)` 行が link 先 program 名への call 参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-load-program-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-load-program-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `LOAD PROGRAM` targets are now searchable** — `EXEC CICS LOAD PROGRAM(...)` lines now emit references to loaded program names.
+
+## 日本語
+
+- **COBOL CICS の `LOAD PROGRAM` target を検索可能にしました** — `EXEC CICS LOAD PROGRAM(...)` 行が load 対象 program 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-mapset-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-mapset-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `MAPSET` targets are now searchable** — `EXEC CICS SEND/RECEIVE ... MAPSET(...)` lines now emit references to BMS mapset names.
+
+## 日本語
+
+- **COBOL CICS の `MAPSET` target を検索可能にしました** — `EXEC CICS SEND/RECEIVE ... MAPSET(...)` 行が BMS mapset 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-read-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-read-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `READ FILE` targets are now searchable** — `EXEC CICS READ FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `READ FILE` target を検索可能にしました** — `EXEC CICS READ FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-readnext-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-readnext-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `READNEXT FILE` targets are now searchable** — `EXEC CICS READNEXT FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `READNEXT FILE` target を検索可能にしました** — `EXEC CICS READNEXT FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-readprev-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-readprev-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `READPREV FILE` targets are now searchable** — `EXEC CICS READPREV FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `READPREV FILE` target を検索可能にしました** — `EXEC CICS READPREV FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-readq-td-queue-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-readq-td-queue-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `READQ TD QUEUE` targets are now searchable** — `EXEC CICS READQ TD QUEUE(...)` lines now emit references to transient data queue names.
+
+## 日本語
+
+- **COBOL CICS の `READQ TD QUEUE` target を検索可能にしました** — `EXEC CICS READQ TD QUEUE(...)` 行が transient data queue 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-readq-ts-queue-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-readq-ts-queue-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `READQ TS QUEUE` targets are now searchable** — `EXEC CICS READQ TS QUEUE(...)` lines now emit references to queue names.
+
+## 日本語
+
+- **COBOL CICS の `READQ TS QUEUE` target を検索可能にしました** — `EXEC CICS READQ TS QUEUE(...)` 行が queue 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-receive-into-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-receive-into-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `RECEIVE INTO` data areas are now searchable** — `EXEC CICS RECEIVE INTO(...)` lines now emit references to receive buffers.
+
+## 日本語
+
+- **COBOL CICS の `RECEIVE INTO` data area を検索可能にしました** — `EXEC CICS RECEIVE INTO(...)` 行が receive buffer への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-receive-map-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-receive-map-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `RECEIVE MAP` targets are now searchable** — `EXEC CICS RECEIVE MAP(...)` lines now emit references to BMS map names.
+
+## 日本語
+
+- **COBOL CICS の `RECEIVE MAP` target を検索可能にしました** — `EXEC CICS RECEIVE MAP(...)` 行が BMS map 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-resetbr-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-resetbr-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `RESETBR FILE` targets are now searchable** — `EXEC CICS RESETBR FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `RESETBR FILE` target を検索可能にしました** — `EXEC CICS RESETBR FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-return-transid-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-return-transid-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `RETURN TRANSID` targets are now searchable** — `EXEC CICS RETURN TRANSID(...)` lines now emit references to transaction ids.
+
+## 日本語
+
+- **COBOL CICS の `RETURN TRANSID` target を検索可能にしました** — `EXEC CICS RETURN TRANSID(...)` 行が transaction id への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-rewrite-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-rewrite-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `REWRITE FILE` targets are now searchable** — `EXEC CICS REWRITE FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `REWRITE FILE` target を検索可能にしました** — `EXEC CICS REWRITE FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-send-from-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-send-from-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `SEND FROM` data areas are now searchable** — `EXEC CICS SEND FROM(...)` lines now emit references to send buffers.
+
+## 日本語
+
+- **COBOL CICS の `SEND FROM` data area を検索可能にしました** — `EXEC CICS SEND FROM(...)` 行が send buffer への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-send-map-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-send-map-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `SEND MAP` targets are now searchable** — `EXEC CICS SEND MAP(...)` lines now emit references to BMS map names.
+
+## 日本語
+
+- **COBOL CICS の `SEND MAP` target を検索可能にしました** — `EXEC CICS SEND MAP(...)` 行が BMS map 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-start-transid-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-start-transid-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `START TRANSID` targets are now searchable** — `EXEC CICS START TRANSID(...)` lines now emit references to transaction ids.
+
+## 日本語
+
+- **COBOL CICS の `START TRANSID` target を検索可能にしました** — `EXEC CICS START TRANSID(...)` 行が transaction id への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-startbr-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-startbr-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `STARTBR FILE` targets are now searchable** — `EXEC CICS STARTBR FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `STARTBR FILE` target を検索可能にしました** — `EXEC CICS STARTBR FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-unlock-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-unlock-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `UNLOCK FILE` targets are now searchable** — `EXEC CICS UNLOCK FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `UNLOCK FILE` target を検索可能にしました** — `EXEC CICS UNLOCK FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-write-file-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-write-file-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `WRITE FILE` targets are now searchable** — `EXEC CICS WRITE FILE(...)` lines now emit references to CICS file names.
+
+## 日本語
+
+- **COBOL CICS の `WRITE FILE` target を検索可能にしました** — `EXEC CICS WRITE FILE(...)` 行が CICS file 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-writeq-td-queue-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-writeq-td-queue-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `WRITEQ TD QUEUE` targets are now searchable** — `EXEC CICS WRITEQ TD QUEUE(...)` lines now emit references to transient data queue names.
+
+## 日本語
+
+- **COBOL CICS の `WRITEQ TD QUEUE` target を検索可能にしました** — `EXEC CICS WRITEQ TD QUEUE(...)` 行が transient data queue 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-writeq-ts-queue-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-writeq-ts-queue-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `WRITEQ TS QUEUE` targets are now searchable** — `EXEC CICS WRITEQ TS QUEUE(...)` lines now emit references to queue names.
+
+## 日本語
+
+- **COBOL CICS の `WRITEQ TS QUEUE` target を検索可能にしました** — `EXEC CICS WRITEQ TS QUEUE(...)` 行が queue 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-cics-xctl-program-call.fixed.md
+++ b/changelog.d/unreleased/+cobol-cics-xctl-program-call.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL CICS `XCTL PROGRAM` transfers are now searchable** — `EXEC CICS XCTL PROGRAM(...)` lines now emit call references to target program names.
+
+## 日本語
+
+- **COBOL CICS の `XCTL PROGRAM` transfer を検索可能にしました** — `EXEC CICS XCTL PROGRAM(...)` 行が遷移先 program 名への call 参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-class-id-symbols.fixed.md
+++ b/changelog.d/unreleased/+cobol-class-id-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **COBOL `CLASS-ID` blocks are now searchable as class symbols** — OO COBOL classes now populate class symbols and procedure containers, including `END CLASS` boundaries.
+
+## 日本語
+
+- **COBOL の `CLASS-ID` block を class symbol として検索可能にしました** — OO COBOL class が class symbol と procedure container に反映され、`END CLASS` 境界も扱えるようになりました。

--- a/changelog.d/unreleased/+cobol-entry-symbols.fixed.md
+++ b/changelog.d/unreleased/+cobol-entry-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cobol.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **COBOL `ENTRY` names are now searchable as symbols** — alternate entry points now appear as function symbols for `symbols`, `definition`, and `inspect` workflows.
+
+## 日本語
+
+- **COBOL の `ENTRY` 名を symbol として検索可能にしました** — alternate entry point が function symbol として出るようになり、`symbols` / `definition` / `inspect` で辿れるようになりました。

--- a/changelog.d/unreleased/+cobol-exec-sql-call-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-exec-sql-call-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL embedded SQL `CALL` targets are now searchable** — `EXEC SQL CALL procedure` lines now emit call references to the stored procedure name.
+
+## 日本語
+
+- **COBOL embedded SQL の `CALL` target を検索可能にしました** — `EXEC SQL CALL procedure` 行が stored procedure 名への call 参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-exec-sql-close-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-exec-sql-close-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL embedded SQL `CLOSE` cursors are now searchable** — `EXEC SQL CLOSE cursor` lines now emit references to the cursor name.
+
+## 日本語
+
+- **COBOL embedded SQL の `CLOSE` cursor を検索可能にしました** — `EXEC SQL CLOSE cursor` 行が cursor 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-exec-sql-execute-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-exec-sql-execute-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL embedded SQL `EXECUTE` statements are now searchable** — `EXEC SQL EXECUTE statement` lines now emit references to the prepared statement name.
+
+## 日本語
+
+- **COBOL embedded SQL の `EXECUTE` statement を検索可能にしました** — `EXEC SQL EXECUTE statement` 行が prepared statement 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-exec-sql-fetch-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-exec-sql-fetch-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL embedded SQL `FETCH` cursors are now searchable** — `EXEC SQL FETCH cursor` lines now emit references to the cursor name.
+
+## 日本語
+
+- **COBOL embedded SQL の `FETCH` cursor を検索可能にしました** — `EXEC SQL FETCH cursor` 行が cursor 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-exec-sql-include-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-exec-sql-include-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL embedded SQL `INCLUDE` targets are now searchable** — `EXEC SQL INCLUDE name` lines now emit references to included copybooks or SQL declarations.
+
+## 日本語
+
+- **COBOL embedded SQL の `INCLUDE` target を検索可能にしました** — `EXEC SQL INCLUDE name` 行が include 対象の copybook / SQL declaration への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-exec-sql-open-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-exec-sql-open-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL embedded SQL `OPEN` cursors are now searchable** — `EXEC SQL OPEN cursor` lines now emit references to the cursor name.
+
+## 日本語
+
+- **COBOL embedded SQL の `OPEN` cursor を検索可能にしました** — `EXEC SQL OPEN cursor` 行が cursor 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-exec-sql-prepare-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-exec-sql-prepare-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL embedded SQL `PREPARE` statements are now searchable** — `EXEC SQL PREPARE statement` lines now emit references to the prepared statement name.
+
+## 日本語
+
+- **COBOL embedded SQL の `PREPARE` statement を検索可能にしました** — `EXEC SQL PREPARE statement` 行が prepared statement 名への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-generate-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-generate-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL `GENERATE` statements are now searchable** — `GENERATE report-name` lines now emit a reference to the generated report target.
+
+## 日本語
+
+- **COBOL の `GENERATE` 文を検索可能にしました** — `GENERATE report-name` 行が生成対象の report への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-initiate-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-initiate-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL `INITIATE` statements are now searchable** — `INITIATE report-name` lines now emit a reference to the report writer target.
+
+## 日本語
+
+- **COBOL の `INITIATE` 文を検索可能にしました** — `INITIATE report-name` 行が Report Writer の対象 report への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-method-id-symbols.fixed.md
+++ b/changelog.d/unreleased/+cobol-method-id-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **COBOL `METHOD-ID` entries are now searchable as function symbols** — OO COBOL methods now appear in symbol-oriented search and inspection results.
+
+## 日本語
+
+- **COBOL の `METHOD-ID` entry を function symbol として検索可能にしました** — OO COBOL method が symbol 検索や inspect 結果に出るようになりました。

--- a/changelog.d/unreleased/+cobol-release-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-release-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL `RELEASE` statements are now searchable** — `RELEASE record-name` lines now emit a reference to the released sort or merge record.
+
+## 日本語
+
+- **COBOL の `RELEASE` 文を検索可能にしました** — `RELEASE record-name` 行が release 対象の sort / merge record への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-return-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-return-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL `RETURN` statements are now searchable** — `RETURN sort-file` lines now emit a reference to the returned sort or merge file.
+
+## 日本語
+
+- **COBOL の `RETURN` 文を検索可能にしました** — `RETURN sort-file` 行が return 対象の sort / merge file への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-start-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-start-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL `START` statements are now searchable** — `START file-name` lines now emit a reference to the indexed file target, improving navigation through COBOL indexed-file access.
+
+## 日本語
+
+- **COBOL の `START` 文を検索可能にしました** — `START file-name` 行が索引ファイル対象への参照を出すようになり、COBOL の indexed-file access をたどりやすくなりました。

--- a/changelog.d/unreleased/+cobol-terminate-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-terminate-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL `TERMINATE` statements are now searchable** — `TERMINATE report-name` lines now emit a reference to the report writer target.
+
+## 日本語
+
+- **COBOL の `TERMINATE` 文を検索可能にしました** — `TERMINATE report-name` 行が Report Writer の対象 report への参照を出すようになりました。

--- a/changelog.d/unreleased/+cobol-use-after-reference.fixed.md
+++ b/changelog.d/unreleased/+cobol-use-after-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **COBOL declarative `USE AFTER` file targets are now searchable** — `USE AFTER ... PROCEDURE ON file-name` lines now emit references to their handled file.
+
+## 日本語
+
+- **COBOL declarative の `USE AFTER` file target を検索可能にしました** — `USE AFTER ... PROCEDURE ON file-name` 行が処理対象 file への参照を出すようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -37,6 +37,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR|ENDBR|UNLOCK)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsQueueReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+READQ\s+TS\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -98,6 +101,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsMapReferenceRegex, "reference"),
         new(CobolExecCicsMapsetReferenceRegex, "reference"),
         new(CobolExecCicsFileReferenceRegex, "reference"),
+        new(CobolExecCicsQueueReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -16,6 +16,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolCopyRegex = new(
         @"^\s*COPY\s+(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecSqlIncludeRegex = new(
+        @"^\s*EXEC\s+SQL\s+INCLUDE\s+(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolGotoRegex = new(
         @"^\s*(?:GO\s+TO|GOTO)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -67,6 +70,7 @@ internal static class CobolReferenceExtractor
         new(CobolCallRegex, "call"),
         new(CobolCancelRegex, "reference"),
         new(CobolCopyRegex, "reference"),
+        new(CobolExecSqlIncludeRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),
         new(CobolSetRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -28,6 +28,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsProgramReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:LOAD)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsMapReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+(?:SEND)\b.*?\bMAP\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -86,6 +89,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecSqlCallRegex, "call"),
         new(CobolExecCicsProgramCallRegex, "call"),
         new(CobolExecCicsProgramReferenceRegex, "reference"),
+        new(CobolExecCicsMapReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR|ENDBR)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -41,7 +41,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:READQ\s+(?:TS|TD)|WRITEQ\s+(?:TS|TD)|DELETEQ\s+TS)\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsResourceReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+ENQ\b.*?\bRESOURCE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:ENQ|DEQ)\b.*?\bRESOURCE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -58,6 +58,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsReceiveReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+RECEIVE\b.*?\bINTO\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsSendReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+SEND\b.*?\bFROM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -126,6 +129,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsAddressReferenceRegex, "reference"),
         new(CobolExecCicsStorageReferenceRegex, "reference"),
         new(CobolExecCicsReceiveReferenceRegex, "reference"),
+        new(CobolExecCicsSendReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -38,7 +38,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR|ENDBR|UNLOCK)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsQueueReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READQ|WRITEQ)\s+TS\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READQ|WRITEQ|DELETEQ)\s+TS\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -23,7 +23,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+SQL\s+CALL\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
-        @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolGotoRegex = new(
         @"^\s*(?:GO\s+TO|GOTO)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -29,7 +29,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:LOAD)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsMapReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:SEND)\b.*?\bMAP\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAP\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -55,6 +55,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsStorageReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:GETMAIN\b.*?\bSET|FREEMAIN\b.*?\bDATA)\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsReceiveReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+RECEIVE\b.*?\bINTO\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -122,6 +125,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsAssignReferenceRegex, "reference"),
         new(CobolExecCicsAddressReferenceRegex, "reference"),
         new(CobolExecCicsStorageReferenceRegex, "reference"),
+        new(CobolExecCicsReceiveReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR|ENDBR)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR|ENDBR|UNLOCK)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -31,6 +31,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsMapReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAP\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsMapsetReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -90,6 +93,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsProgramCallRegex, "call"),
         new(CobolExecCicsProgramReferenceRegex, "reference"),
         new(CobolExecCicsMapReferenceRegex, "reference"),
+        new(CobolExecCicsMapsetReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -49,6 +49,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsAssignReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+ASSIGN\b.*?\bAPPLID\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsAddressReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+ADDRESS\b.*?\bCOMMAREA\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -114,6 +117,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsResourceReferenceRegex, "reference"),
         new(CobolExecCicsTransidReferenceRegex, "reference"),
         new(CobolExecCicsAssignReferenceRegex, "reference"),
+        new(CobolExecCicsAddressReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -22,6 +22,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecSqlCallRegex = new(
         @"^\s*EXEC\s+SQL\s+CALL\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsProgramCallRegex = new(
+        @"^\s*EXEC\s+CICS\s+(?:LINK)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -78,6 +81,7 @@ internal static class CobolReferenceExtractor
         new(CobolCopyRegex, "reference"),
         new(CobolExecSqlIncludeRegex, "reference"),
         new(CobolExecSqlCallRegex, "call"),
+        new(CobolExecCicsProgramCallRegex, "call"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -23,7 +23,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+SQL\s+CALL\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
-        @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolGotoRegex = new(
         @"^\s*(?:GO\s+TO|GOTO)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -29,7 +29,7 @@ internal static class CobolReferenceExtractor
         @"^\s*SEARCH\s+(?:(?:ALL|FIRST)\s+)?(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolSimpleReferenceRegex = new(
-        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN|RELEASE|GENERATE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN|RELEASE|GENERATE|INITIATE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolMoveRegex = new(
         @"^\s*MOVE\b.*?\bTO\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -10,6 +10,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolCallRegex = new(
         @"^\s*CALL\s+(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolCancelRegex = new(
+        @"^\s*CANCEL\s+(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolCopyRegex = new(
         @"^\s*COPY\s+(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -59,6 +62,7 @@ internal static class CobolReferenceExtractor
     private static readonly StatementPattern[] StatementPatterns =
     [
         new(CobolCallRegex, "call"),
+        new(CobolCancelRegex, "reference"),
         new(CobolCopyRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolSetRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -29,7 +29,7 @@ internal static class CobolReferenceExtractor
         @"^\s*SEARCH\s+(?:(?:ALL|FIRST)\s+)?(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolSimpleReferenceRegex = new(
-        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN|RELEASE|GENERATE|INITIATE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN|RELEASE|GENERATE|INITIATE|TERMINATE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolMoveRegex = new(
         @"^\s*MOVE\b.*?\bTO\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -29,7 +29,7 @@ internal static class CobolReferenceExtractor
         @"^\s*SEARCH\s+(?:(?:ALL|FIRST)\s+)?(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolSimpleReferenceRegex = new(
-        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolMoveRegex = new(
         @"^\s*MOVE\b.*?\bTO\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -29,7 +29,7 @@ internal static class CobolReferenceExtractor
         @"^\s*SEARCH\s+(?:(?:ALL|FIRST)\s+)?(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolSimpleReferenceRegex = new(
-        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN|RELEASE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolMoveRegex = new(
         @"^\s*MOVE\b.*?\bTO\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -22,6 +22,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolPerformRegex = new(
         @"^\s*PERFORM\s+(?!(?:VARYING|UNTIL|WITH|TIMES|TEST|THRU|THROUGH)\b)(?<name>[A-Z0-9][A-Z0-9-]*)(?:\s+(?:THRU|THROUGH)\s+(?<end>[A-Z0-9][A-Z0-9-]*))?",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolUseAfterProcedureRegex = new(
+        @"^\s*USE\s+AFTER\s+(?:STANDARD\s+)?(?:ERROR|EXCEPTION)\s+PROCEDURE\s+ON\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolSetRegex = new(
         @"^\s*SET\s+(?<name>[A-Z0-9][A-Z0-9-]*)\s+\b(?:TO\s+TRUE|TO\b)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -65,6 +68,7 @@ internal static class CobolReferenceExtractor
         new(CobolCancelRegex, "reference"),
         new(CobolCopyRegex, "reference"),
         new(CobolGotoRegex, "call"),
+        new(CobolUseAfterProcedureRegex, "reference"),
         new(CobolSetRegex, "reference"),
         new(CobolOpenRegex, "reference"),
         new(CobolSearchRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -22,6 +22,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecSqlCallRegex = new(
         @"^\s*EXEC\s+SQL\s+CALL\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
+        @"^\s*EXEC\s+SQL\s+(?:FETCH)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolGotoRegex = new(
         @"^\s*(?:GO\s+TO|GOTO)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -75,6 +78,7 @@ internal static class CobolReferenceExtractor
         new(CobolCopyRegex, "reference"),
         new(CobolExecSqlIncludeRegex, "reference"),
         new(CobolExecSqlCallRegex, "call"),
+        new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),
         new(CobolSetRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -38,7 +38,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR|ENDBR|UNLOCK)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsQueueReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READQ|WRITEQ|DELETEQ)\s+TS\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READQ\s+(?:TS|TD)|WRITEQ\s+TS|DELETEQ\s+TS)\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -46,6 +46,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsTransidReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:START|RETURN)\b.*?\bTRANSID\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsAssignReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+ASSIGN\b.*?\bAPPLID\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -110,6 +113,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsQueueReferenceRegex, "reference"),
         new(CobolExecCicsResourceReferenceRegex, "reference"),
         new(CobolExecCicsTransidReferenceRegex, "reference"),
+        new(CobolExecCicsAssignReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -52,6 +52,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsAddressReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+ADDRESS\b.*?\bCOMMAREA\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsStorageReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+GETMAIN\b.*?\bSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -118,6 +121,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsTransidReferenceRegex, "reference"),
         new(CobolExecCicsAssignReferenceRegex, "reference"),
         new(CobolExecCicsAddressReferenceRegex, "reference"),
+        new(CobolExecCicsStorageReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -34,6 +34,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsMapsetReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsFileReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+(?:READ)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -94,6 +97,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsProgramReferenceRegex, "reference"),
         new(CobolExecCicsMapReferenceRegex, "reference"),
         new(CobolExecCicsMapsetReferenceRegex, "reference"),
+        new(CobolExecCicsFileReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -40,6 +40,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsQueueReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:READQ\s+(?:TS|TD)|WRITEQ\s+(?:TS|TD)|DELETEQ\s+TS)\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsResourceReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+ENQ\b.*?\bRESOURCE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -102,6 +105,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsMapsetReferenceRegex, "reference"),
         new(CobolExecCicsFileReferenceRegex, "reference"),
         new(CobolExecCicsQueueReferenceRegex, "reference"),
+        new(CobolExecCicsResourceReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -19,6 +19,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecSqlIncludeRegex = new(
         @"^\s*EXEC\s+SQL\s+INCLUDE\s+(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecSqlCallRegex = new(
+        @"^\s*EXEC\s+SQL\s+CALL\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolGotoRegex = new(
         @"^\s*(?:GO\s+TO|GOTO)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -71,6 +74,7 @@ internal static class CobolReferenceExtractor
         new(CobolCancelRegex, "reference"),
         new(CobolCopyRegex, "reference"),
         new(CobolExecSqlIncludeRegex, "reference"),
+        new(CobolExecSqlCallRegex, "call"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),
         new(CobolSetRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -43,6 +43,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsResourceReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:ENQ|DEQ)\b.*?\bRESOURCE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsTransidReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+START\b.*?\bTRANSID\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -106,6 +109,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecCicsFileReferenceRegex, "reference"),
         new(CobolExecCicsQueueReferenceRegex, "reference"),
         new(CobolExecCicsResourceReferenceRegex, "reference"),
+        new(CobolExecCicsTransidReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -29,7 +29,7 @@ internal static class CobolReferenceExtractor
         @"^\s*SEARCH\s+(?:(?:ALL|FIRST)\s+)?(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolSimpleReferenceRegex = new(
-        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN|RELEASE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START|RETURN|RELEASE|GENERATE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolMoveRegex = new(
         @"^\s*MOVE\b.*?\bTO\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -53,7 +53,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+ADDRESS\b.*?\bCOMMAREA\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsStorageReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+GETMAIN\b.*?\bSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:GETMAIN\b.*?\bSET|FREEMAIN\b.*?\bDATA)\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -38,7 +38,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR|ENDBR|UNLOCK)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsQueueReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READQ\s+(?:TS|TD)|WRITEQ\s+TS|DELETEQ\s+TS)\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READQ\s+(?:TS|TD)|WRITEQ\s+(?:TS|TD)|DELETEQ\s+TS)\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -44,7 +44,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:ENQ|DEQ)\b.*?\bRESOURCE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsTransidReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+START\b.*?\bTRANSID\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:START|RETURN)\b.*?\bTRANSID\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -25,6 +25,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsProgramCallRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:LINK|XCTL)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsProgramReferenceRegex = new(
+        @"^\s*EXEC\s+CICS\s+(?:LOAD)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -82,6 +85,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecSqlIncludeRegex, "reference"),
         new(CobolExecSqlCallRegex, "call"),
         new(CobolExecCicsProgramCallRegex, "call"),
+        new(CobolExecCicsProgramReferenceRegex, "reference"),
         new(CobolExecSqlSimpleReferenceRegex, "reference"),
         new(CobolGotoRegex, "call"),
         new(CobolUseAfterProcedureRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -23,7 +23,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+SQL\s+CALL\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
-        @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolGotoRegex = new(
         @"^\s*(?:GO\s+TO|GOTO)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -29,7 +29,7 @@ internal static class CobolReferenceExtractor
         @"^\s*SEARCH\s+(?:(?:ALL|FIRST)\s+)?(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolSimpleReferenceRegex = new(
-        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*(?:READ|WRITE|REWRITE|DELETE|CLOSE|SORT|MERGE|INSPECT|DISPLAY|ACCEPT|START)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolMoveRegex = new(
         @"^\s*MOVE\b.*?\bTO\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -23,7 +23,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+SQL\s+CALL\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
-        @"^\s*EXEC\s+SQL\s+(?:FETCH)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolGotoRegex = new(
         @"^\s*(?:GO\s+TO|GOTO)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -35,7 +35,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:SEND|RECEIVE)\b.*?\bMAPSET\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsFileReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -23,7 +23,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+SQL\s+CALL\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsProgramCallRegex = new(
-        @"^\s*EXEC\s+CICS\s+(?:LINK)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:LINK|XCTL)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -25,6 +25,9 @@ internal static class CobolReferenceExtractor
     private static readonly Regex CobolExecCicsProgramCallRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:LINK|XCTL)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolExecCicsHandleConditionCallRegex = new(
+        @"^\s*EXEC\s+CICS\s+HANDLE\s+CONDITION\b.*?\b[A-Z0-9-]+\s*\(\s*(?<name>[A-Z0-9][A-Z0-9-]*)\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsProgramReferenceRegex = new(
         @"^\s*EXEC\s+CICS\s+(?:LOAD)\b.*?\bPROGRAM\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -118,6 +121,7 @@ internal static class CobolReferenceExtractor
         new(CobolExecSqlIncludeRegex, "reference"),
         new(CobolExecSqlCallRegex, "call"),
         new(CobolExecCicsProgramCallRegex, "call"),
+        new(CobolExecCicsHandleConditionCallRegex, "call"),
         new(CobolExecCicsProgramReferenceRegex, "reference"),
         new(CobolExecCicsMapReferenceRegex, "reference"),
         new(CobolExecCicsMapsetReferenceRegex, "reference"),

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -38,7 +38,7 @@ internal static class CobolReferenceExtractor
         @"^\s*EXEC\s+CICS\s+(?:READ|WRITE|REWRITE|DELETE|STARTBR|READNEXT|READPREV|RESETBR|ENDBR|UNLOCK)\b.*?\bFILE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecCicsQueueReferenceRegex = new(
-        @"^\s*EXEC\s+CICS\s+READQ\s+TS\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
+        @"^\s*EXEC\s+CICS\s+(?:READQ|WRITEQ)\s+TS\b.*?\bQUEUE\s*\(\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolExecSqlSimpleReferenceRegex = new(
         @"^\s*EXEC\s+SQL\s+(?:FETCH|OPEN|CLOSE|PREPARE|EXECUTE)\s+(?<name>[A-Z0-9][A-Z0-9-]*)\b",

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cobol.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cobol.cs
@@ -42,6 +42,35 @@ public static partial class SymbolExtractor
             if (!inProcedureDivision)
                 continue;
 
+            var entryMatch = CobolEntryRegex.Match(line);
+            if (entryMatch.Success)
+            {
+                var entryName = CobolSymbolNameNormalizer.Normalize(entryMatch.Groups["name"].Value);
+                if (string.IsNullOrWhiteSpace(entryName))
+                    continue;
+
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    i + 1,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "function",
+                        Name = entryName,
+                        Line = i + 1,
+                        StartLine = i + 1,
+                        StartColumn = entryMatch.Groups["name"].Index,
+                        EndLine = i + 1,
+                        Signature = line.Trim(),
+                        ContainerKind = programName != null ? "class" : null,
+                        ContainerName = programName,
+                        ContainerQualifiedName = programName,
+                    },
+                    line);
+                continue;
+            }
+
             var sectionMatch = CobolSectionHeaderRegex.Match(line);
             if (sectionMatch.Success)
             {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -733,6 +733,7 @@ public static partial class SymbolExtractor
             // COBOL は brace ではなく program ID 単位で構成されるため、抽出は保守的に
             // program ひとつにつき 1 symbol に絞る。
             new("class", new Regex(@"^\s*(?:IDENTIFICATION\s+DIVISION\.\s*)?(?:PROGRAM|CLASS)-ID\.\s*(?<name>[A-Z0-9][A-Z0-9-]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("function", new Regex(@"^\s*METHOD-ID\.\s*(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
         ],
         ["javascript"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -118,7 +118,7 @@ public static partial class SymbolExtractor
         @"(?:" + JavaQualifiedIdentifierPattern + @"(?:\s*<[^;=(){}]+>)?(?:\s*\[\s*\])*)";
     private const string KotlinIdentifierPattern = @"(?:\w+|`[^`\r\n]+`)";
     private static readonly Regex CobolProgramIdLineRegex = new(
-        @"^\s*(?:IDENTIFICATION\s+DIVISION\.\s*)?PROGRAM-ID\.\s*(?<name>[A-Z0-9][A-Z0-9-]*)\b",
+        @"^\s*(?:IDENTIFICATION\s+DIVISION\.\s*)?(?:PROGRAM|CLASS)-ID\.\s*(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolProcedureDivisionRegex = new(
         @"^\s*PROCEDURE\s+DIVISION\.\s*$",
@@ -133,7 +133,7 @@ public static partial class SymbolExtractor
         @"^\s{0,6}(?<name>[A-Z0-9][A-Z0-9-]*)\.\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolEndProgramRegex = new(
-        @"^\s*END\s+PROGRAM(?:\s+(?<name>[A-Z0-9][A-Z0-9-]*))?\.\s*$",
+        @"^\s*END\s+(?:PROGRAM|CLASS)(?:\s+(?<name>[A-Z0-9][A-Z0-9-]*))?\.\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex PhpGroupUseRegex = new(
         @"^\s*use\s+(?:(?<type>function|const)\s+)?(?<prefix>[\w\\]+\\)\{\s*(?<items>[^{}]+?)\s*\}\s*;",
@@ -732,7 +732,7 @@ public static partial class SymbolExtractor
             // Keep the extraction deliberately small and conservative: one symbol per program.
             // COBOL は brace ではなく program ID 単位で構成されるため、抽出は保守的に
             // program ひとつにつき 1 symbol に絞る。
-            new("class", new Regex(@"^\s*(?:IDENTIFICATION\s+DIVISION\.\s*)?PROGRAM-ID\.\s*(?<name>[A-Z0-9][A-Z0-9-]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("class", new Regex(@"^\s*(?:IDENTIFICATION\s+DIVISION\.\s*)?(?:PROGRAM|CLASS)-ID\.\s*(?<name>[A-Z0-9][A-Z0-9-]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
         ],
         ["javascript"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -123,6 +123,9 @@ public static partial class SymbolExtractor
     private static readonly Regex CobolProcedureDivisionRegex = new(
         @"^\s*PROCEDURE\s+DIVISION\.\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex CobolEntryRegex = new(
+        @"^\s*ENTRY\s+(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[A-Z0-9][A-Z0-9-]*))",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CobolSectionHeaderRegex = new(
         @"^\s{0,6}(?<name>[A-Z0-9][A-Z0-9-]*)\s+SECTION\.\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1180,6 +1180,7 @@ public class ReferenceExtractorTests
 
     [Theory]
     [InlineData("RETURN SORT-WORK", "SORT-WORK")]
+    [InlineData("RELEASE SORT-RECORD", "SORT-RECORD")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1219,6 +1219,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS GETMAIN SET(CUSTOMER-PTR) FLENGTH(CUSTOMER-LENGTH) END-EXEC", "CUSTOMER-PTR")]
     [InlineData("EXEC CICS FREEMAIN DATA(CUSTOMER-PTR) END-EXEC", "CUSTOMER-PTR")]
     [InlineData("EXEC CICS RECEIVE INTO(CUSTOMER-INPUT) LENGTH(CUSTOMER-LENGTH) END-EXEC", "CUSTOMER-INPUT")]
+    [InlineData("EXEC CICS SEND FROM(CUSTOMER-OUTPUT) LENGTH(CUSTOMER-LENGTH) END-EXEC", "CUSTOMER-OUTPUT")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1187,6 +1187,7 @@ public class ReferenceExtractorTests
     [InlineData("USE AFTER STANDARD ERROR PROCEDURE ON CUSTOMER-FILE", "CUSTOMER-FILE")]
     [InlineData("EXEC SQL INCLUDE CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     [InlineData("EXEC SQL FETCH CUSTOMER-CURSOR INTO :CUSTOMER-ID END-EXEC", "CUSTOMER-CURSOR")]
+    [InlineData("EXEC SQL OPEN CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1207,6 +1207,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS UNLOCK FILE('CUSTOMER-FILE') END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS READQ TS QUEUE('CUSTOMER-QUEUE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-QUEUE")]
     [InlineData("EXEC CICS WRITEQ TS QUEUE('CUSTOMER-QUEUE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-QUEUE")]
+    [InlineData("EXEC CICS DELETEQ TS QUEUE('CUSTOMER-QUEUE') END-EXEC", "CUSTOMER-QUEUE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1202,6 +1202,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS STARTBR FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS READNEXT FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS READPREV FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS RESETBR FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1198,6 +1198,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS READ FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS WRITE FILE('CUSTOMER-FILE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS REWRITE FILE('CUSTOMER-FILE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS DELETE FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1217,6 +1217,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS ASSIGN APPLID(CURRENT-APPLID) END-EXEC", "CURRENT-APPLID")]
     [InlineData("EXEC CICS ADDRESS COMMAREA(CUSTOMER-COMMAREA) END-EXEC", "CUSTOMER-COMMAREA")]
     [InlineData("EXEC CICS GETMAIN SET(CUSTOMER-PTR) FLENGTH(CUSTOMER-LENGTH) END-EXEC", "CUSTOMER-PTR")]
+    [InlineData("EXEC CICS FREEMAIN DATA(CUSTOMER-PTR) END-EXEC", "CUSTOMER-PTR")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1185,6 +1185,7 @@ public class ReferenceExtractorTests
     [InlineData("INITIATE SALES-REPORT", "SALES-REPORT")]
     [InlineData("TERMINATE SALES-REPORT", "SALES-REPORT")]
     [InlineData("USE AFTER STANDARD ERROR PROCEDURE ON CUSTOMER-FILE", "CUSTOMER-FILE")]
+    [InlineData("EXEC SQL INCLUDE CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1113,6 +1113,7 @@ public class ReferenceExtractorTests
                 READ CUSTOMER-FILE
                 WRITE CUSTOMER-RECORD
                 SEARCH ALL CUSTOMER-TABLE
+                START CUSTOMER-FILE KEY IS >= CUSTOMER-KEY
                 SET HAS-ITEM TO TRUE
                 MOVE SOURCE-VALUE TO DEST-VALUE
                 ADD AMOUNT TO TOTAL

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1210,6 +1210,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS DELETEQ TS QUEUE('CUSTOMER-QUEUE') END-EXEC", "CUSTOMER-QUEUE")]
     [InlineData("EXEC CICS READQ TD QUEUE('CUSTOMER-TD') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-TD")]
     [InlineData("EXEC CICS WRITEQ TD QUEUE('CUSTOMER-TD') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-TD")]
+    [InlineData("EXEC CICS ENQ RESOURCE('CUSTOMER-LOCK') END-EXEC", "CUSTOMER-LOCK")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1206,6 +1206,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS ENDBR FILE('CUSTOMER-FILE') END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS UNLOCK FILE('CUSTOMER-FILE') END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS READQ TS QUEUE('CUSTOMER-QUEUE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-QUEUE")]
+    [InlineData("EXEC CICS WRITEQ TS QUEUE('CUSTOMER-QUEUE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-QUEUE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1209,6 +1209,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS WRITEQ TS QUEUE('CUSTOMER-QUEUE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-QUEUE")]
     [InlineData("EXEC CICS DELETEQ TS QUEUE('CUSTOMER-QUEUE') END-EXEC", "CUSTOMER-QUEUE")]
     [InlineData("EXEC CICS READQ TD QUEUE('CUSTOMER-TD') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-TD")]
+    [InlineData("EXEC CICS WRITEQ TD QUEUE('CUSTOMER-TD') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-TD")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1199,6 +1199,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS WRITE FILE('CUSTOMER-FILE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS REWRITE FILE('CUSTOMER-FILE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS DELETE FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS STARTBR FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1196,6 +1196,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS SEND MAP('CUSTOMER-MAP') MAPSET('CUSTOMER-SET') END-EXEC", "CUSTOMER-SET")]
     [InlineData("EXEC CICS RECEIVE MAP('CUSTOMER-MAP') INTO(CUSTOMER-AREA) END-EXEC", "CUSTOMER-MAP")]
     [InlineData("EXEC CICS READ FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS WRITE FILE('CUSTOMER-FILE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1195,6 +1195,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS SEND MAP('CUSTOMER-MAP') MAPSET('CUSTOMER-SET') END-EXEC", "CUSTOMER-MAP")]
     [InlineData("EXEC CICS SEND MAP('CUSTOMER-MAP') MAPSET('CUSTOMER-SET') END-EXEC", "CUSTOMER-SET")]
     [InlineData("EXEC CICS RECEIVE MAP('CUSTOMER-MAP') INTO(CUSTOMER-AREA) END-EXEC", "CUSTOMER-MAP")]
+    [InlineData("EXEC CICS READ FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1186,6 +1186,7 @@ public class ReferenceExtractorTests
     [InlineData("TERMINATE SALES-REPORT", "SALES-REPORT")]
     [InlineData("USE AFTER STANDARD ERROR PROCEDURE ON CUSTOMER-FILE", "CUSTOMER-FILE")]
     [InlineData("EXEC SQL INCLUDE CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
+    [InlineData("EXEC SQL FETCH CUSTOMER-CURSOR INTO :CUSTOMER-ID END-EXEC", "CUSTOMER-CURSOR")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1181,6 +1181,7 @@ public class ReferenceExtractorTests
     [Theory]
     [InlineData("RETURN SORT-WORK", "SORT-WORK")]
     [InlineData("RELEASE SORT-RECORD", "SORT-RECORD")]
+    [InlineData("GENERATE SALES-REPORT", "SALES-REPORT")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1200,6 +1200,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS REWRITE FILE('CUSTOMER-FILE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS DELETE FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS STARTBR FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS READNEXT FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1218,6 +1218,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS ADDRESS COMMAREA(CUSTOMER-COMMAREA) END-EXEC", "CUSTOMER-COMMAREA")]
     [InlineData("EXEC CICS GETMAIN SET(CUSTOMER-PTR) FLENGTH(CUSTOMER-LENGTH) END-EXEC", "CUSTOMER-PTR")]
     [InlineData("EXEC CICS FREEMAIN DATA(CUSTOMER-PTR) END-EXEC", "CUSTOMER-PTR")]
+    [InlineData("EXEC CICS RECEIVE INTO(CUSTOMER-INPUT) LENGTH(CUSTOMER-LENGTH) END-EXEC", "CUSTOMER-INPUT")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1197,6 +1197,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS RECEIVE MAP('CUSTOMER-MAP') INTO(CUSTOMER-AREA) END-EXEC", "CUSTOMER-MAP")]
     [InlineData("EXEC CICS READ FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS WRITE FILE('CUSTOMER-FILE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS REWRITE FILE('CUSTOMER-FILE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1208,6 +1208,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS READQ TS QUEUE('CUSTOMER-QUEUE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-QUEUE")]
     [InlineData("EXEC CICS WRITEQ TS QUEUE('CUSTOMER-QUEUE') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-QUEUE")]
     [InlineData("EXEC CICS DELETEQ TS QUEUE('CUSTOMER-QUEUE') END-EXEC", "CUSTOMER-QUEUE")]
+    [InlineData("EXEC CICS READQ TD QUEUE('CUSTOMER-TD') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-TD")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1237,6 +1237,7 @@ public class ReferenceExtractorTests
 
     [Theory]
     [InlineData("EXEC SQL CALL CUSTOMER-PROC(:CUSTOMER-ID) END-EXEC", "CUSTOMER-PROC")]
+    [InlineData("EXEC CICS LINK PROGRAM('CUSTOMER-SERVICE') END-EXEC", "CUSTOMER-SERVICE")]
     public void Extract_CobolExternalCallStatement_CapturesSearchableCall(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1182,6 +1182,7 @@ public class ReferenceExtractorTests
     [InlineData("RETURN SORT-WORK", "SORT-WORK")]
     [InlineData("RELEASE SORT-RECORD", "SORT-RECORD")]
     [InlineData("GENERATE SALES-REPORT", "SALES-REPORT")]
+    [InlineData("INITIATE SALES-REPORT", "SALES-REPORT")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1215,6 +1215,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS START TRANSID('PAY1') FROM(CUSTOMER-RECORD) END-EXEC", "PAY1")]
     [InlineData("EXEC CICS RETURN TRANSID('PAY1') COMMAREA(CUSTOMER-RECORD) END-EXEC", "PAY1")]
     [InlineData("EXEC CICS ASSIGN APPLID(CURRENT-APPLID) END-EXEC", "CURRENT-APPLID")]
+    [InlineData("EXEC CICS ADDRESS COMMAREA(CUSTOMER-COMMAREA) END-EXEC", "CUSTOMER-COMMAREA")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1113,7 +1113,7 @@ public class ReferenceExtractorTests
                 READ CUSTOMER-FILE
                 WRITE CUSTOMER-RECORD
                 SEARCH ALL CUSTOMER-TABLE
-                START CUSTOMER-FILE KEY IS >= CUSTOMER-KEY
+                START ORDER-FILE KEY IS >= ORDER-KEY
                 SET HAS-ITEM TO TRUE
                 MOVE SOURCE-VALUE TO DEST-VALUE
                 ADD AMOUNT TO TOTAL
@@ -1146,6 +1146,10 @@ public class ReferenceExtractorTests
             && reference.ContainerName == "MAIN-SECTION");
         Assert.Contains(references, reference =>
             reference.SymbolName == "CUSTOMER-TABLE"
+            && reference.ReferenceKind == "reference"
+            && reference.ContainerName == "MAIN-SECTION");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "ORDER-FILE"
             && reference.ReferenceKind == "reference"
             && reference.ContainerName == "MAIN-SECTION");
         Assert.Contains(references, reference =>

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1193,6 +1193,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC SQL EXECUTE CUSTOMER-STMT END-EXEC", "CUSTOMER-STMT")]
     [InlineData("EXEC CICS LOAD PROGRAM('PRICE-PROGRAM') END-EXEC", "PRICE-PROGRAM")]
     [InlineData("EXEC CICS SEND MAP('CUSTOMER-MAP') MAPSET('CUSTOMER-SET') END-EXEC", "CUSTOMER-MAP")]
+    [InlineData("EXEC CICS RECEIVE MAP('CUSTOMER-MAP') INTO(CUSTOMER-AREA) END-EXEC", "CUSTOMER-MAP")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1216,6 +1216,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS RETURN TRANSID('PAY1') COMMAREA(CUSTOMER-RECORD) END-EXEC", "PAY1")]
     [InlineData("EXEC CICS ASSIGN APPLID(CURRENT-APPLID) END-EXEC", "CURRENT-APPLID")]
     [InlineData("EXEC CICS ADDRESS COMMAREA(CUSTOMER-COMMAREA) END-EXEC", "CUSTOMER-COMMAREA")]
+    [InlineData("EXEC CICS GETMAIN SET(CUSTOMER-PTR) FLENGTH(CUSTOMER-LENGTH) END-EXEC", "CUSTOMER-PTR")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1183,6 +1183,7 @@ public class ReferenceExtractorTests
     [InlineData("RELEASE SORT-RECORD", "SORT-RECORD")]
     [InlineData("GENERATE SALES-REPORT", "SALES-REPORT")]
     [InlineData("INITIATE SALES-REPORT", "SALES-REPORT")]
+    [InlineData("TERMINATE SALES-REPORT", "SALES-REPORT")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1213,6 +1213,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS ENQ RESOURCE('CUSTOMER-LOCK') END-EXEC", "CUSTOMER-LOCK")]
     [InlineData("EXEC CICS DEQ RESOURCE('CUSTOMER-LOCK') END-EXEC", "CUSTOMER-LOCK")]
     [InlineData("EXEC CICS START TRANSID('PAY1') FROM(CUSTOMER-RECORD) END-EXEC", "PAY1")]
+    [InlineData("EXEC CICS RETURN TRANSID('PAY1') COMMAREA(CUSTOMER-RECORD) END-EXEC", "PAY1")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1204,6 +1204,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS READPREV FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS RESETBR FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS ENDBR FILE('CUSTOMER-FILE') END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS UNLOCK FILE('CUSTOMER-FILE') END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1189,6 +1189,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC SQL FETCH CUSTOMER-CURSOR INTO :CUSTOMER-ID END-EXEC", "CUSTOMER-CURSOR")]
     [InlineData("EXEC SQL OPEN CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     [InlineData("EXEC SQL CLOSE CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
+    [InlineData("EXEC SQL PREPARE CUSTOMER-STMT FROM :SQL-TEXT END-EXEC", "CUSTOMER-STMT")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1190,6 +1190,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC SQL OPEN CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     [InlineData("EXEC SQL CLOSE CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     [InlineData("EXEC SQL PREPARE CUSTOMER-STMT FROM :SQL-TEXT END-EXEC", "CUSTOMER-STMT")]
+    [InlineData("EXEC SQL EXECUTE CUSTOMER-STMT END-EXEC", "CUSTOMER-STMT")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1191,6 +1191,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC SQL CLOSE CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     [InlineData("EXEC SQL PREPARE CUSTOMER-STMT FROM :SQL-TEXT END-EXEC", "CUSTOMER-STMT")]
     [InlineData("EXEC SQL EXECUTE CUSTOMER-STMT END-EXEC", "CUSTOMER-STMT")]
+    [InlineData("EXEC CICS LOAD PROGRAM('PRICE-PROGRAM') END-EXEC", "PRICE-PROGRAM")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1268,6 +1268,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC SQL CALL CUSTOMER-PROC(:CUSTOMER-ID) END-EXEC", "CUSTOMER-PROC")]
     [InlineData("EXEC CICS LINK PROGRAM('CUSTOMER-SERVICE') END-EXEC", "CUSTOMER-SERVICE")]
     [InlineData("EXEC CICS XCTL PROGRAM('NEXT-PROGRAM') END-EXEC", "NEXT-PROGRAM")]
+    [InlineData("EXEC CICS HANDLE CONDITION ERROR(ERROR-HANDLER) END-EXEC", "ERROR-HANDLER")]
     public void Extract_CobolExternalCallStatement_CapturesSearchableCall(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1188,6 +1188,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC SQL INCLUDE CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     [InlineData("EXEC SQL FETCH CUSTOMER-CURSOR INTO :CUSTOMER-ID END-EXEC", "CUSTOMER-CURSOR")]
     [InlineData("EXEC SQL OPEN CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
+    [InlineData("EXEC SQL CLOSE CUSTOMER-CURSOR END-EXEC", "CUSTOMER-CURSOR")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1211,6 +1211,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS READQ TD QUEUE('CUSTOMER-TD') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-TD")]
     [InlineData("EXEC CICS WRITEQ TD QUEUE('CUSTOMER-TD') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-TD")]
     [InlineData("EXEC CICS ENQ RESOURCE('CUSTOMER-LOCK') END-EXEC", "CUSTOMER-LOCK")]
+    [InlineData("EXEC CICS DEQ RESOURCE('CUSTOMER-LOCK') END-EXEC", "CUSTOMER-LOCK")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1193,6 +1193,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC SQL EXECUTE CUSTOMER-STMT END-EXEC", "CUSTOMER-STMT")]
     [InlineData("EXEC CICS LOAD PROGRAM('PRICE-PROGRAM') END-EXEC", "PRICE-PROGRAM")]
     [InlineData("EXEC CICS SEND MAP('CUSTOMER-MAP') MAPSET('CUSTOMER-SET') END-EXEC", "CUSTOMER-MAP")]
+    [InlineData("EXEC CICS SEND MAP('CUSTOMER-MAP') MAPSET('CUSTOMER-SET') END-EXEC", "CUSTOMER-SET")]
     [InlineData("EXEC CICS RECEIVE MAP('CUSTOMER-MAP') INTO(CUSTOMER-AREA) END-EXEC", "CUSTOMER-MAP")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1205,6 +1205,29 @@ public class ReferenceExtractorTests
             && reference.ContainerName == "MAIN-SECTION");
     }
 
+    [Theory]
+    [InlineData("CANCEL \"SERVICE-PROGRAM\"", "SERVICE-PROGRAM")]
+    public void Extract_CobolLiteralTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
+    {
+        var content = $$"""
+            IDENTIFICATION DIVISION.
+            PROGRAM-ID. hello-world.
+            PROCEDURE DIVISION.
+            MAIN-SECTION SECTION.
+                {{statement}}
+                STOP RUN.
+            END PROGRAM hello-world.
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cobol", content);
+        var references = ReferenceExtractor.Extract(1, "cobol", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == expectedSymbolName
+            && reference.ReferenceKind == "reference"
+            && reference.ContainerName == "MAIN-SECTION");
+    }
+
     [Fact]
     public void Extract_VueScriptSetup_DetectsJavaScriptTypeScriptCalls()
     {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1212,6 +1212,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS WRITEQ TD QUEUE('CUSTOMER-TD') FROM(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-TD")]
     [InlineData("EXEC CICS ENQ RESOURCE('CUSTOMER-LOCK') END-EXEC", "CUSTOMER-LOCK")]
     [InlineData("EXEC CICS DEQ RESOURCE('CUSTOMER-LOCK') END-EXEC", "CUSTOMER-LOCK")]
+    [InlineData("EXEC CICS START TRANSID('PAY1') FROM(CUSTOMER-RECORD) END-EXEC", "PAY1")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1192,6 +1192,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC SQL PREPARE CUSTOMER-STMT FROM :SQL-TEXT END-EXEC", "CUSTOMER-STMT")]
     [InlineData("EXEC SQL EXECUTE CUSTOMER-STMT END-EXEC", "CUSTOMER-STMT")]
     [InlineData("EXEC CICS LOAD PROGRAM('PRICE-PROGRAM') END-EXEC", "PRICE-PROGRAM")]
+    [InlineData("EXEC CICS SEND MAP('CUSTOMER-MAP') MAPSET('CUSTOMER-SET') END-EXEC", "CUSTOMER-MAP")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1230,6 +1230,29 @@ public class ReferenceExtractorTests
             && reference.ContainerName == "MAIN-SECTION");
     }
 
+    [Theory]
+    [InlineData("EXEC SQL CALL CUSTOMER-PROC(:CUSTOMER-ID) END-EXEC", "CUSTOMER-PROC")]
+    public void Extract_CobolExternalCallStatement_CapturesSearchableCall(string statement, string expectedSymbolName)
+    {
+        var content = $$"""
+            IDENTIFICATION DIVISION.
+            PROGRAM-ID. hello-world.
+            PROCEDURE DIVISION.
+            MAIN-SECTION SECTION.
+                {{statement}}
+                STOP RUN.
+            END PROGRAM hello-world.
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cobol", content);
+        var references = ReferenceExtractor.Extract(1, "cobol", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == expectedSymbolName
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "MAIN-SECTION");
+    }
+
     [Fact]
     public void Extract_VueScriptSetup_DetectsJavaScriptTypeScriptCalls()
     {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1205,6 +1205,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS RESETBR FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS ENDBR FILE('CUSTOMER-FILE') END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS UNLOCK FILE('CUSTOMER-FILE') END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS READQ TS QUEUE('CUSTOMER-QUEUE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-QUEUE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1184,6 +1184,7 @@ public class ReferenceExtractorTests
     [InlineData("GENERATE SALES-REPORT", "SALES-REPORT")]
     [InlineData("INITIATE SALES-REPORT", "SALES-REPORT")]
     [InlineData("TERMINATE SALES-REPORT", "SALES-REPORT")]
+    [InlineData("USE AFTER STANDARD ERROR PROCEDURE ON CUSTOMER-FILE", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1178,6 +1178,29 @@ public class ReferenceExtractorTests
             && reference.ContainerName == "MAIN-SECTION");
     }
 
+    [Theory]
+    [InlineData("RETURN SORT-WORK", "SORT-WORK")]
+    public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
+    {
+        var content = $$"""
+            IDENTIFICATION DIVISION.
+            PROGRAM-ID. hello-world.
+            PROCEDURE DIVISION.
+            MAIN-SECTION SECTION.
+                {{statement}}
+                STOP RUN.
+            END PROGRAM hello-world.
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cobol", content);
+        var references = ReferenceExtractor.Extract(1, "cobol", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == expectedSymbolName
+            && reference.ReferenceKind == "reference"
+            && reference.ContainerName == "MAIN-SECTION");
+    }
+
     [Fact]
     public void Extract_VueScriptSetup_DetectsJavaScriptTypeScriptCalls()
     {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1203,6 +1203,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS READNEXT FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS READPREV FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS RESETBR FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS ENDBR FILE('CUSTOMER-FILE') END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1238,6 +1238,7 @@ public class ReferenceExtractorTests
     [Theory]
     [InlineData("EXEC SQL CALL CUSTOMER-PROC(:CUSTOMER-ID) END-EXEC", "CUSTOMER-PROC")]
     [InlineData("EXEC CICS LINK PROGRAM('CUSTOMER-SERVICE') END-EXEC", "CUSTOMER-SERVICE")]
+    [InlineData("EXEC CICS XCTL PROGRAM('NEXT-PROGRAM') END-EXEC", "NEXT-PROGRAM")]
     public void Extract_CobolExternalCallStatement_CapturesSearchableCall(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1201,6 +1201,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS DELETE FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS STARTBR FILE('CUSTOMER-FILE') RIDFLD(CUSTOMER-KEY) END-EXEC", "CUSTOMER-FILE")]
     [InlineData("EXEC CICS READNEXT FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
+    [InlineData("EXEC CICS READPREV FILE('CUSTOMER-FILE') INTO(CUSTOMER-RECORD) END-EXEC", "CUSTOMER-FILE")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1214,6 +1214,7 @@ public class ReferenceExtractorTests
     [InlineData("EXEC CICS DEQ RESOURCE('CUSTOMER-LOCK') END-EXEC", "CUSTOMER-LOCK")]
     [InlineData("EXEC CICS START TRANSID('PAY1') FROM(CUSTOMER-RECORD) END-EXEC", "PAY1")]
     [InlineData("EXEC CICS RETURN TRANSID('PAY1') COMMAREA(CUSTOMER-RECORD) END-EXEC", "PAY1")]
+    [InlineData("EXEC CICS ASSIGN APPLID(CURRENT-APPLID) END-EXEC", "CURRENT-APPLID")]
     public void Extract_CobolSingleTargetStatement_CapturesSearchableReference(string statement, string expectedSymbolName)
     {
         var content = $$"""

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -730,6 +730,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CobolClassId_DetectsClassSymbolAndContainers()
+    {
+        const string content = """
+            IDENTIFICATION DIVISION.
+            CLASS-ID. customer-service.
+            PROCEDURE DIVISION.
+            MAIN-SECTION SECTION.
+                DISPLAY "A".
+            END CLASS customer-service.
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cobol", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "class" && symbol.Name == "CUSTOMER-SERVICE");
+        Assert.Contains(symbols, symbol =>
+            symbol.Kind == "function"
+            && symbol.Name == "MAIN-SECTION"
+            && symbol.ContainerName == "CUSTOMER-SERVICE");
+    }
+
+    [Fact]
     public void Extract_VueScriptSetup_DetectsTypeScriptSymbols()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -751,6 +751,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CobolMethodId_DetectsFunctionSymbol()
+    {
+        const string content = """
+            IDENTIFICATION DIVISION.
+            CLASS-ID. customer-service.
+            METHOD-ID. "load-customer".
+            PROCEDURE DIVISION.
+                DISPLAY "A".
+            END METHOD load-customer.
+            END CLASS customer-service.
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cobol", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "LOAD-CUSTOMER");
+    }
+
+    [Fact]
     public void Extract_VueScriptSetup_DetectsTypeScriptSymbols()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -703,6 +703,7 @@ public class SymbolExtractorTests
             PROGRAM-ID. hello-world.
             PROCEDURE DIVISION.
             MAIN-SECTION SECTION.
+                ENTRY "ALT-ENTRY".
                 PERFORM HELPER-SECTION
                 PERFORM HELPER-PARA THRU EXIT-PARA
                 STOP RUN.
@@ -719,6 +720,7 @@ public class SymbolExtractorTests
         var symbols = SymbolExtractor.Extract(1, "cobol", content);
 
         Assert.Contains(symbols, symbol => symbol.Kind == "class" && symbol.Name == "HELLO-WORLD");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "ALT-ENTRY");
         Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "MAIN-SECTION");
         Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "HELPER-SECTION");
         Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "HELPER-PARA");


### PR DESCRIPTION
## Summary

- Expand COBOL reference extraction across CICS file, queue, resource, transaction, storage, terminal, and handler patterns.
- Add COBOL symbol/search coverage for ENTRY, CLASS-ID, METHOD-ID, and related callable/reference forms.
- Add focused tests and changelog fragments for each scoped improvement.

## Why

COBOL and CICS programs often express important dependencies through dialect-specific statements such as `EXEC CICS ...`, `EXEC SQL ...`, `HANDLE CONDITION`, queue operations, and storage/terminal data areas. These were only partially emitted as searchable references or calls, which made code search less complete for COBOL users.

## Validation

- Per-commit targeted tests and changelog validation were run before each commit.
- Per-commit `dotnet build`, `cdidx index . --commits HEAD --json`, and `cdidx status --check --json` were run after each commit.
- Per-commit adversarial review found no blocking/actionable issues after the Round 1 test-strengthening remediation.
- Final full test run: `4321 passed, 3 skipped, 0 failed`.
- Final `cdidx status --check --json`: index fresh.

## Notes

This branch contains 50 scoped COBOL search improvement rounds plus one remediation commit that strengthened the Round 1 test after review.