### PR TITLE
Append per-flag value-type Hint to missing-value CLI errors (#1507)

### DIFF
--- a/changelog.d/unreleased/1507.changed.md
+++ b/changelog.d/unreleased/1507.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+issues:
+  - 1507
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Missing-value CLI errors now print a per-flag `Hint:` line (#1507)** — running a `cdidx` query command with a value-taking flag but no value (e.g. `cdidx search --limit`) now prints both the original `Error: --limit requires a value.` line and a follow-up `Hint:` line that names the expected value type or range and gives a concrete example (`Hint: pass a positive integer, e.g. --limit 20 (default 20).`). Hints are sourced from a single per-flag metadata table inside `QueryCommandRunner`, so `--limit`, `--top`, `--db`, `--lang`, `--query`, `--kind`, `--depth`, `--path`, `--exclude-path`, `--since`, `--start`, `--end`, `--before`, `--after`, `--focus-line`, `--focus-column`, `--focus-length`, `--name`, `--snippet-lines`, and `--max-line-width` all surface consistent guidance across `search`, `find`, `symbols`, `references`, `callers`, `callees`, `definition`, `impact`, `excerpt`, `files`, `hotspots`, `unused`, and other query commands. Users no longer have to consult `--help` to recover from a trivially missed value.
+
+## 日本語
+
+- **CLI フラグの値欠如エラーがフラグごとの `Hint:` 行を出すようになりました (#1507)** — 値を取るフラグに値を付け忘れて `cdidx` のクエリコマンドを実行した場合（例: `cdidx search --limit`）、従来の `Error: --limit requires a value.` 行に加えて、期待する値の型や範囲と具体例を示す `Hint:` 行（例: `Hint: pass a positive integer, e.g. --limit 20 (default 20).`）を続けて出力するようになりました。ヒントは `QueryCommandRunner` 内の単一のフラグ別メタデータテーブルから供給され、`--limit` / `--top` / `--db` / `--lang` / `--query` / `--kind` / `--depth` / `--path` / `--exclude-path` / `--since` / `--start` / `--end` / `--before` / `--after` / `--focus-line` / `--focus-column` / `--focus-length` / `--name` / `--snippet-lines` / `--max-line-width` が `search` / `find` / `symbols` / `references` / `callers` / `callees` / `definition` / `impact` / `excerpt` / `files` / `hotspots` / `unused` などのクエリコマンド全体で一貫した案内を返します。値を付け忘れただけの軽微なミスから復旧するために `--help` を見直す必要はありません。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -1191,7 +1191,7 @@ public static class QueryCommandRunner
                 else
                 {
                     if (i + 1 >= args.Length)
-                        return $"Error: {arg} requires a value";
+                        return BuildMissingOptionValueError(arg);
                     value = args[i + 1];
                     i++;
                 }
@@ -3151,8 +3151,7 @@ public static class QueryCommandRunner
     {
         if (string.IsNullOrWhiteSpace(dbPath))
         {
-            Console.Error.WriteLine("Error: --db requires a value.");
-            Console.Error.WriteLine("Hint: pass a concrete database path with `--db <path>` or omit `--db` to use `.cdidx/codeindex.db`.");
+            Console.Error.WriteLine(BuildMissingOptionValueError("--db"));
             return CommandExitCodes.UsageError;
         }
 
@@ -4157,6 +4156,56 @@ public static class QueryCommandRunner
             ["--focus-length"] = 100_000,
         };
 
+    // Per-flag hints appended to "Error: <flag> requires a value." so users learn the expected
+    // value type or range without consulting `--help`. Routed through BuildMissingOptionValueError
+    // so every missing-value site reuses the same table and the messages stay consistent.
+    // 「<flag> requires a value.」 missing-value error に追記するフラグ別ヒント。
+    // すべての missing-value 経路を BuildMissingOptionValueError 経由にして、コマンド間で
+    // メッセージを揃え、ヒントの単一情報源を維持する。
+    private static readonly Dictionary<string, string> MissingOptionValueHints = new(StringComparer.Ordinal)
+    {
+        ["--db"] = "pass a path to a CodeIndex SQLite database, e.g. `--db .cdidx/codeindex.db`, or omit `--db` to use `.cdidx/codeindex.db`.",
+        ["--limit"] = "pass a positive integer, e.g. `--limit 20` (default 20).",
+        ["--top"] = "pass a positive integer, e.g. `--top 20` (alias for `--limit`, default 20).",
+        ["--lang"] = "pass a language identifier, e.g. `--lang csharp`. Run `cdidx languages` for the supported set.",
+        ["--query"] = "pass a search literal, e.g. `--query \"authenticate\"`. Use the `--query` form when the literal starts with `-`.",
+        ["--kind"] = "pass a kind identifier, e.g. `--kind function`. definition/symbols/hotspots/unused take a symbol kind; references/callers/callees take a reference kind such as `call`, `instantiate`, or `subscribe`. Run the command's `--help` for the kind list.",
+        ["--depth"] = "pass a non-negative integer, e.g. `--depth 5` (default 5).",
+        ["--path"] = "pass a glob-style path pattern, e.g. `--path src/**`. Repeat `--path` to add more patterns.",
+        ["--exclude-path"] = "pass a glob-style path pattern to exclude, e.g. `--exclude-path tests/**`. Repeat `--exclude-path` to add more.",
+        ["--since"] = "pass an ISO 8601 datetime, e.g. `--since 2024-01-01` or `--since 2024-01-01T00:00:00Z`.",
+        ["--start"] = "pass a 1-based line number, e.g. `--start 10`.",
+        ["--end"] = "pass a 1-based line number greater than or equal to `--start`, e.g. `--end 20`.",
+        ["--before"] = "pass a non-negative integer of context lines before each match, e.g. `--before 2`.",
+        ["--after"] = "pass a non-negative integer of context lines after each match, e.g. `--after 2`.",
+        ["--focus-line"] = "pass a 1-based line number to focus on, e.g. `--focus-line 12`.",
+        ["--focus-column"] = "pass a 1-based column number to keep visible, e.g. `--focus-column 80`.",
+        ["--focus-length"] = "pass a positive integer for the focused span width, e.g. `--focus-length 1` (default 1).",
+        ["--name"] = "pass a literal symbol name, e.g. `--name UserService`. Repeat `--name` to add more names.",
+        ["--snippet-lines"] = "pass an integer between 1 and 20, e.g. `--snippet-lines 8` (default 8).",
+        ["--max-line-width"] = "pass a non-negative integer (`0` disables clamping), e.g. `--max-line-width 512` (default 512).",
+    };
+
+    // Build a missing-value error string with optional caller-supplied hint lines first, then the
+    // per-flag hint from MissingOptionValueHints. Newline-separated so each Hint stays on its own
+    // line when written via Console.Error.WriteLine. Returns just the base error if no hint exists.
+    // 呼び出し元固有のヒント (例: inline-form) を先に、テーブル由来のフラグ別ヒントを後ろに追記する。
+    // Console.Error.WriteLine 経由で出力されたとき各 Hint が別行になるよう改行で連結する。
+    private static string BuildMissingOptionValueError(string optionName, params string?[] extraHintLines)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append("Error: ").Append(optionName).Append(" requires a value.");
+        foreach (var hint in extraHintLines)
+        {
+            if (string.IsNullOrEmpty(hint))
+                continue;
+            sb.Append('\n').Append(hint);
+        }
+        if (MissingOptionValueHints.TryGetValue(optionName, out var perFlagHint))
+            sb.Append('\n').Append("Hint: ").Append(perFlagHint);
+        return sb.ToString();
+    }
+
     private static bool TryParsePositiveInt(string rawValue, string optionName, out int value, out string? error)
     {
         if (string.Equals(optionName, "--max-line-width", StringComparison.Ordinal))
@@ -4212,7 +4261,7 @@ public static class QueryCommandRunner
         if (index + 1 >= args.Length)
         {
             value = null;
-            error = $"Error: {optionName} requires a value.";
+            error = BuildMissingOptionValueError(optionName);
             return false;
         }
 
@@ -4228,7 +4277,7 @@ public static class QueryCommandRunner
         if (IsRecognizedOptionToken(candidate))
         {
             value = null;
-            error = $"Error: {optionName} requires a value.";
+            error = BuildMissingOptionValueError(optionName);
             return false;
         }
 
@@ -4245,7 +4294,7 @@ public static class QueryCommandRunner
             if (string.IsNullOrWhiteSpace(inlineValue))
             {
                 value = null;
-                error = $"Error: {optionName} requires a value.";
+                error = BuildMissingOptionValueError(optionName);
                 return false;
             }
 
@@ -4257,7 +4306,7 @@ public static class QueryCommandRunner
         if (index + 1 >= args.Length)
         {
             value = null;
-            error = $"Error: {optionName} requires a value.";
+            error = BuildMissingOptionValueError(optionName);
             return false;
         }
 
@@ -4278,22 +4327,23 @@ public static class QueryCommandRunner
         if (!allowSeparatedDashPrefixedLiteralValue && IsRecognizedOptionToken(candidate))
         {
             value = null;
-            error = $"Error: {optionName} requires a value.";
+            error = BuildMissingOptionValueError(optionName);
             return false;
         }
         if (optionName != "--query" && IsRejectedSeparatedStringValue(candidate, allowSeparatedDashPrefixedLiteralValue))
         {
             value = null;
-            error = allowSeparatedDashPrefixedLiteralValue && candidate.StartsWith("--", StringComparison.Ordinal)
-                ? $"Error: {optionName} requires a value. Hint: if the literal value starts with `--`, pass it as `{optionName}=<value>`."
-                : $"Error: {optionName} requires a value.";
+            var inlineFormHint = allowSeparatedDashPrefixedLiteralValue && candidate.StartsWith("--", StringComparison.Ordinal)
+                ? $"Hint: if the literal value starts with `--`, pass it as `{optionName}=<value>`."
+                : null;
+            error = BuildMissingOptionValueError(optionName, inlineFormHint);
             return false;
         }
 
         if (string.IsNullOrWhiteSpace(candidate))
         {
             value = null;
-            error = $"Error: {optionName} requires a value.";
+            error = BuildMissingOptionValueError(optionName);
             return false;
         }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -1881,6 +1881,155 @@ jobs:
         Assert.DoesNotContain("Unhandled exception", stderr);
     }
 
+    // Issue #1507: missing-value errors for CLI flags must append a per-flag `Hint:` line that
+    // shows the expected value type or range (e.g. positive integer, glob pattern, language id),
+    // so users do not need to consult `--help` for trivial mistakes. The hint is sourced from
+    // a single per-flag metadata table so every command surfaces consistent guidance.
+    // Issue #1507: 値欠如エラーには、フラグごとに期待する値の型/範囲を示す `Hint:` 行を
+    // 追記する（例: 正の整数、glob、言語識別子）。`--help` を見なくてもユーザーが復旧できる。
+    // ヒントは単一のメタデータテーブルから供給され、コマンド間で一貫した案内を出す。
+    [Theory]
+    [InlineData(new[] { "QueryCommandRunner", "--limit" }, "search", "--limit", "pass a positive integer", "--limit 20")]
+    [InlineData(new[] { "QueryCommandRunner", "--top" }, "search", "--limit", "pass a positive integer", "--limit 20")]
+    [InlineData(new[] { "QueryCommandRunner", "--db" }, "search", "--db", "pass a path to a CodeIndex SQLite database", ".cdidx/codeindex.db")]
+    [InlineData(new[] { "QueryCommandRunner", "--lang" }, "search", "--lang", "pass a language identifier", "--lang csharp")]
+    [InlineData(new[] { "QueryCommandRunner", "--path" }, "search", "--path", "pass a glob-style path pattern", "--path src/**")]
+    [InlineData(new[] { "QueryCommandRunner", "--exclude-path" }, "search", "--exclude-path", "pass a glob-style path pattern to exclude", "--exclude-path tests/**")]
+    [InlineData(new[] { "QueryCommandRunner", "--snippet-lines" }, "search", "--snippet-lines", "pass an integer between 1 and 20", "--snippet-lines 8")]
+    [InlineData(new[] { "QueryCommandRunner", "--max-line-width" }, "search", "--max-line-width", "pass a non-negative integer", "--max-line-width 512")]
+    public void RunSearch_MissingOptionValueAppendsPerFlagHint_Issue1507(
+        string[] args,
+        string command,
+        string optionName,
+        string expectedHintFragment,
+        string expectedExampleFragment)
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(args, _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains($"Error: {optionName} requires a value.", stderr);
+        Assert.Contains($"Hint: {expectedHintFragment}", stderr);
+        Assert.Contains(expectedExampleFragment, stderr);
+        Assert.Contains($"Usage: {ConsoleUi.GetUsageLine(command)}", stderr);
+    }
+
+    // Issue #1507: command-specific value-taking flags should also surface the per-flag hint, so
+    // commands that wire through TryReadStringOptionValue / TryReadRawOptionValue stay consistent
+    // with the search-side coverage.
+    // Issue #1507: コマンド固有の値取りフラグも同じテーブル経由でヒントを表示する。
+    [Fact]
+    public void RunSymbols_MissingNameValueShowsPerFlagHint_Issue1507()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(["--name"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: --name requires a value.", stderr);
+        Assert.Contains("Hint: pass a literal symbol name", stderr);
+        Assert.Contains("--name UserService", stderr);
+    }
+
+    [Fact]
+    public void RunImpact_MissingDepthValueShowsPerFlagHint_Issue1507()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunImpact(["QueryCommandRunner", "--depth"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: --depth requires a value.", stderr);
+        Assert.Contains("Hint: pass a non-negative integer", stderr);
+        Assert.Contains("--depth 5", stderr);
+    }
+
+    [Fact]
+    public void RunDefinition_MissingKindValueShowsPerFlagHint_Issue1507()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunDefinition(["QueryCommandRunner", "--kind"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: --kind requires a value.", stderr);
+        Assert.Contains("Hint: pass a kind identifier", stderr);
+        Assert.Contains("--kind function", stderr);
+    }
+
+    [Fact]
+    public void RunExcerpt_MissingStartValueShowsPerFlagHint_Issue1507()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunExcerpt(["src/CodeIndex/Program.cs", "--start"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: --start requires a value.", stderr);
+        Assert.Contains("Hint: pass a 1-based line number", stderr);
+        Assert.Contains("--start 10", stderr);
+    }
+
+    [Fact]
+    public void RunFiles_MissingSinceValueShowsPerFlagHint_Issue1507()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunFiles(["--since"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: --since requires a value.", stderr);
+        Assert.Contains("Hint: pass an ISO 8601 datetime", stderr);
+        Assert.Contains("--since 2024-01-01", stderr);
+    }
+
+    // Issue #1507: when a separated `--db --foo` shape rejects the next token as a recognized
+    // option, both the inline-form hint AND the per-flag hint must surface so users know why
+    // the parser stopped *and* what value to pass.
+    // Issue #1507: `--db --foo` のような separated dashed literal が拒否されたときは、
+    // inline-form ヒント (`--db=<value>` 形式) と、フラグ別の値ヒントを両方表示する。
+    [Fact]
+    public void RunSearch_DbDoubleDashLiteralKeepsBothHints_Issue1507()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["QueryCommandRunner", "--db", "--mystery"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: --db requires a value.", stderr);
+        Assert.Contains("Hint: if the literal value starts with `--`, pass it as `--db=<value>`.", stderr);
+        Assert.Contains("Hint: pass a path to a CodeIndex SQLite database", stderr);
+    }
+
+    // Issue #1507: `find` validates its options through ValidateFindArgs (separate path from
+    // ParseArgs), so the per-flag hint table must apply there too. Otherwise users running
+    // `cdidx find foo --path` would still see the bare "requires a value" message.
+    // Issue #1507: `find` は ValidateFindArgs 経由で値検証する独自経路を持つので、
+    // この経路でもフラグ別ヒントを表示する。
+    [Fact]
+    public void RunFind_MissingPathValueShowsPerFlagHint_Issue1507()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue1507_find_missing_path");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["foo", "--db", dbPath, "--path"], _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Contains("Error: --path requires a value.", stderr);
+            Assert.Contains("Hint: pass a glob-style path pattern", stderr);
+            Assert.Contains("--path src/**", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    // Issue #1507: `WithDb` surfaces the missing --db error when ParseArgs accepted an empty
+    // DbPath (e.g. via the CLI default fallback being cleared). Even at this late site the
+    // per-flag hint must come from the same metadata table, not a hard-coded one-off string.
+    // Issue #1507: WithDb 経路の missing --db エラーも、同じメタデータテーブル由来のヒントを使う。
+    [Fact]
+    public void WithDb_BlankDbPathSurfacesPerFlagHint_Issue1507()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["QueryCommandRunner", "--db="], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: --db requires a value.", stderr);
+        Assert.Contains("Hint: pass a path to a CodeIndex SQLite database", stderr);
+    }
+
     [Theory]
     [InlineData("search-extra", "unexpected extra positional argument(s) for search")]
     [InlineData("excerpt-extra", "unexpected extra positional argument(s) for excerpt")]


### PR DESCRIPTION
## Summary

- When a query-side CLI flag like `--limit`, `--db`, `--lang`, `--path`, or `--snippet-lines` is passed without a value, the runner now appends a per-flag `Hint:` line that names the expected value type or range and gives a concrete example (e.g. `Hint: pass a positive integer, e.g. --limit 20 (default 20).`). Users no longer need to consult `--help` after a trivial typo (#1507).
- Hints are sourced from a single per-flag metadata table inside `QueryCommandRunner`, and every missing-value site funnels through one `BuildMissingOptionValueError` helper, so coverage stays consistent across `search`, `find`, `symbols`, `references`, `callers`, `callees`, `definition`, `impact`, `excerpt`, `files`, `hotspots`, `unused`, and other query commands.
- The previous inline-form hint (`Hint: if the literal value starts with --, pass it as <flag>=<value>`) is preserved by passing it through the helper as an extra hint line, so cases like `search --db --max-line-width` show both the inline-form hint and the per-flag value hint.

## Validation

- `dotnet build CodeIndex.sln -c Release` — clean (0 warnings, 0 errors)
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~QueryCommandRunner|FullyQualifiedName~Issue1507|FullyQualifiedName~ProgramCli"` — 969/969 passed
- Manual smoke (rebuilt Debug binary): `search --limit`, `search --db`, `search --db --max-line-width` each emit the new per-flag `Hint:` line(s) as expected, including the dual-hint case for inline-form ambiguity.

## Documentation / changelog

- Bilingual fragment added: `changelog.d/unreleased/1507.changed.md`
- No README / DEVELOPER_GUIDE / USER_GUIDE updates needed — this change refines the wording of an existing CLI error path; no documented contract or flag surface changes.

## Follow-up candidates

- None observed during implementation.

Fixes #1507
