### PR TITLE
Normalize Terraform dotted queries for references (#1502)

### DIFF
--- a/changelog.d/unreleased/1502.fixed.md
+++ b/changelog.d/unreleased/1502.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1502
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Terraform dotted queries (`var.X`, `local.Y`, `module.Z`, `data.TYPE.X`) now resolve to references (#1502)** — references emitted by the Terraform extractor are stored under the bare symbol name (e.g. `instances`), so user-facing queries copied straight from HCL such as `cdidx references var.instances` previously returned no results. The query layer now strips Terraform's dotted prefixes before searching, matching the behavior already used for JavaScript CommonJS dotted exports.
+
+## 日本語
+
+- **Terraform のドット付きクエリ（`var.X` / `local.Y` / `module.Z` / `data.TYPE.X`）から参照を引けるようになりました (#1502)** — Terraform 抽出器が出力する参照は bare 名（例: `instances`）で格納されるため、HCL からそのまま貼り付けた `cdidx references var.instances` のようなクエリでは結果が 0 件になっていました。クエリ層で Terraform のドット付き prefix を除去し、JavaScript の CommonJS ドット付きエクスポートと同じ取り扱いに揃えました。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 
@@ -653,7 +654,49 @@ public partial class DbReader
         if (!string.IsNullOrWhiteSpace(lang) && string.Equals(lang, "javascript", StringComparison.OrdinalIgnoreCase))
             return NormalizeJavaScriptSymbolSearchQuery(query);
 
+        // Terraform dotted prefixes (var.X / local.X / module.X / data.TYPE.X) are stored as bare names in
+        // the references and symbols tables. Strip the prefix so queries pasted from HCL still resolve.
+        // Terraform の dotted prefix（var.X / local.X / module.X / data.TYPE.X）は参照/シンボルの bare 名で格納されるため、
+        // HCL からそのまま貼り付けたクエリでも解決できるよう prefix を取り除く。
+        var terraformNormalized = NormalizeTerraformDottedQuery(query, lang);
+        if (terraformNormalized != null)
+            return terraformNormalized;
+
         return NormalizeCSharpVerbatimQuery(query, lang);
+    }
+
+    private static readonly Regex TerraformVarLocalModuleQueryRegex = new(
+        @"^(?:var|local|module)\.(?<name>[A-Za-z_]\w*)(?:\..*)?$",
+        RegexOptions.Compiled);
+
+    private static readonly Regex TerraformDataQueryRegex = new(
+        @"^data\.[A-Za-z_]\w*\.(?<name>[A-Za-z_]\w*)(?:\..*)?$",
+        RegexOptions.Compiled);
+
+    private static string? NormalizeTerraformDottedQuery(string? query, string? lang)
+    {
+        if (!string.IsNullOrWhiteSpace(lang)
+            && !string.Equals(lang, "terraform", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(query))
+            return null;
+
+        var trimmed = query.Trim();
+        if (trimmed.Length == 0)
+            return null;
+
+        var simpleMatch = TerraformVarLocalModuleQueryRegex.Match(trimmed);
+        if (simpleMatch.Success)
+            return simpleMatch.Groups["name"].Value;
+
+        var dataMatch = TerraformDataQueryRegex.Match(trimmed);
+        if (dataMatch.Success)
+            return dataMatch.Groups["name"].Value;
+
+        return null;
     }
 
     private static string? ComputeSwiftBacktickAlias(string? query, string? lang)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -279,6 +279,59 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchReferences_TerraformDottedQueriesResolveToBareNames_Issue1502()
+    {
+        // Issue #1502: references stored by the Terraform extractor use bare symbol names
+        // (e.g. "instances", "regions", "max_size"), but users naturally query the HCL form
+        // (`var.instances`, `local.regions`). Without prefix normalization at the query
+        // layer, `cdidx references var.instances` returned nothing.
+        // Issue #1502: Terraform extractor は bare 名（"instances" 等）で参照を格納するが、
+        // 利用者は HCL 形式（`var.instances` 等）で問い合わせる。クエリ層で prefix を
+        // 取り除かないと、`cdidx references var.instances` が空になる。
+        InsertIndexedFile(
+            "main.tf",
+            "terraform",
+            """
+            variable "instances" {
+              type = map(object({ size = string }))
+            }
+
+            variable "max_size" {
+              type = number
+            }
+
+            locals {
+              regions = ["us-east-1", "us-west-2"]
+              suffix  = "demo"
+            }
+
+            output "ids" {
+              value = var.max_size
+            }
+
+            resource "aws_instance" "fleet" {
+              for_each = var.instances
+              count    = length(local.regions)
+              tags     = local.suffix
+            }
+            """);
+
+        var varInstances = _reader.SearchReferences("var.instances", lang: "terraform", exact: true);
+        Assert.Contains(varInstances, reference => reference.SymbolName == "instances" && reference.Path == "main.tf");
+
+        var localRegions = _reader.SearchReferences("local.regions", lang: "terraform", exact: true);
+        Assert.Contains(localRegions, reference => reference.SymbolName == "regions" && reference.Path == "main.tf");
+
+        var varMaxSize = _reader.SearchReferences("var.max_size", lang: "terraform", exact: true);
+        Assert.Contains(varMaxSize, reference => reference.SymbolName == "max_size" && reference.Path == "main.tf");
+
+        // Lang inference also works when caller omits lang (extension-only path).
+        // lang を省略した場合（拡張子推論のみ）も解決できることを確認する。
+        var inferredLocalSuffix = _reader.SearchReferences("local.suffix", lang: null, exact: true);
+        Assert.Contains(inferredLocalSuffix, reference => reference.SymbolName == "suffix" && reference.Path == "main.tf");
+    }
+
+    [Fact]
     public void SearchSymbols_JavaScriptCommonJsBracketExportQueriesResolveToLeafNames()
     {
         InsertIndexedFile(

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1698,6 +1698,51 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Terraform_VarOrLocal_AsRawObject_IsReferenced_Issue1502()
+    {
+        const string content = """
+            variable "instances" {
+              type = map(object({ size = string }))
+            }
+
+            variable "max_size" {
+              type = number
+            }
+
+            locals {
+              regions = ["us-east-1", "us-west-2"]
+              suffix  = "demo"
+            }
+
+            output "ids" {
+              value = var.max_size
+            }
+
+            resource "aws_instance" "fleet" {
+              for_each = var.instances
+              count    = length(local.regions)
+              tags     = local.suffix
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "terraform", content);
+        var references = ReferenceExtractor.Extract(1, "terraform", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "instances"
+            && reference.ReferenceKind == "reference"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "max_size"
+            && reference.ReferenceKind == "reference"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "regions"
+            && reference.ReferenceKind == "reference"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "suffix"
+            && reference.ReferenceKind == "reference"));
+    }
+
+    [Fact]
     public void Extract_CsharpExpressionBodiedMembers_AttributeToIndividualMember()
     {
         // issue #233: expression-bodied methods and properties must attribute their


### PR DESCRIPTION
## Summary

- Strip Terraform's `var.X`, `local.X`, `module.X`, and `data.TYPE.X` prefixes inside `DbReader.NormalizeSymbolSearchQuery` so dotted HCL-style queries resolve against references and symbols, which the extractor stores under bare names.
- Matches the existing JS CommonJS dotted-export normalization behavior.
- Adds regression coverage at both the extractor and the DbReader query layer.

## Root cause

The Terraform reference extractor emits references with the bare symbol name (e.g. `instances`, `regions`, `max_size`). The CLI/MCP query path passes user input through `NormalizeSymbolSearchQuery`, which had Rust and JavaScript handling but no Terraform handling. A user-facing query such as `references var.instances` matched nothing because the stored reference is keyed on `instances`. This change normalizes the four HCL dotted prefixes to their leaf name before the search runs.

## Validation

- `dotnet test CodeIndex.sln -c Release` — 4468 passed, 3 perf tests skipped, 0 failed.
- New tests added:
  - `tests/CodeIndex.Tests/DbReaderTests.cs::SearchReferences_TerraformDottedQueriesResolveToBareNames_Issue1502` — exercises `var.X`, `local.X`, `var.max_size`, and `local.suffix` with `lang: "terraform"` and `lang: null`.
  - `tests/CodeIndex.Tests/ReferenceExtractorTests.cs::Extract_Terraform_VarOrLocal_AsRawObject_IsReferenced_Issue1502` — fixture pulled from the issue (for_each / count / output value).

## Changelog

- `changelog.d/unreleased/1502.fixed.md` (bilingual `fixed` fragment).

Fixes #1502
