### PR TITLE
Emit CSS #id selector references (#1498)

### DIFF
--- a/changelog.d/unreleased/1498.fixed.md
+++ b/changelog.d/unreleased/1498.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1498
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **CSS reference extractor now emits `#id` selector references (#1498)** — `body #header { ... }` now produces a `reference` edge to `#header`, so `callers` / `impact` follow CSS ID selectors instead of treating defined IDs as unused. Hex color literals such as `#fff` and `#abc123` in property values are still ignored.
+
+## 日本語
+
+- **CSS の参照抽出が `#id` セレクタ参照を発行するようになりました (#1498)** — `body #header { ... }` が `#header` への `reference` エッジを生成するようになり、`callers` / `impact` で CSS の ID セレクタを追跡できます。プロパティ値中の `#fff` や `#abc123` などの hex color リテラルは引き続き無視されます。

--- a/src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
@@ -19,6 +19,13 @@ internal static class CssReferenceExtractor
     private static readonly Regex CssAnimationNameValueRegex = new(@"\banimation-name\s*:\s*(?<value>[^;{}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CssAnimationShorthandValueRegex = new(@"\banimation\s*:\s*(?<value>[^;{}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CssClassSelectorReferenceRegex = new(@"(?<![A-Za-z0-9_-])\.(?<name>[\w-]+)", RegexOptions.Compiled);
+    // First char restricted to letter/`_`/`-` so numeric hex colors like `#336699`
+    // do not match. Letter-only hex colors (`#fff`) are still ambiguous; the
+    // emission site additionally requires a selector-position context to skip them.
+    // 数値開始の hex color (`#336699`) を弾くため最初の文字を letter / `_` / `-` に限定する。
+    // `#fff` のような文字だけの hex color は曖昧なので、呼び出し側でセレクタ位置の
+    // コンテキストをさらに要求して除外する。
+    private static readonly Regex CssIdSelectorReferenceRegex = new(@"(?<![A-Za-z0-9_-])#(?<name>[A-Za-z_-][\w-]*)", RegexOptions.Compiled);
 
     private static readonly ReferencePattern[] CssReferencePatterns =
     [
@@ -308,6 +315,15 @@ internal static class CssReferenceExtractor
         HashSet<string>? definitionNames,
         SymbolRecord? container)
     {
+        // ID selectors (`#name`) are emitted only in selector-position segments
+        // because `#fff` / `#abc123` color literals also match the regex. A
+        // segment is treated as selector position when it terminates at `{`
+        // on the current line (clear selector → block opener) or when the
+        // entire line is a selector-list continuation (trimmed line ends with `,`).
+        // ID セレクタ (`#name`) は `#fff` 等の color literal とパターンが衝突するため、
+        // セレクタ位置のセグメントでのみ参照を発行する。セグメントが本行内で `{` で
+        // 終わる場合、または行末カンマで selector list が継続する場合をセレクタ位置とみなす。
+        var isSelectorContinuationLine = preparedLine.TrimEnd().EndsWith(',');
         var segmentStart = 0;
         while (segmentStart < preparedLine.Length)
         {
@@ -320,10 +336,15 @@ internal static class CssReferenceExtractor
             if (trimmedStart < segmentEnd && preparedLine[trimmedStart] != '@')
             {
                 var selectorSegment = preparedLine[trimmedStart..segmentEnd];
+                var isIdSelectorContext = braceIndex >= 0
+                    || (segmentStart == 0 && isSelectorContinuationLine);
                 foreach (var (partStart, partEnd) in EnumerateCssSelectorListSegments(selectorSegment))
                 {
                     var selectorPart = selectorSegment[partStart..partEnd];
-                    if (!ContainsCssClassSelectorReferenceCandidate(selectorPart))
+                    var hasClassCandidate = ContainsCssClassSelectorReferenceCandidate(selectorPart);
+                    var hasIdCandidate = isIdSelectorContext
+                        && ContainsCssIdSelectorReferenceCandidate(selectorPart);
+                    if (!hasClassCandidate && !hasIdCandidate)
                         continue;
 
                     var selectorPartTrimStart = 0;
@@ -331,22 +352,36 @@ internal static class CssReferenceExtractor
                         selectorPartTrimStart++;
 
                     var selectorPartBody = selectorPart[selectorPartTrimStart..];
-                    foreach (Match match in CssClassSelectorReferenceRegex.Matches(selectorPartBody))
-                    {
-                        var nameGroup = match.Groups["name"];
-                        var name = "." + nameGroup.Value;
-                        if (definitionNames != null && definitionNames.Contains(name))
-                            continue;
 
-                        ReferenceExtractor.AddReference(
+                    if (hasClassCandidate)
+                    {
+                        EmitCssSelectorMatches(
+                            CssClassSelectorReferenceRegex,
+                            selectorPartBody,
+                            ".",
+                            trimmedStart + partStart + selectorPartTrimStart,
+                            context,
+                            lineNumber,
                             references,
                             seen,
                             fileId,
-                            name,
-                            trimmedStart + partStart + selectorPartTrimStart + match.Groups["name"].Index - 1,
-                            "reference",
+                            definitionNames,
+                            container);
+                    }
+
+                    if (hasIdCandidate)
+                    {
+                        EmitCssSelectorMatches(
+                            CssIdSelectorReferenceRegex,
+                            selectorPartBody,
+                            "#",
+                            trimmedStart + partStart + selectorPartTrimStart,
                             context,
                             lineNumber,
+                            references,
+                            seen,
+                            fileId,
+                            definitionNames,
                             container);
                     }
                 }
@@ -356,6 +391,39 @@ internal static class CssReferenceExtractor
                 break;
 
             segmentStart = braceIndex + 1;
+        }
+    }
+
+    private static void EmitCssSelectorMatches(
+        Regex regex,
+        string selectorPartBody,
+        string prefix,
+        int baseColumn,
+        string context,
+        int lineNumber,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        HashSet<string>? definitionNames,
+        SymbolRecord? container)
+    {
+        foreach (Match match in regex.Matches(selectorPartBody))
+        {
+            var nameGroup = match.Groups["name"];
+            var name = prefix + nameGroup.Value;
+            if (definitionNames != null && definitionNames.Contains(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                baseColumn + nameGroup.Index - 1,
+                "reference",
+                context,
+                lineNumber,
+                container);
         }
     }
 
@@ -403,6 +471,12 @@ internal static class CssReferenceExtractor
     }
 
     private static bool ContainsCssClassSelectorReferenceCandidate(string selectorPart)
+        => ContainsCssSelectorReferenceCandidate(selectorPart, '.');
+
+    private static bool ContainsCssIdSelectorReferenceCandidate(string selectorPart)
+        => ContainsCssSelectorReferenceCandidate(selectorPart, '#');
+
+    private static bool ContainsCssSelectorReferenceCandidate(string selectorPart, char prefix)
     {
         var bracketDepth = 0;
         char quote = '\0';
@@ -434,7 +508,7 @@ internal static class CssReferenceExtractor
                 continue;
             }
 
-            if (bracketDepth == 0 && ch == '.')
+            if (bracketDepth == 0 && ch == prefix)
                 return true;
         }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1513,6 +1513,40 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Css_IdSelectors_AreReferenced()
+    {
+        const string content = """
+            #header { color: blue; }
+            body #header { padding: 0; }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+        var references = ReferenceExtractor.Extract(1, "css", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "#header"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
+    public void Extract_Css_HexColorLiterals_DoNotEmitIdReferences()
+    {
+        const string content = """
+            .card {
+                color: #fff;
+                background: #abc123;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+        var references = ReferenceExtractor.Extract(1, "css", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName.StartsWith("#")
+            && reference.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_Terraform_DottedReferences_AreReferenced()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Add `CssIdSelectorReferenceRegex` and emit `reference` edges for `#id` selectors in CSS, so `body #header { ... }` now follows back to the `#header { ... }` definition via `callers` / `impact`.
- Gate ID emission to selector-position segments (segment terminates at `{` on the current line, or the line is a selector-list continuation ending with `,`). This keeps `#fff` / `#abc123` color literals in property values from being misread as IDs.

Fixes #1498.

## Test plan

- [x] `dotnet build CodeIndex.sln -c Release` — succeeds.
- [x] `dotnet test CodeIndex.sln -c Release --no-build` — 4446 pass, 0 fail, 3 skipped.
- [x] New tests:
  - `Extract_Css_IdSelectors_AreReferenced` — `body #header { ... }` emits a `#header` reference.
  - `Extract_Css_HexColorLiterals_DoNotEmitIdReferences` — `color: #fff;` / `background: #abc123;` do not emit `#`-prefixed references.

## Related issues filed

- #2127 — CSS extractor does not emit references for compound selectors (`tag.class`, `tag#id`). Pre-existing limitation noticed while reviewing this change; not in scope here.