### PR TITLE
Reuse SQLite connection across MCP tool calls (#1494)

### DIFF
--- a/changelog.d/unreleased/1494.changed.md
+++ b/changelog.d/unreleased/1494.changed.md
@@ -1,0 +1,18 @@
+---
+category: changed
+issues:
+  - 1494
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP sessions reuse a single SQLite connection across tool calls (#1494)** — `McpServer` now opens a per-session `DbContext` on the first tool invocation and reuses it for every subsequent call, so each tool request no longer pays the cost of reopening the SQLite connection, reapplying pragmas, re-registering SQL functions, and rerunning `TryMigrateForRead` round trips. `cdidx mcp` and `McpServer` are now `IDisposable`; in long-running sessions a small `excerpt` or `status` call is now dominated by the actual query work instead of connection setup.
+
+## 日本語
+
+- **MCP セッション内のツール呼び出しが SQLite 接続を再利用するようになりました (#1494)** — `McpServer` は初回ツール呼び出し時に `DbContext` を開き、以降の呼び出しではこれを再利用します。これにより、ツール呼び出しごとに SQLite 接続を開き直したり PRAGMA を再適用したり SQL 関数を再登録したり `TryMigrateForRead` を流したりするコストを支払わなくなります。`cdidx mcp` および `McpServer` は `IDisposable` を実装するようになり、長時間のセッションでは小さな `excerpt` / `status` 呼び出しがコネクション準備ではなく実際のクエリ処理に支配されるようになります。

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -145,7 +145,7 @@ internal static class ProgramRunner
             return CommandExitCodes.UsageError;
         }
 
-        var server = new McpServer(options.DbPath, appVersion, options.DbPathExplicit);
+        using var server = new McpServer(options.DbPath, appVersion, options.DbPathExplicit);
         server.RunAsync().GetAwaiter().GetResult();
         return CommandExitCodes.Success;
     }

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -13,7 +13,7 @@ namespace CodeIndex.Mcp;
 /// stdin/stdout上のJSON-RPC 2.0によるMCPサーバー。
 /// Protocol version: 2024-11-05
 /// </summary>
-public partial class McpServer
+public partial class McpServer : IDisposable
 {
     private readonly string _dbPath;
     private readonly bool _dbPathExplicit;
@@ -21,6 +21,21 @@ public partial class McpServer
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly Func<JsonNode, string> _serializeResponse;
     private bool _running = true;
+    // Per-session DbContext reused across MCP tool calls. Holding the connection open
+    // avoids reopening SQLite, reapplying pragmas, and re-registering every SQL function
+    // on each invocation (issue #1494).
+    // セッション内で MCP ツール呼び出しごとに再利用する DbContext。接続再開・PRAGMA 再適用・
+    // SQL 関数再登録のコストを毎回払わないために保持する（#1494）。
+    private DbContext? _sharedDb;
+    // TryMigrateForRead is a read-path concern (legacy / read-only sandbox DBs). It is
+    // idempotent but does run PRAGMA table_info + CREATE INDEX IF NOT EXISTS round trips,
+    // so we run it once per session. Write tools (`index`, `backfill_fold`) cover the same
+    // surface via InitializeSchema, which also flips this flag through MarkSharedDbMigrated.
+    // TryMigrateForRead は read path 向けの遅延移行で、レガシー DB / read-only サンドボックス
+    // でのみ意味を持つ。冪等だが PRAGMA table_info などの往復が発生するため、セッションで一度だけ
+    // 実行する。書き込みツールは InitializeSchema で同等以上の DDL を流すため、そこでフラグを立てる。
+    private bool _sharedDbReadMigrated;
+    private bool _disposed;
 
     private const string ProtocolVersion = "2025-03-26";
     private const int MaxLimit = 200;
@@ -277,12 +292,67 @@ public partial class McpServer
         // CLI と同じく file: URI を受け付け、サンドボックス用の escape hatch に到達できるようにする。
         var isUri = _dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
         if (!isUri && !File.Exists(_dbPath))
+        {
+            // Drop any stale cached context so the next tool call can re-open after the user
+            // creates the DB (e.g. via an external `cdidx index`). Without this, a missed
+            // file lookup would leave a closed/disposed handle blocking later open attempts.
+            // ユーザーが後から DB を作った場合に再オープンできるよう、キャッシュをここで破棄。
+            CloseSharedDb();
             return CreateToolErrorResponse(true, id, $"Database not found: {_dbPath}. Run 'cdidx index <projectPath>' first.");
+        }
 
-        using var db = new DbContext(_dbPath);
-        db.TryMigrateForRead();
+        var db = GetOrOpenSharedDb();
+        if (!_sharedDbReadMigrated)
+        {
+            db.TryMigrateForRead();
+            _sharedDbReadMigrated = true;
+        }
         var reader = new DbReader(db.Connection, db.IsReadOnly);
         return action(reader);
+    }
+
+    /// <summary>
+    /// Open the per-session DbContext on first use and reuse it on every subsequent call.
+    /// Centralising the open lets us pay the connection setup, pragma application, and SQL
+    /// function registration once per MCP session instead of once per tool invocation
+    /// (#1494). The MCP loop is single-threaded, so no locking is required.
+    /// MCP セッション初回呼び出し時に DbContext を開き、以後は再利用する。接続セットアップや
+    /// PRAGMA・SQL 関数登録のコストを毎ツール呼び出しごとに払わないようにする（#1494）。
+    /// MCP ループは単一スレッドのためロック不要。
+    /// </summary>
+    internal DbContext GetOrOpenSharedDb()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_sharedDb != null)
+            return _sharedDb;
+
+        _sharedDb = new DbContext(_dbPath);
+        return _sharedDb;
+    }
+
+    /// <summary>
+    /// Mark the shared DbContext as already covered by `TryMigrateForRead`. Write tools that
+    /// run `InitializeSchema` reuse the same connection, so the read path can skip the
+    /// migration round trip on later calls.
+    /// 書き込みツールが InitializeSchema を流した後の共有 DbContext に対し、read path の
+    /// TryMigrateForRead を省略するためのマーカ。
+    /// </summary>
+    internal void MarkSharedDbMigrated() => _sharedDbReadMigrated = true;
+
+    private void CloseSharedDb()
+    {
+        _sharedDb?.Dispose();
+        _sharedDb = null;
+        _sharedDbReadMigrated = false;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        CloseSharedDb();
+        GC.SuppressFinalize(this);
     }
 
     // --- JSON-RPC helpers / JSON-RPCヘルパー ---

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1543,9 +1543,12 @@ public partial class McpServer
         if (!Directory.Exists(projectPath))
             return CreateToolErrorResponse(id, "Directory not found");
 
-        // Determine DB path — use the provided _dbPath or default
-        // DBパスを決定 — 指定された_dbPathまたはデフォルトを使用
-        using var db = new DbContext(_dbPath);
+        // Reuse the per-session DbContext (issue #1494) instead of opening a fresh
+        // connection on every index call. InitializeSchema below is idempotent so the
+        // shared connection still picks up legacy-DB migrations on demand.
+        // index 呼び出しごとに新しい接続を開かず、セッション共有 DbContext を再利用する（#1494）。
+        // 後段の InitializeSchema は冪等なので共有接続でもレガシー DB の移行は正しく走る。
+        var db = GetOrOpenSharedDb();
         var priorFoldVersion = db.GetMetaString("fold_key_version");
         var priorFoldFingerprint = db.GetMetaString("fold_key_fingerprint");
         var priorCSharpSymbolNameContractVersion = db.GetMetaString(DbContext.CSharpSymbolNameContractVersionMetaKey);
@@ -1571,6 +1574,7 @@ public partial class McpServer
         }
 
         db.InitializeSchema();
+        MarkSharedDbMigrated();
 
         var writer = new DbWriter(db.Connection);
         var indexer = new FileIndexer(projectPath, GitHelper.ResolveIgnoreCase(projectPath), GitHelper.TryGetRepositoryRoot(projectPath) ?? Path.GetFullPath(projectPath));
@@ -1800,8 +1804,12 @@ public partial class McpServer
 
         try
         {
-            using var db = new DbContext(_dbPath);
+            // Reuse the per-session DbContext (issue #1494). InitializeSchema is idempotent
+            // and remains correct on a long-lived connection.
+            // セッション共有 DbContext を再利用する（#1494）。InitializeSchema は冪等。
+            var db = GetOrOpenSharedDb();
             db.InitializeSchema();
+            MarkSharedDbMigrated();
             var writer = new DbWriter(db.Connection);
             var userVersionBefore = db.GetUserVersion();
             var currentFoldVersion = NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -232,9 +232,101 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void ToolsCall_ReusesDbContextAcrossInvocations()
+    {
+        // #1494: every MCP tool call used to construct a fresh DbContext (and reopen the
+        // SQLite connection, reapply pragmas, re-register every SQL function). The session
+        // should now cache a single DbContext after the first tool call and reuse it.
+        // #1494: 旧実装はツール呼び出しごとに DbContext を作り直していたため、SQLite 接続再開・
+        // PRAGMA 再適用・SQL 関数再登録のコストを毎回払っていた。セッション内では一度だけ開いた
+        // DbContext を再利用するようになっていることを検証する。
+        Assert.Null(GetSharedDbContextField(_server));
+
+        var first = _server.HandleMessage(JsonNode.Parse(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status"}}""")!);
+        Assert.False(first!["result"]?["isError"]?.GetValue<bool>() ?? false);
+        var afterFirst = GetSharedDbContextField(_server);
+        Assert.NotNull(afterFirst);
+
+        var second = _server.HandleMessage(JsonNode.Parse(
+            """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"status"}}""")!);
+        Assert.False(second!["result"]?["isError"]?.GetValue<bool>() ?? false);
+        Assert.Same(afterFirst, GetSharedDbContextField(_server));
+    }
+
+    [Fact]
+    public void ToolsCall_DbMissingThenCreated_ReopensSharedContext()
+    {
+        // The cached DbContext must drop itself when the file is missing so a follow-up call
+        // — after the user runs `cdidx index` from another shell — can succeed instead of
+        // failing against a stale handle.
+        // DB ファイルが消えた場合はキャッシュをクリアし、外部で再作成された後の呼び出しで
+        // 古いハンドルに失敗せず再オープンできることを確認する。
+        var missingPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_reopen_{Guid.NewGuid():N}.db");
+        using var server = new McpServer(missingPath, ConsoleUi.LoadVersion());
+        try
+        {
+            var miss = server.HandleMessage(JsonNode.Parse(
+                """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status"}}""")!)!;
+            Assert.True(miss["result"]?["isError"]?.GetValue<bool>() ?? false);
+            Assert.Null(GetSharedDbContextField(server));
+
+            using (var seed = new DbContext(missingPath))
+            {
+                seed.InitializeSchema();
+            }
+
+            var hit = server.HandleMessage(JsonNode.Parse(
+                """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"status"}}""")!)!;
+            Assert.False(hit["result"]?["isError"]?.GetValue<bool>() ?? false);
+            Assert.NotNull(GetSharedDbContextField(server));
+        }
+        finally
+        {
+            server.Dispose();
+            DeleteFileRobust(missingPath);
+        }
+    }
+
+    [Fact]
+    public void Dispose_ReleasesSharedDbContext()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_dispose_{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var seed = new DbContext(dbPath))
+            {
+                seed.InitializeSchema();
+            }
+
+            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            _ = server.HandleMessage(JsonNode.Parse(
+                """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status"}}""")!);
+            Assert.NotNull(GetSharedDbContextField(server));
+
+            server.Dispose();
+
+            Assert.Null(GetSharedDbContextField(server));
+            Assert.Throws<ObjectDisposedException>(() => server.GetOrOpenSharedDb());
+        }
+        finally
+        {
+            DeleteFileRobust(dbPath);
+        }
+    }
+
+    private static DbContext? GetSharedDbContextField(McpServer server)
+    {
+        var field = typeof(McpServer).GetField("_sharedDb",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (DbContext?)field!.GetValue(server);
+    }
+
+    [Fact]
     public async Task ProcessLineAsync_WhenResponseSerializationFails_ReturnsJsonRpcError()
     {
-        var server = new McpServer(
+        using var server = new McpServer(
             _dbPath,
             ConsoleUi.LoadVersion(),
             false,
@@ -579,7 +671,7 @@ public class McpServerTests : IDisposable
             using (var db = new DbContext(dbPath))
             {
                 db.InitializeSchema();
-                var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+                using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
                 var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"files","arguments":{"query":"nonexistent_xyz_123"}}}""")!;
                 var response = server.HandleMessage(request)!;
                 using var document = JsonDocument.Parse(response.ToJsonString());
@@ -1078,7 +1170,7 @@ public class McpServerTests : IDisposable
     {
         InsertIndexedFile("src/session.py", "python", "def login(user, password):\n    return Run(user)\n");
         DropGraphExactFallbackIndexes();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"references","arguments":{"query":"Run","exact":true}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -1371,7 +1463,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateSqlGraphContractFixtureDb(projectRoot);
             DowngradeSqlGraphContractRows(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"analyze_symbol","arguments":{"query":"fn_Target","lang":"sql","exact":true}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -1396,7 +1488,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateSqlGraphContractFixtureDb(projectRoot);
             DowngradeSqlGraphContractRows(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"references","arguments":{"query":"fn_Target","lang":"sql"}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -1422,7 +1514,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateMixedSqlGraphContractFixtureDb(projectRoot);
             DowngradeSqlGraphContractRows(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"callers","arguments":{"query":"N","exact":true}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -2184,7 +2276,7 @@ public class McpServerTests : IDisposable
     {
         InsertIndexedFile("src/session.py", "python", "def login(user, password):\n    return Run(user)\n");
         DropGraphExactFallbackIndexes();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"analyze_symbol","arguments":{"query":"Run","exact":true}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -2199,7 +2291,7 @@ public class McpServerTests : IDisposable
     {
         InsertIndexedFile("src/session.py", "python", "def login(user, password):\n    return Run(user)\n");
         DropGraphExactFallbackIndexes();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"analyze_symbol","arguments":{"query":"Run"}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -2216,7 +2308,7 @@ public class McpServerTests : IDisposable
     {
         InsertIndexedFile("src/session.py", "python", "def Run(user):\n    return user\n\ndef login(user, password):\n    return Run(user)\n");
         DropSymbolExactFallbackIndex();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"symbols","arguments":{"query":"Run","exact":true}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -2233,7 +2325,7 @@ public class McpServerTests : IDisposable
     {
         InsertIndexedFile("src/session.py", "python", "def Run(user):\n    return user\n");
         DropSymbolExactFallbackIndex();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"symbols","arguments":{"exact":true,"limit":1}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -2251,7 +2343,7 @@ public class McpServerTests : IDisposable
     {
         InsertIndexedFile("src/session.py", "python", "def Run(user):\n    return user\n\ndef login(user, password):\n    return Run(user)\n");
         DropSymbolExactFallbackIndex();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"definition","arguments":{"query":"Run","exact":true}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -2295,7 +2387,7 @@ public class McpServerTests : IDisposable
         InsertIndexedFile("src/session.py", "python", "def Run(user):\n    return user\n\ndef login(user, password):\n    return Run(user)\n");
         ForceLegacyExactFallbackMode();
         DropSymbolExactFallbackIndex();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"analyze_symbol","arguments":{"query":"Run","exact":true}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -2313,7 +2405,7 @@ public class McpServerTests : IDisposable
         InsertIndexedFile("docs/guide.md", "markdown", "# Heading\n\nSee also `Run`.\n");
         ForceLegacyExactFallbackMode();
         DropGraphExactFallbackIndexes();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"analyze_symbol","arguments":{"query":"Heading","lang":"markdown","exact":true}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -2332,7 +2424,7 @@ public class McpServerTests : IDisposable
         InsertIndexedFile("docs/guide.md", "markdown", "# Heading\n\nSee also `Run`.\n");
         ForceLegacyExactFallbackMode();
         DropGraphExactFallbackIndexes();
-        var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+        using var readOnlyServer = new McpServer(new Uri(_dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
 
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"analyze_symbol","arguments":{"query":"Run","path":"docs/","exact":true}}}""")!;
         var response = readOnlyServer.HandleMessage(request)!;
@@ -2518,7 +2610,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateSqlGraphContractFixtureDb(projectRoot);
             DowngradeSqlGraphContractRows(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var definitionRequest = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"definition","arguments":{"query":"fn_Target","lang":"sql","exact":true}}}""")!;
             var definitionResponse = server.HandleMessage(definitionRequest)!;
@@ -2554,7 +2646,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateSqlGraphContractFixtureDb(projectRoot);
             DowngradeSqlGraphContractRows(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"impact_analysis","arguments":{"query":"fn_Target","lang":"sql"}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -2580,7 +2672,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateMixedSqlGraphContractFixtureDb(projectRoot);
             DowngradeSqlGraphContractRows(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"analyze_symbol","arguments":{"query":"N","exact":true}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -2605,7 +2697,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateSqlGraphContractZeroResultFixtureDb(projectRoot);
             DowngradeSqlGraphContractVersion(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deps","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -2631,7 +2723,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateSqlGraphContractZeroResultFixtureDb(projectRoot);
             DowngradeSqlGraphContractVersion(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"symbol_hotspots","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -2657,7 +2749,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateSqlGraphContractZeroResultFixtureDb(projectRoot);
             DowngradeSqlGraphContractVersion(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"unused_symbols","arguments":{"kind":"interface"}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -2684,7 +2776,7 @@ public class McpServerTests : IDisposable
         {
             var dbPath = CreateSqlGraphContractZeroResultFixtureDb(projectRoot);
             DowngradeSqlGraphContractVersion(dbPath);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"symbol_hotspots","arguments":{"kind":"class"}}}""")!;
             var response = server.HandleMessage(request)!;
@@ -2727,7 +2819,7 @@ public class McpServerTests : IDisposable
         var dbPath = CreateLegacyDbWithoutIndexedAt();
         try
         {
-            var readOnlyServer = new McpServer(new Uri(dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+            using var readOnlyServer = new McpServer(new Uri(dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"files","arguments":{"query":"nonexistent_xyz_123"}}}""")!;
             var response = readOnlyServer.HandleMessage(request)!;
             using var document = JsonDocument.Parse(response.ToJsonString());
@@ -2758,7 +2850,7 @@ public class McpServerTests : IDisposable
             using (var db = new DbContext(dbPath))
             {
                 db.InitializeSchema();
-                var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+                using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
                 var request = JsonNode.Parse($$$"""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"{{{toolName}}}","arguments":{{{argsJson}}}}}""")!;
                 var response = server.HandleMessage(request)!;
@@ -3245,7 +3337,7 @@ public class McpServerTests : IDisposable
                 writer.MarkGraphReady();
             }
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -3316,7 +3408,7 @@ public class McpServerTests : IDisposable
                 cmd.ExecuteNonQuery();
             }
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -3366,7 +3458,7 @@ public class McpServerTests : IDisposable
             var sourcePath = Path.Combine(projectRoot, "src", "app.cs");
             File.WriteAllText(sourcePath, "class App { void Run() {} }\n");
 
-            var readOnlyServer = new McpServer(new Uri(dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
+            using var readOnlyServer = new McpServer(new Uri(dbPath).AbsoluteUri + "?immutable=1", ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
             var response = readOnlyServer.HandleMessage(request)!;
 
@@ -3407,7 +3499,7 @@ public class McpServerTests : IDisposable
 
             File.WriteAllText(Path.Combine(projectRoot, "src", "app.cs"), "class App { void Run() {} }\n");
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -3445,7 +3537,7 @@ public class McpServerTests : IDisposable
 
             File.WriteAllText(Path.Combine(projectRoot, "src", "app.cs"), "class App { void Run() {} }\n");
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: true);
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: true);
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -3489,7 +3581,7 @@ public class McpServerTests : IDisposable
             File.WriteAllText(Path.Combine(projectRoot, "src", "app.cs"), "class App { void Run() {} }\n");
 
             var dbUri = new Uri(dbPath).AbsoluteUri + "?immutable=1";
-            var server = new McpServer(dbUri, ConsoleUi.LoadVersion(), dbPathExplicit: true);
+            using var server = new McpServer(dbUri, ConsoleUi.LoadVersion(), dbPathExplicit: true);
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -3530,7 +3622,7 @@ public class McpServerTests : IDisposable
 
             File.WriteAllText(Path.Combine(projectRoot, "src", "app.cs"), "class App { void Run() {} }\n");
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: true);
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: true);
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -3785,7 +3877,7 @@ public class McpServerTests : IDisposable
             TestProjectHelper.RunGit(fixtureDir, "commit", "-m", "init-b");
             File.SetLastWriteTimeUtc(sourcePathB, DateTime.UtcNow.AddSeconds(2));
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var indexRequest = new JsonObject
             {
                 ["jsonrpc"] = "2.0",
@@ -3833,7 +3925,7 @@ public class McpServerTests : IDisposable
             TestProjectHelper.RunGit(fixtureDir, "commit", "-m", "init");
             var expectedHead = TestProjectHelper.RunGit(fixtureDir, "rev-parse", "HEAD").Trim();
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var indexRequest = new JsonObject
             {
                 ["jsonrpc"] = "2.0",
@@ -3939,7 +4031,7 @@ public class McpServerTests : IDisposable
         try
         {
             File.WriteAllText(Path.Combine(fixtureDir, "app.cs"), "public class App { public void Straße() { } }");
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var firstIndex = new JsonObject
             {
@@ -4024,7 +4116,7 @@ public class McpServerTests : IDisposable
         try
         {
             File.WriteAllText(Path.Combine(fixtureDir, "app.cs"), "public class App { public void Run() { } }");
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var firstIndex = new JsonObject
             {
@@ -4087,7 +4179,7 @@ public class McpServerTests : IDisposable
         try
         {
             File.WriteAllText(Path.Combine(fixtureDir, "app.cs"), "public class App { }");
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var request = new JsonObject
             {
@@ -4154,7 +4246,7 @@ public class McpServerTests : IDisposable
                     }
                 }
                 """);
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var firstIndex = new JsonObject
             {
@@ -4224,7 +4316,7 @@ public class McpServerTests : IDisposable
             File.WriteAllText(Path.Combine(srcDir, "Api.Part1.cs"), "public partial class Api { public void Run() { } }");
             File.WriteAllText(Path.Combine(srcDir, "Api.Part2.cs"), "public partial class Api { public void Run(int value) { } }");
             File.WriteAllText(Path.Combine(srcDir, "Caller.cs"), "public class Caller { public void Call(Api api) { api.Run(); api.Run(1); } }");
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var firstIndex = new JsonObject
             {
@@ -4296,7 +4388,7 @@ public class McpServerTests : IDisposable
             File.WriteAllText(Path.Combine(srcDir, "Api.Part1.cs"), "public partial class Api { public void Run() { } }");
             File.WriteAllText(Path.Combine(srcDir, "Api.Part2.cs"), "public partial class Api { public void Run(int value) { } }");
             File.WriteAllText(Path.Combine(srcDir, "Caller.cs"), "public class Caller { public void Call(Api api) { api.Run(); api.Run(1); } }");
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var firstIndex = new JsonObject
             {
@@ -4385,7 +4477,7 @@ public class McpServerTests : IDisposable
                 writer.MarkGraphReady();
             }
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"symbol_hotspots","arguments":{"lang":"csharp","kind":"function"}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -4438,7 +4530,7 @@ public class McpServerTests : IDisposable
                 writer.SetMeta(DbContext.GetHotspotFamilyMarkerFingerprintMetaKey("csharp"), null);
             }
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"symbol_hotspots","arguments":{"lang":"csharp","kind":"function"}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -4476,7 +4568,7 @@ public class McpServerTests : IDisposable
                 writer.SetMeta(DbContext.GetHotspotFamilyMarkerFingerprintMetaKey("csharp"), null);
             }
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"symbol_hotspots","arguments":{"lang":"csharp","kind":"function"}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -4515,7 +4607,7 @@ public class McpServerTests : IDisposable
             originalMode = File.GetUnixFileMode(unreadableDir);
             File.SetUnixFileMode(unreadableDir, UnixFileMode.None);
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = new JsonObject
             {
                 ["jsonrpc"] = "2.0",
@@ -4555,7 +4647,7 @@ public class McpServerTests : IDisposable
 
         try
         {
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"backfill_fold","arguments":{}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -4576,7 +4668,7 @@ public class McpServerTests : IDisposable
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_backfill_missing_{Guid.NewGuid():N}.db");
         var dbUri = new Uri(dbPath).AbsoluteUri;
-        var server = new McpServer(dbUri, ConsoleUi.LoadVersion());
+        using var server = new McpServer(dbUri, ConsoleUi.LoadVersion());
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"backfill_fold","arguments":{}}}""")!;
         var response = server.HandleMessage(request)!;
 
@@ -4841,7 +4933,7 @@ public class McpServerTests : IDisposable
                 writer.MarkGraphReady();
             }
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"unused_symbols","arguments":{"lang":"csharp"}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -5452,7 +5544,7 @@ public class McpServerTests : IDisposable
                 }]);
             }
 
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
             var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"unused_symbols","arguments":{"lang":"csharp"}}}""")!;
             var response = server.HandleMessage(request)!;
 
@@ -5480,7 +5572,7 @@ public class McpServerTests : IDisposable
         try
         {
             File.WriteAllText(Path.Combine(fixtureDir, "intl.py"), "def Straße():\n    pass\n");
-            var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
             var firstIndex = new JsonObject
             {
@@ -5719,7 +5811,7 @@ public class McpServerTests : IDisposable
     [Fact]
     public void ToolsCall_Search_DbNotFound_ReturnsError()
     {
-        var server = new McpServer("/nonexistent/path/test.db", "0.1.1");
+        using var server = new McpServer("/nonexistent/path/test.db", "0.1.1");
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search","arguments":{"query":"test"}}}""")!;
         var response = server.HandleMessage(request)!;
 
@@ -6120,6 +6212,7 @@ public class McpServerTests : IDisposable
 
     public void Dispose()
     {
+        _server.Dispose();
         _db.Dispose();
         DeleteDbPath();
         TestProjectHelper.DeleteDirectory(_projectRoot);


### PR DESCRIPTION
## Summary

- Fixes #1494: MCP tool calls used to construct a fresh `DbContext` (and reopen the SQLite connection, reapply pragmas, re-register every SQL function, and rerun `TryMigrateForRead`) on every invocation. `McpServer` now opens a single per-session `DbContext` on the first tool call and reuses it for every subsequent call, so short tools like `excerpt`, `status`, and `find_in_file` are dominated by query work instead of connection setup.
- `McpServer` and the `cdidx mcp` entry point are now `IDisposable` so the cached connection is released cleanly on shutdown. The shared context is dropped automatically if the DB file goes missing between calls so a follow-up `cdidx index` can re-open without leaving a stale handle.
- Write tools (`index`, `backfill_fold`) reuse the same shared connection. After `InitializeSchema()` runs on the shared context, the read path skips the redundant `TryMigrateForRead` round trip via `MarkSharedDbMigrated()`.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -c Release` — clean.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~McpServer"` — 235 passed, 0 failed.
- `dotnet run --project tools/CodeIndex.Changelog -- check` — Validated 1 changelog fragment.
- Full `dotnet test CodeIndex.sln -c Release` (run prior to compaction) — 4447 passed, 0 failed.

## Changelog Fragment

- `changelog.d/unreleased/1494.changed.md`

## Follow-up Candidates

- #2119

Fixes #1494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
