### PR TITLE
[codex] Improve PHP search coverage

### DIFF
--- a/changelog.d/unreleased/+php-attribute-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-attribute-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP attributes now emit type references** — attribute classes such as `#[Route(...)]` and `#[\App\Http\Middleware\RequiresAuth]` now appear as `type_reference` entries without treating named arguments as types.
+
+## 日本語
+
+- **PHP attributes を型参照として索引するようになりました** — `#[Route(...)]` や `#[\App\Http\Middleware\RequiresAuth]` のような attribute class を `type_reference` として出し、名前付き引数は型として扱いません。

--- a/changelog.d/unreleased/+php-backed-enum-types.fixed.md
+++ b/changelog.d/unreleased/+php-backed-enum-types.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP backed enum symbols now record their backing type** — declarations such as `enum Status: string` now keep `string` in symbol metadata, improving enum search results.
+
+## 日本語
+
+- **PHP backed enum シンボルが backing type を記録するようになりました** — `enum Status: string` のような宣言で `string` をシンボル metadata に保持し、enum 検索結果を改善します。

--- a/changelog.d/unreleased/+php-catch-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-catch-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP catch union types are now indexed** — `catch (\App\Exception\FirstException|SecondException $e)` now emits type references for each exception type.
+
+## 日本語
+
+- **PHP の catch union 型を索引するようになりました** — `catch (\App\Exception\FirstException|SecondException $e)` で各例外型を type reference として出します。

--- a/changelog.d/unreleased/+php-define-constant-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-define-constant-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP `define()` constants are now searchable** — literal global constants declared with `define('NAME', ...)` or `define("NAME", ...)` now appear as symbols.
+
+## 日本語
+
+- **PHP の `define()` 定数を検索できるようになりました** — `define('NAME', ...)` や `define("NAME", ...)` で宣言された literal なグローバル定数をシンボルとして出します。

--- a/changelog.d/unreleased/+php-group-use-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-group-use-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP group `use` imports now emit type references** — grouped class imports such as `use App\Domain\{User, Team\Member};` now appear in reference search results, while grouped function and const imports stay excluded from type references.
+
+## 日本語
+
+- **PHP のグループ `use` import を型参照として索引するようになりました** — `use App\Domain\{User, Team\Member};` のような grouped class import が reference 検索結果に出るようになり、grouped function / const import は引き続き type reference から除外します。

--- a/changelog.d/unreleased/+php-inheritance-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-inheritance-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP inheritance clauses are now indexed as type references** — `extends` and `implements` targets now appear in reference results, including qualified and comma-separated interface names.
+
+## 日本語
+
+- **PHP の継承句を型参照として索引するようになりました** — `extends` / `implements` の対象を、完全修飾名やカンマ区切り interface 名も含めて reference 結果へ出します。

--- a/changelog.d/unreleased/+php-instanceof-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-instanceof-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP `instanceof` operands are now indexed as type references** — expressions such as `$value instanceof \App\Domain\UserService` now emit both qualified and short type-reference entries.
+
+## 日本語
+
+- **PHP の `instanceof` 右辺を型参照として索引するようになりました** — `$value instanceof \App\Domain\UserService` のような式で、完全修飾名と短い型名の両方を type reference として出します。

--- a/changelog.d/unreleased/+php-method-modifier-order.fixed.md
+++ b/changelog.d/unreleased/+php-method-modifier-order.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP method symbols tolerate modifier order used in real code** — declarations such as `abstract protected function normalize()` and `final public static function make()` are now indexed as functions with visibility preserved.
+
+## 日本語
+
+- **PHP メソッドシンボルが実コードの修飾子順序に対応しました** — `abstract protected function normalize()` や `final public static function make()` のような宣言を、visibility を保った function として索引します。

--- a/changelog.d/unreleased/+php-mixed-group-use-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-mixed-group-use-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP mixed group imports now keep function and const entries out of type references** — `use App\{User, function make_user, const ROLE};` records `User` as a type reference without emitting function or const imports as types.
+
+## 日本語
+
+- **PHP の mixed group import で function / const 要素を型参照から除外するようになりました** — `use App\{User, function make_user, const ROLE};` は `User` だけを type reference として記録し、function / const import を型として出さなくなります。

--- a/changelog.d/unreleased/+php-multiline-promoted-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-multiline-promoted-property-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP multiline constructor promotion is now searchable** — promoted properties declared on separate `__construct(` parameter lines now emit `property` symbols while ordinary parameters remain ignored.
+
+## 日本語
+
+- **PHP の複数行 constructor promotion を検索できるようになりました** — `__construct(` の各パラメータ行に書かれた promoted property を `property` シンボルとして出し、通常パラメータは引き続き無視します。

--- a/changelog.d/unreleased/+php-parameter-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-parameter-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP parameter class types are now indexed** — typed parameters such as `Request $request` and `?User $user` now emit type references while builtin scalar types remain ignored.
+
+## 日本語
+
+- **PHP の引数 class 型を索引するようになりました** — `Request $request` や `?User $user` のような型付き引数を type reference として出し、builtin scalar 型は無視します。

--- a/changelog.d/unreleased/+php-promoted-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-promoted-property-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP constructor-promoted properties are now searchable** — same-line `__construct(public string $id, ...)` declarations now emit `property` symbols for promoted members without indexing ordinary parameters.
+
+## 日本語
+
+- **PHP の constructor promotion プロパティを検索できるようになりました** — 同一行の `__construct(public string $id, ...)` 宣言から promotion されたメンバーを `property` シンボルとして出し、通常パラメータは索引しません。

--- a/changelog.d/unreleased/+php-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-property-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP class properties are now searchable as symbols** — `public`, `protected`, `private`, and legacy `var` property declarations now appear as `property` symbols, so member-access references can navigate back to declarations.
+
+## 日本語
+
+- **PHP のクラスプロパティをシンボルとして検索できるようになりました** — `public`、`protected`、`private`、旧式の `var` プロパティ宣言を `property` シンボルとして出すため、メンバーアクセス参照から宣言へ辿りやすくなりました。

--- a/changelog.d/unreleased/+php-property-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-property-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP property class types are now indexed** — property declarations such as `private User|Guest $owner` now emit type references for non-builtin property types.
+
+## 日本語
+
+- **PHP のプロパティ class 型を索引するようになりました** — `private User|Guest $owner` のようなプロパティ宣言で、builtin ではないプロパティ型を type reference として出します。

--- a/changelog.d/unreleased/+php-return-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-return-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP return class types are now indexed** — return declarations such as `(): Response|JsonResponse` now emit type references for non-builtin result types.
+
+## 日本語
+
+- **PHP の戻り値 class 型を索引するようになりました** — `(): Response|JsonResponse` のような戻り値宣言で、builtin ではない結果型を type reference として出します。

--- a/changelog.d/unreleased/+php-same-line-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-same-line-property-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP same-line property lists keep every declared member searchable** — declarations such as `public string $first, $last;` now index the later properties too, while ignoring commas inside defaults and string literals.
+
+## 日本語
+
+- **PHP の同一行プロパティリストで全メンバーを検索可能にしました** — `public string $first, $last;` のような宣言で後続プロパティも索引し、初期値や文字列リテラル内のカンマは無視します。

--- a/changelog.d/unreleased/+php-static-member-references.fixed.md
+++ b/changelog.d/unreleased/+php-static-member-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP static constants and enum cases now emit member references** — `Config::VERSION` and `Priority::Low` now index `VERSION` and `Low` as references while method calls such as `Config::rebuild()` remain calls only.
+
+## 日本語
+
+- **PHP の static 定数と enum case をメンバー参照として索引するようになりました** — `Config::VERSION` や `Priority::Low` で `VERSION` / `Low` を reference として出し、`Config::rebuild()` のようなメソッド呼び出しは call のままにします。

--- a/changelog.d/unreleased/+php-static-property-references.fixed.md
+++ b/changelog.d/unreleased/+php-static-property-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP static property accesses now emit member references** — `Config::$cache` now indexes `cache` as a reference while preserving the existing class-side type reference.
+
+## 日本語
+
+- **PHP の static property access をメンバー参照として索引するようになりました** — `Config::$cache` で既存の class 側 type reference に加えて `cache` を reference として出します。

--- a/changelog.d/unreleased/+php-trait-adaptation-use-references.fixed.md
+++ b/changelog.d/unreleased/+php-trait-adaptation-use-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP trait-use adaptation blocks now emit type references** — `use A, B { ... }` now records the trait names before the adaptation block.
+
+## 日本語
+
+- **PHP の trait-use adaptation block を型参照として索引するようになりました** — `use A, B { ... }` で adaptation block の前にある trait 名を記録します。

--- a/changelog.d/unreleased/+php-trait-alias-method-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-trait-alias-method-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP trait adaptation aliases now emit function symbols** — methods introduced with `Trait::method as aliasName;` are now searchable, while visibility-only adaptations are ignored.
+
+## 日本語
+
+- **PHP trait adaptation の alias を function シンボルとして索引するようになりました** — `Trait::method as aliasName;` で導入されるメソッドを検索可能にし、visibility 変更だけの adaptation は除外します。

--- a/changelog.d/unreleased/+php-typed-class-constant-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-typed-class-constant-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP typed class constants are now indexed by constant name** — declarations such as `public const string VERSION = ...` now emit `VERSION` with the declared type instead of being missed.
+
+## 日本語
+
+- **PHP の型付きクラス定数を定数名で索引するようになりました** — `public const string VERSION = ...` のような宣言を取り落とさず、宣言型付きの `VERSION` として出します。

--- a/changelog.d/unreleased/+php-use-const-references.fixed.md
+++ b/changelog.d/unreleased/+php-use-const-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP `use const` imports now emit references** — single, grouped, and mixed constant imports now add constant-name references without treating function imports as constants.
+
+## 日本語
+
+- **PHP の `use const` import を参照として索引するようになりました** — 単体、グループ、mixed group の const import が定数名の reference を追加し、function import を定数扱いしなくなります。

--- a/changelog.d/unreleased/+php-use-function-references.fixed.md
+++ b/changelog.d/unreleased/+php-use-function-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP `use function` imports now emit references** — single, grouped, and mixed function imports now add function-name references, making imported functions discoverable by reference search without treating const imports as functions.
+
+## 日本語
+
+- **PHP の `use function` import を参照として索引するようになりました** — 単体、グループ、mixed group の function import が関数名の reference を追加し、const import を関数扱いせずに reference 検索で見つけられるようになります。

--- a/changelog.d/unreleased/+php-use-type-references.fixed.md
+++ b/changelog.d/unreleased/+php-use-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHP `use` type imports now emit type references** — class imports and trait-use lines now appear in reference results, while `use function` and `use const` stay excluded from type references.
+
+## 日本語
+
+- **PHP の `use` 型 import を型参照として索引するようになりました** — class import と trait-use 行を reference 結果へ出し、`use function` / `use const` は type reference から除外します。

--- a/changelog.d/unreleased/+php-variable-closure-symbols.fixed.md
+++ b/changelog.d/unreleased/+php-variable-closure-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP variable-bound closures are now searchable** — assignments such as `$handler = function (...) {}` and `$mapper = fn (...) => ...` now emit function symbols named after the bound variable.
+
+## 日本語
+
+- **PHP の変数束縛 closure を検索できるようになりました** — `$handler = function (...) {}` や `$mapper = fn (...) => ...` のような代入を、束縛先の変数名を持つ function シンボルとして出します。

--- a/changelog.d/unreleased/+phpdoc-extends-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-extends-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@extends` types now emit type references** — generic parent declarations, including `@phpstan-extends` and `@psalm-extends`, now contribute parent and type-argument references.
+
+## 日本語
+
+- **PHPDoc `@extends` の型を型参照として索引するようになりました** — `@phpstan-extends` / `@psalm-extends` を含む generic parent 宣言が、親型と型引数の reference を追加します。

--- a/changelog.d/unreleased/+phpdoc-implements-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-implements-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@implements` types now emit type references** — generic interface declarations, including PHPStan and Psalm variants, now contribute interface and type-argument references.
+
+## 日本語
+
+- **PHPDoc `@implements` の型を型参照として索引するようになりました** — PHPStan / Psalm 形式を含む generic interface 宣言が、interface 型と型引数の reference を追加します。

--- a/changelog.d/unreleased/+phpdoc-import-type-source-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-import-type-source-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc imported type sources now emit type references** — `@phpstan-import-type` and `@psalm-import-type` `from` classes now appear in type reference search.
+
+## 日本語
+
+- **PHPDoc import-type の参照元を型参照として索引するようになりました** — `@phpstan-import-type` / `@psalm-import-type` の `from` class が type reference 検索に出るようになります。

--- a/changelog.d/unreleased/+phpdoc-import-type-symbols.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-import-type-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc imported type aliases now emit type symbols** — `@phpstan-import-type` and `@psalm-import-type` imports are now searchable, using the local `as` alias when present.
+
+## 日本語
+
+- **PHPDoc import-type alias を type シンボルとして索引するようになりました** — `@phpstan-import-type` / `@psalm-import-type` import が検索可能になり、`as` alias がある場合はローカル alias 名を使います。

--- a/changelog.d/unreleased/+phpdoc-method-composite-return-symbols.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-method-composite-return-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@method` symbols now accept composite return types** — nullable, union, intersection, and generic return type spellings no longer prevent dynamic method declarations from being indexed.
+
+## 日本語
+
+- **PHPDoc `@method` シンボルが複合戻り値型を受け付けるようになりました** — nullable / union / intersection / generic の戻り値型表記で、動的メソッド宣言の索引が落ちなくなります。

--- a/changelog.d/unreleased/+phpdoc-method-parameter-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-method-parameter-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@method` parameter types now emit type references** — dynamic method parameter annotations now contribute non-builtin parameter types to reference search.
+
+## 日本語
+
+- **PHPDoc `@method` の引数型を型参照として索引するようになりました** — 動的メソッドの parameter annotation が、組み込み型以外の引数型 reference を検索へ追加します。

--- a/changelog.d/unreleased/+phpdoc-method-return-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-method-return-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@method` return types now emit type references** — dynamic method declarations now contribute documented return types and generic arguments to reference search.
+
+## 日本語
+
+- **PHPDoc `@method` の戻り値型を型参照として索引するようになりました** — 動的メソッド宣言が、記録された戻り値型と generic 引数の reference を検索へ追加します。

--- a/changelog.d/unreleased/+phpdoc-method-symbols.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-method-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@method` declarations now emit function symbols** — dynamic methods documented on PHP classes are now searchable as function symbols, including optional return type metadata.
+
+## 日本語
+
+- **PHPDoc `@method` 宣言を function シンボルとして索引するようになりました** — PHP クラスに docblock で記録された動的メソッドが、任意の戻り値型 metadata とともに function symbol として検索可能になります。

--- a/changelog.d/unreleased/+phpdoc-mixin-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-mixin-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@mixin` types now emit type references** — dynamic mixin declarations now contribute referenced mixin types and generic arguments to search.
+
+## 日本語
+
+- **PHPDoc `@mixin` の型を型参照として索引するようになりました** — dynamic mixin 宣言が、mixin 型と generic 引数の reference を検索へ追加します。

--- a/changelog.d/unreleased/+phpdoc-param-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-param-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@param` types now emit type references** — docblock-only parameter types such as `@param \App\Models\User|Guest $actor` now participate in type reference search.
+
+## 日本語
+
+- **PHPDoc `@param` の型を型参照として索引するようになりました** — `@param \App\Models\User|Guest $actor` のような docblock 専用の引数型が type reference 検索に反映されます。

--- a/changelog.d/unreleased/+phpdoc-param-variant-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-param-variant-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc parameter tag variants now emit type references** — `@phpstan-param`, `@psalm-param`, and `@param-out` are now indexed like regular `@param` tags.
+
+## 日本語
+
+- **PHPDoc parameter tag variant を型参照として索引するようになりました** — `@phpstan-param` / `@psalm-param` / `@param-out` を通常の `@param` と同様に扱います。

--- a/changelog.d/unreleased/+phpdoc-property-symbols.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-property-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc dynamic properties now emit property symbols** — `@property`, `@property-read`, and `@property-write` declarations are now searchable with their documented types.
+
+## 日本語
+
+- **PHPDoc の動的プロパティを property シンボルとして索引するようになりました** — `@property` / `@property-read` / `@property-write` 宣言が、記録された型とともに検索可能になります。

--- a/changelog.d/unreleased/+phpdoc-property-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-property-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@property` types now emit type references** — dynamic property declarations now contribute their documented property types and generic arguments to reference search.
+
+## 日本語
+
+- **PHPDoc `@property` の型を型参照として索引するようになりました** — 動的プロパティ宣言が、記録されたプロパティ型と generic 引数の reference を検索へ追加します。

--- a/changelog.d/unreleased/+phpdoc-property-variant-symbols.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-property-variant-symbols.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc analyzer property tags now emit property symbols** — `@phpstan-property*` and `@psalm-property*` declarations are now indexed like regular `@property` tags.
+
+## 日本語
+
+- **PHPDoc analyzer property tag を property シンボルとして索引するようになりました** — `@phpstan-property*` / `@psalm-property*` 宣言を通常の `@property` と同様に扱います。

--- a/changelog.d/unreleased/+phpdoc-property-variant-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-property-variant-type-references.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc analyzer property tags now emit type references** — `@phpstan-property*` and `@psalm-property*` types are now indexed like regular `@property` tags.
+
+## 日本語
+
+- **PHPDoc analyzer property tag の型を型参照として索引するようになりました** — `@phpstan-property*` / `@psalm-property*` の型を通常の `@property` と同様に扱います。

--- a/changelog.d/unreleased/+phpdoc-return-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-return-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@return` types now emit type references** — return types documented only in PHPDoc now participate in type reference search.
+
+## 日本語
+
+- **PHPDoc `@return` の型を型参照として索引するようになりました** — PHPDoc にだけ書かれた戻り値型が type reference 検索に反映されます。

--- a/changelog.d/unreleased/+phpdoc-return-variant-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-return-variant-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc analyzer return tags now emit type references** — `@phpstan-return` and `@psalm-return` are now indexed like regular `@return` tags.
+
+## 日本語
+
+- **PHPDoc analyzer return tag を型参照として索引するようになりました** — `@phpstan-return` / `@psalm-return` を通常の `@return` と同様に扱います。

--- a/changelog.d/unreleased/+phpdoc-template-bound-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-template-bound-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc template bounds now emit type references** — `@template T of Foo` and `@template U as Bar` constraints now contribute referenced bound types to search.
+
+## 日本語
+
+- **PHPDoc template bound を型参照として索引するようになりました** — `@template T of Foo` / `@template U as Bar` の制約型が reference 検索に反映されます。

--- a/changelog.d/unreleased/+phpdoc-throws-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-throws-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@throws` types now emit type references** — documented exception types now appear in type reference search.
+
+## 日本語
+
+- **PHPDoc `@throws` の型を型参照として索引するようになりました** — docblock に記録された例外型が type reference 検索に出るようになります。

--- a/changelog.d/unreleased/+phpdoc-type-alias-symbols.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-type-alias-symbols.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc type aliases now emit type symbols** — `@phpstan-type`, `@psalm-type`, and plain `@type` aliases are now searchable with their aliased expression.
+
+## 日本語
+
+- **PHPDoc type alias を type シンボルとして索引するようになりました** — `@phpstan-type` / `@psalm-type` / 通常の `@type` alias が、alias 先の式とともに検索可能になります。

--- a/changelog.d/unreleased/+phpdoc-type-alias-target-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-type-alias-target-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc type alias targets now emit type references** — types mentioned inside `@phpstan-type`, `@psalm-type`, and `@type` alias expressions now participate in reference search.
+
+## 日本語
+
+- **PHPDoc type alias の alias 先を型参照として索引するようになりました** — `@phpstan-type` / `@psalm-type` / `@type` の alias 式に含まれる型が reference 検索に反映されます。

--- a/changelog.d/unreleased/+phpdoc-var-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-var-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@var` types now emit type references** — variable and property types documented with `@var` now appear in type reference search.
+
+## 日本語
+
+- **PHPDoc `@var` の型を型参照として索引するようになりました** — `@var` で記録された変数・プロパティ型が type reference 検索に出るようになります。

--- a/changelog.d/unreleased/+phpdoc-var-variant-type-references.fixed.md
+++ b/changelog.d/unreleased/+phpdoc-var-variant-type-references.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc analyzer var tags now emit type references** — `@phpstan-var` and `@psalm-var` are now indexed like regular `@var` tags.
+
+## 日本語
+
+- **PHPDoc analyzer var tag を型参照として索引するようになりました** — `@phpstan-var` / `@psalm-var` を通常の `@var` と同様に扱います。

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -33,6 +33,10 @@ internal static class PhpReferenceExtractor
         @"(?:^|[(,])\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*[|&]\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s+\$[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex PropertyTypeRegex = new(
+        @"^\s*(?:public|private|protected|var)\s+(?:(?:static|readonly)\s+)*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*[|&]\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s+\$[A-Za-z_]\w*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly HashSet<string> BuiltinTypeNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "array", "bool", "callable", "false", "float", "int", "iterable", "mixed", "never",
@@ -252,6 +256,34 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
     {
         foreach (Match match in ParameterTypeRegex.Matches(preparedLine))
+        {
+            foreach (Capture capture in match.Groups["name"].Captures)
+            {
+                if (IsPhpBuiltinTypeName(capture.Value))
+                    continue;
+
+                AddPhpTypeReferenceFromQualifiedName(
+                    capture,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+            }
+        }
+    }
+
+    public static void EmitPropertyTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in PropertyTypeRegex.Matches(preparedLine))
         {
             foreach (Capture capture in match.Groups["name"].Captures)
             {

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -17,6 +17,14 @@ internal static class PhpReferenceExtractor
         @"(?:#\[\s*|,\s*)(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\b(?=\s*(?:\(|,|\]))",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex DocblockParamTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@param\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex DocblockTypeNameRegex = new(
+        @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly Regex InstanceofRegex = new(
         @"\binstanceof\s+(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
@@ -76,8 +84,40 @@ internal static class PhpReferenceExtractor
     private static readonly HashSet<string> BuiltinTypeNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "array", "bool", "callable", "false", "float", "int", "iterable", "mixed", "never",
-        "null", "object", "self", "static", "string", "true", "void",
+        "class", "null", "numeric", "object", "resource", "scalar", "self", "static", "string", "true", "void",
     };
+
+    public static void EmitDocblockParamTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = DocblockParamTypeRegex.Match(originalLine);
+        if (!match.Success)
+            return;
+
+        var typesGroup = match.Groups["types"];
+        foreach (Match typeMatch in DocblockTypeNameRegex.Matches(typesGroup.Value))
+        {
+            var nameGroup = typeMatch.Groups["name"];
+            if (IsPhpBuiltinTypeName(nameGroup.Value))
+                continue;
+
+            AddPhpTypeReferenceFromName(
+                nameGroup.Value,
+                typesGroup.Index + nameGroup.Index,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container);
+        }
+    }
 
     public static void EmitAttributeReferences(
         string preparedLine,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -37,6 +37,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?extends\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockImplementsTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?implements\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -185,6 +189,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockExtendsTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockImplementsTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockImplementsTypeRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -49,6 +49,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@property(?:-read|-write)?\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockMethodReturnTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@method\s+(?:static\s+)?(?<types>[^\s()]+)\s+[A-Za-z_]\w*\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -251,6 +255,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockPropertyTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockMethodReturnTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockMethodReturnTypeRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -65,6 +65,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@template(?:-[A-Za-z_]\w*)?\s+[A-Za-z_]\w*\s+(?:of|as)\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockTypeAliasTargetRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?type\s+[A-Za-z_]\w*\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -332,6 +336,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockTemplateBoundTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockTypeAliasTargetReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockTypeAliasTargetRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -17,6 +17,10 @@ internal static class PhpReferenceExtractor
         @"(?:#\[\s*|,\s*)(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\b(?=\s*(?:\(|,|\]))",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex InstanceofRegex = new(
+        @"\binstanceof\s+(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     public static void EmitAttributeReferences(
         string preparedLine,
         List<ReferenceRecord> references,
@@ -145,12 +149,81 @@ internal static class PhpReferenceExtractor
         }
     }
 
+    public static void EmitInstanceofReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in InstanceofRegex.Matches(preparedLine))
+        {
+            AddPhpTypeReferenceFromQualifiedName(
+                match.Groups["name"],
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
     private static bool IsPhpCallAfterStaticMember(string line, int index)
     {
         while (index < line.Length && char.IsWhiteSpace(line[index]))
             index++;
 
         return index < line.Length && line[index] == '(';
+    }
+
+    private static void AddPhpTypeReferenceFromQualifiedName(
+        Group nameGroup,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var rawName = nameGroup.Value;
+        var trimmedName = rawName.TrimStart('\\');
+        if (trimmedName.Length == 0)
+            return;
+
+        var leadingBackslashCount = rawName.Length - trimmedName.Length;
+        var qualifiedNameIndex = nameGroup.Index + leadingBackslashCount;
+        if (trimmedName.Contains('\\', StringComparison.Ordinal))
+        {
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                trimmedName,
+                qualifiedNameIndex,
+                "type_reference",
+                context,
+                lineNumber,
+                container);
+        }
+
+        var shortNameStart = trimmedName.LastIndexOf('\\') + 1;
+        var shortName = trimmedName[shortNameStart..];
+        if (shortName.Length == 0)
+            return;
+
+        ReferenceExtractor.AddReference(
+            references,
+            seen,
+            fileId,
+            shortName,
+            qualifiedNameIndex + shortNameStart,
+            "type_reference",
+            context,
+            lineNumber,
+            container);
     }
 
     public static void EmitObjectMemberAccessReferences(

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -33,6 +33,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@throws\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockExtendsTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?extends\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -163,6 +167,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockThrowsTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockExtendsTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockExtendsTypeRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -21,6 +21,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@param\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockReturnTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@return\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -95,8 +99,45 @@ internal static class PhpReferenceExtractor
         string context,
         int lineNumber,
         SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockParamTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockReturnTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockReturnTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    private static void EmitDocblockTypeReferences(
+        Regex tagRegex,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
     {
-        var match = DocblockParamTypeRegex.Match(originalLine);
+        var match = tagRegex.Match(originalLine);
         if (!match.Success)
             return;
 

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -29,6 +29,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@var\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockThrowsTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@throws\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -141,6 +145,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockVarTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockThrowsTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockThrowsTypeRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -18,7 +18,7 @@ internal static class PhpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex DocblockParamTypeRegex = new(
-        @"^\s*(?:/\*\*)?\s*\*?\s*@param\s+(?<types>\S+)",
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?param(?:-out)?\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockReturnTypeRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -22,7 +22,7 @@ internal static class PhpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockReturnTypeRegex = new(
-        @"^\s*(?:/\*\*)?\s*\*?\s*@return\s+(?<types>\S+)",
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?return\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockVarTypeRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -37,6 +37,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:public|private|protected|var)\s+(?:(?:static|readonly)\s+)*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*[|&]\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s+\$[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex InheritanceTypeRegex = new(
+        @"\b(?:extends|implements)\s+(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*,\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly HashSet<string> BuiltinTypeNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "array", "bool", "callable", "false", "float", "int", "iterable", "mixed", "never",
@@ -290,6 +294,31 @@ internal static class PhpReferenceExtractor
                 if (IsPhpBuiltinTypeName(capture.Value))
                     continue;
 
+                AddPhpTypeReferenceFromQualifiedName(
+                    capture,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+            }
+        }
+    }
+
+    public static void EmitInheritanceTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in InheritanceTypeRegex.Matches(preparedLine))
+        {
+            foreach (Capture capture in match.Groups["name"].Captures)
+            {
                 AddPhpTypeReferenceFromQualifiedName(
                     capture,
                     references,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -45,8 +45,20 @@ internal static class PhpReferenceExtractor
         @"^\s*use\s+(?!(?:function|const)\b)(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?(?:\s*,\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s*;",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex UseFunctionRegex = new(
+        @"^\s*use\s+function\s+(?<imports>.+?)\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex UseFunctionItemRegex = new(
+        @"(?:^|,)\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex GroupUseTypeRegex = new(
         @"^\s*use\s+(?!(?:function|const)\b)(?<prefix>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\\\{\s*(?<items>[^{}]+?)\s*\}\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex GroupUseFunctionRegex = new(
+        @"^\s*use\s+function\s+(?<prefix>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\\\{\s*(?<items>[^{}]+?)\s*\}\s*;",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex GroupUseTypeItemRegex = new(
@@ -376,6 +388,50 @@ internal static class PhpReferenceExtractor
         }
     }
 
+    public static void EmitUseFunctionReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var groupFunctionMatch = GroupUseFunctionRegex.Match(preparedLine);
+        if (groupFunctionMatch.Success)
+        {
+            EmitGroupUseFunctionReferences(groupFunctionMatch, references, seen, fileId, context, lineNumber, container, requireFunctionKind: false);
+            return;
+        }
+
+        var groupMatch = GroupUseTypeRegex.Match(preparedLine);
+        if (groupMatch.Success)
+        {
+            EmitGroupUseFunctionReferences(groupMatch, references, seen, fileId, context, lineNumber, container, requireFunctionKind: true);
+            return;
+        }
+
+        var match = UseFunctionRegex.Match(preparedLine);
+        if (!match.Success)
+            return;
+
+        var importsGroup = match.Groups["imports"];
+        foreach (Match itemMatch in UseFunctionItemRegex.Matches(importsGroup.Value))
+        {
+            var itemGroup = itemMatch.Groups["name"];
+            AddPhpReferenceFromName(
+                itemGroup.Value,
+                importsGroup.Index + itemGroup.Index,
+                "reference",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
     private static void EmitGroupUseTypeReferences(
         Match groupMatch,
         List<ReferenceRecord> references,
@@ -408,6 +464,52 @@ internal static class PhpReferenceExtractor
             AddPhpTypeReferenceFromName(
                 prefix + "\\" + trimmedItemName,
                 prefixGroup.Index,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container,
+                shortNameIndex);
+        }
+    }
+
+    private static void EmitGroupUseFunctionReferences(
+        Match groupMatch,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        bool requireFunctionKind)
+    {
+        var prefixGroup = groupMatch.Groups["prefix"];
+        var prefix = prefixGroup.Value.TrimEnd('\\');
+        if (prefix.Length == 0)
+            return;
+
+        var itemsGroup = groupMatch.Groups["items"];
+        foreach (Match itemMatch in GroupUseTypeItemRegex.Matches(itemsGroup.Value))
+        {
+            var isFunctionImport = itemMatch.Groups["kind"].Success
+                && itemMatch.Groups["kind"].Value.Equals("function", StringComparison.OrdinalIgnoreCase);
+            if (requireFunctionKind != isFunctionImport)
+                continue;
+
+            var itemGroup = itemMatch.Groups["name"];
+            var rawItemName = itemGroup.Value;
+            var trimmedItemName = rawItemName.TrimStart('\\');
+            if (trimmedItemName.Length == 0)
+                continue;
+
+            var leadingBackslashCount = rawItemName.Length - trimmedItemName.Length;
+            var itemShortNameStart = trimmedItemName.LastIndexOf('\\') + 1;
+            var shortNameIndex = itemsGroup.Index + itemGroup.Index + leadingBackslashCount + itemShortNameStart;
+            AddPhpReferenceFromName(
+                prefix + "\\" + trimmedItemName,
+                prefixGroup.Index,
+                "reference",
                 references,
                 seen,
                 fileId,
@@ -458,6 +560,29 @@ internal static class PhpReferenceExtractor
         int lineNumber,
         SymbolRecord? container,
         int? shortNameIndexOverride = null)
+        => AddPhpReferenceFromName(
+            rawName,
+            nameIndex,
+            "type_reference",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container,
+            shortNameIndexOverride);
+
+    private static void AddPhpReferenceFromName(
+        string rawName,
+        int nameIndex,
+        string referenceKind,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        int? shortNameIndexOverride = null)
     {
         var trimmedName = rawName.TrimStart('\\');
         if (trimmedName.Length == 0)
@@ -473,7 +598,7 @@ internal static class PhpReferenceExtractor
                 fileId,
                 trimmedName,
                 qualifiedNameIndex,
-                "type_reference",
+                referenceKind,
                 context,
                 lineNumber,
                 container);
@@ -490,7 +615,7 @@ internal static class PhpReferenceExtractor
             fileId,
             shortName,
             shortNameIndexOverride ?? qualifiedNameIndex + shortNameStart,
-            "type_reference",
+            referenceKind,
             context,
             lineNumber,
             container);

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -45,6 +45,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@mixin\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockPropertyTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@property(?:-read|-write)?\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -229,6 +233,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockMixinTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockPropertyTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockPropertyTypeRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -53,6 +53,14 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@method\s+(?:static\s+)?(?<types>[^\s()]+)\s+[A-Za-z_]\w*\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockMethodParameterListRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@method\s+(?:static\s+)?(?:[^\s()]+\s+)?[A-Za-z_]\w*\s*\((?<params>[^)]*)\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex DocblockMethodParameterTypeRegex = new(
+        @"(?:^|,)\s*(?<types>[^\s,]+)\s+\$[A-Za-z_]\w*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -281,6 +289,35 @@ internal static class PhpReferenceExtractor
             lineNumber,
             container);
 
+    public static void EmitDocblockMethodParameterTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = DocblockMethodParameterListRegex.Match(originalLine);
+        if (!match.Success)
+            return;
+
+        var paramsGroup = match.Groups["params"];
+        foreach (Match parameterMatch in DocblockMethodParameterTypeRegex.Matches(paramsGroup.Value))
+        {
+            var typesGroup = parameterMatch.Groups["types"];
+            EmitDocblockTypeGroupReferences(
+                typesGroup.Value,
+                paramsGroup.Index + typesGroup.Index,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
     private static void EmitDocblockTypeReferences(
         Regex tagRegex,
         string originalLine,
@@ -296,7 +333,28 @@ internal static class PhpReferenceExtractor
             return;
 
         var typesGroup = match.Groups["types"];
-        foreach (Match typeMatch in DocblockTypeNameRegex.Matches(typesGroup.Value))
+        EmitDocblockTypeGroupReferences(
+            typesGroup.Value,
+            typesGroup.Index,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+    }
+
+    private static void EmitDocblockTypeGroupReferences(
+        string typeExpression,
+        int typeExpressionIndex,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match typeMatch in DocblockTypeNameRegex.Matches(typeExpression))
         {
             var nameGroup = typeMatch.Groups["name"];
             if (IsPhpBuiltinTypeName(nameGroup.Value))
@@ -304,7 +362,7 @@ internal static class PhpReferenceExtractor
 
             AddPhpTypeReferenceFromName(
                 nameGroup.Value,
-                typesGroup.Index + nameGroup.Index,
+                typeExpressionIndex + nameGroup.Index,
                 references,
                 seen,
                 fileId,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -125,7 +125,32 @@ internal static class PhpReferenceExtractor
                     lineNumber,
                     container);
             }
+
+            var memberGroup = match.Groups["member"];
+            if (memberGroup.Success
+                && !memberGroup.Value.Equals("class", StringComparison.OrdinalIgnoreCase)
+                && !IsPhpCallAfterStaticMember(preparedLine, memberGroup.Index + memberGroup.Length))
+            {
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    memberGroup.Value,
+                    memberGroup.Index,
+                    "reference",
+                    context,
+                    lineNumber,
+                    container);
+            }
         }
+    }
+
+    private static bool IsPhpCallAfterStaticMember(string line, int index)
+    {
+        while (index < line.Length && char.IsWhiteSpace(line[index]))
+            index++;
+
+        return index < line.Length && line[index] == '(';
     }
 
     public static void EmitObjectMemberAccessReferences(

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -21,6 +21,10 @@ internal static class PhpReferenceExtractor
         @"\binstanceof\s+(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex CatchTypeRegex = new(
+        @"\bcatch\s*\(\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*\|\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s+\$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     public static void EmitAttributeReferences(
         string preparedLine,
         List<ReferenceRecord> references,
@@ -171,6 +175,31 @@ internal static class PhpReferenceExtractor
         }
     }
 
+    public static void EmitCatchTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in CatchTypeRegex.Matches(preparedLine))
+        {
+            foreach (Capture capture in match.Groups["name"].Captures)
+            {
+                AddPhpTypeReferenceFromQualifiedName(
+                    capture,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+            }
+        }
+    }
+
     private static bool IsPhpCallAfterStaticMember(string line, int index)
     {
         while (index < line.Length && char.IsWhiteSpace(line[index]))
@@ -180,7 +209,7 @@ internal static class PhpReferenceExtractor
     }
 
     private static void AddPhpTypeReferenceFromQualifiedName(
-        Group nameGroup,
+        Capture nameGroup,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -26,7 +26,7 @@ internal static class PhpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockVarTypeRegex = new(
-        @"^\s*(?:/\*\*)?\s*\*?\s*@var\s+(?<types>\S+)",
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?var\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockThrowsTypeRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -45,6 +45,14 @@ internal static class PhpReferenceExtractor
         @"^\s*use\s+(?!(?:function|const)\b)(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?(?:\s*,\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s*;",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex GroupUseTypeRegex = new(
+        @"^\s*use\s+(?!(?:function|const)\b)(?<prefix>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\\\{\s*(?<items>[^{}]+?)\s*\}\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex GroupUseTypeItemRegex = new(
+        @"(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly HashSet<string> BuiltinTypeNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "array", "bool", "callable", "false", "float", "int", "iterable", "mixed", "never",
@@ -344,6 +352,13 @@ internal static class PhpReferenceExtractor
         int lineNumber,
         SymbolRecord? container)
     {
+        var groupMatch = GroupUseTypeRegex.Match(preparedLine);
+        if (groupMatch.Success)
+        {
+            EmitGroupUseTypeReferences(groupMatch, references, seen, fileId, context, lineNumber, container);
+            return;
+        }
+
         var match = UseTypeRegex.Match(preparedLine);
         if (!match.Success)
             return;
@@ -358,6 +373,45 @@ internal static class PhpReferenceExtractor
                 context,
                 lineNumber,
                 container);
+        }
+    }
+
+    private static void EmitGroupUseTypeReferences(
+        Match groupMatch,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var prefixGroup = groupMatch.Groups["prefix"];
+        var prefix = prefixGroup.Value.TrimEnd('\\');
+        if (prefix.Length == 0)
+            return;
+
+        var itemsGroup = groupMatch.Groups["items"];
+        foreach (Match itemMatch in GroupUseTypeItemRegex.Matches(itemsGroup.Value))
+        {
+            var itemGroup = itemMatch.Groups["name"];
+            var rawItemName = itemGroup.Value;
+            var trimmedItemName = rawItemName.TrimStart('\\');
+            if (trimmedItemName.Length == 0)
+                continue;
+
+            var leadingBackslashCount = rawItemName.Length - trimmedItemName.Length;
+            var itemShortNameStart = trimmedItemName.LastIndexOf('\\') + 1;
+            var shortNameIndex = itemsGroup.Index + itemGroup.Index + leadingBackslashCount + itemShortNameStart;
+            AddPhpTypeReferenceFromName(
+                prefix + "\\" + trimmedItemName,
+                prefixGroup.Index,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container,
+                shortNameIndex);
         }
     }
 
@@ -381,14 +435,33 @@ internal static class PhpReferenceExtractor
         string context,
         int lineNumber,
         SymbolRecord? container)
+        => AddPhpTypeReferenceFromName(
+            nameGroup.Value,
+            nameGroup.Index,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    private static void AddPhpTypeReferenceFromName(
+        string rawName,
+        int nameIndex,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        int? shortNameIndexOverride = null)
     {
-        var rawName = nameGroup.Value;
         var trimmedName = rawName.TrimStart('\\');
         if (trimmedName.Length == 0)
             return;
 
         var leadingBackslashCount = rawName.Length - trimmedName.Length;
-        var qualifiedNameIndex = nameGroup.Index + leadingBackslashCount;
+        var qualifiedNameIndex = nameIndex + leadingBackslashCount;
         if (trimmedName.Contains('\\', StringComparison.Ordinal))
         {
             ReferenceExtractor.AddReference(
@@ -413,7 +486,7 @@ internal static class PhpReferenceExtractor
             seen,
             fileId,
             shortName,
-            qualifiedNameIndex + shortNameStart,
+            shortNameIndexOverride ?? qualifiedNameIndex + shortNameStart,
             "type_reference",
             context,
             lineNumber,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -41,6 +41,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?implements\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockMixinTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@mixin\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -207,6 +211,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockImplementsTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockMixinTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockMixinTypeRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -13,6 +13,64 @@ internal static class PhpReferenceExtractor
         @"(?:\?->|->)\s*(?<name>[A-Za-z_]\w*)(?!\s*\()",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex AttributeRegex = new(
+        @"(?:#\[\s*|,\s*)(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\b(?=\s*(?:\(|,|\]))",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static void EmitAttributeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        if (!preparedLine.Contains("#[", StringComparison.Ordinal))
+            return;
+
+        foreach (Match match in AttributeRegex.Matches(preparedLine))
+        {
+            var nameGroup = match.Groups["name"];
+            var rawName = nameGroup.Value;
+            var trimmedName = rawName.TrimStart('\\');
+            if (trimmedName.Length == 0)
+                continue;
+
+            var leadingBackslashCount = rawName.Length - trimmedName.Length;
+            var qualifiedNameIndex = nameGroup.Index + leadingBackslashCount;
+            if (trimmedName.Contains('\\', StringComparison.Ordinal))
+            {
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    trimmedName,
+                    qualifiedNameIndex,
+                    "type_reference",
+                    context,
+                    lineNumber,
+                    container);
+            }
+
+            var shortNameStart = trimmedName.LastIndexOf('\\') + 1;
+            var shortName = trimmedName[shortNameStart..];
+            if (shortName.Length == 0)
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                shortName,
+                qualifiedNameIndex + shortNameStart,
+                "type_reference",
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
     public static void EmitStaticAccessReferences(
         string preparedLine,
         List<ReferenceRecord> references,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -25,6 +25,16 @@ internal static class PhpReferenceExtractor
         @"\bcatch\s*\(\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*\|\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s+\$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex ReturnTypeRegex = new(
+        @"\)\s*:\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*\|\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> BuiltinTypeNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "array", "bool", "callable", "false", "float", "int", "iterable", "mixed", "never",
+        "null", "object", "self", "static", "string", "true", "void",
+    };
+
     public static void EmitAttributeReferences(
         string preparedLine,
         List<ReferenceRecord> references,
@@ -200,6 +210,34 @@ internal static class PhpReferenceExtractor
         }
     }
 
+    public static void EmitReturnTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in ReturnTypeRegex.Matches(preparedLine))
+        {
+            foreach (Capture capture in match.Groups["name"].Captures)
+            {
+                if (IsPhpBuiltinTypeName(capture.Value))
+                    continue;
+
+                AddPhpTypeReferenceFromQualifiedName(
+                    capture,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+            }
+        }
+    }
+
     private static bool IsPhpCallAfterStaticMember(string line, int index)
     {
         while (index < line.Length && char.IsWhiteSpace(line[index]))
@@ -207,6 +245,10 @@ internal static class PhpReferenceExtractor
 
         return index < line.Length && line[index] == '(';
     }
+
+    private static bool IsPhpBuiltinTypeName(string name)
+        => !name.Contains('\\', StringComparison.Ordinal)
+           && BuiltinTypeNames.Contains(name.TrimStart('\\'));
 
     private static void AddPhpTypeReferenceFromQualifiedName(
         Capture nameGroup,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -61,6 +61,10 @@ internal static class PhpReferenceExtractor
         @"(?:^|,)\s*(?<types>[^\s,]+)\s+\$[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex DocblockTemplateBoundTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@template(?:-[A-Za-z_]\w*)?\s+[A-Za-z_]\w*\s+(?:of|as)\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -317,6 +321,24 @@ internal static class PhpReferenceExtractor
                 container);
         }
     }
+
+    public static void EmitDocblockTemplateBoundTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockTemplateBoundTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
 
     private static void EmitDocblockTypeReferences(
         Regex tagRegex,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -6,7 +6,7 @@ namespace CodeIndex.Indexer;
 internal static class PhpReferenceExtractor
 {
     private static readonly Regex StaticAccessRegex = new(
-        @"(?<![\w$\\])(?<name>(?:\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))::(?<member>[A-Za-z_]\w*)",
+        @"(?<![\w$\\])(?<name>(?:\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))::\$?(?<member>[A-Za-z_]\w*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex ObjectMemberAccessRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -41,6 +41,10 @@ internal static class PhpReferenceExtractor
         @"\b(?:extends|implements)\s+(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*,\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex UseTypeRegex = new(
+        @"^\s*use\s+(?!(?:function|const)\b)(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?(?:\s*,\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly HashSet<string> BuiltinTypeNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "array", "bool", "callable", "false", "float", "int", "iterable", "mixed", "never",
@@ -328,6 +332,32 @@ internal static class PhpReferenceExtractor
                     lineNumber,
                     container);
             }
+        }
+    }
+
+    public static void EmitUseTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var match = UseTypeRegex.Match(preparedLine);
+        if (!match.Success)
+            return;
+
+        foreach (Capture capture in match.Groups["name"].Captures)
+        {
+            AddPhpTypeReferenceFromQualifiedName(
+                capture,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -29,6 +29,10 @@ internal static class PhpReferenceExtractor
         @"\)\s*:\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*\|\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex ParameterTypeRegex = new(
+        @"(?:^|[(,])\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s*[|&]\s*\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s+\$[A-Za-z_]\w*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly HashSet<string> BuiltinTypeNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "array", "bool", "callable", "false", "float", "int", "iterable", "mixed", "never",
@@ -220,6 +224,34 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
     {
         foreach (Match match in ReturnTypeRegex.Matches(preparedLine))
+        {
+            foreach (Capture capture in match.Groups["name"].Captures)
+            {
+                if (IsPhpBuiltinTypeName(capture.Value))
+                    continue;
+
+                AddPhpTypeReferenceFromQualifiedName(
+                    capture,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+            }
+        }
+    }
+
+    public static void EmitParameterTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in ParameterTypeRegex.Matches(preparedLine))
         {
             foreach (Capture capture in match.Groups["name"].Captures)
             {

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -69,6 +69,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?type\s+[A-Za-z_]\w*\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockImportTypeSourceRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?import-type\s+[A-Za-z_]\w*\s+from\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -354,6 +358,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockTypeAliasTargetRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockImportTypeSourceReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockImportTypeSourceRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -49,7 +49,11 @@ internal static class PhpReferenceExtractor
         @"^\s*use\s+function\s+(?<imports>.+?)\s*;",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
-    private static readonly Regex UseFunctionItemRegex = new(
+    private static readonly Regex UseConstRegex = new(
+        @"^\s*use\s+const\s+(?<imports>.+?)\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex UseImportItemRegex = new(
         @"(?:^|,)\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
@@ -59,6 +63,10 @@ internal static class PhpReferenceExtractor
 
     private static readonly Regex GroupUseFunctionRegex = new(
         @"^\s*use\s+function\s+(?<prefix>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\\\{\s*(?<items>[^{}]+?)\s*\}\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex GroupUseConstRegex = new(
+        @"^\s*use\s+const\s+(?<prefix>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\\\{\s*(?<items>[^{}]+?)\s*\}\s*;",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex GroupUseTypeItemRegex = new(
@@ -400,14 +408,14 @@ internal static class PhpReferenceExtractor
         var groupFunctionMatch = GroupUseFunctionRegex.Match(preparedLine);
         if (groupFunctionMatch.Success)
         {
-            EmitGroupUseFunctionReferences(groupFunctionMatch, references, seen, fileId, context, lineNumber, container, requireFunctionKind: false);
+            EmitGroupUseImportReferences(groupFunctionMatch, references, seen, fileId, context, lineNumber, container, "function", requireImportKind: false);
             return;
         }
 
         var groupMatch = GroupUseTypeRegex.Match(preparedLine);
         if (groupMatch.Success)
         {
-            EmitGroupUseFunctionReferences(groupMatch, references, seen, fileId, context, lineNumber, container, requireFunctionKind: true);
+            EmitGroupUseImportReferences(groupMatch, references, seen, fileId, context, lineNumber, container, "function", requireImportKind: true);
             return;
         }
 
@@ -416,7 +424,51 @@ internal static class PhpReferenceExtractor
             return;
 
         var importsGroup = match.Groups["imports"];
-        foreach (Match itemMatch in UseFunctionItemRegex.Matches(importsGroup.Value))
+        foreach (Match itemMatch in UseImportItemRegex.Matches(importsGroup.Value))
+        {
+            var itemGroup = itemMatch.Groups["name"];
+            AddPhpReferenceFromName(
+                itemGroup.Value,
+                importsGroup.Index + itemGroup.Index,
+                "reference",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container);
+        }
+    }
+
+    public static void EmitUseConstReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        var groupConstMatch = GroupUseConstRegex.Match(preparedLine);
+        if (groupConstMatch.Success)
+        {
+            EmitGroupUseImportReferences(groupConstMatch, references, seen, fileId, context, lineNumber, container, "const", requireImportKind: false);
+            return;
+        }
+
+        var groupMatch = GroupUseTypeRegex.Match(preparedLine);
+        if (groupMatch.Success)
+        {
+            EmitGroupUseImportReferences(groupMatch, references, seen, fileId, context, lineNumber, container, "const", requireImportKind: true);
+            return;
+        }
+
+        var match = UseConstRegex.Match(preparedLine);
+        if (!match.Success)
+            return;
+
+        var importsGroup = match.Groups["imports"];
+        foreach (Match itemMatch in UseImportItemRegex.Matches(importsGroup.Value))
         {
             var itemGroup = itemMatch.Groups["name"];
             AddPhpReferenceFromName(
@@ -474,7 +526,7 @@ internal static class PhpReferenceExtractor
         }
     }
 
-    private static void EmitGroupUseFunctionReferences(
+    private static void EmitGroupUseImportReferences(
         Match groupMatch,
         List<ReferenceRecord> references,
         HashSet<string> seen,
@@ -482,7 +534,8 @@ internal static class PhpReferenceExtractor
         string context,
         int lineNumber,
         SymbolRecord? container,
-        bool requireFunctionKind)
+        string importKind,
+        bool requireImportKind)
     {
         var prefixGroup = groupMatch.Groups["prefix"];
         var prefix = prefixGroup.Value.TrimEnd('\\');
@@ -492,9 +545,9 @@ internal static class PhpReferenceExtractor
         var itemsGroup = groupMatch.Groups["items"];
         foreach (Match itemMatch in GroupUseTypeItemRegex.Matches(itemsGroup.Value))
         {
-            var isFunctionImport = itemMatch.Groups["kind"].Success
-                && itemMatch.Groups["kind"].Value.Equals("function", StringComparison.OrdinalIgnoreCase);
-            if (requireFunctionKind != isFunctionImport)
+            var isTargetKind = itemMatch.Groups["kind"].Success
+                && itemMatch.Groups["kind"].Value.Equals(importKind, StringComparison.OrdinalIgnoreCase);
+            if (requireImportKind != isTargetKind)
                 continue;
 
             var itemGroup = itemMatch.Groups["name"];

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -50,7 +50,7 @@ internal static class PhpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex GroupUseTypeItemRegex = new(
-        @"(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?",
+        @"(?:^|,)\s*(?:(?<kind>function|const)\s+)?(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly HashSet<string> BuiltinTypeNames = new(StringComparer.OrdinalIgnoreCase)
@@ -393,6 +393,9 @@ internal static class PhpReferenceExtractor
         var itemsGroup = groupMatch.Groups["items"];
         foreach (Match itemMatch in GroupUseTypeItemRegex.Matches(itemsGroup.Value))
         {
+            if (itemMatch.Groups["kind"].Success)
+                continue;
+
             var itemGroup = itemMatch.Groups["name"];
             var rawItemName = itemGroup.Value;
             var trimmedItemName = rawItemName.TrimStart('\\');

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -25,6 +25,10 @@ internal static class PhpReferenceExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@return\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex DocblockVarTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@var\s+(?<types>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex DocblockTypeNameRegex = new(
         @"(?<![-\w\\])\??(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\[\])?(?![-\w\\])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -119,6 +123,24 @@ internal static class PhpReferenceExtractor
         SymbolRecord? container)
         => EmitDocblockTypeReferences(
             DocblockReturnTypeRegex,
+            originalLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    public static void EmitDocblockVarTypeReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+        => EmitDocblockTypeReferences(
+            DocblockVarTypeRegex,
             originalLine,
             references,
             seen,

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -90,7 +90,7 @@ internal static class PhpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex UseTypeRegex = new(
-        @"^\s*use\s+(?!(?:function|const)\b)(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?(?:\s*,\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s*;",
+        @"^\s*use\s+(?!(?:function|const)\b)(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+[A-Za-z_]\w*)?(?:\s*,\s*(?<name>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*))*\s*(?:;|\{)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex UseFunctionRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -46,7 +46,7 @@ internal static class PhpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockPropertyTypeRegex = new(
-        @"^\s*(?:/\*\*)?\s*\*?\s*@property(?:-read|-write)?\s+(?<types>\S+)",
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?property(?:-read|-write)?\s+(?<types>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockMethodReturnTypeRegex = new(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1887,6 +1887,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitParameterTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1245,7 +1245,7 @@ public static partial class ReferenceExtractor
                 }
             }
 
-            if (language == "php" && originalLine.Contains("@var", StringComparison.OrdinalIgnoreCase))
+            if (language == "php" && originalLine.Contains("var", StringComparison.OrdinalIgnoreCase))
             {
                 var docblockContext = originalLine.Trim();
                 if (docblockContext.Length > 0)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1354,6 +1354,14 @@ public static partial class ReferenceExtractor
                         docblockContext,
                         lineNumber,
                         FindInnermostContainer(containerCandidates, lineNumber));
+                    PhpReferenceExtractor.EmitDocblockMethodParameterTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
                 }
             }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1905,6 +1905,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitInheritanceTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1277,6 +1277,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("extends", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockExtendsTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1381,6 +1381,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("type", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockTypeAliasTargetReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1325,6 +1325,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("@property", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockPropertyTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1213,6 +1213,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("@param", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockParamTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1914,6 +1914,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitUseTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1197,6 +1197,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("#[", StringComparison.Ordinal))
+            {
+                var attributeContext = originalLine.Trim();
+                if (attributeContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitAttributeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        attributeContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1878,6 +1878,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitReturnTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1229,7 +1229,7 @@ public static partial class ReferenceExtractor
                 }
             }
 
-            if (language == "php" && originalLine.Contains("@return", StringComparison.OrdinalIgnoreCase))
+            if (language == "php" && originalLine.Contains("return", StringComparison.OrdinalIgnoreCase))
             {
                 var docblockContext = originalLine.Trim();
                 if (docblockContext.Length > 0)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1896,6 +1896,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitPropertyTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1341,6 +1341,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("@method", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockMethodReturnTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1394,6 +1394,14 @@ public static partial class ReferenceExtractor
                         docblockContext,
                         lineNumber,
                         FindInnermostContainer(containerCandidates, lineNumber));
+                    PhpReferenceExtractor.EmitDocblockImportTypeSourceReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
                 }
             }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1293,6 +1293,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("implements", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockImplementsTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1213,7 +1213,7 @@ public static partial class ReferenceExtractor
                 }
             }
 
-            if (language == "php" && originalLine.Contains("@param", StringComparison.OrdinalIgnoreCase))
+            if (language == "php" && originalLine.Contains("param", StringComparison.OrdinalIgnoreCase))
             {
                 var docblockContext = originalLine.Trim();
                 if (docblockContext.Length > 0)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1309,6 +1309,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("@mixin", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockMixinTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1869,6 +1869,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitCatchTypeReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1325,7 +1325,7 @@ public static partial class ReferenceExtractor
                 }
             }
 
-            if (language == "php" && originalLine.Contains("@property", StringComparison.OrdinalIgnoreCase))
+            if (language == "php" && originalLine.Contains("property", StringComparison.OrdinalIgnoreCase))
             {
                 var docblockContext = originalLine.Trim();
                 if (docblockContext.Length > 0)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1365,6 +1365,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("@template", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockTemplateBoundTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1932,6 +1932,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitUseConstReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1229,6 +1229,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("@return", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockReturnTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1261,6 +1261,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("@throws", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockThrowsTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1245,6 +1245,22 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php" && originalLine.Contains("@var", StringComparison.OrdinalIgnoreCase))
+            {
+                var docblockContext = originalLine.Trim();
+                if (docblockContext.Length > 0)
+                {
+                    PhpReferenceExtractor.EmitDocblockVarTypeReferences(
+                        originalLine,
+                        references,
+                        seen,
+                        fileId,
+                        docblockContext,
+                        lineNumber,
+                        FindInnermostContainer(containerCandidates, lineNumber));
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(preparedLine))
             {
                 if (language == "csharp"

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1923,6 +1923,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitUseFunctionReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1860,6 +1860,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container);
 
+                PhpReferenceExtractor.EmitInstanceofReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
+
                 PhpReferenceExtractor.EmitObjectMemberAccessReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -31,6 +31,10 @@ public static partial class SymbolExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@property(?:-read|-write)?\s+(?<returnType>[^\s]+)\s+\$(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex PhpTraitAliasRegex = new(
+        @"^\s*(?:[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*::)?[A-Za-z_]\w*\s+as\s+(?:(?:public|protected|private)\s+)?(?<name>(?!public\b|protected\b|private\b)[A-Za-z_]\w*)\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)
     {
         if (string.IsNullOrWhiteSpace(line))
@@ -230,6 +234,36 @@ public static partial class SymbolExtractor
                     EndLine = lineNumber,
                     Signature = line.Trim(),
                     ReturnType = match.Groups["returnType"].Value,
+                },
+                line);
+        }
+    }
+
+    private static void ExtractPhpTraitAliasSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var match = PhpTraitAliasRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var lineNumber = lineIndex + 1;
+            var nameGroup = match.Groups["name"];
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "function",
+                    Name = nameGroup.Value,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    StartColumn = nameGroup.Index,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
                 },
                 line);
         }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -23,6 +23,10 @@ public static partial class SymbolExtractor
         @"^\s*(?:(?<visibility>public|private|protected)\s+)(?:(?:readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex PhpDocblockMethodRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@method\s+(?:static\s+)?(?:(?<returnType>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*(?:<[^>\r\n]+>)?|\$this|self|static)\s+)?(?<name>[A-Za-z_]\w*)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)
     {
         if (string.IsNullOrWhiteSpace(line))
@@ -160,6 +164,39 @@ public static partial class SymbolExtractor
                     },
                     line);
             }
+        }
+    }
+
+    private static void ExtractPhpDocblockMethodSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var match = PhpDocblockMethodRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var lineNumber = lineIndex + 1;
+            var nameGroup = match.Groups["name"];
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "function",
+                    Name = nameGroup.Value,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    StartColumn = nameGroup.Index,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                    ReturnType = match.Groups["returnType"].Success
+                        ? match.Groups["returnType"].Value
+                        : null,
+                },
+                line);
         }
     }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -24,7 +24,7 @@ public static partial class SymbolExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex PhpDocblockMethodRegex = new(
-        @"^\s*(?:/\*\*)?\s*\*?\s*@method\s+(?:static\s+)?(?:(?<returnType>\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*(?:<[^>\r\n]+>)?|\$this|self|static)\s+)?(?<name>[A-Za-z_]\w*)\s*\(",
+        @"^\s*(?:/\*\*)?\s*\*?\s*@method\s+(?:static\s+)?(?:(?<returnType>[^\s()]+)\s+)?(?<name>[A-Za-z_]\w*)\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -318,11 +318,21 @@ public static partial class SymbolExtractor
             if (ch != ',' || parenDepth != 0 || bracketDepth != 0 || braceDepth != 0)
                 continue;
 
-            yield return (text[segmentStart..index].Trim(), segmentStart);
+            yield return TrimPhpCommaSegment(text, segmentStart, index);
             segmentStart = index + 1;
         }
 
-        yield return (text[segmentStart..].Trim(), segmentStart);
+        yield return TrimPhpCommaSegment(text, segmentStart, text.Length);
+    }
+
+    private static (string Text, int StartColumn) TrimPhpCommaSegment(string text, int start, int end)
+    {
+        while (start < end && char.IsWhiteSpace(text[start]))
+            start++;
+        while (end > start && char.IsWhiteSpace(text[end - 1]))
+            end--;
+
+        return (text[start..end], start);
     }
 
 }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -39,6 +39,10 @@ public static partial class SymbolExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?type\s+(?<name>[A-Za-z_]\w*)\s+(?<returnType>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex PhpDocblockImportTypeRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?import-type\s+(?<imported>[A-Za-z_]\w*)\s+from\s+(?<returnType>\S+)(?:\s+as\s+(?<alias>[A-Za-z_]\w*))?",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)
     {
         if (string.IsNullOrWhiteSpace(line))
@@ -284,6 +288,39 @@ public static partial class SymbolExtractor
 
             var lineNumber = lineIndex + 1;
             var nameGroup = match.Groups["name"];
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "type",
+                    Name = nameGroup.Value,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    StartColumn = nameGroup.Index,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                    ReturnType = match.Groups["returnType"].Value,
+                },
+                line);
+        }
+    }
+
+    private static void ExtractPhpDocblockImportTypeSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var match = PhpDocblockImportTypeRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var lineNumber = lineIndex + 1;
+            var nameGroup = match.Groups["alias"].Success
+                ? match.Groups["alias"]
+                : match.Groups["imported"];
             AddSymbolRecord(
                 symbols,
                 cssSeenSymbols: null,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -11,6 +11,14 @@ public static partial class SymbolExtractor
         @"^\s*(?:(?<visibility>public|private|protected|var)\s+)(?:(?:static|readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex PhpSameLineConstructorRegex = new(
+        @"\bfunction\s+__construct\s*\((?<parameters>[^)]*)\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex PhpPromotedPropertyParameterRegex = new(
+        @"(?:(?<visibility>public|private|protected)\s+)(?:(?:readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)
     {
         if (string.IsNullOrWhiteSpace(line))
@@ -221,5 +229,100 @@ public static partial class SymbolExtractor
 
     private static bool IsPhpIdentifierPart(char ch)
         => ch == '_' || char.IsLetterOrDigit(ch);
+
+    private static void ExtractPhpPromotedConstructorProperties(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var constructorMatch = PhpSameLineConstructorRegex.Match(line);
+            if (!constructorMatch.Success)
+                continue;
+
+            var lineNumber = lineIndex + 1;
+            var parameters = constructorMatch.Groups["parameters"];
+            foreach (var parameter in EnumeratePhpTopLevelCommaSegments(parameters.Value))
+            {
+                var match = PhpPromotedPropertyParameterRegex.Match(parameter.Text);
+                if (!match.Success)
+                    continue;
+
+                var name = match.Groups["name"].Value;
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    lineNumber,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "property",
+                        Name = name,
+                        Line = lineNumber,
+                        StartLine = lineNumber,
+                        StartColumn = parameters.Index + parameter.StartColumn + match.Groups["name"].Index,
+                        EndLine = lineNumber,
+                        Signature = line.Trim(),
+                        Visibility = match.Groups["visibility"].Value,
+                        ReturnType = match.Groups["returnType"].Success
+                            ? match.Groups["returnType"].Value
+                            : null,
+                    },
+                    line);
+            }
+        }
+    }
+
+    private static IEnumerable<(string Text, int StartColumn)> EnumeratePhpTopLevelCommaSegments(string text)
+    {
+        var segmentStart = 0;
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        var braceDepth = 0;
+        var quote = '\0';
+
+        for (var index = 0; index < text.Length; index++)
+        {
+            var ch = text[index];
+            if (quote != '\0')
+            {
+                if (ch == '\\' && index + 1 < text.Length)
+                {
+                    index++;
+                    continue;
+                }
+
+                if (ch == quote)
+                    quote = '\0';
+                continue;
+            }
+
+            if (ch is '\'' or '"')
+            {
+                quote = ch;
+                continue;
+            }
+
+            if (ch == '(')
+                parenDepth++;
+            else if (ch == ')' && parenDepth > 0)
+                parenDepth--;
+            else if (ch == '[')
+                bracketDepth++;
+            else if (ch == ']' && bracketDepth > 0)
+                bracketDepth--;
+            else if (ch == '{')
+                braceDepth++;
+            else if (ch == '}' && braceDepth > 0)
+                braceDepth--;
+
+            if (ch != ',' || parenDepth != 0 || bracketDepth != 0 || braceDepth != 0)
+                continue;
+
+            yield return (text[segmentStart..index].Trim(), segmentStart);
+            segmentStart = index + 1;
+        }
+
+        yield return (text[segmentStart..].Trim(), segmentStart);
+    }
 
 }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -35,6 +35,10 @@ public static partial class SymbolExtractor
         @"^\s*(?:[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*::)?[A-Za-z_]\w*\s+as\s+(?:(?:public|protected|private)\s+)?(?<name>(?!public\b|protected\b|private\b)[A-Za-z_]\w*)\s*;",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex PhpDocblockTypeAliasRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?type\s+(?<name>[A-Za-z_]\w*)\s+(?<returnType>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)
     {
         if (string.IsNullOrWhiteSpace(line))
@@ -264,6 +268,37 @@ public static partial class SymbolExtractor
                     StartColumn = nameGroup.Index,
                     EndLine = lineNumber,
                     Signature = line.Trim(),
+                },
+                line);
+        }
+    }
+
+    private static void ExtractPhpDocblockTypeAliasSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var match = PhpDocblockTypeAliasRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var lineNumber = lineIndex + 1;
+            var nameGroup = match.Groups["name"];
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "type",
+                    Name = nameGroup.Value,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    StartColumn = nameGroup.Index,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                    ReturnType = match.Groups["returnType"].Value,
                 },
                 line);
         }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -15,6 +15,10 @@ public static partial class SymbolExtractor
         @"\bfunction\s+__construct\s*\((?<parameters>[^)]*)\)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex PhpConstructorStartRegex = new(
+        @"\bfunction\s+__construct\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex PhpPromotedPropertyParameterRegex = new(
         @"(?:(?<visibility>public|private|protected)\s+)(?:(?:readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -236,40 +240,81 @@ public static partial class SymbolExtractor
         {
             var line = lines[lineIndex];
             var constructorMatch = PhpSameLineConstructorRegex.Match(line);
-            if (!constructorMatch.Success)
+            var constructorStart = PhpConstructorStartRegex.IsMatch(line);
+            if (!constructorMatch.Success && !constructorStart)
                 continue;
 
-            var lineNumber = lineIndex + 1;
-            var parameters = constructorMatch.Groups["parameters"];
-            foreach (var parameter in EnumeratePhpTopLevelCommaSegments(parameters.Value))
+            if (constructorMatch.Success)
             {
-                var match = PhpPromotedPropertyParameterRegex.Match(parameter.Text);
-                if (!match.Success)
-                    continue;
+                var lineNumber = lineIndex + 1;
+                var parameters = constructorMatch.Groups["parameters"];
+                foreach (var parameter in EnumeratePhpTopLevelCommaSegments(parameters.Value))
+                {
+                    AddPhpPromotedPropertySymbol(
+                        fileId,
+                        symbols,
+                        line,
+                        lineNumber,
+                        parameters.Index + parameter.StartColumn,
+                        parameter.Text);
+                }
+            }
 
-                var name = match.Groups["name"].Value;
-                AddSymbolRecord(
+            if (constructorMatch.Success || !constructorStart)
+                continue;
+
+            for (var parameterLineIndex = lineIndex + 1;
+                 parameterLineIndex < lines.Length && parameterLineIndex <= lineIndex + 64;
+                 parameterLineIndex++)
+            {
+                var parameterLine = lines[parameterLineIndex];
+                AddPhpPromotedPropertySymbol(
+                    fileId,
                     symbols,
-                    cssSeenSymbols: null,
-                    lineNumber,
-                    new SymbolRecord
-                    {
-                        FileId = fileId,
-                        Kind = "property",
-                        Name = name,
-                        Line = lineNumber,
-                        StartLine = lineNumber,
-                        StartColumn = parameters.Index + parameter.StartColumn + match.Groups["name"].Index,
-                        EndLine = lineNumber,
-                        Signature = line.Trim(),
-                        Visibility = match.Groups["visibility"].Value,
-                        ReturnType = match.Groups["returnType"].Success
-                            ? match.Groups["returnType"].Value
-                            : null,
-                    },
-                    line);
+                    parameterLine,
+                    parameterLineIndex + 1,
+                    0,
+                    parameterLine);
+
+                if (parameterLine.Contains(')'))
+                    break;
             }
         }
+    }
+
+    private static void AddPhpPromotedPropertySymbol(
+        long fileId,
+        List<SymbolRecord> symbols,
+        string line,
+        int lineNumber,
+        int baseColumn,
+        string parameterText)
+    {
+        var match = PhpPromotedPropertyParameterRegex.Match(parameterText);
+        if (!match.Success)
+            return;
+
+        var name = match.Groups["name"].Value;
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineNumber,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "property",
+                Name = name,
+                Line = lineNumber,
+                StartLine = lineNumber,
+                StartColumn = baseColumn + match.Groups["name"].Index,
+                EndLine = lineNumber,
+                Signature = line.Trim(),
+                Visibility = match.Groups["visibility"].Value,
+                ReturnType = match.Groups["returnType"].Success
+                    ? match.Groups["returnType"].Value
+                    : null,
+            },
+            line);
     }
 
     private static IEnumerable<(string Text, int StartColumn)> EnumeratePhpTopLevelCommaSegments(string text)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -20,7 +20,7 @@ public static partial class SymbolExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex PhpPromotedPropertyParameterRegex = new(
-        @"(?:(?<visibility>public|private|protected)\s+)(?:(?:readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b",
+        @"^\s*(?:(?<visibility>public|private|protected)\s+)(?:(?:readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -27,6 +27,10 @@ public static partial class SymbolExtractor
         @"^\s*(?:/\*\*)?\s*\*?\s*@method\s+(?:static\s+)?(?:(?<returnType>[^\s()]+)\s+)?(?<name>[A-Za-z_]\w*)\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex PhpDocblockPropertyRegex = new(
+        @"^\s*(?:/\*\*)?\s*\*?\s*@property(?:-read|-write)?\s+(?<returnType>[^\s]+)\s+\$(?<name>[A-Za-z_]\w*)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)
     {
         if (string.IsNullOrWhiteSpace(line))
@@ -195,6 +199,37 @@ public static partial class SymbolExtractor
                     ReturnType = match.Groups["returnType"].Success
                         ? match.Groups["returnType"].Value
                         : null,
+                },
+                line);
+        }
+    }
+
+    private static void ExtractPhpDocblockPropertySymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var match = PhpDocblockPropertyRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var lineNumber = lineIndex + 1;
+            var nameGroup = match.Groups["name"];
+            AddSymbolRecord(
+                symbols,
+                cssSeenSymbols: null,
+                lineNumber,
+                new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = nameGroup.Value,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    StartColumn = nameGroup.Index,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                    ReturnType = match.Groups["returnType"].Value,
                 },
                 line);
         }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -28,7 +28,7 @@ public static partial class SymbolExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex PhpDocblockPropertyRegex = new(
-        @"^\s*(?:/\*\*)?\s*\*?\s*@property(?:-read|-write)?\s+(?<returnType>[^\s]+)\s+\$(?<name>[A-Za-z_]\w*)\b",
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?property(?:-read|-write)?\s+(?<returnType>[^\s]+)\s+\$(?<name>[A-Za-z_]\w*)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex PhpTraitAliasRegex = new(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -7,6 +7,10 @@ namespace CodeIndex.Indexer;
 
 public static partial class SymbolExtractor
 {
+    private static readonly Regex PhpPropertyDeclarationHeadRegex = new(
+        @"^\s*(?:(?<visibility>public|private|protected|var)\s+)(?:(?:static|readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static void ExtractPhpImportSymbols(List<SymbolRecord> symbols, string line, int lineNumber)
     {
         if (string.IsNullOrWhiteSpace(line))
@@ -109,5 +113,113 @@ public static partial class SymbolExtractor
                 Signature = line.Trim()
             });
     }
+
+    private static void ExtractPhpAdditionalPropertySymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var match = PhpPropertyDeclarationHeadRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var lineNumber = lineIndex + 1;
+            var firstNameEnd = match.Groups["name"].Index + match.Groups["name"].Length;
+            foreach (var candidate in EnumeratePhpAdditionalPropertyNames(line, firstNameEnd))
+            {
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols: null,
+                    lineNumber,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "property",
+                        Name = candidate.Name,
+                        Line = lineNumber,
+                        StartLine = lineNumber,
+                        StartColumn = candidate.Column,
+                        EndLine = lineNumber,
+                        Signature = line.Trim(),
+                        Visibility = match.Groups["visibility"].Value,
+                        ReturnType = match.Groups["returnType"].Success
+                            ? match.Groups["returnType"].Value
+                            : null,
+                    },
+                    line);
+            }
+        }
+    }
+
+    private static IEnumerable<(string Name, int Column)> EnumeratePhpAdditionalPropertyNames(string line, int startColumn)
+    {
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        var braceDepth = 0;
+        var quote = '\0';
+
+        for (var index = Math.Max(0, startColumn); index < line.Length; index++)
+        {
+            var ch = line[index];
+            if (quote != '\0')
+            {
+                if (ch == '\\' && index + 1 < line.Length)
+                {
+                    index++;
+                    continue;
+                }
+
+                if (ch == quote)
+                    quote = '\0';
+                continue;
+            }
+
+            if (ch is '\'' or '"')
+            {
+                quote = ch;
+                continue;
+            }
+
+            if (ch == '/' && index + 1 < line.Length && line[index + 1] == '/')
+                yield break;
+            if (ch == '#')
+                yield break;
+            if (ch == ';' && parenDepth == 0 && bracketDepth == 0 && braceDepth == 0)
+                yield break;
+
+            if (ch == '(')
+                parenDepth++;
+            else if (ch == ')' && parenDepth > 0)
+                parenDepth--;
+            else if (ch == '[')
+                bracketDepth++;
+            else if (ch == ']' && bracketDepth > 0)
+                bracketDepth--;
+            else if (ch == '{')
+                braceDepth++;
+            else if (ch == '}' && braceDepth > 0)
+                braceDepth--;
+
+            if (ch != ',' || parenDepth != 0 || bracketDepth != 0 || braceDepth != 0)
+                continue;
+
+            var nameStart = index + 1;
+            while (nameStart < line.Length && char.IsWhiteSpace(line[nameStart]))
+                nameStart++;
+            if (nameStart >= line.Length || line[nameStart] != '$')
+                continue;
+
+            var nameColumn = nameStart + 1;
+            var nameEnd = nameColumn;
+            while (nameEnd < line.Length && IsPhpIdentifierPart(line[nameEnd]))
+                nameEnd++;
+
+            if (nameEnd > nameColumn)
+                yield return (line[nameColumn..nameEnd], nameColumn);
+        }
+    }
+
+    private static bool IsPhpIdentifierPart(char ch)
+        => ch == '_' || char.IsLetterOrDigit(ch);
 
 }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1454,6 +1454,9 @@ public static partial class SymbolExtractor
         ],
         ["php"] =
         [
+            // Variable-bound closures / 変数に束縛されたクロージャ
+            new("function", new Regex(@"^\s*\$(?<name>\w+)\s*=\s*(?:static\s+)?function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
+            new("function", new Regex(@"^\s*\$(?<name>\w+)\s*=\s*(?:static\s+)?fn\s*\(", RegexOptions.Compiled), BodyStyle.None),
             // Const declaration / 定数宣言
             new("function", new Regex(@"^\s*(?:(?<visibility>public|private|protected)\s+)?const\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Class property declarations / クラスプロパティ宣言

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3727,6 +3727,8 @@ public static partial class SymbolExtractor
             ExtractPhpDocblockMethodSymbols(fileId, lines, symbols);
         if (lang == "php")
             ExtractPhpDocblockPropertySymbols(fileId, lines, symbols);
+        if (lang == "php")
+            ExtractPhpTraitAliasSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         if (lang == "go")
             AssignGoMethodReceiverContainers(symbols);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3714,6 +3714,8 @@ public static partial class SymbolExtractor
             ExtractPythonClassAttributeSymbols(fileId, lines, symbols);
         if (lang == "perl")
             ExtractPerlHashConstantSymbols(fileId, lines, symbols);
+        if (lang == "php")
+            ExtractPhpAdditionalPropertySymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         if (lang == "go")
             AssignGoMethodReceiverContainers(symbols);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3725,6 +3725,8 @@ public static partial class SymbolExtractor
             ExtractPhpPromotedConstructorProperties(fileId, lines, symbols);
         if (lang == "php")
             ExtractPhpDocblockMethodSymbols(fileId, lines, symbols);
+        if (lang == "php")
+            ExtractPhpDocblockPropertySymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         if (lang == "go")
             AssignGoMethodReceiverContainers(symbols);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1459,6 +1459,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*\$(?<name>\w+)\s*=\s*(?:static\s+)?fn\s*\(", RegexOptions.Compiled), BodyStyle.None),
             // Const declaration / 定数宣言
             new("function", new Regex(@"^\s*define\s*\(\s*['""](?<name>[A-Za-z_]\w*)['""]\s*,", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:(?<visibility>public|private|protected)\s+)?const\s+(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),
             new("function", new Regex(@"^\s*(?:(?<visibility>public|private|protected)\s+)?const\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Class property declarations / クラスプロパティ宣言
             new("property", new Regex(@"^\s*(?:(?<visibility>public|private|protected|var)\s+)(?:(?:static|readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3729,6 +3729,8 @@ public static partial class SymbolExtractor
             ExtractPhpDocblockPropertySymbols(fileId, lines, symbols);
         if (lang == "php")
             ExtractPhpTraitAliasSymbols(fileId, lines, symbols);
+        if (lang == "php")
+            ExtractPhpDocblockTypeAliasSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         if (lang == "go")
             AssignGoMethodReceiverContainers(symbols);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1456,6 +1456,8 @@ public static partial class SymbolExtractor
         [
             // Const declaration / 定数宣言
             new("function", new Regex(@"^\s*(?:(?<visibility>public|private|protected)\s+)?const\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
+            // Class property declarations / クラスプロパティ宣言
+            new("property", new Regex(@"^\s*(?:(?<visibility>public|private|protected|var)\s+)(?:(?:static|readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),
             new("function", new Regex(@"^\s*(?:(?<visibility>public|private|protected)\s+)?(?:(?:static|abstract|final)\s+)*function\s+(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Class with expanded modifiers: abstract, final, readonly (PHP 8.2+)
             // 拡張修飾子対応: abstract, final, readonly (PHP 8.2+)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3731,6 +3731,8 @@ public static partial class SymbolExtractor
             ExtractPhpTraitAliasSymbols(fileId, lines, symbols);
         if (lang == "php")
             ExtractPhpDocblockTypeAliasSymbols(fileId, lines, symbols);
+        if (lang == "php")
+            ExtractPhpDocblockImportTypeSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         if (lang == "go")
             AssignGoMethodReceiverContainers(symbols);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1458,6 +1458,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*\$(?<name>\w+)\s*=\s*(?:static\s+)?function\s*\(", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*\$(?<name>\w+)\s*=\s*(?:static\s+)?fn\s*\(", RegexOptions.Compiled), BodyStyle.None),
             // Const declaration / 定数宣言
+            new("function", new Regex(@"^\s*define\s*\(\s*['""](?<name>[A-Za-z_]\w*)['""]\s*,", RegexOptions.Compiled | RegexOptions.IgnoreCase), BodyStyle.None),
             new("function", new Regex(@"^\s*(?:(?<visibility>public|private|protected)\s+)?const\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Class property declarations / クラスプロパティ宣言
             new("property", new Regex(@"^\s*(?:(?<visibility>public|private|protected|var)\s+)(?:(?:static|readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3716,6 +3716,8 @@ public static partial class SymbolExtractor
             ExtractPerlHashConstantSymbols(fileId, lines, symbols);
         if (lang == "php")
             ExtractPhpAdditionalPropertySymbols(fileId, lines, symbols);
+        if (lang == "php")
+            ExtractPhpPromotedConstructorProperties(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         if (lang == "go")
             AssignGoMethodReceiverContainers(symbols);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1469,7 +1469,7 @@ public static partial class SymbolExtractor
             new("class",    new Regex(@"^\s*(?:(?:abstract|final|readonly)\s+)*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(@"^\s*interface\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("trait", new Regex(@"^\s*trait\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
-            new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
+            new("enum",     new Regex(@"^\s*enum\s+(?<name>\w+)(?:\s*:\s*(?<returnType>[A-Za-z_\\][\w\\]*))?", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
             new("property", new Regex(@"^\s*case\s+(?<name>\w+)(?:\s*=\s*(?<returnType>[^;]+?))?\s*;", RegexOptions.Compiled), BodyStyle.None, ReturnTypeGroup: "returnType"),
             // Namespace / 名前空間
             new("namespace", new Regex(@"^\s*namespace\s+(?<name>[\w\\]+)", RegexOptions.Compiled), BodyStyle.Brace),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1458,7 +1458,7 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?:(?<visibility>public|private|protected)\s+)?const\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None, "visibility"),
             // Class property declarations / クラスプロパティ宣言
             new("property", new Regex(@"^\s*(?:(?<visibility>public|private|protected|var)\s+)(?:(?:static|readonly)\s+)*(?:(?<returnType>\??[A-Za-z_\\][\w\\]*(?:\s*[|&]\s*\??[A-Za-z_\\][\w\\]*)*)\s+)?\$(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None, "visibility", ReturnTypeGroup: "returnType"),
-            new("function", new Regex(@"^\s*(?:(?<visibility>public|private|protected)\s+)?(?:(?:static|abstract|final)\s+)*function\s+(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("function", new Regex(@"^\s*(?:(?:(?<visibility>public|private|protected)|static|abstract|final)\s+)*function\s+(?<name>\w+)\s*\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Class with expanded modifiers: abstract, final, readonly (PHP 8.2+)
             // 拡張修飾子対応: abstract, final, readonly (PHP 8.2+)
             new("class",    new Regex(@"^\s*(?:(?:abstract|final|readonly)\s+)*class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3723,6 +3723,8 @@ public static partial class SymbolExtractor
             ExtractPhpAdditionalPropertySymbols(fileId, lines, symbols);
         if (lang == "php")
             ExtractPhpPromotedConstructorProperties(fileId, lines, symbols);
+        if (lang == "php")
+            ExtractPhpDocblockMethodSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
         if (lang == "go")
             AssignGoMethodReceiverContainers(symbols);

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9986,6 +9986,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockPropertyTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @property-read \App\Models\User $owner
+             * @property Collection<Invoice> $invoices
+             */
+            final class Account {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Models\\User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Collection" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Invoice" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9752,6 +9752,9 @@ public class ReferenceExtractorTests
             use const App\Service\USER_ROLE;
             class Consumer {
                 use Auditable, SoftDeletes;
+                use Timestampable, Blameable {
+                    Timestampable::touch insteadof Blameable;
+                }
             }
             ?>
             """;
@@ -9763,6 +9766,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "UserService" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Auditable" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "SoftDeletes" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Timestampable" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Blameable" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "make_user" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "USER_ROLE" && reference.ReferenceKind == "type_reference");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9509,6 +9509,7 @@ public class ReferenceExtractorTests
             function inspect(): void {
                 Config::rebuild();
                 Config::VERSION;
+                Config::$cache;
                 \App\Models\Config::class;
                 \App\Models\Config::rebuild();
                 Priority::Low;
@@ -9523,6 +9524,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.Column == 6);
         Assert.Contains(references, reference => reference.SymbolName == "Priority" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "VERSION" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "cache" && reference.ReferenceKind == "reference");
         Assert.Contains(references, reference => reference.SymbolName == "Low" && reference.ReferenceKind == "reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "rebuild" && reference.ReferenceKind == "reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "class" && reference.ReferenceKind == "reference");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10009,6 +10009,7 @@ public class ReferenceExtractorTests
             /**
              * @property-read \App\Models\User $owner
              * @property Collection<Invoice> $invoices
+             * @psalm-property-write Money $balance
              */
             final class Account {}
             ?>
@@ -10021,6 +10022,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Collection" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Invoice" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Money" && reference.ReferenceKind == "type_reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9522,6 +9522,10 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "Config" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.Column == 6);
         Assert.Contains(references, reference => reference.SymbolName == "Priority" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "VERSION" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Low" && reference.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "rebuild" && reference.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "class" && reference.ReferenceKind == "reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "self" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "static" && reference.ReferenceKind == "type_reference");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9906,6 +9906,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockThrowsTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @throws \App\Exceptions\DomainException|RuntimeFailure
+             */
+            function execute(): void {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Exceptions\\DomainException" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "DomainException" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "RuntimeFailure" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9816,7 +9816,30 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "trim_name" && reference.ReferenceKind == "reference");
         Assert.Contains(references, reference => reference.SymbolName == "App\\Mixed\\make_profile" && reference.ReferenceKind == "reference");
         Assert.Contains(references, reference => reference.SymbolName == "make_profile" && reference.ReferenceKind == "reference");
-        Assert.DoesNotContain(references, reference => reference.SymbolName == "DEFAULT_PROFILE" && reference.ReferenceKind == "reference");
+    }
+
+    [Fact]
+    public void Extract_PhpUseConstImports_EmitReferences()
+    {
+        const string content = """
+            <?php
+            use const App\Config\DEFAULT_ROLE as ROLE;
+            use const App\Config\{APP_NAME, TIMEOUT as TIMEOUT_LIMIT};
+            use App\Mixed\{User, function make_profile, const DEFAULT_PROFILE};
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Config\\DEFAULT_ROLE" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "DEFAULT_ROLE" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Config\\APP_NAME" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "APP_NAME" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Config\\TIMEOUT" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "TIMEOUT" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Mixed\\DEFAULT_PROFILE" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "DEFAULT_PROFILE" && reference.ReferenceKind == "reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9926,6 +9926,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockExtendsTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @phpstan-extends \App\Repository\BaseRepository<UserModel>
+             */
+            final class UserRepository extends BaseRepository {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Repository\\BaseRepository" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "BaseRepository" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "UserModel" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9679,6 +9679,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpParameterTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            function handle(Request $request, ?User $user, string $name): Response {
+                return new Response();
+            }
+            function complex(Request|User $actor, Logger&Aware $logger): void {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "Request" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Logger" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Aware" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "?User" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "string" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9946,6 +9946,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockImplementsTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @psalm-implements \App\Contracts\Handler<InputMessage>
+             */
+            final class MessageHandler implements Handler {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Contracts\\Handler" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Handler" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "InputMessage" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9768,6 +9768,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpGroupUseTypeImports_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            use App\Domain\{User, Team\Member as TeamMember};
+            use function App\Domain\{make_user};
+            use const App\Domain\{USER_ROLE};
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Domain\\User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Domain\\Team\\Member" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Member" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "make_user" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "USER_ROLE" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10030,6 +10030,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockMethodParameterTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @method Result process(InputMessage|array $message, ?Context $context)
+             */
+            final class Processor {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "InputMessage" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Context" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "array" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "message" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9882,6 +9882,7 @@ public class ReferenceExtractorTests
             <?php
             /**
              * @return \App\Http\Response|JsonPayload|null
+             * @psalm-return \App\Http\StreamedResponse
              */
             function respond() {}
             ?>
@@ -9893,6 +9894,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "App\\Http\\Response" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Response" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "JsonPayload" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Http\\StreamedResponse" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "StreamedResponse" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "null" && reference.ReferenceKind == "type_reference");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9887,6 +9887,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockVarTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /** @var \App\Cache\Store<CacheItem>|null $store */
+            $store = resolve_store();
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Cache\\Store" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Store" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "CacheItem" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "null" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10056,6 +10056,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockTemplateBounds_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @template-covariant T of \App\Contracts\Entity
+             * @template U as BaseModel
+             */
+            final class Repository {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Contracts\\Entity" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Entity" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "BaseModel" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9743,6 +9743,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpUseTypeImports_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            use App\Service\UserService as Service;
+            use function App\Service\make_user;
+            use const App\Service\USER_ROLE;
+            class Consumer {
+                use Auditable, SoftDeletes;
+            }
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Service\\UserService" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "UserService" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Auditable" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "SoftDeletes" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "make_user" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "USER_ROLE" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10008,6 +10008,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockMethodReturnTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @method static Builder<UserModel>|null whereEmail(string $email)
+             * @method refresh()
+             */
+            final class UserQuery {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "Builder" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "UserModel" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "null" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "refresh" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9724,6 +9724,25 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpInheritanceTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            class UserController extends \App\Http\BaseController implements Responsable, Middleware {}
+            interface JsonResponsable extends Responsable {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Http\\BaseController" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "BaseController" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Responsable" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Middleware" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9773,6 +9773,7 @@ public class ReferenceExtractorTests
         const string content = """
             <?php
             use App\Domain\{User, Team\Member as TeamMember};
+            use App\Mixed\{Profile, function make_profile, const DEFAULT_PROFILE};
             use function App\Domain\{make_user};
             use const App\Domain\{USER_ROLE};
             ?>
@@ -9785,6 +9786,10 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "App\\Domain\\Team\\Member" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Member" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Mixed\\Profile" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Profile" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "make_profile" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "DEFAULT_PROFILE" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "make_user" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "USER_ROLE" && reference.ReferenceKind == "type_reference");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9843,6 +9843,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockParamTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @param \App\Models\User|Guest|null $actor
+             * @param Collection<User>[] $users
+             */
+            function handle($actor, $users): void {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Models\\User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Guest" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Collection" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "null" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9631,6 +9631,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpCatchUnionTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            try {
+                risky();
+            } catch (\App\Exception\FirstException|SecondException $exception) {
+                recover($exception);
+            }
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Exception\\FirstException" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "FirstException" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "SecondException" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "catch" && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9653,6 +9653,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpReturnTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            function handle(): Response|JsonResponse {
+                return new JsonResponse();
+            }
+            function maybe(): ?Response {
+                return null;
+            }
+            function scalar(): string {
+                return 'ok';
+            }
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "Response" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "JsonResponse" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "?Response" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "string" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9795,6 +9795,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpUseFunctionImports_EmitReferences()
+    {
+        const string content = """
+            <?php
+            use function App\Text\slugify as slug;
+            use function App\Text\{title_case, trim_name as trimName};
+            use App\Mixed\{User, function make_profile, const DEFAULT_PROFILE};
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Text\\slugify" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "slugify" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Text\\title_case" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "title_case" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Text\\trim_name" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "trim_name" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Mixed\\make_profile" && reference.ReferenceKind == "reference");
+        Assert.Contains(references, reference => reference.SymbolName == "make_profile" && reference.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "DEFAULT_PROFILE" && reference.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9855,6 +9855,8 @@ public class ReferenceExtractorTests
             /**
              * @param \App\Models\User|Guest|null $actor
              * @param Collection<User>[] $users
+             * @phpstan-param \App\DTO\UserInput $input
+             * @param-out HydratedUser $actor
              */
             function handle($actor, $users): void {}
             ?>
@@ -9867,6 +9869,9 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Guest" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Collection" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\DTO\\UserInput" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "UserInput" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "HydratedUser" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "null" && reference.ReferenceKind == "type_reference");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9905,6 +9905,7 @@ public class ReferenceExtractorTests
         const string content = """
             <?php
             /** @var \App\Cache\Store<CacheItem>|null $store */
+            /** @phpstan-var \App\Cache\TaggedStore $tagged */
             $store = resolve_store();
             ?>
             """;
@@ -9915,6 +9916,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "App\\Cache\\Store" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Store" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "CacheItem" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Cache\\TaggedStore" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "TaggedStore" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "null" && reference.ReferenceKind == "type_reference");
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10077,6 +10077,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockTypeAliasTargets_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @phpstan-type UserShape array{owner:\App\Models\User,invoice:Invoice}
+             */
+            final class Shapes {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Models\\User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Invoice" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "array" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9966,6 +9966,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockMixinTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @mixin \App\Eloquent\Builder<UserModel>
+             */
+            final class User {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Eloquent\\Builder" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Builder" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "UserModel" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9866,6 +9866,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockReturnTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            /**
+             * @return \App\Http\Response|JsonPayload|null
+             */
+            function respond() {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Http\\Response" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Response" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "JsonPayload" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "null" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9702,6 +9702,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpPropertyTypes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            class Profile {
+                private User|Guest $owner;
+                protected static ?Logger $logger;
+                public string $name;
+            }
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Guest" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "Logger" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "string" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9584,6 +9584,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpAttributes_EmitTypeReferences()
+    {
+        const string content = """
+            <?php
+            #[Route('/users', methods: ['GET'])]
+            #[\App\Http\Middleware\RequiresAuth]
+            class UserController {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "Route" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "RequiresAuth" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Http\\Middleware\\RequiresAuth" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "methods" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -9610,6 +9610,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpInstanceof_EmitsTypeReferences()
+    {
+        const string content = """
+            <?php
+            function accepts($value): bool {
+                return $value instanceof \App\Domain\UserService
+                    || $value instanceof LocalHandler;
+            }
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Domain\\UserService" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "UserService" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "LocalHandler" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "instanceof" && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_UnsupportedLanguage_ReturnsEmpty()
     {
         const string content = "hello = world";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10096,6 +10096,7 @@ public class ReferenceExtractorTests
             <?php
             /**
              * @phpstan-type UserShape array{owner:\App\Models\User,invoice:Invoice}
+             * @phpstan-import-type RemoteShape from \App\Types\RemoteSource
              */
             final class Shapes {}
             ?>
@@ -10107,6 +10108,8 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference => reference.SymbolName == "App\\Models\\User" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "User" && reference.ReferenceKind == "type_reference");
         Assert.Contains(references, reference => reference.SymbolName == "Invoice" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "App\\Types\\RemoteSource" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "RemoteSource" && reference.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, reference => reference.SymbolName == "array" && reference.ReferenceKind == "type_reference");
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12552,6 +12552,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsDefineConstants()
+    {
+        var content = """
+            <?php
+            define('APP_ENV', 'testing');
+            define("FEATURE_FLAG", true);
+            DEFINE('UPPER_DEFINE', true);
+            define($dynamic, true);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "APP_ENV");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "FEATURE_FLAG");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "UPPER_DEFINE");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "dynamic");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12495,6 +12495,8 @@ public class SymbolExtractorTests
             <?php
             class User {
                 public function __construct(
+                    // public string $commented,
+                    /* private string $blockCommented, */
                     public string $id,
                     private readonly ?Profile $profile,
                     string $local = 'x,y',
@@ -12507,6 +12509,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "id" && s.ReturnType == "string");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "profile" && s.ReturnType == "?Profile");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "commented");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "blockCommented");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12582,6 +12582,7 @@ public class SymbolExtractorTests
              * @property \App\Models\User $owner
              * @property-read Collection<User> $items
              * @property-write ?string $status
+             * @phpstan-property-read Money $balance
              */
             class UserPresenter {}
             """;
@@ -12591,6 +12592,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "owner" && s.ReturnType == "\\App\\Models\\User");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "items" && s.ReturnType == "Collection<User>");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "status" && s.ReturnType == "?string");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "balance" && s.ReturnType == "Money");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12571,6 +12571,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsTypedClassConstants()
+    {
+        var content = """
+            <?php
+            class Config {
+                public const string VERSION = '1.0';
+                protected const int|float LIMIT = 10;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "VERSION" && s.ReturnType == "string" && s.Visibility == "public");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "LIMIT" && s.ReturnType == "int|float" && s.Visibility == "protected");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "string");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12467,6 +12467,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsSameLinePromotedConstructorProperties()
+    {
+        var content = """
+            <?php
+            class User {
+                public function __construct(public string $id, private readonly ?Profile $profile, string $local = 'x,y') {}
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "id" && s.ReturnType == "string");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "profile" && s.ReturnType == "?Profile");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12613,6 +12613,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsDocblockTypeAliases()
+    {
+        var content = """
+            <?php
+            /**
+             * @phpstan-type UserShape array{id:int,name:string}
+             * @psalm-type EmailAddress non-empty-string
+             */
+            class UserTypes {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "type" && s.Name == "UserShape" && s.ReturnType == "array{id:int,name:string}");
+        Assert.Contains(symbols, s => s.Kind == "type" && s.Name == "EmailAddress" && s.ReturnType == "non-empty-string");
+    }
+
+    [Fact]
     public void Extract_PHP_DetectsDefineConstants()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12514,6 +12514,23 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsMethodsWithModifiersBeforeVisibility()
+    {
+        var content = """
+            <?php
+            abstract class BaseService {
+                abstract protected function normalize();
+                final public static function make(): self {}
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "normalize" && s.Visibility == "protected");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "make" && s.Visibility == "public");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12531,6 +12531,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsVariableBoundClosures()
+    {
+        var content = """
+            <?php
+            $handler = function (Request $request) {
+                return $request;
+            };
+            $mapper = fn (User $user) => $user->id;
+            $staticFactory = static function () {
+                return new User();
+            };
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "handler");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "mapper");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "staticFactory");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12622,6 +12622,8 @@ public class SymbolExtractorTests
             /**
              * @phpstan-type UserShape array{id:int,name:string}
              * @psalm-type EmailAddress non-empty-string
+             * @phpstan-import-type RemoteShape from \App\Types\RemoteSource as LocalShape
+             * @psalm-import-type ExternalShape from \App\Types\ExternalSource
              */
             class UserTypes {}
             """;
@@ -12630,6 +12632,8 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "type" && s.Name == "UserShape" && s.ReturnType == "array{id:int,name:string}");
         Assert.Contains(symbols, s => s.Kind == "type" && s.Name == "EmailAddress" && s.ReturnType == "non-empty-string");
+        Assert.Contains(symbols, s => s.Kind == "type" && s.Name == "LocalShape" && s.ReturnType == "\\App\\Types\\RemoteSource");
+        Assert.Contains(symbols, s => s.Kind == "type" && s.Name == "ExternalShape" && s.ReturnType == "\\App\\Types\\ExternalSource");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12481,6 +12481,11 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "id" && s.ReturnType == "string");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "profile" && s.ReturnType == "?Profile");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local");
+
+        var profile = Assert.Single(symbols, s => s.Kind == "property" && s.Name == "profile");
+        var profileLine = content.Split('\n')[profile.Line - 1];
+        Assert.NotNull(profile.StartColumn);
+        Assert.Equal('p', profileLine[profile.StartColumn.Value]);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12552,6 +12552,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsDocblockMethods()
+    {
+        var content = """
+            <?php
+            /**
+             * @method static Builder<User> whereEmail(string $email)
+             * @method refresh()
+             */
+            class UserQuery {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "whereEmail" && s.ReturnType == "Builder<User>");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "refresh" && s.ReturnType == null);
+    }
+
+    [Fact]
     public void Extract_PHP_DetectsDefineConstants()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12445,6 +12445,28 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsAdditionalSameLineClassProperties()
+    {
+        var content = """
+            <?php
+            class User {
+                public string $firstName, $lastName;
+                protected $flags = ['a', 'b'], $state;
+                private $literal = ", $notAProperty", $real;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "firstName" && s.ReturnType == "string" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "lastName" && s.ReturnType == "string" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "flags" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "state" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "real" && s.ContainerName == "User");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "notAProperty");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12371,9 +12371,9 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Config");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "VERSION");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "getName");
-        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Status");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Status" && s.ReturnType == "string");
         Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "OrderStatus");
-        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Priority");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Priority" && s.ReturnType == "int");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Active" && s.ContainerName == "Status" && s.ReturnType == "'active'");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Pending" && s.ContainerName == "Status" && s.ReturnType == "'pending'");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Draft" && s.ContainerName == "OrderStatus" && s.ReturnType == null);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12489,6 +12489,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsMultilinePromotedConstructorProperties()
+    {
+        var content = """
+            <?php
+            class User {
+                public function __construct(
+                    public string $id,
+                    private readonly ?Profile $profile,
+                    string $local = 'x,y',
+                ) {}
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "id" && s.ReturnType == "string");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "profile" && s.ReturnType == "?Profile");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12421,6 +12421,30 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsClassProperties()
+    {
+        var content = """
+            <?php
+            class User {
+                public string $name;
+                protected static ?Profile $profile = null;
+                var $legacy;
+
+                public function rename(string $name): void {
+                    $local = $name;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "name" && s.ReturnType == "string" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "profile" && s.ReturnType == "?Profile" && s.ContainerName == "User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "legacy" && s.ContainerName == "User");
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "local");
+    }
+
+    [Fact]
     public void Extract_Swift_DetectsActorAndTypealias()
     {
         var content = "public actor NetworkManager {\n    func fetch() { }\n}\n\npublic typealias Handler = (Data) -> Void\n\ntypealias UserID = Int\npublic typealias Callback = (Int) -> Int\n\ndistributed actor RemoteWorker { }";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12558,6 +12558,8 @@ public class SymbolExtractorTests
             <?php
             /**
              * @method static Builder<User> whereEmail(string $email)
+             * @method ?User findByEmail(string $email)
+             * @method User|Guest resolveActor(int $id)
              * @method refresh()
              */
             class UserQuery {}
@@ -12566,6 +12568,8 @@ public class SymbolExtractorTests
         var symbols = SymbolExtractor.Extract(1, "php", content);
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "whereEmail" && s.ReturnType == "Builder<User>");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "findByEmail" && s.ReturnType == "?User");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "resolveActor" && s.ReturnType == "User|Guest");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "refresh" && s.ReturnType == null);
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12574,6 +12574,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsDocblockProperties()
+    {
+        var content = """
+            <?php
+            /**
+             * @property \App\Models\User $owner
+             * @property-read Collection<User> $items
+             * @property-write ?string $status
+             */
+            class UserPresenter {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "owner" && s.ReturnType == "\\App\\Models\\User");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "items" && s.ReturnType == "Collection<User>");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "status" && s.ReturnType == "?string");
+    }
+
+    [Fact]
     public void Extract_PHP_DetectsDefineConstants()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12594,6 +12594,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DetectsTraitAliasMethods()
+    {
+        var content = """
+            <?php
+            class User {
+                use Timestampable {
+                    Timestampable::touch as touchTimestamp;
+                    touch as private;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "touchTimestamp");
+        Assert.DoesNotContain(symbols, s => s.Kind == "function" && s.Name == "private");
+    }
+
+    [Fact]
     public void Extract_PHP_DetectsDefineConstants()
     {
         var content = """


### PR DESCRIPTION
## Summary

Expand PHP and PHPDoc indexing across symbols and references so search/callers/impact light up PHP-specific constructs that were previously invisible.

- **PHP symbols**: property symbol extraction (multi-name lists, same-line lists, promoted constructor properties incl. multiline, modifier-order tolerance), variable-bound closures, define() constants, typed class constants, backed enum types, and trait alias method symbols.
- **PHP references**: instanceof / catch / return / parameter / property / inheritance / attribute type references; use (type, function, const), group use (incl. mixed groups), static property and member references, and trait adaptation use references.
- **PHPDoc symbols**: method symbols (incl. composite return shapes), property symbols (incl. tag variants), type alias symbols, and import type symbols.
- **PHPDoc references**: @param / @return / @var / @throws / @extends / @implements / @mixin / @property / @method (return + parameter) type references, template bounds, type alias targets, import type sources, and tag variant references.

## Validation

- dotnet test (SymbolExtractor / ReferenceExtractor suites updated with PHP and PHPDoc coverage)

## Documentation / Changelog

Added 48 changelog fragments under changelog.d/unreleased/ covering each indexed PHP and PHPDoc construct (+php-*.fixed.md and +phpdoc-*.fixed.md).

## Follow-ups

- None identified; further PHP construct coverage can be added incrementally as needs surface.

Generated with Claude Code
