### PR TITLE
Drop sync-over-async on git stderr in GitHelper (#1497)

### DIFF
--- a/changelog.d/unreleased/1497.fixed.md
+++ b/changelog.d/unreleased/1497.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1497
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+---
+
+## English
+
+- **`GitHelper` no longer uses sync-over-async on git stderr (#1497)** — `GetChangedFilesFromCommit` and `TryRunGit` previously called `process.StandardError.ReadToEndAsync()` and then `errorTask.GetAwaiter().GetResult()`, which risked thread-pool starvation when the same helpers were reached from MCP request handlers via `WorkspaceMetadataEnricher`. Both call sites now drain stdout and stderr concurrently via `Process.BeginOutputReadLine` / `BeginErrorReadLine`, a purely synchronous pattern that preserves the original deadlock-resistance against full stderr pipe buffers without blocking on a `Task`.
+
+## 日本語
+
+- **`GitHelper` が git の stderr を sync-over-async で読まなくなりました (#1497)** — `GetChangedFilesFromCommit` と `TryRunGit` は `process.StandardError.ReadToEndAsync()` の結果を `GetAwaiter().GetResult()` で待っていたため、`WorkspaceMetadataEnricher` 経由で MCP リクエストハンドラから呼ばれた際にスレッドプール枯渇のリスクがありました。両方の呼び出しを `Process.BeginOutputReadLine` / `BeginErrorReadLine` による純粋な同期パターンに置き換え、`Task` 待ちなしで stderr パイプ満杯時のデッドロック耐性を維持します。

--- a/changelog.d/unreleased/1497.fixed.md
+++ b/changelog.d/unreleased/1497.fixed.md
@@ -4,7 +4,6 @@ issues:
   - 1497
 affected:
   - src/CodeIndex/Cli/GitHelper.cs
-  - tests/CodeIndex.Tests/GitHelperTests.cs
 ---
 
 ## English

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using System.Text.RegularExpressions;
 using CodeIndex.Indexer;
 
@@ -76,17 +77,10 @@ public static class GitHelper
         psi.ArgumentList.Add("--name-only");
         psi.ArgumentList.Add(commitId);
 
-        using var process = Process.Start(psi)
+        var (exitCode, output, error) = RunProcessCapturingOutput(psi)
             ?? throw new InvalidOperationException("Failed to start git process / gitプロセスの起動に失敗");
-        // Read stderr asynchronously to avoid deadlock when stderr buffer fills
-        // before stdout is fully consumed. See: MS docs on Process.StandardOutput.
-        // stderrバッファが満杯になった時のデッドロックを防ぐため非同期で読む。
-        var errorTask = process.StandardError.ReadToEndAsync();
-        var output = process.StandardOutput.ReadToEnd();
-        var error = errorTask.GetAwaiter().GetResult();
-        process.WaitForExit();
 
-        if (process.ExitCode != 0)
+        if (exitCode != 0)
             throw new InvalidOperationException($"git diff-tree failed for commit {commitId}: {error.Trim()}");
 
         return output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
@@ -185,21 +179,44 @@ public static class GitHelper
                 }
             }
 
-            using var process = Process.Start(psi);
-            if (process == null)
+            var result = RunProcessCapturingOutput(psi);
+            if (result == null)
                 return null;
 
-            var errorTask = process.StandardError.ReadToEndAsync();
-            var output = process.StandardOutput.ReadToEnd();
-            var error = errorTask.GetAwaiter().GetResult();
-            process.WaitForExit();
-
-            return process.ExitCode == 0 ? output : null;
+            var (exitCode, output, _) = result.Value;
+            return exitCode == 0 ? output : null;
         }
         catch
         {
             return null;
         }
+    }
+
+    // Drain stdout and stderr concurrently via Process's own event-based reader threads so a
+    // full stderr pipe buffer cannot deadlock a blocking stdout read. Returns null if the
+    // process fails to start; otherwise the caller decides how to interpret the exit code.
+    // stdoutとstderrを同時に汲み出す。Process自前のイベントスレッドを使うことで
+    // stderrパイプ満杯による stdout 読み取りデッドロックを防ぎ、
+    // 非同期APIを GetAwaiter().GetResult() で待つ sync-over-async も避ける。
+    private static (int ExitCode, string Output, string Error)? RunProcessCapturingOutput(ProcessStartInfo psi)
+    {
+        using var process = new Process { StartInfo = psi };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        // Always terminate captured lines with '\n' (not Environment.NewLine) so callers that
+        // split on '\n' see identical output on Windows and POSIX — git writes LF-only to pipes.
+        // キャプチャ行は常に '\n' 区切りにし、Windows/POSIX 双方で git のパイプ出力(LF)と一致させる。
+        process.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.Append(e.Data).Append('\n'); };
+        process.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.Append(e.Data).Append('\n'); };
+
+        if (!process.Start())
+            return null;
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        return (process.ExitCode, stdout.ToString(), stderr.ToString());
     }
 
     private static bool ProbeFileSystemIgnoreCase(string projectRoot)

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -211,48 +211,6 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task GetChangedFilesFromCommit_HandlesLargeOutputWithoutDeadlock()
-    {
-        // Regression for #1497: the helper must read stdout/stderr concurrently so a commit
-        // whose changed-file list exceeds the OS pipe buffer cannot deadlock the process.
-        // Windows anonymous pipes default to ~4 KiB and POSIX pipes to ~64 KiB; we push past
-        // the POSIX threshold with long filenames rather than many files so NTFS file
-        // creation on Windows CI does not balloon the runtime.
-        // #1497 リグレッション: stdout/stderr を同時に汲み出すためデッドロックしない。
-        // POSIX のパイプバッファ(~64KiB)を超えるサイズをファイル数ではなく
-        // 長いファイル名で稼ぐことで、Windows NTFS のファイル作成コストを抑える。
-        var repoDir = CreateGitRepo();
-
-        const int fileCount = 500;
-        var namePadding = new string('x', 130);
-        var expected = new List<string>(fileCount);
-        for (var i = 0; i < fileCount; i++)
-        {
-            // ≈140 chars + newline per filename × 500 ≈ 70 KiB of diff-tree --name-only output,
-            // comfortably above the 64 KiB POSIX pipe buffer.
-            // ≈140文字+改行 × 500 ≈ 70 KiB の出力で 64 KiB の POSIX パイプバッファを超える。
-            var name = $"f_{namePadding}_{i:0000}.txt";
-            File.WriteAllText(Path.Combine(repoDir, name), "x\n");
-            expected.Add(name);
-        }
-        RunGit(repoDir, "add", "-A");
-        RunGit(repoDir, "commit", "-m", "many files");
-
-        var commitId = RunGit(repoDir, "rev-parse", "HEAD").Trim();
-
-        // Cap the call so a regression (deadlocked process) fails loudly instead of hanging
-        // the test runner indefinitely.
-        // リグレッションでデッドロックしてもテストランナーを止めないようタイムアウトする。
-        var task = Task.Run(() => GitHelper.GetChangedFilesFromCommit(repoDir, commitId));
-        var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(30)));
-        Assert.True(completed == task,
-            "GetChangedFilesFromCommit deadlocked on large diff-tree output");
-
-        Assert.Equal(expected.OrderBy(x => x).ToArray(),
-            (await task).OrderBy(x => x).ToArray());
-    }
-
-    [Fact]
     public void TryGetHeadCommit_ReturnsHeadCommitForRepo()
     {
         var repoDir = CreateGitRepo();

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -214,18 +214,24 @@ public class GitHelperTests : IDisposable
     public async Task GetChangedFilesFromCommit_HandlesLargeOutputWithoutDeadlock()
     {
         // Regression for #1497: the helper must read stdout/stderr concurrently so a commit
-        // whose changed-file list exceeds the OS pipe buffer (typically 64 KiB) cannot
-        // deadlock the process. Each filename is long enough that ~2000 files easily push
-        // diff-tree --name-only output past the buffer threshold.
-        // #1497 リグレッション: stdout/stderr を同時に汲み出すため、変更ファイル一覧が
-        // パイプバッファ（通常 64KiB）を超えるコミットでもデッドロックしない。
+        // whose changed-file list exceeds the OS pipe buffer cannot deadlock the process.
+        // Windows anonymous pipes default to ~4 KiB and POSIX pipes to ~64 KiB; we push past
+        // the POSIX threshold with long filenames rather than many files so NTFS file
+        // creation on Windows CI does not balloon the runtime.
+        // #1497 リグレッション: stdout/stderr を同時に汲み出すためデッドロックしない。
+        // POSIX のパイプバッファ(~64KiB)を超えるサイズをファイル数ではなく
+        // 長いファイル名で稼ぐことで、Windows NTFS のファイル作成コストを抑える。
         var repoDir = CreateGitRepo();
 
-        const int fileCount = 2000;
+        const int fileCount = 500;
+        var namePadding = new string('x', 130);
         var expected = new List<string>(fileCount);
         for (var i = 0; i < fileCount; i++)
         {
-            var name = $"file_with_a_reasonably_long_name_to_exceed_pipe_buffer_{i:0000}.txt";
+            // ≈140 chars + newline per filename × 500 ≈ 70 KiB of diff-tree --name-only output,
+            // comfortably above the 64 KiB POSIX pipe buffer.
+            // ≈140文字+改行 × 500 ≈ 70 KiB の出力で 64 KiB の POSIX パイプバッファを超える。
+            var name = $"f_{namePadding}_{i:0000}.txt";
             File.WriteAllText(Path.Combine(repoDir, name), "x\n");
             expected.Add(name);
         }

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -211,6 +211,42 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public async Task GetChangedFilesFromCommit_HandlesLargeOutputWithoutDeadlock()
+    {
+        // Regression for #1497: the helper must read stdout/stderr concurrently so a commit
+        // whose changed-file list exceeds the OS pipe buffer (typically 64 KiB) cannot
+        // deadlock the process. Each filename is long enough that ~2000 files easily push
+        // diff-tree --name-only output past the buffer threshold.
+        // #1497 リグレッション: stdout/stderr を同時に汲み出すため、変更ファイル一覧が
+        // パイプバッファ（通常 64KiB）を超えるコミットでもデッドロックしない。
+        var repoDir = CreateGitRepo();
+
+        const int fileCount = 2000;
+        var expected = new List<string>(fileCount);
+        for (var i = 0; i < fileCount; i++)
+        {
+            var name = $"file_with_a_reasonably_long_name_to_exceed_pipe_buffer_{i:0000}.txt";
+            File.WriteAllText(Path.Combine(repoDir, name), "x\n");
+            expected.Add(name);
+        }
+        RunGit(repoDir, "add", "-A");
+        RunGit(repoDir, "commit", "-m", "many files");
+
+        var commitId = RunGit(repoDir, "rev-parse", "HEAD").Trim();
+
+        // Cap the call so a regression (deadlocked process) fails loudly instead of hanging
+        // the test runner indefinitely.
+        // リグレッションでデッドロックしてもテストランナーを止めないようタイムアウトする。
+        var task = Task.Run(() => GitHelper.GetChangedFilesFromCommit(repoDir, commitId));
+        var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(30)));
+        Assert.True(completed == task,
+            "GetChangedFilesFromCommit deadlocked on large diff-tree output");
+
+        Assert.Equal(expected.OrderBy(x => x).ToArray(),
+            (await task).OrderBy(x => x).ToArray());
+    }
+
+    [Fact]
     public void TryGetHeadCommit_ReturnsHeadCommitForRepo()
     {
         var repoDir = CreateGitRepo();


### PR DESCRIPTION
## Summary

- Replace the sync-over-async stderr read in `GitHelper.GetChangedFilesFromCommit` and `GitHelper.TryRunGit` with a shared `RunProcessCapturingOutput` helper that drains stdout and stderr concurrently via `Process.BeginOutputReadLine` / `BeginErrorReadLine`. The new helper is purely synchronous (no `Task` to `GetAwaiter().GetResult()` on) so it cannot starve the thread pool when reached from MCP request handlers via `WorkspaceMetadataEnricher.Enrich → TryGetHeadCommit → TryRunGit`, and it preserves the original deadlock-resistance against a full stderr pipe buffer.
- Captured stream lines are terminated with `\n` explicitly (not `Environment.NewLine`) so Windows callers see identical output to POSIX, matching git's LF-only pipe writes and the prior `ReadToEnd()` behavior.
- Add bilingual changelog fragment `changelog.d/unreleased/1497.fixed.md` (category `fixed`).

## Notes

The issue's scope is "audit `GitHelper` for the same pattern in other commands" — `TryRunGit` is the other call site and is included. The issue also suggests "make `GetChangedFilesFromCommit` (and any callers in the chain) `async`", but propagating `async` would ripple through `IndexCommandRunner.Run` (sync CLI entry point returning `int`) without an async caller to benefit from it; only `TryRunGit` is reached from MCP, and the pure-sync event-based pattern resolves the thread-pool concern at the source without an API change. If a future MCP path needs `GetChangedFilesFromCommitAsync` we can add it then.

An earlier revision of this PR added a regression test that committed many long-named files to exceed the 64 KiB POSIX pipe buffer. On Windows CI the NTFS file-creation cost (even after Defender exclusions) inflated the Test step well past the macOS/Ubuntu baseline. Dropped the test for now — `GitHelper.RunProcessCapturingOutput` is structurally correct on all platforms (event-based drain is .NET's documented non-blocking pattern), the 17 existing `GitHelperTests` exercise every helper code path end-to-end, and we can revisit with a POSIX-only test if we later need to defend the >64 KiB threshold explicitly.

## Test plan

- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~GitHelperTests"` — 17 passed
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` — 4445 passed, 3 skipped (full suite on the prior revision that included the regression test)
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` — fragment validates

Fixes #1497
