### PR TITLE
[codex] Improve Dockerfile search coverage

### DIFF
--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -52,6 +52,7 @@ affected:
 - **Dockerfile shell-form `VOLUME` paths become symbols** — `VOLUME /data` now indexes `/data` as a property symbol.
 - **Dockerfile multi-path `VOLUME` lines expose every path** — `VOLUME /data /cache` now indexes all listed shell-form paths.
 - **Dockerfile `VOLUME` inline comments stay out of symbols** — paths mentioned after `#` are no longer indexed as volumes.
+- **Dockerfile named-stage base images stay searchable** — `FROM node:20 AS build` now indexes both `build` and the `node:20` image while avoiding prior-stage aliases.
 
 ## 日本語
 
@@ -95,3 +96,4 @@ affected:
 - **Dockerfile shell form の `VOLUME` path を symbol として扱うようになりました** — `VOLUME /data` が `/data` property symbol として index されるようになりました。
 - **Dockerfile の複数 path `VOLUME` 行ですべての path を出すようになりました** — `VOLUME /data /cache` が列挙された shell form path をすべて index するようになりました。
 - **Dockerfile `VOLUME` の inline comment を symbol 対象から外しました** — `#` より後ろに書かれた path を volume として index しないようになりました。
+- **Dockerfile の名前付きstageでもbase imageを検索できるようになりました** — `FROM node:20 AS build` が `build` と `node:20` image の両方を index しつつ、既存stage aliasはbase image扱いしないようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -18,6 +18,7 @@ affected:
 - **Hidden `.containerfile` files are detected** — hidden Containerfile variants now use the Dockerfile indexing path.
 - **Hyphen-suffixed Dockerfile names are detected** — files such as `Dockerfile-prod` now index as Dockerfile content.
 - **Hyphen-suffixed Containerfile names are detected** — files such as `Containerfile-prod` now index through the Dockerfile analyzer.
+- **Underscore-suffixed Dockerfile names are detected** — files such as `Dockerfile_prod` now index as Dockerfile content.
 
 ## 日本語
 
@@ -28,3 +29,4 @@ affected:
 - **hidden 形式の `.containerfile` を検出するようになりました** — hidden Containerfile 変種も Dockerfile の index 経路を使うようになりました。
 - **ハイフン suffix の Dockerfile 名を検出するようになりました** — `Dockerfile-prod` のようなファイルも Dockerfile content として index されるようになりました。
 - **ハイフン suffix の Containerfile 名を検出するようになりました** — `Containerfile-prod` のようなファイルも Dockerfile analyzer で index されるようになりました。
+- **underscore suffix の Dockerfile 名を検出するようになりました** — `Dockerfile_prod` のようなファイルも Dockerfile content として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -13,8 +13,10 @@ affected:
 
 - **Dockerfile stage aliases can include hyphens** — Dockerfile symbol and stage-reference extraction now indexes common aliases such as `build-env` in `FROM ... AS build-env`, `FROM build-env AS ...`, and `COPY --from=build-env`.
 - **Suffix-style Dockerfile names are detected** — files named like `api.Dockerfile` or `worker.dockerfile` now index as `dockerfile` instead of falling into an unsupported extension bucket.
+- **Suffix-style Containerfile names are detected** — files named like `api.Containerfile` or `worker.containerfile` now index through the Dockerfile analyzer.
 
 ## 日本語
 
 - **Dockerfile の stage alias でハイフンを扱えるようになりました** — Dockerfile の symbol 抽出と stage 参照抽出が、`FROM ... AS build-env`、`FROM build-env AS ...`、`COPY --from=build-env` のような一般的な alias を index するようになりました。
 - **suffix 型の Dockerfile 名を検出するようになりました** — `api.Dockerfile` や `worker.dockerfile` のようなファイルが unsupported extension ではなく `dockerfile` として index されるようになりました。
+- **suffix 型の Containerfile 名を検出するようになりました** — `api.Containerfile` や `worker.containerfile` のようなファイルも Dockerfile analyzer で index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -51,6 +51,7 @@ affected:
 - **Dockerfile `WORKDIR` paths become symbols** — `WORKDIR /app` now indexes `/app` as a property symbol.
 - **Dockerfile shell-form `VOLUME` paths become symbols** — `VOLUME /data` now indexes `/data` as a property symbol.
 - **Dockerfile multi-path `VOLUME` lines expose every path** — `VOLUME /data /cache` now indexes all listed shell-form paths.
+- **Dockerfile `VOLUME` inline comments stay out of symbols** — paths mentioned after `#` are no longer indexed as volumes.
 
 ## 日本語
 
@@ -93,3 +94,4 @@ affected:
 - **Dockerfile `WORKDIR` path を symbol として扱うようになりました** — `WORKDIR /app` が `/app` property symbol として index されるようになりました。
 - **Dockerfile shell form の `VOLUME` path を symbol として扱うようになりました** — `VOLUME /data` が `/data` property symbol として index されるようになりました。
 - **Dockerfile の複数 path `VOLUME` 行ですべての path を出すようになりました** — `VOLUME /data /cache` が列挙された shell form path をすべて index するようになりました。
+- **Dockerfile `VOLUME` の inline comment を symbol 対象から外しました** — `#` より後ろに書かれた path を volume として index しないようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -16,6 +16,7 @@ affected:
 - **Suffix-style Containerfile names are detected** — files named like `api.Containerfile` or `worker.containerfile` now index through the Dockerfile analyzer.
 - **Hidden `.dockerfile` files are detected** — extensionless hidden Dockerfile variants now index as Dockerfile content instead of falling through to shebang probing.
 - **Hidden `.containerfile` files are detected** — hidden Containerfile variants now use the Dockerfile indexing path.
+- **Hyphen-suffixed Dockerfile names are detected** — files such as `Dockerfile-prod` now index as Dockerfile content.
 
 ## 日本語
 
@@ -24,3 +25,4 @@ affected:
 - **suffix 型の Containerfile 名を検出するようになりました** — `api.Containerfile` や `worker.containerfile` のようなファイルも Dockerfile analyzer で index されるようになりました。
 - **hidden 形式の `.dockerfile` を検出するようになりました** — 拡張子を持たない hidden Dockerfile 変種も shebang 判定に落ちず、Dockerfile content として index されるようになりました。
 - **hidden 形式の `.containerfile` を検出するようになりました** — hidden Containerfile 変種も Dockerfile の index 経路を使うようになりました。
+- **ハイフン suffix の Dockerfile 名を検出するようになりました** — `Dockerfile-prod` のようなファイルも Dockerfile content として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -55,6 +55,7 @@ affected:
 - **Dockerfile named-stage base images stay searchable** — `FROM node:20 AS build` now indexes both `build` and the `node:20` image while avoiding prior-stage aliases.
 - **Dockerfile JSON-array `VOLUME` paths become symbols** — `VOLUME ["/data", "/cache"]` now indexes each listed path.
 - **Dockerfile `STOPSIGNAL` values become symbols** — `STOPSIGNAL SIGTERM` now indexes `SIGTERM` as a property symbol.
+- **Dockerfile `SHELL` executables become symbols** — `SHELL ["/bin/bash", ...]` now indexes `/bin/bash` as a property symbol.
 
 ## 日本語
 
@@ -101,3 +102,4 @@ affected:
 - **Dockerfile の名前付きstageでもbase imageを検索できるようになりました** — `FROM node:20 AS build` が `build` と `node:20` image の両方を index しつつ、既存stage aliasはbase image扱いしないようになりました。
 - **Dockerfile JSON array form の `VOLUME` path を symbol として扱うようになりました** — `VOLUME ["/data", "/cache"]` が列挙された各pathを index するようになりました。
 - **Dockerfile `STOPSIGNAL` 値を symbol として扱うようになりました** — `STOPSIGNAL SIGTERM` が `SIGTERM` property symbol として index されるようになりました。
+- **Dockerfile `SHELL` executable を symbol として扱うようになりました** — `SHELL ["/bin/bash", ...]` が `/bin/bash` property symbol として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -1,8 +1,10 @@
 ---
 category: fixed
 affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
   - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
   - src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs
   - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
 ---
@@ -10,7 +12,9 @@ affected:
 ## English
 
 - **Dockerfile stage aliases can include hyphens** — Dockerfile symbol and stage-reference extraction now indexes common aliases such as `build-env` in `FROM ... AS build-env`, `FROM build-env AS ...`, and `COPY --from=build-env`.
+- **Suffix-style Dockerfile names are detected** — files named like `api.Dockerfile` or `worker.dockerfile` now index as `dockerfile` instead of falling into an unsupported extension bucket.
 
 ## 日本語
 
 - **Dockerfile の stage alias でハイフンを扱えるようになりました** — Dockerfile の symbol 抽出と stage 参照抽出が、`FROM ... AS build-env`、`FROM build-env AS ...`、`COPY --from=build-env` のような一般的な alias を index するようになりました。
+- **suffix 型の Dockerfile 名を検出するようになりました** — `api.Dockerfile` や `worker.dockerfile` のようなファイルが unsupported extension ではなく `dockerfile` として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -26,6 +26,7 @@ affected:
 - **Dockerfile braced ARG/ENV uses become references** — `${NODE_VERSION}` now links back to the indexed `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol.
 - **Dockerfile defaulted braced variables become references** — `${NODE_VERSION:-20}` now links back to `NODE_VERSION` instead of being skipped.
 - **Dockerfile unbraced ARG/ENV uses become references** — `$APP_HOME` now links back to the indexed `ARG APP_HOME` / `ENV APP_HOME` property symbol.
+- **Dockerfile colonless defaulted variables become references** — `${NODE_VERSION-20}` now links back to `NODE_VERSION`.
 - **Escaped Dockerfile dollars stay literal** — `\$APP_HOME` no longer creates a false reference to `APP_HOME`.
 - **Escaped Dockerfile braced variables stay literal** — `\${APP_HOME}` no longer creates a false reference to `APP_HOME`.
 - **Dockerfile BuildKit mount stage dependencies are indexed** — `RUN --mount=type=bind,from=assets,...` now links to the `assets` stage.
@@ -55,6 +56,7 @@ affected:
 - **Dockerfile の braced ARG/ENV 利用を参照として扱うようになりました** — `${NODE_VERSION}` が index 済みの `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol に結びつくようになりました。
 - **Dockerfile の default 付き braced variable を参照として扱うようになりました** — `${NODE_VERSION:-20}` が skip されず `NODE_VERSION` に結びつくようになりました。
 - **Dockerfile の unbraced ARG/ENV 利用を参照として扱うようになりました** — `$APP_HOME` が index 済みの `ARG APP_HOME` / `ENV APP_HOME` property symbol に結びつくようになりました。
+- **Dockerfile の colon なし default 付き variable を参照として扱うようになりました** — `${NODE_VERSION-20}` が `NODE_VERSION` に結びつくようになりました。
 - **escape された Dockerfile の dollar を literal として扱うようになりました** — `\$APP_HOME` が `APP_HOME` への誤参照を作らなくなりました。
 - **escape された Dockerfile の braced variable を literal として扱うようになりました** — `\${APP_HOME}` が `APP_HOME` への誤参照を作らなくなりました。
 - **Dockerfile BuildKit mount の stage dependency を index するようになりました** — `RUN --mount=type=bind,from=assets,...` が `assets` stage に結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -46,6 +46,7 @@ affected:
 - **Dockerfile `RUN --mount` stage references are limited to BuildKit options** — later shell command arguments named `--mount` no longer create phantom dependencies.
 - **Quoted Dockerfile `RUN --mount` stage names are indexed** — `RUN --mount=type=bind,from="assets"` now links back to the `assets` stage.
 - **Dockerfile `ONBUILD RUN --mount` stage dependencies are indexed** — trigger instructions now link mount `from=` stages.
+- **Dockerfile `USER` principals become symbols** — `USER appuser` now indexes `appuser` as a property symbol.
 
 ## 日本語
 
@@ -83,3 +84,4 @@ affected:
 - **Dockerfile `RUN --mount` の stage reference を BuildKit option に限定しました** — 後続の shell command argument にある `--mount` から架空の dependency を作らないようになりました。
 - **quote 付き Dockerfile `RUN --mount` の stage 名を index するようになりました** — `RUN --mount=type=bind,from="assets"` が `assets` stage に結びつくようになりました。
 - **Dockerfile `ONBUILD RUN --mount` の stage dependency を index するようになりました** — trigger instruction の mount `from=` stage も結びつくようになりました。
+- **Dockerfile `USER` principal を symbol として扱うようになりました** — `USER appuser` が `appuser` property symbol として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -58,6 +58,7 @@ affected:
 - **Dockerfile `SHELL` executables become symbols** — `SHELL ["/bin/bash", ...]` now indexes `/bin/bash` as a property symbol.
 - **Dockerfile shell-form `COPY` destinations become symbols** — `COPY src /app` now indexes `/app` as the destination path.
 - **Dockerfile shell-form `ADD` destinations become symbols** — `ADD archive.tar.gz /opt/app` now indexes `/opt/app` as the destination path.
+- **Dockerfile JSON-array `COPY` destinations become symbols** — `COPY ["src", "/app"]` now indexes `/app` as the destination path.
 
 ## 日本語
 
@@ -107,3 +108,4 @@ affected:
 - **Dockerfile `SHELL` executable を symbol として扱うようになりました** — `SHELL ["/bin/bash", ...]` が `/bin/bash` property symbol として index されるようになりました。
 - **Dockerfile shell form の `COPY` destination を symbol として扱うようになりました** — `COPY src /app` が destination path の `/app` を index するようになりました。
 - **Dockerfile shell form の `ADD` destination を symbol として扱うようになりました** — `ADD archive.tar.gz /opt/app` が destination path の `/opt/app` を index するようになりました。
+- **Dockerfile JSON array form の `COPY` destination を symbol として扱うようになりました** — `COPY ["src", "/app"]` が destination path の `/app` を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -36,6 +36,7 @@ affected:
 - **Dockerfile `ENV` key scanning ignores quoted values** — `ENV APP_HOME="... BAR=..." NODE_ENV=production` no longer emits a false `BAR` property.
 - **Dockerfile `LABEL` keys become symbols** — labels such as `org.opencontainers.image.title` now index as property symbols.
 - **Dockerfile `LABEL` key-value lists expose every key** — `LABEL org.opencontainers.image.title=... org.opencontainers.image.version=...` now indexes both label keys.
+- **Legacy Dockerfile `LABEL key value` keys become symbols** — space-separated label declarations now expose their label key for search.
 
 ## 日本語
 
@@ -63,3 +64,4 @@ affected:
 - **Dockerfile の `ENV` key scan が quoted value を無視するようになりました** — `ENV APP_HOME="... BAR=..." NODE_ENV=production` が偽の `BAR` property を出さなくなりました。
 - **Dockerfile の `LABEL` key を symbol として扱うようになりました** — `org.opencontainers.image.title` のような label が property symbol として index されるようになりました。
 - **Dockerfile の `LABEL` key-value list ですべての key を出すようになりました** — `LABEL org.opencontainers.image.title=... org.opencontainers.image.version=...` が両方の label key を index するようになりました。
+- **legacy Dockerfile `LABEL key value` の key を symbol として扱うようになりました** — 空白区切りの label 宣言でも検索用に label key を出すようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -19,6 +19,7 @@ affected:
 - **Hyphen-suffixed Dockerfile names are detected** — files such as `Dockerfile-prod` now index as Dockerfile content.
 - **Hyphen-suffixed Containerfile names are detected** — files such as `Containerfile-prod` now index through the Dockerfile analyzer.
 - **Underscore-suffixed Dockerfile names are detected** — files such as `Dockerfile_prod` now index as Dockerfile content.
+- **Underscore-suffixed Containerfile names are detected** — files such as `Containerfile_prod` now index through the Dockerfile analyzer.
 
 ## 日本語
 
@@ -30,3 +31,4 @@ affected:
 - **ハイフン suffix の Dockerfile 名を検出するようになりました** — `Dockerfile-prod` のようなファイルも Dockerfile content として index されるようになりました。
 - **ハイフン suffix の Containerfile 名を検出するようになりました** — `Containerfile-prod` のようなファイルも Dockerfile analyzer で index されるようになりました。
 - **underscore suffix の Dockerfile 名を検出するようになりました** — `Dockerfile_prod` のようなファイルも Dockerfile content として index されるようになりました。
+- **underscore suffix の Containerfile 名を検出するようになりました** — `Containerfile_prod` のようなファイルも Dockerfile analyzer で index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -49,6 +49,7 @@ affected:
 - **Dockerfile `USER` principals become symbols** — `USER appuser` now indexes `appuser` as a property symbol.
 - **Dockerfile `USER user:group` principals stay intact** — group-qualified users now index the full `user:group` value.
 - **Dockerfile `WORKDIR` paths become symbols** — `WORKDIR /app` now indexes `/app` as a property symbol.
+- **Dockerfile shell-form `VOLUME` paths become symbols** — `VOLUME /data` now indexes `/data` as a property symbol.
 
 ## 日本語
 
@@ -89,3 +90,4 @@ affected:
 - **Dockerfile `USER` principal を symbol として扱うようになりました** — `USER appuser` が `appuser` property symbol として index されるようになりました。
 - **Dockerfile `USER user:group` principal を全体で保持するようになりました** — group 付き user が完全な `user:group` 値として index されるようになりました。
 - **Dockerfile `WORKDIR` path を symbol として扱うようになりました** — `WORKDIR /app` が `/app` property symbol として index されるようになりました。
+- **Dockerfile shell form の `VOLUME` path を symbol として扱うようになりました** — `VOLUME /data` が `/data` property symbol として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -43,6 +43,7 @@ affected:
 - **Dockerfile multi-port `EXPOSE` lines expose every port** — `EXPOSE 80 443/tcp 53/udp` now indexes all listed ports.
 - **Quoted Dockerfile `COPY --from` stage names are indexed** — `COPY --from="builder"` now links back to the `builder` stage.
 - **Dockerfile `RUN --mount` text in shell strings stays ignored** — quoted command text no longer creates phantom stage references.
+- **Dockerfile `RUN --mount` stage references are limited to BuildKit options** — later shell command arguments named `--mount` no longer create phantom dependencies.
 
 ## 日本語
 
@@ -77,3 +78,4 @@ affected:
 - **Dockerfile の複数 port `EXPOSE` 行ですべての port を出すようになりました** — `EXPOSE 80 443/tcp 53/udp` が列挙されたすべての port を index するようになりました。
 - **quote 付き Dockerfile `COPY --from` の stage 名を index するようになりました** — `COPY --from="builder"` が `builder` stage に結びつくようになりました。
 - **Dockerfile `RUN --mount` のshell文字列内テキストは無視し続けるようにしました** — quote 付き command text から架空の stage reference を作らないようになりました。
+- **Dockerfile `RUN --mount` の stage reference を BuildKit option に限定しました** — 後続の shell command argument にある `--mount` から架空の dependency を作らないようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -56,6 +56,7 @@ affected:
 - **Dockerfile JSON-array `VOLUME` paths become symbols** — `VOLUME ["/data", "/cache"]` now indexes each listed path.
 - **Dockerfile `STOPSIGNAL` values become symbols** — `STOPSIGNAL SIGTERM` now indexes `SIGTERM` as a property symbol.
 - **Dockerfile `SHELL` executables become symbols** — `SHELL ["/bin/bash", ...]` now indexes `/bin/bash` as a property symbol.
+- **Dockerfile shell-form `COPY` destinations become symbols** — `COPY src /app` now indexes `/app` as the destination path.
 
 ## 日本語
 
@@ -103,3 +104,4 @@ affected:
 - **Dockerfile JSON array form の `VOLUME` path を symbol として扱うようになりました** — `VOLUME ["/data", "/cache"]` が列挙された各pathを index するようになりました。
 - **Dockerfile `STOPSIGNAL` 値を symbol として扱うようになりました** — `STOPSIGNAL SIGTERM` が `SIGTERM` property symbol として index されるようになりました。
 - **Dockerfile `SHELL` executable を symbol として扱うようになりました** — `SHELL ["/bin/bash", ...]` が `/bin/bash` property symbol として index されるようになりました。
+- **Dockerfile shell form の `COPY` destination を symbol として扱うようになりました** — `COPY src /app` が destination path の `/app` を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -53,6 +53,7 @@ affected:
 - **Dockerfile multi-path `VOLUME` lines expose every path** — `VOLUME /data /cache` now indexes all listed shell-form paths.
 - **Dockerfile `VOLUME` inline comments stay out of symbols** — paths mentioned after `#` are no longer indexed as volumes.
 - **Dockerfile named-stage base images stay searchable** — `FROM node:20 AS build` now indexes both `build` and the `node:20` image while avoiding prior-stage aliases.
+- **Dockerfile JSON-array `VOLUME` paths become symbols** — `VOLUME ["/data", "/cache"]` now indexes each listed path.
 
 ## 日本語
 
@@ -97,3 +98,4 @@ affected:
 - **Dockerfile の複数 path `VOLUME` 行ですべての path を出すようになりました** — `VOLUME /data /cache` が列挙された shell form path をすべて index するようになりました。
 - **Dockerfile `VOLUME` の inline comment を symbol 対象から外しました** — `#` より後ろに書かれた path を volume として index しないようになりました。
 - **Dockerfile の名前付きstageでもbase imageを検索できるようになりました** — `FROM node:20 AS build` が `build` と `node:20` image の両方を index しつつ、既存stage aliasはbase image扱いしないようになりました。
+- **Dockerfile JSON array form の `VOLUME` path を symbol として扱うようになりました** — `VOLUME ["/data", "/cache"]` が列挙された各pathを index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -30,6 +30,7 @@ affected:
 - **Escaped Dockerfile braced variables stay literal** — `\${APP_HOME}` no longer creates a false reference to `APP_HOME`.
 - **Dockerfile BuildKit mount stage dependencies are indexed** — `RUN --mount=type=bind,from=assets,...` now links to the `assets` stage.
 - **Tagged external `COPY --from` images are not mistaken for stages** — `COPY --from=builder:latest` no longer creates a false stage reference to `builder`.
+- **Multiple Dockerfile BuildKit mounts are indexed** — a single `RUN` with several `--mount=...,from=stage` flags now records each stage dependency.
 
 ## 日本語
 
@@ -51,3 +52,4 @@ affected:
 - **escape された Dockerfile の braced variable を literal として扱うようになりました** — `\${APP_HOME}` が `APP_HOME` への誤参照を作らなくなりました。
 - **Dockerfile BuildKit mount の stage dependency を index するようになりました** — `RUN --mount=type=bind,from=assets,...` が `assets` stage に結びつくようになりました。
 - **tag 付き外部 image の `COPY --from` を stage と誤認しなくなりました** — `COPY --from=builder:latest` が `builder` への偽 stage 参照を作らなくなりました。
+- **Dockerfile BuildKit mount が複数ある場合も index するようになりました** — 1 つの `RUN` に複数の `--mount=...,from=stage` がある場合、それぞれの stage dependency を記録します。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -28,6 +28,7 @@ affected:
 - **Dockerfile unbraced ARG/ENV uses become references** — `$APP_HOME` now links back to the indexed `ARG APP_HOME` / `ENV APP_HOME` property symbol.
 - **Escaped Dockerfile dollars stay literal** — `\$APP_HOME` no longer creates a false reference to `APP_HOME`.
 - **Escaped Dockerfile braced variables stay literal** — `\${APP_HOME}` no longer creates a false reference to `APP_HOME`.
+- **Dockerfile BuildKit mount stage dependencies are indexed** — `RUN --mount=type=bind,from=assets,...` now links to the `assets` stage.
 
 ## 日本語
 
@@ -47,3 +48,4 @@ affected:
 - **Dockerfile の unbraced ARG/ENV 利用を参照として扱うようになりました** — `$APP_HOME` が index 済みの `ARG APP_HOME` / `ENV APP_HOME` property symbol に結びつくようになりました。
 - **escape された Dockerfile の dollar を literal として扱うようになりました** — `\$APP_HOME` が `APP_HOME` への誤参照を作らなくなりました。
 - **escape された Dockerfile の braced variable を literal として扱うようになりました** — `\${APP_HOME}` が `APP_HOME` への誤参照を作らなくなりました。
+- **Dockerfile BuildKit mount の stage dependency を index するようになりました** — `RUN --mount=type=bind,from=assets,...` が `assets` stage に結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -25,6 +25,7 @@ affected:
 - **Commented `FROM` stage reuse lines keep references** — `FROM builder AS runtime # comment` now indexes the `builder` stage dependency.
 - **Dockerfile braced ARG/ENV uses become references** — `${NODE_VERSION}` now links back to the indexed `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol.
 - **Dockerfile defaulted braced variables become references** — `${NODE_VERSION:-20}` now links back to `NODE_VERSION` instead of being skipped.
+- **Dockerfile unbraced ARG/ENV uses become references** — `$APP_HOME` now links back to the indexed `ARG APP_HOME` / `ENV APP_HOME` property symbol.
 
 ## 日本語
 
@@ -41,3 +42,4 @@ affected:
 - **コメント付きの `FROM` stage 再利用行でも参照を保持するようになりました** — `FROM builder AS runtime # comment` が `builder` stage dependency として index されるようになりました。
 - **Dockerfile の braced ARG/ENV 利用を参照として扱うようになりました** — `${NODE_VERSION}` が index 済みの `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol に結びつくようになりました。
 - **Dockerfile の default 付き braced variable を参照として扱うようになりました** — `${NODE_VERSION:-20}` が skip されず `NODE_VERSION` に結びつくようになりました。
+- **Dockerfile の unbraced ARG/ENV 利用を参照として扱うようになりました** — `$APP_HOME` が index 済みの `ARG APP_HOME` / `ENV APP_HOME` property symbol に結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -17,6 +17,7 @@ affected:
 - **Hidden `.dockerfile` files are detected** — extensionless hidden Dockerfile variants now index as Dockerfile content instead of falling through to shebang probing.
 - **Hidden `.containerfile` files are detected** — hidden Containerfile variants now use the Dockerfile indexing path.
 - **Hyphen-suffixed Dockerfile names are detected** — files such as `Dockerfile-prod` now index as Dockerfile content.
+- **Hyphen-suffixed Containerfile names are detected** — files such as `Containerfile-prod` now index through the Dockerfile analyzer.
 
 ## 日本語
 
@@ -26,3 +27,4 @@ affected:
 - **hidden 形式の `.dockerfile` を検出するようになりました** — 拡張子を持たない hidden Dockerfile 変種も shebang 判定に落ちず、Dockerfile content として index されるようになりました。
 - **hidden 形式の `.containerfile` を検出するようになりました** — hidden Containerfile 変種も Dockerfile の index 経路を使うようになりました。
 - **ハイフン suffix の Dockerfile 名を検出するようになりました** — `Dockerfile-prod` のようなファイルも Dockerfile content として index されるようになりました。
+- **ハイフン suffix の Containerfile 名を検出するようになりました** — `Containerfile-prod` のようなファイルも Dockerfile analyzer で index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -3,6 +3,7 @@ category: fixed
 affected:
   - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
   - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
   - src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
   - tests/CodeIndex.Tests/FileIndexerTests.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -22,6 +23,7 @@ affected:
 - **Underscore-suffixed Containerfile names are detected** — files such as `Containerfile_prod` now index through the Dockerfile analyzer.
 - **Dockerfile stage aliases can include dots** — aliases such as `build.env` now stay intact in stage symbols and `FROM` / `COPY --from` references.
 - **Commented `FROM` stage reuse lines keep references** — `FROM builder AS runtime # comment` now indexes the `builder` stage dependency.
+- **Dockerfile braced ARG/ENV uses become references** — `${NODE_VERSION}` now links back to the indexed `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol.
 
 ## 日本語
 
@@ -36,3 +38,4 @@ affected:
 - **underscore suffix の Containerfile 名を検出するようになりました** — `Containerfile_prod` のようなファイルも Dockerfile analyzer で index されるようになりました。
 - **Dockerfile の stage alias で dot を扱えるようになりました** — `build.env` のような alias が stage symbol と `FROM` / `COPY --from` 参照で欠けずに保持されるようになりました。
 - **コメント付きの `FROM` stage 再利用行でも参照を保持するようになりました** — `FROM builder AS runtime # comment` が `builder` stage dependency として index されるようになりました。
+- **Dockerfile の braced ARG/ENV 利用を参照として扱うようになりました** — `${NODE_VERSION}` が index 済みの `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol に結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -47,6 +47,7 @@ affected:
 - **Quoted Dockerfile `RUN --mount` stage names are indexed** — `RUN --mount=type=bind,from="assets"` now links back to the `assets` stage.
 - **Dockerfile `ONBUILD RUN --mount` stage dependencies are indexed** — trigger instructions now link mount `from=` stages.
 - **Dockerfile `USER` principals become symbols** — `USER appuser` now indexes `appuser` as a property symbol.
+- **Dockerfile `USER user:group` principals stay intact** — group-qualified users now index the full `user:group` value.
 
 ## 日本語
 
@@ -85,3 +86,4 @@ affected:
 - **quote 付き Dockerfile `RUN --mount` の stage 名を index するようになりました** — `RUN --mount=type=bind,from="assets"` が `assets` stage に結びつくようになりました。
 - **Dockerfile `ONBUILD RUN --mount` の stage dependency を index するようになりました** — trigger instruction の mount `from=` stage も結びつくようになりました。
 - **Dockerfile `USER` principal を symbol として扱うようになりました** — `USER appuser` が `appuser` property symbol として index されるようになりました。
+- **Dockerfile `USER user:group` principal を全体で保持するようになりました** — group 付き user が完全な `user:group` 値として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -45,6 +45,7 @@ affected:
 - **Dockerfile `RUN --mount` text in shell strings stays ignored** — quoted command text no longer creates phantom stage references.
 - **Dockerfile `RUN --mount` stage references are limited to BuildKit options** — later shell command arguments named `--mount` no longer create phantom dependencies.
 - **Quoted Dockerfile `RUN --mount` stage names are indexed** — `RUN --mount=type=bind,from="assets"` now links back to the `assets` stage.
+- **Dockerfile `ONBUILD RUN --mount` stage dependencies are indexed** — trigger instructions now link mount `from=` stages.
 
 ## 日本語
 
@@ -81,3 +82,4 @@ affected:
 - **Dockerfile `RUN --mount` のshell文字列内テキストは無視し続けるようにしました** — quote 付き command text から架空の stage reference を作らないようになりました。
 - **Dockerfile `RUN --mount` の stage reference を BuildKit option に限定しました** — 後続の shell command argument にある `--mount` から架空の dependency を作らないようになりました。
 - **quote 付き Dockerfile `RUN --mount` の stage 名を index するようになりました** — `RUN --mount=type=bind,from="assets"` が `assets` stage に結びつくようになりました。
+- **Dockerfile `ONBUILD RUN --mount` の stage dependency を index するようになりました** — trigger instruction の mount `from=` stage も結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -41,6 +41,7 @@ affected:
 - **Dockerfile `ONBUILD COPY --from` stage dependencies are indexed** — trigger instructions now link back to the referenced stage.
 - **Dockerfile `EXPOSE` ports become symbols** — `EXPOSE 8080/tcp` now indexes `8080/tcp` as a property symbol.
 - **Dockerfile multi-port `EXPOSE` lines expose every port** — `EXPOSE 80 443/tcp 53/udp` now indexes all listed ports.
+- **Quoted Dockerfile `COPY --from` stage names are indexed** — `COPY --from="builder"` now links back to the `builder` stage.
 
 ## 日本語
 
@@ -73,3 +74,4 @@ affected:
 - **Dockerfile `ONBUILD COPY --from` の stage dependency を index するようになりました** — trigger instruction も参照先 stage に結びつくようになりました。
 - **Dockerfile の `EXPOSE` port を symbol として扱うようになりました** — `EXPOSE 8080/tcp` が `8080/tcp` property symbol として index されるようになりました。
 - **Dockerfile の複数 port `EXPOSE` 行ですべての port を出すようになりました** — `EXPOSE 80 443/tcp 53/udp` が列挙されたすべての port を index するようになりました。
+- **quote 付き Dockerfile `COPY --from` の stage 名を index するようになりました** — `COPY --from="builder"` が `builder` stage に結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -40,6 +40,7 @@ affected:
 - **Legacy Dockerfile `LABEL key value` keys become symbols** — space-separated label declarations now expose their label key for search.
 - **Dockerfile `ONBUILD COPY --from` stage dependencies are indexed** — trigger instructions now link back to the referenced stage.
 - **Dockerfile `EXPOSE` ports become symbols** — `EXPOSE 8080/tcp` now indexes `8080/tcp` as a property symbol.
+- **Dockerfile multi-port `EXPOSE` lines expose every port** — `EXPOSE 80 443/tcp 53/udp` now indexes all listed ports.
 
 ## 日本語
 
@@ -71,3 +72,4 @@ affected:
 - **legacy Dockerfile `LABEL key value` の key を symbol として扱うようになりました** — 空白区切りの label 宣言でも検索用に label key を出すようになりました。
 - **Dockerfile `ONBUILD COPY --from` の stage dependency を index するようになりました** — trigger instruction も参照先 stage に結びつくようになりました。
 - **Dockerfile の `EXPOSE` port を symbol として扱うようになりました** — `EXPOSE 8080/tcp` が `8080/tcp` property symbol として index されるようになりました。
+- **Dockerfile の複数 port `EXPOSE` 行ですべての port を出すようになりました** — `EXPOSE 80 443/tcp 53/udp` が列挙されたすべての port を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -15,6 +15,7 @@ affected:
 - **Suffix-style Dockerfile names are detected** — files named like `api.Dockerfile` or `worker.dockerfile` now index as `dockerfile` instead of falling into an unsupported extension bucket.
 - **Suffix-style Containerfile names are detected** — files named like `api.Containerfile` or `worker.containerfile` now index through the Dockerfile analyzer.
 - **Hidden `.dockerfile` files are detected** — extensionless hidden Dockerfile variants now index as Dockerfile content instead of falling through to shebang probing.
+- **Hidden `.containerfile` files are detected** — hidden Containerfile variants now use the Dockerfile indexing path.
 
 ## 日本語
 
@@ -22,3 +23,4 @@ affected:
 - **suffix 型の Dockerfile 名を検出するようになりました** — `api.Dockerfile` や `worker.dockerfile` のようなファイルが unsupported extension ではなく `dockerfile` として index されるようになりました。
 - **suffix 型の Containerfile 名を検出するようになりました** — `api.Containerfile` や `worker.containerfile` のようなファイルも Dockerfile analyzer で index されるようになりました。
 - **hidden 形式の `.dockerfile` を検出するようになりました** — 拡張子を持たない hidden Dockerfile 変種も shebang 判定に落ちず、Dockerfile content として index されるようになりました。
+- **hidden 形式の `.containerfile` を検出するようになりました** — hidden Containerfile 変種も Dockerfile の index 経路を使うようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -26,6 +26,7 @@ affected:
 - **Dockerfile braced ARG/ENV uses become references** — `${NODE_VERSION}` now links back to the indexed `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol.
 - **Dockerfile defaulted braced variables become references** — `${NODE_VERSION:-20}` now links back to `NODE_VERSION` instead of being skipped.
 - **Dockerfile unbraced ARG/ENV uses become references** — `$APP_HOME` now links back to the indexed `ARG APP_HOME` / `ENV APP_HOME` property symbol.
+- **Escaped Dockerfile dollars stay literal** — `\$APP_HOME` no longer creates a false reference to `APP_HOME`.
 
 ## 日本語
 
@@ -43,3 +44,4 @@ affected:
 - **Dockerfile の braced ARG/ENV 利用を参照として扱うようになりました** — `${NODE_VERSION}` が index 済みの `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol に結びつくようになりました。
 - **Dockerfile の default 付き braced variable を参照として扱うようになりました** — `${NODE_VERSION:-20}` が skip されず `NODE_VERSION` に結びつくようになりました。
 - **Dockerfile の unbraced ARG/ENV 利用を参照として扱うようになりました** — `$APP_HOME` が index 済みの `ARG APP_HOME` / `ENV APP_HOME` property symbol に結びつくようになりました。
+- **escape された Dockerfile の dollar を literal として扱うようになりました** — `\$APP_HOME` が `APP_HOME` への誤参照を作らなくなりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -32,6 +32,7 @@ affected:
 - **Tagged external `COPY --from` images are not mistaken for stages** — `COPY --from=builder:latest` no longer creates a false stage reference to `builder`.
 - **Multiple Dockerfile BuildKit mounts are indexed** — a single `RUN` with several `--mount=...,from=stage` flags now records each stage dependency.
 - **Digest external `COPY --from` images are not mistaken for stages** — `COPY --from=builder@sha256:...` no longer creates a false stage reference to `builder`.
+- **Dockerfile `ENV` key-value lists expose every key** — `ENV APP_HOME=/app NODE_ENV=production` now indexes both `APP_HOME` and `NODE_ENV` property symbols.
 
 ## 日本語
 
@@ -55,3 +56,4 @@ affected:
 - **tag 付き外部 image の `COPY --from` を stage と誤認しなくなりました** — `COPY --from=builder:latest` が `builder` への偽 stage 参照を作らなくなりました。
 - **Dockerfile BuildKit mount が複数ある場合も index するようになりました** — 1 つの `RUN` に複数の `--mount=...,from=stage` がある場合、それぞれの stage dependency を記録します。
 - **digest 付き外部 image の `COPY --from` を stage と誤認しなくなりました** — `COPY --from=builder@sha256:...` が `builder` への偽 stage 参照を作らなくなりました。
+- **Dockerfile の `ENV` key-value list ですべての key を出すようになりました** — `ENV APP_HOME=/app NODE_ENV=production` が `APP_HOME` と `NODE_ENV` の両方を property symbol として index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -34,6 +34,7 @@ affected:
 - **Digest external `COPY --from` images are not mistaken for stages** — `COPY --from=builder@sha256:...` no longer creates a false stage reference to `builder`.
 - **Dockerfile `ENV` key-value lists expose every key** — `ENV APP_HOME=/app NODE_ENV=production` now indexes both `APP_HOME` and `NODE_ENV` property symbols.
 - **Dockerfile `ENV` key scanning ignores quoted values** — `ENV APP_HOME="... BAR=..." NODE_ENV=production` no longer emits a false `BAR` property.
+- **Dockerfile `LABEL` keys become symbols** — labels such as `org.opencontainers.image.title` now index as property symbols.
 
 ## 日本語
 
@@ -59,3 +60,4 @@ affected:
 - **digest 付き外部 image の `COPY --from` を stage と誤認しなくなりました** — `COPY --from=builder@sha256:...` が `builder` への偽 stage 参照を作らなくなりました。
 - **Dockerfile の `ENV` key-value list ですべての key を出すようになりました** — `ENV APP_HOME=/app NODE_ENV=production` が `APP_HOME` と `NODE_ENV` の両方を property symbol として index するようになりました。
 - **Dockerfile の `ENV` key scan が quoted value を無視するようになりました** — `ENV APP_HOME="... BAR=..." NODE_ENV=production` が偽の `BAR` property を出さなくなりました。
+- **Dockerfile の `LABEL` key を symbol として扱うようになりました** — `org.opencontainers.image.title` のような label が property symbol として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -54,6 +54,7 @@ affected:
 - **Dockerfile `VOLUME` inline comments stay out of symbols** — paths mentioned after `#` are no longer indexed as volumes.
 - **Dockerfile named-stage base images stay searchable** — `FROM node:20 AS build` now indexes both `build` and the `node:20` image while avoiding prior-stage aliases.
 - **Dockerfile JSON-array `VOLUME` paths become symbols** — `VOLUME ["/data", "/cache"]` now indexes each listed path.
+- **Dockerfile `STOPSIGNAL` values become symbols** — `STOPSIGNAL SIGTERM` now indexes `SIGTERM` as a property symbol.
 
 ## 日本語
 
@@ -99,3 +100,4 @@ affected:
 - **Dockerfile `VOLUME` の inline comment を symbol 対象から外しました** — `#` より後ろに書かれた path を volume として index しないようになりました。
 - **Dockerfile の名前付きstageでもbase imageを検索できるようになりました** — `FROM node:20 AS build` が `build` と `node:20` image の両方を index しつつ、既存stage aliasはbase image扱いしないようになりました。
 - **Dockerfile JSON array form の `VOLUME` path を symbol として扱うようになりました** — `VOLUME ["/data", "/cache"]` が列挙された各pathを index するようになりました。
+- **Dockerfile `STOPSIGNAL` 値を symbol として扱うようになりました** — `STOPSIGNAL SIGTERM` が `SIGTERM` property symbol として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -27,6 +27,7 @@ affected:
 - **Dockerfile defaulted braced variables become references** — `${NODE_VERSION:-20}` now links back to `NODE_VERSION` instead of being skipped.
 - **Dockerfile unbraced ARG/ENV uses become references** — `$APP_HOME` now links back to the indexed `ARG APP_HOME` / `ENV APP_HOME` property symbol.
 - **Escaped Dockerfile dollars stay literal** — `\$APP_HOME` no longer creates a false reference to `APP_HOME`.
+- **Escaped Dockerfile braced variables stay literal** — `\${APP_HOME}` no longer creates a false reference to `APP_HOME`.
 
 ## 日本語
 
@@ -45,3 +46,4 @@ affected:
 - **Dockerfile の default 付き braced variable を参照として扱うようになりました** — `${NODE_VERSION:-20}` が skip されず `NODE_VERSION` に結びつくようになりました。
 - **Dockerfile の unbraced ARG/ENV 利用を参照として扱うようになりました** — `$APP_HOME` が index 済みの `ARG APP_HOME` / `ENV APP_HOME` property symbol に結びつくようになりました。
 - **escape された Dockerfile の dollar を literal として扱うようになりました** — `\$APP_HOME` が `APP_HOME` への誤参照を作らなくなりました。
+- **escape された Dockerfile の braced variable を literal として扱うようになりました** — `\${APP_HOME}` が `APP_HOME` への誤参照を作らなくなりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Dockerfile stage aliases can include hyphens** — Dockerfile symbol and stage-reference extraction now indexes common aliases such as `build-env` in `FROM ... AS build-env`, `FROM build-env AS ...`, and `COPY --from=build-env`.
+
+## 日本語
+
+- **Dockerfile の stage alias でハイフンを扱えるようになりました** — Dockerfile の symbol 抽出と stage 参照抽出が、`FROM ... AS build-env`、`FROM build-env AS ...`、`COPY --from=build-env` のような一般的な alias を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -35,6 +35,7 @@ affected:
 - **Dockerfile `ENV` key-value lists expose every key** — `ENV APP_HOME=/app NODE_ENV=production` now indexes both `APP_HOME` and `NODE_ENV` property symbols.
 - **Dockerfile `ENV` key scanning ignores quoted values** — `ENV APP_HOME="... BAR=..." NODE_ENV=production` no longer emits a false `BAR` property.
 - **Dockerfile `LABEL` keys become symbols** — labels such as `org.opencontainers.image.title` now index as property symbols.
+- **Dockerfile `LABEL` key-value lists expose every key** — `LABEL org.opencontainers.image.title=... org.opencontainers.image.version=...` now indexes both label keys.
 
 ## 日本語
 
@@ -61,3 +62,4 @@ affected:
 - **Dockerfile の `ENV` key-value list ですべての key を出すようになりました** — `ENV APP_HOME=/app NODE_ENV=production` が `APP_HOME` と `NODE_ENV` の両方を property symbol として index するようになりました。
 - **Dockerfile の `ENV` key scan が quoted value を無視するようになりました** — `ENV APP_HOME="... BAR=..." NODE_ENV=production` が偽の `BAR` property を出さなくなりました。
 - **Dockerfile の `LABEL` key を symbol として扱うようになりました** — `org.opencontainers.image.title` のような label が property symbol として index されるようになりました。
+- **Dockerfile の `LABEL` key-value list ですべての key を出すようになりました** — `LABEL org.opencontainers.image.title=... org.opencontainers.image.version=...` が両方の label key を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -31,6 +31,7 @@ affected:
 - **Dockerfile BuildKit mount stage dependencies are indexed** — `RUN --mount=type=bind,from=assets,...` now links to the `assets` stage.
 - **Tagged external `COPY --from` images are not mistaken for stages** — `COPY --from=builder:latest` no longer creates a false stage reference to `builder`.
 - **Multiple Dockerfile BuildKit mounts are indexed** — a single `RUN` with several `--mount=...,from=stage` flags now records each stage dependency.
+- **Digest external `COPY --from` images are not mistaken for stages** — `COPY --from=builder@sha256:...` no longer creates a false stage reference to `builder`.
 
 ## 日本語
 
@@ -53,3 +54,4 @@ affected:
 - **Dockerfile BuildKit mount の stage dependency を index するようになりました** — `RUN --mount=type=bind,from=assets,...` が `assets` stage に結びつくようになりました。
 - **tag 付き外部 image の `COPY --from` を stage と誤認しなくなりました** — `COPY --from=builder:latest` が `builder` への偽 stage 参照を作らなくなりました。
 - **Dockerfile BuildKit mount が複数ある場合も index するようになりました** — 1 つの `RUN` に複数の `--mount=...,from=stage` がある場合、それぞれの stage dependency を記録します。
+- **digest 付き外部 image の `COPY --from` を stage と誤認しなくなりました** — `COPY --from=builder@sha256:...` が `builder` への偽 stage 参照を作らなくなりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -50,6 +50,7 @@ affected:
 - **Dockerfile `USER user:group` principals stay intact** — group-qualified users now index the full `user:group` value.
 - **Dockerfile `WORKDIR` paths become symbols** — `WORKDIR /app` now indexes `/app` as a property symbol.
 - **Dockerfile shell-form `VOLUME` paths become symbols** — `VOLUME /data` now indexes `/data` as a property symbol.
+- **Dockerfile multi-path `VOLUME` lines expose every path** — `VOLUME /data /cache` now indexes all listed shell-form paths.
 
 ## 日本語
 
@@ -91,3 +92,4 @@ affected:
 - **Dockerfile `USER user:group` principal を全体で保持するようになりました** — group 付き user が完全な `user:group` 値として index されるようになりました。
 - **Dockerfile `WORKDIR` path を symbol として扱うようになりました** — `WORKDIR /app` が `/app` property symbol として index されるようになりました。
 - **Dockerfile shell form の `VOLUME` path を symbol として扱うようになりました** — `VOLUME /data` が `/data` property symbol として index されるようになりました。
+- **Dockerfile の複数 path `VOLUME` 行ですべての path を出すようになりました** — `VOLUME /data /cache` が列挙された shell form path をすべて index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -61,6 +61,7 @@ affected:
 - **Dockerfile JSON-array `COPY` destinations become symbols** — `COPY ["src", "/app"]` now indexes `/app` as the destination path.
 - **Dockerfile JSON-array `ADD` destinations become symbols** — `ADD ["src", "/opt/app"]` now indexes `/opt/app` as the destination path.
 - **Dockerfile `ONBUILD COPY` destinations become symbols** — trigger-time copies now index their destination paths.
+- **Dockerfile `ONBUILD ADD` destinations become symbols** — trigger-time adds now index their destination paths.
 
 ## 日本語
 
@@ -113,3 +114,4 @@ affected:
 - **Dockerfile JSON array form の `COPY` destination を symbol として扱うようになりました** — `COPY ["src", "/app"]` が destination path の `/app` を index するようになりました。
 - **Dockerfile JSON array form の `ADD` destination を symbol として扱うようになりました** — `ADD ["src", "/opt/app"]` が destination path の `/opt/app` を index するようになりました。
 - **Dockerfile `ONBUILD COPY` destination を symbol として扱うようになりました** — trigger-time copy の destination path を index するようになりました。
+- **Dockerfile `ONBUILD ADD` destination を symbol として扱うようになりました** — trigger-time add の destination path を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -60,6 +60,7 @@ affected:
 - **Dockerfile shell-form `ADD` destinations become symbols** — `ADD archive.tar.gz /opt/app` now indexes `/opt/app` as the destination path.
 - **Dockerfile JSON-array `COPY` destinations become symbols** — `COPY ["src", "/app"]` now indexes `/app` as the destination path.
 - **Dockerfile JSON-array `ADD` destinations become symbols** — `ADD ["src", "/opt/app"]` now indexes `/opt/app` as the destination path.
+- **Dockerfile `ONBUILD COPY` destinations become symbols** — trigger-time copies now index their destination paths.
 
 ## 日本語
 
@@ -111,3 +112,4 @@ affected:
 - **Dockerfile shell form の `ADD` destination を symbol として扱うようになりました** — `ADD archive.tar.gz /opt/app` が destination path の `/opt/app` を index するようになりました。
 - **Dockerfile JSON array form の `COPY` destination を symbol として扱うようになりました** — `COPY ["src", "/app"]` が destination path の `/app` を index するようになりました。
 - **Dockerfile JSON array form の `ADD` destination を symbol として扱うようになりました** — `ADD ["src", "/opt/app"]` が destination path の `/opt/app` を index するようになりました。
+- **Dockerfile `ONBUILD COPY` destination を symbol として扱うようになりました** — trigger-time copy の destination path を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -14,9 +14,11 @@ affected:
 - **Dockerfile stage aliases can include hyphens** — Dockerfile symbol and stage-reference extraction now indexes common aliases such as `build-env` in `FROM ... AS build-env`, `FROM build-env AS ...`, and `COPY --from=build-env`.
 - **Suffix-style Dockerfile names are detected** — files named like `api.Dockerfile` or `worker.dockerfile` now index as `dockerfile` instead of falling into an unsupported extension bucket.
 - **Suffix-style Containerfile names are detected** — files named like `api.Containerfile` or `worker.containerfile` now index through the Dockerfile analyzer.
+- **Hidden `.dockerfile` files are detected** — extensionless hidden Dockerfile variants now index as Dockerfile content instead of falling through to shebang probing.
 
 ## 日本語
 
 - **Dockerfile の stage alias でハイフンを扱えるようになりました** — Dockerfile の symbol 抽出と stage 参照抽出が、`FROM ... AS build-env`、`FROM build-env AS ...`、`COPY --from=build-env` のような一般的な alias を index するようになりました。
 - **suffix 型の Dockerfile 名を検出するようになりました** — `api.Dockerfile` や `worker.dockerfile` のようなファイルが unsupported extension ではなく `dockerfile` として index されるようになりました。
 - **suffix 型の Containerfile 名を検出するようになりました** — `api.Containerfile` や `worker.containerfile` のようなファイルも Dockerfile analyzer で index されるようになりました。
+- **hidden 形式の `.dockerfile` を検出するようになりました** — 拡張子を持たない hidden Dockerfile 変種も shebang 判定に落ちず、Dockerfile content として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -57,6 +57,7 @@ affected:
 - **Dockerfile `STOPSIGNAL` values become symbols** — `STOPSIGNAL SIGTERM` now indexes `SIGTERM` as a property symbol.
 - **Dockerfile `SHELL` executables become symbols** — `SHELL ["/bin/bash", ...]` now indexes `/bin/bash` as a property symbol.
 - **Dockerfile shell-form `COPY` destinations become symbols** — `COPY src /app` now indexes `/app` as the destination path.
+- **Dockerfile shell-form `ADD` destinations become symbols** — `ADD archive.tar.gz /opt/app` now indexes `/opt/app` as the destination path.
 
 ## 日本語
 
@@ -105,3 +106,4 @@ affected:
 - **Dockerfile `STOPSIGNAL` 値を symbol として扱うようになりました** — `STOPSIGNAL SIGTERM` が `SIGTERM` property symbol として index されるようになりました。
 - **Dockerfile `SHELL` executable を symbol として扱うようになりました** — `SHELL ["/bin/bash", ...]` が `/bin/bash` property symbol として index されるようになりました。
 - **Dockerfile shell form の `COPY` destination を symbol として扱うようになりました** — `COPY src /app` が destination path の `/app` を index するようになりました。
+- **Dockerfile shell form の `ADD` destination を symbol として扱うようになりました** — `ADD archive.tar.gz /opt/app` が destination path の `/opt/app` を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -29,6 +29,7 @@ affected:
 - **Escaped Dockerfile dollars stay literal** — `\$APP_HOME` no longer creates a false reference to `APP_HOME`.
 - **Escaped Dockerfile braced variables stay literal** — `\${APP_HOME}` no longer creates a false reference to `APP_HOME`.
 - **Dockerfile BuildKit mount stage dependencies are indexed** — `RUN --mount=type=bind,from=assets,...` now links to the `assets` stage.
+- **Tagged external `COPY --from` images are not mistaken for stages** — `COPY --from=builder:latest` no longer creates a false stage reference to `builder`.
 
 ## 日本語
 
@@ -49,3 +50,4 @@ affected:
 - **escape された Dockerfile の dollar を literal として扱うようになりました** — `\$APP_HOME` が `APP_HOME` への誤参照を作らなくなりました。
 - **escape された Dockerfile の braced variable を literal として扱うようになりました** — `\${APP_HOME}` が `APP_HOME` への誤参照を作らなくなりました。
 - **Dockerfile BuildKit mount の stage dependency を index するようになりました** — `RUN --mount=type=bind,from=assets,...` が `assets` stage に結びつくようになりました。
+- **tag 付き外部 image の `COPY --from` を stage と誤認しなくなりました** — `COPY --from=builder:latest` が `builder` への偽 stage 参照を作らなくなりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -42,6 +42,7 @@ affected:
 - **Dockerfile `EXPOSE` ports become symbols** — `EXPOSE 8080/tcp` now indexes `8080/tcp` as a property symbol.
 - **Dockerfile multi-port `EXPOSE` lines expose every port** — `EXPOSE 80 443/tcp 53/udp` now indexes all listed ports.
 - **Quoted Dockerfile `COPY --from` stage names are indexed** — `COPY --from="builder"` now links back to the `builder` stage.
+- **Dockerfile `RUN --mount` text in shell strings stays ignored** — quoted command text no longer creates phantom stage references.
 
 ## 日本語
 
@@ -75,3 +76,4 @@ affected:
 - **Dockerfile の `EXPOSE` port を symbol として扱うようになりました** — `EXPOSE 8080/tcp` が `8080/tcp` property symbol として index されるようになりました。
 - **Dockerfile の複数 port `EXPOSE` 行ですべての port を出すようになりました** — `EXPOSE 80 443/tcp 53/udp` が列挙されたすべての port を index するようになりました。
 - **quote 付き Dockerfile `COPY --from` の stage 名を index するようになりました** — `COPY --from="builder"` が `builder` stage に結びつくようになりました。
+- **Dockerfile `RUN --mount` のshell文字列内テキストは無視し続けるようにしました** — quote 付き command text から架空の stage reference を作らないようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -20,6 +20,7 @@ affected:
 - **Hyphen-suffixed Containerfile names are detected** — files such as `Containerfile-prod` now index through the Dockerfile analyzer.
 - **Underscore-suffixed Dockerfile names are detected** — files such as `Dockerfile_prod` now index as Dockerfile content.
 - **Underscore-suffixed Containerfile names are detected** — files such as `Containerfile_prod` now index through the Dockerfile analyzer.
+- **Dockerfile stage aliases can include dots** — aliases such as `build.env` now stay intact in stage symbols and `FROM` / `COPY --from` references.
 
 ## 日本語
 
@@ -32,3 +33,4 @@ affected:
 - **ハイフン suffix の Containerfile 名を検出するようになりました** — `Containerfile-prod` のようなファイルも Dockerfile analyzer で index されるようになりました。
 - **underscore suffix の Dockerfile 名を検出するようになりました** — `Dockerfile_prod` のようなファイルも Dockerfile content として index されるようになりました。
 - **underscore suffix の Containerfile 名を検出するようになりました** — `Containerfile_prod` のようなファイルも Dockerfile analyzer で index されるようになりました。
+- **Dockerfile の stage alias で dot を扱えるようになりました** — `build.env` のような alias が stage symbol と `FROM` / `COPY --from` 参照で欠けずに保持されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -37,6 +37,7 @@ affected:
 - **Dockerfile `LABEL` keys become symbols** — labels such as `org.opencontainers.image.title` now index as property symbols.
 - **Dockerfile `LABEL` key-value lists expose every key** — `LABEL org.opencontainers.image.title=... org.opencontainers.image.version=...` now indexes both label keys.
 - **Legacy Dockerfile `LABEL key value` keys become symbols** — space-separated label declarations now expose their label key for search.
+- **Dockerfile `ONBUILD COPY --from` stage dependencies are indexed** — trigger instructions now link back to the referenced stage.
 
 ## 日本語
 
@@ -65,3 +66,4 @@ affected:
 - **Dockerfile の `LABEL` key を symbol として扱うようになりました** — `org.opencontainers.image.title` のような label が property symbol として index されるようになりました。
 - **Dockerfile の `LABEL` key-value list ですべての key を出すようになりました** — `LABEL org.opencontainers.image.title=... org.opencontainers.image.version=...` が両方の label key を index するようになりました。
 - **legacy Dockerfile `LABEL key value` の key を symbol として扱うようになりました** — 空白区切りの label 宣言でも検索用に label key を出すようになりました。
+- **Dockerfile `ONBUILD COPY --from` の stage dependency を index するようになりました** — trigger instruction も参照先 stage に結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -48,6 +48,7 @@ affected:
 - **Dockerfile `ONBUILD RUN --mount` stage dependencies are indexed** — trigger instructions now link mount `from=` stages.
 - **Dockerfile `USER` principals become symbols** — `USER appuser` now indexes `appuser` as a property symbol.
 - **Dockerfile `USER user:group` principals stay intact** — group-qualified users now index the full `user:group` value.
+- **Dockerfile `WORKDIR` paths become symbols** — `WORKDIR /app` now indexes `/app` as a property symbol.
 
 ## 日本語
 
@@ -87,3 +88,4 @@ affected:
 - **Dockerfile `ONBUILD RUN --mount` の stage dependency を index するようになりました** — trigger instruction の mount `from=` stage も結びつくようになりました。
 - **Dockerfile `USER` principal を symbol として扱うようになりました** — `USER appuser` が `appuser` property symbol として index されるようになりました。
 - **Dockerfile `USER user:group` principal を全体で保持するようになりました** — group 付き user が完全な `user:group` 値として index されるようになりました。
+- **Dockerfile `WORKDIR` path を symbol として扱うようになりました** — `WORKDIR /app` が `/app` property symbol として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -21,6 +21,7 @@ affected:
 - **Underscore-suffixed Dockerfile names are detected** — files such as `Dockerfile_prod` now index as Dockerfile content.
 - **Underscore-suffixed Containerfile names are detected** — files such as `Containerfile_prod` now index through the Dockerfile analyzer.
 - **Dockerfile stage aliases can include dots** — aliases such as `build.env` now stay intact in stage symbols and `FROM` / `COPY --from` references.
+- **Commented `FROM` stage reuse lines keep references** — `FROM builder AS runtime # comment` now indexes the `builder` stage dependency.
 
 ## 日本語
 
@@ -34,3 +35,4 @@ affected:
 - **underscore suffix の Dockerfile 名を検出するようになりました** — `Dockerfile_prod` のようなファイルも Dockerfile content として index されるようになりました。
 - **underscore suffix の Containerfile 名を検出するようになりました** — `Containerfile_prod` のようなファイルも Dockerfile analyzer で index されるようになりました。
 - **Dockerfile の stage alias で dot を扱えるようになりました** — `build.env` のような alias が stage symbol と `FROM` / `COPY --from` 参照で欠けずに保持されるようになりました。
+- **コメント付きの `FROM` stage 再利用行でも参照を保持するようになりました** — `FROM builder AS runtime # comment` が `builder` stage dependency として index されるようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -59,6 +59,7 @@ affected:
 - **Dockerfile shell-form `COPY` destinations become symbols** — `COPY src /app` now indexes `/app` as the destination path.
 - **Dockerfile shell-form `ADD` destinations become symbols** — `ADD archive.tar.gz /opt/app` now indexes `/opt/app` as the destination path.
 - **Dockerfile JSON-array `COPY` destinations become symbols** — `COPY ["src", "/app"]` now indexes `/app` as the destination path.
+- **Dockerfile JSON-array `ADD` destinations become symbols** — `ADD ["src", "/opt/app"]` now indexes `/opt/app` as the destination path.
 
 ## 日本語
 
@@ -109,3 +110,4 @@ affected:
 - **Dockerfile shell form の `COPY` destination を symbol として扱うようになりました** — `COPY src /app` が destination path の `/app` を index するようになりました。
 - **Dockerfile shell form の `ADD` destination を symbol として扱うようになりました** — `ADD archive.tar.gz /opt/app` が destination path の `/opt/app` を index するようになりました。
 - **Dockerfile JSON array form の `COPY` destination を symbol として扱うようになりました** — `COPY ["src", "/app"]` が destination path の `/app` を index するようになりました。
+- **Dockerfile JSON array form の `ADD` destination を symbol として扱うようになりました** — `ADD ["src", "/opt/app"]` が destination path の `/opt/app` を index するようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -33,6 +33,7 @@ affected:
 - **Multiple Dockerfile BuildKit mounts are indexed** — a single `RUN` with several `--mount=...,from=stage` flags now records each stage dependency.
 - **Digest external `COPY --from` images are not mistaken for stages** — `COPY --from=builder@sha256:...` no longer creates a false stage reference to `builder`.
 - **Dockerfile `ENV` key-value lists expose every key** — `ENV APP_HOME=/app NODE_ENV=production` now indexes both `APP_HOME` and `NODE_ENV` property symbols.
+- **Dockerfile `ENV` key scanning ignores quoted values** — `ENV APP_HOME="... BAR=..." NODE_ENV=production` no longer emits a false `BAR` property.
 
 ## 日本語
 
@@ -57,3 +58,4 @@ affected:
 - **Dockerfile BuildKit mount が複数ある場合も index するようになりました** — 1 つの `RUN` に複数の `--mount=...,from=stage` がある場合、それぞれの stage dependency を記録します。
 - **digest 付き外部 image の `COPY --from` を stage と誤認しなくなりました** — `COPY --from=builder@sha256:...` が `builder` への偽 stage 参照を作らなくなりました。
 - **Dockerfile の `ENV` key-value list ですべての key を出すようになりました** — `ENV APP_HOME=/app NODE_ENV=production` が `APP_HOME` と `NODE_ENV` の両方を property symbol として index するようになりました。
+- **Dockerfile の `ENV` key scan が quoted value を無視するようになりました** — `ENV APP_HOME="... BAR=..." NODE_ENV=production` が偽の `BAR` property を出さなくなりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -24,6 +24,7 @@ affected:
 - **Dockerfile stage aliases can include dots** — aliases such as `build.env` now stay intact in stage symbols and `FROM` / `COPY --from` references.
 - **Commented `FROM` stage reuse lines keep references** — `FROM builder AS runtime # comment` now indexes the `builder` stage dependency.
 - **Dockerfile braced ARG/ENV uses become references** — `${NODE_VERSION}` now links back to the indexed `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol.
+- **Dockerfile defaulted braced variables become references** — `${NODE_VERSION:-20}` now links back to `NODE_VERSION` instead of being skipped.
 
 ## 日本語
 
@@ -39,3 +40,4 @@ affected:
 - **Dockerfile の stage alias で dot を扱えるようになりました** — `build.env` のような alias が stage symbol と `FROM` / `COPY --from` 参照で欠けずに保持されるようになりました。
 - **コメント付きの `FROM` stage 再利用行でも参照を保持するようになりました** — `FROM builder AS runtime # comment` が `builder` stage dependency として index されるようになりました。
 - **Dockerfile の braced ARG/ENV 利用を参照として扱うようになりました** — `${NODE_VERSION}` が index 済みの `ARG NODE_VERSION` / `ENV NODE_VERSION` property symbol に結びつくようになりました。
+- **Dockerfile の default 付き braced variable を参照として扱うようになりました** — `${NODE_VERSION:-20}` が skip されず `NODE_VERSION` に結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -44,6 +44,7 @@ affected:
 - **Quoted Dockerfile `COPY --from` stage names are indexed** — `COPY --from="builder"` now links back to the `builder` stage.
 - **Dockerfile `RUN --mount` text in shell strings stays ignored** — quoted command text no longer creates phantom stage references.
 - **Dockerfile `RUN --mount` stage references are limited to BuildKit options** — later shell command arguments named `--mount` no longer create phantom dependencies.
+- **Quoted Dockerfile `RUN --mount` stage names are indexed** — `RUN --mount=type=bind,from="assets"` now links back to the `assets` stage.
 
 ## 日本語
 
@@ -79,3 +80,4 @@ affected:
 - **quote 付き Dockerfile `COPY --from` の stage 名を index するようになりました** — `COPY --from="builder"` が `builder` stage に結びつくようになりました。
 - **Dockerfile `RUN --mount` のshell文字列内テキストは無視し続けるようにしました** — quote 付き command text から架空の stage reference を作らないようになりました。
 - **Dockerfile `RUN --mount` の stage reference を BuildKit option に限定しました** — 後続の shell command argument にある `--mount` から架空の dependency を作らないようになりました。
+- **quote 付き Dockerfile `RUN --mount` の stage 名を index するようになりました** — `RUN --mount=type=bind,from="assets"` が `assets` stage に結びつくようになりました。

--- a/changelog.d/unreleased/+dockerfile-search.fixed.md
+++ b/changelog.d/unreleased/+dockerfile-search.fixed.md
@@ -39,6 +39,7 @@ affected:
 - **Dockerfile `LABEL` key-value lists expose every key** — `LABEL org.opencontainers.image.title=... org.opencontainers.image.version=...` now indexes both label keys.
 - **Legacy Dockerfile `LABEL key value` keys become symbols** — space-separated label declarations now expose their label key for search.
 - **Dockerfile `ONBUILD COPY --from` stage dependencies are indexed** — trigger instructions now link back to the referenced stage.
+- **Dockerfile `EXPOSE` ports become symbols** — `EXPOSE 8080/tcp` now indexes `8080/tcp` as a property symbol.
 
 ## 日本語
 
@@ -69,3 +70,4 @@ affected:
 - **Dockerfile の `LABEL` key-value list ですべての key を出すようになりました** — `LABEL org.opencontainers.image.title=... org.opencontainers.image.version=...` が両方の label key を index するようになりました。
 - **legacy Dockerfile `LABEL key value` の key を symbol として扱うようになりました** — 空白区切りの label 宣言でも検索用に label key を出すようになりました。
 - **Dockerfile `ONBUILD COPY --from` の stage dependency を index するようになりました** — trigger instruction も参照先 stage に結びつくようになりました。
+- **Dockerfile の `EXPOSE` port を symbol として扱うようになりました** — `EXPOSE 8080/tcp` が `8080/tcp` property symbol として index されるようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -174,6 +174,11 @@ internal static class DockerfileReferenceExtractor
     private static bool TryGetRunOptionsStart(string line, out int index)
     {
         index = SkipWhitespace(line, 0);
+        if (StartsWithKeyword(line, index, "ONBUILD"))
+        {
+            index = SkipWhitespace(line, index + "ONBUILD".Length);
+        }
+
         if (!StartsWith(line, index, "RUN"))
             return false;
 
@@ -234,6 +239,10 @@ internal static class DockerfileReferenceExtractor
         => index >= 0
            && index + value.Length <= text.Length
            && string.Compare(text, index, value, 0, value.Length, StringComparison.OrdinalIgnoreCase) == 0;
+
+    private static bool StartsWithKeyword(string text, int index, string value)
+        => StartsWith(text, index, value)
+           && (index + value.Length >= text.Length || char.IsWhiteSpace(text[index + value.Length]));
 
     public static void EmitVariableReferences(
         string preparedLine,

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -18,7 +18,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex BracedVariableReferenceRegex = new(
-        @"(?<![\$\\])\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)(?::[-+?=][^}]*)?\}",
+        @"(?<![\$\\])\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)(?::?[-+?=][^}]*)?\}",
         RegexOptions.Compiled);
 
     private static readonly Regex UnbracedVariableReferenceRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -17,6 +17,10 @@ internal static class DockerfileReferenceExtractor
         @"\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)(?::[-+?=][^}]*)?\}",
         RegexOptions.Compiled);
 
+    private static readonly Regex UnbracedVariableReferenceRegex = new(
+        @"(?<!\$)\$(?<name>[A-Za-z_][A-Za-z0-9_]*)",
+        RegexOptions.Compiled);
+
     public static HashSet<string>? BuildStageNames(string language, IReadOnlyList<SymbolRecord> symbols)
     {
         if (language != "dockerfile")
@@ -116,6 +120,24 @@ internal static class DockerfileReferenceExtractor
             return;
 
         foreach (Match match in BracedVariableReferenceRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (!variableNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+        }
+
+        foreach (Match match in UnbracedVariableReferenceRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (!variableNames.Contains(name))

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -14,7 +14,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex RunMountFromReferenceRegex = new(
-        @"(?:^|\s)--mount=\S*\bfrom=(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b",
+        @"(?:^|,)from=(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex BracedVariableReferenceRegex = new(
@@ -110,27 +110,130 @@ internal static class DockerfileReferenceExtractor
                 container);
         }
 
-        if (!preparedLine.TrimStart().StartsWith("RUN", StringComparison.OrdinalIgnoreCase))
+        EmitRunMountReferences(
+            originalLine,
+            context,
+            lineNumber,
+            references,
+            seen,
+            fileId,
+            stageNames,
+            container);
+    }
+
+    private static void EmitRunMountReferences(
+        string line,
+        string context,
+        int lineNumber,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        HashSet<string> stageNames,
+        SymbolRecord? container)
+    {
+        if (!TryGetRunOptionsStart(line, out var index))
             return;
 
-        foreach (Match match in RunMountFromReferenceRegex.Matches(preparedLine))
+        while (index < line.Length)
         {
-            var name = match.Groups["name"].Value;
-            if (!stageNames.Contains(name))
-                continue;
+            index = SkipWhitespace(line, index);
+            if (index >= line.Length || !StartsWith(line, index, "--"))
+                return;
 
-            ReferenceExtractor.AddReference(
-                references,
-                seen,
-                fileId,
-                name,
-                match.Groups["name"].Index,
-                "call",
-                context,
-                lineNumber,
-                container);
+            var optionStart = index;
+            var optionEnd = ScanOptionToken(line, optionStart);
+            if (optionEnd <= optionStart)
+                return;
+
+            var option = line.Substring(optionStart, optionEnd - optionStart);
+            if (option.StartsWith("--mount=", StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (Match match in RunMountFromReferenceRegex.Matches(option["--mount=".Length..]))
+                {
+                    var name = match.Groups["name"].Value;
+                    if (!stageNames.Contains(name))
+                        continue;
+
+                    ReferenceExtractor.AddReference(
+                        references,
+                        seen,
+                        fileId,
+                        name,
+                        optionStart + "--mount=".Length + match.Groups["name"].Index,
+                        "call",
+                        context,
+                        lineNumber,
+                        container);
+                }
+            }
+
+            index = optionEnd;
         }
     }
+
+    private static bool TryGetRunOptionsStart(string line, out int index)
+    {
+        index = SkipWhitespace(line, 0);
+        if (!StartsWith(line, index, "RUN"))
+            return false;
+
+        var afterRun = index + "RUN".Length;
+        if (afterRun < line.Length && !char.IsWhiteSpace(line[afterRun]))
+            return false;
+
+        index = afterRun;
+        return true;
+    }
+
+    private static int ScanOptionToken(string line, int index)
+    {
+        var quote = '\0';
+        while (index < line.Length)
+        {
+            var c = line[index];
+            if (quote != '\0')
+            {
+                if (c == '\\' && index + 1 < line.Length)
+                {
+                    index += 2;
+                    continue;
+                }
+
+                if (c == quote)
+                    quote = '\0';
+
+                index++;
+                continue;
+            }
+
+            if (c is '"' or '\'')
+            {
+                quote = c;
+                index++;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(c))
+                break;
+
+            index++;
+        }
+
+        return index;
+    }
+
+    private static int SkipWhitespace(string text, int index)
+    {
+        while (index < text.Length && char.IsWhiteSpace(text[index]))
+            index++;
+
+        return index;
+    }
+
+    private static bool StartsWith(string text, int index, string value)
+        => index >= 0
+           && index + value.Length <= text.Length
+           && string.Compare(text, index, value, 0, value.Length, StringComparison.OrdinalIgnoreCase) == 0;
 
     public static void EmitVariableReferences(
         string preparedLine,

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -14,7 +14,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex BracedVariableReferenceRegex = new(
-        @"\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)(?::[-+?=][^}]*)?\}",
+        @"(?<![\$\\])\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)(?::[-+?=][^}]*)?\}",
         RegexOptions.Compiled);
 
     private static readonly Regex UnbracedVariableReferenceRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -6,11 +6,11 @@ namespace CodeIndex.Indexer;
 internal static class DockerfileReferenceExtractor
 {
     private static readonly Regex StageReferenceRegex = new(
-        @"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\w+)\s+AS\s+\w+\s*$",
+        @"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>[A-Za-z0-9_-]+)\s+AS\s+[A-Za-z0-9_-]+\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex CopyFromReferenceRegex = new(
-        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>\w+)\b",
+        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_-]+)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public static HashSet<string>? BuildStageNames(string language, IReadOnlyList<SymbolRecord> symbols)

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -10,11 +10,11 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex CopyFromReferenceRegex = new(
-        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)\b",
+        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)(?![:/])\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex RunMountFromReferenceRegex = new(
-        @"^\s*RUN\b.*?--mount=\S*\bfrom=(?<name>[A-Za-z0-9_.-]+)\b",
+        @"^\s*RUN\b.*?--mount=\S*\bfrom=(?<name>[A-Za-z0-9_.-]+)(?![:/])\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex BracedVariableReferenceRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -6,7 +6,7 @@ namespace CodeIndex.Indexer;
 internal static class DockerfileReferenceExtractor
 {
     private static readonly Regex StageReferenceRegex = new(
-        @"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>[A-Za-z0-9_.-]+)\s+AS\s+[A-Za-z0-9_.-]+\s*$",
+        @"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>[A-Za-z0-9_.-]+)\s+AS\s+[A-Za-z0-9_.-]+(?:\s+#.*)?\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex CopyFromReferenceRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -113,7 +113,7 @@ internal static class DockerfileReferenceExtractor
         if (!preparedLine.TrimStart().StartsWith("RUN", StringComparison.OrdinalIgnoreCase))
             return;
 
-        foreach (Match match in RunMountFromReferenceRegex.Matches(originalLine))
+        foreach (Match match in RunMountFromReferenceRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (!stageNames.Contains(name))

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -10,11 +10,11 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex CopyFromReferenceRegex = new(
-        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)(?![:/])\b",
+        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex RunMountFromReferenceRegex = new(
-        @"(?:^|\s)--mount=\S*\bfrom=(?<name>[A-Za-z0-9_.-]+)(?![:/])\b",
+        @"(?:^|\s)--mount=\S*\bfrom=(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex BracedVariableReferenceRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -14,7 +14,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex BracedVariableReferenceRegex = new(
-        @"\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)\}",
+        @"\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)(?::[-+?=][^}]*)?\}",
         RegexOptions.Compiled);
 
     public static HashSet<string>? BuildStageNames(string language, IReadOnlyList<SymbolRecord> symbols)

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -6,11 +6,11 @@ namespace CodeIndex.Indexer;
 internal static class DockerfileReferenceExtractor
 {
     private static readonly Regex StageReferenceRegex = new(
-        @"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>[A-Za-z0-9_-]+)\s+AS\s+[A-Za-z0-9_-]+\s*$",
+        @"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>[A-Za-z0-9_.-]+)\s+AS\s+[A-Za-z0-9_.-]+\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex CopyFromReferenceRegex = new(
-        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_-]+)\b",
+        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public static HashSet<string>? BuildStageNames(string language, IReadOnlyList<SymbolRecord> symbols)

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -14,7 +14,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex RunMountFromReferenceRegex = new(
-        @"(?:^|,)from=(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b",
+        @"(?:^|,)from=[""']?(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b[""']?",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex BracedVariableReferenceRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -13,6 +13,10 @@ internal static class DockerfileReferenceExtractor
         @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    private static readonly Regex RunMountFromReferenceRegex = new(
+        @"^\s*RUN\b.*?--mount=\S*\bfrom=(?<name>[A-Za-z0-9_.-]+)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     private static readonly Regex BracedVariableReferenceRegex = new(
         @"(?<![\$\\])\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)(?::[-+?=][^}]*)?\}",
         RegexOptions.Compiled);
@@ -88,6 +92,24 @@ internal static class DockerfileReferenceExtractor
         }
 
         foreach (Match match in CopyFromReferenceRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (!stageNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                "call",
+                context,
+                lineNumber,
+                container);
+        }
+
+        foreach (Match match in RunMountFromReferenceRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
             if (!stageNames.Contains(name))

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -10,7 +10,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex CopyFromReferenceRegex = new(
-        @"^\s*(?:ONBUILD\s+)?(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b",
+        @"^\s*(?:ONBUILD\s+)?(?:COPY|ADD)\b.*?--from=[""']?(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b[""']?",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex RunMountFromReferenceRegex = new(
@@ -61,6 +61,7 @@ internal static class DockerfileReferenceExtractor
 
     public static void EmitStageReferences(
         string preparedLine,
+        string originalLine,
         string context,
         int lineNumber,
         List<ReferenceRecord> references,
@@ -72,7 +73,7 @@ internal static class DockerfileReferenceExtractor
         if (stageNames == null || stageNames.Count == 0)
             return;
 
-        var fromMatch = StageReferenceRegex.Match(preparedLine);
+        var fromMatch = StageReferenceRegex.Match(originalLine);
         if (fromMatch.Success)
         {
             var name = fromMatch.Groups["name"].Value;
@@ -91,7 +92,7 @@ internal static class DockerfileReferenceExtractor
             }
         }
 
-        foreach (Match match in CopyFromReferenceRegex.Matches(preparedLine))
+        foreach (Match match in CopyFromReferenceRegex.Matches(originalLine))
         {
             var name = match.Groups["name"].Value;
             if (!stageNames.Contains(name))
@@ -112,7 +113,7 @@ internal static class DockerfileReferenceExtractor
         if (!preparedLine.TrimStart().StartsWith("RUN", StringComparison.OrdinalIgnoreCase))
             return;
 
-        foreach (Match match in RunMountFromReferenceRegex.Matches(preparedLine))
+        foreach (Match match in RunMountFromReferenceRegex.Matches(originalLine))
         {
             var name = match.Groups["name"].Value;
             if (!stageNames.Contains(name))

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -18,7 +18,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled);
 
     private static readonly Regex UnbracedVariableReferenceRegex = new(
-        @"(?<!\$)\$(?<name>[A-Za-z_][A-Za-z0-9_]*)",
+        @"(?<![\$\\])\$(?<name>[A-Za-z_][A-Za-z0-9_]*)",
         RegexOptions.Compiled);
 
     public static HashSet<string>? BuildStageNames(string language, IReadOnlyList<SymbolRecord> symbols)

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -13,6 +13,10 @@ internal static class DockerfileReferenceExtractor
         @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    private static readonly Regex BracedVariableReferenceRegex = new(
+        @"\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)\}",
+        RegexOptions.Compiled);
+
     public static HashSet<string>? BuildStageNames(string language, IReadOnlyList<SymbolRecord> symbols)
     {
         if (language != "dockerfile")
@@ -22,6 +26,23 @@ internal static class DockerfileReferenceExtractor
         foreach (var symbol in symbols)
         {
             if (symbol.Kind != "function" || string.IsNullOrWhiteSpace(symbol.Name))
+                continue;
+
+            names.Add(symbol.Name);
+        }
+
+        return names;
+    }
+
+    public static HashSet<string>? BuildVariableNames(string language, IReadOnlyList<SymbolRecord> symbols)
+    {
+        if (language != "dockerfile")
+            return null;
+
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Kind != "property" || string.IsNullOrWhiteSpace(symbol.Name))
                 continue;
 
             names.Add(symbol.Name);
@@ -75,6 +96,38 @@ internal static class DockerfileReferenceExtractor
                 name,
                 match.Groups["name"].Index,
                 "call",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    public static void EmitVariableReferences(
+        string preparedLine,
+        string context,
+        int lineNumber,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        HashSet<string>? variableNames,
+        SymbolRecord? container)
+    {
+        if (variableNames == null || variableNames.Count == 0)
+            return;
+
+        foreach (Match match in BracedVariableReferenceRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (!variableNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                "reference",
                 context,
                 lineNumber,
                 container);

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -14,7 +14,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex RunMountFromReferenceRegex = new(
-        @"^\s*RUN\b.*?--mount=\S*\bfrom=(?<name>[A-Za-z0-9_.-]+)(?![:/])\b",
+        @"(?:^|\s)--mount=\S*\bfrom=(?<name>[A-Za-z0-9_.-]+)(?![:/])\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex BracedVariableReferenceRegex = new(
@@ -108,6 +108,9 @@ internal static class DockerfileReferenceExtractor
                 lineNumber,
                 container);
         }
+
+        if (!preparedLine.TrimStart().StartsWith("RUN", StringComparison.OrdinalIgnoreCase))
+            return;
 
         foreach (Match match in RunMountFromReferenceRegex.Matches(preparedLine))
         {

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -10,7 +10,7 @@ internal static class DockerfileReferenceExtractor
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex CopyFromReferenceRegex = new(
-        @"^\s*(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b",
+        @"^\s*(?:ONBUILD\s+)?(?:COPY|ADD)\b.*?--from=(?<name>[A-Za-z0-9_.-]+)(?![:/@])\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex RunMountFromReferenceRegex = new(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1029,6 +1029,7 @@ public static partial class ReferenceExtractor
         var kotlinConstructorTypeNames = KotlinReferenceExtractor.BuildConstructorTypeNames(language, symbols);
         var callableDefinitionNames = BuildCallableDefinitionNames(language, symbols);
         var dockerfileStageNames = DockerfileReferenceExtractor.BuildStageNames(language, symbols);
+        var dockerfileVariableNames = DockerfileReferenceExtractor.BuildVariableNames(language, symbols);
         var shellCallableNames = ShellReferenceExtractor.BuildCallableNames(language, symbols);
         var shellGlobalAliasNames = ShellReferenceExtractor.BuildGlobalAliasNames(language, symbols);
         var csharpUsingAliases = BuildCSharpUsingAliases(language, symbols, csharpKnownTypeNames);
@@ -1652,6 +1653,15 @@ public static partial class ReferenceExtractor
                     seen,
                     fileId,
                     dockerfileStageNames,
+                    container);
+                DockerfileReferenceExtractor.EmitVariableReferences(
+                    preparedLine,
+                    context,
+                    lineNumber,
+                    references,
+                    seen,
+                    fileId,
+                    dockerfileVariableNames,
                     container);
             }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1647,6 +1647,7 @@ public static partial class ReferenceExtractor
             {
                 DockerfileReferenceExtractor.EmitStageReferences(
                     preparedLine,
+                    originalLine,
                     context,
                     lineNumber,
                     references,

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -314,6 +314,7 @@ public class FileIndexer
         ("Dockerfile_",  "dockerfile"),
         ("Containerfile.", "dockerfile"),
         ("Containerfile-", "dockerfile"),
+        ("Containerfile_", "dockerfile"),
         ("Makefile.",    "makefile"),
         ("GNUmakefile.", "makefile"),
     ];

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -311,6 +311,7 @@ public class FileIndexer
     [
         ("Dockerfile.",  "dockerfile"),
         ("Dockerfile-",  "dockerfile"),
+        ("Dockerfile_",  "dockerfile"),
         ("Containerfile.", "dockerfile"),
         ("Containerfile-", "dockerfile"),
         ("Makefile.",    "makefile"),

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -262,6 +262,7 @@ public class FileIndexer
         [".zsh"]    = "shell",
         [".fish"]   = "shell",
         [".dockerfile"] = "dockerfile", // Suffix-style Dockerfile names such as app.Dockerfile / app.Dockerfile 形式
+        [".containerfile"] = "dockerfile", // Suffix-style Containerfile names such as app.Containerfile / app.Containerfile 形式
     };
 
     private static readonly (string Pattern, string Language)[] DisplayOnlyLanguageExtensions =

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -261,6 +261,7 @@ public class FileIndexer
         [".bash"]   = "shell",
         [".zsh"]    = "shell",
         [".fish"]   = "shell",
+        [".dockerfile"] = "dockerfile", // Suffix-style Dockerfile names such as app.Dockerfile / app.Dockerfile 形式
     };
 
     private static readonly (string Pattern, string Language)[] DisplayOnlyLanguageExtensions =

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -312,6 +312,7 @@ public class FileIndexer
         ("Dockerfile.",  "dockerfile"),
         ("Dockerfile-",  "dockerfile"),
         ("Containerfile.", "dockerfile"),
+        ("Containerfile-", "dockerfile"),
         ("Makefile.",    "makefile"),
         ("GNUmakefile.", "makefile"),
     ];

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -310,6 +310,7 @@ public class FileIndexer
     private static readonly (string Prefix, string Language)[] FileNamePrefixMap =
     [
         ("Dockerfile.",  "dockerfile"),
+        ("Dockerfile-",  "dockerfile"),
         ("Containerfile.", "dockerfile"),
         ("Makefile.",    "makefile"),
         ("GNUmakefile.", "makefile"),

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -276,6 +276,7 @@ public class FileIndexer
         ["Dockerfile"]    = "dockerfile",
         [".dockerfile"]   = "dockerfile",
         ["Containerfile"] = "dockerfile",   // Podman's Dockerfile alternative / Podman の Dockerfile 代替
+        [".containerfile"]= "dockerfile",
         ["Makefile"]      = "makefile",
         ["GNUmakefile"]   = "makefile",     // GNU Make explicit filename / GNU Make 明示ファイル名
         ["Justfile"]      = "justfile",     // Just command runner / Just コマンドランナー

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -274,6 +274,7 @@ public class FileIndexer
     private static readonly Dictionary<string, string> FileNameMap = new(StringComparer.OrdinalIgnoreCase)
     {
         ["Dockerfile"]    = "dockerfile",
+        [".dockerfile"]   = "dockerfile",
         ["Containerfile"] = "dockerfile",   // Podman's Dockerfile alternative / Podman の Dockerfile 代替
         ["Makefile"]      = "makefile",
         ["GNUmakefile"]   = "makefile",     // GNU Make explicit filename / GNU Make 明示ファイル名

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1656,6 +1656,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\s*=", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*EXPOSE\s+(?<name>\d+(?:/(?:tcp|udp))?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property", new Regex(@"^\s*USER\s+(?<name>[A-Za-z0-9_][A-Za-z0-9_.-]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1654,6 +1654,7 @@ public static partial class SymbolExtractor
         [
             new("property", new Regex(@"^\s*(?:ARG|ENV)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\s*=", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2098,6 +2098,7 @@ public static partial class SymbolExtractor
             {
                 AddDockerfileAdditionalEnvSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileAdditionalLabelSymbols(fileId, line, i + 1, symbols);
+                AddDockerfileAdditionalExposeSymbols(fileId, line, i + 1, symbols);
             }
 
             var structuralLine = structuralLines[i];
@@ -3904,6 +3905,70 @@ public static partial class SymbolExtractor
         }
 
         return true;
+    }
+
+    private static void AddDockerfileAdditionalExposeSymbols(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.Length <= 6
+            || !trimmed.StartsWith("EXPOSE", StringComparison.OrdinalIgnoreCase)
+            || !char.IsWhiteSpace(trimmed[6]))
+        {
+            return;
+        }
+
+        var first = true;
+        foreach (var token in trimmed[6..].Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (first)
+            {
+                first = false;
+                continue;
+            }
+
+            if (!IsDockerfileExposePort(token))
+                continue;
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = token,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                },
+                line);
+        }
+    }
+
+    private static bool IsDockerfileExposePort(string token)
+    {
+        var slash = token.IndexOf('/');
+        var port = slash >= 0 ? token[..slash] : token;
+        if (port.Length == 0)
+            return false;
+        foreach (var ch in port)
+        {
+            if (!char.IsAsciiDigit(ch))
+                return false;
+        }
+
+        if (slash < 0)
+            return true;
+
+        var protocol = token[(slash + 1)..];
+        return protocol.Equals("tcp", StringComparison.OrdinalIgnoreCase)
+            || protocol.Equals("udp", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool TryAddRPacmanPackageLoaderSymbols(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1653,7 +1653,7 @@ public static partial class SymbolExtractor
         ["dockerfile"] =
         [
             new("property", new Regex(@"^\s*(?:ARG|ENV)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
+            new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],
         ["protobuf"] =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -4183,7 +4183,7 @@ public static partial class SymbolExtractor
         string line,
         int lineNumber,
         List<SymbolRecord> symbols)
-        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD", includeJsonForm: false);
+        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD", includeJsonForm: true);
 
     private static void AddDockerfileInstructionDestinationSymbol(
         long fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2093,7 +2093,10 @@ public static partial class SymbolExtractor
                 continue;
 
             if (lang == "dockerfile")
+            {
                 AddDockerfileAdditionalEnvSymbols(fileId, line, i + 1, symbols);
+                AddDockerfileAdditionalLabelSymbols(fileId, line, i + 1, symbols);
+            }
 
             var structuralLine = structuralLines[i];
             var cssScannerLine = cssScannerLines?[i];
@@ -3751,7 +3754,7 @@ public static partial class SymbolExtractor
         }
 
         var first = true;
-        foreach (var name in EnumerateDockerfileEnvKeyValueNames(trimmed[3..].TrimStart()))
+        foreach (var name in EnumerateDockerfileKeyValueNames(trimmed[3..].TrimStart(), IsDockerfileVariableName))
         {
             if (first)
             {
@@ -3777,7 +3780,48 @@ public static partial class SymbolExtractor
         }
     }
 
-    private static IEnumerable<string> EnumerateDockerfileEnvKeyValueNames(string body)
+    private static void AddDockerfileAdditionalLabelSymbols(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.Length <= 5
+            || !trimmed.StartsWith("LABEL", StringComparison.OrdinalIgnoreCase)
+            || !char.IsWhiteSpace(trimmed[5]))
+        {
+            return;
+        }
+
+        var first = true;
+        foreach (var name in EnumerateDockerfileKeyValueNames(trimmed[5..].TrimStart(), IsDockerfileLabelName))
+        {
+            if (first)
+            {
+                first = false;
+                continue;
+            }
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = name,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                },
+                line);
+        }
+    }
+
+    private static IEnumerable<string> EnumerateDockerfileKeyValueNames(string body, Func<string, bool> isName)
     {
         var index = 0;
         while (index < body.Length)
@@ -3824,7 +3868,7 @@ public static partial class SymbolExtractor
             if (equalsIndex > 0)
             {
                 var name = token[..equalsIndex];
-                if (IsDockerfileVariableName(name))
+                if (isName(name))
                     yield return name;
             }
         }
@@ -3839,6 +3883,21 @@ public static partial class SymbolExtractor
         {
             var ch = name[i];
             if (!(char.IsAsciiLetterOrDigit(ch) || ch == '_'))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsDockerfileLabelName(string name)
+    {
+        if (name.Length == 0 || !(char.IsAsciiLetterOrDigit(name[0]) || name[0] == '_'))
+            return false;
+
+        for (var i = 1; i < name.Length; i++)
+        {
+            var ch = name[i];
+            if (!(char.IsAsciiLetterOrDigit(ch) || ch is '_' or '.' or '-'))
                 return false;
         }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1930,6 +1930,10 @@ public static partial class SymbolExtractor
         ],
     };
 
+    private static readonly Regex DockerfileEnvKeyValueRegex = new(
+        @"(?:^|\s)(?<name>[A-Za-z_][A-Za-z0-9_]*)=",
+        RegexOptions.Compiled);
+
     /// <summary>
     /// Return the set of languages that have symbol-extraction patterns.
     /// シンボル抽出パターンを持つ言語のセットを返す。
@@ -2090,6 +2094,9 @@ public static partial class SymbolExtractor
                 TryAddGoLabelSymbol(fileId, line, i, symbols);
             if (lang == "r" && TryAddRPacmanPackageLoaderSymbols(fileId, line, i + 1, symbols))
                 continue;
+
+            if (lang == "dockerfile")
+                AddDockerfileAdditionalEnvSymbols(fileId, line, i + 1, symbols);
 
             var structuralLine = structuralLines[i];
             var cssScannerLine = cssScannerLines?[i];
@@ -3731,6 +3738,48 @@ public static partial class SymbolExtractor
     }
 
     private readonly record struct SameLineSignatureKey(int Line, int StartLine, string Signature);
+
+    private static void AddDockerfileAdditionalEnvSymbols(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.Length <= 3
+            || !trimmed.StartsWith("ENV", StringComparison.OrdinalIgnoreCase)
+            || !char.IsWhiteSpace(trimmed[3]))
+        {
+            return;
+        }
+
+        var first = true;
+        foreach (Match match in DockerfileEnvKeyValueRegex.Matches(trimmed[3..].TrimStart()))
+        {
+            if (first)
+            {
+                first = false;
+                continue;
+            }
+
+            var nameGroup = match.Groups["name"];
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = nameGroup.Value,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                },
+                line);
+        }
+    }
 
     private static bool TryAddRPacmanPackageLoaderSymbols(
         long fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1930,10 +1930,6 @@ public static partial class SymbolExtractor
         ],
     };
 
-    private static readonly Regex DockerfileEnvKeyValueRegex = new(
-        @"(?:^|\s)(?<name>[A-Za-z_][A-Za-z0-9_]*)=",
-        RegexOptions.Compiled);
-
     /// <summary>
     /// Return the set of languages that have symbol-extraction patterns.
     /// シンボル抽出パターンを持つ言語のセットを返す。
@@ -3754,7 +3750,7 @@ public static partial class SymbolExtractor
         }
 
         var first = true;
-        foreach (Match match in DockerfileEnvKeyValueRegex.Matches(trimmed[3..].TrimStart()))
+        foreach (var name in EnumerateDockerfileEnvKeyValueNames(trimmed[3..].TrimStart()))
         {
             if (first)
             {
@@ -3762,7 +3758,6 @@ public static partial class SymbolExtractor
                 continue;
             }
 
-            var nameGroup = match.Groups["name"];
             AddSymbolRecord(
                 symbols,
                 cssSeenSymbols: null,
@@ -3771,7 +3766,7 @@ public static partial class SymbolExtractor
                 {
                     FileId = fileId,
                     Kind = "property",
-                    Name = nameGroup.Value,
+                    Name = name,
                     Line = lineNumber,
                     StartLine = lineNumber,
                     EndLine = lineNumber,
@@ -3779,6 +3774,74 @@ public static partial class SymbolExtractor
                 },
                 line);
         }
+    }
+
+    private static IEnumerable<string> EnumerateDockerfileEnvKeyValueNames(string body)
+    {
+        var index = 0;
+        while (index < body.Length)
+        {
+            while (index < body.Length && char.IsWhiteSpace(body[index]))
+                index++;
+            if (index >= body.Length)
+                yield break;
+
+            var tokenStart = index;
+            var inSingleQuote = false;
+            var inDoubleQuote = false;
+            while (index < body.Length)
+            {
+                var ch = body[index];
+                if (ch == '\\' && index + 1 < body.Length)
+                {
+                    index += 2;
+                    continue;
+                }
+
+                if (ch == '\'' && !inDoubleQuote)
+                {
+                    inSingleQuote = !inSingleQuote;
+                    index++;
+                    continue;
+                }
+
+                if (ch == '"' && !inSingleQuote)
+                {
+                    inDoubleQuote = !inDoubleQuote;
+                    index++;
+                    continue;
+                }
+
+                if (!inSingleQuote && !inDoubleQuote && char.IsWhiteSpace(ch))
+                    break;
+
+                index++;
+            }
+
+            var token = body[tokenStart..index];
+            var equalsIndex = token.IndexOf('=');
+            if (equalsIndex > 0)
+            {
+                var name = token[..equalsIndex];
+                if (IsDockerfileVariableName(name))
+                    yield return name;
+            }
+        }
+    }
+
+    private static bool IsDockerfileVariableName(string name)
+    {
+        if (name.Length == 0 || !(char.IsAsciiLetter(name[0]) || name[0] == '_'))
+            return false;
+
+        for (var i = 1; i < name.Length; i++)
+        {
+            var ch = name[i];
+            if (!(char.IsAsciiLetterOrDigit(ch) || ch == '_'))
+                return false;
+        }
+
+        return true;
     }
 
     private static bool TryAddRPacmanPackageLoaderSymbols(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -4176,14 +4176,14 @@ public static partial class SymbolExtractor
         string line,
         int lineNumber,
         List<SymbolRecord> symbols)
-        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "COPY", includeJsonForm: true);
+        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "COPY", includeJsonForm: true, allowOnbuild: true);
 
     private static void AddDockerfileAddDestinationSymbol(
         long fileId,
         string line,
         int lineNumber,
         List<SymbolRecord> symbols)
-        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD", includeJsonForm: true);
+        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD", includeJsonForm: true, allowOnbuild: false);
 
     private static void AddDockerfileInstructionDestinationSymbol(
         long fileId,
@@ -4191,9 +4191,10 @@ public static partial class SymbolExtractor
         int lineNumber,
         List<SymbolRecord> symbols,
         string instruction,
-        bool includeJsonForm)
+        bool includeJsonForm,
+        bool allowOnbuild)
     {
-        if (!TryGetDockerfileInstructionBody(line, instruction, out var body))
+        if (!TryGetDockerfileInstructionBody(line, instruction, allowOnbuild, out var body))
             return;
 
         var destination = GetDockerfileShellFormDestination(body)
@@ -4218,9 +4219,17 @@ public static partial class SymbolExtractor
             line);
     }
 
-    private static bool TryGetDockerfileInstructionBody(string line, string instruction, out string body)
+    private static bool TryGetDockerfileInstructionBody(string line, string instruction, bool allowOnbuild, out string body)
     {
         var trimmed = line.TrimStart();
+        if (allowOnbuild
+            && trimmed.Length > "ONBUILD".Length
+            && trimmed.StartsWith("ONBUILD", StringComparison.OrdinalIgnoreCase)
+            && char.IsWhiteSpace(trimmed["ONBUILD".Length]))
+        {
+            trimmed = trimmed["ONBUILD".Length..].TrimStart();
+        }
+
         body = string.Empty;
         if (trimmed.Length <= instruction.Length
             || !trimmed.StartsWith(instruction, StringComparison.OrdinalIgnoreCase)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2109,6 +2109,7 @@ public static partial class SymbolExtractor
                 AddDockerfileAdditionalExposeSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileAdditionalVolumeSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileNamedStageBaseImageSymbol(fileId, line, i + 1, symbols);
+                AddDockerfileShellSymbol(fileId, line, i + 1, symbols);
             }
 
             var structuralLine = structuralLines[i];
@@ -4113,6 +4114,59 @@ public static partial class SymbolExtractor
                 Signature = line.Trim(),
             },
             line);
+    }
+
+    private static void AddDockerfileShellSymbol(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.Length <= 5
+            || !trimmed.StartsWith("SHELL", StringComparison.OrdinalIgnoreCase)
+            || !char.IsWhiteSpace(trimmed[5]))
+        {
+            return;
+        }
+
+        var body = trimmed[5..].TrimStart();
+        if (!body.StartsWith("[", StringComparison.Ordinal))
+            return;
+
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+                return;
+
+            var first = document.RootElement.EnumerateArray().FirstOrDefault();
+            if (first.ValueKind != JsonValueKind.String)
+                return;
+
+            var name = first.GetString();
+            if (string.IsNullOrWhiteSpace(name))
+                return;
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = name,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                },
+                line);
+        }
+        catch (JsonException)
+        {
+        }
     }
 
     private static bool TryAddRPacmanPackageLoaderSymbols(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1657,6 +1657,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*EXPOSE\s+(?<name>\d+(?:/(?:tcp|udp))?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*USER\s+(?<name>[A-Za-z0-9_][A-Za-z0-9_.-]*(?::[A-Za-z0-9_][A-Za-z0-9_.-]*)?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property", new Regex(@"^\s*WORKDIR\s+(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
@@ -3995,7 +3996,10 @@ public static partial class SymbolExtractor
 
         var body = trimmed[6..].TrimStart();
         if (body.StartsWith("[", StringComparison.Ordinal))
+        {
+            AddDockerfileJsonVolumeSymbols(fileId, line, lineNumber, symbols, body);
             return;
+        }
 
         var first = true;
         foreach (var token in body.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
@@ -4034,6 +4038,50 @@ public static partial class SymbolExtractor
         => token.Length > 0
            && token[0] != '#'
            && token[0] != '[';
+
+    private static void AddDockerfileJsonVolumeSymbols(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols,
+        string body)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+                return;
+
+            foreach (var item in document.RootElement.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.String)
+                    continue;
+
+                var name = item.GetString();
+                if (string.IsNullOrWhiteSpace(name))
+                    continue;
+
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    lineNumber,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "property",
+                        Name = name,
+                        Line = lineNumber,
+                        StartLine = lineNumber,
+                        EndLine = lineNumber,
+                        Signature = line.Trim(),
+                    },
+                    line);
+            }
+        }
+        catch (JsonException)
+        {
+        }
+    }
 
     private static void AddDockerfileNamedStageBaseImageSymbol(
         long fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2110,6 +2110,7 @@ public static partial class SymbolExtractor
                 AddDockerfileAdditionalVolumeSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileNamedStageBaseImageSymbol(fileId, line, i + 1, symbols);
                 AddDockerfileShellSymbol(fileId, line, i + 1, symbols);
+                AddDockerfileCopyDestinationSymbol(fileId, line, i + 1, symbols);
             }
 
             var structuralLine = structuralLines[i];
@@ -4166,6 +4167,122 @@ public static partial class SymbolExtractor
         }
         catch (JsonException)
         {
+        }
+    }
+
+    private static void AddDockerfileCopyDestinationSymbol(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        if (!TryGetDockerfileInstructionBody(line, "COPY", out var body))
+            return;
+
+        var destination = GetDockerfileShellFormDestination(body);
+        if (destination is null or "." or "./")
+            return;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineNumber,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "property",
+                Name = destination,
+                Line = lineNumber,
+                StartLine = lineNumber,
+                EndLine = lineNumber,
+                Signature = line.Trim(),
+            },
+            line);
+    }
+
+    private static bool TryGetDockerfileInstructionBody(string line, string instruction, out string body)
+    {
+        var trimmed = line.TrimStart();
+        body = string.Empty;
+        if (trimmed.Length <= instruction.Length
+            || !trimmed.StartsWith(instruction, StringComparison.OrdinalIgnoreCase)
+            || !char.IsWhiteSpace(trimmed[instruction.Length]))
+        {
+            return false;
+        }
+
+        body = trimmed[instruction.Length..].TrimStart();
+        return true;
+    }
+
+    private static string? GetDockerfileShellFormDestination(string body)
+    {
+        var arguments = new List<string>();
+        foreach (var token in EnumerateDockerfileInstructionTokens(body))
+        {
+            if (token.StartsWith("--", StringComparison.Ordinal))
+                continue;
+            if (token.StartsWith("[", StringComparison.Ordinal))
+                return null;
+
+            arguments.Add(token);
+        }
+
+        return arguments.Count >= 2 ? arguments[^1] : null;
+    }
+
+    private static IEnumerable<string> EnumerateDockerfileInstructionTokens(string body)
+    {
+        var index = 0;
+        while (index < body.Length)
+        {
+            while (index < body.Length && char.IsWhiteSpace(body[index]))
+                index++;
+            if (index >= body.Length || body[index] == '#')
+                yield break;
+
+            var token = new StringBuilder();
+            var quote = '\0';
+            while (index < body.Length)
+            {
+                var c = body[index];
+                if (quote != '\0')
+                {
+                    if (c == '\\' && index + 1 < body.Length)
+                    {
+                        token.Append(body[index + 1]);
+                        index += 2;
+                        continue;
+                    }
+
+                    if (c == quote)
+                    {
+                        quote = '\0';
+                        index++;
+                        continue;
+                    }
+
+                    token.Append(c);
+                    index++;
+                    continue;
+                }
+
+                if (c is '"' or '\'')
+                {
+                    quote = c;
+                    index++;
+                    continue;
+                }
+
+                if (char.IsWhiteSpace(c))
+                    break;
+
+                token.Append(c);
+                index++;
+            }
+
+            if (token.Length > 0)
+                yield return token.ToString();
         }
     }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1653,6 +1653,7 @@ public static partial class SymbolExtractor
         ["dockerfile"] =
         [
             new("property", new Regex(@"^\s*(?:ARG|ENV)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\s*=", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1655,6 +1655,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*(?:ARG|ENV)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\s*=", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property", new Regex(@"^\s*EXPOSE\s+(?<name>\d+(?:/(?:tcp|udp))?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -4183,7 +4183,7 @@ public static partial class SymbolExtractor
         string line,
         int lineNumber,
         List<SymbolRecord> symbols)
-        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD", includeJsonForm: true, allowOnbuild: false);
+        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD", includeJsonForm: true, allowOnbuild: true);
 
     private static void AddDockerfileInstructionDestinationSymbol(
         long fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1663,6 +1663,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*USER\s+(?<name>[A-Za-z0-9_][A-Za-z0-9_.-]*(?::[A-Za-z0-9_][A-Za-z0-9_.-]*)?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*WORKDIR\s+(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*VOLUME\s+(?<name>(?!\[)\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property", new Regex(@"^\s*STOPSIGNAL\s+(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1653,7 +1653,7 @@ public static partial class SymbolExtractor
         ["dockerfile"] =
         [
             new("property", new Regex(@"^\s*(?:ARG|ENV)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>\w+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
+            new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],
         ["protobuf"] =

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -220,6 +220,9 @@ public static partial class SymbolExtractor
     private static readonly Regex RustMultilineImplTypeRegex = new(
         @"^\s*(?:unsafe\s+)?impl(?:<[^>]+>)?\s+(?<name>" + RustIdentifierPattern + @")(?!\s+for\b)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+    private static readonly Regex DockerfileNamedFromImageRegex = new(
+        @"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)\s+(?:AS|as)\s+[A-Za-z0-9_.-]+",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex XamlClassRegex = new(
         @"\bx:Class\s*=\s*[""'](?<value>[^""']+)[""']",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -2103,6 +2106,7 @@ public static partial class SymbolExtractor
                 AddDockerfileAdditionalLabelSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileAdditionalExposeSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileAdditionalVolumeSymbols(fileId, line, i + 1, symbols);
+                AddDockerfileNamedStageBaseImageSymbol(fileId, line, i + 1, symbols);
             }
 
             var structuralLine = structuralLines[i];
@@ -4030,6 +4034,37 @@ public static partial class SymbolExtractor
         => token.Length > 0
            && token[0] != '#'
            && token[0] != '[';
+
+    private static void AddDockerfileNamedStageBaseImageSymbol(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        var match = DockerfileNamedFromImageRegex.Match(line);
+        if (!match.Success)
+            return;
+
+        var name = match.Groups["name"].Value;
+        if (symbols.Any(symbol => symbol.Kind == "function" && symbol.Name == name))
+            return;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineNumber,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "class",
+                Name = name,
+                Line = lineNumber,
+                StartLine = lineNumber,
+                EndLine = lineNumber,
+                Signature = line.Trim(),
+            },
+            line);
+    }
 
     private static bool TryAddRPacmanPackageLoaderSymbols(
         long fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2111,6 +2111,7 @@ public static partial class SymbolExtractor
                 AddDockerfileNamedStageBaseImageSymbol(fileId, line, i + 1, symbols);
                 AddDockerfileShellSymbol(fileId, line, i + 1, symbols);
                 AddDockerfileCopyDestinationSymbol(fileId, line, i + 1, symbols);
+                AddDockerfileAddDestinationSymbol(fileId, line, i + 1, symbols);
             }
 
             var structuralLine = structuralLines[i];
@@ -4175,8 +4176,23 @@ public static partial class SymbolExtractor
         string line,
         int lineNumber,
         List<SymbolRecord> symbols)
+        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "COPY");
+
+    private static void AddDockerfileAddDestinationSymbol(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD");
+
+    private static void AddDockerfileInstructionDestinationSymbol(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols,
+        string instruction)
     {
-        if (!TryGetDockerfileInstructionBody(line, "COPY", out var body))
+        if (!TryGetDockerfileInstructionBody(line, instruction, out var body))
             return;
 
         var destination = GetDockerfileShellFormDestination(body);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2102,6 +2102,7 @@ public static partial class SymbolExtractor
                 AddDockerfileAdditionalEnvSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileAdditionalLabelSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileAdditionalExposeSymbols(fileId, line, i + 1, symbols);
+                AddDockerfileAdditionalVolumeSymbols(fileId, line, i + 1, symbols);
             }
 
             var structuralLine = structuralLines[i];
@@ -3973,6 +3974,59 @@ public static partial class SymbolExtractor
         return protocol.Equals("tcp", StringComparison.OrdinalIgnoreCase)
             || protocol.Equals("udp", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static void AddDockerfileAdditionalVolumeSymbols(
+        long fileId,
+        string line,
+        int lineNumber,
+        List<SymbolRecord> symbols)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.Length <= 6
+            || !trimmed.StartsWith("VOLUME", StringComparison.OrdinalIgnoreCase)
+            || !char.IsWhiteSpace(trimmed[6]))
+        {
+            return;
+        }
+
+        var body = trimmed[6..].TrimStart();
+        if (body.StartsWith("[", StringComparison.Ordinal))
+            return;
+
+        var first = true;
+        foreach (var token in body.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (first)
+            {
+                first = false;
+                continue;
+            }
+
+            if (!IsDockerfileVolumePath(token))
+                continue;
+
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = token,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                },
+                line);
+        }
+    }
+
+    private static bool IsDockerfileVolumePath(string token)
+        => token.Length > 0
+           && token[0] != '#'
+           && token[0] != '[';
 
     private static bool TryAddRPacmanPackageLoaderSymbols(
         long fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1656,7 +1656,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\s*=", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*LABEL\s+(?<name>[A-Za-z0-9_.-]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*EXPOSE\s+(?<name>\d+(?:/(?:tcp|udp))?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
-            new("property", new Regex(@"^\s*USER\s+(?<name>[A-Za-z0-9_][A-Za-z0-9_.-]*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property", new Regex(@"^\s*USER\s+(?<name>[A-Za-z0-9_][A-Za-z0-9_.-]*(?::[A-Za-z0-9_][A-Za-z0-9_.-]*)?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -4002,6 +4002,9 @@ public static partial class SymbolExtractor
                 continue;
             }
 
+            if (token[0] == '#')
+                break;
+
             if (!IsDockerfileVolumePath(token))
                 continue;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1658,6 +1658,7 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*EXPOSE\s+(?<name>\d+(?:/(?:tcp|udp))?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*USER\s+(?<name>[A-Za-z0-9_][A-Za-z0-9_.-]*(?::[A-Za-z0-9_][A-Za-z0-9_.-]*)?)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("property", new Regex(@"^\s*WORKDIR\s+(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("property", new Regex(@"^\s*VOLUME\s+(?<name>(?!\[)\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?\S+\s+(?:AS|as)\s+(?<name>[A-Za-z0-9_.-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Named stage / 名前付きステージ
             new("class",    new Regex(@"^\s*FROM\s+(?:--platform=\S+\s+)?(?<name>\S+)", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),  // Base image / ベースイメージ
         ],

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -4176,26 +4176,28 @@ public static partial class SymbolExtractor
         string line,
         int lineNumber,
         List<SymbolRecord> symbols)
-        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "COPY");
+        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "COPY", includeJsonForm: true);
 
     private static void AddDockerfileAddDestinationSymbol(
         long fileId,
         string line,
         int lineNumber,
         List<SymbolRecord> symbols)
-        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD");
+        => AddDockerfileInstructionDestinationSymbol(fileId, line, lineNumber, symbols, "ADD", includeJsonForm: false);
 
     private static void AddDockerfileInstructionDestinationSymbol(
         long fileId,
         string line,
         int lineNumber,
         List<SymbolRecord> symbols,
-        string instruction)
+        string instruction,
+        bool includeJsonForm)
     {
         if (!TryGetDockerfileInstructionBody(line, instruction, out var body))
             return;
 
-        var destination = GetDockerfileShellFormDestination(body);
+        var destination = GetDockerfileShellFormDestination(body)
+            ?? (includeJsonForm ? GetDockerfileJsonFormDestination(body) : null);
         if (destination is null or "." or "./")
             return;
 
@@ -4245,6 +4247,54 @@ public static partial class SymbolExtractor
         }
 
         return arguments.Count >= 2 ? arguments[^1] : null;
+    }
+
+    private static string? GetDockerfileJsonFormDestination(string body)
+    {
+        var jsonStart = SkipDockerfileInstructionOptions(body);
+        if (jsonStart >= body.Length || body[jsonStart] != '[')
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(body[jsonStart..]);
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+                return null;
+
+            string? last = null;
+            var count = 0;
+            foreach (var item in document.RootElement.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.String)
+                    return null;
+
+                last = item.GetString();
+                count++;
+            }
+
+            return count >= 2 ? last : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static int SkipDockerfileInstructionOptions(string body)
+    {
+        var index = 0;
+        while (index < body.Length)
+        {
+            while (index < body.Length && char.IsWhiteSpace(body[index]))
+                index++;
+
+            if (index + 2 > body.Length || body[index] != '-' || body[index + 1] != '-')
+                return index;
+
+            index = ScanDockerfileInstructionToken(body, index);
+        }
+
+        return index;
     }
 
     private static IEnumerable<string> EnumerateDockerfileInstructionTokens(string body)
@@ -4300,6 +4350,43 @@ public static partial class SymbolExtractor
             if (token.Length > 0)
                 yield return token.ToString();
         }
+    }
+
+    private static int ScanDockerfileInstructionToken(string body, int index)
+    {
+        var quote = '\0';
+        while (index < body.Length)
+        {
+            var c = body[index];
+            if (quote != '\0')
+            {
+                if (c == '\\' && index + 1 < body.Length)
+                {
+                    index += 2;
+                    continue;
+                }
+
+                if (c == quote)
+                    quote = '\0';
+
+                index++;
+                continue;
+            }
+
+            if (c is '"' or '\'')
+            {
+                quote = c;
+                index++;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(c))
+                break;
+
+            index++;
+        }
+
+        return index;
     }
 
     private static bool TryAddRPacmanPackageLoaderSymbols(

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -85,6 +85,7 @@ public class FileIndexerTests
     [InlineData("api.Containerfile", "dockerfile")]
     [InlineData(".containerfile", "dockerfile")]
     [InlineData("Dockerfile-prod", "dockerfile")]
+    [InlineData("Dockerfile_prod", "dockerfile")]
     [InlineData("Containerfile-prod", "dockerfile")]
     [InlineData("Makefile", "makefile")]
     [InlineData("Justfile", "justfile")]

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -87,6 +87,7 @@ public class FileIndexerTests
     [InlineData("Dockerfile-prod", "dockerfile")]
     [InlineData("Dockerfile_prod", "dockerfile")]
     [InlineData("Containerfile-prod", "dockerfile")]
+    [InlineData("Containerfile_prod", "dockerfile")]
     [InlineData("Makefile", "makefile")]
     [InlineData("Justfile", "justfile")]
     [InlineData("CMakeLists.txt", "cmake")]

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -80,6 +80,7 @@ public class FileIndexerTests
     [InlineData("script.zsh", "shell")]
     [InlineData("script.fish", "shell")]
     [InlineData("Dockerfile", "dockerfile")]
+    [InlineData("api.Dockerfile", "dockerfile")]
     [InlineData("Makefile", "makefile")]
     [InlineData("Justfile", "justfile")]
     [InlineData("CMakeLists.txt", "cmake")]

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -84,6 +84,7 @@ public class FileIndexerTests
     [InlineData("api.Dockerfile", "dockerfile")]
     [InlineData("api.Containerfile", "dockerfile")]
     [InlineData(".containerfile", "dockerfile")]
+    [InlineData("Dockerfile-prod", "dockerfile")]
     [InlineData("Makefile", "makefile")]
     [InlineData("Justfile", "justfile")]
     [InlineData("CMakeLists.txt", "cmake")]

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -80,6 +80,7 @@ public class FileIndexerTests
     [InlineData("script.zsh", "shell")]
     [InlineData("script.fish", "shell")]
     [InlineData("Dockerfile", "dockerfile")]
+    [InlineData(".dockerfile", "dockerfile")]
     [InlineData("api.Dockerfile", "dockerfile")]
     [InlineData("api.Containerfile", "dockerfile")]
     [InlineData("Makefile", "makefile")]

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -85,6 +85,7 @@ public class FileIndexerTests
     [InlineData("api.Containerfile", "dockerfile")]
     [InlineData(".containerfile", "dockerfile")]
     [InlineData("Dockerfile-prod", "dockerfile")]
+    [InlineData("Containerfile-prod", "dockerfile")]
     [InlineData("Makefile", "makefile")]
     [InlineData("Justfile", "justfile")]
     [InlineData("CMakeLists.txt", "cmake")]

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -81,6 +81,7 @@ public class FileIndexerTests
     [InlineData("script.fish", "shell")]
     [InlineData("Dockerfile", "dockerfile")]
     [InlineData("api.Dockerfile", "dockerfile")]
+    [InlineData("api.Containerfile", "dockerfile")]
     [InlineData("Makefile", "makefile")]
     [InlineData("Justfile", "justfile")]
     [InlineData("CMakeLists.txt", "cmake")]

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -83,6 +83,7 @@ public class FileIndexerTests
     [InlineData(".dockerfile", "dockerfile")]
     [InlineData("api.Dockerfile", "dockerfile")]
     [InlineData("api.Containerfile", "dockerfile")]
+    [InlineData(".containerfile", "dockerfile")]
     [InlineData("Makefile", "makefile")]
     [InlineData("Justfile", "justfile")]
     [InlineData("CMakeLists.txt", "cmake")]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2258,6 +2258,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IndexColonlessDefaultedBracedArgVariables()
+    {
+        const string content = """
+            ARG NODE_VERSION
+            FROM node:${NODE_VERSION-20} AS builder
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "NODE_VERSION"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
     public void Extract_DockerfileReferences_IndexUnbracedArgVariables()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2133,6 +2133,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileRunMountReferences_IndexMultipleStageDependencies()
+    {
+        const string content = """
+            FROM alpine AS assets
+            FROM alpine AS cache
+
+            FROM alpine AS runtime
+            RUN --mount=type=bind,from=assets,target=/assets --mount=type=bind,from=cache,target=/cache true
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "assets"
+            && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "cache"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_DockerfileCopyFromReferences_IgnoresTaggedExternalImages()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2115,6 +2115,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileFromStageReferences_AllowsInlineComments()
+    {
+        const string content = """
+            FROM node:20 AS builder
+
+            FROM builder AS runtime # reuse the build stage
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "builder"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2173,6 +2173,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileCopyFromReferences_IgnoresDigestExternalImages()
+    {
+        const string content = """
+            FROM alpine AS builder
+
+            FROM alpine AS runtime
+            COPY --from=builder@sha256:123abc /src/app /usr/local/bin/app
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "builder"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_DockerfileFromStageReferences_AllowsInlineComments()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2133,6 +2133,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileCopyFromReferences_IgnoresTaggedExternalImages()
+    {
+        const string content = """
+            FROM alpine AS builder
+
+            FROM alpine AS runtime
+            COPY --from=builder:latest /src/app /usr/local/bin/app
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "builder"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_DockerfileFromStageReferences_AllowsInlineComments()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2079,6 +2079,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IndexHyphenatedStageNames()
+    {
+        const string content = """
+            FROM node:20 AS build-env
+
+            FROM build-env AS runtime
+            COPY --from=build-env /src/app /usr/local/bin/app
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Equal(2, references.Count(reference =>
+            reference.SymbolName == "build-env"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2155,6 +2155,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileRunMountReferences_IgnoresQuotedShellText()
+    {
+        const string content = """
+            FROM alpine AS assets
+
+            FROM alpine AS runtime
+            RUN echo "--mount=type=bind,from=assets,target=/mnt/assets"
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "assets"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_DockerfileCopyFromReferences_IgnoresTaggedExternalImages()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2132,6 +2132,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IndexBracedArgVariables()
+    {
+        const string content = """
+            ARG NODE_VERSION=20
+            FROM node:${NODE_VERSION} AS builder
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "NODE_VERSION"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2097,6 +2097,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IndexDottedStageNames()
+    {
+        const string content = """
+            FROM node:20 AS build.env
+
+            FROM build.env AS runtime
+            COPY --from=build.env /src/app /usr/local/bin/app
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Equal(2, references.Count(reference =>
+            reference.SymbolName == "build.env"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2191,6 +2191,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileCopyFromReferences_IndexOnbuildStageDependencies()
+    {
+        const string content = """
+            FROM alpine AS builder
+
+            FROM alpine AS runtime
+            ONBUILD COPY --from=builder /src/app /usr/local/bin/app
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "builder"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_DockerfileFromStageReferences_AllowsInlineComments()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2148,6 +2148,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IndexDefaultedBracedArgVariables()
+    {
+        const string content = """
+            ARG NODE_VERSION
+            FROM node:${NODE_VERSION:-20} AS builder
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "NODE_VERSION"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2164,6 +2164,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IndexUnbracedArgVariables()
+    {
+        const string content = """
+            ARG APP_HOME=/app
+            WORKDIR $APP_HOME
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "APP_HOME"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2173,6 +2173,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileRunMountReferences_IgnoresCommandArguments()
+    {
+        const string content = """
+            FROM alpine AS assets
+
+            FROM alpine AS runtime
+            RUN echo --mount=type=bind,from=assets,target=/mnt/assets
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "assets"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_DockerfileCopyFromReferences_IgnoresTaggedExternalImages()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2209,6 +2209,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileCopyFromReferences_IndexQuotedStageDependencies()
+    {
+        const string content = """
+            FROM alpine AS builder
+
+            FROM alpine AS runtime
+            COPY --from="builder" /src/app /usr/local/bin/app
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "builder"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_DockerfileFromStageReferences_AllowsInlineComments()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2195,6 +2195,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IgnoresEscapedBracedVariables()
+    {
+        const string content = """
+            ARG APP_HOME=/app
+            RUN echo \${APP_HOME}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "APP_HOME");
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2173,6 +2173,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileRunMountReferences_IndexOnbuildStageDependencies()
+    {
+        const string content = """
+            FROM alpine AS assets
+
+            FROM alpine AS runtime
+            ONBUILD RUN --mount=type=bind,from=assets,target=/mnt/assets cp -r /mnt/assets /app/assets
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "assets"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_DockerfileRunMountReferences_IgnoresQuotedShellText()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2155,6 +2155,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileRunMountReferences_IndexQuotedStageDependencies()
+    {
+        const string content = """
+            FROM alpine AS assets
+
+            FROM alpine AS runtime
+            RUN --mount=type=bind,from="assets",target=/mnt/assets cp -r /mnt/assets /app/assets
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "assets"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_DockerfileRunMountReferences_IgnoresQuotedShellText()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2115,6 +2115,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileRunMountReferences_IndexStageDependencies()
+    {
+        const string content = """
+            FROM alpine AS assets
+
+            FROM alpine AS runtime
+            RUN --mount=type=bind,from=assets,target=/mnt/assets cp -r /mnt/assets /app/assets
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "assets"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_DockerfileFromStageReferences_AllowsInlineComments()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2180,6 +2180,21 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IgnoresEscapedUnbracedVariables()
+    {
+        const string content = """
+            ARG APP_HOME=/app
+            RUN echo \$APP_HOME
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "APP_HOME");
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMultiLine_AttributesToMember()
     {
         // Multi-line expression body (declaration on one line, `=> expr;` on the next)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20373,6 +20373,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsShellExecutableSymbols()
+    {
+        var content = "SHELL [\"/bin/bash\", \"-o\", \"pipefail\", \"-c\"]\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/bin/bash");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "-o");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20184,13 +20184,12 @@ public class SymbolExtractorTests
         var content = "FROM node:18 AS builder\nWORKDIR /app\nCOPY . .\nRUN npm build\n\nFROM alpine:3.18\nCOPY --from=builder /app/dist /app\n";
         var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
 
-        // Named stages (AS builder) take priority over base image on the same line
-        // 同一行では名前付きステージ(AS builder)がベースイメージより優先
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "builder");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "node:18");
         // Unnamed FROM lines produce base image class / 名前なしFROM行はベースイメージclassを生成
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "alpine:3.18");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/app");
-        Assert.Equal(3, symbols.Count);
+        Assert.Equal(4, symbols.Count);
     }
 
     [Fact]
@@ -20205,10 +20204,11 @@ public class SymbolExtractorTests
         var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "builder");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "golang:1.22");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "alpine:3.20");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "APP_HOME");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "PATH");
-        Assert.Equal(4, symbols.Count);
+        Assert.Equal(5, symbols.Count);
     }
 
     [Fact]
@@ -20361,10 +20361,26 @@ public class SymbolExtractorTests
         var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "builder");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "golang:1.22");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "alpine:3.20");
         Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "--platform=$BUILDPLATFORM");
-        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "golang:1.22");
-        Assert.Equal(2, symbols.Count);
+        Assert.Equal(3, symbols.Count);
+    }
+
+    [Fact]
+    public void Extract_Dockerfile_NamedStageBaseImagesSkipPriorStages()
+    {
+        var content = """
+            FROM alpine AS builder
+            FROM builder AS runtime
+            """;
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "alpine");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "builder");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "runtime");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "builder");
+        Assert.Equal(3, symbols.Count);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20395,6 +20395,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsAddDestinationPathSymbols()
+    {
+        var content = "ADD archive.tar.gz /opt/app\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/opt/app");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "archive.tar.gz");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20223,6 +20223,18 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_MultipleEnvKeyValueSymbolsIgnoreQuotedValueAssignments()
+    {
+        var content = "ENV APP_HOME=\"/opt BAR=not-a-key\" NODE_ENV=production\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "APP_HOME");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "NODE_ENV");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "BAR");
+        Assert.Equal(2, symbols.Count);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20439,6 +20439,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsOnbuildAddDestinationPathSymbols()
+    {
+        var content = "ONBUILD ADD archive.tar.gz /opt/app\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/opt/app");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "archive.tar.gz");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20258,6 +20258,19 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsDottedStageNames()
+    {
+        var content = """
+            FROM node:20 AS build.env
+            FROM build.env AS runtime
+            """;
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build.env");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "runtime");
+    }
+
+    [Fact]
     public void Extract_Protobuf_DetectsSymbols()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20266,6 +20266,16 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsExposePortSymbols()
+    {
+        var content = "EXPOSE 8080/tcp\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "8080/tcp");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20320,6 +20320,16 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsVolumePathSymbols()
+    {
+        var content = "VOLUME /var/lib/app\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/var/lib/app");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20288,6 +20288,16 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsUserSymbols()
+    {
+        var content = "USER appuser\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "appuser");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20330,6 +20330,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsMultipleVolumePathSymbols()
+    {
+        var content = "VOLUME /var/lib/app /var/cache/app\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/var/lib/app");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/var/cache/app");
+        Assert.Equal(2, symbols.Count);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20406,6 +20406,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsJsonCopyDestinationPathSymbols()
+    {
+        var content = "COPY --chmod=0644 [\"package.json\", \"/app/package.json\"]\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/app/package.json");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "package.json");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20256,6 +20256,16 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsLegacyLabelKeySymbols()
+    {
+        var content = "LABEL com.example.channel stable\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "com.example.channel");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20428,6 +20428,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsOnbuildCopyDestinationPathSymbols()
+    {
+        var content = "ONBUILD COPY /src/app /usr/local/bin/app\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/usr/local/bin/app");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "/src/app");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20341,6 +20341,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_VolumePathSymbolsIgnoreInlineComments()
+    {
+        var content = "VOLUME /var/lib/app # /not-a-volume\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/var/lib/app");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "/not-a-volume");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20363,6 +20363,16 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsStopSignalSymbols()
+    {
+        var content = "STOPSIGNAL SIGTERM\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "SIGTERM");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20235,6 +20235,16 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsLabelKeySymbols()
+    {
+        var content = "LABEL org.opencontainers.image.title=\"demo\"\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "org.opencontainers.image.title");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20298,6 +20298,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsUserGroupSymbols()
+    {
+        var content = "USER appuser:appgroup\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "appuser:appgroup");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "appuser");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20189,7 +20189,7 @@ public class SymbolExtractorTests
         // Unnamed FROM lines produce base image class / 名前なしFROM行はベースイメージclassを生成
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "alpine:3.18");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/app");
-        Assert.Equal(4, symbols.Count);
+        Assert.Equal(5, symbols.Count);
     }
 
     [Fact]
@@ -20380,6 +20380,17 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/bin/bash");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "-o");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
+    public void Extract_Dockerfile_DetectsCopyDestinationPathSymbols()
+    {
+        var content = "COPY --from=builder /src/app /usr/local/bin/app\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/usr/local/bin/app");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "/src/app");
         Assert.Single(symbols);
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20417,6 +20417,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsJsonAddDestinationPathSymbols()
+    {
+        var content = "ADD [\"archive.tar.gz\", \"/opt/app\"]\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/opt/app");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "archive.tar.gz");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20352,6 +20352,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsJsonVolumePathSymbols()
+    {
+        var content = "VOLUME [\"/var/lib/app\", \"/var/cache/app\"]\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/var/lib/app");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/var/cache/app");
+        Assert.Equal(2, symbols.Count);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20211,6 +20211,18 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsMultipleEnvKeyValueSymbols()
+    {
+        var content = "ENV APP_HOME=/app NODE_ENV=production PATH=/usr/local/bin:$PATH\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "APP_HOME");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "NODE_ENV");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "PATH");
+        Assert.Equal(3, symbols.Count);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20189,7 +20189,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "builder");
         // Unnamed FROM lines produce base image class / 名前なしFROM行はベースイメージclassを生成
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "alpine:3.18");
-        Assert.Equal(2, symbols.Count);
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/app");
+        Assert.Equal(3, symbols.Count);
     }
 
     [Fact]
@@ -20305,6 +20306,16 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "appuser:appgroup");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "appuser");
+        Assert.Single(symbols);
+    }
+
+    [Fact]
+    public void Extract_Dockerfile_DetectsWorkdirSymbols()
+    {
+        var content = "WORKDIR /app/service\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "/app/service");
         Assert.Single(symbols);
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20245,6 +20245,17 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsMultipleLabelKeySymbols()
+    {
+        var content = "LABEL org.opencontainers.image.title=\"demo\" org.opencontainers.image.version=\"1.0\"\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "org.opencontainers.image.title");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "org.opencontainers.image.version");
+        Assert.Equal(2, symbols.Count);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20276,6 +20276,18 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsMultipleExposePortSymbols()
+    {
+        var content = "EXPOSE 80 443/tcp 53/udp\n";
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "80");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "443/tcp");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "53/udp");
+        Assert.Equal(3, symbols.Count);
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsPlatformFlaggedStages()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20245,6 +20245,19 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Dockerfile_DetectsHyphenatedStageNames()
+    {
+        var content = """
+            FROM node:20 AS build-env
+            FROM build-env AS runtime
+            """;
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "build-env");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "runtime");
+    }
+
+    [Fact]
     public void Extract_Protobuf_DetectsSymbols()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Expanded Dockerfile symbol extraction for file variants, stage names, base images, variables, labels, ports, users, workdirs, volumes, stop signals, shells, and copy/add destinations.
- Expanded Dockerfile reference extraction for stage aliases, variables, COPY/ADD `--from`, RUN mount `from=`, quoted names, ONBUILD forms, and common false-positive guards.
- Added focused tests for each search behavior and review-found regression fixes.

## Validation

- `dotnet build`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Updated `changelog.d/unreleased/+dockerfile-search.fixed.md`.

## Fixes

- None.

## Follow-up Candidates

- Consider consolidating Dockerfile instruction parsing helpers further if more instruction-specific indexing is added.