### PR TITLE
[codex] Improve R search indexing coverage

### DIFF
--- a/changelog.d/unreleased/+r-assign-function-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-assign-function-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R `assign()` function definitions now surface in symbol search** — clear definitions such as `assign("build_plot", function(...))` are indexed by the assigned function name.
+
+## 日本語
+
+- **R の `assign()` 関数定義がシンボル検索に出るようになりました** — `assign("build_plot", function(...))` のような明確な定義を、代入先の関数名で索引します。

--- a/changelog.d/unreleased/+r-assign-named-function-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-assign-named-function-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R named-argument `assign()` function definitions now surface in symbol search** — `assign(x = "format_model", value = function(...))` is indexed by the assigned function name.
+
+## 日本語
+
+- **R の named argument 形式の `assign()` 関数定義がシンボル検索に出るようになりました** — `assign(x = "format_model", value = function(...))` を代入先の関数名で索引します。

--- a/changelog.d/unreleased/+r-assign-shorthand-function-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-assign-shorthand-function-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R `assign()` shorthand function definitions now surface in symbol search** — `assign("compact_plot", \(data) data)` is indexed by the assigned function name.
+
+## 日本語
+
+- **R の `assign()` shorthand function 定義がシンボル検索に出るようになりました** — `assign("compact_plot", \(data) data)` を代入先の関数名で索引します。

--- a/changelog.d/unreleased/+r-backtick-call-references.fixed.md
+++ b/changelog.d/unreleased/+r-backtick-call-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R backtick-named function calls now appear in reference search** — calls such as `` `plot-model`(x) `` and `` `%||%`(x, y) `` are emitted as call references.
+
+## 日本語
+
+- **R のバッククォート名付き関数呼び出しが参照検索に出るようになりました** — `` `plot-model`(x) `` や `` `%||%`(x, y) `` のような呼び出しを call 参照として記録します。

--- a/changelog.d/unreleased/+r-backtick-dollar-member-references.fixed.md
+++ b/changelog.d/unreleased/+r-backtick-dollar-member-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `$` references now handle backtick receiver names** — member accesses such as `` `reactive data`$value `` and `` `reactive data`$`has space` `` are indexed as qualified references.
+
+## 日本語
+
+- **R の `$` 参照がバッククォート付き receiver 名に対応しました** — `` `reactive data`$value `` や `` `reactive data`$`has space` `` を qualified reference として索引します。

--- a/changelog.d/unreleased/+r-backtick-equals-functions.fixed.md
+++ b/changelog.d/unreleased/+r-backtick-equals-functions.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R backtick-named `=` function assignments now surface in symbol search** — definitions such as `` `plot-model` = function(...) `` are indexed like their `<-` equivalents.
+
+## 日本語
+
+- **R のバッククォート名付き `=` 関数代入がシンボル検索に出るようになりました** — `` `plot-model` = function(...) `` のような定義を `<-` 形式と同じく索引します。

--- a/changelog.d/unreleased/+r-backtick-namespace-refs.fixed.md
+++ b/changelog.d/unreleased/+r-backtick-namespace-refs.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R namespace references now include backtick-quoted operator names** — `cdidx` records R namespace references such as `` pkg::`%>%` `` and `` pkg:::`%||%` `` as searchable references to both the qualified target and the operator leaf name.
+
+## 日本語
+
+- **R の namespace 参照で backtick 付き演算子名も拾うようになりました** — `cdidx` は `` pkg::`%>%` `` や `` pkg:::`%||%` `` のような R の namespace 参照を、修飾済みターゲットと演算子の leaf 名の両方に対する検索可能な参照として記録します。

--- a/changelog.d/unreleased/+r-bracket-member-references.fixed.md
+++ b/changelog.d/unreleased/+r-bracket-member-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `[[...]]` member accesses now surface in reference search** — string-keyed lookups such as `data[["value"]]` and `input[['go']]` are indexed as the same qualified references as `$` access.
+
+## 日本語
+
+- **R の `[[...]]` member access が参照検索に出るようになりました** — `data[["value"]]` や `input[['go']]` のような文字列キー access を `$` と同じ qualified reference として索引します。

--- a/changelog.d/unreleased/+r-data-call-references.fixed.md
+++ b/changelog.d/unreleased/+r-data-call-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `data()` calls now surface in reference search** — dataset names and `package =` values are indexed from calls such as `data("iris", package = "datasets")`.
+
+## 日本語
+
+- **R の `data()` 呼び出しが参照検索に出るようになりました** — `data("iris", package = "datasets")` のような呼び出しから dataset 名と `package =` 値を索引します。

--- a/changelog.d/unreleased/+r-dollar-member-references.fixed.md
+++ b/changelog.d/unreleased/+r-dollar-member-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `$` member accesses now surface in reference search** — expressions such as `input$go`, `data$value`, and backtick member names emit both qualified and leaf references.
+
+## 日本語
+
+- **R の `$` member access が参照検索に出るようになりました** — `input$go`、`data$value`、バッククォート付き member 名から qualified / leaf の両方の参照を記録します。

--- a/changelog.d/unreleased/+r-help-example-references.fixed.md
+++ b/changelog.d/unreleased/+r-help-example-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `help()` and `example()` calls now surface in reference search** — documentation topics and `package =` values are indexed as references.
+
+## 日本語
+
+- **R の `help()` / `example()` 呼び出しが参照検索に出るようになりました** — documentation topic と `package =` 値を reference として索引します。

--- a/changelog.d/unreleased/+r-infix-operator-call-references.fixed.md
+++ b/changelog.d/unreleased/+r-infix-operator-call-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R infix operator calls now appear in reference search** — operator functions such as `%>%` and `%||%` are emitted as call references when used in infix form.
+
+## 日本語
+
+- **R の infix operator 呼び出しが参照検索に出るようになりました** — `%>%` や `%||%` のような operator function を infix 形式で使った場合に call 参照として記録します。

--- a/changelog.d/unreleased/+r-install-github-references.fixed.md
+++ b/changelog.d/unreleased/+r-install-github-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R GitHub package install calls now surface in reference search** — `remotes::install_github()` and `devtools::install_github()` repository specs are indexed while named options are ignored.
+
+## 日本語
+
+- **R の GitHub package install 呼び出しが参照検索に出るようになりました** — `remotes::install_github()` / `devtools::install_github()` の repository spec を索引し、named option は無視します。

--- a/changelog.d/unreleased/+r-install-packages-references.fixed.md
+++ b/changelog.d/unreleased/+r-install-packages-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `install.packages()` calls now surface in reference search** — quoted package names, including vector entries, are indexed while named options such as `repos =` are ignored.
+
+## 日本語
+
+- **R の `install.packages()` 呼び出しが参照検索に出るようになりました** — quoted package 名や vector 内の entry を索引し、`repos =` のような named option は無視します。

--- a/changelog.d/unreleased/+r-library-help-imports.fixed.md
+++ b/changelog.d/unreleased/+r-library-help-imports.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R `library(help = ...)` calls now surface as package imports** — help-oriented `library()` / `require()` calls index the referenced package name for symbol search.
+
+## 日本語
+
+- **R の `library(help = ...)` 呼び出しが package import として出るようになりました** — help 表示用の `library()` / `require()` 呼び出しから参照先 package 名を symbol search に索引します。

--- a/changelog.d/unreleased/+r-library-named-import-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-library-named-import-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R named package loader calls now surface as import symbols** — forms such as `library(package = "stringr")` and `require(package = tidyr)` are indexed by package name.
+
+## 日本語
+
+- **R の named package loader call が import シンボルとして出るようになりました** — `library(package = "stringr")` や `require(package = tidyr)` のような形式をパッケージ名で索引します。

--- a/changelog.d/unreleased/+r-load-all-references.fixed.md
+++ b/changelog.d/unreleased/+r-load-all-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `load_all()` development loaders now surface in reference search** — `devtools::load_all()` and `pkgload::load_all()` path arguments are indexed as references.
+
+## 日本語
+
+- **R の `load_all()` 開発用 loader が参照検索に出るようになりました** — `devtools::load_all()` / `pkgload::load_all()` の path 引数を reference として索引します。

--- a/changelog.d/unreleased/+r-namespace-directive-references.fixed.md
+++ b/changelog.d/unreleased/+r-namespace-directive-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `NAMESPACE` import/export directives now produce symbol references** — `importFrom(pkg, name)` records both `pkg::name` and `name`, while `export(...)`, `exportClasses(...)`, and `exportMethods(...)` record exported names without adding noisy directive calls.
+
+## 日本語
+
+- **R の `NAMESPACE` import/export ディレクティブがシンボル参照を生成するようになりました** — `importFrom(pkg, name)` は `pkg::name` と `name` の両方を記録し、`export(...)` / `exportClasses(...)` / `exportMethods(...)` はノイズになるディレクティブ call を出さずに export 対象名を記録します。

--- a/changelog.d/unreleased/+r-namespace-file-detection.fixed.md
+++ b/changelog.d/unreleased/+r-namespace-file-detection.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **R package `NAMESPACE` files are now detected as R** — extensionless `NAMESPACE` files are indexed in the R language bucket so package export/import directives participate in scoped search.
+
+## 日本語
+
+- **R パッケージの `NAMESPACE` ファイルを R として検出するようになりました** — 拡張子のない `NAMESPACE` ファイルを R 言語として index するため、package の export/import ディレクティブも scoped search の対象になります。

--- a/changelog.d/unreleased/+r-namespace-import-classes-methods-references.fixed.md
+++ b/changelog.d/unreleased/+r-namespace-import-classes-methods-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R NAMESPACE class and method imports now surface in reference search** — `importClassesFrom()` and `importMethodsFrom()` directives are indexed like `importFrom()` with package-qualified and leaf references.
+
+## 日本語
+
+- **R NAMESPACE の class / method import が参照検索に出るようになりました** — `importClassesFrom()` と `importMethodsFrom()` を `importFrom()` と同様に package-qualified / leaf reference として索引します。

--- a/changelog.d/unreleased/+r-namespace-import-references.fixed.md
+++ b/changelog.d/unreleased/+r-namespace-import-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `NAMESPACE` package imports now remain searchable** — `import(pkg)` directives emit a package reference while suppressing the directive helper call.
+
+## 日本語
+
+- **R の `NAMESPACE` パッケージ import が検索に残るようになりました** — `import(pkg)` ディレクティブは directive helper call を抑止しつつ、パッケージ参照を記録します。

--- a/changelog.d/unreleased/+r-namespace-package-install-references.fixed.md
+++ b/changelog.d/unreleased/+r-namespace-package-install-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `renv::install()` and `pak::pkg_install()` calls now surface in reference search** — quoted package names and vector entries are indexed like `install.packages()`.
+
+## 日本語
+
+- **R の `renv::install()` / `pak::pkg_install()` 呼び出しが参照検索に出るようになりました** — quoted package 名や vector 内の entry を `install.packages()` と同様に索引します。

--- a/changelog.d/unreleased/+r-namespaced-package-loader-imports.fixed.md
+++ b/changelog.d/unreleased/+r-namespaced-package-loader-imports.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R namespace-qualified package loader calls now surface as import symbols** — forms such as `base::library("readr")` and `base::requireNamespace(package = "rlang")` are indexed by package name.
+
+## 日本語
+
+- **R の namespace 修飾付き package loader call が import シンボルとして出るようになりました** — `base::library("readr")` や `base::requireNamespace(package = "rlang")` のような形式をパッケージ名で索引します。

--- a/changelog.d/unreleased/+r-namespaced-source-import-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-namespaced-source-import-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R namespace-qualified `source()` calls now surface as import symbols** — forms such as `base::source("R/helpers.R")` are indexed by sourced path.
+
+## 日本語
+
+- **R の namespace 修飾付き `source()` 呼び出しが import シンボルとして出るようになりました** — `base::source("R/helpers.R")` のような形式を source 先パスで索引します。

--- a/changelog.d/unreleased/+r-pacman-pload-comment-filter.fixed.md
+++ b/changelog.d/unreleased/+r-pacman-pload-comment-filter.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R `pacman::p_load()` import extraction now ignores trailing comments** — package-like text after `#` is no longer indexed as an import.
+
+## 日本語
+
+- **R の `pacman::p_load()` import 抽出が末尾コメントを無視するようになりました** — `#` 以降の package 風テキストを import として索引しません。

--- a/changelog.d/unreleased/+r-pacman-pload-imports.fixed.md
+++ b/changelog.d/unreleased/+r-pacman-pload-imports.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R `pacman::p_load()` calls now surface as package imports** — multiple bare or quoted package arguments are indexed as import symbols.
+
+## 日本語
+
+- **R の `pacman::p_load()` 呼び出しが package import として出るようになりました** — 裸名または引用付きの複数 package 引数を import symbol として索引します。

--- a/changelog.d/unreleased/+r-profile-file-detection.fixed.md
+++ b/changelog.d/unreleased/+r-profile-file-detection.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **R startup profile files are now detected as R** — `.Rprofile` and `Rprofile.site` are indexed in the R language bucket so startup hooks and helper definitions are available to scoped search.
+
+## 日本語
+
+- **R の起動プロファイルファイルを R として検出するようになりました** — `.Rprofile` と `Rprofile.site` を R 言語として index するため、起動時 hook や helper 定義も scoped search の対象になります。

--- a/changelog.d/unreleased/+r-rightward-function-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-rightward-function-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R rightward function assignments now surface in symbol search** — definitions such as `function(x) x + 1 -> increment` and `\(x) x -> name` are indexed by the assigned function name.
+
+## 日本語
+
+- **R の右代入 function 定義がシンボル検索に出るようになりました** — `function(x) x + 1 -> increment` や `\(x) x -> name` のような定義を代入先の関数名で索引します。

--- a/changelog.d/unreleased/+r-roxygen-import-references.fixed.md
+++ b/changelog.d/unreleased/+r-roxygen-import-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R roxygen `@import` tags now surface in reference search** — package-level roxygen imports such as `@import ggplot2 dplyr` are indexed as package references.
+
+## 日本語
+
+- **R の roxygen `@import` タグが参照検索に出るようになりました** — `@import ggplot2 dplyr` のような package-level import を package reference として索引します。

--- a/changelog.d/unreleased/+r-roxygen-importfrom-references.fixed.md
+++ b/changelog.d/unreleased/+r-roxygen-importfrom-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R roxygen `@importFrom` tags now surface in reference search** — `@importFrom`, `@importMethodsFrom`, and `@importClassesFrom` comments emit package-qualified and leaf references.
+
+## 日本語
+
+- **R の roxygen `@importFrom` タグが参照検索に出るようになりました** — `@importFrom`、`@importMethodsFrom`、`@importClassesFrom` コメントから package-qualified / leaf の両方の参照を記録します。

--- a/changelog.d/unreleased/+r-roxygen-method-references.fixed.md
+++ b/changelog.d/unreleased/+r-roxygen-method-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R roxygen `@method` tags now surface in reference search** — S3 method tags emit the synthesized method name plus generic and class references.
+
+## 日本語
+
+- **R の roxygen `@method` タグが参照検索に出るようになりました** — S3 method tag から合成 method 名、generic、class の参照を記録します。

--- a/changelog.d/unreleased/+r-s3method-directive-references.fixed.md
+++ b/changelog.d/unreleased/+r-s3method-directive-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `NAMESPACE` S3 method directives now create searchable references** — `S3method(generic, class)` records the generated `generic.class` method name plus its generic and class parts, while suppressing the directive helper call.
+
+## 日本語
+
+- **R の `NAMESPACE` S3 method ディレクティブが検索可能な参照を生成するようになりました** — `S3method(generic, class)` は生成される `generic.class` メソッド名と generic / class 部分を記録し、directive helper call は抑止します。

--- a/changelog.d/unreleased/+r-setgroupgeneric-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-setgroupgeneric-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R `setGroupGeneric()` declarations now surface in symbol search** — group generic names are indexed alongside existing `setGeneric()` coverage.
+
+## 日本語
+
+- **R の `setGroupGeneric()` 宣言がシンボル検索に出るようになりました** — group generic 名を既存の `setGeneric()` 対応と同じく索引します。

--- a/changelog.d/unreleased/+r-shiny-bracket-output-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-shiny-bracket-output-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R Shiny bracket-style output renderers now surface in symbol search** — `output[["detail-plot"]] <- renderPlot(...)` is indexed by output id.
+
+## 日本語
+
+- **R Shiny の bracket 形式 output renderer がシンボル検索に出るようになりました** — `output[["detail-plot"]] <- renderPlot(...)` を output id で索引します。

--- a/changelog.d/unreleased/+r-shiny-output-render-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-shiny-output-render-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R Shiny output renderers now surface in symbol search** — `output$plot <- renderPlot(...)` and related renderers are indexed by output id.
+
+## 日本語
+
+- **R Shiny の output renderer がシンボル検索に出るようになりました** — `output$plot <- renderPlot(...)` などの renderer を output id で索引します。

--- a/changelog.d/unreleased/+r-shiny-reactive-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-shiny-reactive-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R Shiny reactive assignments now surface in symbol search** — named `reactive()`, `eventReactive()`, `observe()`, and `observeEvent()` assignments are indexed by their binding name.
+
+## 日本語
+
+- **R Shiny の reactive 代入がシンボル検索に出るようになりました** — `reactive()` / `eventReactive()` / `observe()` / `observeEvent()` の名前付き代入を binding 名で索引します。

--- a/changelog.d/unreleased/+r-shorthand-function-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-shorthand-function-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R shorthand function assignments now surface in symbol search** — definitions such as `compact <- \(x) x + 1` are indexed like `function(...)` assignments.
+
+## 日本語
+
+- **R の shorthand function 代入がシンボル検索に出るようになりました** — `compact <- \(x) x + 1` のような定義を `function(...)` 代入と同じく索引します。

--- a/changelog.d/unreleased/+r-slot-member-references.fixed.md
+++ b/changelog.d/unreleased/+r-slot-member-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R S4 slot accesses now surface in reference search** — expressions such as `model@coefficients`, backtick slot names, and backtick receiver names emit qualified and leaf references.
+
+## 日本語
+
+- **R の S4 slot access が参照検索に出るようになりました** — `model@coefficients`、バッククォート付き slot 名、バッククォート付き receiver 名から qualified / leaf の両方の参照を記録します。

--- a/changelog.d/unreleased/+r-source-call-retention.fixed.md
+++ b/changelog.d/unreleased/+r-source-call-retention.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `source()` call references are retained alongside sourced file paths** — dynamic `source(path_var)` usages remain searchable by call while static paths also appear as references.
+
+## 日本語
+
+- **R の `source()` call 参照を source 先ファイルパスと併せて維持するようになりました** — `source(path_var)` のような動的な利用も call として検索でき、静的パスも参照として記録します。

--- a/changelog.d/unreleased/+r-source-file-import-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-source-file-import-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R `source()` file loads now surface as import symbols** — explicit file loads such as `source("R/helpers.R")` are indexed by the sourced path.
+
+## 日本語
+
+- **R の `source()` ファイル読み込みが import シンボルとして出るようになりました** — `source("R/helpers.R")` のような明示的な読み込みを source 先パスで索引します。

--- a/changelog.d/unreleased/+r-source-file-references.fixed.md
+++ b/changelog.d/unreleased/+r-source-file-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `source()` calls now record the sourced file path as a reference** — explicit source paths appear in reference search while the helper call itself is suppressed.
+
+## 日本語
+
+- **R の `source()` 呼び出しが source 先ファイルパスを参照として記録するようになりました** — 明示された source 先パスを参照検索に出し、helper call 自体は抑止します。

--- a/changelog.d/unreleased/+r-superassignment-functions.fixed.md
+++ b/changelog.d/unreleased/+r-superassignment-functions.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R superassignment function definitions are now indexed** — `cdidx` recognizes `name <<- function(...)` and backtick-escaped variants as function symbols, so symbol search no longer misses functions assigned into enclosing environments.
+
+## 日本語
+
+- **R の superassignment による関数定義も index されるようになりました** — `cdidx` は `name <<- function(...)` と backtick 付きの同種構文を関数シンボルとして認識するため、外側の環境へ代入された関数が symbol search から抜けなくなります。

--- a/changelog.d/unreleased/+r-sys-source-file-references.fixed.md
+++ b/changelog.d/unreleased/+r-sys-source-file-references.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `sys.source()` file loads now match `source()` search coverage** — sourced paths are indexed as import symbols and emitted as references.
+
+## 日本語
+
+- **R の `sys.source()` ファイル読み込みが `source()` と同じ検索対象になりました** — source 先パスを import シンボルとして索引し、参照としても記録します。

--- a/changelog.d/unreleased/+r-system-file-references.fixed.md
+++ b/changelog.d/unreleased/+r-system-file-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `system.file()` calls now surface in reference search** — positional resource path segments and `package =` values are indexed as references.
+
+## 日本語
+
+- **R の `system.file()` 呼び出しが参照検索に出るようになりました** — positional resource path segment と `package =` 値を reference として索引します。

--- a/changelog.d/unreleased/+r-testthat-bdd-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-testthat-bdd-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R testthat BDD blocks now surface in symbol search** — `describe()` and `it()` descriptions are indexed as searchable test symbols, including namespace-qualified calls.
+
+## 日本語
+
+- **R の testthat BDD block がシンボル検索に出るようになりました** — `describe()` と `it()` の description を、namespace 修飾付き呼び出しも含めて検索可能なテストシンボルとして索引します。

--- a/changelog.d/unreleased/+r-testthat-case-symbols.fixed.md
+++ b/changelog.d/unreleased/+r-testthat-case-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **R `test_that()` cases now surface in symbol search** — testthat case descriptions are indexed as searchable test symbols, including namespace-qualified calls.
+
+## 日本語
+
+- **R の `test_that()` case がシンボル検索に出るようになりました** — testthat の case description を、namespace 修飾付き呼び出しも含めて検索可能なテストシンボルとして索引します。

--- a/changelog.d/unreleased/+r-usedynlib-directive-references.fixed.md
+++ b/changelog.d/unreleased/+r-usedynlib-directive-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `NAMESPACE` native library directives now keep package references searchable** — `useDynLib(pkg, ...)` emits the package name as a reference while suppressing the directive helper call.
+
+## 日本語
+
+- **R の `NAMESPACE` ネイティブライブラリ directive がパッケージ参照を検索に残すようになりました** — `useDynLib(pkg, ...)` は directive helper call を抑止しつつ、パッケージ名を参照として記録します。

--- a/changelog.d/unreleased/+r-usedynlib-routine-references.fixed.md
+++ b/changelog.d/unreleased/+r-usedynlib-routine-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R NAMESPACE `useDynLib()` routine names now surface in reference search** — native entries such as `routine_a` and backtick-escaped routine names are indexed alongside the package reference.
+
+## 日本語
+
+- **R NAMESPACE の `useDynLib()` routine 名が参照検索に出るようになりました** — `routine_a` やバッククォート付き routine 名のような native entry を package reference とあわせて索引します。

--- a/changelog.d/unreleased/+r-vignette-references.fixed.md
+++ b/changelog.d/unreleased/+r-vignette-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **R `vignette()` calls now surface in reference search** — vignette topics and `package =` values are indexed as references.
+
+## 日本語
+
+- **R の `vignette()` 呼び出しが参照検索に出るようになりました** — vignette topic と `package =` 値を reference として索引します。

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -38,6 +38,12 @@ internal static class RReferenceExtractor
     private static readonly Regex InfixOperatorCallRegex = new(
         @"(?<!`)(?<name>%[^%\s]+%)(?!`)",
         RegexOptions.Compiled);
+    private static readonly Regex SourceFileReferenceRegex = new(
+        @"^\s*(?:(?:[\w.]+)::)?source\s*\(\s*(?:file\s*=\s*)?['""](?<path>[^'""]+)['""]",
+        RegexOptions.Compiled);
+    private static readonly Regex SourceFileReferenceStartRegex = new(
+        @"^\s*(?:(?:[\w.]+)::)?source\s*\(",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -306,6 +312,37 @@ internal static class RReferenceExtractor
                 lineNumber,
                 container);
         }
+    }
+
+    public static void EmitSourceFileReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (!SourceFileReferenceStartRegex.IsMatch(preparedLine))
+            return;
+
+        var line = StripRNamespaceDirectiveComment(originalLine);
+        var match = SourceFileReferenceRegex.Match(line);
+        if (!match.Success)
+            return;
+
+        var path = match.Groups["path"];
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            path.Value,
+            path.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
     }
 
     private static IEnumerable<(string Name, int Index)> EnumerateNamespaceDirectiveNames(string value, int baseIndex)

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -44,6 +44,9 @@ internal static class RReferenceExtractor
     private static readonly Regex SourceFileReferenceStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex DollarMemberReferenceRegex = new(
+        @"(?<![\w.])(?<receiver>[A-Za-z.][\w.]*)\$(?:(?:`(?<backtickName>[^`]+)`)|(?<name>[A-Za-z.][\w.]*))",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -343,6 +346,50 @@ internal static class RReferenceExtractor
             context,
             lineNumber,
             container);
+    }
+
+    public static void EmitDollarMemberReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        HashSet<string>? definitionNames)
+    {
+        foreach (Match match in DollarMemberReferenceRegex.Matches(preparedLine))
+        {
+            var receiver = match.Groups["receiver"].Value;
+            var backtickNameGroup = match.Groups["backtickName"];
+            var nameGroup = backtickNameGroup.Success ? backtickNameGroup : match.Groups["name"];
+            var name = nameGroup.Value;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                $"{receiver}${name}",
+                match.Groups["receiver"].Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+
+            if (definitionNames != null && definitionNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameGroup.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
     }
 
     private static IEnumerable<(string Name, int Index)> EnumerateNamespaceDirectiveNames(string value, int baseIndex)

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -26,6 +26,9 @@ internal static class RReferenceExtractor
     private static readonly Regex NamespaceUseDynLibDirectiveRegex = new(
         @"^\s*useDynLib\s*\(\s*(?:`(?<packageBacktick>[^`]+)`|['""](?<packageQuoted>[^'""]+)['""]|(?<package>[\w.]+))",
         RegexOptions.Compiled);
+    private static readonly Regex NamespaceUseDynLibRoutineRegex = new(
+        @"(?:^|,)\s*(?!(?:\.[A-Za-z.][\w.]*|[A-Za-z.][\w.]*\s*=))(?:`(?<backtickName>[^`]+)`|['""](?<quotedName>[^'""]+)['""]|(?<name>[A-Za-z.][\w.]*))",
+        RegexOptions.Compiled);
     private static readonly Regex NamespaceDirectiveStartRegex = new(
         @"^\s*(?:import\s*\(|import(?:Classes|Methods)?From\s*\(|export(?:Classes|Methods)?\s*\(|S3method\s*\(|useDynLib\s*\()",
         RegexOptions.Compiled);
@@ -252,6 +255,30 @@ internal static class RReferenceExtractor
                     fileId,
                     package.Value.Name,
                     package.Value.Index,
+                    "reference",
+                    context,
+                    lineNumber,
+                    container);
+            }
+
+            var routinesStart = useDynLibMatch.Index + useDynLibMatch.Length;
+            var routines = directiveLine[routinesStart..];
+            foreach (Match routineMatch in NamespaceUseDynLibRoutineRegex.Matches(routines))
+            {
+                var routine = GetNamespaceDirectiveToken(
+                    routineMatch,
+                    "backtickName",
+                    "quotedName",
+                    "name");
+                if (routine == null)
+                    continue;
+
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    routine.Value.Name,
+                    routinesStart + routine.Value.Index,
                     "reference",
                     context,
                     lineNumber,

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -45,7 +45,7 @@ internal static class RReferenceExtractor
         @"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(",
         RegexOptions.Compiled);
     private static readonly Regex DollarMemberReferenceRegex = new(
-        @"(?<![\w.])(?<receiver>[A-Za-z.][\w.]*)\$(?:(?:`(?<backtickName>[^`]+)`)|(?<name>[A-Za-z.][\w.]*))",
+        @"(?<![\w.])(?:(?:`(?<backtickReceiver>[^`]+)`)|(?<receiver>[A-Za-z.][\w.]*))\$(?:(?:`(?<backtickName>[^`]+)`)|(?<name>[A-Za-z.][\w.]*))",
         RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
@@ -360,7 +360,9 @@ internal static class RReferenceExtractor
     {
         foreach (Match match in DollarMemberReferenceRegex.Matches(preparedLine))
         {
-            var receiver = match.Groups["receiver"].Value;
+            var backtickReceiverGroup = match.Groups["backtickReceiver"];
+            var receiverGroup = backtickReceiverGroup.Success ? backtickReceiverGroup : match.Groups["receiver"];
+            var receiver = receiverGroup.Value;
             var backtickNameGroup = match.Groups["backtickName"];
             var nameGroup = backtickNameGroup.Success ? backtickNameGroup : match.Groups["name"];
             var name = nameGroup.Value;
@@ -370,7 +372,7 @@ internal static class RReferenceExtractor
                 seen,
                 fileId,
                 $"{receiver}${name}",
-                match.Groups["receiver"].Index,
+                receiverGroup.Index,
                 "reference",
                 context,
                 lineNumber,

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -39,10 +39,10 @@ internal static class RReferenceExtractor
         @"(?<!`)(?<name>%[^%\s]+%)(?!`)",
         RegexOptions.Compiled);
     private static readonly Regex SourceFileReferenceRegex = new(
-        @"^\s*(?:(?:[\w.]+)::)?source\s*\(\s*(?:file\s*=\s*)?['""](?<path>[^'""]+)['""]",
+        @"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(\s*(?:file\s*=\s*)?['""](?<path>[^'""]+)['""]",
         RegexOptions.Compiled);
     private static readonly Regex SourceFileReferenceStartRegex = new(
-        @"^\s*(?:(?:[\w.]+)::)?source\s*\(",
+        @"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(",
         RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -53,6 +53,9 @@ internal static class RReferenceExtractor
     private static readonly Regex SlotMemberReferenceRegex = new(
         @"(?<![\w.])(?:(?:`(?<backtickReceiver>[^`]+)`)|(?<receiver>[A-Za-z.][\w.]*))@(?:(?:`(?<backtickName>[^`]+)`)|(?<name>[A-Za-z.][\w.]*))",
         RegexOptions.Compiled);
+    private static readonly Regex RoxygenImportFromTagRegex = new(
+        @"^\s*#'\s*@(?:importFrom|importClassesFrom|importMethodsFrom)\s+(?<package>[\w.]+)\s+(?<names>.*)$",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -250,6 +253,46 @@ internal static class RReferenceExtractor
         var exportNamesGroup = exportMatch.Groups["names"];
         foreach (var (name, nameIndex) in EnumerateNamespaceDirectiveNames(exportNamesGroup.Value, exportNamesGroup.Index))
         {
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameIndex,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    public static void EmitRoxygenImportFromReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = RoxygenImportFromTagRegex.Match(originalLine);
+        if (!match.Success)
+            return;
+
+        var package = match.Groups["package"];
+        var namesGroup = match.Groups["names"];
+        foreach (var (name, nameIndex) in EnumerateNamespaceDirectiveNames(namesGroup.Value, namesGroup.Index))
+        {
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                $"{package.Value}::{name}",
+                package.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
             ReferenceExtractor.AddReference(
                 references,
                 seen,

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -20,6 +20,12 @@ internal static class RReferenceExtractor
     private static readonly Regex NamespaceExportDirectiveRegex = new(
         @"^\s*export(?:Classes|Methods)?\s*\(\s*(?<names>[^)]*)\)",
         RegexOptions.Compiled);
+    private static readonly Regex NamespaceS3MethodDirectiveRegex = new(
+        @"^\s*S3method\s*\(\s*(?:`(?<genericBacktick>[^`]+)`|['""](?<genericQuoted>[^'""]+)['""]|(?<generic>[A-Za-z.][\w.]*))\s*,\s*(?:`(?<classBacktick>[^`]+)`|['""](?<classQuoted>[^'""]+)['""]|(?<class>[A-Za-z.][\w.]*))(?:\s*,\s*(?:`(?<methodBacktick>[^`]+)`|['""](?<methodQuoted>[^'""]+)['""]|(?<method>[A-Za-z.][\w.]*)))?\s*\)",
+        RegexOptions.Compiled);
+    private static readonly Regex NamespaceDirectiveStartRegex = new(
+        @"^\s*(?:import\s*\(|importFrom\s*\(|export(?:Classes|Methods)?\s*\(|S3method\s*\()",
+        RegexOptions.Compiled);
     private static readonly Regex NamespaceDirectiveNameRegex = new(
         @"`(?<backtickName>[^`]+)`|(?<name>[A-Za-z.][\w.]*)",
         RegexOptions.Compiled);
@@ -72,6 +78,7 @@ internal static class RReferenceExtractor
 
     public static void EmitNamespaceDirectiveReferences(
         string preparedLine,
+        string originalLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -79,7 +86,11 @@ internal static class RReferenceExtractor
         int lineNumber,
         SymbolRecord? container)
     {
-        var importFromMatch = NamespaceImportFromDirectiveRegex.Match(preparedLine);
+        var directiveLine = NamespaceDirectiveStartRegex.IsMatch(preparedLine)
+            ? StripRNamespaceDirectiveComment(originalLine)
+            : preparedLine;
+
+        var importFromMatch = NamespaceImportFromDirectiveRegex.Match(directiveLine);
         if (importFromMatch.Success)
         {
             var package = importFromMatch.Groups["package"].Value;
@@ -111,7 +122,7 @@ internal static class RReferenceExtractor
             return;
         }
 
-        var importMatch = NamespaceImportDirectiveRegex.Match(preparedLine);
+        var importMatch = NamespaceImportDirectiveRegex.Match(directiveLine);
         if (importMatch.Success)
         {
             ReferenceExtractor.AddReference(
@@ -127,7 +138,63 @@ internal static class RReferenceExtractor
             return;
         }
 
-        var exportMatch = NamespaceExportDirectiveRegex.Match(preparedLine);
+        var s3MethodMatch = NamespaceS3MethodDirectiveRegex.Match(directiveLine);
+        if (s3MethodMatch.Success)
+        {
+            var generic = GetNamespaceDirectiveToken(
+                s3MethodMatch,
+                "genericBacktick",
+                "genericQuoted",
+                "generic");
+            var @class = GetNamespaceDirectiveToken(
+                s3MethodMatch,
+                "classBacktick",
+                "classQuoted",
+                "class");
+            var explicitMethod = GetNamespaceDirectiveToken(
+                s3MethodMatch,
+                "methodBacktick",
+                "methodQuoted",
+                "method");
+            if (generic != null && @class != null)
+            {
+                var method = explicitMethod ?? ($"{generic.Value.Name}.{@class.Value.Name}", generic.Value.Index);
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    method.Name,
+                    method.Index,
+                    "reference",
+                    context,
+                    lineNumber,
+                    container);
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    generic.Value.Name,
+                    generic.Value.Index,
+                    "reference",
+                    context,
+                    lineNumber,
+                    container);
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    @class.Value.Name,
+                    @class.Value.Index,
+                    "reference",
+                    context,
+                    lineNumber,
+                    container);
+            }
+
+            return;
+        }
+
+        var exportMatch = NamespaceExportDirectiveRegex.Match(directiveLine);
         if (!exportMatch.Success)
             return;
 
@@ -155,5 +222,69 @@ internal static class RReferenceExtractor
             var nameGroup = backtickNameGroup.Success ? backtickNameGroup : match.Groups["name"];
             yield return (nameGroup.Value, baseIndex + nameGroup.Index + (backtickNameGroup.Success ? 1 : 0));
         }
+    }
+
+    private static (string Name, int Index)? GetNamespaceDirectiveToken(Match match, params string[] groupNames)
+    {
+        foreach (var groupName in groupNames)
+        {
+            var group = match.Groups[groupName];
+            if (group.Success)
+                return (group.Value, group.Index);
+        }
+
+        return null;
+    }
+
+    private static string StripRNamespaceDirectiveComment(string line)
+    {
+        var inBacktickIdentifier = false;
+        var quote = '\0';
+        for (var i = 0; i < line.Length; i++)
+        {
+            var ch = line[i];
+            if (quote != '\0')
+            {
+                if (ch == '\\' && i + 1 < line.Length)
+                {
+                    i++;
+                    continue;
+                }
+
+                if (ch == quote)
+                    quote = '\0';
+                continue;
+            }
+
+            if (inBacktickIdentifier)
+            {
+                if (ch == '\\' && i + 1 < line.Length)
+                {
+                    i++;
+                    continue;
+                }
+
+                if (ch == '`')
+                    inBacktickIdentifier = false;
+                continue;
+            }
+
+            if (ch is '\'' or '"')
+            {
+                quote = ch;
+                continue;
+            }
+
+            if (ch == '`')
+            {
+                inBacktickIdentifier = true;
+                continue;
+            }
+
+            if (ch == '#')
+                return line[..i];
+        }
+
+        return line;
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -44,6 +44,15 @@ internal static class RReferenceExtractor
     private static readonly Regex SourceFileReferenceStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex DataCallStartRegex = new(
+        @"^\s*(?:(?:[\w.]+)::)?data\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex DataCallDatasetRegex = new(
+        @"(?:\(|,)\s*(?:list\s*=\s*)?['""](?<name>[^'""]+)['""]",
+        RegexOptions.Compiled);
+    private static readonly Regex DataCallPackageRegex = new(
+        @"\bpackage\s*=\s*['""](?<name>[^'""]+)['""]",
+        RegexOptions.Compiled);
     private static readonly Regex DollarMemberReferenceRegex = new(
         @"(?<![\w.])(?:(?:`(?<backtickReceiver>[^`]+)`)|(?<receiver>[A-Za-z.][\w.]*))\$(?:(?:`(?<backtickName>[^`]+)`)|(?<name>[A-Za-z.][\w.]*))",
         RegexOptions.Compiled);
@@ -484,6 +493,52 @@ internal static class RReferenceExtractor
             fileId,
             path.Value,
             path.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
+    }
+
+    public static void EmitDataCallReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (!DataCallStartRegex.IsMatch(preparedLine))
+            return;
+
+        var line = StripRNamespaceDirectiveComment(originalLine);
+        foreach (Match match in DataCallDatasetRegex.Matches(line))
+        {
+            var name = match.Groups["name"];
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name.Value,
+                name.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+
+        var packageMatch = DataCallPackageRegex.Match(line);
+        if (!packageMatch.Success)
+            return;
+
+        var package = packageMatch.Groups["name"];
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            package.Value,
+            package.Index,
             "reference",
             context,
             lineNumber,

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -47,6 +47,9 @@ internal static class RReferenceExtractor
     private static readonly Regex DollarMemberReferenceRegex = new(
         @"(?<![\w.])(?:(?:`(?<backtickReceiver>[^`]+)`)|(?<receiver>[A-Za-z.][\w.]*))\$(?:(?:`(?<backtickName>[^`]+)`)|(?<name>[A-Za-z.][\w.]*))",
         RegexOptions.Compiled);
+    private static readonly Regex BracketMemberReferenceRegex = new(
+        @"(?<![\w.])(?:(?:`(?<backtickReceiver>[^`]+)`)|(?<receiver>[A-Za-z.][\w.]*))\s*\[\[\s*(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*\]\]",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -365,6 +368,56 @@ internal static class RReferenceExtractor
             var receiver = receiverGroup.Value;
             var backtickNameGroup = match.Groups["backtickName"];
             var nameGroup = backtickNameGroup.Success ? backtickNameGroup : match.Groups["name"];
+            var name = nameGroup.Value;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                $"{receiver}${name}",
+                receiverGroup.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+
+            if (definitionNames != null && definitionNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameGroup.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    public static void EmitBracketMemberReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        HashSet<string>? definitionNames)
+    {
+        if (!preparedLine.Contains("[[", StringComparison.Ordinal))
+            return;
+
+        var line = StripRNamespaceDirectiveComment(originalLine);
+        foreach (Match match in BracketMemberReferenceRegex.Matches(line))
+        {
+            var backtickReceiverGroup = match.Groups["backtickReceiver"];
+            var receiverGroup = backtickReceiverGroup.Success ? backtickReceiverGroup : match.Groups["receiver"];
+            var receiver = receiverGroup.Value;
+            var nameGroup = match.Groups["name"];
             var name = nameGroup.Value;
 
             ReferenceExtractor.AddReference(

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -59,6 +59,9 @@ internal static class RReferenceExtractor
     private static readonly Regex InstallPackagesCallStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?install\.packages\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex NamespacePackageInstallCallStartRegex = new(
+        @"^\s*(?:(?:renv)::install|(?:pak)::pkg_install)\s*\(",
+        RegexOptions.Compiled);
     private static readonly Regex InstallPackagesNameRegex = new(
         @"(?:\(|,)\s*(?!(?:[A-Za-z.][\w.]*\s*=))(?:c\s*\(\s*)?['""](?<name>[^'""]+)['""]",
         RegexOptions.Compiled);
@@ -588,7 +591,52 @@ internal static class RReferenceExtractor
         int lineNumber,
         SymbolRecord? container)
     {
-        if (!InstallPackagesCallStartRegex.IsMatch(preparedLine))
+        EmitPackageNameArgumentReferences(
+            preparedLine,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container,
+            InstallPackagesCallStartRegex);
+    }
+
+    public static void EmitNamespacePackageInstallReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        EmitPackageNameArgumentReferences(
+            preparedLine,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container,
+            NamespacePackageInstallCallStartRegex);
+    }
+
+    private static void EmitPackageNameArgumentReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Regex startRegex)
+    {
+        if (!startRegex.IsMatch(preparedLine))
             return;
 
         var line = StripRNamespaceDirectiveComment(originalLine);

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -32,6 +32,9 @@ internal static class RReferenceExtractor
     private static readonly Regex NamespaceDirectiveNameRegex = new(
         @"`(?<backtickName>[^`]+)`|(?<name>[A-Za-z.][\w.]*)",
         RegexOptions.Compiled);
+    private static readonly Regex BacktickCallRegex = new(
+        @"`(?<name>[^`]+)`\s*\(",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -236,6 +239,36 @@ internal static class RReferenceExtractor
                 name,
                 nameIndex,
                 "reference",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    public static void EmitBacktickCallReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        HashSet<string>? definitionNames)
+    {
+        foreach (Match match in BacktickCallRegex.Matches(preparedLine))
+        {
+            var nameGroup = match.Groups["name"];
+            var name = nameGroup.Value;
+            if (definitionNames != null && definitionNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameGroup.Index,
+                "call",
                 context,
                 lineNumber,
                 container);

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -56,6 +56,12 @@ internal static class RReferenceExtractor
     private static readonly Regex DataCallPackageRegex = new(
         @"\bpackage\s*=\s*['""](?<name>[^'""]+)['""]",
         RegexOptions.Compiled);
+    private static readonly Regex InstallPackagesCallStartRegex = new(
+        @"^\s*(?:(?:[\w.]+)::)?install\.packages\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex InstallPackagesNameRegex = new(
+        @"(?:\(|,)\s*(?!(?:[A-Za-z.][\w.]*\s*=))(?:c\s*\(\s*)?['""](?<name>[^'""]+)['""]",
+        RegexOptions.Compiled);
     private static readonly Regex DollarMemberReferenceRegex = new(
         @"(?<![\w.])(?:(?:`(?<backtickReceiver>[^`]+)`)|(?<receiver>[A-Za-z.][\w.]*))\$(?:(?:`(?<backtickName>[^`]+)`)|(?<name>[A-Za-z.][\w.]*))",
         RegexOptions.Compiled);
@@ -570,6 +576,36 @@ internal static class RReferenceExtractor
             context,
             lineNumber,
             container);
+    }
+
+    public static void EmitInstallPackagesReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (!InstallPackagesCallStartRegex.IsMatch(preparedLine))
+            return;
+
+        var line = StripRNamespaceDirectiveComment(originalLine);
+        foreach (Match match in InstallPackagesNameRegex.Matches(line))
+        {
+            var name = match.Groups["name"];
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name.Value,
+                name.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
     }
 
     public static void EmitDollarMemberReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -11,6 +11,15 @@ internal static class RReferenceExtractor
     private static readonly Regex NamespaceReferenceRegex = new(
         @"(?<![\w.])(?<package>[\w.]+)(?<sep>:::?)(?:(?<backtickName>`[^`]+`)|(?<name>[\w.]+))",
         RegexOptions.Compiled);
+    private static readonly Regex NamespaceImportFromDirectiveRegex = new(
+        @"^\s*importFrom\s*\(\s*(?<package>[\w.]+)\s*,(?<names>[^)]*)\)",
+        RegexOptions.Compiled);
+    private static readonly Regex NamespaceExportDirectiveRegex = new(
+        @"^\s*export(?:Classes|Methods)?\s*\(\s*(?<names>[^)]*)\)",
+        RegexOptions.Compiled);
+    private static readonly Regex NamespaceDirectiveNameRegex = new(
+        @"`(?<backtickName>[^`]+)`|(?<name>[A-Za-z.][\w.]*)",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -55,6 +64,77 @@ internal static class RReferenceExtractor
                 context,
                 lineNumber,
                 container);
+        }
+    }
+
+    public static void EmitNamespaceDirectiveReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var importFromMatch = NamespaceImportFromDirectiveRegex.Match(preparedLine);
+        if (importFromMatch.Success)
+        {
+            var package = importFromMatch.Groups["package"].Value;
+            var namesGroup = importFromMatch.Groups["names"];
+            foreach (var (name, nameIndex) in EnumerateNamespaceDirectiveNames(namesGroup.Value, namesGroup.Index))
+            {
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    $"{package}::{name}",
+                    importFromMatch.Groups["package"].Index,
+                    "reference",
+                    context,
+                    lineNumber,
+                    container);
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    nameIndex,
+                    "reference",
+                    context,
+                    lineNumber,
+                    container);
+            }
+
+            return;
+        }
+
+        var exportMatch = NamespaceExportDirectiveRegex.Match(preparedLine);
+        if (!exportMatch.Success)
+            return;
+
+        var exportNamesGroup = exportMatch.Groups["names"];
+        foreach (var (name, nameIndex) in EnumerateNamespaceDirectiveNames(exportNamesGroup.Value, exportNamesGroup.Index))
+        {
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameIndex,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    private static IEnumerable<(string Name, int Index)> EnumerateNamespaceDirectiveNames(string value, int baseIndex)
+    {
+        foreach (Match match in NamespaceDirectiveNameRegex.Matches(value))
+        {
+            var backtickNameGroup = match.Groups["backtickName"];
+            var nameGroup = backtickNameGroup.Success ? backtickNameGroup : match.Groups["name"];
+            yield return (nameGroup.Value, baseIndex + nameGroup.Index + (backtickNameGroup.Success ? 1 : 0));
         }
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -9,7 +9,7 @@ internal static class RReferenceExtractor
     // even when they are not invoked as calls.
     // R の namespace 参照 `pkg::fun` / `pkg:::fun` を参照として記録する。
     private static readonly Regex NamespaceReferenceRegex = new(
-        @"(?<![\w.])(?<package>[\w.]+)(?<sep>:::?)(?<name>[\w.]+)",
+        @"(?<![\w.])(?<package>[\w.]+)(?<sep>:::?)(?:(?<backtickName>`[^`]+`)|(?<name>[\w.]+))",
         RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
@@ -26,7 +26,11 @@ internal static class RReferenceExtractor
         {
             var package = match.Groups["package"].Value;
             var separator = match.Groups["sep"].Value;
-            var name = match.Groups["name"].Value;
+            var backtickNameGroup = match.Groups["backtickName"];
+            var nameGroup = backtickNameGroup.Success ? backtickNameGroup : match.Groups["name"];
+            var name = backtickNameGroup.Success
+                ? backtickNameGroup.Value[1..^1]
+                : nameGroup.Value;
             ReferenceExtractor.AddReference(
                 references,
                 seen,
@@ -46,7 +50,7 @@ internal static class RReferenceExtractor
                 seen,
                 fileId,
                 name,
-                match.Groups["name"].Index,
+                nameGroup.Index + (backtickNameGroup.Success ? 1 : 0),
                 "reference",
                 context,
                 lineNumber,

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -50,6 +50,9 @@ internal static class RReferenceExtractor
     private static readonly Regex BracketMemberReferenceRegex = new(
         @"(?<![\w.])(?:(?:`(?<backtickReceiver>[^`]+)`)|(?<receiver>[A-Za-z.][\w.]*))\s*\[\[\s*(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*\]\]",
         RegexOptions.Compiled);
+    private static readonly Regex SlotMemberReferenceRegex = new(
+        @"(?<![\w.])(?:(?:`(?<backtickReceiver>[^`]+)`)|(?<receiver>[A-Za-z.][\w.]*))@(?:(?:`(?<backtickName>[^`]+)`)|(?<name>[A-Za-z.][\w.]*))",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -425,6 +428,52 @@ internal static class RReferenceExtractor
                 seen,
                 fileId,
                 $"{receiver}${name}",
+                receiverGroup.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+
+            if (definitionNames != null && definitionNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameGroup.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    public static void EmitSlotMemberReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        HashSet<string>? definitionNames)
+    {
+        foreach (Match match in SlotMemberReferenceRegex.Matches(preparedLine))
+        {
+            var backtickReceiverGroup = match.Groups["backtickReceiver"];
+            var receiverGroup = backtickReceiverGroup.Success ? backtickReceiverGroup : match.Groups["receiver"];
+            var receiver = receiverGroup.Value;
+            var backtickNameGroup = match.Groups["backtickName"];
+            var nameGroup = backtickNameGroup.Success ? backtickNameGroup : match.Groups["name"];
+            var name = nameGroup.Value;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                $"{receiver}@{name}",
                 receiverGroup.Index,
                 "reference",
                 context,

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -56,6 +56,9 @@ internal static class RReferenceExtractor
     private static readonly Regex RoxygenImportFromTagRegex = new(
         @"^\s*#'\s*@(?:importFrom|importClassesFrom|importMethodsFrom)\s+(?<package>[\w.]+)\s+(?<names>.*)$",
         RegexOptions.Compiled);
+    private static readonly Regex RoxygenImportTagRegex = new(
+        @"^\s*#'\s*@import\s+(?<packages>.*)$",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -299,6 +302,35 @@ internal static class RReferenceExtractor
                 fileId,
                 name,
                 nameIndex,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    public static void EmitRoxygenImportReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = RoxygenImportTagRegex.Match(originalLine);
+        if (!match.Success)
+            return;
+
+        var packagesGroup = match.Groups["packages"];
+        foreach (var (package, packageIndex) in EnumerateNamespaceDirectiveNames(packagesGroup.Value, packagesGroup.Index))
+        {
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                package,
+                packageIndex,
                 "reference",
                 context,
                 lineNumber,

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -15,7 +15,7 @@ internal static class RReferenceExtractor
         @"^\s*import\s*\(\s*(?<package>[\w.]+)(?:\s*,|\s*\))",
         RegexOptions.Compiled);
     private static readonly Regex NamespaceImportFromDirectiveRegex = new(
-        @"^\s*importFrom\s*\(\s*(?<package>[\w.]+)\s*,(?<names>[^)]*)\)",
+        @"^\s*import(?:Classes|Methods)?From\s*\(\s*(?<package>[\w.]+)\s*,(?<names>[^)]*)\)",
         RegexOptions.Compiled);
     private static readonly Regex NamespaceExportDirectiveRegex = new(
         @"^\s*export(?:Classes|Methods)?\s*\(\s*(?<names>[^)]*)\)",
@@ -27,7 +27,7 @@ internal static class RReferenceExtractor
         @"^\s*useDynLib\s*\(\s*(?:`(?<packageBacktick>[^`]+)`|['""](?<packageQuoted>[^'""]+)['""]|(?<package>[\w.]+))",
         RegexOptions.Compiled);
     private static readonly Regex NamespaceDirectiveStartRegex = new(
-        @"^\s*(?:import\s*\(|importFrom\s*\(|export(?:Classes|Methods)?\s*\(|S3method\s*\(|useDynLib\s*\()",
+        @"^\s*(?:import\s*\(|import(?:Classes|Methods)?From\s*\(|export(?:Classes|Methods)?\s*\(|S3method\s*\(|useDynLib\s*\()",
         RegexOptions.Compiled);
     private static readonly Regex NamespaceDirectiveNameRegex = new(
         @"`(?<backtickName>[^`]+)`|(?<name>[A-Za-z.][\w.]*)",

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -11,6 +11,9 @@ internal static class RReferenceExtractor
     private static readonly Regex NamespaceReferenceRegex = new(
         @"(?<![\w.])(?<package>[\w.]+)(?<sep>:::?)(?:(?<backtickName>`[^`]+`)|(?<name>[\w.]+))",
         RegexOptions.Compiled);
+    private static readonly Regex NamespaceImportDirectiveRegex = new(
+        @"^\s*import\s*\(\s*(?<package>[\w.]+)(?:\s*,|\s*\))",
+        RegexOptions.Compiled);
     private static readonly Regex NamespaceImportFromDirectiveRegex = new(
         @"^\s*importFrom\s*\(\s*(?<package>[\w.]+)\s*,(?<names>[^)]*)\)",
         RegexOptions.Compiled);
@@ -105,6 +108,22 @@ internal static class RReferenceExtractor
                     container);
             }
 
+            return;
+        }
+
+        var importMatch = NamespaceImportDirectiveRegex.Match(preparedLine);
+        if (importMatch.Success)
+        {
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                importMatch.Groups["package"].Value,
+                importMatch.Groups["package"].Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
             return;
         }
 

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -59,6 +59,9 @@ internal static class RReferenceExtractor
     private static readonly Regex RoxygenImportTagRegex = new(
         @"^\s*#'\s*@import\s+(?<packages>.*)$",
         RegexOptions.Compiled);
+    private static readonly Regex RoxygenMethodTagRegex = new(
+        @"^\s*#'\s*@method\s+(?:`(?<genericBacktick>[^`]+)`|['""](?<genericQuoted>[^'""]+)['""]|(?<generic>[^\s]+))\s+(?:`(?<classBacktick>[^`]+)`|['""](?<classQuoted>[^'""]+)['""]|(?<class>[^\s]+))",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -336,6 +339,64 @@ internal static class RReferenceExtractor
                 lineNumber,
                 container);
         }
+    }
+
+    public static void EmitRoxygenMethodReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = RoxygenMethodTagRegex.Match(originalLine);
+        if (!match.Success)
+            return;
+
+        var generic = GetNamespaceDirectiveToken(
+            match,
+            "genericBacktick",
+            "genericQuoted",
+            "generic");
+        var @class = GetNamespaceDirectiveToken(
+            match,
+            "classBacktick",
+            "classQuoted",
+            "class");
+        if (generic == null || @class == null)
+            return;
+
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            $"{generic.Value.Name}.{@class.Value.Name}",
+            generic.Value.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            generic.Value.Name,
+            generic.Value.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            @class.Value.Name,
+            @class.Value.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
     }
 
     public static void EmitBacktickCallReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -62,6 +62,9 @@ internal static class RReferenceExtractor
     private static readonly Regex NamespacePackageInstallCallStartRegex = new(
         @"^\s*(?:(?:renv)::install|(?:pak)::pkg_install)\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex GitHubPackageInstallCallStartRegex = new(
+        @"^\s*(?:(?:remotes|devtools)::)install_github\s*\(",
+        RegexOptions.Compiled);
     private static readonly Regex InstallPackagesNameRegex = new(
         @"(?:\(|,)\s*(?!(?:[A-Za-z.][\w.]*\s*=))(?:c\s*\(\s*)?['""](?<name>[^'""]+)['""]",
         RegexOptions.Compiled);
@@ -623,6 +626,28 @@ internal static class RReferenceExtractor
             lineNumber,
             container,
             NamespacePackageInstallCallStartRegex);
+    }
+
+    public static void EmitGitHubPackageInstallReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        EmitPackageNameArgumentReferences(
+            preparedLine,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container,
+            GitHubPackageInstallCallStartRegex);
     }
 
     private static void EmitPackageNameArgumentReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -47,6 +47,9 @@ internal static class RReferenceExtractor
     private static readonly Regex SourceFileReferenceStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex LoadAllReferenceRegex = new(
+        @"^\s*(?:(?:devtools|pkgload)::)load_all\s*\(\s*(?:path\s*=\s*)?['""](?<path>[^'""]+)['""]",
+        RegexOptions.Compiled);
     private static readonly Regex DataCallStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?data\s*\(",
         RegexOptions.Compiled);
@@ -522,6 +525,33 @@ internal static class RReferenceExtractor
 
         var line = StripRNamespaceDirectiveComment(originalLine);
         var match = SourceFileReferenceRegex.Match(line);
+        if (!match.Success)
+            return;
+
+        var path = match.Groups["path"];
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            path.Value,
+            path.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
+    }
+
+    public static void EmitLoadAllReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var line = StripRNamespaceDirectiveComment(originalLine);
+        var match = LoadAllReferenceRegex.Match(line);
         if (!match.Success)
             return;
 

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -65,6 +65,12 @@ internal static class RReferenceExtractor
     private static readonly Regex SystemFilePathPartRegex = new(
         @"(?:\(|,)\s*(?!(?:[A-Za-z.][\w.]*\s*=))['""](?<name>[^'""]+)['""]",
         RegexOptions.Compiled);
+    private static readonly Regex VignetteCallStartRegex = new(
+        @"^\s*(?:(?:[\w.]+)::)?vignette\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex DocumentationTopicRegex = new(
+        @"(?:\(|,)\s*(?!(?:[A-Za-z.][\w.]*\s*=))['""](?<name>[^'""]+)['""]",
+        RegexOptions.Compiled);
     private static readonly Regex InstallPackagesCallStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?install\.packages\s*\(",
         RegexOptions.Compiled);
@@ -635,6 +641,75 @@ internal static class RReferenceExtractor
 
         var line = StripRNamespaceDirectiveComment(originalLine);
         foreach (Match match in SystemFilePathPartRegex.Matches(line))
+        {
+            var name = match.Groups["name"];
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name.Value,
+                name.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+
+        var packageMatch = DataCallPackageRegex.Match(line);
+        if (!packageMatch.Success)
+            return;
+
+        var package = packageMatch.Groups["name"];
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            package.Value,
+            package.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
+    }
+
+    public static void EmitVignetteReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        EmitDocumentationTopicReferences(
+            preparedLine,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container,
+            VignetteCallStartRegex);
+    }
+
+    private static void EmitDocumentationTopicReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Regex startRegex)
+    {
+        if (!startRegex.IsMatch(preparedLine))
+            return;
+
+        var line = StripRNamespaceDirectiveComment(originalLine);
+        foreach (Match match in DocumentationTopicRegex.Matches(line))
         {
             var name = match.Groups["name"];
             ReferenceExtractor.AddReference(

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -35,6 +35,9 @@ internal static class RReferenceExtractor
     private static readonly Regex BacktickCallRegex = new(
         @"`(?<name>[^`]+)`\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex InfixOperatorCallRegex = new(
+        @"(?<!`)(?<name>%[^%\s]+%)(?!`)",
+        RegexOptions.Compiled);
 
     public static void EmitNamespaceReferences(
         string preparedLine,
@@ -256,6 +259,36 @@ internal static class RReferenceExtractor
         HashSet<string>? definitionNames)
     {
         foreach (Match match in BacktickCallRegex.Matches(preparedLine))
+        {
+            var nameGroup = match.Groups["name"];
+            var name = nameGroup.Value;
+            if (definitionNames != null && definitionNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameGroup.Index,
+                "call",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    public static void EmitInfixOperatorCallReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        HashSet<string>? definitionNames)
+    {
+        foreach (Match match in InfixOperatorCallRegex.Matches(preparedLine))
         {
             var nameGroup = match.Groups["name"];
             var name = nameGroup.Value;

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -59,6 +59,12 @@ internal static class RReferenceExtractor
     private static readonly Regex DataCallPackageRegex = new(
         @"\bpackage\s*=\s*['""](?<name>[^'""]+)['""]",
         RegexOptions.Compiled);
+    private static readonly Regex SystemFileCallStartRegex = new(
+        @"^\s*(?:(?:[\w.]+)::)?system\.file\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex SystemFilePathPartRegex = new(
+        @"(?:\(|,)\s*(?!(?:[A-Za-z.][\w.]*\s*=))['""](?<name>[^'""]+)['""]",
+        RegexOptions.Compiled);
     private static readonly Regex InstallPackagesCallStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?install\.packages\s*\(",
         RegexOptions.Compiled);
@@ -583,6 +589,52 @@ internal static class RReferenceExtractor
 
         var line = StripRNamespaceDirectiveComment(originalLine);
         foreach (Match match in DataCallDatasetRegex.Matches(line))
+        {
+            var name = match.Groups["name"];
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name.Value,
+                name.Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+
+        var packageMatch = DataCallPackageRegex.Match(line);
+        if (!packageMatch.Success)
+            return;
+
+        var package = packageMatch.Groups["name"];
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            package.Value,
+            package.Index,
+            "reference",
+            context,
+            lineNumber,
+            container);
+    }
+
+    public static void EmitSystemFileReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (!SystemFileCallStartRegex.IsMatch(preparedLine))
+            return;
+
+        var line = StripRNamespaceDirectiveComment(originalLine);
+        foreach (Match match in SystemFilePathPartRegex.Matches(line))
         {
             var name = match.Groups["name"];
             ReferenceExtractor.AddReference(

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -23,8 +23,11 @@ internal static class RReferenceExtractor
     private static readonly Regex NamespaceS3MethodDirectiveRegex = new(
         @"^\s*S3method\s*\(\s*(?:`(?<genericBacktick>[^`]+)`|['""](?<genericQuoted>[^'""]+)['""]|(?<generic>[A-Za-z.][\w.]*))\s*,\s*(?:`(?<classBacktick>[^`]+)`|['""](?<classQuoted>[^'""]+)['""]|(?<class>[A-Za-z.][\w.]*))(?:\s*,\s*(?:`(?<methodBacktick>[^`]+)`|['""](?<methodQuoted>[^'""]+)['""]|(?<method>[A-Za-z.][\w.]*)))?\s*\)",
         RegexOptions.Compiled);
+    private static readonly Regex NamespaceUseDynLibDirectiveRegex = new(
+        @"^\s*useDynLib\s*\(\s*(?:`(?<packageBacktick>[^`]+)`|['""](?<packageQuoted>[^'""]+)['""]|(?<package>[\w.]+))",
+        RegexOptions.Compiled);
     private static readonly Regex NamespaceDirectiveStartRegex = new(
-        @"^\s*(?:import\s*\(|importFrom\s*\(|export(?:Classes|Methods)?\s*\(|S3method\s*\()",
+        @"^\s*(?:import\s*\(|importFrom\s*\(|export(?:Classes|Methods)?\s*\(|S3method\s*\(|useDynLib\s*\()",
         RegexOptions.Compiled);
     private static readonly Regex NamespaceDirectiveNameRegex = new(
         @"`(?<backtickName>[^`]+)`|(?<name>[A-Za-z.][\w.]*)",
@@ -185,6 +188,31 @@ internal static class RReferenceExtractor
                     fileId,
                     @class.Value.Name,
                     @class.Value.Index,
+                    "reference",
+                    context,
+                    lineNumber,
+                    container);
+            }
+
+            return;
+        }
+
+        var useDynLibMatch = NamespaceUseDynLibDirectiveRegex.Match(directiveLine);
+        if (useDynLibMatch.Success)
+        {
+            var package = GetNamespaceDirectiveToken(
+                useDynLibMatch,
+                "packageBacktick",
+                "packageQuoted",
+                "package");
+            if (package != null)
+            {
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    package.Value.Name,
+                    package.Value.Index,
                     "reference",
                     context,
                     lineNumber,

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -68,6 +68,9 @@ internal static class RReferenceExtractor
     private static readonly Regex VignetteCallStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?vignette\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex HelpExampleCallStartRegex = new(
+        @"^\s*(?:(?:[\w.]+)::)?(?:help|example)\s*\(",
+        RegexOptions.Compiled);
     private static readonly Regex DocumentationTopicRegex = new(
         @"(?:\(|,)\s*(?!(?:[A-Za-z.][\w.]*\s*=))['""](?<name>[^'""]+)['""]",
         RegexOptions.Compiled);
@@ -692,6 +695,28 @@ internal static class RReferenceExtractor
             lineNumber,
             container,
             VignetteCallStartRegex);
+    }
+
+    public static void EmitHelpExampleReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        EmitDocumentationTopicReferences(
+            preparedLine,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container,
+            HelpExampleCallStartRegex);
     }
 
     private static void EmitDocumentationTopicReferences(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -1852,7 +1852,7 @@ public static partial class ReferenceExtractor
             result = MaskRustLifetimeTokens(result);
         if (lang != "cobol")
         {
-            var stringLiteralRegex = lang == "kotlin"
+            var stringLiteralRegex = lang is "kotlin" or "r"
                 ? NonBacktickStringLiteralRegex
                 : StringLiteralRegex;
             result = stringLiteralRegex.Replace(result, "\"\"");

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -1861,7 +1861,9 @@ public static partial class ReferenceExtractor
 
         if (UsesHashComments(lang))
         {
-            var hashIndex = result.IndexOf('#');
+            var hashIndex = lang == "r"
+                ? FindRHashCommentStart(result)
+                : result.IndexOf('#');
             if (hashIndex >= 0)
                 result = result[..hashIndex];
         }
@@ -1907,6 +1909,31 @@ public static partial class ReferenceExtractor
         }
 
         return result;
+    }
+
+    private static int FindRHashCommentStart(string line)
+    {
+        var inBacktickIdentifier = false;
+        for (var i = 0; i < line.Length; i++)
+        {
+            var ch = line[i];
+            if (inBacktickIdentifier && ch == '\\' && i + 1 < line.Length)
+            {
+                i++;
+                continue;
+            }
+
+            if (ch == '`')
+            {
+                inBacktickIdentifier = !inBacktickIdentifier;
+                continue;
+            }
+
+            if (ch == '#' && !inBacktickIdentifier)
+                return i;
+        }
+
+        return -1;
     }
 
     private static string MaskRustLifetimeTokens(string line)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2615,6 +2615,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitNamespacePackageInstallReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 RReferenceExtractor.EmitDollarMemberReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1185,6 +1185,14 @@ public static partial class ReferenceExtractor
                         roxygenContext,
                         lineNumber,
                         container: null);
+                    RReferenceExtractor.EmitRoxygenMethodReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        roxygenContext,
+                        lineNumber,
+                        container: null);
                 }
             }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -229,7 +229,7 @@ public static partial class ReferenceExtractor
         {
             "library", "cat", "paste", "paste0", "sprintf", "stop", "warning", "message",
             "invisible", "tryCatch", "withCallingHandlers", "requireNamespace", "next", "break", "repeat",
-            "import", "importFrom", "export", "exportClasses", "exportMethods", "S3method",
+            "import", "importFrom", "export", "exportClasses", "exportMethods", "S3method", "useDynLib",
         },
         // PowerShell keywords / PowerShell キーワード
         ["powershell"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2597,6 +2597,14 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitLoadAllReferences(
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 RReferenceExtractor.EmitDataCallReferences(
                     preparedLine,
                     originalLine,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -229,7 +229,7 @@ public static partial class ReferenceExtractor
         {
             "library", "cat", "paste", "paste0", "sprintf", "stop", "warning", "message",
             "invisible", "tryCatch", "withCallingHandlers", "requireNamespace", "next", "break", "repeat",
-            "import", "importFrom", "export", "exportClasses", "exportMethods", "S3method", "useDynLib", "source",
+            "import", "importFrom", "export", "exportClasses", "exportMethods", "S3method", "useDynLib",
         },
         // PowerShell keywords / PowerShell キーワード
         ["powershell"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2538,6 +2538,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitBacktickCallReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    definitionNames);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2547,6 +2547,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     definitionNames);
+                RReferenceExtractor.EmitInfixOperatorCallReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    definitionNames);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2574,6 +2574,16 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     definitionNames);
+                RReferenceExtractor.EmitBracketMemberReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    definitionNames);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -229,7 +229,7 @@ public static partial class ReferenceExtractor
         {
             "library", "cat", "paste", "paste0", "sprintf", "stop", "warning", "message",
             "invisible", "tryCatch", "withCallingHandlers", "requireNamespace", "next", "break", "repeat",
-            "import", "importFrom", "export", "exportClasses", "exportMethods",
+            "import", "importFrom", "export", "exportClasses", "exportMethods", "S3method",
         },
         // PowerShell keywords / PowerShell キーワード
         ["powershell"] = new HashSet<string>(StringComparer.Ordinal)
@@ -2531,6 +2531,7 @@ public static partial class ReferenceExtractor
                     definitionNames);
                 RReferenceExtractor.EmitNamespaceDirectiveReferences(
                     preparedLine,
+                    originalLine,
                     references,
                     seen,
                     fileId,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2614,6 +2614,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitSystemFileReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 RReferenceExtractor.EmitInstallPackagesReferences(
                     preparedLine,
                     originalLine,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2597,6 +2597,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitDataCallReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 RReferenceExtractor.EmitDollarMemberReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -229,6 +229,7 @@ public static partial class ReferenceExtractor
         {
             "library", "cat", "paste", "paste0", "sprintf", "stop", "warning", "message",
             "invisible", "tryCatch", "withCallingHandlers", "requireNamespace", "next", "break", "repeat",
+            "import", "importFrom", "export", "exportClasses", "exportMethods",
         },
         // PowerShell keywords / PowerShell キーワード
         ["powershell"] = new HashSet<string>(StringComparer.Ordinal)
@@ -2528,6 +2529,14 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     definitionNames);
+                RReferenceExtractor.EmitNamespaceDirectiveReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1164,6 +1164,22 @@ public static partial class ReferenceExtractor
                 jvmInDelimitedDocComment = nextJvmDelimitedDocComment;
             }
 
+            if (language == "r")
+            {
+                var roxygenContext = originalLine.Trim();
+                if (roxygenContext.Length > 0)
+                {
+                    RReferenceExtractor.EmitRoxygenImportFromReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        roxygenContext,
+                        lineNumber,
+                        container: null);
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -229,7 +229,7 @@ public static partial class ReferenceExtractor
         {
             "library", "cat", "paste", "paste0", "sprintf", "stop", "warning", "message",
             "invisible", "tryCatch", "withCallingHandlers", "requireNamespace", "next", "break", "repeat",
-            "import", "importFrom", "export", "exportClasses", "exportMethods", "S3method", "useDynLib",
+            "import", "importFrom", "export", "exportClasses", "exportMethods", "S3method", "useDynLib", "source",
         },
         // PowerShell keywords / PowerShell キーワード
         ["powershell"] = new HashSet<string>(StringComparer.Ordinal)
@@ -2556,6 +2556,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     definitionNames);
+                RReferenceExtractor.EmitSourceFileReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2632,6 +2632,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitHelpExampleReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 RReferenceExtractor.EmitInstallPackagesReferences(
                     preparedLine,
                     originalLine,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2606,6 +2606,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitInstallPackagesReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 RReferenceExtractor.EmitDollarMemberReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2584,6 +2584,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     definitionNames);
+                RReferenceExtractor.EmitSlotMemberReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    definitionNames);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2565,6 +2565,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitDollarMemberReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    definitionNames);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2623,6 +2623,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitVignetteReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 RReferenceExtractor.EmitInstallPackagesReferences(
                     preparedLine,
                     originalLine,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1177,6 +1177,14 @@ public static partial class ReferenceExtractor
                         roxygenContext,
                         lineNumber,
                         container: null);
+                    RReferenceExtractor.EmitRoxygenImportReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        roxygenContext,
+                        lineNumber,
+                        container: null);
                 }
             }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2624,6 +2624,15 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     container);
+                RReferenceExtractor.EmitGitHubPackageInstallReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 RReferenceExtractor.EmitDollarMemberReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -283,6 +283,7 @@ public class FileIndexer
         ["Podfile"]       = "ruby",         // CocoaPods dependency manifest / CocoaPods 依存マニフェスト
         ["Guardfile"]     = "ruby",         // Guard file-watcher / Guard ファイルウォッチャー
         ["Capfile"]       = "ruby",         // Capistrano deployment / Capistrano デプロイ
+        ["NAMESPACE"]     = "r",            // R package namespace directives / R パッケージ namespace ディレクティブ
         ["BUILD"]         = "python",       // Bazel Starlark build file / Bazel Starlark ビルドファイル
         ["BUILD.bazel"]   = "python",
         ["WORKSPACE"]     = "python",       // Bazel workspace / Bazel ワークスペース

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -284,6 +284,8 @@ public class FileIndexer
         ["Guardfile"]     = "ruby",         // Guard file-watcher / Guard ファイルウォッチャー
         ["Capfile"]       = "ruby",         // Capistrano deployment / Capistrano デプロイ
         ["NAMESPACE"]     = "r",            // R package namespace directives / R パッケージ namespace ディレクティブ
+        [".Rprofile"]     = "r",            // R startup profile / R 起動プロファイル
+        ["Rprofile.site"] = "r",            // Site-wide R startup profile / サイト共通 R 起動プロファイル
         ["BUILD"]         = "python",       // Bazel Starlark build file / Bazel Starlark ビルドファイル
         ["BUILD.bazel"]   = "python",
         ["WORKSPACE"]     = "python",       // Bazel workspace / Bazel ワークスペース

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1560,6 +1560,8 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:describe|it)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*output\$(?<name>[\w.]+)\s*<<?-\s*render\w+\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*output\s*\[\s*\[\s*['""](?<name>[^'""]+)['""]\s*\]\s*\]\s*<<?-\s*render\w+\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*(?:<<?-|=)\s*(?:reactive|eventReactive|observe|observeEvent)\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*(?:<<?-|=)\s*(?:reactive|eventReactive|observe|observeEvent)\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1561,7 +1561,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setGeneric|setGroupGeneric)\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("import",   new Regex(@"^\s*(?:library|require|requireNamespace)\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?:library|require|requireNamespace)\s*\(\s*(?:(?:package|pkg)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1554,6 +1554,8 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*=\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*assign\s*\(\s*(?:x\s*=\s*)?['""](?<name>[^'""]+)['""]\s*,\s*(?:value\s*=\s*)?(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?:function\s*\(|\\\s*\()[^\r\n#]*(?:->>|->)\s*`(?<name>[^`]+)`", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?:function\s*\(|\\\s*\()[^\r\n#]*(?:->>|->)\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1561,7 +1561,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setGeneric|setGroupGeneric)\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
-            new("import",   new Regex(@"^\s*(?:library|require|requireNamespace)\s*\(\s*(?:(?:package|pkg)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:library|require|requireNamespace)\s*\(\s*(?:(?:package|pkg)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(\s*(?:file\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1562,6 +1562,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*(?:library|require|requireNamespace)\s*\(\s*(?:(?:package|pkg)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*source\s*\(\s*(?:file\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1549,10 +1549,10 @@ public static partial class SymbolExtractor
         ],
         ["r"] =
         [
-            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<<?-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<<?-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<<?-\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<<?-\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*=\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*assign\s*\(\s*(?:x\s*=\s*)?['""](?<name>[^'""]+)['""]\s*,\s*(?:value\s*=\s*)?function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1569,6 +1569,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setGeneric|setGroupGeneric)\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            new("import",   new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:library|require)\s*\(\s*help\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:library|require|requireNamespace)\s*\(\s*(?:(?:package|pkg)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(\s*(?:file\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1553,7 +1553,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<<?-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("function", new Regex(@"^\s*assign\s*\(\s*['""](?<name>[^'""]+)['""]\s*,\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*assign\s*\(\s*(?:x\s*=\s*)?['""](?<name>[^'""]+)['""]\s*,\s*(?:value\s*=\s*)?function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1549,8 +1549,8 @@ public static partial class SymbolExtractor
         ],
         ["r"] =
         [
-            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
-            new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<<?-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<<?-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1553,6 +1553,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<<?-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*assign\s*\(\s*['""](?<name>[^'""]+)['""]\s*,\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1562,7 +1562,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*(?:library|require|requireNamespace)\s*\(\s*(?:(?:package|pkg)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*source\s*\(\s*(?:file\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?:source|sys\.source)\s*\(\s*(?:file\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1557,6 +1557,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:function\s*\(|\\\s*\()[^\r\n#]*(?:->>|->)\s*`(?<name>[^`]+)`", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?:function\s*\(|\\\s*\()[^\r\n#]*(?:->>|->)\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?test_that\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:describe|it)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1562,7 +1562,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*(?:library|require|requireNamespace)\s*\(\s*(?:(?:package|pkg)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"^\s*(?:source|sys\.source)\s*\(\s*(?:file\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:source|sys\.source)\s*\(\s*(?:file\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["lua"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1553,7 +1553,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<<?-\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*=\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
-            new("function", new Regex(@"^\s*assign\s*\(\s*(?:x\s*=\s*)?['""](?<name>[^'""]+)['""]\s*,\s*(?:value\s*=\s*)?function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*assign\s*\(\s*(?:x\s*=\s*)?['""](?<name>[^'""]+)['""]\s*,\s*(?:value\s*=\s*)?(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1551,6 +1551,7 @@ public static partial class SymbolExtractor
         [
             new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*<<?-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*<<?-\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*`(?<name>[^`]+)`\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3734,12 +3734,13 @@ public static partial class SymbolExtractor
         int lineNumber,
         List<SymbolRecord> symbols)
     {
-        var startMatch = RPacmanPackageLoaderStartRegex.Match(line);
+        var codeLine = StripRCommentForPackageLoader(line);
+        var startMatch = RPacmanPackageLoaderStartRegex.Match(codeLine);
         if (!startMatch.Success)
             return false;
 
         var argsStart = startMatch.Index + startMatch.Length;
-        var args = line[argsStart..];
+        var args = codeLine[argsStart..];
         var added = false;
         foreach (Match match in RPacmanPackageLoaderArgumentRegex.Matches(args))
         {
@@ -3768,6 +3769,52 @@ public static partial class SymbolExtractor
         }
 
         return added;
+    }
+
+    private static string StripRCommentForPackageLoader(string line)
+    {
+        var inBacktickIdentifier = false;
+        var quote = '\0';
+        for (var i = 0; i < line.Length; i++)
+        {
+            var ch = line[i];
+            if (quote != '\0')
+            {
+                if (ch == '\\' && i + 1 < line.Length)
+                {
+                    i++;
+                    continue;
+                }
+
+                if (ch == quote)
+                    quote = '\0';
+                continue;
+            }
+
+            if (inBacktickIdentifier)
+            {
+                if (ch == '`')
+                    inBacktickIdentifier = false;
+                continue;
+            }
+
+            if (ch == '`')
+            {
+                inBacktickIdentifier = true;
+                continue;
+            }
+
+            if (ch is '"' or '\'')
+            {
+                quote = ch;
+                continue;
+            }
+
+            if (ch == '#')
+                return line[..i];
+        }
+
+        return line;
     }
 
     private static bool TryGetSameLineSignatureKey(SymbolRecord symbol, out SameLineSignatureKey key)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1556,6 +1556,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*assign\s*\(\s*(?:x\s*=\s*)?['""](?<name>[^'""]+)['""]\s*,\s*(?:value\s*=\s*)?(?:function\s*\(|\\\s*\()", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?:function\s*\(|\\\s*\()[^\r\n#]*(?:->>|->)\s*`(?<name>[^`]+)`", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?:function\s*\(|\\\s*\()[^\r\n#]*(?:->>|->)\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?test_that\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -117,6 +117,12 @@ public static partial class SymbolExtractor
     private const string JavaReturnTypePattern =
         @"(?:" + JavaQualifiedIdentifierPattern + @"(?:\s*<[^;=(){}]+>)?(?:\s*\[\s*\])*)";
     private const string KotlinIdentifierPattern = @"(?:\w+|`[^`\r\n]+`)";
+    private static readonly Regex RPacmanPackageLoaderStartRegex = new(
+        @"^\s*(?:(?:[\w.]+)::)?p_load\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex RPacmanPackageLoaderArgumentRegex = new(
+        @"(?:^|,)\s*(?!(?:[A-Za-z.][\w.]*\s*=))(?:['""](?<quotedName>[^'""]+)['""]|(?<name>[A-Za-z.][\w.]*))",
+        RegexOptions.Compiled);
     private static readonly Regex CobolProgramIdLineRegex = new(
         @"^\s*(?:IDENTIFICATION\s+DIVISION\.\s*)?PROGRAM-ID\.\s*(?<name>[A-Z0-9][A-Z0-9-]*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -2078,6 +2084,8 @@ public static partial class SymbolExtractor
             }
             if (lang == "go")
                 TryAddGoLabelSymbol(fileId, line, i, symbols);
+            if (lang == "r" && TryAddRPacmanPackageLoaderSymbols(fileId, line, i + 1, symbols))
+                continue;
 
             var structuralLine = structuralLines[i];
             var cssScannerLine = cssScannerLines?[i];
@@ -3719,6 +3727,48 @@ public static partial class SymbolExtractor
     }
 
     private readonly record struct SameLineSignatureKey(int Line, int StartLine, string Signature);
+
+    private static bool TryAddRPacmanPackageLoaderSymbols(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        var startMatch = RPacmanPackageLoaderStartRegex.Match(line);
+        if (!startMatch.Success)
+            return false;
+
+        var argsStart = startMatch.Index + startMatch.Length;
+        var args = line[argsStart..];
+        var added = false;
+        foreach (Match match in RPacmanPackageLoaderArgumentRegex.Matches(args))
+        {
+            var quotedNameGroup = match.Groups["quotedName"];
+            var nameGroup = quotedNameGroup.Success ? quotedNameGroup : match.Groups["name"];
+            if (!nameGroup.Success)
+                continue;
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "import",
+                    Name = nameGroup.Value,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    StartColumn = argsStart + nameGroup.Index,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                },
+                line);
+            added = true;
+        }
+
+        return added;
+    }
 
     private static bool TryGetSameLineSignatureKey(SymbolRecord symbol, out SameLineSignatureKey key)
     {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1558,6 +1558,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:function\s*\(|\\\s*\()[^\r\n#]*(?:->>|->)\s*(?<name>[\w.]+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?test_that\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:describe|it)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*output\$(?<name>[\w.]+)\s*<<?-\s*render\w+\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1559,6 +1559,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?test_that\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:describe|it)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*output\$(?<name>[\w.]+)\s*<<?-\s*render\w+\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*output\s*\[\s*\[\s*['""](?<name>[^'""]+)['""]\s*\]\s*\]\s*<<?-\s*render\w+\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setClass|setRefClass|setClassUnion|setOldClass|R6Class)\s*\(\s*(?:(?:Class|classes|className|classname|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1558,7 +1558,7 @@ public static partial class SymbolExtractor
             new("class",    new Regex(@"^\s*(?:(?:[\w.]+)::)?setIs\s*\(.*?\b(?:class2|to)\s*=\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("class",    new Regex(@"^\s*inherit\s*=\s*(?:c\(\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[A-Z][\w.]*))", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setValidity\s*\(\s*(?:(?:Class|class|classes|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
-            new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setGeneric\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?(?:setGeneric|setGroupGeneric)\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?:[\w.]+)::)?setMethod\s*\(\s*(?:(?:f|generic|name)\s*=\s*)?(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))\s*,", RegexOptions.Compiled), BodyStyle.None),
             new("function", new Regex(@"^\s*(?<visibility>public|private|active)\s*=\s*list\(\s*(?<name>[\w.]+)\s*=\s*function\s*\(", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             new("import",   new Regex(@"^\s*(?:library|require|requireNamespace)\s*\(\s*(?:['""](?<name>[^'""]+)['""]|(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -90,6 +90,7 @@ public class FileIndexerTests
     [InlineData("Podfile", "ruby")]
     [InlineData("Guardfile", "ruby")]
     [InlineData("Capfile", "ruby")]
+    [InlineData("NAMESPACE", "r")]
     [InlineData("GNUmakefile", "makefile")]
     [InlineData("Containerfile", "dockerfile")]
     [InlineData("BUILD", "python")]
@@ -416,6 +417,7 @@ public class FileIndexerTests
         Assert.Equal("makefile", map["GNUmakefile"]);
         Assert.Equal("ruby", map["Gemfile"]);
         Assert.Equal("ruby", map["Rakefile"]);
+        Assert.Equal("r", map["NAMESPACE"]);
         Assert.Equal("python", map["BUILD.bazel"]);
         Assert.Equal("python", map["pyproject.toml"]);
         Assert.Equal("python", map["requirements.txt"]);

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -91,6 +91,8 @@ public class FileIndexerTests
     [InlineData("Guardfile", "ruby")]
     [InlineData("Capfile", "ruby")]
     [InlineData("NAMESPACE", "r")]
+    [InlineData(".Rprofile", "r")]
+    [InlineData("Rprofile.site", "r")]
     [InlineData("GNUmakefile", "makefile")]
     [InlineData("Containerfile", "dockerfile")]
     [InlineData("BUILD", "python")]
@@ -418,6 +420,8 @@ public class FileIndexerTests
         Assert.Equal("ruby", map["Gemfile"]);
         Assert.Equal("ruby", map["Rakefile"]);
         Assert.Equal("r", map["NAMESPACE"]);
+        Assert.Equal("r", map[".Rprofile"]);
+        Assert.Equal("r", map["Rprofile.site"]);
         Assert.Equal("python", map["BUILD.bazel"]);
         Assert.Equal("python", map["pyproject.toml"]);
         Assert.Equal("python", map["requirements.txt"]);

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14643,6 +14643,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsInfixOperatorCallSites()
+    {
+        const string content = """
+            run <- function(data, fallback) {
+                data %>% transform()
+                fallback %||% list()
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "%>%"
+            && r.ReferenceKind == "call"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "%||%"
+            && r.ReferenceKind == "call"
+            && r.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceImportFromAndExportDirectives()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14647,6 +14647,8 @@ public class ReferenceExtractorTests
             docs <- function() {
                 vignette("dplyr")
                 utils::vignette("programming", package = "dplyr")
+                help("filter", package = "dplyr")
+                utils::example("lm")
             }
             """;
 
@@ -14659,6 +14661,14 @@ public class ReferenceExtractorTests
             && r.ContainerName == "docs");
         Assert.Contains(references, r =>
             r.SymbolName == "programming"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "docs");
+        Assert.Contains(references, r =>
+            r.SymbolName == "filter"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "docs");
+        Assert.Contains(references, r =>
+            r.SymbolName == "lm"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "docs");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14623,6 +14623,7 @@ public class ReferenceExtractorTests
     public void Extract_R_DetectsNamespaceImportFromAndExportDirectives()
     {
         const string content = """
+            import(methods)
             importFrom(dplyr, filter, select)
             export(plot_model, `%.%`)
             exportClasses(Person)
@@ -14635,9 +14636,11 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "filter" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "dplyr::select" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "select" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "methods" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "plot_model" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "%.%" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "Person" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "import" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "importFrom" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "export" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "exportClasses" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14620,6 +14620,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsBacktickCallSites()
+    {
+        const string content = """
+            run <- function(data) {
+                `plot-model`(data)
+                `%||%`(data, list())
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "plot-model"
+            && r.ReferenceKind == "call"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "%||%"
+            && r.ReferenceKind == "call"
+            && r.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceImportFromAndExportDirectives()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14566,6 +14566,55 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsBacktickNamespaceReferenceOperators()
+    {
+        const string content = """
+            lookup <- function(df) {
+                magrittr::`%>%`
+                rlang:::`%||%`
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "magrittr::%>%"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+        Assert.Contains(references, r =>
+            r.SymbolName == "%>%"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+        Assert.Contains(references, r =>
+            r.SymbolName == "rlang:::%||%"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+        Assert.Contains(references, r =>
+            r.SymbolName == "%||%"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+    }
+
+    [Fact]
+    public void Extract_R_PreservesQualifiedBacktickNamespaceReferencesWhenLeafIsDefinedLocally()
+    {
+        const string content = """
+            `%>%` <- function(lhs, rhs) magrittr::`%>%`(lhs, rhs)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "magrittr::%>%"
+            && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "%>%"
+            && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_PowerShell_DetectsCallSites()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14531,7 +14531,10 @@ public class ReferenceExtractorTests
             r.SymbolName == "R/models/fit.R"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "load_helpers");
-        Assert.DoesNotContain(references, r => r.SymbolName == "source" && r.ReferenceKind == "call");
+        Assert.Contains(references, r =>
+            r.SymbolName == "source"
+            && r.ReferenceKind == "call"
+            && r.ContainerName == "load_helpers");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14517,6 +14517,7 @@ public class ReferenceExtractorTests
             load_helpers <- function() {
                 source("R/helpers.R")
                 base::source(file = "R/models/fit.R", local = TRUE)
+                sys.source("R/bootstrap.R", envir = environment())
             }
             """;
 
@@ -14529,6 +14530,10 @@ public class ReferenceExtractorTests
             && r.ContainerName == "load_helpers");
         Assert.Contains(references, r =>
             r.SymbolName == "R/models/fit.R"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "load_helpers");
+        Assert.Contains(references, r =>
+            r.SymbolName == "R/bootstrap.R"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "load_helpers");
         Assert.Contains(references, r =>

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14705,6 +14705,8 @@ public class ReferenceExtractorTests
                 data$value
                 input$go
                 data$`has space`
+                `reactive data`$value
+                `reactive data`$`has space`
             }
             """;
 
@@ -14729,6 +14731,14 @@ public class ReferenceExtractorTests
             && r.ContainerName == "run");
         Assert.Contains(references, r =>
             r.SymbolName == "data$has space"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "reactive data$value"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "reactive data$has space"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "run");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14902,6 +14902,34 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsRoxygenMethodReferences()
+    {
+        const string content = """
+            #' @method print model
+            #' @method "[" indexed
+            print.model <- function(x, ...) {
+                x
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "print.model"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "print"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "model"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "[.indexed"
+            && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_R_PreservesQualifiedBacktickNamespaceReferencesWhenLeafIsDefinedLocally()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14597,6 +14597,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsHashInsideBacktickNamespaceReferences()
+    {
+        const string content = """
+            lookup <- function() {
+                pkg::`a#b` # fake_call()
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "pkg::a#b"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+        Assert.Contains(references, r =>
+            r.SymbolName == "a#b"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "lookup");
+        Assert.DoesNotContain(references, r => r.SymbolName == "fake_call");
+    }
+
+    [Fact]
     public void Extract_R_PreservesQualifiedBacktickNamespaceReferencesWhenLeafIsDefinedLocally()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14543,6 +14543,33 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsDataCallReferences()
+    {
+        const string content = """
+            run <- function() {
+                data("iris", package = "datasets")
+                utils::data(list = "mtcars")
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "iris"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "datasets"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "mtcars"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceReferenceOperators()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14698,6 +14698,42 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsDollarMemberReferences()
+    {
+        const string content = """
+            run <- function(data, input) {
+                data$value
+                input$go
+                data$`has space`
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "data$value"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "value"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "input$go"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "go"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "data$has space"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceImportFromAndExportDirectives()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14851,6 +14851,36 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsRoxygenImportFromReferences()
+    {
+        const string content = """
+            #' Build a plot.
+            #' @importFrom dplyr filter select
+            #' @importMethodsFrom methods show
+            #' @importClassesFrom Matrix sparseMatrix
+            plot_model <- function(data) {
+                filter(data)
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "dplyr::filter"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "select"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "methods::show"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "Matrix::sparseMatrix"
+            && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_R_PreservesQualifiedBacktickNamespaceReferencesWhenLeafIsDefinedLocally()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14518,6 +14518,8 @@ public class ReferenceExtractorTests
                 source("R/helpers.R")
                 base::source(file = "R/models/fit.R", local = TRUE)
                 sys.source("R/bootstrap.R", envir = environment())
+                devtools::load_all("pkg")
+                pkgload::load_all(path = "localpkg")
             }
             """;
 
@@ -14534,6 +14536,14 @@ public class ReferenceExtractorTests
             && r.ContainerName == "load_helpers");
         Assert.Contains(references, r =>
             r.SymbolName == "R/bootstrap.R"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "load_helpers");
+        Assert.Contains(references, r =>
+            r.SymbolName == "pkg"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "load_helpers");
+        Assert.Contains(references, r =>
+            r.SymbolName == "localpkg"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "load_helpers");
         Assert.Contains(references, r =>

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14625,6 +14625,8 @@ public class ReferenceExtractorTests
         const string content = """
             import(methods)
             importFrom(dplyr, filter, select)
+            S3method(print, model)
+            S3method("[", indexed, `[.indexed`)
             export(plot_model, `%.%`)
             exportClasses(Person)
             """;
@@ -14637,11 +14639,18 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "dplyr::select" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "select" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "methods" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "print.model" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "print" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "model" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "[.indexed" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "[" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "indexed" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "plot_model" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "%.%" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "Person" && r.ReferenceKind == "reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "import" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "importFrom" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "S3method" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "export" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "exportClasses" && r.ReferenceKind == "call");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14578,6 +14578,7 @@ public class ReferenceExtractorTests
                 utils::install.packages(c("ggplot2", "data.table"), repos = "https://example.invalid")
                 renv::install("tibble")
                 pak::pkg_install(c("readr", "stringr"))
+                remotes::install_github("r-lib/cli", ref = "main")
             }
             """;
 
@@ -14608,7 +14609,12 @@ public class ReferenceExtractorTests
             r.SymbolName == "stringr"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "bootstrap");
+        Assert.Contains(references, r =>
+            r.SymbolName == "r-lib/cli"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "bootstrap");
         Assert.DoesNotContain(references, r => r.SymbolName == "https://example.invalid");
+        Assert.DoesNotContain(references, r => r.SymbolName == "main");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14744,6 +14744,42 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsBracketMemberReferences()
+    {
+        const string content = """
+            run <- function(data, input) {
+                data[["value"]]
+                input[['go']]
+                `reactive data`[["has space"]]
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "data$value"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "value"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "input$go"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "go"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "reactive data$has space"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceImportFromAndExportDirectives()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14641,6 +14641,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsVignetteReferences()
+    {
+        const string content = """
+            docs <- function() {
+                vignette("dplyr")
+                utils::vignette("programming", package = "dplyr")
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "dplyr"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "docs");
+        Assert.Contains(references, r =>
+            r.SymbolName == "programming"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "docs");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceReferenceOperators()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14576,6 +14576,8 @@ public class ReferenceExtractorTests
             bootstrap <- function() {
                 install.packages("dplyr")
                 utils::install.packages(c("ggplot2", "data.table"), repos = "https://example.invalid")
+                renv::install("tibble")
+                pak::pkg_install(c("readr", "stringr"))
             }
             """;
 
@@ -14592,6 +14594,18 @@ public class ReferenceExtractorTests
             && r.ContainerName == "bootstrap");
         Assert.Contains(references, r =>
             r.SymbolName == "data.table"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "bootstrap");
+        Assert.Contains(references, r =>
+            r.SymbolName == "tibble"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "bootstrap");
+        Assert.Contains(references, r =>
+            r.SymbolName == "readr"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "bootstrap");
+        Assert.Contains(references, r =>
+            r.SymbolName == "stringr"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "bootstrap");
         Assert.DoesNotContain(references, r => r.SymbolName == "https://example.invalid");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14844,6 +14844,8 @@ public class ReferenceExtractorTests
         const string content = """
             import(methods)
             importFrom(dplyr, filter, select)
+            importClassesFrom(methods, Person)
+            importMethodsFrom(stats, predict)
             S3method(print, model)
             S3method("[", indexed, `[.indexed`)
             useDynLib("mypkg", .registration = TRUE)
@@ -14859,6 +14861,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "dplyr::select" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "select" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "methods" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "methods::Person" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "stats::predict" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "print.model" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "print" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "model" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14848,7 +14848,7 @@ public class ReferenceExtractorTests
             importMethodsFrom(stats, predict)
             S3method(print, model)
             S3method("[", indexed, `[.indexed`)
-            useDynLib("mypkg", .registration = TRUE)
+            useDynLib("mypkg", routine_a, `routine-b`, .registration = TRUE)
             export(plot_model, `%.%`)
             exportClasses(Person)
             """;
@@ -14870,6 +14870,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "[" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "indexed" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "mypkg" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "routine_a" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "routine-b" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "plot_model" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "%.%" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "Person" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14881,6 +14881,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsRoxygenImportReferences()
+    {
+        const string content = """
+            #' @import ggplot2 dplyr
+            plot_model <- function(data) {
+                ggplot(data)
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "ggplot2"
+            && r.ReferenceKind == "reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "dplyr"
+            && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_R_PreservesQualifiedBacktickNamespaceReferencesWhenLeafIsDefinedLocally()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14627,6 +14627,7 @@ public class ReferenceExtractorTests
             importFrom(dplyr, filter, select)
             S3method(print, model)
             S3method("[", indexed, `[.indexed`)
+            useDynLib("mypkg", .registration = TRUE)
             export(plot_model, `%.%`)
             exportClasses(Person)
             """;
@@ -14645,12 +14646,14 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "[.indexed" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "[" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "indexed" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "mypkg" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "plot_model" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "%.%" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "Person" && r.ReferenceKind == "reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "import" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "importFrom" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "S3method" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "useDynLib" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "export" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "exportClasses" && r.ReferenceKind == "call");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14620,6 +14620,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsNamespaceImportFromAndExportDirectives()
+    {
+        const string content = """
+            importFrom(dplyr, filter, select)
+            export(plot_model, `%.%`)
+            exportClasses(Person)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "dplyr::filter" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "filter" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "dplyr::select" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "select" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "plot_model" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "%.%" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "Person" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "importFrom" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "export" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "exportClasses" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_R_PreservesQualifiedBacktickNamespaceReferencesWhenLeafIsDefinedLocally()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14511,6 +14511,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsSourceFileReferences()
+    {
+        const string content = """
+            load_helpers <- function() {
+                source("R/helpers.R")
+                base::source(file = "R/models/fit.R", local = TRUE)
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "R/helpers.R"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "load_helpers");
+        Assert.Contains(references, r =>
+            r.SymbolName == "R/models/fit.R"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "load_helpers");
+        Assert.DoesNotContain(references, r => r.SymbolName == "source" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceReferenceOperators()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14559,6 +14559,7 @@ public class ReferenceExtractorTests
             run <- function() {
                 data("iris", package = "datasets")
                 utils::data(list = "mtcars")
+                system.file("extdata", "sample.csv", package = "readr", mustWork = TRUE)
             }
             """;
 
@@ -14575,6 +14576,18 @@ public class ReferenceExtractorTests
             && r.ContainerName == "run");
         Assert.Contains(references, r =>
             r.SymbolName == "mtcars"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "extdata"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "sample.csv"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "readr"
             && r.ReferenceKind == "reference"
             && r.ContainerName == "run");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14570,6 +14570,34 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsInstallPackagesReferences()
+    {
+        const string content = """
+            bootstrap <- function() {
+                install.packages("dplyr")
+                utils::install.packages(c("ggplot2", "data.table"), repos = "https://example.invalid")
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "dplyr"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "bootstrap");
+        Assert.Contains(references, r =>
+            r.SymbolName == "ggplot2"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "bootstrap");
+        Assert.Contains(references, r =>
+            r.SymbolName == "data.table"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "bootstrap");
+        Assert.DoesNotContain(references, r => r.SymbolName == "https://example.invalid");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceReferenceOperators()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14780,6 +14780,38 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsSlotMemberReferences()
+    {
+        const string content = """
+            run <- function(model) {
+                model@coefficients
+                model@`fit value`
+                `model object`@metadata
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+        var references = ReferenceExtractor.Extract(1, "r", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "model@coefficients"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "coefficients"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "model@fit value"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+        Assert.Contains(references, r =>
+            r.SymbolName == "model object@metadata"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "run");
+    }
+
+    [Fact]
     public void Extract_R_DetectsNamespaceImportFromAndExportDirectives()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18545,12 +18545,17 @@ public class SymbolExtractorTests
               model
             })
 
+            assign("compact_plot", \(data) data)
+            assign(x = "label_model", value = \(model) model)
+
             assign("not_a_function", 42)
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build_plot");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "format_model");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "compact_plot");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "label_model");
         Assert.DoesNotContain(symbols, s => s.Name == "not_a_function");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18511,6 +18511,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsAssignFunctionDefinitions()
+    {
+        // R: assign() can install a function under a string name.
+        // R: assign() は文字列名で function を配置できる。
+        const string content = """
+            assign("build_plot", function(data) {
+              data
+            })
+
+            assign("not_a_function", 42)
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build_plot");
+        Assert.DoesNotContain(symbols, s => s.Name == "not_a_function");
+    }
+
+    [Fact]
     public void Extract_R_DetectsS4AndReferenceClassDefinitions()
     {
         // R: setClass, setClassUnion, setIs, setRefClass, R6Class, setGeneric, setMethod, inherit metadata / R: setClass、setClassUnion、setIs、setRefClass、R6Class、setGeneric、setMethod、inherit メタデータ

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18464,6 +18464,7 @@ public class SymbolExtractorTests
             base::requireNamespace(package = "rlang")
             library(help = "stats")
             base::require(help = utils)
+            pacman::p_load(lubridate, "data.table", janitor, character.only = FALSE)
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
@@ -18476,6 +18477,9 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "rlang");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stats");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "utils");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "lubridate");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "data.table");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "janitor");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18562,6 +18562,31 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsShinyReactiveSymbols()
+    {
+        // Shiny reactive assignments are named server endpoints even though they are not function().
+        // Shiny reactive 代入は function() ではないが名前付き server endpoint。
+        const string content = """
+            filtered <- reactive({
+              data
+            })
+
+            selected = eventReactive(input$go, {
+              input$id
+            })
+
+            `refresh-cache` <- observeEvent(input$refresh, {
+              update_cache()
+            })
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "filtered");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "selected");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "refresh-cache");
+    }
+
+    [Fact]
     public void Extract_R_DetectsBacktickEscapedFunctionNames()
     {
         // Backtick-escaped names are valid R identifiers / バッククォート付きの名前は R の有効な識別子

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18462,6 +18462,8 @@ public class SymbolExtractorTests
             require(package = tidyr)
             base::library("readr")
             base::requireNamespace(package = "rlang")
+            library(help = "stats")
+            base::require(help = utils)
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
@@ -18472,6 +18474,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "tidyr");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "readr");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "rlang");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stats");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "utils");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18558,6 +18558,8 @@ public class SymbolExtractorTests
 
             methods::setGeneric(f = "normalize", function(x) standardGeneric("normalize"))
 
+            methods::setGroupGeneric(name = "transformGroup")
+
             methods::setMethod(f = show, signature(object = "Person"), function(object) {
               object
             })
@@ -18579,6 +18581,7 @@ public class SymbolExtractorTests
         var state = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "state");
         Assert.Equal("active", state.Visibility);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "transformGroup");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "show");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18478,11 +18478,16 @@ public class SymbolExtractorTests
             my_plot <- function(x) {
               x
             }
+
+            `print-model` = function(value) {
+              value
+            }
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "plot-model");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "my_plot");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "print-model");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18520,11 +18520,16 @@ public class SymbolExtractorTests
               data
             })
 
+            assign(x = "format_model", value = function(model) {
+              model
+            })
+
             assign("not_a_function", 42)
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build_plot");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "format_model");
         Assert.DoesNotContain(symbols, s => s.Name == "not_a_function");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18458,12 +18458,16 @@ public class SymbolExtractorTests
             library("ggplot2")
             requireNamespace("jsonlite", quietly = TRUE)
             require(dplyr)
+            library(package = "stringr")
+            require(package = tidyr)
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "ggplot2");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "jsonlite");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "dplyr");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stringr");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "tidyr");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18514,6 +18514,29 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsTestthatBddBlocks()
+    {
+        // testthat also exposes describe()/it() BDD-style test blocks.
+        // testthat には describe()/it() の BDD 形式 test block もある。
+        const string content = """
+            describe("model plotting", {
+              it("renders residuals", {
+                expect_s3_class(plot_residuals(model), "ggplot")
+              })
+            })
+
+            testthat::it("handles missing values", {
+              expect_true(all(is.na(clean(data))))
+            })
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "model plotting");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "renders residuals");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "handles missing values");
+    }
+
+    [Fact]
     public void Extract_R_DetectsBacktickEscapedFunctionNames()
     {
         // Backtick-escaped names are valid R identifiers / バッククォート付きの名前は R の有効な識別子

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18537,6 +18537,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsShinyOutputRenderSymbols()
+    {
+        // Shiny output renderers define user-visible server endpoints.
+        // Shiny output renderer はユーザーに見える server endpoint を定義する。
+        const string content = """
+            output$summary_plot <- renderPlot({
+              plot(data)
+            })
+
+            output$table <- renderTable({
+              data
+            })
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "summary_plot");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "table");
+    }
+
+    [Fact]
     public void Extract_R_DetectsBacktickEscapedFunctionNames()
     {
         // Backtick-escaped names are valid R identifiers / バッククォート付きの名前は R の有効な識別子

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18460,6 +18460,8 @@ public class SymbolExtractorTests
             require(dplyr)
             library(package = "stringr")
             require(package = tidyr)
+            base::library("readr")
+            base::requireNamespace(package = "rlang")
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
@@ -18468,6 +18470,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "dplyr");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "stringr");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "tidyr");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "readr");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "rlang");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18515,6 +18515,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsShorthandFunctionAssignments()
+    {
+        // R 4.1 shorthand functions use \(...) instead of function(...).
+        // R 4.1 の shorthand function は function(...) の代わりに \(...) を使う。
+        const string content = """
+            compact <- \(x) x + 1
+            `plot-model` = \(data) data
+            global <<- \(value) value
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "compact");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "plot-model");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "global");
+    }
+
+    [Fact]
     public void Extract_R_DetectsAssignFunctionDefinitions()
     {
         // R: assign() can install a function under a string name.

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18494,6 +18494,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsTestthatTestCases()
+    {
+        // R testthat cases are useful search units in package test suites.
+        // R の testthat case は package test suite で有用な検索単位。
+        const string content = """
+            test_that("filters missing rows", {
+              expect_equal(drop_missing(data), expected)
+            })
+
+            testthat::test_that("plots model output", {
+              expect_s3_class(plot_model(model), "ggplot")
+            })
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "filters missing rows");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "plots model output");
+    }
+
+    [Fact]
     public void Extract_R_DetectsBacktickEscapedFunctionNames()
     {
         // Backtick-escaped names are valid R identifiers / バッククォート付きの名前は R の有効な識別子

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18471,6 +18471,21 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsSourceFileImports()
+    {
+        // R: source() loads another R file and should be searchable as an import.
+        // R: source() は別の R ファイルを読み込むため import として検索可能にする。
+        const string content = """
+            source("R/helpers.R")
+            source(file = "R/models/fit.R", local = TRUE)
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/helpers.R");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/models/fit.R");
+    }
+
+    [Fact]
     public void Extract_R_DetectsBacktickEscapedFunctionNames()
     {
         // Backtick-escaped names are valid R identifiers / バッククォート付きの名前は R の有効な識別子

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18479,12 +18479,14 @@ public class SymbolExtractorTests
             source("R/helpers.R")
             source(file = "R/models/fit.R", local = TRUE)
             sys.source("R/bootstrap.R", envir = environment())
+            base::source("R/base_helpers.R")
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/helpers.R");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/models/fit.R");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/bootstrap.R");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/base_helpers.R");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18478,11 +18478,13 @@ public class SymbolExtractorTests
         const string content = """
             source("R/helpers.R")
             source(file = "R/models/fit.R", local = TRUE)
+            sys.source("R/bootstrap.R", envir = environment())
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/helpers.R");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/models/fit.R");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "R/bootstrap.R");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18555,6 +18555,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_R_DetectsRightwardFunctionAssignments()
+    {
+        // R supports rightward assignment forms for function values.
+        // R は function 値の右代入形式もサポートする。
+        const string content = """
+            function(x) x + 1 -> increment
+            function(data) data ->> global_transform
+            \(value) value -> `plot-model`
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "increment");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "global_transform");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "plot-model");
+    }
+
+    [Fact]
     public void Extract_R_DetectsAssignFunctionDefinitions()
     {
         // R: assign() can install a function under a string name.

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18549,11 +18549,16 @@ public class SymbolExtractorTests
             output$table <- renderTable({
               data
             })
+
+            output[["detail-plot"]] <- renderPlot({
+              plot(detail)
+            })
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "summary_plot");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "table");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "detail-plot");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18464,7 +18464,7 @@ public class SymbolExtractorTests
             base::requireNamespace(package = "rlang")
             library(help = "stats")
             base::require(help = utils)
-            pacman::p_load(lubridate, "data.table", janitor, character.only = FALSE)
+            pacman::p_load(lubridate, "data.table", janitor, character.only = FALSE) # , fakepkg
             """;
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
@@ -18480,6 +18480,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "lubridate");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "data.table");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "janitor");
+        Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "fakepkg");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -18443,7 +18443,7 @@ public class SymbolExtractorTests
     {
         // Ordinary assignment should not be detected as a function
         // 通常の代入は関数として検出されないこと
-        var content = "x <- 42\ny <- some_func(x)\nz <- list(1, 2, 3)";
+        var content = "x <- 42\ny <- some_func(x)\nz <- list(1, 2, 3)\nglobal <<- 42";
         var symbols = SymbolExtractor.Extract(1, "r", content);
 
         Assert.DoesNotContain(symbols, s => s.Kind == "function");
@@ -18483,6 +18483,26 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "plot-model");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "my_plot");
+    }
+
+    [Fact]
+    public void Extract_R_DetectsSuperassignmentFunctionDefinitions()
+    {
+        // R: superassignment can define functions in an enclosing environment.
+        // R: superassignment は外側の環境へ関数を定義できる。
+        const string content = """
+            register_handler <<- function(event) {
+              event
+            }
+
+            `plot-model` <<- function(data) {
+              data
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "r", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "register_handler");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "plot-model");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Expands R search coverage across symbols and references with 50 focused commits.
- Adds extraction for R-specific constructs including backtick namespaces, assignment forms, NAMESPACE directives, source loaders, testthat/Shiny patterns, member access, roxygen tags, package loaders, installation calls, data/system/vignette/help references, and related edge cases.
- Adds focused tests for the new R indexing behavior and bilingual changelog fragments for each user-visible fix.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests|FullyQualifiedName~SymbolExtractorTests|FullyQualifiedName~FileIndexerTests|FullyQualifiedName~Changelog" --no-restore`
- `dotnet build CodeIndex.sln --no-restore`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

Ordinary implementation work did not require README or guide updates. Each user-visible indexing fix has a bilingual unreleased changelog fragment.

<details>
<summary>Changelog fragments</summary>

- `changelog.d/unreleased/+r-assign-function-symbols.fixed.md`
- `changelog.d/unreleased/+r-assign-named-function-symbols.fixed.md`
- `changelog.d/unreleased/+r-assign-shorthand-function-symbols.fixed.md`
- `changelog.d/unreleased/+r-backtick-call-references.fixed.md`
- `changelog.d/unreleased/+r-backtick-dollar-member-references.fixed.md`
- `changelog.d/unreleased/+r-backtick-equals-functions.fixed.md`
- `changelog.d/unreleased/+r-backtick-namespace-refs.fixed.md`
- `changelog.d/unreleased/+r-bracket-member-references.fixed.md`
- `changelog.d/unreleased/+r-data-call-references.fixed.md`
- `changelog.d/unreleased/+r-dollar-member-references.fixed.md`
- `changelog.d/unreleased/+r-help-example-references.fixed.md`
- `changelog.d/unreleased/+r-infix-operator-call-references.fixed.md`
- `changelog.d/unreleased/+r-install-github-references.fixed.md`
- `changelog.d/unreleased/+r-install-packages-references.fixed.md`
- `changelog.d/unreleased/+r-library-help-imports.fixed.md`
- `changelog.d/unreleased/+r-library-named-import-symbols.fixed.md`
- `changelog.d/unreleased/+r-load-all-references.fixed.md`
- `changelog.d/unreleased/+r-namespace-directive-references.fixed.md`
- `changelog.d/unreleased/+r-namespace-file-detection.fixed.md`
- `changelog.d/unreleased/+r-namespace-import-classes-methods-references.fixed.md`
- `changelog.d/unreleased/+r-namespace-import-references.fixed.md`
- `changelog.d/unreleased/+r-namespace-package-install-references.fixed.md`
- `changelog.d/unreleased/+r-namespaced-package-loader-imports.fixed.md`
- `changelog.d/unreleased/+r-namespaced-source-import-symbols.fixed.md`
- `changelog.d/unreleased/+r-pacman-pload-comment-filter.fixed.md`
- `changelog.d/unreleased/+r-pacman-pload-imports.fixed.md`
- `changelog.d/unreleased/+r-profile-file-detection.fixed.md`
- `changelog.d/unreleased/+r-rightward-function-symbols.fixed.md`
- `changelog.d/unreleased/+r-roxygen-import-references.fixed.md`
- `changelog.d/unreleased/+r-roxygen-importfrom-references.fixed.md`
- `changelog.d/unreleased/+r-roxygen-method-references.fixed.md`
- `changelog.d/unreleased/+r-s3method-directive-references.fixed.md`
- `changelog.d/unreleased/+r-setgroupgeneric-symbols.fixed.md`
- `changelog.d/unreleased/+r-shiny-bracket-output-symbols.fixed.md`
- `changelog.d/unreleased/+r-shiny-output-render-symbols.fixed.md`
- `changelog.d/unreleased/+r-shiny-reactive-symbols.fixed.md`
- `changelog.d/unreleased/+r-shorthand-function-symbols.fixed.md`
- `changelog.d/unreleased/+r-slot-member-references.fixed.md`
- `changelog.d/unreleased/+r-source-call-retention.fixed.md`
- `changelog.d/unreleased/+r-source-file-import-symbols.fixed.md`
- `changelog.d/unreleased/+r-source-file-references.fixed.md`
- `changelog.d/unreleased/+r-superassignment-functions.fixed.md`
- `changelog.d/unreleased/+r-sys-source-file-references.fixed.md`
- `changelog.d/unreleased/+r-system-file-references.fixed.md`
- `changelog.d/unreleased/+r-testthat-bdd-symbols.fixed.md`
- `changelog.d/unreleased/+r-testthat-case-symbols.fixed.md`
- `changelog.d/unreleased/+r-usedynlib-directive-references.fixed.md`
- `changelog.d/unreleased/+r-usedynlib-routine-references.fixed.md`
- `changelog.d/unreleased/+r-vignette-references.fixed.md`

</details>

## Follow-up candidates

- Add further R coverage for formula-specific references and multi-line call parsing if needed.
- Re-run CI after GitHub Actions completes and address any platform-specific failures.