### PR TITLE
Increase MCP stdio buffer to 64 KB

### DIFF
--- a/changelog.d/unreleased/1496.internal.md
+++ b/changelog.d/unreleased/1496.internal.md
@@ -1,0 +1,15 @@
+---
+category: internal
+issues:
+  - 1496
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+---
+
+## English
+
+- **MCP stdio loop uses a 64 KB buffer (#1496)** — the JSON-RPC server now constructs its `StreamReader`/`StreamWriter` with an explicit 64 KB buffer instead of the .NET 1 KB default, so near-`MaxLineLength` (1 MB) payloads such as large `batch_query` requests no longer force the StreamReader to grow its internal buffer through many doublings.
+
+## 日本語
+
+- **MCP stdioループで64KBバッファを使用 (#1496)** — JSON-RPCサーバーが`StreamReader`/`StreamWriter`を.NETの既定1KBではなく64KBバッファで構築するようになり、`batch_query`などの`MaxLineLength`(1MB)近いペイロードでもStreamReaderの内部バッファを繰り返し拡張せずに処理できるようになりました。

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -26,6 +26,11 @@ public partial class McpServer
     private const int MaxLimit = 200;
     private const int MaxQueryLength = 1000;
     private const int MaxLineLength = 1_000_000; // 1 MB per JSON-RPC message / 1メッセージあたり最大1MB
+    // Stdio buffer for the JSON-RPC loop. Sized to fit typical large MCP payloads (e.g. batch_query)
+    // in a single read so the StreamReader does not grow from its 1 KB default toward MaxLineLength.
+    // JSON-RPCループのstdioバッファ。大きめのMCPペイロードを1回の読み取りで吸収し、
+    // StreamReaderのデフォルト1KBから繰り返し拡張されるのを避けるサイズ。
+    private const int StdioBufferSize = 64 * 1024;
 
     public McpServer(string dbPath, string version, bool dbPathExplicit = false)
         : this(dbPath, version, dbPathExplicit, null)
@@ -58,8 +63,8 @@ public partial class McpServer
 
         using var stdin = Console.OpenStandardInput();
         using var stdout = Console.OpenStandardOutput();
-        using var reader = new StreamReader(stdin, Encoding.UTF8);
-        using var writer = new StreamWriter(stdout, new UTF8Encoding(false)) { AutoFlush = true };
+        using var reader = new StreamReader(stdin, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: StdioBufferSize);
+        using var writer = new StreamWriter(stdout, new UTF8Encoding(false), bufferSize: StdioBufferSize) { AutoFlush = true };
 
         while (_running)
         {


### PR DESCRIPTION
## Summary

- Construct the MCP `StreamReader`/`StreamWriter` with an explicit 64 KB buffer instead of the .NET 1 KB default, so near-`MaxLineLength` (1 MB) JSON-RPC payloads (e.g. large `batch_query` requests) no longer force the StreamReader to grow its internal buffer through many doublings before a full line is read.
- Introduce a dedicated `StdioBufferSize` constant alongside the existing `MaxLineLength` to make the relationship between the two explicit.
- `detectEncodingFromByteOrderMarks` is kept at its default `true` so BOM handling matches the prior behavior.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug` — succeeded, 0 warnings, 0 errors.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~McpServer"` — 232 / 232 passed.
- `dotnet run --project tools/CodeIndex.Changelog/CodeIndex.Changelog.csproj -- check` — validated 1 fragment.

## Documentation / changelog

- Added bilingual changelog fragment: `changelog.d/unreleased/1496.internal.md` (category `internal`).
- No user-facing docs (`README.md`, etc.) require updates: there are no new flags, no new errors, and no CLI/MCP output changes — only an internal buffer-size adjustment.

## Issues

Fixes #1496

## Follow-up candidates

- None.
