### PR TITLE
Document inclusive maxDepth for transitive callers (#1879)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -995,7 +995,7 @@ Once configured, the AI can directly call these tools:
 | `outline` | Show all symbols in a single file with line numbers, signatures, and container-depth nesting |
 | `status` | Database statistics |
 | `deps` | File-level dependency edges from the reference graph |
-| `impact_analysis` | Compute transitive callers of a symbol; use `maxDepth: 0` to resolve the symbol only, or rely on single-type fallback to heuristic file-level dependency hints and partial-definition hints |
+| `impact_analysis` | Compute transitive callers of a symbol (inclusive `maxDepth`: `maxDepth: N` returns callers at depth 1..N — a chain A→B→C→D queried against D with `maxDepth: 2` yields C at depth 1 and B at depth 2); use `maxDepth: 0` to resolve the symbol only, or rely on single-type fallback to heuristic file-level dependency hints and partial-definition hints |
 | `unused_symbols` | Find symbols defined but never referenced, with confidence buckets for dead-code triage |
 | `symbol_hotspots` | Find high-impact symbols; unique names use codebase-wide counts, duplicate-name families fall back conservatively |
 | `batch_query` | Execute multiple queries in a single call (MCP only, max 10) |
@@ -2020,7 +2020,7 @@ OpenAI Codex CLI (`codex.json` または `~/.codex/config.json`):
 | `outline` | 1ファイルの全シンボルを行番号・シグネチャ・コンテナ深さに応じたネスト付きで表示 |
 | `status` | データベース統計情報 |
 | `deps` | 参照グラフからファイル間依存エッジを表示 |
-| `impact_analysis` | シンボルの推移的 caller を算出し、`maxDepth: 0` で symbol 解決のみを行い、単一定義の型は heuristic な file-level dependency hint にフォールバックし、複数定義時はヒントも返す |
+| `impact_analysis` | シンボルの推移的 caller を算出（`maxDepth` は inclusive で、`maxDepth: N` 指定時は depth 1〜N の caller を返す。例: A→B→C→D のチェーンで D を `maxDepth: 2` 検索すると C(depth=1) と B(depth=2) が返る）。`maxDepth: 0` で symbol 解決のみを行い、単一定義の型は heuristic な file-level dependency hint にフォールバックし、複数定義時はヒントも返す |
 | `unused_symbols` | 定義されているが参照されていないシンボルを bucket 付きで検索（デッドコード検出向け） |
 | `symbol_hotspots` | 影響の大きいシンボルを検索。一意名は codebase 全体件数、同名ファミリーは保守的に縮退 |
 | `batch_query` | 複数クエリを1回で実行（MCP専用、最大10件） |

--- a/changelog.d/unreleased/1879.docs.md
+++ b/changelog.d/unreleased/1879.docs.md
@@ -1,0 +1,19 @@
+---
+category: docs
+issues:
+  - 1879
+affected:
+  - src/CodeIndex/Database/DbReader.GraphQueries.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Mcp/McpToolDefinitions.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Documented `GetTransitiveCallers` / `impact_analysis` `maxDepth` as inclusive (#1879)** — verified with a 3-hop chain fixture that `maxDepth: N` returns callers at depth 1..N inclusive (e.g. `--depth 2` against the leaf of a chain A→B→C→D returns C at depth 1 and B at depth 2), clarified the inclusive bound in the C# docstrings, the BFS enqueue comment, the `cdidx impact --depth` help text, the MCP `impact_analysis.maxDepth` description, and the `impact_analysis` entry in USER_GUIDE, and added a regression test pinning the depth=1/2/3 contract.
+
+## 日本語
+
+- **`GetTransitiveCallers` / `impact_analysis` の `maxDepth` が inclusive であることを明文化 (#1879)** — 3-hop チェーンの fixture で `maxDepth: N` が depth 1〜N (inclusive) の caller を返すこと (例: A→B→C→D の leaf に対する `--depth 2` が C(depth=1) と B(depth=2) を返すこと) を検証し、C# の docstring、BFS の enqueue コメント、`cdidx impact --depth` のヘルプ、MCP `impact_analysis.maxDepth` の説明、USER_GUIDE の `impact_analysis` 項目に inclusive である旨を反映し、depth=1/2/3 の契約を固定する regression test を追加しました。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -402,7 +402,7 @@ public static class ConsoleUi
         Console.WriteLine("  --kind <kind>              definition/symbols/hotspots/unused: symbol kind; references: reference kind (call/instantiate/subscribe/attribute/annotation); callers/callees: call-graph kinds only (call/instantiate/subscribe — metadata kinds rejected, use references instead); validate: issue kind");
         Console.WriteLine("  --count                    Count only; search/definition/references/callers/callees/symbols/files/find/unused ignore --limit, impact/hotspots still use visible page counts");
         Console.WriteLine("  --since <datetime>         Filter to files modified since this timestamp (ISO 8601)");
-        Console.WriteLine("  --depth <n>                Max BFS depth for impact analysis (default: 5)");
+        Console.WriteLine("  --depth <n>                Max BFS depth for impact analysis, inclusive (default: 5; --depth 2 returns callers at depth 1 and 2; --depth 0 resolves the symbol without traversing callers)");
         Console.WriteLine("  --reverse                  Reverse direction for deps (show dependents)");
         Console.WriteLine("  --group-by-name            hotspots: collapse rows sharing (name, kind) across files into one line");
         Console.WriteLine("  Note: if a query itself starts with '-', pass it with --query <query> or -- <query>; for option values that start with '--', use --opt=<value>.");

--- a/src/CodeIndex/Database/DbReader.GraphQueries.cs
+++ b/src/CodeIndex/Database/DbReader.GraphQueries.cs
@@ -782,8 +782,13 @@ public partial class DbReader
     /// <summary>
     /// Compute transitive callers of a symbol using BFS with exact matching.
     /// Returns each unique caller in the call chain with its depth from the root symbol.
-    /// Truncation is signaled via the Truncated property in results.
+    /// The <paramref name="maxDepth"/> bound is inclusive: when <paramref name="maxDepth"/> is N,
+    /// callers at depth 1 through N are returned (so a chain A→B→C→D queried against D with
+    /// <c>maxDepth: 2</c> yields C at depth 1 and B at depth 2). Truncation is signaled via the
+    /// Truncated property in results.
     /// 完全一致の BFS でシンボルの推移的呼び出し元を算出。各呼び出し元とルートシンボルからの深さを返す。
+    /// <paramref name="maxDepth"/> は inclusive で、N を指定すると depth 1〜N の caller を返す
+    /// (例: A→B→C→D のチェーンで D を <c>maxDepth: 2</c> 検索すると C(depth=1) と B(depth=2) を返す)。
     /// 結果が切り詰められた場合は Truncated フラグで通知する。
     /// </summary>
     public (List<ImpactResult> Results, bool Truncated) GetTransitiveCallers(string symbolName, int maxDepth = 5, int limit = 50, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false)
@@ -852,6 +857,12 @@ public partial class DbReader
                         ReferenceCount = caller.ReferenceCount,
                     });
 
+                    // Only recurse if the just-added caller (at depth + 1) is strictly below
+                    // maxDepth, so that the next BFS step can reach depth + 2 ≤ maxDepth.
+                    // This keeps the maxDepth bound inclusive of depth = maxDepth results.
+                    // 追加した caller (depth + 1) が maxDepth より小さいときだけ再帰し、
+                    // 次の BFS で depth + 2 ≤ maxDepth まで到達できるようにする。
+                    // これにより maxDepth は inclusive な上限として機能する。
                     if (caller.CallerName != null
                         && caller.CallerName != SyntheticTopLevelCallerName
                         && depth + 1 < maxDepth)
@@ -880,8 +891,11 @@ public partial class DbReader
     /// <summary>
     /// Analyze impact for a query by combining transitive callers with symbol-resolution
     /// metadata and a class-like file-dependency fallback when symbol-level callers are absent.
+    /// The <paramref name="maxDepth"/> bound is inclusive (callers at depth 1..N are returned);
+    /// <c>maxDepth: 0</c> short-circuits to symbol resolution only.
     /// impact 用に caller BFS と解決メタデータを束ね、class 系で caller 不在なら
-    /// file dependency をフォールバックとして返す。
+    /// file dependency をフォールバックとして返す。<paramref name="maxDepth"/> は inclusive で
+    /// N 指定時は depth 1〜N の caller を返し、<c>maxDepth: 0</c> は symbol 解決のみで終了する。
     /// </summary>
     public ImpactAnalysisResult AnalyzeImpact(string symbolName, int maxDepth = 5, int limit = 50, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false)
     {

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -260,7 +260,7 @@ public partial class McpServer
                     ["properties"] = new JsonObject
                     {
                         ["query"] = new JsonObject { ["type"] = "string", ["description"] = "Symbol name to analyze impact for" },
-                        ["maxDepth"] = new JsonObject { ["type"] = "integer", ["description"] = "Max BFS depth (default: 5; 0 resolves the symbol without traversing callers)", ["default"] = 5, ["minimum"] = 0 },
+                        ["maxDepth"] = new JsonObject { ["type"] = "integer", ["description"] = "Max BFS depth, inclusive (default: 5; maxDepth: N returns callers at depth 1..N, so a chain A→B→C→D queried against D with maxDepth: 2 yields C at depth 1 and B at depth 2; 0 resolves the symbol without traversing callers)", ["default"] = 5, ["minimum"] = 0 },
                         ["limit"] = new JsonObject { ["type"] = "integer", ["description"] = "Max total callers or heuristic file-level dependency hints to return (default: 50). Check `truncated` when the limit is reached.", ["default"] = 50 },
                         ["lang"] = new JsonObject { ["type"] = "string", ["description"] = "Filter by language" },
                         ["path"] = new JsonObject { ["oneOf"] = new JsonArray { new JsonObject { ["type"] = "string" }, new JsonObject { ["type"] = "array", ["items"] = new JsonObject { ["type"] = "string" } } }, ["description"] = "Prefer or restrict paths containing this text. Accepts a single string or an array; multiple values are OR'd together." },

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -9138,6 +9138,57 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void GetTransitiveCallers_MaxDepthIsInclusiveAcrossChain()
+    {
+        // Regression for #1879: an audit suspected an off-by-one in the depth bound
+        // (i.e. that --depth=2 would only reach depth 1). Verify with a 3-hop chain
+        // ImpactNodeA → ImpactNodeB → ImpactNodeC → ImpactLeaf that maxDepth is inclusive:
+        //  - maxDepth=1 returns only the direct caller (ImpactNodeC at depth 1);
+        //  - maxDepth=2 also returns ImpactNodeB at depth 2;
+        //  - maxDepth=3 also returns ImpactNodeA at depth 3.
+        // #1879 回帰: maxDepth が inclusive であること (--depth=2 が depth 2 まで到達する) を
+        // 3-hop チェーン ImpactNodeA → ImpactNodeB → ImpactNodeC → ImpactLeaf で確認する。
+        InsertIndexedFile("src/impact_depth_chain.cs", "csharp",
+            """
+            public static class ImpactDepthChain
+            {
+                public static void ImpactLeaf() { }
+                public static void ImpactNodeC() { ImpactLeaf(); }
+                public static void ImpactNodeB() { ImpactNodeC(); }
+                public static void ImpactNodeA() { ImpactNodeB(); }
+            }
+            """);
+
+        var (depth1, truncated1) = _reader.GetTransitiveCallers(
+            "ImpactLeaf", maxDepth: 1, limit: 20, lang: "csharp", pathPatterns: ["impact_depth_chain"]);
+        var (depth2, truncated2) = _reader.GetTransitiveCallers(
+            "ImpactLeaf", maxDepth: 2, limit: 20, lang: "csharp", pathPatterns: ["impact_depth_chain"]);
+        var (depth3, truncated3) = _reader.GetTransitiveCallers(
+            "ImpactLeaf", maxDepth: 3, limit: 20, lang: "csharp", pathPatterns: ["impact_depth_chain"]);
+
+        Assert.False(truncated1);
+        Assert.False(truncated2);
+        Assert.False(truncated3);
+
+        var depth1Pairs = depth1.Select(r => (r.CallerName, r.Depth)).ToArray();
+        Assert.Equal(new (string?, int)[] { ("ImpactNodeC", 1) }, depth1Pairs);
+
+        var depth2Pairs = depth2
+            .Select(r => (r.CallerName, r.Depth))
+            .OrderBy(p => p.Depth)
+            .ToArray();
+        Assert.Equal(new (string?, int)[] { ("ImpactNodeC", 1), ("ImpactNodeB", 2) }, depth2Pairs);
+
+        var depth3Pairs = depth3
+            .Select(r => (r.CallerName, r.Depth))
+            .OrderBy(p => p.Depth)
+            .ToArray();
+        Assert.Equal(
+            new (string?, int)[] { ("ImpactNodeC", 1), ("ImpactNodeB", 2), ("ImpactNodeA", 3) },
+            depth3Pairs);
+    }
+
+    [Fact]
     public void AnalyzeImpact_ClassSymbolReturnsHeuristicFileDependencyHints()
     {
         InsertIndexedFile("src/FolderDiffService.cs", "csharp",


### PR DESCRIPTION
## Summary

Verified with a 3-hop call-chain fixture that `GetTransitiveCallers` and `impact_analysis` already return callers at depth 1..N inclusive when `maxDepth=N` (the audit's off-by-one suspicion in #1879 is not a real bug). Made the inclusive bound explicit everywhere the depth contract is described, and added a regression test that pins depth=1/2/3 against a `ImpactNodeA → ImpactNodeB → ImpactNodeC → ImpactLeaf` chain so future refactors cannot silently break the contract.

## Changes

- `src/CodeIndex/Database/DbReader.GraphQueries.cs`: added inclusive-bound wording to `GetTransitiveCallers` / `AnalyzeImpact` docstrings (EN + JA) and an explanatory bilingual comment next to the `depth + 1 < maxDepth` enqueue check.
- `src/CodeIndex/Cli/ConsoleUi.cs`: the `--depth` help line for the impact command now states the bound is inclusive and gives a `--depth 2` example.
- `src/CodeIndex/Mcp/McpToolDefinitions.cs`: the `impact_analysis.maxDepth` description now states the bound is inclusive and gives the A→B→C→D / `maxDepth: 2` example.
- `USER_GUIDE.md`: `impact_analysis` row in both EN and JA tool tables now describes the inclusive `maxDepth` contract.
- `tests/CodeIndex.Tests/DbReaderTests.cs`: new `GetTransitiveCallers_MaxDepthIsInclusiveAcrossChain` regression test covering depth=1/2/3 on a real C# call chain.
- `changelog.d/unreleased/1879.docs.md`: bilingual changelog fragment.

## Validation

- Targeted dotnet test runs (`FullyQualifiedName~GetTransitiveCallers`, `~AnalyzeImpact|~ConsoleUi|~McpToolDefinitions|~ImpactAnalysis`, `~QueryCommandRunner|~ProgramCli`) — all pass (5 + 77 + 910 = 992 tests).
- dotnet build of `src/CodeIndex/CodeIndex.csproj -c Debug` — 0 warnings, 0 errors.
- Local index status (via the in-repo dotnet harness) confirmed sufficient for code search; no schema changes, so no regeneration needed.

## Test plan

- [x] New regression test confirms `maxDepth=1` returns only `ImpactNodeC`, `maxDepth=2` returns `ImpactNodeC + ImpactNodeB`, `maxDepth=3` returns `ImpactNodeC + ImpactNodeB + ImpactNodeA`.
- [x] Existing transitive-callers / impact-analysis / CLI tests still pass.

## Follow-up candidates

- #2120
- #2121
- #2122
- #1432

Fixes #1879
