### PR TITLE
Cover Dockerfile conditional expansion forms with regression tests

### DIFF
--- a/changelog.d/unreleased/1500.internal.md
+++ b/changelog.d/unreleased/1500.internal.md
@@ -1,0 +1,15 @@
+---
+category: internal
+issues:
+  - 1500
+affected:
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Cover `${VAR:?...}`, `${VAR:+...}`, `${VAR:=...}` Dockerfile expansion forms with regression tests (#1500)** — the `DockerfileReferenceExtractor` braced-variable regex already matched these conditional parameter expansion forms via its existing `(?::?[-+?=][^}]*)?` modifier group, but only the `:-` and colon-less default forms had explicit tests; add explicit regression coverage for the error-if-unset, use-alternate, and assign-default forms so future regex changes cannot silently regress them.
+
+## 日本語
+
+- **`${VAR:?...}` / `${VAR:+...}` / `${VAR:=...}` の Dockerfile 展開形式を回帰テストでカバー (#1500)** — `DockerfileReferenceExtractor` の波括弧変数正規表現は既存の `(?::?[-+?=][^}]*)?` 修飾子グループでこれらの条件付きパラメータ展開を既に処理していましたが、明示的なテストは `:-` および colon 無しのデフォルト形式のみでした。エラー指示・代替値・既定値代入の各形式に明示的な回帰テストを追加し、今後の正規表現変更で無断退行しないようにします。

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2380,6 +2380,54 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileReferences_IndexErrorIfUnsetBracedArgVariables()
+    {
+        const string content = """
+            ARG REQUIRED_VAR
+            RUN echo ${REQUIRED_VAR:?must be set}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "REQUIRED_VAR"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
+    public void Extract_DockerfileReferences_IndexUseAlternateBracedArgVariables()
+    {
+        const string content = """
+            ARG FEATURE_FLAG
+            RUN echo ${FEATURE_FLAG:+--enable}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "FEATURE_FLAG"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
+    public void Extract_DockerfileReferences_IndexAssignDefaultBracedArgVariables()
+    {
+        const string content = """
+            ARG PORT
+            RUN echo ${PORT:=8080}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+        var references = ReferenceExtractor.Extract(1, "dockerfile", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "PORT"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
     public void Extract_DockerfileReferences_IgnoresEscapedUnbracedVariables()
     {
         const string content = """


### PR DESCRIPTION
## Summary

Investigation of #1500 showed that `DockerfileReferenceExtractor.BracedVariableReferenceRegex` **already** handles every conditional parameter expansion form — its existing modifier group `(?::?[-+?=][^}]*)?` matches `${VAR:?…}`, `${VAR:+…}`, `${VAR:=…}`, `${VAR:-…}`, and their colon-less variants. Only the `:-` and `-` (default-value) forms had explicit tests, however, so a future regex change could silently regress the other three forms.

- Add three regression tests in `tests/CodeIndex.Tests/ReferenceExtractorTests.cs` for the `:?` (error-if-unset), `:+` (use-alternate), and `:=` (assign-default) forms.
- No production-code change is required.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~Dockerfile"` — 55 / 55 passed (52 existing + 3 new).
- `dotnet run --project tools/CodeIndex.Changelog -- check` — validated 1 fragment.

## Documentation / changelog

- Added bilingual changelog fragment: `changelog.d/unreleased/1500.internal.md` (category `internal`).
- No user-facing docs change: behavior was already correct; the PR only documents the contract with tests.

## Issues

Fixes #1500

## Follow-up candidates

- #2123 — Dockerfile variable extractor misses nested `${...}` inside conditional expansion defaults (noticed while investigating the regex; out of scope here).
