### PR TITLE
Reject whitespace-only CLI queries with a distinct error (#1505)

### DIFF
--- a/changelog.d/unreleased/1505.fixed.md
+++ b/changelog.d/unreleased/1505.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1505
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Whitespace-only CLI queries now fail fast with a distinct error (#1505)** — `cdidx search`, `definition`, `references`, `callers`, `callees`, `find`, `inspect`, and `impact` now emit `Error: <command> query cannot be empty or whitespace-only` when the positional query is present but resolves to an empty or whitespace-only value (e.g. `cdidx search "   "`). The original `requires a query argument` message is still used when the query is genuinely missing, so users can distinguish a forgotten argument from a shell-quoting accident before reaching runtime.
+
+## 日本語
+
+- **空白のみの CLI クエリを明確なエラーで早期に弾くようにしました (#1505)** — `cdidx search` / `definition` / `references` / `callers` / `callees` / `find` / `inspect` / `impact` は、引数自体は渡されているが空文字または空白のみに評価される場合（例: `cdidx search "   "`）に `Error: <command> query cannot be empty or whitespace-only` を出力するようになりました。引数が本当に未指定のケースでは従来通り `requires a query argument` を維持するため、引数の付け忘れとシェルのクォートミスをユーザーが runtime に到達する前に区別できます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -98,6 +98,8 @@ public static class QueryCommandRunner
             Console.Error.WriteLine(exactError);
             return CommandExitCodes.UsageError;
         }
+        if (TryWriteBlankQueryError(options, "search"))
+            return CommandExitCodes.UsageError;
         if (options.Query == null)
         {
             WriteUsageError(
@@ -190,6 +192,8 @@ public static class QueryCommandRunner
                 : "0");
             return CommandExitCodes.Success;
         }
+        if (TryWriteBlankQueryError(options, "definition"))
+            return CommandExitCodes.UsageError;
         if (string.IsNullOrWhiteSpace(options.Query))
         {
             WriteUsageError(
@@ -327,6 +331,8 @@ public static class QueryCommandRunner
             Console.Error.WriteLine(exactError);
             return CommandExitCodes.UsageError;
         }
+        if (TryWriteBlankQueryError(options, "references"))
+            return CommandExitCodes.UsageError;
         if (string.IsNullOrWhiteSpace(options.Query))
         {
             WriteUsageError(
@@ -449,6 +455,8 @@ public static class QueryCommandRunner
             Console.Error.WriteLine(exactError);
             return CommandExitCodes.UsageError;
         }
+        if (TryWriteBlankQueryError(options, "callers"))
+            return CommandExitCodes.UsageError;
         if (string.IsNullOrWhiteSpace(options.Query))
         {
             WriteUsageError(
@@ -571,6 +579,8 @@ public static class QueryCommandRunner
             Console.Error.WriteLine(exactError);
             return CommandExitCodes.UsageError;
         }
+        if (TryWriteBlankQueryError(options, "callees"))
+            return CommandExitCodes.UsageError;
         if (string.IsNullOrWhiteSpace(options.Query))
         {
             WriteUsageError(
@@ -1043,6 +1053,13 @@ public static class QueryCommandRunner
             Console.Error.WriteLine(FindUsage);
             return CommandExitCodes.UsageError;
         }
+        if (options.Query is not null && string.IsNullOrWhiteSpace(options.Query))
+        {
+            Console.Error.WriteLine("Error: find query cannot be empty or whitespace-only");
+            Console.Error.WriteLine("Hint: Pass a non-empty value after `find`; empty or whitespace-only arguments (e.g. `\"\"` or `\"   \"`) are rejected.");
+            Console.Error.WriteLine(FindUsage);
+            return CommandExitCodes.UsageError;
+        }
         if (string.IsNullOrWhiteSpace(options.Query))
         {
             Console.Error.WriteLine("Error: find requires a query argument");
@@ -1334,6 +1351,8 @@ public static class QueryCommandRunner
             Console.Error.WriteLine(exactError);
             return CommandExitCodes.UsageError;
         }
+        if (TryWriteBlankQueryError(options, "inspect"))
+            return CommandExitCodes.UsageError;
         if (string.IsNullOrWhiteSpace(options.Query))
         {
             WriteUsageError(
@@ -1756,6 +1775,8 @@ public static class QueryCommandRunner
         if (TryWriteUnsupportedOptionError("impact", cmdArgs, ["--", "--query", "--db", "--json", "--limit", "--top", "--lang", "--count", "--path", "--exclude-path", "--exclude-tests", "--depth"], options.Query))
             return CommandExitCodes.UsageError;
         if (TryWriteParseError(options, "impact"))
+            return CommandExitCodes.UsageError;
+        if (TryWriteBlankQueryError(options, "impact"))
             return CommandExitCodes.UsageError;
         if (string.IsNullOrWhiteSpace(options.Query))
         {
@@ -3312,6 +3333,25 @@ public static class QueryCommandRunner
         Console.Error.WriteLine($"Error: {message}");
         Console.Error.WriteLine($"Hint: {hint}");
         Console.Error.WriteLine($"Usage: {usage}");
+    }
+
+    // Reject queries that were supplied but resolve to empty / whitespace-only text so the user gets
+    // a distinct error instead of the generic "<cmd> requires a query argument" message that fires
+    // when the positional was actually missing. The null case is left to the existing missing-query
+    // checks in each runner (issue #1505).
+    // 入力されたクエリが空白のみ・空文字に正規化されたケースを「引数未指定」とは区別して
+    // 専用エラーで弾く。null（未指定）は各 runner の既存チェックに委ねる (issue #1505)。
+    private static bool TryWriteBlankQueryError(QueryCommandOptions options, string commandName)
+    {
+        if (options.Query is null)
+            return false;
+        if (!string.IsNullOrWhiteSpace(options.Query))
+            return false;
+        WriteUsageError(
+            $"{commandName} query cannot be empty or whitespace-only",
+            GetUsageLineOrThrow(commandName),
+            $"Pass a non-empty value after `{commandName}`; empty or whitespace-only arguments (e.g. `\"\"` or `\"   \"`) are rejected.");
+        return true;
     }
 
     private static void WriteValidationError(string message, string hint)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -26662,17 +26662,86 @@ jobs:
     }
 
     [Fact]
-    public void RunInspect_BlankQueryReturnsUsageError()
+    public void RunInspect_BlankQueryReturnsDistinctUsageError()
     {
         var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunInspect(
             ["   "],
             _jsonOptions));
 
         Assert.Equal(CommandExitCodes.UsageError, exitCode);
-        Assert.Contains("Error: inspect requires a symbol query argument", stderr);
-        Assert.Contains("Hint: Add the symbol you want to inspect", stderr);
+        Assert.Contains("Error: inspect query cannot be empty or whitespace-only", stderr);
+        Assert.DoesNotContain("inspect requires a symbol query argument", stderr);
+        Assert.Contains("empty or whitespace-only arguments", stderr);
         Assert.Contains($"Usage: {ConsoleUi.GetUsageLine("inspect")}", stderr);
     }
+
+    [Theory]
+    [InlineData("search")]
+    [InlineData("definition")]
+    [InlineData("references")]
+    [InlineData("callers")]
+    [InlineData("callees")]
+    [InlineData("impact")]
+    public void QueryCommands_WhitespaceQueryReturnUsageErrorWithDistinctMessage(string commandName)
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => RunQueryCommand(commandName, ["   "]));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains($"Error: {commandName} query cannot be empty or whitespace-only", stderr);
+        Assert.DoesNotContain($"{commandName} requires a", stderr);
+        Assert.Contains($"Usage: {ConsoleUi.GetUsageLine(commandName)}", stderr);
+    }
+
+    [Theory]
+    [InlineData("search", "search requires a query argument")]
+    [InlineData("definition", "definition requires a symbol query argument")]
+    [InlineData("references", "references requires a symbol query argument")]
+    [InlineData("callers", "callers requires a symbol query argument")]
+    [InlineData("callees", "callees requires a caller query argument")]
+    [InlineData("impact", "impact requires a symbol query argument")]
+    public void QueryCommands_MissingQueryStillReportsRequiresArgument(string commandName, string expectedMessage)
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => RunQueryCommand(commandName, []));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains($"Error: {expectedMessage}", stderr);
+        Assert.DoesNotContain("query cannot be empty or whitespace-only", stderr);
+    }
+
+    [Fact]
+    public void RunFind_WhitespaceQueryReturnsDistinctUsageError()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+            ["   ", "--path", "src/**/*.cs"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: find query cannot be empty or whitespace-only", stderr);
+        Assert.DoesNotContain("find requires a query argument", stderr);
+    }
+
+    [Fact]
+    public void RunFind_MissingQueryStillReportsRequiresArgument()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+            ["--path", "src/**/*.cs"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: find requires a query argument", stderr);
+        Assert.DoesNotContain("query cannot be empty or whitespace-only", stderr);
+    }
+
+    private int RunQueryCommand(string commandName, string[] args) => commandName switch
+    {
+        "search" => QueryCommandRunner.RunSearch(args, _jsonOptions),
+        "definition" => QueryCommandRunner.RunDefinition(args, _jsonOptions),
+        "references" => QueryCommandRunner.RunReferences(args, _jsonOptions),
+        "callers" => QueryCommandRunner.RunCallers(args, _jsonOptions),
+        "callees" => QueryCommandRunner.RunCallees(args, _jsonOptions),
+        "impact" => QueryCommandRunner.RunImpact(args, _jsonOptions),
+        _ => throw new InvalidOperationException($"Unsupported command: {commandName}"),
+    };
 
     [Fact]
     public void RunInspect_BareVerbatimQueryWithExactReturnsUsageError()


### PR DESCRIPTION
## Summary
- Whitespace-only positional queries on `cdidx search`, `definition`, `references`, `callers`, `callees`, `find`, `inspect`, and `impact` now fail fast with a distinct `Error: <command> query cannot be empty or whitespace-only` message instead of the generic `requires a query argument` message that fires when the argument was actually missing.
- The original `requires a query argument` message stays in place for the truly missing case so users can distinguish a forgotten argument from a shell-quoting accident (e.g. `cdidx search "   "`).
- Added a shared `TryWriteBlankQueryError` helper in `QueryCommandRunner.cs` and bilingual changelog fragment `changelog.d/unreleased/1505.fixed.md`.

Fixes #1505

## Follow-ups (out of scope)
- #2144 — `symbols` command does not flow through the new helper; whitespace-only positional still slips past `BuildSymbolQueryList` `IsNullOrEmpty` normalization.
- #2145 — MCP `Missing required parameter: <name>` conflates missing and whitespace-only inputs across ~8 handler sites in `McpToolHandlers.cs`.

## Test plan
- [x] `dotnet build CodeIndex.sln -c Debug`
- [x] `dotnet test CodeIndex.sln -c Debug --filter "FullyQualifiedName~QueryCommandRunner"` (909 passed)
- [x] `dotnet test CodeIndex.sln -c Debug` (full suite: 4476 passed, 3 skipped)
- [x] `dotnet ./tools/CodeIndex.Changelog/bin/Debug/net8.0/CodeIndex.Changelog.dll check`
