### PR TITLE
Make SetReadyBit atomic across writers (#1513)

### DIFF
--- a/changelog.d/unreleased/1513.fixed.md
+++ b/changelog.d/unreleased/1513.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1513
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/ConcurrencyTests.cs
+---
+
+## English
+
+- **Ready-bit stamping no longer drops a flag under concurrent cdidx writers (#1513)** — `SetReadyBit` now wraps its `PRAGMA user_version` read-modify-write in `BEGIN IMMEDIATE` so SQLite serialises it across processes. Previously two parallel `cdidx` runs (e.g. CI plus a local rebuild) could each read the same prior value, OR in their own flag, and the second writer's PRAGMA write would clobber the first writer's flag — leaving `fold_ready` / `graph_table_available` / `issues_table_available` reporting `false` even though both runs had completed successfully.
+
+## 日本語
+
+- **並列 cdidx writer 下でも ready-bit が消えなくなりました (#1513)** — `SetReadyBit` は `PRAGMA user_version` の read-modify-write を `BEGIN IMMEDIATE` で囲うようになり、SQLite がプロセス間で直列化します。これまでは 2 つの `cdidx` 実行 (例: CI とローカルの rebuild) が同じ prior 値を読み、それぞれ自分の flag を OR してから書き戻していたため、後勝ちで一方の flag が落ち、両方の実行が成功しているにもかかわらず `fold_ready` / `graph_table_available` / `issues_table_available` が `false` のままになることがありました。

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -2027,11 +2027,40 @@ public class DbWriter
 
     private void SetReadyBit(int flag)
     {
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = "PRAGMA user_version";
-        var raw = cmd.ExecuteScalar();
-        int current = raw is long l ? (int)l : (raw is int i ? i : 0);
-        Execute($"PRAGMA user_version = {current | flag}");
+        // The ready bits share a single PRAGMA user_version word, so two parallel
+        // cdidx writers (e.g. CI + a local rebuild) can each read the same prior
+        // value, OR in their own flag, and the slower writer's PRAGMA write clobbers
+        // the faster writer's flag. Wrap the read-modify-write in BEGIN IMMEDIATE so
+        // SQLite's reserved write lock serialises it across processes (issue #1513).
+        bool ownTransaction = !IsInTransaction();
+        if (ownTransaction)
+            Execute("BEGIN IMMEDIATE");
+        try
+        {
+            int current;
+            using (var read = _conn.CreateCommand())
+            {
+                read.CommandText = "PRAGMA user_version";
+                var raw = read.ExecuteScalar();
+                current = raw is long l ? (int)l : (raw is int i ? i : 0);
+            }
+            int next = current | flag;
+            if (next != current)
+                Execute($"PRAGMA user_version = {next}");
+            if (ownTransaction)
+            {
+                Execute("COMMIT");
+                ownTransaction = false;
+            }
+        }
+        catch
+        {
+            if (ownTransaction)
+            {
+                try { Execute("ROLLBACK"); } catch { /* best effort */ }
+            }
+            throw;
+        }
     }
 
     private static List<string> BuildSupportedLanguageParameters(SqliteCommand cmd, IReadOnlyCollection<string> supportedLanguages)

--- a/tests/CodeIndex.Tests/ConcurrencyTests.cs
+++ b/tests/CodeIndex.Tests/ConcurrencyTests.cs
@@ -463,6 +463,63 @@ public class ConcurrencyTests : IDisposable
             $"Sample: {string.Join(", ", violations.Take(3).Select(v => $"{v.kind}: scoped={v.scoped:o} workspace={v.workspace:o} hasEntrypoint={v.hasEntrypoint}"))}");
     }
 
+    [Fact]
+    public async Task SetReadyBit_ConcurrentWriters_DoNotLoseFlags()
+    {
+        // Issue #1513 regression: SetReadyBit's PRAGMA user_version read-modify-write
+        // must serialise across writers. Without an immediate write lock, two parallel
+        // cdidx processes can each read the same prior value, OR in their own flag,
+        // and the slower writer's PRAGMA write clobbers the faster writer's flag.
+        // The fix wraps the read+write in BEGIN IMMEDIATE; this test races MarkGraphReady
+        // against MarkIssuesReady from two separate connections across many iterations
+        // so a regression to non-atomic behaviour drops at least one flag with high probability.
+        // Issue #1513 回帰テスト: SetReadyBit の PRAGMA user_version read-modify-write が
+        // 書き込みプロセス間で直列化されることを検証する。BEGIN IMMEDIATE が無いと
+        // 2 つの並列 writer が同じ prior 値を読み、それぞれの flag を OR して書き戻す際に
+        // 後勝ちで一方の flag が消える。多くの反復で MarkGraphReady と MarkIssuesReady を
+        // 競合させ、回帰時にどちらかの flag が落ちる確率を高める。
+        const int iterations = 50;
+        var lostFlagIterations = new List<(int iteration, int finalUserVersion)>();
+        for (int i = 0; i < iterations; i++)
+        {
+            using (var resetCmd = _db.Connection.CreateCommand())
+            {
+                resetCmd.CommandText = "PRAGMA user_version = 0";
+                resetCmd.ExecuteNonQuery();
+            }
+
+            using var start = new ManualResetEventSlim(false);
+            var graphTask = Task.Run(() =>
+            {
+                using var graphDb = new DbContext(_dbPath);
+                var w = new DbWriter(graphDb.Connection);
+                start.Wait();
+                w.MarkGraphReady();
+            });
+            var issuesTask = Task.Run(() =>
+            {
+                using var issuesDb = new DbContext(_dbPath);
+                var w = new DbWriter(issuesDb.Connection);
+                start.Wait();
+                w.MarkIssuesReady();
+            });
+
+            start.Set();
+            await Task.WhenAll(graphTask, issuesTask);
+
+            var finalVersion = _db.GetUserVersion();
+            bool graphSet = (finalVersion & DbContext.GraphReadyFlag) != 0;
+            bool issuesSet = (finalVersion & DbContext.IssuesReadyFlag) != 0;
+            if (!graphSet || !issuesSet)
+                lostFlagIterations.Add((i, finalVersion));
+        }
+
+        Assert.True(
+            lostFlagIterations.Count == 0,
+            $"SetReadyBit lost a flag in {lostFlagIterations.Count}/{iterations} iterations. " +
+            $"Sample: {string.Join(", ", lostFlagIterations.Take(3).Select(v => $"i={v.iteration} user_version={v.finalUserVersion}"))}");
+    }
+
     private static List<ReferenceRecord> BuildReferenceBatch(long fileId, string label, int count)
     {
         var refs = new List<ReferenceRecord>(count);


### PR DESCRIPTION
## Summary

- `SetReadyBit` wrapped its PRAGMA `user_version` read-modify-write with `BEGIN IMMEDIATE` so two parallel CodeIndex writers (e.g. CI plus a local rebuild) can no longer each read the same prior value, OR in their own flag, and have the slower writer's PRAGMA write clobber the faster writer's flag. Without this, `fold_ready` / `graph_table_available` / `issues_table_available` could report `false` even after both runs completed successfully.
- The fix only acquires the immediate write lock when `SetReadyBit` is the outermost transaction; current callers never nest, and the comment documents the contract.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj` -- clean
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj` -- clean
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` -- 4517 passed, 3 perf-only skips
- `dotnet test --filter "FullyQualifiedName~ConcurrencyTests"` -- 6/6 passed
- New regression test `SetReadyBit_ConcurrentWriters_DoNotLoseFlags`: confirmed it fails 50/50 iterations against the pre-fix code (temporarily reintroduced) and passes 50/50 against the new code.
- `dotnet run --project tools/CodeIndex.Changelog -- check` -- 16 fragments validated.

## Documentation / Changelog

- `changelog.d/unreleased/1513.fixed.md` (bilingual fragment, category `fixed`).
- No CLI/MCP contract change, so no doc update required.

## Follow-up candidates

- None.

Fixes #1513
