### PR TITLE
Emit CSS @import and SCSS @include references

### DIFF
--- a/changelog.d/unreleased/1501.fixed.md
+++ b/changelog.d/unreleased/1501.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 1501
+affected:
+  - src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **CSS extractor now emits `@import` and SCSS `@include` edges (#1501)** — `@import "..."` / `@import url(...)` now produce `import`-kind reference edges to the imported stylesheet, and SCSS `@include name(args)` produces a `call`-kind edge to the mixin definition, so cross-stylesheet dependencies surface in `references` / `impact` and SCSS mixins no longer appear as zero-usage symbols.
+
+## 日本語
+
+- **CSS extractor が `@import` と SCSS `@include` のエッジを出力するようになりました (#1501)** — `@import "..."` / `@import url(...)` が取り込み先 stylesheet への `import` 種別の参照エッジを生成し、SCSS の `@include name(args)` が mixin 定義への `call` 種別エッジを生成します。これにより `references` / `impact` で stylesheet 間依存が可視化され、SCSS の mixin が未使用シンボル扱いされなくなります。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -3685,7 +3685,7 @@ public static class QueryCommandRunner
     // 宣言型、generic 制約、`throws`、`is`/`as`/`instanceof`、XML-doc `cref` 対象向けに出力する
     // compile-time な `type_reference` エッジを含む。
     private static readonly string[] AllValidReferenceKinds =
-        ["annotation", "attribute", "call", "instantiate", "subscribe", "type_reference"];
+        ["annotation", "attribute", "call", "import", "instantiate", "subscribe", "type_reference"];
     // Reference kinds that `callers` / `callees` can legitimately return. Metadata kinds
     // (`attribute` / `annotation`) and type-position edges (`type_reference`) are structurally
     // not call-graph edges, so those queries are rejected at the CLI / MCP boundary.

--- a/src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
@@ -15,6 +15,10 @@ internal static class CssReferenceExtractor
         @"@extend\s+(?<name>[%.][A-Za-z_][\w-]*)",
         RegexOptions.Compiled);
 
+    private static readonly Regex ScssIncludeReferenceRegex = new(
+        @"@include\s+(?<name>[A-Za-z_][\w-]*)",
+        RegexOptions.Compiled);
+
     private static readonly Regex CssCustomPropertyReferenceRegex = new(@"\bvar\(\s*--(?<name>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CssAnimationNameValueRegex = new(@"\banimation-name\s*:\s*(?<value>[^;{}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex CssAnimationShorthandValueRegex = new(@"\banimation\s*:\s*(?<value>[^;{}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -26,6 +30,10 @@ internal static class CssReferenceExtractor
     // `#fff` のような文字だけの hex color は曖昧なので、呼び出し側でセレクタ位置の
     // コンテキストをさらに要求して除外する。
     private static readonly Regex CssIdSelectorReferenceRegex = new(@"(?<![A-Za-z0-9_-])#(?<name>[A-Za-z_-][\w-]*)", RegexOptions.Compiled);
+    private static readonly Regex CssImportReferenceRegex = new(
+        @"@import\s+(?:url\(\s*)?(?:""(?<name>[^""]+)""|'(?<name>[^']+)'|(?<name>[^\s)""';]+))",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex CssInlineBlockCommentRegex = new(@"/\*.*?\*/", RegexOptions.Compiled);
 
     private static readonly ReferencePattern[] CssReferencePatterns =
     [
@@ -36,6 +44,7 @@ internal static class CssReferenceExtractor
     [
         new(ScssVariableReferenceRegex, "call", SkipVariableDeclarations: true),
         new(ScssExtendReferenceRegex, "call"),
+        new(ScssIncludeReferenceRegex, "call"),
     ];
 
     private static readonly HashSet<string> CssAnimationShorthandIgnoredTokens = new(StringComparer.OrdinalIgnoreCase)
@@ -49,6 +58,7 @@ internal static class CssReferenceExtractor
 
     public static void EmitCss(
         string preparedLine,
+        string originalLine,
         string context,
         int lineNumber,
         List<ReferenceRecord> references,
@@ -97,6 +107,31 @@ internal static class CssReferenceExtractor
             fileId,
             definitionNames,
             container);
+
+        // `@import "theme.css";` paths are stripped by the shared string-literal masker, so the
+        // regex must scan the original (comment-stripped) line. Comment-strip locally to avoid
+        // false positives on `/* @import "fake.css"; */`.
+        // 共有の文字列リテラルマスカーが `@import "theme.css";` のパスを潰すため、@import の
+        // パターンは元行（ブロックコメント除去後）に対して走らせる。`/* @import "fake.css"; */`
+        // のような偽陽性を避けるため、ここでローカルに `/* */` を除去する。
+        var importScanLine = CssInlineBlockCommentRegex.Replace(originalLine, " ");
+        foreach (Match match in CssImportReferenceRegex.Matches(importScanLine))
+        {
+            var nameGroup = match.Groups["name"];
+            if (!nameGroup.Success || nameGroup.Value.Length == 0)
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                nameGroup.Value,
+                nameGroup.Index,
+                "import",
+                context,
+                lineNumber,
+                container);
+        }
     }
 
     public static void EmitScss(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1829,6 +1829,7 @@ public static partial class ReferenceExtractor
             {
                 CssReferenceExtractor.EmitCss(
                     preparedLine,
+                    originalLine,
                     context,
                     lineNumber,
                     references,

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -11178,7 +11178,9 @@ jobs:
             Assert.Equal(CommandExitCodes.NotFound, exitCode);
             Assert.Contains("symbol kind", stderr);
             Assert.Contains("filters by reference kind", stderr);
-            Assert.Contains("call, instantiate, subscribe", stderr);
+            Assert.Contains("call", stderr);
+            Assert.Contains("instantiate", stderr);
+            Assert.Contains("subscribe", stderr);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2783,6 +2783,118 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CSS_ScssIncludeReferences_AreIndexedAsCall()
+    {
+        // issue #1501: SCSS `@include name(args)` is a mixin invocation and must produce a
+        // `call` edge to the mixin definition, otherwise mixins appear as zero-usage symbols
+        // and `callers` / `impact` cannot trace mixin call graphs.
+        // issue #1501: SCSS の `@include name(args)` は mixin 呼び出しであり、定義への `call`
+        // エッジを出さなければ mixin が未使用シンボル扱いになり、`callers` / `impact` でも
+        // mixin の呼び出し関係を辿れない。
+        const string content = """
+            @mixin border-radius($radius) {
+              border-radius: $radius;
+            }
+
+            @mixin reset {
+              margin: 0;
+            }
+
+            .card {
+              @include border-radius(4px);
+              @include reset;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+        var references = ReferenceExtractor.Extract(1, "css", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "border-radius"
+            && reference.ReferenceKind == "call"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "reset"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
+    public void Extract_CSS_AtImportReferences_AreIndexedAsImport()
+    {
+        // issue #1501: stylesheet-level `@import "..."` / `@import url(...)` declarations
+        // express cross-stylesheet dependency edges, so the extractor must emit `import`-kind
+        // edges or `impact` underreports the blast radius of editing a shared theme stylesheet.
+        // issue #1501: stylesheet レベルの `@import "..."` / `@import url(...)` は
+        // 跨ぎ参照のエッジであり、`import` 種別のエッジを出さないと共通テーマ stylesheet を
+        // 編集した際の `impact` が影響範囲を取りこぼす。
+        const string content = """
+            @import "theme.css";
+            @import 'reset.css';
+            @import url("typography.css");
+            @import url('layout.css');
+            @import url(utilities.css);
+            @import "media.css" screen and (min-width: 600px);
+
+            .page {
+              color: black;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+        var references = ReferenceExtractor.Extract(1, "css", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "theme.css"
+            && reference.ReferenceKind == "import"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "reset.css"
+            && reference.ReferenceKind == "import"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "typography.css"
+            && reference.ReferenceKind == "import"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "layout.css"
+            && reference.ReferenceKind == "import"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "utilities.css"
+            && reference.ReferenceKind == "import"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "media.css"
+            && reference.ReferenceKind == "import"));
+    }
+
+    [Fact]
+    public void Extract_CSS_MixedCssAndScssImportAndInclude_EmitBothEdgeKinds()
+    {
+        // issue #1501 mixed-extension fixture: a `.scss` entry point pulls in a `.css`
+        // partial via `@import` and invokes a mixin via `@include`. Both edge kinds must
+        // surface so the graph captures the cross-file dependency *and* the mixin call.
+        // issue #1501 の mixed-extension fixture: `.scss` のエントリポイントが `@import` で
+        // `.css` パーシャルを取り込み、`@include` で mixin を呼び出す。両エッジを同時に
+        // 出力できないとファイル間依存と mixin 呼び出しの片方が欠落する。
+        const string content = """
+            @import "tokens.css";
+
+            @mixin elevated($depth) {
+              box-shadow: 0 $depth 0 rgba(0, 0, 0, 0.1);
+            }
+
+            .card {
+              @include elevated(2px);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+        var references = ReferenceExtractor.Extract(1, "css", content, symbols);
+
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "tokens.css"
+            && reference.ReferenceKind == "import"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "elevated"
+            && reference.ReferenceKind == "call"));
+    }
+
+    [Fact]
     public void Extract_CsharpAllmanBlockBodiedProperty_WithBlockComment_AttributesToProperty()
     {
         // issue #233 fourth review follow-up: a multi-line /* ... */ block comment


### PR DESCRIPTION
## Summary

- Fixes #1501: `CssReferenceExtractor` now emits `import`-kind edges for `@import "..."` / `@import url(...)` (quoted, single-quoted, and unquoted url forms) and `call`-kind edges for SCSS `@include name(args)` mixin invocations, so stylesheet dependencies appear in `references` / `impact` and SCSS mixins stop showing as zero-usage symbols.
- The `@import` regex scans the original line (not the shared `preparedLine`) because the string-literal masker would otherwise blank the imported path; a local `/* ... */` strip avoids false positives on commented-out `@import` lines.
- `import` is added to `QueryCommandRunner.AllValidReferenceKinds` so `references --kind import` works without the "not a known reference kind" hint.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -c Release` — clean.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~Extract_CSS_|FullyQualifiedName~ReferenceExtractorTests"` — 1128 passed, 0 failed.
- `dotnet test CodeIndex.sln -c Release` — 4447 passed, 0 failed (run before the latest rebase onto origin/main; focused suites green after rebase).
- `dotnet run --project tools/CodeIndex.Changelog -- check` — Validated 1 changelog fragment.

## Changelog Fragment

- `changelog.d/unreleased/1501.fixed.md`

## Follow-up

- #2138

Fixes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
