### PR TITLE
[codex] Improve Fortran search coverage

### DIFF
--- a/changelog.d/unreleased/+fortran-access-list-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-access-list-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran access lists now appear in reference search** — explicit `public :: name` and `private :: name` declarations index the listed module symbols.
+
+## 日本語
+
+- **Fortran の access list が参照検索に出るようになりました** — 明示的な `public :: name` / `private :: name` 宣言で、列挙された module symbol を索引します。

--- a/changelog.d/unreleased/+fortran-access-no-colon-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-access-no-colon-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran access statements without `::` now appear in reference search** — `public name` and `private name` are indexed the same way as `public :: name` and `private :: name`.
+
+## 日本語
+
+- **`::` を省略した Fortran access 文が参照検索に出るようになりました** — `public name` と `private name` を `public :: name` / `private :: name` と同じように索引します。

--- a/changelog.d/unreleased/+fortran-allocate-object-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-allocate-object-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `allocate` object lists now appear in reference search** — allocated objects in `allocate(Type :: object)` and `allocate(object, stat=...)` are indexed while keyword arguments are ignored.
+
+## 日本語
+
+- **Fortran の `allocate` object list が参照検索に出るようになりました** — `allocate(Type :: object)` や `allocate(object, stat=...)` の確保対象を索引し、keyword 引数は除外します。

--- a/changelog.d/unreleased/+fortran-allocate-source-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-allocate-source-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `allocate` source and mold arguments now appear in reference search** — simple names on the right-hand side of `source=` and `mold=` are indexed as references.
+
+## 日本語
+
+- **Fortran の `allocate` source/mold 引数が参照検索に出るようになりました** — `source=` と `mold=` の右辺にある simple name を参照として索引します。

--- a/changelog.d/unreleased/+fortran-allocate-type.fixed.md
+++ b/changelog.d/unreleased/+fortran-allocate-type.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran typed `allocate` statements now record allocation type references** — `allocate(TypeName :: value)` now indexes `TypeName` as a type reference so dynamic allocation dependencies are searchable.
+
+## 日本語
+
+- **Fortran の型付き `allocate` 文が確保型の参照を記録するようになりました** — `allocate(TypeName :: value)` の `TypeName` を型参照として索引し、動的確保の依存を検索できるようにしました。

--- a/changelog.d/unreleased/+fortran-allocation-status-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-allocation-status-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran allocation status arguments now appear in reference search** — `stat=` and `errmsg=` variables on `allocate` and `deallocate` statements are indexed as references.
+
+## 日本語
+
+- **Fortran の allocation status 引数が参照検索に出るようになりました** — `allocate` / `deallocate` 文の `stat=` と `errmsg=` 変数を参照として索引します。

--- a/changelog.d/unreleased/+fortran-associate-target-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-associate-target-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `associate` targets now appear in reference search** — selectors such as `associate (alias => target)` index the target name.
+
+## 日本語
+
+- **Fortran の `associate` target が参照検索に出るようになりました** — `associate (alias => target)` のような selector で target 側の名前を索引します。

--- a/changelog.d/unreleased/+fortran-attribute-variable-symbols.fixed.md
+++ b/changelog.d/unreleased/+fortran-attribute-variable-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran attribute-only variable declarations now appear in symbol search** — declarations such as `allocatable :: work` and `pointer :: node` are indexed as properties.
+
+## 日本語
+
+- **Fortran の属性のみの変数宣言が symbol search に出るようになりました** — `allocatable :: work` や `pointer :: node` のような宣言を property として索引します。

--- a/changelog.d/unreleased/+fortran-binding-target-list.fixed.md
+++ b/changelog.d/unreleased/+fortran-binding-target-list.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran binding target lists are fully indexed** — generic/type-bound declarations such as `generic :: assignment(=) => assign_a, assign_b` now index every implementation target.
+
+## 日本語
+
+- **Fortran の binding target list をすべて索引するようになりました** — `generic :: assignment(=) => assign_a, assign_b` のような generic/type-bound 宣言で、すべての実装ターゲットを索引します。

--- a/changelog.d/unreleased/+fortran-binding-target-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-binding-target-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran type-bound binding targets now appear in reference search** — `procedure :: binding => implementation` and `generic :: assignment(=) => assign_impl` declarations index their implementation targets.
+
+## 日本語
+
+- **Fortran の type-bound binding target が参照検索に出るようになりました** — `procedure :: binding => implementation` や `generic :: assignment(=) => assign_impl` の宣言で、実装側ターゲットを索引します。

--- a/changelog.d/unreleased/+fortran-blank-common-member-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-blank-common-member-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran blank common member names now appear in reference search** — declarations such as `common state, flag` index the listed blank common members.
+
+## 日本語
+
+- **Fortran の blank common member 名が参照検索に出るようになりました** — `common state, flag` のような宣言で列挙された blank common member を索引します。

--- a/changelog.d/unreleased/+fortran-block-data-symbol.fixed.md
+++ b/changelog.d/unreleased/+fortran-block-data-symbol.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Named Fortran `block data` units are now searchable** — `block data constants_block` declarations are indexed as symbols with their body ranges.
+
+## 日本語
+
+- **名前付き Fortran `block data` 単位が検索できるようになりました** — `block data constants_block` 宣言を本体範囲付きのシンボルとして索引します。

--- a/changelog.d/unreleased/+fortran-common-block-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-common-block-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran common block names now appear in reference search** — declarations such as `common /repository_state/ value` index the named common block.
+
+## 日本語
+
+- **Fortran の common block 名が参照検索に出るようになりました** — `common /repository_state/ value` のような宣言で、名前付き common block を索引します。

--- a/changelog.d/unreleased/+fortran-common-member-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-common-member-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran common block member names now appear in reference search** — declarations such as `common /state/ value, flag` index both the block and listed members.
+
+## 日本語
+
+- **Fortran の common block member 名が参照検索に出るようになりました** — `common /state/ value, flag` のような宣言で block 名だけでなく列挙された member も索引します。

--- a/changelog.d/unreleased/+fortran-common-member-symbols.fixed.md
+++ b/changelog.d/unreleased/+fortran-common-member-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran `common` block members now appear in symbol search** — member names in `common /block/ a, b` declarations are indexed as properties.
+
+## 日本語
+
+- **Fortran の `common` block member が symbol search に出るようになりました** — `common /block/ a, b` の member 名を property として索引します。

--- a/changelog.d/unreleased/+fortran-compact-import-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-compact-import-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Compact Fortran `import` statements now appear in reference search** — `import::Name` and `import, only:Name` are indexed like spaced interface import statements.
+
+## 日本語
+
+- **compact な Fortran `import` 文が参照検索に出るようになりました** — `import::Name` と `import, only:Name` を空白ありの interface import と同じように索引します。

--- a/changelog.d/unreleased/+fortran-compact-use-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-compact-use-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Compact Fortran `use::module` statements now appear in reference search** — compact module imports, `only:` lists, and rename lists are indexed like spaced `use :: module` statements.
+
+## 日本語
+
+- **compact な Fortran `use::module` 文が参照検索に出るようになりました** — 空白なしの module import、`only:` list、rename list を、空白ありの `use :: module` と同じように索引します。

--- a/changelog.d/unreleased/+fortran-data-groups-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-data-groups-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran multi-group `data` statements now appear fully in reference search** — declarations such as `data a /1/, b /2/` index each initialized object list.
+
+## 日本語
+
+- **Fortran の複数 group `data` 文が参照検索にすべて出るようになりました** — `data a /1/, b /2/` のような宣言で、各初期化対象リストを索引します。

--- a/changelog.d/unreleased/+fortran-data-object-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-data-object-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `data` object lists now appear in reference search** — declarations such as `data a, b /.../` index the initialized object names.
+
+## 日本語
+
+- **Fortran の `data` object list が参照検索に出るようになりました** — `data a, b /.../` のような宣言で、初期化対象の名前を索引します。

--- a/changelog.d/unreleased/+fortran-deallocate-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-deallocate-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `deallocate` object lists now appear in reference search** — targets in `deallocate(a, b, stat=...)` are indexed while keyword arguments are ignored.
+
+## 日本語
+
+- **Fortran の `deallocate` object list が参照検索に出るようになりました** — `deallocate(a, b, stat=...)` の対象を索引し、keyword 引数は除外します。

--- a/changelog.d/unreleased/+fortran-derived-types.fixed.md
+++ b/changelog.d/unreleased/+fortran-derived-types.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran derived types are now searchable as definitions** — `type :: Name` and `type, extends(Base) :: Name` declarations are indexed as type definitions, and `extends(Base)` is recorded as a type reference for definition/reference search.
+
+## 日本語
+
+- **Fortran の派生型定義を検索できるようになりました** — `type :: Name` と `type, extends(Base) :: Name` の宣言を型定義として索引し、`extends(Base)` も definition/reference 検索用の型参照として記録します。

--- a/changelog.d/unreleased/+fortran-entry-symbol.fixed.md
+++ b/changelog.d/unreleased/+fortran-entry-symbol.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran `entry` procedures are now searchable** — `entry alternate_name(...)` declarations are indexed as function symbols.
+
+## 日本語
+
+- **Fortran の `entry` 手続きが検索できるようになりました** — `entry alternate_name(...)` 宣言を関数シンボルとして索引します。

--- a/changelog.d/unreleased/+fortran-enumerator-symbols.fixed.md
+++ b/changelog.d/unreleased/+fortran-enumerator-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran enumerators are now searchable** — `enumerator :: color_red = 1, color_blue = 2` declarations index each enumerator as a property symbol.
+
+## 日本語
+
+- **Fortran の enumerator が検索できるようになりました** — `enumerator :: color_red = 1, color_blue = 2` 宣言で、各 enumerator を property symbol として索引します。

--- a/changelog.d/unreleased/+fortran-equivalence-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-equivalence-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `equivalence` lists now appear in reference search** — declarations such as `equivalence (a, b)` index each associated name.
+
+## 日本語
+
+- **Fortran の `equivalence` list が参照検索に出るようになりました** — `equivalence (a, b)` のような宣言で、関連付けられた各名前を索引します。

--- a/changelog.d/unreleased/+fortran-external-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-external-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran external procedure declarations now appear in reference search** — `external legacy_hook, repository_probe` declarations index each named external procedure.
+
+## 日本語
+
+- **Fortran の external 手続き宣言が参照検索に出るようになりました** — `external legacy_hook, repository_probe` 宣言で、各 external 手続き名を索引します。

--- a/changelog.d/unreleased/+fortran-finalizer-no-colon-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-finalizer-no-colon-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran finalizer declarations without `::` now appear in reference search** — `final cleanup` is indexed the same way as `final :: cleanup`.
+
+## 日本語
+
+- **`::` を省略した Fortran finalizer 宣言が参照検索に出るようになりました** — `final cleanup` を `final :: cleanup` と同じように索引します。

--- a/changelog.d/unreleased/+fortran-finalizer-nospace-colon-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-finalizer-nospace-colon-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran finalizer declarations with compact `::` now appear in reference search** — `final::cleanup` is indexed the same way as spaced finalizer declarations.
+
+## 日本語
+
+- **空白なし `::` の Fortran finalizer 宣言が参照検索に出るようになりました** — `final::cleanup` を空白ありの finalizer 宣言と同じように索引します。

--- a/changelog.d/unreleased/+fortran-finalizer-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-finalizer-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran finalizer declarations now appear in reference search** — `final :: cleanup, destroy` declarations index each finalizer procedure.
+
+## 日本語
+
+- **Fortran の finalizer 宣言が参照検索に出るようになりました** — `final :: cleanup, destroy` 宣言で列挙された各 finalizer 手続きを索引します。

--- a/changelog.d/unreleased/+fortran-import-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-import-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran interface imports now appear in reference search** — `import :: Name` and `import, only: Name` statements now index imported names as type references for dependency lookups.
+
+## 日本語
+
+- **Fortran interface の import が参照検索に出るようになりました** — `import :: Name` と `import, only: Name` の import 名を型参照として索引し、依存検索で辿れるようにしました。

--- a/changelog.d/unreleased/+fortran-include-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-include-reference.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/FortranReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `include` targets now appear in reference search** — quoted include paths such as `include 'constants.inc'` are indexed as references so included source dependencies can be found.
+
+## 日本語
+
+- **Fortran の `include` 対象が参照検索に出るようになりました** — `include 'constants.inc'` のような引用付き include path を参照として索引し、取り込み元ソースの依存を見つけられるようにしました。

--- a/changelog.d/unreleased/+fortran-intrinsic-kind-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-intrinsic-kind-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran intrinsic kind parameters now appear in reference search** — declarations such as `integer(c_int)` and `real(kind=real64)` index their named kind parameters as type references.
+
+## 日本語
+
+- **Fortran の intrinsic 型 kind パラメータが参照検索に出るようになりました** — `integer(c_int)` や `real(kind=real64)` のような宣言で、名前付き kind パラメータを型参照として索引します。

--- a/changelog.d/unreleased/+fortran-intrinsic-procedure-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-intrinsic-procedure-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran intrinsic procedure declarations now appear in reference search** — `intrinsic sin, cos` declarations index each named intrinsic procedure.
+
+## 日本語
+
+- **Fortran の intrinsic 手続き宣言が参照検索に出るようになりました** — `intrinsic sin, cos` 宣言で、各 intrinsic 手続き名を索引します。

--- a/changelog.d/unreleased/+fortran-module-procedure-body.fixed.md
+++ b/changelog.d/unreleased/+fortran-module-procedure-body.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran `module procedure` implementations now keep body ranges** — submodule implementations such as `module procedure normalize_impl ... end procedure` are indexed as function symbols with bodies.
+
+## 日本語
+
+- **Fortran の `module procedure` 実装が本体範囲付きで検索できるようになりました** — `module procedure normalize_impl ... end procedure` のような submodule 実装を、本体範囲付きの function symbol として索引します。

--- a/changelog.d/unreleased/+fortran-namelist-member-references.fixed.md
+++ b/changelog.d/unreleased/+fortran-namelist-member-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran namelist member names now appear in reference search** — declarations such as `namelist /config/ value, status` index both the group and listed members.
+
+## 日本語
+
+- **Fortran の namelist member 名が参照検索に出るようになりました** — `namelist /config/ value, status` のような宣言で group 名だけでなく列挙された member も索引します。

--- a/changelog.d/unreleased/+fortran-namelist-member-symbols.fixed.md
+++ b/changelog.d/unreleased/+fortran-namelist-member-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran `namelist` members now appear in symbol search** — names in `namelist /group/ a, b` declarations are indexed as properties.
+
+## 日本語
+
+- **Fortran の `namelist` member が symbol search に出るようになりました** — `namelist /group/ a, b` の名前を property として索引します。

--- a/changelog.d/unreleased/+fortran-namelist-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-namelist-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran namelist group names now appear in reference search** — declarations such as `namelist /repository_config/ value` index the named namelist group.
+
+## 日本語
+
+- **Fortran の namelist group 名が参照検索に出るようになりました** — `namelist /repository_config/ value` のような宣言で、名前付き namelist group を索引します。

--- a/changelog.d/unreleased/+fortran-old-parameter-symbols.fixed.md
+++ b/changelog.d/unreleased/+fortran-old-parameter-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Old-style Fortran `parameter (...)` constants are now searchable as symbols** — declarations such as `parameter (size = 4, limit = selected_int_kind(9))` index each constant.
+
+## 日本語
+
+- **旧形式の Fortran `parameter (...)` 定数が symbol として検索できるようになりました** — `parameter (size = 4, limit = selected_int_kind(9))` のような宣言で各定数を索引します。

--- a/changelog.d/unreleased/+fortran-old-typed-variable-symbols.fixed.md
+++ b/changelog.d/unreleased/+fortran-old-typed-variable-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Old-style Fortran typed variable declarations are now searchable as symbols** — declarations such as `integer count, total` index each declared name without requiring `::`.
+
+## 日本語
+
+- **旧形式の Fortran 型付き変数宣言が symbol として検索できるようになりました** — `integer count, total` のような宣言で、`::` がなくても各名前を索引します。

--- a/changelog.d/unreleased/+fortran-parameter-symbols.fixed.md
+++ b/changelog.d/unreleased/+fortran-parameter-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran `parameter` constants are now searchable** — typed declarations such as `integer, parameter :: max_rank = 8, default_rank = 2` index each parameter as a property symbol.
+
+## 日本語
+
+- **Fortran の `parameter` 定数が検索できるようになりました** — `integer, parameter :: max_rank = 8, default_rank = 2` のような型付き宣言で、各 parameter を property symbol として索引します。

--- a/changelog.d/unreleased/+fortran-pointer-assignment-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-pointer-assignment-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran pointer assignment targets now appear in reference search** — assignments such as `callback => resolver` index the target name while ignoring `null()` resets.
+
+## 日本語
+
+- **Fortran の pointer assignment target が参照検索に出るようになりました** — `callback => resolver` のような代入で target 名を索引し、`null()` への reset は除外します。

--- a/changelog.d/unreleased/+fortran-procedure-interface.fixed.md
+++ b/changelog.d/unreleased/+fortran-procedure-interface.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `procedure(Interface)` declarations now record interface references** — procedure pointer and dummy procedure declarations now index the interface name as a type reference for dependency search.
+
+## 日本語
+
+- **Fortran の `procedure(Interface)` 宣言が interface 参照を記録するようになりました** — procedure pointer や dummy procedure の宣言で interface 名を型参照として索引し、依存検索で見つけられるようにしました。

--- a/changelog.d/unreleased/+fortran-save-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-save-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `save` declarations now appear in reference search** — named objects and common blocks in `save` statements are indexed as references.
+
+## 日本語
+
+- **Fortran の `save` 宣言が参照検索に出るようになりました** — `save` 文の named object と common block を参照として索引します。

--- a/changelog.d/unreleased/+fortran-select-type.fixed.md
+++ b/changelog.d/unreleased/+fortran-select-type.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `select type` guards now appear in reference search** — `type is (Name)` and `class is (Name)` branches are indexed as type references so type-dispatch dependencies are discoverable.
+
+## 日本語
+
+- **Fortran の `select type` guard が参照検索に出るようになりました** — `type is (Name)` と `class is (Name)` の分岐を型参照として索引し、型分岐の依存を見つけられるようにしました。

--- a/changelog.d/unreleased/+fortran-submodule-parent-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-submodule-parent-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran submodule parent dependencies now appear in reference search** — `submodule (parent:ancestor) child` declarations index the parent module and ancestor submodule names.
+
+## 日本語
+
+- **Fortran submodule の親依存が参照検索に出るようになりました** — `submodule (parent:ancestor) child` 宣言で、親 module と ancestor submodule 名を索引します。

--- a/changelog.d/unreleased/+fortran-type-bound-call.fixed.md
+++ b/changelog.d/unreleased/+fortran-type-bound-call.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran type-bound `call object%method()` targets now resolve to the method** — explicit `call` statements with `%` receiver chains index the final procedure name instead of recording the receiver object as a phantom call.
+
+## 日本語
+
+- **Fortran の type-bound `call object%method()` が method を指すようになりました** — `%` receiver chain 付きの明示 `call` 文では receiver object の phantom call ではなく、最後の procedure 名を索引します。

--- a/changelog.d/unreleased/+fortran-typed-variable-symbols.fixed.md
+++ b/changelog.d/unreleased/+fortran-typed-variable-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Fortran typed variable and component declarations are now searchable as symbols** — declarations such as `integer :: x` and `real :: a, b` index each declared name as a property symbol.
+
+## 日本語
+
+- **Fortran の型付き変数・component 宣言が symbol として検索できるようになりました** — `integer :: x` や `real :: a, b` のような宣言で各名前を property symbol として索引します。

--- a/changelog.d/unreleased/+fortran-use-alias-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-use-alias-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `use only` aliases now appear in reference search** — imports such as `use mod, only: local_name => remote_name` index the local alias as well as the remote symbol.
+
+## 日本語
+
+- **Fortran の `use only` alias が参照検索に出るようになりました** — `use mod, only: local_name => remote_name` のような import で、remote symbol に加えて local alias も索引します。

--- a/changelog.d/unreleased/+fortran-use-only.fixed.md
+++ b/changelog.d/unreleased/+fortran-use-only.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `use ... only:` imports now appear in reference search** — imported names listed after `only:` are indexed as type references alongside the module name, so dependency searches can find explicit Fortran imports.
+
+## 日本語
+
+- **Fortran の `use ... only:` import が参照検索に出るようになりました** — `only:` の後に列挙された import 名を module 名と合わせて型参照として索引し、明示的な Fortran import を依存検索で見つけられるようにしました。

--- a/changelog.d/unreleased/+fortran-use-rename-list-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-use-rename-list-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `use` rename lists without `only:` now appear in reference search** — `use module, local => remote` indexes both the local alias and remote symbol.
+
+## 日本語
+
+- **`only:` なしの Fortran `use` rename list が参照検索に出るようになりました** — `use module, local => remote` で local alias と remote symbol の両方を索引します。

--- a/changelog.d/unreleased/+fortran-use-rename-target-reference.fixed.md
+++ b/changelog.d/unreleased/+fortran-use-rename-target-reference.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Fortran `use ... only:` rename targets now appear in reference search** — `local => remote` imports index the remote symbol as well as the local alias.
+
+## 日本語
+
+- **Fortran の `use ... only:` rename 元が参照検索に出るようになりました** — `local => remote` 形式の import で、local alias だけでなく remote symbol も索引します。

--- a/src/CodeIndex/Indexer/References/Languages/FortranReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FortranReferenceExtractor.cs
@@ -6,6 +6,7 @@ internal static class FortranReferenceExtractor
 {
     public static void EmitTypePositionReferences(
         string preparedLine,
+        string originalLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -17,7 +18,7 @@ internal static class FortranReferenceExtractor
         LanguageReferenceExtractionSupport.EmitTypePositionReferences(
             "fortran",
             preparedLine,
-            preparedLine,
+            originalLine,
             references,
             seen,
             fileId,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1605,7 +1605,7 @@ public static partial class ReferenceExtractor
             else if (language == "vb")
                 VisualBasicReferenceExtractor.EmitTypePositionReferences(preparedLine, references, seen, fileId, context, lineNumber, ResolveContainerForCall);
             else if (language == "fortran")
-                FortranReferenceExtractor.EmitTypePositionReferences(preparedLine, references, seen, fileId, context, lineNumber, ResolveContainerForCall, container);
+                FortranReferenceExtractor.EmitTypePositionReferences(preparedLine, originalLine, references, seen, fileId, context, lineNumber, ResolveContainerForCall, container);
             else if (language == "pascal")
                 PascalReferenceExtractor.EmitTypePositionReferences(preparedLine, references, seen, fileId, context, lineNumber, ResolveContainerForCall, container);
             else if (language == "objc")

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -351,7 +351,7 @@ internal static class LanguageReferenceExtractionSupport
         @"^\s*intrinsic(?:\s*::)?\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranAccessListRegex = new(
-        @"^\s*(?:public|private)\s*::\s*(?<list>.+)$",
+        @"^\s*(?:public|private)(?:\s*::\s*|\s+)(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranFinalizerRegex = new(
         @"^\s*final(?:\s*::)?\s+(?<list>.+)$",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -326,6 +326,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranUseAliasRegex = new(
         @"(?:^|,)\s*(?<alias>[A-Za-z_]\w*)\s*=>\s*[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranUseAliasTargetRegex = new(
+        @"(?:^|,)\s*[A-Za-z_]\w*\s*=>\s*(?<target>[A-Za-z_]\w*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranImportRegex = new(
         @"^\s*import(?:\s*,\s*only)?(?:\s*::|\s*:)?\s+(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3768,6 +3771,12 @@ internal static class LanguageReferenceExtractionSupport
             foreach (Match match in FortranUseAliasRegex.Matches(list.Value))
             {
                 var group = match.Groups["alias"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "type_reference", context, lineNumber, container);
+            }
+
+            foreach (Match match in FortranUseAliasTargetRegex.Matches(list.Value))
+            {
+                var group = match.Groups["target"];
                 ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "type_reference", context, lineNumber, container);
             }
         }

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -350,6 +350,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranIntrinsicProcedureRegex = new(
         @"^\s*intrinsic(?:\s*::)?\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranAccessListRegex = new(
+        @"^\s*(?:public|private)\s*::\s*(?<list>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSimpleListNameRegex = new(
         @"(?:^|,)\s*(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -3805,6 +3808,17 @@ internal static class LanguageReferenceExtractionSupport
         if (intrinsicProcedureMatch.Success)
         {
             var list = intrinsicProcedureMatch.Groups["list"];
+            foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+            }
+        }
+
+        var accessListMatch = FortranAccessListRegex.Match(preparedLine);
+        if (accessListMatch.Success)
+        {
+            var list = accessListMatch.Groups["list"];
             foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
             {
                 var group = match.Groups["name"];

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -395,6 +395,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranBindingTargetRegex = new(
         @"(?:=>|,)\s*(?:(?:[A-Za-z_]\w*)\s*=>\s*)?(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranPointerAssignmentRegex = new(
+        @"^\s*(?:[A-Za-z_]\w*(?:\s*%\s*[A-Za-z_]\w*)*)\s*=>\s*(?<name>[A-Za-z_]\w*)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
         @"^\s*call\s+(?:(?:[A-Za-z_]\w*)\s*%\s*)*(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3880,6 +3883,14 @@ internal static class LanguageReferenceExtractionSupport
                     ReferenceExtractor.AddReference(references, seen, fileId, group.Value, targetListMatch.Index + group.Index, "reference", context, lineNumber, container);
                 }
             }
+        }
+
+        var pointerAssignmentMatch = FortranPointerAssignmentRegex.Match(preparedLine);
+        if (pointerAssignmentMatch.Success)
+        {
+            var group = pointerAssignmentMatch.Groups["name"];
+            if (!group.Value.Equals("null", StringComparison.OrdinalIgnoreCase))
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, group.Index, "reference", context, lineNumber, container);
         }
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -413,6 +413,12 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranPointerAssignmentRegex = new(
         @"^\s*(?:[A-Za-z_]\w*(?:\s*%\s*[A-Za-z_]\w*)*)\s*=>\s*(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranAssociateLineRegex = new(
+        @"^\s*associate\s*\((?<list>.+)\)\s*$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranAssociateTargetRegex = new(
+        @"(?:^|,)\s*[A-Za-z_]\w*\s*=>\s*(?<name>[A-Za-z_]\w*)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
         @"^\s*call\s+(?:(?:[A-Za-z_]\w*)\s*%\s*)*(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3956,6 +3962,17 @@ internal static class LanguageReferenceExtractionSupport
             var group = pointerAssignmentMatch.Groups["name"];
             if (!group.Value.Equals("null", StringComparison.OrdinalIgnoreCase))
                 ReferenceExtractor.AddReference(references, seen, fileId, group.Value, group.Index, "reference", context, lineNumber, container);
+        }
+
+        var associateMatch = FortranAssociateLineRegex.Match(preparedLine);
+        if (associateMatch.Success)
+        {
+            var list = associateMatch.Groups["list"];
+            foreach (Match match in FortranAssociateTargetRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+            }
         }
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -347,6 +347,12 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranNamelistLineRegex = new(
         @"^\s*namelist\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranEquivalenceLineRegex = new(
+        @"^\s*equivalence\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranParenthesizedNameListRegex = new(
+        @"\((?<list>[^()]*)\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSlashGroupNameRegex = new(
         @"/\s*(?<name>[A-Za-z_]\w*)\s*/",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -3846,6 +3852,19 @@ internal static class LanguageReferenceExtractionSupport
             {
                 var group = match.Groups["name"];
                 ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+            }
+        }
+
+        if (FortranEquivalenceLineRegex.IsMatch(preparedLine))
+        {
+            foreach (Match listMatch in FortranParenthesizedNameListRegex.Matches(preparedLine))
+            {
+                var list = listMatch.Groups["list"];
+                foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+                {
+                    var group = match.Groups["name"];
+                    ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+                }
             }
         }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -323,6 +323,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranUseOnlyRegex = new(
         @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+[A-Za-z_]\w*\s*,\s*only\s*:\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranImportRegex = new(
+        @"^\s*import(?:\s*,\s*only)?(?:\s*::|\s*:)?\s+(?<list>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranTypeRegex = new(
         @"\b(?:type|class)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3704,6 +3707,10 @@ internal static class LanguageReferenceExtractionSupport
         var useOnlyMatch = FortranUseOnlyRegex.Match(preparedLine);
         if (useOnlyMatch.Success)
             EmitCommaSeparatedNames(useOnlyMatch.Groups["list"].Value, useOnlyMatch.Groups["list"].Index, "fortran", references, seen, fileId, context, lineNumber, container);
+
+        var importMatch = FortranImportRegex.Match(preparedLine);
+        if (importMatch.Success)
+            EmitCommaSeparatedNames(importMatch.Groups["list"].Value, importMatch.Groups["list"].Index, "fortran", references, seen, fileId, context, lineNumber, container);
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))
         {

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -336,7 +336,7 @@ internal static class LanguageReferenceExtractionSupport
         @"\bprocedure\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
-        @"^\s*call\s+(?<name>[A-Za-z_]\w*)\b",
+        @"^\s*call\s+(?:(?:[A-Za-z_]\w*)\s*%\s*)*(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     private static readonly Regex PascalUsesRegex = new(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -329,6 +329,12 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranIncludeRegex = new(
         @"^\s*include\s*['""](?<name>[^'""]+)['""]",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranCommonLineRegex = new(
+        @"^\s*common\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranCommonBlockRegex = new(
+        @"/\s*(?<name>[A-Za-z_]\w*)\s*/",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranTypeRegex = new(
         @"\b(?:type|class)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3739,6 +3745,12 @@ internal static class LanguageReferenceExtractionSupport
 
         foreach (Match match in FortranIncludeRegex.Matches(originalLine))
             ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
+
+        if (FortranCommonLineRegex.IsMatch(preparedLine))
+        {
+            foreach (Match match in FortranCommonBlockRegex.Matches(preparedLine))
+                ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
+        }
 
         if (FortranProcedureBindingLineRegex.IsMatch(preparedLine))
         {

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -354,7 +354,7 @@ internal static class LanguageReferenceExtractionSupport
         @"^\s*(?:public|private)(?:\s*::\s*|\s+)(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranFinalizerRegex = new(
-        @"^\s*final(?:\s*::)?\s+(?<list>.+)$",
+        @"^\s*final(?:\s*::\s*|\s+)(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSimpleListNameRegex = new(
         @"(?:^|,)\s*(?<name>[A-Za-z_]\w*)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -326,6 +326,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranImportRegex = new(
         @"^\s*import(?:\s*,\s*only)?(?:\s*::|\s*:)?\s+(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranIncludeRegex = new(
+        @"^\s*include\s*['""](?<name>[^'""]+)['""]",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranTypeRegex = new(
         @"\b(?:type|class)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -453,7 +456,7 @@ internal static class LanguageReferenceExtractionSupport
                 EmitVbTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
                 break;
             case "fortran":
-                EmitFortranTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
+                EmitFortranTypeReferences(preparedLine, originalLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
                 break;
             case "pascal":
                 EmitPascalTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, container);
@@ -3699,6 +3702,7 @@ internal static class LanguageReferenceExtractionSupport
 
     private static void EmitFortranTypeReferences(
         string preparedLine,
+        string originalLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -3717,6 +3721,9 @@ internal static class LanguageReferenceExtractionSupport
         var importMatch = FortranImportRegex.Match(preparedLine);
         if (importMatch.Success)
             EmitCommaSeparatedNames(importMatch.Groups["list"].Value, importMatch.Groups["list"].Index, "fortran", references, seen, fileId, context, lineNumber, container);
+
+        foreach (Match match in FortranIncludeRegex.Matches(originalLine))
+            ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))
         {

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -318,13 +318,13 @@ internal static class LanguageReferenceExtractionSupport
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     private static readonly Regex FortranUseRegex = new(
-        @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+(?<name>[A-Za-z_]\w*)",
+        @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::\s*|\s+)(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranUseOnlyRegex = new(
-        @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+[A-Za-z_]\w*\s*,\s*only\s*:\s*(?<list>.+)$",
+        @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::\s*|\s+)[A-Za-z_]\w*\s*,\s*only\s*:\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranUseRenameListRegex = new(
-        @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+[A-Za-z_]\w*\s*,\s*(?!only\s*:)(?<list>.+)$",
+        @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::\s*|\s+)[A-Za-z_]\w*\s*,\s*(?!only\s*:)(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranUseAliasRegex = new(
         @"(?:^|,)\s*(?<alias>[A-Za-z_]\w*)\s*=>\s*[A-Za-z_]\w*",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -329,6 +329,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranExtendsRegex = new(
         @"\bextends\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranProcedureTypeRegex = new(
+        @"\bprocedure\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
         @"^\s*call\s+(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3709,6 +3712,12 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         foreach (Match match in FortranExtendsRegex.Matches(preparedLine))
+        {
+            var group = match.Groups["type"];
+            ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");
+        }
+
+        foreach (Match match in FortranProcedureTypeRegex.Matches(preparedLine))
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -3822,7 +3822,7 @@ internal static class LanguageReferenceExtractionSupport
                 ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
         }
 
-        if (isFortranNamelistLine)
+        if (isFortranCommonLine || isFortranNamelistLine)
         {
             foreach (Match memberListMatch in FortranSlashGroupMemberListRegex.Matches(preparedLine))
             {

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -401,6 +401,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranAllocateTypeSpecRegex = new(
         @"\ballocate\s*\(\s*(?<type>[A-Za-z_]\w*)\s*::",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranDeallocateListRegex = new(
+        @"^\s*deallocate\s*\((?<list>.*)\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranIntrinsicKeywordKindRegex = new(
         @"\b(?:integer|real|complex|logical|character)\s*\([^)\r\n]*\bkind\s*=\s*(?<type>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -4027,6 +4030,30 @@ internal static class LanguageReferenceExtractionSupport
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");
+        }
+
+        var deallocateListMatch = FortranDeallocateListRegex.Match(preparedLine);
+        if (deallocateListMatch.Success)
+        {
+            var list = deallocateListMatch.Groups["list"];
+            foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(list.Value))
+            {
+                var segment = list.Value.Substring(segmentStart, segmentLength);
+                if (segment.Contains('=', StringComparison.Ordinal))
+                    continue;
+
+                var leading = 0;
+                while (leading < segment.Length && char.IsWhiteSpace(segment[leading]))
+                    leading++;
+                if (leading >= segment.Length || !IsIdentifierStart(segment[leading]))
+                    continue;
+
+                var end = leading + 1;
+                while (end < segment.Length && IsSimpleIdentifierPart(segment[end]))
+                    end++;
+
+                ReferenceExtractor.AddReference(references, seen, fileId, segment[leading..end], list.Index + segmentStart + leading, "reference", context, lineNumber, container);
+            }
         }
 
         foreach (Match match in FortranIntrinsicKeywordKindRegex.Matches(preparedLine))

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -341,6 +341,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranCommonLineRegex = new(
         @"^\s*common\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranBlankCommonMemberListRegex = new(
+        @"^\s*common\s+(?<list>[^/].*)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranNamelistLineRegex = new(
         @"^\s*namelist\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3832,6 +3835,17 @@ internal static class LanguageReferenceExtractionSupport
                     var group = match.Groups["name"];
                     ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
                 }
+            }
+        }
+
+        var blankCommonMemberListMatch = FortranBlankCommonMemberListRegex.Match(preparedLine);
+        if (blankCommonMemberListMatch.Success)
+        {
+            var list = blankCommonMemberListMatch.Groups["list"];
+            foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -347,6 +347,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranExternalRegex = new(
         @"^\s*external(?:\s*::)?\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranIntrinsicProcedureRegex = new(
+        @"^\s*intrinsic(?:\s*::)?\s*(?<list>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSimpleListNameRegex = new(
         @"(?:^|,)\s*(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -3791,6 +3794,17 @@ internal static class LanguageReferenceExtractionSupport
         if (externalMatch.Success)
         {
             var list = externalMatch.Groups["list"];
+            foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+            }
+        }
+
+        var intrinsicProcedureMatch = FortranIntrinsicProcedureRegex.Match(preparedLine);
+        if (intrinsicProcedureMatch.Success)
+        {
+            var list = intrinsicProcedureMatch.Groups["list"];
             foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
             {
                 var group = match.Groups["name"];

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -354,7 +354,7 @@ internal static class LanguageReferenceExtractionSupport
         @"^\s*(?:public|private)\s*::\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranFinalizerRegex = new(
-        @"^\s*final\s*::\s*(?<list>.+)$",
+        @"^\s*final(?:\s*::)?\s+(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSimpleListNameRegex = new(
         @"(?:^|,)\s*(?<name>[A-Za-z_]\w*)",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -353,6 +353,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranAccessListRegex = new(
         @"^\s*(?:public|private)\s*::\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranFinalizerRegex = new(
+        @"^\s*final\s*::\s*(?<list>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSimpleListNameRegex = new(
         @"(?:^|,)\s*(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -3819,6 +3822,17 @@ internal static class LanguageReferenceExtractionSupport
         if (accessListMatch.Success)
         {
             var list = accessListMatch.Groups["list"];
+            foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+            }
+        }
+
+        var finalizerMatch = FortranFinalizerRegex.Match(preparedLine);
+        if (finalizerMatch.Success)
+        {
+            var list = finalizerMatch.Groups["list"];
             foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
             {
                 var group = match.Groups["name"];

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -344,6 +344,12 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranAllocateTypeSpecRegex = new(
         @"\ballocate\s*\(\s*(?<type>[A-Za-z_]\w*)\s*::",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranIntrinsicKeywordKindRegex = new(
+        @"\b(?:integer|real|complex|logical|character)\s*\([^)\r\n]*\bkind\s*=\s*(?<type>[A-Za-z_]\w*)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranIntrinsicPositionalKindRegex = new(
+        @"\b(?:integer|real|complex|logical)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
         @"^\s*call\s+(?:(?:[A-Za-z_]\w*)\s*%\s*)*(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3750,6 +3756,18 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         foreach (Match match in FortranAllocateTypeSpecRegex.Matches(preparedLine))
+        {
+            var group = match.Groups["type"];
+            ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");
+        }
+
+        foreach (Match match in FortranIntrinsicKeywordKindRegex.Matches(preparedLine))
+        {
+            var group = match.Groups["type"];
+            ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");
+        }
+
+        foreach (Match match in FortranIntrinsicPositionalKindRegex.Matches(preparedLine))
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -353,6 +353,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranParenthesizedNameListRegex = new(
         @"\((?<list>[^()]*)\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranDataObjectListRegex = new(
+        @"^\s*data\s+(?<list>[^/]+?)/",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSlashGroupNameRegex = new(
         @"/\s*(?<name>[A-Za-z_]\w*)\s*/",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -3865,6 +3868,17 @@ internal static class LanguageReferenceExtractionSupport
                     var group = match.Groups["name"];
                     ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
                 }
+            }
+        }
+
+        var dataObjectListMatch = FortranDataObjectListRegex.Match(preparedLine);
+        if (dataObjectListMatch.Success)
+        {
+            var list = dataObjectListMatch.Groups["list"];
+            foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -350,6 +350,12 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranIntrinsicPositionalKindRegex = new(
         @"\b(?:integer|real|complex|logical)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranProcedureBindingLineRegex = new(
+        @"^\s*(?:procedure|generic)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranBindingTargetRegex = new(
+        @"=>\s*(?<name>[A-Za-z_]\w*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
         @"^\s*call\s+(?:(?:[A-Za-z_]\w*)\s*%\s*)*(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3730,6 +3736,12 @@ internal static class LanguageReferenceExtractionSupport
 
         foreach (Match match in FortranIncludeRegex.Matches(originalLine))
             ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
+
+        if (FortranProcedureBindingLineRegex.IsMatch(preparedLine))
+        {
+            foreach (Match match in FortranBindingTargetRegex.Matches(preparedLine))
+                ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
+        }
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))
         {

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -320,6 +320,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranUseRegex = new(
         @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranUseOnlyRegex = new(
+        @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+[A-Za-z_]\w*\s*,\s*only\s*:\s*(?<list>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranTypeRegex = new(
         @"\b(?:type|class)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3694,6 +3697,10 @@ internal static class LanguageReferenceExtractionSupport
     {
         foreach (Match match in FortranUseRegex.Matches(preparedLine))
             ReferenceExtractor.AddReference(references, seen, fileId, match, "type_reference", context, lineNumber, container);
+
+        var useOnlyMatch = FortranUseOnlyRegex.Match(preparedLine);
+        if (useOnlyMatch.Success)
+            EmitCommaSeparatedNames(useOnlyMatch.Groups["list"].Value, useOnlyMatch.Groups["list"].Index, "fortran", references, seen, fileId, context, lineNumber, container);
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))
         {

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -323,6 +323,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranTypeRegex = new(
         @"\b(?:type|class)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranExtendsRegex = new(
+        @"\bextends\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
         @"^\s*call\s+(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3693,6 +3696,12 @@ internal static class LanguageReferenceExtractionSupport
             ReferenceExtractor.AddReference(references, seen, fileId, match, "type_reference", context, lineNumber, container);
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))
+        {
+            var group = match.Groups["type"];
+            ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");
+        }
+
+        foreach (Match match in FortranExtendsRegex.Matches(preparedLine))
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -404,6 +404,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranAllocateListRegex = new(
         @"^\s*allocate\s*\((?<list>.*)\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranAllocateSourceKeywordRegex = new(
+        @"\b(?:source|mold)\s*=\s*(?<name>[A-Za-z_]\w*)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranDeallocateListRegex = new(
         @"^\s*deallocate\s*\((?<list>.*)\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -4065,6 +4068,12 @@ internal static class LanguageReferenceExtractionSupport
                     end++;
 
                 ReferenceExtractor.AddReference(references, seen, fileId, segment[leading..end], objectListStart + segmentStart + leading, "reference", context, lineNumber, container);
+            }
+
+            foreach (Match match in FortranAllocateSourceKeywordRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -323,6 +323,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranUseOnlyRegex = new(
         @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+[A-Za-z_]\w*\s*,\s*only\s*:\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranUseRenameListRegex = new(
+        @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+[A-Za-z_]\w*\s*,\s*(?!only\s*:)(?<list>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranUseAliasRegex = new(
         @"(?:^|,)\s*(?<alias>[A-Za-z_]\w*)\s*=>\s*[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -3768,6 +3771,23 @@ internal static class LanguageReferenceExtractionSupport
             EmitCommaSeparatedNames(useOnlyMatch.Groups["list"].Value, useOnlyMatch.Groups["list"].Index, "fortran", references, seen, fileId, context, lineNumber, container);
 
             var list = useOnlyMatch.Groups["list"];
+            foreach (Match match in FortranUseAliasRegex.Matches(list.Value))
+            {
+                var group = match.Groups["alias"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "type_reference", context, lineNumber, container);
+            }
+
+            foreach (Match match in FortranUseAliasTargetRegex.Matches(list.Value))
+            {
+                var group = match.Groups["target"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "type_reference", context, lineNumber, container);
+            }
+        }
+
+        var useRenameMatch = FortranUseRenameListRegex.Match(preparedLine);
+        if (useRenameMatch.Success)
+        {
+            var list = useRenameMatch.Groups["list"];
             foreach (Match match in FortranUseAliasRegex.Matches(list.Value))
             {
                 var group = match.Groups["alias"];

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -356,6 +356,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranDataObjectListRegex = new(
         @"^\s*data\s+(?<list>[^/]+?)/",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranSaveRegex = new(
+        @"^\s*save(?:\s*::|\s+)(?<list>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSlashGroupNameRegex = new(
         @"/\s*(?<name>[A-Za-z_]\w*)\s*/",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -3881,6 +3884,20 @@ internal static class LanguageReferenceExtractionSupport
         if (dataObjectListMatch.Success)
         {
             var list = dataObjectListMatch.Groups["list"];
+            foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+            }
+        }
+
+        var saveMatch = FortranSaveRegex.Match(preparedLine);
+        if (saveMatch.Success)
+        {
+            var list = saveMatch.Groups["list"];
+            foreach (Match match in FortranSlashGroupNameRegex.Matches(list.Value))
+                ReferenceExtractor.AddReference(references, seen, fileId, match.Groups["name"].Value, list.Index + match.Groups["name"].Index, "reference", context, lineNumber, container);
+
             foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
             {
                 var group = match.Groups["name"];

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -347,6 +347,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranSlashGroupNameRegex = new(
         @"/\s*(?<name>[A-Za-z_]\w*)\s*/",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranSlashGroupMemberListRegex = new(
+        @"/\s*[A-Za-z_]\w*\s*/(?<list>[^/]*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSubmoduleParentRegex = new(
         @"^\s*submodule\s*\(\s*(?<parent>[A-Za-z_]\w*)(?:\s*:\s*(?<ancestor>[A-Za-z_]\w*))?\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3811,10 +3814,25 @@ internal static class LanguageReferenceExtractionSupport
         foreach (Match match in FortranIncludeRegex.Matches(originalLine))
             ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
 
-        if (FortranCommonLineRegex.IsMatch(preparedLine) || FortranNamelistLineRegex.IsMatch(preparedLine))
+        var isFortranCommonLine = FortranCommonLineRegex.IsMatch(preparedLine);
+        var isFortranNamelistLine = FortranNamelistLineRegex.IsMatch(preparedLine);
+        if (isFortranCommonLine || isFortranNamelistLine)
         {
             foreach (Match match in FortranSlashGroupNameRegex.Matches(preparedLine))
                 ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
+        }
+
+        if (isFortranNamelistLine)
+        {
+            foreach (Match memberListMatch in FortranSlashGroupMemberListRegex.Matches(preparedLine))
+            {
+                var list = memberListMatch.Groups["list"];
+                foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+                {
+                    var group = match.Groups["name"];
+                    ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+                }
+            }
         }
 
         var submoduleMatch = FortranSubmoduleParentRegex.Match(preparedLine);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -353,8 +353,11 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranParenthesizedNameListRegex = new(
         @"\((?<list>[^()]*)\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex FortranDataObjectListRegex = new(
-        @"^\s*data\s+(?<list>[^/]+?)/",
+    private static readonly Regex FortranDataLineRegex = new(
+        @"^\s*data\s+(?<tail>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranDataObjectGroupRegex = new(
+        @"(?:^|,)\s*(?<list>[^/]+?)\s*/",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranSaveRegex = new(
         @"^\s*save(?:\s*::|\s+)(?<list>.+)$",
@@ -3880,14 +3883,18 @@ internal static class LanguageReferenceExtractionSupport
             }
         }
 
-        var dataObjectListMatch = FortranDataObjectListRegex.Match(preparedLine);
-        if (dataObjectListMatch.Success)
+        var dataLineMatch = FortranDataLineRegex.Match(preparedLine);
+        if (dataLineMatch.Success)
         {
-            var list = dataObjectListMatch.Groups["list"];
-            foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+            var tail = dataLineMatch.Groups["tail"];
+            foreach (Match groupMatch in FortranDataObjectGroupRegex.Matches(tail.Value))
             {
-                var group = match.Groups["name"];
-                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+                var list = groupMatch.Groups["list"];
+                foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+                {
+                    var group = match.Groups["name"];
+                    ReferenceExtractor.AddReference(references, seen, fileId, group.Value, tail.Index + list.Index + group.Index, "reference", context, lineNumber, container);
+                }
             }
         }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -338,6 +338,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranSlashGroupNameRegex = new(
         @"/\s*(?<name>[A-Za-z_]\w*)\s*/",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranSubmoduleParentRegex = new(
+        @"^\s*submodule\s*\(\s*(?<parent>[A-Za-z_]\w*)(?:\s*:\s*(?<ancestor>[A-Za-z_]\w*))?\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranTypeRegex = new(
         @"\b(?:type|class)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3753,6 +3756,17 @@ internal static class LanguageReferenceExtractionSupport
         {
             foreach (Match match in FortranSlashGroupNameRegex.Matches(preparedLine))
                 ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
+        }
+
+        var submoduleMatch = FortranSubmoduleParentRegex.Match(preparedLine);
+        if (submoduleMatch.Success)
+        {
+            var parent = submoduleMatch.Groups["parent"];
+            ReferenceExtractor.AddReference(references, seen, fileId, parent.Value, parent.Index, "type_reference", context, lineNumber, container);
+
+            var ancestor = submoduleMatch.Groups["ancestor"];
+            if (ancestor.Success)
+                ReferenceExtractor.AddReference(references, seen, fileId, ancestor.Value, ancestor.Index, "type_reference", context, lineNumber, container);
         }
 
         if (FortranProcedureBindingLineRegex.IsMatch(preparedLine))

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -338,6 +338,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranProcedureTypeRegex = new(
         @"\bprocedure\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranAllocateTypeSpecRegex = new(
+        @"\ballocate\s*\(\s*(?<type>[A-Za-z_]\w*)\s*::",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
         @"^\s*call\s+(?:(?:[A-Za-z_]\w*)\s*%\s*)*(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3734,6 +3737,12 @@ internal static class LanguageReferenceExtractionSupport
         }
 
         foreach (Match match in FortranProcedureTypeRegex.Matches(preparedLine))
+        {
+            var group = match.Groups["type"];
+            ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");
+        }
+
+        foreach (Match match in FortranAllocateTypeSpecRegex.Matches(preparedLine))
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -353,8 +353,11 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranProcedureBindingLineRegex = new(
         @"^\s*(?:procedure|generic)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranBindingTargetListRegex = new(
+        @"=>.*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranBindingTargetRegex = new(
-        @"=>\s*(?<name>[A-Za-z_]\w*)",
+        @"(?:=>|,)\s*(?:(?:[A-Za-z_]\w*)\s*=>\s*)?(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranCallRegex = new(
         @"^\s*call\s+(?:(?:[A-Za-z_]\w*)\s*%\s*)*(?<name>[A-Za-z_]\w*)\b",
@@ -3739,8 +3742,15 @@ internal static class LanguageReferenceExtractionSupport
 
         if (FortranProcedureBindingLineRegex.IsMatch(preparedLine))
         {
-            foreach (Match match in FortranBindingTargetRegex.Matches(preparedLine))
-                ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
+            var targetListMatch = FortranBindingTargetListRegex.Match(preparedLine);
+            if (targetListMatch.Success)
+            {
+                foreach (Match match in FortranBindingTargetRegex.Matches(targetListMatch.Value))
+                {
+                    var group = match.Groups["name"];
+                    ReferenceExtractor.AddReference(references, seen, fileId, group.Value, targetListMatch.Index + group.Index, "reference", context, lineNumber, container);
+                }
+            }
         }
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -401,6 +401,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranAllocateTypeSpecRegex = new(
         @"\ballocate\s*\(\s*(?<type>[A-Za-z_]\w*)\s*::",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranAllocateListRegex = new(
+        @"^\s*allocate\s*\((?<list>.*)\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranDeallocateListRegex = new(
         @"^\s*deallocate\s*\((?<list>.*)\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -4030,6 +4033,39 @@ internal static class LanguageReferenceExtractionSupport
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");
+        }
+
+        var allocateListMatch = FortranAllocateListRegex.Match(preparedLine);
+        if (allocateListMatch.Success)
+        {
+            var list = allocateListMatch.Groups["list"];
+            var objectList = list.Value;
+            var objectListStart = list.Index;
+            var typeSpecEnd = objectList.IndexOf("::", StringComparison.Ordinal);
+            if (typeSpecEnd >= 0)
+            {
+                objectListStart += typeSpecEnd + 2;
+                objectList = objectList[(typeSpecEnd + 2)..];
+            }
+
+            foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(objectList))
+            {
+                var segment = objectList.Substring(segmentStart, segmentLength);
+                if (segment.Contains('=', StringComparison.Ordinal))
+                    continue;
+
+                var leading = 0;
+                while (leading < segment.Length && char.IsWhiteSpace(segment[leading]))
+                    leading++;
+                if (leading >= segment.Length || !IsIdentifierStart(segment[leading]))
+                    continue;
+
+                var end = leading + 1;
+                while (end < segment.Length && IsSimpleIdentifierPart(segment[end]))
+                    end++;
+
+                ReferenceExtractor.AddReference(references, seen, fileId, segment[leading..end], objectListStart + segmentStart + leading, "reference", context, lineNumber, container);
+            }
         }
 
         var deallocateListMatch = FortranDeallocateListRegex.Match(preparedLine);

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -341,6 +341,12 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranSubmoduleParentRegex = new(
         @"^\s*submodule\s*\(\s*(?<parent>[A-Za-z_]\w*)(?:\s*:\s*(?<ancestor>[A-Za-z_]\w*))?\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranExternalRegex = new(
+        @"^\s*external(?:\s*::)?\s*(?<list>.+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranSimpleListNameRegex = new(
+        @"(?:^|,)\s*(?<name>[A-Za-z_]\w*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranTypeRegex = new(
         @"\b(?:type|class)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3767,6 +3773,17 @@ internal static class LanguageReferenceExtractionSupport
             var ancestor = submoduleMatch.Groups["ancestor"];
             if (ancestor.Success)
                 ReferenceExtractor.AddReference(references, seen, fileId, ancestor.Value, ancestor.Index, "type_reference", context, lineNumber, container);
+        }
+
+        var externalMatch = FortranExternalRegex.Match(preparedLine);
+        if (externalMatch.Success)
+        {
+            var list = externalMatch.Groups["list"];
+            foreach (Match match in FortranSimpleListNameRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+            }
         }
 
         if (FortranProcedureBindingLineRegex.IsMatch(preparedLine))

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -333,7 +333,7 @@ internal static class LanguageReferenceExtractionSupport
         @"(?:^|,)\s*[A-Za-z_]\w*\s*=>\s*(?<target>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranImportRegex = new(
-        @"^\s*import(?:\s*,\s*only)?(?:\s*::|\s*:)?\s+(?<list>.+)$",
+        @"^\s*import(?:\s*,\s*only)?(?:\s*::\s*|\s*:\s*|\s+)(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranIncludeRegex = new(
         @"^\s*include\s*['""](?<name>[^'""]+)['""]",

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -407,6 +407,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranAllocateSourceKeywordRegex = new(
         @"\b(?:source|mold)\s*=\s*(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranAllocationStatusKeywordRegex = new(
+        @"\b(?:stat|errmsg)\s*=\s*(?<name>[A-Za-z_]\w*)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranDeallocateListRegex = new(
         @"^\s*deallocate\s*\((?<list>.*)\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -4075,6 +4078,12 @@ internal static class LanguageReferenceExtractionSupport
                 var group = match.Groups["name"];
                 ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
             }
+
+            foreach (Match match in FortranAllocationStatusKeywordRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
+            }
         }
 
         var deallocateListMatch = FortranDeallocateListRegex.Match(preparedLine);
@@ -4098,6 +4107,12 @@ internal static class LanguageReferenceExtractionSupport
                     end++;
 
                 ReferenceExtractor.AddReference(references, seen, fileId, segment[leading..end], list.Index + segmentStart + leading, "reference", context, lineNumber, container);
+            }
+
+            foreach (Match match in FortranAllocationStatusKeywordRegex.Matches(list.Value))
+            {
+                var group = match.Groups["name"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "reference", context, lineNumber, container);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -329,6 +329,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranTypeRegex = new(
         @"\b(?:type|class)\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranTypeGuardRegex = new(
+        @"\b(?:type|class)\s+is\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex FortranExtendsRegex = new(
         @"\bextends\s*\(\s*(?<type>[A-Za-z_]\w*)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3713,6 +3716,12 @@ internal static class LanguageReferenceExtractionSupport
             EmitCommaSeparatedNames(importMatch.Groups["list"].Value, importMatch.Groups["list"].Index, "fortran", references, seen, fileId, context, lineNumber, container);
 
         foreach (Match match in FortranTypeRegex.Matches(preparedLine))
+        {
+            var group = match.Groups["type"];
+            ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");
+        }
+
+        foreach (Match match in FortranTypeGuardRegex.Matches(preparedLine))
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), "fortran");

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -332,7 +332,10 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranCommonLineRegex = new(
         @"^\s*common\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    private static readonly Regex FortranCommonBlockRegex = new(
+    private static readonly Regex FortranNamelistLineRegex = new(
+        @"^\s*namelist\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranSlashGroupNameRegex = new(
         @"/\s*(?<name>[A-Za-z_]\w*)\s*/",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranTypeRegex = new(
@@ -3746,9 +3749,9 @@ internal static class LanguageReferenceExtractionSupport
         foreach (Match match in FortranIncludeRegex.Matches(originalLine))
             ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
 
-        if (FortranCommonLineRegex.IsMatch(preparedLine))
+        if (FortranCommonLineRegex.IsMatch(preparedLine) || FortranNamelistLineRegex.IsMatch(preparedLine))
         {
-            foreach (Match match in FortranCommonBlockRegex.Matches(preparedLine))
+            foreach (Match match in FortranSlashGroupNameRegex.Matches(preparedLine))
                 ReferenceExtractor.AddReference(references, seen, fileId, match, "reference", context, lineNumber, container);
         }
 

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -323,6 +323,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex FortranUseOnlyRegex = new(
         @"^\s*use(?:\s*,\s*(?:intrinsic|non_intrinsic))?(?:\s*::)?\s+[A-Za-z_]\w*\s*,\s*only\s*:\s*(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    private static readonly Regex FortranUseAliasRegex = new(
+        @"(?:^|,)\s*(?<alias>[A-Za-z_]\w*)\s*=>\s*[A-Za-z_]\w*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FortranImportRegex = new(
         @"^\s*import(?:\s*,\s*only)?(?:\s*::|\s*:)?\s+(?<list>.+)$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3749,7 +3752,16 @@ internal static class LanguageReferenceExtractionSupport
 
         var useOnlyMatch = FortranUseOnlyRegex.Match(preparedLine);
         if (useOnlyMatch.Success)
+        {
             EmitCommaSeparatedNames(useOnlyMatch.Groups["list"].Value, useOnlyMatch.Groups["list"].Index, "fortran", references, seen, fileId, context, lineNumber, container);
+
+            var list = useOnlyMatch.Groups["list"];
+            foreach (Match match in FortranUseAliasRegex.Matches(list.Value))
+            {
+                var group = match.Groups["alias"];
+                ReferenceExtractor.AddReference(references, seen, fileId, group.Value, list.Index + group.Index, "type_reference", context, lineNumber, container);
+            }
+        }
 
         var importMatch = FortranImportRegex.Match(preparedLine);
         if (importMatch.Success)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
@@ -29,7 +29,7 @@ public static partial class SymbolExtractor
             if (blockKind == "module" && IsFortranModuleProcedureEndLine(trimmed))
                 continue;
 
-            if (blockKind is "subroutine" or "function" && IsFortranRoutineEndLine(trimmed))
+            if (blockKind is "subroutine" or "function" or "procedure" && IsFortranRoutineEndLine(trimmed))
             {
                 if (nestedRoutineDepth > 0)
                 {
@@ -50,7 +50,7 @@ public static partial class SymbolExtractor
             if (bodyStartLine == null)
                 bodyStartLine = i + 1;
 
-            if (blockKind is "subroutine" or "function"
+            if (blockKind is "subroutine" or "function" or "procedure"
                 && IsFortranRoutineStartLine(trimmed))
             {
                 nestedRoutineDepth++;
@@ -167,7 +167,13 @@ public static partial class SymbolExtractor
         if (StartsWithFortranWord(trimmed, "module"))
         {
             var remainder = trimmed["module".Length..].TrimStart();
-            if (StartsWithFortranWord(remainder, "procedure") || StartsWithFortranWord(remainder, "subroutine") || StartsWithFortranWord(remainder, "function"))
+            if (StartsWithFortranWord(remainder, "procedure"))
+            {
+                kind = "procedure";
+                return true;
+            }
+
+            if (StartsWithFortranWord(remainder, "subroutine") || StartsWithFortranWord(remainder, "function"))
                 return false;
 
             kind = "module";
@@ -276,7 +282,8 @@ public static partial class SymbolExtractor
         var remainder = trimmedLine["end".Length..].TrimStart();
         return remainder.Length == 0
             || StartsWithFortranWord(remainder, "subroutine")
-            || StartsWithFortranWord(remainder, "function");
+            || StartsWithFortranWord(remainder, "function")
+            || StartsWithFortranWord(remainder, "procedure");
     }
 
     private static bool IsFortranRoutineStartLine(string trimmedLine) =>

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
@@ -192,6 +192,12 @@ public static partial class SymbolExtractor
             return true;
         }
 
+        if (IsFortranDerivedTypeStartLine(trimmed))
+        {
+            kind = "type";
+            return true;
+        }
+
         if (ContainsFortranWord(trimmed, "subroutine"))
         {
             kind = "subroutine";
@@ -205,6 +211,19 @@ public static partial class SymbolExtractor
         }
 
         return false;
+    }
+
+    private static bool IsFortranDerivedTypeStartLine(string trimmedLine)
+    {
+        if (!StartsWithFortranWord(trimmedLine, "type"))
+            return false;
+
+        var remainder = trimmedLine["type".Length..].TrimStart();
+        if (remainder.Length == 0 || remainder.StartsWith('('))
+            return false;
+
+        return !StartsWithFortranWord(remainder, "is")
+            && !StartsWithFortranWord(remainder, "default");
     }
 
     private static bool IsFortranBlockEndLine(string trimmedLine, string blockKind)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
@@ -192,6 +192,16 @@ public static partial class SymbolExtractor
             return true;
         }
 
+        if (StartsWithFortranWord(trimmed, "block"))
+        {
+            var remainder = trimmed["block".Length..].TrimStart();
+            if (StartsWithFortranWord(remainder, "data"))
+            {
+                kind = "block data";
+                return true;
+            }
+        }
+
         if (IsFortranDerivedTypeStartLine(trimmed))
         {
             kind = "type";

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1274,6 +1274,8 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*(?:(?:allocatable|pointer|target|optional|save|dimension\s*\([^)]+\)|intent\s*\([^)]+\))\s*,\s*)*(?:allocatable|pointer|target|optional|save|dimension\s*\([^)]+\)|intent\s*\([^)]+\))\s*(?:::)?\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Common block members / common block メンバー
             new("property", new Regex(@"^\s*common\s+(?:/\s*[A-Za-z_]\w*\s*/\s*)?(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Namelist members / namelist メンバー
+            new("property", new Regex(@"^\s*namelist\s+/\s*[A-Za-z_]\w*\s*/\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1256,6 +1256,8 @@ public static partial class SymbolExtractor
             new("namespace", new Regex(@"^\s*submodule\s*\(\s*[^)]*\)\s*(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Program units / プログラム本体
             new("class", new Regex(@"^\s*program\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
+            // Derived types / 派生型
+            new("class", new Regex(@"^\s*type(?!\s*\()\b(?:\s*,\s*(?:abstract|public|private|sequence|bind\s*\([^)]+\)|extends\s*\([^)]+\)))*\s*(?:::)?\s*(?!(?:is|default)\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Procedure declarations in interfaces / interface 内の手続き宣言

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1268,6 +1268,8 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*parameter\s*\(\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)\)\s*(?:!.*)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed variables and components / 型付き変数・component
             new("property", new Regex(@"^\s*(?<returnType>(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)))\s*(?:,\s*(?![^:\r\n]*\bparameter\b)[^:\r\n]*)?::\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            // Old-style typed variables without :: / :: なしの旧形式型付き変数
+            new("property", new Regex(@"^\s*(?<returnType>(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)))\s+(?!(?:function|subroutine)\b)(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1272,6 +1272,8 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*(?<returnType>(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)))\s+(?!(?:function|subroutine)\b)(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
             // Attribute-only variables / 属性のみの変数宣言
             new("property", new Regex(@"^\s*(?:(?:allocatable|pointer|target|optional|save|dimension\s*\([^)]+\)|intent\s*\([^)]+\))\s*,\s*)*(?:allocatable|pointer|target|optional|save|dimension\s*\([^)]+\)|intent\s*\([^)]+\))\s*(?:::)?\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Common block members / common block メンバー
+            new("property", new Regex(@"^\s*common\s+(?:/\s*[A-Za-z_]\w*\s*/\s*)?(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1260,6 +1260,8 @@ public static partial class SymbolExtractor
             new("class", new Regex(@"^\s*type(?!\s*\()\b(?:\s*,\s*(?:abstract|public|private|sequence|bind\s*\([^)]+\)|extends\s*\([^)]+\)))*\s*(?:::)?\s*(?!(?:is|default)\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
+            // Entry points / entry 手続き
+            new("function", new Regex(@"^\s*entry\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Procedure declarations in interfaces / interface 内の手続き宣言
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*(?:(?:module\s+)?procedure)(?:\s*\([^)]+\))?(?:\s*,\s*[A-Za-z_]\w*)*\s*(?:::\s*)?(?<name>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed or untyped functions / 型付き・型なし関数

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1262,6 +1262,8 @@ public static partial class SymbolExtractor
             new("class", new Regex(@"^\s*type(?!\s*\()\b(?:\s*,\s*(?:abstract|public|private|sequence|bind\s*\([^)]+\)|extends\s*\([^)]+\)))*\s*(?:::)?\s*(?!(?:is|default)\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Enumerators / enumerator 定数
             new("property", new Regex(@"^\s*enumerator(?:\s*::)?\s*(?<name>[A-Za-z_]\w*)(?<enumTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Parameter constants / parameter 定数
+            new("property", new Regex(@"^\s*(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\))\s*,[^:\r\n]*\bparameter\b[^:\r\n]*::\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き
@@ -2973,6 +2975,11 @@ public static partial class SymbolExtractor
                             && pattern.BodyStyle == BodyStyle.None
                             ? TryExpandFortranEnumeratorDeclaratorList(patternMatchLine, match)
                             : null;
+                        var fortranParameterEntries = lang == "fortran"
+                            && pattern.Kind == "property"
+                            && pattern.BodyStyle == BodyStyle.None
+                            ? TryExpandFortranParameterDeclaratorList(patternMatchLine, match)
+                            : null;
 
                         if (pythonImportEntries != null)
                         {
@@ -3057,6 +3064,32 @@ public static partial class SymbolExtractor
                         else if (fortranEnumeratorEntries != null)
                         {
                             foreach (var entry in fortranEnumeratorEntries)
+                            {
+                                AddSymbolRecord(
+                                    symbols,
+                                    cssSeenSymbols,
+                                    startLine,
+                                    new SymbolRecord
+                                    {
+                                        FileId = fileId,
+                                        Kind = kind,
+                                        Name = entry.Name,
+                                        Line = startLine,
+                                        StartLine = startLine,
+                                        StartColumn = entry.StartColumn,
+                                        EndLine = Math.Max(startLine, endLine),
+                                        BodyStartLine = bodyStartLine,
+                                        BodyEndLine = bodyEndLine,
+                                        Signature = signature,
+                                        Visibility = TryGetGroup(match, pattern.VisibilityGroup),
+                                        ReturnType = NormalizeMetadata(rawReturnType),
+                                    },
+                                    line);
+                            }
+                        }
+                        else if (fortranParameterEntries != null)
+                        {
+                            foreach (var entry in fortranParameterEntries)
                             {
                                 AddSymbolRecord(
                                     symbols,
@@ -4622,6 +4655,48 @@ public static partial class SymbolExtractor
 
         var listStart = match.Groups["name"].Index;
         var listEnd = match.Groups["enumTail"].Index + match.Groups["enumTail"].Length;
+        if (listStart < 0 || listStart >= patternMatchLine.Length || listEnd <= listStart)
+            return null;
+        if (listEnd > patternMatchLine.Length)
+            listEnd = patternMatchLine.Length;
+
+        var list = patternMatchLine[listStart..listEnd];
+        var results = new List<(string Name, int StartColumn)>();
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(list))
+        {
+            var segment = list.Substring(segmentStart, segmentLength);
+            var leading = 0;
+            while (leading < segment.Length && char.IsWhiteSpace(segment[leading]))
+                leading++;
+            if (leading >= segment.Length)
+                continue;
+
+            if (segment[leading] != '_' && !char.IsLetter(segment[leading]))
+                return null;
+
+            var index = leading + 1;
+            while (index < segment.Length && (segment[index] == '_' || char.IsLetterOrDigit(segment[index])))
+                index++;
+
+            var name = segment[leading..index];
+            if (name.Length == 0)
+                return null;
+
+            results.Add((name, listStart + segmentStart + leading));
+        }
+
+        return results.Count > 1 ? results : null;
+    }
+
+    private static List<(string Name, int StartColumn)>? TryExpandFortranParameterDeclaratorList(
+        string patternMatchLine,
+        Match match)
+    {
+        if (!match.Groups["name"].Success || !match.Groups["paramTail"].Success)
+            return null;
+
+        var listStart = match.Groups["name"].Index;
+        var listEnd = match.Groups["paramTail"].Index + match.Groups["paramTail"].Length;
         if (listStart < 0 || listStart >= patternMatchLine.Length || listEnd <= listStart)
             return null;
         if (listEnd > patternMatchLine.Length)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1266,6 +1266,8 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\))\s*,[^:\r\n]*\bparameter\b[^:\r\n]*::\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Old-style parameter constants / 旧形式 parameter 定数
             new("property", new Regex(@"^\s*parameter\s*\(\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)\)\s*(?:!.*)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Typed variables and components / 型付き変数・component
+            new("property", new Regex(@"^\s*(?<returnType>(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)))\s*(?:,\s*(?![^:\r\n]*\bparameter\b)[^:\r\n]*)?::\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1260,6 +1260,8 @@ public static partial class SymbolExtractor
             new("class", new Regex(@"^\s*block\s+data\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Derived types / 派生型
             new("class", new Regex(@"^\s*type(?!\s*\()\b(?:\s*,\s*(?:abstract|public|private|sequence|bind\s*\([^)]+\)|extends\s*\([^)]+\)))*\s*(?:::)?\s*(?!(?:is|default)\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
+            // Enumerators / enumerator 定数
+            new("property", new Regex(@"^\s*enumerator(?:\s*::)?\s*(?<name>[A-Za-z_]\w*)(?<enumTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き
@@ -2966,6 +2968,11 @@ public static partial class SymbolExtractor
                             && pattern.BodyStyle == BodyStyle.None
                             ? TryExpandSwiftEnumCaseDeclaratorList(patternMatchLine, absoluteStartColumn, match)
                             : null;
+                        var fortranEnumeratorEntries = lang == "fortran"
+                            && pattern.Kind == "property"
+                            && pattern.BodyStyle == BodyStyle.None
+                            ? TryExpandFortranEnumeratorDeclaratorList(patternMatchLine, match)
+                            : null;
 
                         if (pythonImportEntries != null)
                         {
@@ -3043,6 +3050,32 @@ public static partial class SymbolExtractor
                                         Signature = signature,
                                         Visibility = TryGetGroup(match, pattern.VisibilityGroup),
                                         ReturnType = NormalizeMetadata(entry.ReturnType),
+                                    },
+                                    line);
+                            }
+                        }
+                        else if (fortranEnumeratorEntries != null)
+                        {
+                            foreach (var entry in fortranEnumeratorEntries)
+                            {
+                                AddSymbolRecord(
+                                    symbols,
+                                    cssSeenSymbols,
+                                    startLine,
+                                    new SymbolRecord
+                                    {
+                                        FileId = fileId,
+                                        Kind = kind,
+                                        Name = entry.Name,
+                                        Line = startLine,
+                                        StartLine = startLine,
+                                        StartColumn = entry.StartColumn,
+                                        EndLine = Math.Max(startLine, endLine),
+                                        BodyStartLine = bodyStartLine,
+                                        BodyEndLine = bodyEndLine,
+                                        Signature = signature,
+                                        Visibility = TryGetGroup(match, pattern.VisibilityGroup),
+                                        ReturnType = NormalizeMetadata(rawReturnType),
                                     },
                                     line);
                             }
@@ -4575,6 +4608,48 @@ public static partial class SymbolExtractor
                 return null;
 
             results.Add((name, listStart + segmentStart + nameStart, rawValue));
+        }
+
+        return results.Count > 1 ? results : null;
+    }
+
+    private static List<(string Name, int StartColumn)>? TryExpandFortranEnumeratorDeclaratorList(
+        string patternMatchLine,
+        Match match)
+    {
+        if (!match.Groups["name"].Success || !match.Groups["enumTail"].Success)
+            return null;
+
+        var listStart = match.Groups["name"].Index;
+        var listEnd = match.Groups["enumTail"].Index + match.Groups["enumTail"].Length;
+        if (listStart < 0 || listStart >= patternMatchLine.Length || listEnd <= listStart)
+            return null;
+        if (listEnd > patternMatchLine.Length)
+            listEnd = patternMatchLine.Length;
+
+        var list = patternMatchLine[listStart..listEnd];
+        var results = new List<(string Name, int StartColumn)>();
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(list))
+        {
+            var segment = list.Substring(segmentStart, segmentLength);
+            var leading = 0;
+            while (leading < segment.Length && char.IsWhiteSpace(segment[leading]))
+                leading++;
+            if (leading >= segment.Length)
+                continue;
+
+            if (segment[leading] != '_' && !char.IsLetter(segment[leading]))
+                return null;
+
+            var index = leading + 1;
+            while (index < segment.Length && (segment[index] == '_' || char.IsLetterOrDigit(segment[index])))
+                index++;
+
+            var name = segment[leading..index];
+            if (name.Length == 0)
+                return null;
+
+            results.Add((name, listStart + segmentStart + leading));
         }
 
         return results.Count > 1 ? results : null;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1268,6 +1268,8 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き
             new("function", new Regex(@"^\s*entry\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Module procedure implementations / module procedure 実装
+            new("function", new Regex(@"^\s*module\s+procedure\s+(?<name>[A-Za-z_]\w*)\s*(?:!.*)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Procedure declarations in interfaces / interface 内の手続き宣言
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|impure)\s+)*(?:(?:module\s+)?procedure)(?:\s*\([^)]+\))?(?:\s*,\s*[A-Za-z_]\w*)*\s*(?:::\s*)?(?<name>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Typed or untyped functions / 型付き・型なし関数

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1270,6 +1270,8 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*(?<returnType>(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)))\s*(?:,\s*(?![^:\r\n]*\bparameter\b)[^:\r\n]*)?::\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
             // Old-style typed variables without :: / :: なしの旧形式型付き変数
             new("property", new Regex(@"^\s*(?<returnType>(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\)))\s+(?!(?:function|subroutine)\b)(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            // Attribute-only variables / 属性のみの変数宣言
+            new("property", new Regex(@"^\s*(?:(?:allocatable|pointer|target|optional|save|dimension\s*\([^)]+\)|intent\s*\([^)]+\))\s*,\s*)*(?:allocatable|pointer|target|optional|save|dimension\s*\([^)]+\)|intent\s*\([^)]+\))\s*(?:::)?\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1264,6 +1264,8 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*enumerator(?:\s*::)?\s*(?<name>[A-Za-z_]\w*)(?<enumTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Parameter constants / parameter 定数
             new("property", new Regex(@"^\s*(?:(?:integer|real|logical|complex)(?:\s*\([^)]+\))?|character(?:\s*\([^)]+\))?|double\s+precision|type\s*\([^)]+\)|class\s*\([^)]+\))\s*,[^:\r\n]*\bparameter\b[^:\r\n]*::\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            // Old-style parameter constants / 旧形式 parameter 定数
+            new("property", new Regex(@"^\s*parameter\s*\(\s*(?<name>[A-Za-z_]\w*)(?<paramTail>.*)\)\s*(?:!.*)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             // Subroutines / サブルーチン
             new("function", new Regex(@"^\s*(?:(?:pure|elemental|recursive|module|impure)\s+)*subroutine\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Entry points / entry 手続き

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1256,6 +1256,8 @@ public static partial class SymbolExtractor
             new("namespace", new Regex(@"^\s*submodule\s*\(\s*[^)]*\)\s*(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Program units / プログラム本体
             new("class", new Regex(@"^\s*program\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
+            // Block data program units / block data プログラム単位
+            new("class", new Regex(@"^\s*block\s+data\s+(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Derived types / 派生型
             new("class", new Regex(@"^\s*type(?!\s*\()\b(?:\s*,\s*(?:abstract|public|private|sequence|bind\s*\([^)]+\)|extends\s*\([^)]+\)))*\s*(?:::)?\s*(?!(?:is|default)\b)(?<name>[A-Za-z_]\w*)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.FortranEnd),
             // Subroutines / サブルーチン

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11544,6 +11544,11 @@ public class ReferenceExtractorTests
               end type RepositoryBase
               type, extends(RepositoryBase) :: Repository
               end type Repository
+              abstract interface
+                subroutine create_repository()
+                  import :: RepositoryFactory
+                end subroutine create_repository
+              end interface
             contains
               subroutine run(repo)
                 type(Repository) :: repo
@@ -11563,6 +11568,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryBase" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11595,8 +11595,8 @@ public class ReferenceExtractorTests
                 call process(repo)
                 call repo%persist()
                 allocate(RepositoryAllocator :: allocated_repo)
-                allocate(plain_repo, source=template_repo, stat=status_code)
-                deallocate(allocated_repo, temporary_repo, stat=status_code)
+                allocate(plain_repo, source=template_repo, stat=allocate_status)
+                deallocate(allocated_repo, temporary_repo, stat=deallocate_status, errmsg=deallocate_message)
                 select type (repo)
                 type is (RepositorySnapshot)
                   call repo%persist()
@@ -11684,8 +11684,11 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "allocated_repo" && r.ReferenceKind == "reference" && r.Context.Contains("allocate(RepositoryAllocator", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "plain_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "template_repo" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "allocate_status" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "allocated_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "temporary_repo" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "deallocate_status" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "deallocate_message" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositorySnapshot" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryView" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11595,6 +11595,7 @@ public class ReferenceExtractorTests
                 call process(repo)
                 call repo%persist()
                 allocate(RepositoryAllocator :: allocated_repo)
+                deallocate(allocated_repo, temporary_repo, stat=status_code)
                 select type (repo)
                 type is (RepositorySnapshot)
                   call repo%persist()
@@ -11679,6 +11680,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryAllocator" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "allocated_repo" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "temporary_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositorySnapshot" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryView" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11564,6 +11564,7 @@ public class ReferenceExtractorTests
                 character(kind=c_char, len=1) :: delimiter
                 common /repository_state/ status_code
                 namelist /repository_config/ delimiter
+                external legacy_hook, repository_probe
                 value = prefix() // suffix()
                 call process(repo)
                 call repo%persist()
@@ -11602,6 +11603,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "assign_repository_alt" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "repository_probe" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11582,6 +11582,7 @@ public class ReferenceExtractorTests
                 namelist /repository_config/ delimiter, status_code
                 equivalence (status_code, legacy_status), (delimiter, legacy_delimiter)
                 data status_code, delimiter /0, ','/
+                data delayed_status /1/, delayed_flag /2/
                 save :: saved_repository
                 save /repository_state/
                 external legacy_hook, repository_probe
@@ -11660,6 +11661,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "legacy_delimiter" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("data", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("data", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "delayed_status" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "delayed_flag" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "saved_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference" && r.Context.Contains("save", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11557,6 +11557,7 @@ public class ReferenceExtractorTests
                 value = prefix() // suffix()
                 call process(repo)
                 call repo%persist()
+                allocate(RepositoryAllocator :: allocated_repo)
                 select type (repo)
                 type is (RepositorySnapshot)
                   call repo%persist()
@@ -11578,6 +11579,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "RepositoryAllocator" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositorySnapshot" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryView" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11539,6 +11539,7 @@ public class ReferenceExtractorTests
     {
         const string content = """
             module demo_mod
+              include 'repository_kinds.inc'
               use, intrinsic :: iso_c_binding, only: c_ptr, c_int
               type :: RepositoryBase
               end type RepositoryBase
@@ -11571,6 +11572,7 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "fortran", content);
         var references = ReferenceExtractor.Extract(1, "fortran", content, symbols);
 
+        Assert.Contains(references, r => r.SymbolName == "repository_kinds.inc" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "iso_c_binding" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "c_ptr" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11550,6 +11550,7 @@ public class ReferenceExtractorTests
               contains
                 procedure :: persist => persist_impl
                 generic :: assignment(=) => assign_repository, assign_repository_alt
+                final :: cleanup_repository, close_repository
               end type Repository
               abstract interface
                 subroutine create_repository()
@@ -11607,6 +11608,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "persist_impl" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "assign_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "assign_repository_alt" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "cleanup_repository" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "close_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11539,7 +11539,7 @@ public class ReferenceExtractorTests
     {
         const string content = """
             module demo_mod
-              use iso_c_binding
+              use, intrinsic :: iso_c_binding, only: c_ptr, c_int
               type :: RepositoryBase
               end type RepositoryBase
               type, extends(RepositoryBase) :: Repository
@@ -11558,6 +11558,8 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "fortran", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "iso_c_binding" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "c_ptr" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryBase" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11578,7 +11578,7 @@ public class ReferenceExtractorTests
                 real(kind=real64) :: elapsed
                 character(kind=c_char, len=1) :: delimiter
                 common /repository_state/ status_code
-                namelist /repository_config/ delimiter
+                namelist /repository_config/ delimiter, status_code
                 external legacy_hook, repository_probe
                 intrinsic sin, cos
                 value = prefix() // suffix()
@@ -11643,6 +11643,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "release_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_probe" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "sin" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11542,6 +11542,8 @@ public class ReferenceExtractorTests
               include 'repository_kinds.inc'
               use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_char, repository_ptr => c_ptr
               use, intrinsic :: iso_fortran_env, only: real64
+              public :: Repository, create_repository
+              private :: legacy_hook
               type :: RepositoryBase
               end type RepositoryBase
               type, extends(RepositoryBase) :: Repository
@@ -11595,6 +11597,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "demo_mod" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "demo_parent" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "create_repository" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference" && r.Context.Contains("private ::", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference" && r.Context.Contains("integer(c_int)", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference" && r.Context.Contains("real(kind=real64)", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "c_char" && r.ReferenceKind == "type_reference" && r.Context.Contains("character(kind=c_char", StringComparison.Ordinal));

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11565,6 +11565,7 @@ public class ReferenceExtractorTests
                 common /repository_state/ status_code
                 namelist /repository_config/ delimiter
                 external legacy_hook, repository_probe
+                intrinsic sin, cos
                 value = prefix() // suffix()
                 call process(repo)
                 call repo%persist()
@@ -11606,6 +11607,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_probe" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "sin" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "cos" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11580,6 +11580,7 @@ public class ReferenceExtractorTests
                 common /repository_state/ status_code, delimiter
                 common anonymous_state, anonymous_flag
                 namelist /repository_config/ delimiter, status_code
+                equivalence (status_code, legacy_status), (delimiter, legacy_delimiter)
                 external legacy_hook, repository_probe
                 intrinsic sin, cos
                 value = prefix() // suffix()
@@ -11650,6 +11651,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "anonymous_flag" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "legacy_status" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "legacy_delimiter" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_probe" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "sin" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11545,6 +11545,9 @@ public class ReferenceExtractorTests
               type :: RepositoryBase
               end type RepositoryBase
               type, extends(RepositoryBase) :: Repository
+              contains
+                procedure :: persist => persist_impl
+                generic :: assignment(=) => assign_repository
               end type Repository
               abstract interface
                 subroutine create_repository()
@@ -11587,6 +11590,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "c_char" && r.ReferenceKind == "type_reference" && r.Context.Contains("character(kind=c_char", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "RepositoryBase" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "persist_impl" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "assign_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11582,6 +11582,8 @@ public class ReferenceExtractorTests
                 external legacy_hook, repository_probe
                 intrinsic sin, cos
                 value = prefix() // suffix()
+                callback => repository_resolver
+                callback => null()
                 call process(repo)
                 call repo%persist()
                 allocate(RepositoryAllocator :: allocated_repo)
@@ -11645,6 +11647,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "repository_probe" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "sin" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "cos" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "repository_resolver" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "null" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "CompactFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "CompactOnlyFactory" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11563,6 +11563,7 @@ public class ReferenceExtractorTests
                 real(kind=real64) :: elapsed
                 character(kind=c_char, len=1) :: delimiter
                 common /repository_state/ status_code
+                namelist /repository_config/ delimiter
                 value = prefix() // suffix()
                 call process(repo)
                 call repo%persist()
@@ -11595,6 +11596,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "assign_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "assign_repository_alt" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11578,6 +11578,7 @@ public class ReferenceExtractorTests
                 real(kind=real64) :: elapsed
                 character(kind=c_char, len=1) :: delimiter
                 common /repository_state/ status_code, delimiter
+                common anonymous_state, anonymous_flag
                 namelist /repository_config/ delimiter, status_code
                 external legacy_hook, repository_probe
                 intrinsic sin, cos
@@ -11645,6 +11646,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("common", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("common", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "anonymous_state" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "anonymous_flag" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11577,7 +11577,7 @@ public class ReferenceExtractorTests
                 integer(c_int) :: status_code
                 real(kind=real64) :: elapsed
                 character(kind=c_char, len=1) :: delimiter
-                common /repository_state/ status_code
+                common /repository_state/ status_code, delimiter
                 namelist /repository_config/ delimiter, status_code
                 external legacy_hook, repository_probe
                 intrinsic sin, cos
@@ -11643,6 +11643,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "release_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("common", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("common", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11556,6 +11556,7 @@ public class ReferenceExtractorTests
                 procedure(RepositoryCallback), pointer :: callback
                 value = prefix() // suffix()
                 call process(repo)
+                call repo%persist()
               end subroutine run
             end module demo_mod
             """;
@@ -11573,6 +11574,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "suffix" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "persist" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "repo" && r.ReferenceKind == "call");
         Assert.Contains(references, r =>
             r.SymbolName == "process"
             && r.ReferenceKind == "call"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11565,6 +11565,8 @@ public class ReferenceExtractorTests
               abstract interface
                 subroutine create_repository()
                   import :: RepositoryFactory
+                  import::CompactFactory
+                  import, only:CompactOnlyFactory
                 end subroutine create_repository
               end interface
             contains
@@ -11644,6 +11646,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "sin" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "cos" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "CompactFactory" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "CompactOnlyFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryAllocator" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11683,6 +11683,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "RepositoryAllocator" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "allocated_repo" && r.ReferenceKind == "reference" && r.Context.Contains("allocate(RepositoryAllocator", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "plain_repo" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "template_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "allocated_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "temporary_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositorySnapshot" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11543,6 +11543,9 @@ public class ReferenceExtractorTests
               use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_char, repository_ptr => c_ptr
               use repositories, only: local_status => remote_status
               use repository_legacy, legacy_local => legacy_remote
+              use::compact_repository
+              use::compact_repository_only, only: compact_symbol
+              use::compact_repository_rename, compact_local => compact_remote
               use, intrinsic :: iso_fortran_env, only: real64
               public :: Repository, create_repository
               public::RepositoryNoSpace
@@ -11607,6 +11610,12 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "repository_legacy" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "legacy_local" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "legacy_remote" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "compact_repository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "compact_repository_only" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "compact_symbol" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "compact_repository_rename" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "compact_local" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "compact_remote" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "iso_fortran_env" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "demo_mod" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11542,6 +11542,7 @@ public class ReferenceExtractorTests
               include 'repository_kinds.inc'
               use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_char, repository_ptr => c_ptr
               use repositories, only: local_status => remote_status
+              use repository_legacy, legacy_local => legacy_remote
               use, intrinsic :: iso_fortran_env, only: real64
               public :: Repository, create_repository
               public::RepositoryNoSpace
@@ -11603,6 +11604,9 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "repositories" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "local_status" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "remote_status" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "repository_legacy" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "legacy_local" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "legacy_remote" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "iso_fortran_env" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "demo_mod" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11541,6 +11541,7 @@ public class ReferenceExtractorTests
             module demo_mod
               include 'repository_kinds.inc'
               use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_char, repository_ptr => c_ptr
+              use repositories, only: local_status => remote_status
               use, intrinsic :: iso_fortran_env, only: real64
               public :: Repository, create_repository
               public::RepositoryNoSpace
@@ -11599,6 +11600,9 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "c_ptr" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "repository_ptr" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "repositories" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "local_status" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "remote_status" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "iso_fortran_env" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "demo_mod" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11557,6 +11557,12 @@ public class ReferenceExtractorTests
                 value = prefix() // suffix()
                 call process(repo)
                 call repo%persist()
+                select type (repo)
+                type is (RepositorySnapshot)
+                  call repo%persist()
+                class is (RepositoryView)
+                  call repo%persist()
+                end select
               end subroutine run
             end module demo_mod
             """;
@@ -11572,6 +11578,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "RepositorySnapshot" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "RepositoryView" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "suffix" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "persist" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11554,6 +11554,7 @@ public class ReferenceExtractorTests
                 procedure :: persist => persist_impl
                 generic :: assignment(=) => assign_repository, assign_repository_alt
                 final :: cleanup_repository, close_repository
+                final::flush_repository
                 final release_repository
               end type Repository
               abstract interface
@@ -11617,6 +11618,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "assign_repository_alt" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "cleanup_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "close_repository" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "flush_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "release_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11540,6 +11540,10 @@ public class ReferenceExtractorTests
         const string content = """
             module demo_mod
               use iso_c_binding
+              type :: RepositoryBase
+              end type RepositoryBase
+              type, extends(RepositoryBase) :: Repository
+              end type Repository
             contains
               subroutine run(repo)
                 type(Repository) :: repo
@@ -11554,6 +11558,7 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "fortran", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "iso_c_binding" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "RepositoryBase" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11551,6 +11551,7 @@ public class ReferenceExtractorTests
                 procedure :: persist => persist_impl
                 generic :: assignment(=) => assign_repository, assign_repository_alt
                 final :: cleanup_repository, close_repository
+                final release_repository
               end type Repository
               abstract interface
                 subroutine create_repository()
@@ -11610,6 +11611,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "assign_repository_alt" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "cleanup_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "close_repository" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "release_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_config" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11587,6 +11587,8 @@ public class ReferenceExtractorTests
                 value = prefix() // suffix()
                 callback => repository_resolver
                 callback => null()
+                associate (resolved_status => repository_status)
+                end associate
                 call process(repo)
                 call repo%persist()
                 allocate(RepositoryAllocator :: allocated_repo)
@@ -11662,6 +11664,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "cos" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_resolver" && r.ReferenceKind == "reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "null" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "repository_status" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "resolved_status" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "CompactFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "CompactOnlyFactory" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11582,6 +11582,8 @@ public class ReferenceExtractorTests
                 namelist /repository_config/ delimiter, status_code
                 equivalence (status_code, legacy_status), (delimiter, legacy_delimiter)
                 data status_code, delimiter /0, ','/
+                save :: saved_repository
+                save /repository_state/
                 external legacy_hook, repository_probe
                 intrinsic sin, cos
                 value = prefix() // suffix()
@@ -11658,6 +11660,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "legacy_delimiter" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("data", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("data", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "saved_repository" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference" && r.Context.Contains("save", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_probe" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "sin" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11543,7 +11543,10 @@ public class ReferenceExtractorTests
               use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_char, repository_ptr => c_ptr
               use, intrinsic :: iso_fortran_env, only: real64
               public :: Repository, create_repository
+              public::RepositoryNoSpace
+              public RepositoryFactory
               private :: legacy_hook
+              private internal_probe
               type :: RepositoryBase
               end type RepositoryBase
               type, extends(RepositoryBase) :: Repository
@@ -11600,7 +11603,10 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "demo_mod" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "demo_parent" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "create_repository" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "RepositoryNoSpace" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "reference" && r.Context.Contains("public RepositoryFactory", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference" && r.Context.Contains("private ::", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "internal_probe" && r.ReferenceKind == "reference" && r.Context.Contains("private internal_probe", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference" && r.Context.Contains("integer(c_int)", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference" && r.Context.Contains("real(kind=real64)", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "c_char" && r.ReferenceKind == "type_reference" && r.Context.Contains("character(kind=c_char", StringComparison.Ordinal));

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11581,6 +11581,7 @@ public class ReferenceExtractorTests
                 common anonymous_state, anonymous_flag
                 namelist /repository_config/ delimiter, status_code
                 equivalence (status_code, legacy_status), (delimiter, legacy_delimiter)
+                data status_code, delimiter /0, ','/
                 external legacy_hook, repository_probe
                 intrinsic sin, cos
                 value = prefix() // suffix()
@@ -11653,6 +11654,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("namelist", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "legacy_status" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "legacy_delimiter" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "status_code" && r.ReferenceKind == "reference" && r.Context.Contains("data", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "delimiter" && r.ReferenceKind == "reference" && r.Context.Contains("data", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "legacy_hook" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "repository_probe" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "sin" && r.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11595,6 +11595,7 @@ public class ReferenceExtractorTests
                 call process(repo)
                 call repo%persist()
                 allocate(RepositoryAllocator :: allocated_repo)
+                allocate(plain_repo, source=template_repo, stat=status_code)
                 deallocate(allocated_repo, temporary_repo, stat=status_code)
                 select type (repo)
                 type is (RepositorySnapshot)
@@ -11680,6 +11681,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryAllocator" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "allocated_repo" && r.ReferenceKind == "reference" && r.Context.Contains("allocate(RepositoryAllocator", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "plain_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "allocated_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "temporary_repo" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositorySnapshot" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11540,7 +11540,8 @@ public class ReferenceExtractorTests
         const string content = """
             module demo_mod
               include 'repository_kinds.inc'
-              use, intrinsic :: iso_c_binding, only: c_ptr, c_int
+              use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_char
+              use, intrinsic :: iso_fortran_env, only: real64
               type :: RepositoryBase
               end type RepositoryBase
               type, extends(RepositoryBase) :: Repository
@@ -11555,6 +11556,9 @@ public class ReferenceExtractorTests
                 type(Repository) :: repo
                 class(User), allocatable :: current
                 procedure(RepositoryCallback), pointer :: callback
+                integer(c_int) :: status_code
+                real(kind=real64) :: elapsed
+                character(kind=c_char, len=1) :: delimiter
                 value = prefix() // suffix()
                 call process(repo)
                 call repo%persist()
@@ -11576,6 +11580,11 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "iso_c_binding" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "c_ptr" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "iso_fortran_env" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference" && r.Context.Contains("integer(c_int)", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference" && r.Context.Contains("real(kind=real64)", StringComparison.Ordinal));
+        Assert.Contains(references, r => r.SymbolName == "c_char" && r.ReferenceKind == "type_reference" && r.Context.Contains("character(kind=c_char", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "RepositoryBase" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11547,7 +11547,7 @@ public class ReferenceExtractorTests
               type, extends(RepositoryBase) :: Repository
               contains
                 procedure :: persist => persist_impl
-                generic :: assignment(=) => assign_repository
+                generic :: assignment(=) => assign_repository, assign_repository_alt
               end type Repository
               abstract interface
                 subroutine create_repository()
@@ -11592,6 +11592,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "persist_impl" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "assign_repository" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "assign_repository_alt" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11576,6 +11576,9 @@ public class ReferenceExtractorTests
                 end select
               end subroutine run
             end module demo_mod
+
+            submodule (demo_mod:demo_parent) demo_child
+            end submodule demo_child
             """;
 
         var symbols = SymbolExtractor.Extract(1, "fortran", content);
@@ -11587,6 +11590,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "iso_fortran_env" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "demo_mod" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "demo_parent" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference" && r.Context.Contains("integer(c_int)", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference" && r.Context.Contains("real(kind=real64)", StringComparison.Ordinal));
         Assert.Contains(references, r => r.SymbolName == "c_char" && r.ReferenceKind == "type_reference" && r.Context.Contains("character(kind=c_char", StringComparison.Ordinal));

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11548,6 +11548,7 @@ public class ReferenceExtractorTests
               subroutine run(repo)
                 type(Repository) :: repo
                 class(User), allocatable :: current
+                procedure(RepositoryCallback), pointer :: callback
                 value = prefix() // suffix()
                 call process(repo)
               end subroutine run
@@ -11563,6 +11564,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "RepositoryBase" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Repository" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "prefix" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "suffix" && r.ReferenceKind == "call");
         Assert.Contains(references, r =>

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11540,7 +11540,7 @@ public class ReferenceExtractorTests
         const string content = """
             module demo_mod
               include 'repository_kinds.inc'
-              use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_char
+              use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_char, repository_ptr => c_ptr
               use, intrinsic :: iso_fortran_env, only: real64
               type :: RepositoryBase
               end type RepositoryBase
@@ -11589,6 +11589,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "iso_c_binding" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "c_ptr" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "c_int" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "repository_ptr" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "iso_fortran_env" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "real64" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "demo_mod" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11562,6 +11562,7 @@ public class ReferenceExtractorTests
                 integer(c_int) :: status_code
                 real(kind=real64) :: elapsed
                 character(kind=c_char, len=1) :: delimiter
+                common /repository_state/ status_code
                 value = prefix() // suffix()
                 call process(repo)
                 call repo%persist()
@@ -11593,6 +11594,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "persist_impl" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "assign_repository" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "assign_repository_alt" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "repository_state" && r.ReferenceKind == "reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryFactory" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RepositoryCallback" && r.ReferenceKind == "type_reference");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11342,6 +11342,9 @@ public class SymbolExtractorTests
               type, extends(point_t) :: colored_point
                 integer :: color
               end type colored_point
+              enum, bind(c)
+                enumerator :: color_red = 1, color_blue = 2
+              end enum
             contains
               integer(kind=4) &
               function split_value(value)
@@ -11403,6 +11406,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "abstract_callback");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "split_value");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "split_subroutine");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "color_red");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "color_blue");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_restart");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11371,6 +11371,10 @@ public class SymbolExtractorTests
 
             submodule (math_utils) math_utils_impl
             contains
+              module procedure normalize_impl
+                print *, "normalize"
+              end procedure normalize_impl
+
               module subroutine expand(v)
               end subroutine expand
             end submodule math_utils_impl
@@ -11453,6 +11457,12 @@ public class SymbolExtractorTests
         var expand = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "expand");
         Assert.Equal("namespace", expand.ContainerKind);
         Assert.Equal("math_utils_impl", expand.ContainerName);
+
+        var normalizeImpl = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_impl");
+        Assert.Equal("namespace", normalizeImpl.ContainerKind);
+        Assert.Equal("math_utils_impl", normalizeImpl.ContainerName);
+        Assert.NotNull(normalizeImpl.BodyStartLine);
+        Assert.NotNull(normalizeImpl.BodyEndLine);
 
         var normalize2 = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize2");
         Assert.Equal("namespace", normalize2.ContainerKind);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11355,6 +11355,7 @@ public class SymbolExtractorTests
               recursive subroutine normalize(v)
                 call normalize2(v) ! function phantom()
                 print *, "subroutine phantom"
+                entry normalize_restart(v)
               contains
                 subroutine normalize_inner()
                 end subroutine normalize_inner
@@ -11399,6 +11400,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "split_subroutine");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_restart");
 
         var mathUtilsImpl = Assert.Single(symbols, s => s.Kind == "namespace" && s.Name == "math_utils_impl");
         Assert.NotNull(mathUtilsImpl.BodyStartLine);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11346,6 +11346,7 @@ public class SymbolExtractorTests
               allocatable :: workspace, scratch
               pointer :: shared_point
               common /work_area/ common_status, common_flag
+              namelist /config_area/ config_status, config_flag
               type, extends(point_t) :: colored_point
                 integer :: color
               end type colored_point
@@ -11430,6 +11431,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "shared_point");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "common_status");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "common_flag");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "config_status");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "config_flag");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_restart");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11339,6 +11339,7 @@ public class SymbolExtractorTests
               type :: point_t
                 integer :: x
               end type point_t
+              integer, parameter :: max_rank = 8, default_rank = 2
               type, extends(point_t) :: colored_point
                 integer :: color
               end type colored_point
@@ -11408,6 +11409,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "split_subroutine");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "color_red");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "color_blue");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "max_rank");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "default_rank");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_restart");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11338,6 +11338,7 @@ public class SymbolExtractorTests
               implicit none
               type :: point_t
                 integer :: x
+                real :: origin_x, origin_y
               end type point_t
               integer, parameter :: max_rank = 8, default_rank = 2
               parameter (legacy_rank = 4, legacy_limit = selected_int_kind(9))
@@ -11440,11 +11441,23 @@ public class SymbolExtractorTests
         Assert.NotNull(point.BodyStartLine);
         Assert.NotNull(point.BodyEndLine);
 
+        var pointX = Assert.Single(symbols, s => s.Kind == "property" && s.Name == "x");
+        Assert.Equal("class", pointX.ContainerKind);
+        Assert.Equal("point_t", pointX.ContainerName);
+        Assert.Equal("integer", pointX.ReturnType);
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "origin_x" && s.ReturnType == "real");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "origin_y" && s.ReturnType == "real");
+
         var coloredPoint = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "colored_point");
         Assert.Equal("namespace", coloredPoint.ContainerKind);
         Assert.Equal("math_utils", coloredPoint.ContainerName);
         Assert.NotNull(coloredPoint.BodyStartLine);
         Assert.NotNull(coloredPoint.BodyEndLine);
+
+        var color = Assert.Single(symbols, s => s.Kind == "property" && s.Name == "color");
+        Assert.Equal("class", color.ContainerKind);
+        Assert.Equal("colored_point", color.ContainerName);
+        Assert.Equal("integer", color.ReturnType);
 
         var normalize = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize");
         Assert.Equal("namespace", normalize.ContainerKind);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11336,6 +11336,12 @@ public class SymbolExtractorTests
                 end subroutine abstract_callback
               end interface
               implicit none
+              type :: point_t
+                integer :: x
+              end type point_t
+              type, extends(point_t) :: colored_point
+                integer :: color
+              end type colored_point
             contains
               integer(kind=4) &
               function split_value(value)
@@ -11401,6 +11407,18 @@ public class SymbolExtractorTests
         var demo = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "demo");
         Assert.NotNull(demo.BodyStartLine);
         Assert.NotNull(demo.BodyEndLine);
+
+        var point = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "point_t");
+        Assert.Equal("namespace", point.ContainerKind);
+        Assert.Equal("math_utils", point.ContainerName);
+        Assert.NotNull(point.BodyStartLine);
+        Assert.NotNull(point.BodyEndLine);
+
+        var coloredPoint = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "colored_point");
+        Assert.Equal("namespace", coloredPoint.ContainerKind);
+        Assert.Equal("math_utils", coloredPoint.ContainerName);
+        Assert.NotNull(coloredPoint.BodyStartLine);
+        Assert.NotNull(coloredPoint.BodyEndLine);
 
         var normalize = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize");
         Assert.Equal("namespace", normalize.ContainerKind);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11345,6 +11345,7 @@ public class SymbolExtractorTests
               integer legacy_count, legacy_total
               allocatable :: workspace, scratch
               pointer :: shared_point
+              common /work_area/ common_status, common_flag
               type, extends(point_t) :: colored_point
                 integer :: color
               end type colored_point
@@ -11427,6 +11428,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "workspace");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "scratch");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "shared_point");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "common_status");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "common_flag");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_restart");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11343,6 +11343,8 @@ public class SymbolExtractorTests
               integer, parameter :: max_rank = 8, default_rank = 2
               parameter (legacy_rank = 4, legacy_limit = selected_int_kind(9))
               integer legacy_count, legacy_total
+              allocatable :: workspace, scratch
+              pointer :: shared_point
               type, extends(point_t) :: colored_point
                 integer :: color
               end type colored_point
@@ -11422,6 +11424,9 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_limit");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_count" && s.ReturnType == "integer");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_total" && s.ReturnType == "integer");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "workspace");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "scratch");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "shared_point");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_restart");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11375,6 +11375,11 @@ public class SymbolExtractorTests
               print *, "hello"
             end program demo
 
+            block data constants_block
+              common /constants/ pi
+              data pi /3.14159/
+            end block data constants_block
+
             integer function add(a, b)
             end function add
 
@@ -11409,6 +11414,10 @@ public class SymbolExtractorTests
         var demo = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "demo");
         Assert.NotNull(demo.BodyStartLine);
         Assert.NotNull(demo.BodyEndLine);
+
+        var constantsBlock = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "constants_block");
+        Assert.NotNull(constantsBlock.BodyStartLine);
+        Assert.NotNull(constantsBlock.BodyEndLine);
 
         var point = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "point_t");
         Assert.Equal("namespace", point.ContainerKind);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11340,6 +11340,7 @@ public class SymbolExtractorTests
                 integer :: x
               end type point_t
               integer, parameter :: max_rank = 8, default_rank = 2
+              parameter (legacy_rank = 4, legacy_limit = selected_int_kind(9))
               type, extends(point_t) :: colored_point
                 integer :: color
               end type colored_point
@@ -11415,6 +11416,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "color_blue");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "max_rank");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "default_rank");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_rank");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_limit");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_restart");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -11342,6 +11342,7 @@ public class SymbolExtractorTests
               end type point_t
               integer, parameter :: max_rank = 8, default_rank = 2
               parameter (legacy_rank = 4, legacy_limit = selected_int_kind(9))
+              integer legacy_count, legacy_total
               type, extends(point_t) :: colored_point
                 integer :: color
               end type colored_point
@@ -11419,6 +11420,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "default_rank");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_rank");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_limit");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_count" && s.ReturnType == "integer");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy_total" && s.ReturnType == "integer");
         Assert.Equal("namespace", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerKind);
         Assert.Equal("math_iface", Assert.Single(symbols, s => s.Kind == "function" && s.Name == "normalize_iface").ContainerName);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize_restart");


### PR DESCRIPTION
## Summary

This PR adds 50 focused Fortran search improvements across reference extraction and symbol extraction.

Highlights:

- Expands Fortran reference search for module procedures, finalizers, access lists, use/import variants, common/namelist/equivalence/data declarations, associate selectors, allocation/deallocation arguments, and related legacy forms.
- Expands Fortran symbol search for module procedure bodies, old-style parameters, typed variables, attribute-only variables, and common/namelist members.
- Adds focused tests for each behavior change and bilingual changelog fragments under `changelog.d/unreleased/`.

## Validation

Per commit, the relevant focused test was run before committing, followed by changelog validation, Release build, changed-file indexing, README outline check, post-commit build, commit indexing, status check, and an adversarial review of `HEAD~1..HEAD`.

Final branch state validation:

- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `git rev-list --count origin/main..HEAD` -> `50`

## Documentation And Changelog

No README behavior contract changes were needed beyond the user-visible changelog entries.

Changelog fragments were added under:

- `changelog.d/unreleased/+fortran-*.fixed.md`

## Follow-Up Candidates

- Continue scanning remaining Fortran constructs for tightly scoped symbol/reference gaps after this PR lands.
