### PR TITLE
Reclassify sparse-checkout skip-worktree paths in status --check

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -503,7 +503,7 @@ Languages:
 
 - scans the current indexable files with the same `FileIndexer` path filters and ignore rules used for indexing;
 - recomputes raw-byte SHA256 checksums and compares them with the DB's saved checksums;
-- reports `index_matches_workspace` plus `workspace_check.changed_files`, `missing_files`, `unindexed_files`, `unverifiable_files`, and `scan_errors`;
+- reports `index_matches_workspace` plus `workspace_check.changed_files`, `missing_files`, `outside_sparse_cone_files`, `unindexed_files`, `unverifiable_files`, and `scan_errors`. Indexed paths whose git index entry is flagged skip-worktree (sparse-checkout cone/non-cone, partial clone, or manual `git update-index --skip-worktree`) land in `outside_sparse_cone_files` and do not fail the freshness gate;
 - exits `0` only when the DB exactly matches the current workspace. Stale indexes exit `5`.
 
 Run it at the start of AI-agent work to decide whether `.cdidx/codeindex.db` can be trusted without reindexing.
@@ -1535,7 +1535,7 @@ Languages:
 
 - indexing と同じ `FileIndexer` の path filter / ignore rule で、現在 index 対象になるファイルを走査します。
 - raw bytes の SHA256 を再計算し、DB に保存された checksum と比較します。
-- `index_matches_workspace` と `workspace_check.changed_files`、`missing_files`、`unindexed_files`、`unverifiable_files`、`scan_errors` を返します。
+- `index_matches_workspace` と `workspace_check.changed_files`、`missing_files`、`outside_sparse_cone_files`、`unindexed_files`、`unverifiable_files`、`scan_errors` を返します。git index で skip-worktree ビットが立っているパス (sparse-checkout cone/non-cone、partial clone、`git update-index --skip-worktree`) は `outside_sparse_cone_files` に分類され、freshness の判定を失敗させません。
 - DB が現在の workspace と完全一致するときだけ終了コード `0`、stale な index では終了コード `5` です。
 
 AI agent の作業開始時はこれを先に実行し、`.cdidx/codeindex.db` を再構築せず信頼できるか判断してください。

--- a/changelog.d/unreleased/1510.fixed.md
+++ b/changelog.d/unreleased/1510.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 1510
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - src/CodeIndex/Cli/IndexFreshnessChecker.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Models/QueryResults.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`cdidx status --check` no longer reports sparse-checkout-absent files as "missing" (#1510)** — Indexed paths whose git index entry has the skip-worktree bit set (sparse-checkout cone or non-cone, partial clone, or manual `git update-index --skip-worktree`) are now counted under a separate `outside_sparse_cone_file_count` / `outside_sparse_cone_files` bucket and surfaced in the human output as `Outside sparse cone : N`. They no longer fail the freshness gate or push the index toward an unnecessary rebuild, so sparse-checkout monorepos can rely on `--check` for stale-detection again.
+
+## 日本語
+
+- **`cdidx status --check` が sparse-checkout で worktree に展開されていないファイルを "missing" として報告しなくなりました (#1510)** — git index 上で skip-worktree ビットが立っているインデックス対象パス (sparse-checkout cone/non-cone、partial clone、`git update-index --skip-worktree` の手動指定) は、新設の `outside_sparse_cone_file_count` / `outside_sparse_cone_files` に分類され、人間向け出力には `Outside sparse cone : N` 行として表示されます。これらは freshness チェックを失敗させず、不要な再 index への誘導も発生しないため、sparse-checkout を使う巨大 monorepo でも `--check` を stale 検出として再び信頼できます。

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -136,6 +136,48 @@ public static class GitHelper
         return output == null ? null : output.Length > 0;
     }
 
+    /// <summary>
+    /// Return the set of tracked paths whose skip-worktree bit is set, scoped to
+    /// the directory the call was made from. Paths are forward-slash separated and
+    /// relative to <paramref name="projectRoot"/>, matching DB / scan-result path form.
+    /// Returns null when git is unavailable; returns an empty set when no entry is
+    /// flagged. Skip-worktree is the mechanism git uses for sparse-checkout (cone or
+    /// non-cone), partial clones, and manual <c>git update-index --skip-worktree</c>.
+    /// projectRoot 配下の git index で skip-worktree ビットを持つトラッキング対象パスを返す。
+    /// 区切り文字は forward slash、projectRoot からの相対表現で DB と揃える。
+    /// git が無い場合は null、該当無しは空集合を返す。sparse-checkout(cone/non-cone)・partial
+    /// clone・手動 update-index --skip-worktree がいずれも同じビットを使うのを横断的に拾う。
+    /// </summary>
+    public static HashSet<string>? TryGetSkipWorktreePaths(string projectRoot)
+        => TryGetSkipWorktreePaths(projectRoot, gitEnvironmentOverrides: null);
+
+    internal static HashSet<string>? TryGetSkipWorktreePaths(
+        string projectRoot,
+        IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides)
+    {
+        var output = TryRunGit(
+            projectRoot,
+            gitEnvironmentOverrides,
+            "-c",
+            "core.quotePath=false",
+            "ls-files",
+            "-t");
+        if (output == null)
+            return null;
+
+        var paths = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var rawLine in output.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            // Format: "<flag> <path>". 'S' (uppercase) marks skip-worktree.
+            // 形式: "<flag> <path>"。'S'(大文字) が skip-worktree を表す。
+            if (line.Length < 3 || line[1] != ' ' || line[0] != 'S')
+                continue;
+            paths.Add(FileIndexer.NormalizePathSeparators(line[2..]));
+        }
+        return paths;
+    }
+
     internal static string? TryGetRepositoryRoot(string projectPath, IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides)
     {
         var cdup = TryRunGit(projectPath, gitEnvironmentOverrides, "rev-parse", "--show-cdup");

--- a/src/CodeIndex/Cli/IndexFreshnessChecker.cs
+++ b/src/CodeIndex/Cli/IndexFreshnessChecker.cs
@@ -83,10 +83,33 @@ internal static class IndexFreshnessChecker
             result.MatchedFileCount++;
         }
 
-        foreach (var path in indexed.Keys.Except(workspace.Keys, StringComparer.Ordinal).OrderBy(path => path, StringComparer.Ordinal))
+        var missingCandidates = indexed.Keys
+            .Except(workspace.Keys, StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+
+        // Skip-worktree paths are intentionally absent from disk (sparse-checkout cone/non-cone,
+        // partial clone, or manual update-index --skip-worktree). Reclassify them so the freshness
+        // gate stops flagging them as "missing" and rebuilds.
+        // skip-worktree のパスは意図的に worktree から外されている(sparse-checkout cone/non-cone、
+        // partial clone、手動の update-index --skip-worktree)。これらを "missing" から切り分け、
+        // 不要な rebuild トリガーを止める。
+        HashSet<string>? skipWorktreePaths = null;
+        if (missingCandidates.Count > 0)
+            skipWorktreePaths = GitHelper.TryGetSkipWorktreePaths(projectRoot);
+
+        foreach (var path in missingCandidates)
         {
-            result.MissingFileCount++;
-            AddSample(result.MissingFiles, path);
+            if (skipWorktreePaths != null && skipWorktreePaths.Contains(path))
+            {
+                result.OutsideSparseConeFileCount++;
+                AddSample(result.OutsideSparseConeFiles, path);
+            }
+            else
+            {
+                result.MissingFileCount++;
+                AddSample(result.MissingFiles, path);
+            }
         }
 
         result.Checked = result.ScanErrorCount == 0;

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -3587,6 +3587,8 @@ public static class QueryCommandRunner
             Console.WriteLine($"  Changed indexed files : {check.ChangedFileCount:N0}{FormatSamples(check.ChangedFiles)}");
         if (check.MissingFileCount > 0)
             Console.WriteLine($"  Missing indexed files : {check.MissingFileCount:N0}{FormatSamples(check.MissingFiles)}");
+        if (check.OutsideSparseConeFileCount > 0)
+            Console.WriteLine($"  Outside sparse cone : {check.OutsideSparseConeFileCount:N0}{FormatSamples(check.OutsideSparseConeFiles)}");
         if (check.UnindexedFileCount > 0)
             Console.WriteLine($"  Unindexed workspace files : {check.UnindexedFileCount:N0}{FormatSamples(check.UnindexedFiles)}");
         if (check.UnverifiableFileCount > 0)

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -97,11 +97,13 @@ public class IndexFreshnessCheckResult
     public int MatchedFileCount { get; set; }
     public int ChangedFileCount { get; set; }
     public int MissingFileCount { get; set; }
+    public int OutsideSparseConeFileCount { get; set; }
     public int UnindexedFileCount { get; set; }
     public int UnverifiableFileCount { get; set; }
     public int ScanErrorCount { get; set; }
     public List<string> ChangedFiles { get; set; } = [];
     public List<string> MissingFiles { get; set; } = [];
+    public List<string> OutsideSparseConeFiles { get; set; } = [];
     public List<string> UnindexedFiles { get; set; } = [];
     public List<string> UnverifiableFiles { get; set; } = [];
     public List<string> ScanErrors { get; set; } = [];

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -27925,6 +27925,137 @@ jobs:
     }
 
     [Fact]
+    public void RunStatus_CheckJson_ReclassifiesSkipWorktreePathsAsOutsideSparseCone()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_status_check_sparse_cone");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            var insidePath = Path.Combine(projectRoot, "src", "inside.cs");
+            var outsidePath = Path.Combine(projectRoot, "src", "outside.cs");
+            File.WriteAllText(insidePath, "class Inside {}\n");
+            File.WriteAllText(outsidePath, "class Outside {}\n");
+            TestProjectHelper.RunGit(projectRoot, "add", "src/inside.cs", "src/outside.cs");
+            TestProjectHelper.RunGit(projectRoot, "commit", "-m", "initial");
+
+            // Flag src/outside.cs skip-worktree and remove it from disk to mimic a sparse-checkout
+            // working tree. The freshness checker must classify it as "outside sparse cone",
+            // not as a true "missing" file.
+            // src/outside.cs に skip-worktree を立て disk からも消し sparse-checkout を再現する。
+            // freshness checker は "outside sparse cone" として分類し "missing" を立ててはいけない。
+            TestProjectHelper.RunGit(projectRoot, "update-index", "--skip-worktree", "src/outside.cs");
+            File.Delete(outsidePath);
+
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/inside.cs", "csharp", "class Inside {}\n");
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/outside.cs", "csharp", "class Outside {}\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath, "--check", "--json"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var check = document.RootElement.GetProperty("workspace_check");
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.True(document.RootElement.GetProperty("index_matches_workspace").GetBoolean());
+            Assert.Equal(0, check.GetProperty("missing_file_count").GetInt32());
+            Assert.Equal(1, check.GetProperty("outside_sparse_cone_file_count").GetInt32());
+            Assert.Equal("src/outside.cs", check.GetProperty("outside_sparse_cone_files")[0].GetString());
+            Assert.Equal("matched", check.GetProperty("reason").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunStatus_CheckJson_KeepsTrulyMissingFilesSeparateFromSparseCone()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_status_check_sparse_mix");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            var keptPath = Path.Combine(projectRoot, "src", "kept.cs");
+            var sparsePath = Path.Combine(projectRoot, "src", "sparse.cs");
+            File.WriteAllText(keptPath, "class Kept {}\n");
+            File.WriteAllText(sparsePath, "class Sparse {}\n");
+            TestProjectHelper.RunGit(projectRoot, "add", "src/kept.cs", "src/sparse.cs");
+            TestProjectHelper.RunGit(projectRoot, "commit", "-m", "initial");
+
+            // src/sparse.cs is skip-worktree → outside cone. src/deleted.cs is indexed only,
+            // never tracked by git → must remain a real "missing" entry.
+            // src/sparse.cs は skip-worktree → cone 外。src/deleted.cs は DB のみで git 追跡無し
+            // → 本当の "missing" として残らなければならない。
+            TestProjectHelper.RunGit(projectRoot, "update-index", "--skip-worktree", "src/sparse.cs");
+            File.Delete(sparsePath);
+
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/kept.cs", "csharp", "class Kept {}\n");
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/sparse.cs", "csharp", "class Sparse {}\n");
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/deleted.cs", "csharp", "class Deleted {}\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath, "--check", "--json"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var check = document.RootElement.GetProperty("workspace_check");
+
+            Assert.Equal(CommandExitCodes.StaleIndex, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.False(document.RootElement.GetProperty("index_matches_workspace").GetBoolean());
+            Assert.Equal(1, check.GetProperty("missing_file_count").GetInt32());
+            Assert.Equal("src/deleted.cs", check.GetProperty("missing_files")[0].GetString());
+            Assert.Equal(1, check.GetProperty("outside_sparse_cone_file_count").GetInt32());
+            Assert.Equal("src/sparse.cs", check.GetProperty("outside_sparse_cone_files")[0].GetString());
+            Assert.Equal("missing_indexed_files", check.GetProperty("reason").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunStatus_CheckHuman_PrintsOutsideSparseConeRow()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_status_check_sparse_human");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            var sparsePath = Path.Combine(projectRoot, "src", "sparse.cs");
+            File.WriteAllText(sparsePath, "class Sparse {}\n");
+            TestProjectHelper.RunGit(projectRoot, "add", "src/sparse.cs");
+            TestProjectHelper.RunGit(projectRoot, "commit", "-m", "initial");
+            TestProjectHelper.RunGit(projectRoot, "update-index", "--skip-worktree", "src/sparse.cs");
+            File.Delete(sparsePath);
+
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/sparse.cs", "csharp", "class Sparse {}\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath, "--check"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Contains("Outside sparse cone : 1", stdout);
+            Assert.Contains("src/sparse.cs", stdout);
+            Assert.DoesNotContain("Missing indexed files", stdout);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunStatus_CheckJson_UsesRepositoryRootIgnoreRulesForSubdirectoryIndex()
     {
         var repoRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_status_check_parent_ignore");


### PR DESCRIPTION
## Summary

- `cdidx status --check` previously flagged every indexed file absent from disk as `missing`, producing false positives in sparse-checkout monorepos.
- `GitHelper.TryGetSkipWorktreePaths` now reads `git ls-files -t` (only when there are missing candidates) and collects entries flagged `S` (the skip-worktree bit used by sparse-checkout cone/non-cone, partial clones, and manual `git update-index --skip-worktree`).
- `IndexFreshnessChecker` partitions missing candidates against that set, routing matching paths into a new `outside_sparse_cone_files` bucket. Those paths are excluded from the freshness gate, so the check no longer trips on sparse-excluded files.
- CLI surfaces the bucket as `Outside sparse cone : N`; JSON gains `outside_sparse_cone_file_count` / `outside_sparse_cone_files`.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SparseCone"` — 3/3
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunStatus"` — 26/26
- `dotnet run --project tools/CodeIndex.Changelog -- check`

## Documentation

- `USER_GUIDE.md` (English + 日本語) — adds `outside_sparse_cone_files` to the documented `status --check` contract.
- `changelog.d/unreleased/1510.fixed.md` (bilingual fragment).

## Test plan

- [x] New unit tests cover isolated reclassification, mixed missing + sparse, and human-readable output rows.
- [x] Existing `RunStatus` / `CheckJson` tests still pass.

Fixes #1510
