### PR TITLE
Defer StripLineLeadingBom StringBuilder allocation until a line-leading BOM is confirmed

### DIFF
--- a/changelog.d/unreleased/1495.internal.md
+++ b/changelog.d/unreleased/1495.internal.md
@@ -1,0 +1,16 @@
+---
+category: internal
+issues:
+  - 1495
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **`StripLineLeadingBom` defers `StringBuilder` allocation until a line-leading BOM is confirmed (#1495)** — files without any `U+FEFF` (the dominant case) and files that only carry mid-line `U+FEFF` (intentional `ZWNBSP` inside string literals etc.) now return the input string unchanged, avoiding a `StringBuilder` allocation and a full-content pass on every indexed text file. The line-leading BOM strip contract from #183 is unchanged and is pinned by new regression tests asserting the no-allocation fast path.
+
+## 日本語
+
+- **`StripLineLeadingBom` が行頭 BOM 確定後まで `StringBuilder` 確保を遅延 (#1495)** — `U+FEFF` を一切含まないファイル (支配的ケース) および行頭以外にのみ `U+FEFF` を持つファイル (文字列リテラル内の意図的な `ZWNBSP` 等) は入力の文字列をそのまま返すようになり、テキストファイル 1 件ごとの `StringBuilder` 割り当てと全文走査を回避します。#183 で定めた「行頭 BOM のみ剥がす」契約はそのまま維持し、回帰テストで no-allocation 経路を固定しています。

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1735,12 +1735,53 @@ public class FileIndexer
     /// </summary>
     internal static string StripLineLeadingBom(string content)
     {
-        if (string.IsNullOrEmpty(content) || !content.Contains('\uFEFF'))
+        if (string.IsNullOrEmpty(content))
             return content;
-        var sb = new StringBuilder(content.Length);
+        // Fast path: BOM-free files (the dominant case) skip the line-tracking
+        // scan and return the input unchanged so no StringBuilder is allocated.
+        // 高速パス: BOM が一切無いファイル (支配的ケース) は行頭追跡走査を回避し、
+        // 入力をそのまま返して StringBuilder を確保しない。
+        if (!content.Contains('\uFEFF'))
+            return content;
+
+        // U+FEFF is present somewhere. Locate the first *line-leading* BOM in a
+        // single pass; if every occurrence is mid-line (intentional ZWNBSP
+        // inside string literals etc.), return the input unchanged so the
+        // no-strip path also avoids any allocation.
+        // U+FEFF が含まれている。最初の「行頭」 BOM を 1 パスで探し、行頭以外
+        // のみ (文字列リテラル内の意図的な ZWNBSP 等) であれば入力をそのまま
+        // 返し、「剥がし不要」のケースでも割り当てを発生させない。
+        int firstStripIndex = -1;
         bool atLineStart = true;
-        foreach (char c in content)
+        for (int i = 0; i < content.Length; i++)
         {
+            char c = content[i];
+            if (c == '\uFEFF' && atLineStart)
+            {
+                firstStripIndex = i;
+                break;
+            }
+            atLineStart = c == '\n';
+        }
+        if (firstStripIndex < 0)
+            return content;
+
+        // Allocate only after at least one line-leading BOM is confirmed. The
+        // capacity accounts for stripping at least the BOM at firstStripIndex.
+        // 少なくとも 1 つの行頭 BOM が確定した時点で初めて確保する。容量は
+        // firstStripIndex の BOM を必ず剥がす分を差し引いた値にしておく。
+        var sb = new StringBuilder(content.Length - 1);
+        if (firstStripIndex > 0)
+            sb.Append(content, 0, firstStripIndex);
+        // The char at firstStripIndex is itself a line-leading BOM; resume
+        // after it with atLineStart = true so consecutive BOMs at the same
+        // logical position (e.g. multiple BOMs right after `\n`) are stripped.
+        // firstStripIndex の文字自体が行頭 BOM。直後から再開し atLineStart を
+        // true に戻すことで `\n` 直後に連続する BOM も同じ論理位置として剥がす。
+        atLineStart = true;
+        for (int i = firstStripIndex + 1; i < content.Length; i++)
+        {
+            char c = content[i];
             if (c == '\uFEFF' && atLineStart)
                 continue;
             sb.Append(c);

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2114,6 +2114,75 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void StripLineLeadingBom_BomFreeContent_ReturnsSameInstance()
+    {
+        // BOM-free content (the dominant case) must hit the fast path and
+        // return the same string instance, asserting no StringBuilder is
+        // allocated. Closes #1495.
+        // BOM が無いファイル (支配的ケース) は高速パスで同じ string インスタンスを
+        // 返し、StringBuilder を割り当てないことを保証する。Closes #1495.
+        var input = "using System;\nnamespace Plain;\nclass C { }\n";
+        var output = FileIndexer.StripLineLeadingBom(input);
+        Assert.Same(input, output);
+    }
+
+    [Fact]
+    public void StripLineLeadingBom_MidLineBomOnly_ReturnsSameInstance()
+    {
+        // Content that carries U+FEFF only mid-line (intentional ZWNBSP in a
+        // string literal, identifier, or comment — never line-leading) must
+        // also hit the no-allocation path and return the same instance, so
+        // the no-op case never pays the StringBuilder cost. Closes #1495.
+        // 行頭以外にのみ U+FEFF を含むファイル (文字列リテラル内の意図的な ZWNBSP 等)
+        // も割り当て無しのパスを通り、同じインスタンスを返すことを保証する。Closes #1495.
+        var input = "var s = \"A\uFEFFB\";\nvar t = \"\uFEFF\";\n";
+        var output = FileIndexer.StripLineLeadingBom(input);
+        Assert.Same(input, output);
+        // Mid-line U+FEFF stays verbatim so the source-of-truth payload is
+        // not silently corrupted for code that embeds ZWNBSP intentionally.
+        // 行頭以外の U+FEFF はそのまま保持し、意図的に ZWNBSP を埋め込んだ
+        // コードの payload を破壊しないことを併せて確認する。
+        Assert.Contains('\uFEFF', output);
+    }
+
+    [Fact]
+    public void StripLineLeadingBom_EmptyContent_ReturnsSameInstance()
+    {
+        // Empty input must short-circuit before any scan or allocation.
+        // 空入力は走査・割り当ての前に短絡することを保証する。
+        Assert.Same(string.Empty, FileIndexer.StripLineLeadingBom(string.Empty));
+    }
+
+    [Fact]
+    public void StripLineLeadingBom_LineLeadingBoms_StrippedWhileMidLineBomPreserved()
+    {
+        // File-leading and post-newline BOMs are stripped, while mid-line
+        // U+FEFF inside a literal is preserved verbatim. This pins the
+        // narrowed #183 contract through the new deferred-allocation path.
+        // 先頭 BOM および `\n` 直後の BOM は剥がし、行内の U+FEFF は
+        // そのまま保持することを確認する。#183 で狭められた契約を新パスで再固定。
+        var input = "\uFEFFline1\n\uFEFFline2 has \"A\uFEFFB\"\nline3\n";
+        var output = FileIndexer.StripLineLeadingBom(input);
+
+        Assert.Equal("line1\nline2 has \"A\uFEFFB\"\nline3\n", output);
+    }
+
+    [Fact]
+    public void StripLineLeadingBom_ConsecutiveLineLeadingBoms_AllStripped()
+    {
+        // Multiple BOMs sharing the same logical line-start (e.g. a doubled
+        // BOM at offset 0 from accidental tool concatenation) must all be
+        // stripped, matching the original foreach loop's invariant that
+        // skipping a BOM does not reset `atLineStart`.
+        // 同じ論理行頭に重なる連続 BOM (オフセット 0 の二重 BOM 等) は全て
+        // 剥がす。元実装の「BOM スキップで atLineStart を更新しない」契約を保つ。
+        var input = "\uFEFF\uFEFFhello\n\uFEFF\uFEFFworld\n";
+        var output = FileIndexer.StripLineLeadingBom(input);
+
+        Assert.Equal("hello\nworld\n", output);
+    }
+
+    [Fact]
     public void BuildRecord_ThrowsForOversizedFile()
     {
         // Files exceeding 10 MB should throw InvalidOperationException


### PR DESCRIPTION
## Summary

- `FileIndexer.StripLineLeadingBom` now defers its `StringBuilder` allocation until a line-leading `U+FEFF` is actually located. BOM-free files (the dominant case) and files that carry `U+FEFF` only mid-line — intentional `ZWNBSP` inside string literals etc. — return the input string unchanged on a no-allocation fast path.
- The narrowed #183 line-leading strip contract is preserved: only `U+FEFF` at offset 0 or immediately after `\n` is removed, and consecutive BOMs sharing the same logical line-start are still all skipped.
- New regression tests pin the no-allocation contract (`Assert.Same(input, output)` for BOM-free, empty, and mid-line-only `U+FEFF` inputs) and the strip/preservation behavior for line-leading and doubled line-leading BOMs.

## Test plan

- [x] `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug` (clean build)
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~FileIndexerTests.StripLineLeadingBom"` — 5/5 pass
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~FileIndexerTests"` — 268/268 pass
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~Bom|FullyQualifiedName~StripLineLeadingBom|FullyQualifiedName~ChunkSplitter|FullyQualifiedName~SymbolExtractor|FullyQualifiedName~ReferenceExtractor"` — 2125/2125 pass (covers all four callers of `StripLineLeadingBom`)
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` — fragment validates

## Follow-up candidates

- See #2117

Fixes #1495.
