### PR TITLE
Add ConfigureAwait(false) to MCP stdio loop awaits (#1493)

### DIFF
--- a/changelog.d/unreleased/1493.fixed.md
+++ b/changelog.d/unreleased/1493.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1493
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+---
+
+## English
+
+- **MCP server stdio loop now uses `ConfigureAwait(false)` (#1493)** — every `await` in the JSON-RPC read/write loop now opts out of capturing the current `SynchronizationContext`, removing per-call overhead in long-running MCP sessions and avoiding latent deadlocks or unintended serialization when a host installs a non-default `SynchronizationContext`.
+
+## 日本語
+
+- **MCP サーバーの stdio ループで `ConfigureAwait(false)` を使うようになりました (#1493)** — JSON-RPC 読み書きループ内のすべての `await` で現在の `SynchronizationContext` のキャプチャを抑制するようにしました。長時間の MCP セッションでの呼び出しオーバーヘッドを削減し、ホストが非デフォルトの `SynchronizationContext` を導入している場合のデッドロックや意図しない直列化リスクを回避します。

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -63,11 +63,11 @@ public partial class McpServer
 
         while (_running)
         {
-            var line = await reader.ReadLineAsync();
+            var line = await reader.ReadLineAsync().ConfigureAwait(false);
             if (line == null)
                 break; // stdin closed / stdinが閉じられた
 
-            await ProcessLineAsync(line, writer);
+            await ProcessLineAsync(line, writer).ConfigureAwait(false);
         }
 
         Console.Error.WriteLine("[cdidx-mcp] Server stopped. Restart `cdidx mcp` when your client reconnects.");
@@ -88,7 +88,7 @@ public partial class McpServer
         {
             Console.Error.WriteLine(BuildOversizedMessageLog(line.Length));
             var errorResponse = CreateErrorResponse(null, -32700, "Message too large");
-            await writer.WriteLineAsync(errorResponse.ToJsonString(_jsonOptions));
+            await writer.WriteLineAsync(errorResponse.ToJsonString(_jsonOptions)).ConfigureAwait(false);
             return;
         }
 
@@ -102,7 +102,7 @@ public partial class McpServer
             var response = HandleMessage(request);
             if (response != null)
             {
-                await writer.WriteLineAsync(_serializeResponse(response));
+                await writer.WriteLineAsync(_serializeResponse(response)).ConfigureAwait(false);
             }
         }
         catch (JsonException ex)
@@ -110,7 +110,7 @@ public partial class McpServer
             // Parse error / パースエラー
             Console.Error.WriteLine(BuildJsonParseErrorLog(ex.Message));
             var errorResponse = CreateErrorResponse(null, -32700, "Parse error");
-            await writer.WriteLineAsync(errorResponse.ToJsonString(_jsonOptions));
+            await writer.WriteLineAsync(errorResponse.ToJsonString(_jsonOptions)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -118,7 +118,7 @@ public partial class McpServer
             if (request is JsonObject requestObj && requestObj.TryGetPropertyValue("id", out var requestId))
             {
                 var errorResponse = CreateErrorResponse(true, requestId, -32603, ex.Message);
-                await writer.WriteLineAsync(errorResponse.ToJsonString(_jsonOptions));
+                await writer.WriteLineAsync(errorResponse.ToJsonString(_jsonOptions)).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `.ConfigureAwait(false)` to every `await` in `McpServer.RunAsync`/`ProcessLineAsync` (read/write stdio loop) so MCP I/O does not capture the host `SynchronizationContext`.
- Removes per-call overhead in long-running MCP sessions and prevents latent deadlocks or unintended serialization when the host installs a non-default `SynchronizationContext`.
- Audited the rest of `src/CodeIndex/Mcp/` (`McpToolDefinitions.cs`, `McpToolHandlers.cs`); no other `await` sites exist there.

## Validation

- `dotnet build CodeIndex.sln -c Release` — succeeds, 0 warnings, 0 errors.
- `dotnet test CodeIndex.sln -c Release --no-build` — 4444 passed, 3 perf tests skipped (default), 0 failures.
- `dotnet test --filter "FullyQualifiedName~McpServerTests"` — 232 passed.
- `dotnet run --project tools/CodeIndex.Changelog -- check` — fragment validates.

## Documentation / Changelog

- No user-visible CLI/MCP output, flags, or contract changes; existing docs already correctly describe the MCP server, so no doc updates were required.
- Bilingual changelog fragment: `changelog.d/unreleased/1493.fixed.md` (category: `fixed`).

## Follow-up candidates

- None identified during this work.

Fixes #1493
