### PR TITLE
Detect shell calls inside command substitution and backticks (#1499)

### DIFF
--- a/changelog.d/unreleased/1499.fixed.md
+++ b/changelog.d/unreleased/1499.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1499
+affected:
+  - src/CodeIndex/Indexer/References/Languages/ShellReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Shell extractor now follows commands inside `$(...)` and backtick substitutions (#1499)** — `ShellReferenceExtractor` re-scans the raw line for `$(...)` command substitution and `` `...` `` backtick substitution spans (including nested `$(outer $(inner))` forms), so call sites such as `result=$(helper)` and ``output=`helper arg` `` now emit `call`-kind reference edges. `callers helper` and `impact` no longer underreport helpers composed via substitution. Single-quoted look-alikes (`'$(helper)'`) remain ignored.
+
+## 日本語
+
+- **Shell 抽出器が `$(...)` とバッククォート substitution 内のコマンドも追跡 (#1499)** — `ShellReferenceExtractor` は raw 行を再走査して `$(...)` コマンド substitution と `` `...` `` バッククォート substitution（`$(outer $(inner))` の入れ子も含む）の内側を追跡するようになり、`result=$(helper)` や ``output=`helper arg` `` のような呼び出しから `call` 種別の参照エッジを生成します。これにより、substitution 経由で呼ばれる helper が `callers helper` や `impact` で漏れなくなります。シングルクォートで囲まれた見た目だけ似たトークン (`'$(helper)'`) は引き続き無視します。

--- a/src/CodeIndex/Indexer/References/Languages/ShellReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/ShellReferenceExtractor.cs
@@ -82,6 +82,24 @@ internal static class ShellReferenceExtractor
         }
 
         var shellSourceLine = StripComment(originalLine);
+
+        // CommandCallRegex requires a statement-start anchor (line start, `;`, `&&`, etc.),
+        // so calls embedded in `$(...)` command substitution or `` `...` `` backticks are
+        // never matched against `preparedLine` alone. PrepareLine also blanks backtick
+        // spans via StringLiteralRegex. Re-scan the raw line so nested `helper` calls in
+        // `result=$(helper)` or ``output=`helper arg` `` still emit call edges (#1499).
+        EmitSubstitutionCalls(
+            shellSourceLine,
+            0,
+            shellSourceLine.Length,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            callableNames,
+            resolveContainerForCall);
+
         foreach (Match match in SourceReferenceRegex.Matches(shellSourceLine))
         {
             var name = NormalizeSourceTargetToken(match.Groups["name"].Value);
@@ -127,6 +145,247 @@ internal static class ShellReferenceExtractor
                 searchIndex = aliasIndex + aliasName.Length;
             }
         }
+    }
+
+    private static void EmitSubstitutionCalls(
+        string line,
+        int spanStart,
+        int spanEnd,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        HashSet<string>? callableNames,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        if (callableNames == null || callableNames.Count == 0)
+            return;
+        if (spanStart < 0 || spanEnd > line.Length || spanStart >= spanEnd)
+            return;
+
+        var i = spanStart;
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+        while (i < spanEnd)
+        {
+            var ch = line[i];
+
+            if (inSingleQuote)
+            {
+                if (ch == '\'')
+                    inSingleQuote = false;
+                i++;
+                continue;
+            }
+
+            if (ch == '\\' && i + 1 < spanEnd)
+            {
+                i += 2;
+                continue;
+            }
+
+            if (!inDoubleQuote && ch == '\'')
+            {
+                inSingleQuote = true;
+                i++;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inDoubleQuote = !inDoubleQuote;
+                i++;
+                continue;
+            }
+
+            if (ch == '$' && i + 1 < spanEnd && line[i + 1] == '(')
+            {
+                var innerStart = i + 2;
+                var innerEnd = FindSubstitutionParenClose(line, innerStart, spanEnd);
+                if (innerEnd < 0)
+                    return;
+
+                ScanSubstitutionInner(
+                    line,
+                    innerStart,
+                    innerEnd,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    callableNames,
+                    resolveContainerForCall);
+                i = innerEnd + 1;
+                continue;
+            }
+
+            if (!inSingleQuote && ch == '`')
+            {
+                var innerStart = i + 1;
+                var innerEnd = FindBacktickClose(line, innerStart, spanEnd);
+                if (innerEnd < 0)
+                    return;
+
+                ScanSubstitutionInner(
+                    line,
+                    innerStart,
+                    innerEnd,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    callableNames,
+                    resolveContainerForCall);
+                i = innerEnd + 1;
+                continue;
+            }
+
+            i++;
+        }
+    }
+
+    private static void ScanSubstitutionInner(
+        string line,
+        int innerStart,
+        int innerEnd,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        HashSet<string> callableNames,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        if (innerStart >= innerEnd)
+            return;
+
+        // CommandCallRegex anchors against statement-start tokens (`^`, `;`, `&&`, ...).
+        // Prepend `;` so the first identifier inside the substitution is recognized as a
+        // command position even though it is not literally at the start of a line.
+        var inner = line.Substring(innerStart, innerEnd - innerStart);
+        var virtualLine = ";" + inner;
+        foreach (Match match in CommandCallRegex.Matches(virtualLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (!callableNames.Contains(name))
+                continue;
+
+            // -1 to undo the synthetic `;` prefix when mapping back to the real line.
+            var callIndex = innerStart + match.Groups["name"].Index - 1;
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                callIndex,
+                "call",
+                context,
+                lineNumber,
+                resolveContainerForCall(callIndex));
+        }
+
+        EmitSubstitutionCalls(
+            line,
+            innerStart,
+            innerEnd,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            callableNames,
+            resolveContainerForCall);
+    }
+
+    private static int FindSubstitutionParenClose(string line, int start, int spanEnd)
+    {
+        var depth = 1;
+        var i = start;
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+        while (i < spanEnd)
+        {
+            var ch = line[i];
+
+            if (inSingleQuote)
+            {
+                if (ch == '\'')
+                    inSingleQuote = false;
+                i++;
+                continue;
+            }
+
+            if (ch == '\\' && i + 1 < spanEnd)
+            {
+                i += 2;
+                continue;
+            }
+
+            if (!inDoubleQuote && ch == '\'')
+            {
+                inSingleQuote = true;
+                i++;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inDoubleQuote = !inDoubleQuote;
+                i++;
+                continue;
+            }
+
+            if (ch == '$' && i + 1 < spanEnd && line[i + 1] == '(')
+            {
+                depth++;
+                i += 2;
+                continue;
+            }
+
+            if (!inDoubleQuote && ch == '(')
+            {
+                depth++;
+                i++;
+                continue;
+            }
+
+            if (ch == ')')
+            {
+                depth--;
+                if (depth == 0)
+                    return i;
+                i++;
+                continue;
+            }
+
+            i++;
+        }
+
+        return -1;
+    }
+
+    private static int FindBacktickClose(string line, int start, int spanEnd)
+    {
+        var i = start;
+        while (i < spanEnd)
+        {
+            var ch = line[i];
+            if (ch == '\\' && i + 1 < spanEnd)
+            {
+                i += 2;
+                continue;
+            }
+
+            if (ch == '`')
+                return i;
+
+            i++;
+        }
+
+        return -1;
     }
 
     private static string NormalizeSourceTargetToken(string token)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -796,6 +796,116 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Shell_DetectsCallsInsideCommandSubstitution()
+    {
+        const string content = """
+            helper() {
+              echo helper
+            }
+
+            other() {
+              echo other
+            }
+
+            run() {
+              result=$(helper)
+              count=$(helper arg)
+              if [ -n "$(other)" ]; then
+                :
+              fi
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+        var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
+
+        Assert.Equal(3, references.Count(reference => reference.ReferenceKind == "call"));
+        Assert.Equal(2, references.Count(reference =>
+            reference.SymbolName == "helper"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "other"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+    }
+
+    [Fact]
+    public void Extract_Shell_DetectsCallsInsideBackticks()
+    {
+        const string content = """
+            helper() {
+              echo helper
+            }
+
+            run() {
+              output=`helper arg`
+              echo "wrapped `helper`"
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+        var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
+
+        Assert.Equal(2, references.Count(reference => reference.ReferenceKind == "call"));
+        Assert.Equal(2, references.Count(reference =>
+            reference.SymbolName == "helper"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run"));
+    }
+
+    [Fact]
+    public void Extract_Shell_DetectsCallsInsideNestedCommandSubstitution()
+    {
+        const string content = """
+            outer() {
+              echo outer
+            }
+
+            inner() {
+              echo inner
+            }
+
+            run() {
+              result=$(outer $(inner))
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+        var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
+
+        Assert.Equal(2, references.Count(reference => reference.ReferenceKind == "call"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "outer"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "inner"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "run");
+    }
+
+    [Fact]
+    public void Extract_Shell_IgnoresSingleQuotedCommandSubstitutionLookAlikes()
+    {
+        const string content = """
+            helper() {
+              echo helper
+            }
+
+            run() {
+              literal='$(helper)'
+              also='`helper`'
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "shell", content);
+        var references = ReferenceExtractor.Extract(1, "shell", content, symbols);
+
+        Assert.Empty(references.Where(reference => reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_Perl_DetectsCallsAndIgnoresHashComments()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- `ShellReferenceExtractor` now re-scans each line for `$(...)` command substitution and `` `...` `` backtick spans (with nested `$(outer $(inner))` support) and emits `call`-kind reference edges for the helpers used there. Previously these call sites were invisible to `callers` / `impact` because `CommandCallRegex` only matches statement-start contexts in `preparedLine`, and `PrepareLine` blanks backtick spans entirely via `StringLiteralRegex`.
- The new scan runs on the raw line (after `StripComment`), so its call indexes point into the original line. Calls inside single quotes (`'$(helper)'`) remain ignored, and the existing top-level command/alias/source-reference behavior is unchanged.

## Test plan

- [x] `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug` (clean build, 0 warnings)
- [x] `dotnet test ... --filter "FullyQualifiedName~Extract_Shell"` — 11/11 pass (4 new tests covering `$(...)`, backticks, nested, and single-quoted-lookalike negative)
- [x] `dotnet test ... --filter "FullyQualifiedName~ReferenceExtractorTests"` — 1112/1112 pass (no regressions)
- [x] `dotnet test ... --filter "FullyQualifiedName~SymbolExtractor|...~ReferenceExtractor|...~FileIndexer|...~ChunkSplitter"` — 2383/2383 pass
- [x] `dotnet test ... --filter "FullyQualifiedName~Shell|...~Bash|...~Zsh|...~Sh|...~PowerShell"` — 1184/1184 pass (covers all shell-flavor surfaces)
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` — fragment validates

## Follow-up candidates

- *(none filed yet — will be appended if duplicate checks identify any substantive gaps.)*

Fixes #1499.
