### PR TITLE
Fix GitHub submit duplicate creation on retry (#1878)

### DIFF
--- a/changelog.d/unreleased/1878.fixed.md
+++ b/changelog.d/unreleased/1878.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1878
+affected:
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+---
+
+## English
+
+- **`suggest_improvement` no longer creates duplicate upstream issues on retry (#1878)** — `GitHubIssueReporter.TryCreateIssueAsync` now searches the target repository for an existing issue that already carries the suggestion hash before posting a new one, so a previous attempt whose response was lost in transit cannot produce a duplicate GitHub issue on retry.
+
+## 日本語
+
+- **`suggest_improvement` の再試行で重複 GitHub Issue が作成されなくなりました (#1878)** — `GitHubIssueReporter.TryCreateIssueAsync` は新規 POST の前に提案ハッシュを含む既存 Issue を対象リポジトリで検索するようになり、過去の送信試行のレスポンスが消失していた場合でも再試行で重複 Issue が作成されることを防ぎます。

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -43,15 +43,30 @@ internal static class GitHubIssueReporter
 {
     // Static HttpClient singleton — .NET best practice for reuse.
     // 静的 HttpClient シングルトン — .NET の再利用ベストプラクティス。
-    private static readonly HttpClient s_httpClient = new()
+    private static readonly HttpClient s_defaultHttpClient = CreateDefaultHttpClient();
+
+    private static HttpClient CreateDefaultHttpClient()
     {
-        DefaultRequestHeaders =
+        var client = new HttpClient
         {
-            { "User-Agent", "cdidx" },
-            { "Accept", "application/vnd.github+json" },
-            { "X-GitHub-Api-Version", "2022-11-28" },
-        }
-    };
+            DefaultRequestHeaders =
+            {
+                { "User-Agent", "cdidx" },
+                { "Accept", "application/vnd.github+json" },
+                { "X-GitHub-Api-Version", "2022-11-28" },
+            }
+        };
+        return client;
+    }
+
+    // Test seam: when set, replaces the default HttpClient so tests can
+    // mock GitHub responses without hitting the network. Production code
+    // never sets this.
+    // テスト用シーム: テスト時にネットワーク非依存で GitHub レスポンスをモックするため、
+    // デフォルトの HttpClient を差し替える。プロダクションコードからは設定しない。
+    internal static HttpClient? s_httpClientOverride;
+
+    private static HttpClient HttpClient => s_httpClientOverride ?? s_defaultHttpClient;
 
     // Target repository for issue creation / Issue 作成先リポジトリ
     private const string RepoOwner = "widthdom";
@@ -74,6 +89,19 @@ internal static class GitHubIssueReporter
 
         try
         {
+            // Idempotency check: if a previous submission attempt actually
+            // created an issue on GitHub but the response was lost in transit,
+            // the local record still shows SubmittedToGitHub=false. Search
+            // GitHub for an existing issue carrying this suggestion's hash
+            // before posting a new one, so retries do not create duplicates.
+            // 冪等性チェック: 過去の送信試行で GitHub 側に Issue が作成されたが
+            // レスポンスが消失した場合、ローカルレコードでは SubmittedToGitHub=false の
+            // ままになる。再試行で重複 Issue を作らないよう、新規 POST 前に
+            // 当該提案ハッシュを含む既存 Issue を検索する。
+            var existingUrl = await FindExistingIssueByHashAsync(record.Hash, token);
+            if (existingUrl != null)
+                return existingUrl;
+
             return await CreateIssueAsync(record, version, token);
         }
         catch (Exception ex)
@@ -83,6 +111,55 @@ internal static class GitHubIssueReporter
             Console.Error.WriteLine(BuildSubmissionFailureMessage(ex.Message));
             return null;
         }
+    }
+
+    /// <summary>
+    /// Search the target GitHub repository for an existing Issue whose body
+    /// contains the suggestion hash. Returns the html_url of the first match,
+    /// or null if no match is found or the hash looks unsafe to search with.
+    /// On any API failure this returns null — the caller falls through to the
+    /// normal create path so an indexing delay never blocks a legitimate
+    /// first submission.
+    /// 当該提案ハッシュを含む既存 Issue を対象リポジトリから検索する。
+    /// 一致した最初の Issue の html_url を返す。一致なし、またはハッシュが
+    /// 検索に使えない形の場合は null。API 失敗時も null を返し、検索遅延に
+    /// よって新規送信がブロックされないようにする。
+    /// </summary>
+    internal static async Task<string?> FindExistingIssueByHashAsync(string hash, string token)
+    {
+        // Defensive: only search with hex-shaped hashes to avoid accidentally
+        // injecting search operators if the field ever held arbitrary text.
+        // 防御的: 検索演算子の混入を避けるため、16進形式のハッシュのみで検索する。
+        if (string.IsNullOrEmpty(hash) || !IsHexHash(hash))
+            return null;
+
+        var query = Uri.EscapeDataString($"repo:{RepoOwner}/{RepoName} \"{hash}\" in:body");
+        var url = $"{ApiBase}/search/issues?q={query}&per_page=1";
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+        requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await HttpClient.SendAsync(requestMessage);
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        var responseJson = await response.Content.ReadAsStringAsync();
+        var node = JsonNode.Parse(responseJson);
+        var items = node?["items"] as JsonArray;
+        if (items == null || items.Count == 0)
+            return null;
+
+        return items[0]?["html_url"]?.GetValue<string>();
+    }
+
+    private static bool IsHexHash(string value)
+    {
+        foreach (var c in value)
+        {
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')))
+                return false;
+        }
+        return true;
     }
 
     /// <summary>
@@ -171,7 +248,7 @@ internal static class GitHubIssueReporter
         };
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        var response = await s_httpClient.SendAsync(requestMessage);
+        var response = await HttpClient.SendAsync(requestMessage);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -1,4 +1,7 @@
+using System.Net;
+using System.Text;
 using CodeIndex.Cli;
+using CodeIndex.Models;
 
 namespace CodeIndex.Tests;
 
@@ -139,10 +142,200 @@ public class GitHubIssueReporterTests : IDisposable
         Assert.Contains("retry `suggest_improvement`", message);
     }
 
+    // --- Idempotency-on-retry tests / 再試行時の冪等性テスト ---
+
+    [Fact]
+    public async Task TryCreateIssueAsync_FindsExistingIssue_DoesNotCreateDuplicate()
+    {
+        // Simulates the failure mode from #1878: a previous submission attempt
+        // created an issue on GitHub but the response was lost in transit,
+        // leaving SubmittedToGitHub=false locally. On retry, the search-by-hash
+        // idempotency check must find the existing issue and short-circuit so
+        // a duplicate is not created.
+        // #1878 の障害モードを再現: 過去の送信で GitHub 側に Issue が作成された
+        // がレスポンスが消失し、ローカルでは SubmittedToGitHub=false のまま。
+        // 再試行時はハッシュ検索による冪等性チェックが既存 Issue を見つけ、
+        // 重複作成を回避すること。
+        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("""
+                {
+                    "total_count": 1,
+                    "items": [
+                        { "html_url": "https://github.com/widthdom/CodeIndex/issues/9999" }
+                    ]
+                }
+                """),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/9999", url);
+            Assert.Equal(1, handler.RequestCount);
+            Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+            Assert.DoesNotContain(handler.Requests, r => r.Method == HttpMethod.Post);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryCreateIssueAsync_NoExistingIssue_CreatesNew()
+    {
+        // Baseline: search returns no items, so the reporter falls through to
+        // POST /issues. The PR adds the search step before create — verify it
+        // does not break the normal create path.
+        // ベースライン: 検索結果が空なら POST /issues に進む。今回追加した検索
+        // ステップが通常の作成パスを壊さないことを確認する。
+        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("""{ "total_count": 0, "items": [] }"""),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = MakeJsonContent("""{ "html_url": "https://github.com/widthdom/CodeIndex/issues/12345" }"""),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/12345", url);
+            Assert.Equal(2, handler.RequestCount);
+            Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+            Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryCreateIssueAsync_SearchApiFails_StillAttemptsCreate()
+    {
+        // Search-API failure (e.g. 5xx or rate limited) must not block a
+        // legitimate first submission. The create POST proceeds as before.
+        // 検索 API 失敗（5xx, レート制限など）でも正規の新規送信は阻害しない。
+        // 検索失敗時は通常の POST 作成パスに進むこと。
+        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = MakeJsonContent("""{ "message": "service unavailable" }"""),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = MakeJsonContent("""{ "html_url": "https://github.com/widthdom/CodeIndex/issues/777" }"""),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/777", url);
+            Assert.Equal(2, handler.RequestCount);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task FindExistingIssueByHashAsync_NonHexHash_ReturnsNullWithoutCallingApi()
+    {
+        // Defensive: only hex hashes are passed to the search query so that
+        // arbitrary text cannot inject GitHub search operators.
+        // 防御的: GitHub 検索演算子を注入できないよう、16進ハッシュのみで検索。
+        var handler = new RecordingHandler();
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var url = await GitHubIssueReporter.FindExistingIssueByHashAsync("not-a-hex-hash", "ghp_test");
+            Assert.Null(url);
+            Assert.Equal(0, handler.RequestCount);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    private static SuggestionRecord MakeRecordWithKnownHash()
+    {
+        var description = "Idempotency retry regression for #1878";
+        return new SuggestionRecord
+        {
+            Category = "other",
+            Language = null,
+            Description = description,
+            Hash = SuggestionStore.ComputeHash("other", null, description),
+            CreatedAt = new DateTime(2026, 5, 15, 0, 0, 0, DateTimeKind.Utc),
+        };
+    }
+
+    private static StringContent MakeJsonContent(string json) =>
+        new(json, Encoding.UTF8, "application/json");
+
     public void Dispose()
     {
         // Restore original env vars / 元の環境変数をリストア
         Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", _originalCdidxToken);
         Environment.SetEnvironmentVariable("GITHUB_TOKEN", _originalGhToken);
+        // Defensive: never leak the override into other tests.
+        // 防御的: オーバーライドを他テストに残さない。
+        GitHubIssueReporter.s_httpClientOverride = null;
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly List<(Func<HttpRequestMessage, bool> Match, HttpResponseMessage Response)> _responses = new();
+        private readonly List<HttpRequestMessage> _requests = new();
+
+        public IReadOnlyList<HttpRequestMessage> Requests => _requests;
+        public int RequestCount => _requests.Count;
+
+        public void AddResponse(Func<HttpRequestMessage, bool> match, HttpResponseMessage response)
+        {
+            _responses.Add((match, response));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _requests.Add(request);
+            foreach (var entry in _responses)
+            {
+                if (entry.Match(request))
+                    return Task.FromResult(entry.Response);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds an idempotency-on-retry search to `GitHubIssueReporter.TryCreateIssueAsync`: before POSTing a new issue, it queries the target repository for an existing issue whose body already contains the suggestion hash. If a previous attempt actually created an issue on the server but the response was lost in transit, retries now match that existing issue and return its URL instead of creating a duplicate.
- Only hex-shaped hashes are passed to the search query so arbitrary text can never inject GitHub search operators. Search failures (5xx, rate limit, indexing latency) fall through to the normal create path so they never block a legitimate first submission.
- Adds an internal `HttpClient` seam so the regression tests can mock the GitHub API without hitting the network. The seam is `internal`-only and the `Dispose` of the test class resets it.

## Test plan

- [x] `dotnet build src/CodeIndex/CodeIndex.csproj` (single-threaded; see note below)
- [x] `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj` (single-threaded; see note below)
- [x] focused tests: GitHubIssueReporter and Suggestion suites — 41 passed, 0 failed
- [x] full test run — 4448 passed, 3 skipped (perf), 0 failed
- New regression tests cover: idempotency hit (no duplicate POST), idempotency miss (normal create path), search-API failure (still attempts create), and the non-hex hash defensive guard.

Note: In this sandboxed environment, MSBuild parallelism hung while resolving project-reference target frameworks; using -m:1 resolved it. CI should not need that flag.

## Changelog

- `changelog.d/unreleased/1878.fixed.md` (bilingual fragment)

## Follow-ups

- #2134 — persist GitHub submit attempt state on `SuggestionRecord` (last error, attempt count, last attempt)
- #2135 — close the GitHub Search indexing-latency window in the hash-search idempotency guard (label-based backstop)
- #1935 — covers transient vs permanent error classification / retry policy (no new issue needed)
- #1408, #1932 — already track the lock/timeout submission concerns mentioned in #1878 (no new issue needed)

Fixes #1878