### PR TITLE
Show usage synopses in --rebuild conflict hint (#1506)

### DIFF
--- a/changelog.d/unreleased/1506.fixed.md
+++ b/changelog.d/unreleased/1506.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1506
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **`cdidx index --rebuild` + `--commits`/`--files` conflict error now shows the valid usage synopses (#1506)** — The conflict-detection `Hint:` line on stderr and the JSON `hint` field now enumerate the three mutually-exclusive forms (`cdidx index <projectPath> --rebuild`, `cdidx index <projectPath> --commits <id> [id ...]`, `cdidx index <projectPath> --files <path> [path ...]`), so users no longer have to re-read `--help` to find the correct command after a flag mistake.
+
+## 日本語
+
+- **`cdidx index --rebuild` と `--commits`/`--files` の競合エラーで正しい使い方の synopsis を表示するようになりました (#1506)** — 競合検出時の stderr の `Hint:` 行と JSON の `hint` フィールドが、互いに排他な 3 つの形式 (`cdidx index <projectPath> --rebuild`、`cdidx index <projectPath> --commits <id> [id ...]`、`cdidx index <projectPath> --files <path> [path ...]`) を列挙するようになり、フラグの組み合わせを誤った場合に `--help` を再度確認しなくても正しいコマンドに到達できます。
+</content>
+</invoke>

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -54,16 +54,22 @@ public static class IndexCommandRunner
 
         if (options.Rebuild && isUpdateMode)
         {
+            // Enumerate the three mutually-exclusive usage forms so the conflict error
+            // does not require a second `--help` round-trip to find the correct command.
+            const string rebuildConflictSynopsis =
+                "`cdidx index <projectPath> --rebuild`, "
+                + "`cdidx index <projectPath> --commits <id> [id ...]`, "
+                + "or `cdidx index <projectPath> --files <path> [path ...]`";
             if (options.Json)
                 Console.WriteLine(JsonSerializer.Serialize(new CommandErrorJsonResult(
                     "error",
                     "--rebuild cannot be used with --commits or --files (rebuild requires a full rescan)",
-                    "Drop `--rebuild` for partial updates, or rerun `cdidx index <projectPath> --rebuild` for a full rescan."),
+                    "Use one of: " + rebuildConflictSynopsis + "."),
                     jsonContext.CommandErrorJsonResult));
             else
             {
                 Console.Error.WriteLine("Error: --rebuild cannot be used with --commits or --files (rebuild requires a full rescan)");
-                Console.Error.WriteLine("Hint: drop `--rebuild` for `--commits`/`--files`, or rerun `cdidx index <projectPath> --rebuild` for a full rescan.");
+                Console.Error.WriteLine("Hint: use one of: " + rebuildConflictSynopsis + ".");
             }
             return CommandExitCodes.UsageError;
         }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -85,8 +85,10 @@ public class IndexCommandRunnerTests
 
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
             Assert.Contains("--rebuild cannot be used with --commits or --files", stderr);
-            Assert.Contains("drop `--rebuild`", stderr);
-            Assert.Contains("cdidx index <projectPath> --rebuild", stderr);
+            Assert.Contains("Hint: use one of:", stderr);
+            Assert.Contains("`cdidx index <projectPath> --rebuild`", stderr);
+            Assert.Contains("`cdidx index <projectPath> --commits <id> [id ...]`", stderr);
+            Assert.Contains("`cdidx index <projectPath> --files <path> [path ...]`", stderr);
         }
         finally
         {
@@ -105,7 +107,12 @@ public class IndexCommandRunnerTests
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
             Assert.Equal("error", json.GetProperty("status").GetString());
             Assert.Contains("--rebuild cannot be used with --commits or --files", json.GetProperty("message").GetString());
-            Assert.Contains("cdidx index <projectPath> --rebuild", json.GetProperty("hint").GetString());
+            var hint = json.GetProperty("hint").GetString();
+            Assert.NotNull(hint);
+            Assert.StartsWith("Use one of:", hint);
+            Assert.Contains("`cdidx index <projectPath> --rebuild`", hint);
+            Assert.Contains("`cdidx index <projectPath> --commits <id> [id ...]`", hint);
+            Assert.Contains("`cdidx index <projectPath> --files <path> [path ...]`", hint);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- `cdidx index --rebuild` combined with `--commits` or `--files` now prints a `Hint:` line (and JSON `hint` field) that enumerates the three mutually-exclusive usage synopses, so users do not have to re-read `--help` to find the correct command after a flag mistake.
- Both stderr and JSON paths share the same synopsis list: `cdidx index <projectPath> --rebuild`, `cdidx index <projectPath> --commits <id> [id ...]`, and `cdidx index <projectPath> --files <path> [path ...]`.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -c Release`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~IndexCommandRunnerTests"` (116 passed)
- `dotnet run --project tools/CodeIndex.Changelog -- check` (11 fragments validated)

## Documentation / Changelog

- `changelog.d/unreleased/1506.fixed.md` (bilingual fragment).
- No other docs reference the hint text being changed.

## Follow-up candidates

- None.

Fixes #1506
