### PR TITLE
Recurse into .gitmodules submodules hosted under SkipDirs (#1511)

### DIFF
--- a/changelog.d/unreleased/1511.added.md
+++ b/changelog.d/unreleased/1511.added.md
@@ -1,0 +1,16 @@
+---
+category: added
+issues:
+  - 1511
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Git submodules declared in `.gitmodules` are now indexed even when hosted under SkipDirs-named directories (#1511)** — `FileIndexer` previously inherited a hard SkipDirs block on entries like `vendor/` or `target/`, so a submodule placed under one of those directories (for example `vendor/foo`) was completely invisible to cdidx and produced no cross-module reference edges. The scanner now parses the repository-root `.gitmodules`, overrides SkipDirs along the path to each declared submodule, and walks the submodule itself with its own `.gitignore` / `.cdidxignore` honored. Files directly inside the SkipDirs-named ancestor (or in unrelated siblings of the submodule) remain excluded so the rest of the SkipDirs policy is unchanged. `EvaluatePathFilter` mirrors this passthrough behavior so `--files` / `--commits` update mode stays consistent with a fresh full scan.
+
+## 日本語
+
+- **`.gitmodules` で宣言された git submodule が SkipDirs 名のディレクトリ配下でも索引されるようになりました (#1511)** — `FileIndexer` は `vendor/` や `target/` のような SkipDirs エントリを無条件にブロックしていたため、その配下に置かれた submodule（例: `vendor/foo`）は cdidx から完全に見えず、モジュール跨ぎの参照エッジが生成されませんでした。スキャナはリポジトリルートの `.gitmodules` を解析し、宣言された各 submodule までの経路で SkipDirs を上書きしつつ、submodule 内部はその独自の `.gitignore` / `.cdidxignore` に従って走査します。SkipDirs 名の祖先直下や submodule と無関係な兄弟ディレクトリは引き続き除外され、SkipDirs ポリシー自体は変わりません。`EvaluatePathFilter` も同じ passthrough 挙動を持つため、`--files` / `--commits` の更新モードはフルスキャンと一致した結果を返します。

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -357,6 +357,20 @@ public class FileIndexer
     private readonly string _ignoreRuleRoot;
     private readonly IReadOnlyList<string> _ancestorIgnoreDirectories;
     private readonly bool _ignoreCase;
+    // Submodule working-tree paths declared in <ignoreRuleRoot>/.gitmodules, relative to
+    // _projectRoot and slash-normalized. Used to override SkipDirs so that submodules
+    // hosted under SkipDirs-named directories (e.g. vendor/foo) remain visible to the
+    // indexer. Empty when .gitmodules is missing or unreadable.
+    // <ignoreRuleRoot>/.gitmodules で宣言された submodule のワークツリーパス（_projectRoot 相対、
+    // スラッシュ正規化済み）。vendor/foo のように SkipDirs 名のディレクトリ配下にある submodule を
+    // 可視化するため SkipDirs を上書きする。.gitmodules が無い・読めない場合は空。
+    private readonly HashSet<string> _submodulePaths;
+    // Ancestor path prefixes of every entry in _submodulePaths (exclusive of the submodule
+    // itself). When such an ancestor matches SkipDirs we pass through it without indexing
+    // its direct files, descending only into the submodule branch.
+    // _submodulePaths 各要素の祖先パス（submodule 自身は含まない）。SkipDirs 名と一致した場合は
+    // 通過モードとしてその直下ファイルを索引せず、submodule 方向のみ降りる。
+    private readonly HashSet<string> _submoduleAncestorPaths;
 
     private sealed class IgnoreRuleSet
     {
@@ -849,6 +863,8 @@ public class FileIndexer
         _ignoreRuleRoot = NormalizeIgnoreRuleRoot(ignoreRuleRoot);
         _ancestorIgnoreDirectories = BuildAncestorIgnoreDirectories(_ignoreRuleRoot, _projectRoot);
         _ignoreCase = ignoreCase;
+        var pathComparer = _ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        (_submodulePaths, _submoduleAncestorPaths) = LoadGitSubmodulePaths(_ignoreRuleRoot, _projectRoot, pathComparer);
     }
 
     private static bool ProbeFileSystemIgnoreCase(string projectRoot)
@@ -1308,13 +1324,37 @@ public class FileIndexer
             return new PathFilterResult(PathFilterKind.IgnoreRulesUnavailable, errors);
 
         var directorySegmentCount = isDirectory ? segments.Length : Math.Max(segments.Length - 1, 0);
+        // Mirror EnumerateDirectory's passthrough behavior so update-mode filters (--files /
+        // --commits) match a fresh full scan: when SkipDirs is overridden because we're
+        // routing toward a declared submodule, files/subdirs that do not themselves lead
+        // to a submodule must still be excluded.
+        // EnumerateDirectory の passthrough と挙動を一致させ、--files / --commits などの
+        // 更新モードのフィルタがフルスキャンと食い違わないようにする。submodule への通過のため
+        // SkipDirs を上書きした場合でも、submodule に到達しないファイル・サブディレクトリは
+        // 引き続き除外する。
+        var inSubmodulePassthrough = false;
         for (var i = 0; i < directorySegmentCount; i++)
         {
             var directoryName = segments[i];
             var childDirectory = Path.Combine(currentDirectory, directoryName);
+            var cumulativeRelPath = NormalizeIgnorePath(Path.GetRelativePath(_projectRoot, childDirectory));
+            var isSubmodule = _submodulePaths.Contains(cumulativeRelPath);
+            var isSubmoduleAncestor = _submoduleAncestorPaths.Contains(cumulativeRelPath);
 
             if (SkipDirs.Contains(directoryName))
+            {
+                if (!isSubmodule && !isSubmoduleAncestor)
+                    return new PathFilterResult(PathFilterKind.ExcludedByDefaultDirectory, errors);
+            }
+            else if (inSubmodulePassthrough && !isSubmodule && !isSubmoduleAncestor)
+            {
                 return new PathFilterResult(PathFilterKind.ExcludedByDefaultDirectory, errors);
+            }
+
+            if (isSubmodule)
+                inSubmodulePassthrough = false;
+            else if (isSubmoduleAncestor)
+                inSubmodulePassthrough = true;
 
             if (activeIgnoreRules.IsIgnored(childDirectory, isDirectory: true))
                 return new PathFilterResult(PathFilterKind.IgnoredByRules, errors);
@@ -1329,6 +1369,13 @@ public class FileIndexer
 
         if (isDirectory)
             return new PathFilterResult(PathFilterKind.None, errors);
+
+        // File directly inside a submodule-ancestor passthrough directory: walker would not
+        // index it, so neither should this filter.
+        // submodule 祖先（passthrough）に直接置かれているファイルは walker も索引しないため
+        // ここでも除外する。
+        if (inSubmodulePassthrough)
+            return new PathFilterResult(PathFilterKind.ExcludedByDefaultDirectory, errors);
 
         var fileName = Path.GetFileName(fullPath);
         if (SkipFiles.Contains(fileName))
@@ -1408,51 +1455,62 @@ public class FileIndexer
             if (!loadResult.IgnoreRulesAvailable)
                 return false;
 
-            foreach (var file in Directory.EnumerateFiles(dir))
+            // Submodule passthrough: we are inside a SkipDirs-named ancestor of a submodule
+            // (e.g. vendor/ on the way to vendor/foo). Honor SkipDirs for this directory's
+            // own files and unrelated subdirs while still descending toward the submodule.
+            // submodule の祖先で SkipDirs 名のディレクトリ（例: vendor/foo の vendor/）の場合は、
+            // 当該ディレクトリの直下ファイルおよび submodule と無関係なサブディレクトリには
+            // SkipDirs を適用しつつ、submodule 方向にだけ降りる。
+            var passthrough = IsSubmoduleAncestorPassthrough(dir);
+
+            if (!passthrough)
             {
-                var fileName = Path.GetFileName(file);
-
-                // Skip excluded file names / 除外ファイル名をスキップ
-                if (SkipFiles.Contains(fileName))
-                    continue;
-
-                if (activeIgnoreRules.IsIgnored(file, isDirectory: false))
-                    continue;
-
-                // GetFileIndexability also rejects file symlinks/reparse points so the update-mode
-                // (--files / --commits) path gets the same skip behavior without a second probe here.
-                // GetFileIndexability もファイル symlink / reparse point を拒否するため、
-                // update モード (--files / --commits) でも同じ skip 挙動が二重プローブ無しで効く。
-                var indexability = GetFileIndexability(file);
-                if (indexability == FileProbeStatus.ProbeFailed)
+                foreach (var file in Directory.EnumerateFiles(dir))
                 {
-                    var relativePath = ToRelativePath(file);
-                    errors.Add(new ScanError(relativePath, "Could not probe file for indexability/language."));
-                    probeFailedFilePaths.Add(relativePath);
-                    continue;
-                }
+                    var fileName = Path.GetFileName(file);
 
-                if (indexability != FileProbeStatus.Supported)
-                {
-                    nonIndexablePaths.Add(ToRelativePath(file));
-                    continue;
-                }
+                    // Skip excluded file names / 除外ファイル名をスキップ
+                    if (SkipFiles.Contains(fileName))
+                        continue;
 
-                // Include files with a known extension/filename or an extensionless recognized shebang
-                // 既知の拡張子・既知ファイル名、または拡張子なしで shebang を認識できるファイルを含める
-                var language = TryDetectLanguage(file);
-                if (language.Status == FileProbeStatus.ProbeFailed)
-                {
-                    var relativePath = ToRelativePath(file);
-                    errors.Add(new ScanError(relativePath, "Could not probe file for indexability/language."));
-                    probeFailedFilePaths.Add(relativePath);
-                    continue;
-                }
+                    if (activeIgnoreRules.IsIgnored(file, isDirectory: false))
+                        continue;
 
-                if (language.Status == FileProbeStatus.Supported)
-                    results.Add(file);
-                else
-                    nonIndexablePaths.Add(ToRelativePath(file));
+                    // GetFileIndexability also rejects file symlinks/reparse points so the update-mode
+                    // (--files / --commits) path gets the same skip behavior without a second probe here.
+                    // GetFileIndexability もファイル symlink / reparse point を拒否するため、
+                    // update モード (--files / --commits) でも同じ skip 挙動が二重プローブ無しで効く。
+                    var indexability = GetFileIndexability(file);
+                    if (indexability == FileProbeStatus.ProbeFailed)
+                    {
+                        var relativePath = ToRelativePath(file);
+                        errors.Add(new ScanError(relativePath, "Could not probe file for indexability/language."));
+                        probeFailedFilePaths.Add(relativePath);
+                        continue;
+                    }
+
+                    if (indexability != FileProbeStatus.Supported)
+                    {
+                        nonIndexablePaths.Add(ToRelativePath(file));
+                        continue;
+                    }
+
+                    // Include files with a known extension/filename or an extensionless recognized shebang
+                    // 既知の拡張子・既知ファイル名、または拡張子なしで shebang を認識できるファイルを含める
+                    var language = TryDetectLanguage(file);
+                    if (language.Status == FileProbeStatus.ProbeFailed)
+                    {
+                        var relativePath = ToRelativePath(file);
+                        errors.Add(new ScanError(relativePath, "Could not probe file for indexability/language."));
+                        probeFailedFilePaths.Add(relativePath);
+                        continue;
+                    }
+
+                    if (language.Status == FileProbeStatus.Supported)
+                        results.Add(file);
+                    else
+                        nonIndexablePaths.Add(ToRelativePath(file));
+                }
             }
 
             // A successful file listing proves the direct children of this directory.
@@ -1463,6 +1521,19 @@ public class FileIndexer
 
             foreach (var subDir in Directory.EnumerateDirectories(dir))
             {
+                // In passthrough mode, only descend into subdirectories that are themselves
+                // submodules or submodule ancestors. Treat siblings the same way SkipDirs
+                // would have treated them at this point.
+                // passthrough 中は、submodule 自体または submodule の祖先に該当する
+                // サブディレクトリのみ降りる。その他は本来 SkipDirs で止まっていた扱いに戻す。
+                if (passthrough && !IsSubmoduleOrAncestor(subDir))
+                {
+                    var subRelative = ToRelativePath(subDir);
+                    listedDirectories.Add(subRelative);
+                    fullyScannedDirectories.Add(subRelative);
+                    continue;
+                }
+
                 // Skip directory symlinks/reparse points to prevent infinite recursion on ancestor loops
                 // and duplicate indexing when a symlink points inside the same tree. Record the symlink
                 // itself as listed (for the immediate-parent purge path) AND as a prune prefix so the
@@ -1503,15 +1574,61 @@ public class FileIndexer
         return fullyScanned;
     }
 
-    private static PathFilterKind GetDirectoryFilterKind(string dir, IgnoreRuleSet activeIgnoreRules, bool isProjectRoot = false)
+    private PathFilterKind GetDirectoryFilterKind(string dir, IgnoreRuleSet activeIgnoreRules, bool isProjectRoot = false)
     {
-        var dirName = Path.GetFileName(Path.TrimEndingDirectorySeparator(dir));
-        if (!isProjectRoot && SkipDirs.Contains(dirName))
-            return PathFilterKind.ExcludedByDefaultDirectory;
+        if (!isProjectRoot)
+        {
+            var dirName = Path.GetFileName(Path.TrimEndingDirectorySeparator(dir));
+            if (SkipDirs.Contains(dirName) && !IsSubmoduleOrAncestor(dir))
+                return PathFilterKind.ExcludedByDefaultDirectory;
+        }
 
         return activeIgnoreRules.IsIgnored(dir, isDirectory: true)
             ? PathFilterKind.IgnoredByRules
             : PathFilterKind.None;
+    }
+
+    // True when relpath under _projectRoot matches a .gitmodules-declared submodule
+    // working-tree path or one of its ancestor directories. Allows the walker to
+    // descend through SkipDirs-named ancestors (e.g. vendor/) to reach declared
+    // submodules without dropping the broader SkipDirs policy elsewhere.
+    // _projectRoot 配下の相対パスが .gitmodules で宣言された submodule のワークツリーまたは
+    // その祖先ディレクトリに一致するときに true。vendor/ のような SkipDirs 名の祖先を
+    // 通過して submodule に到達できるよう、限定的に SkipDirs を上書きする。
+    private bool IsSubmoduleOrAncestor(string dir)
+    {
+        if (_submodulePaths.Count == 0)
+            return false;
+        var relPath = ToRelativePath(dir);
+        if (relPath.Length == 0)
+            return false;
+        return _submodulePaths.Contains(relPath) || _submoduleAncestorPaths.Contains(relPath);
+    }
+
+    private bool IsSubmoduleAncestorPassthrough(string dir)
+    {
+        if (_submoduleAncestorPaths.Count == 0)
+            return false;
+        var relPath = ToRelativePath(dir);
+        if (relPath.Length == 0)
+            return false;
+        if (_submodulePaths.Contains(relPath))
+            return false;
+        if (!_submoduleAncestorPaths.Contains(relPath))
+            return false;
+        // Passthrough propagates from any SkipDirs-named ancestor along the path. If no
+        // segment of relPath matches SkipDirs, this directory would have been walked
+        // normally without our override, so the override is not in effect here.
+        // SkipDirs 名の祖先からは下方向に passthrough を伝播する。relPath のどの segment も
+        // SkipDirs に該当しない場合、我々の上書き無しでも walker は通っていたはずなので
+        // ここでの上書きは効いていない。
+        var segments = relPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var segment in segments)
+        {
+            if (SkipDirs.Contains(segment))
+                return true;
+        }
+        return false;
     }
 
     private IgnoreRuleLoadResult LoadIgnoreRulesForDirectory(
@@ -1607,6 +1724,125 @@ public class FileIndexer
         }
 
         return directories;
+    }
+
+    // Parse <ignoreRuleRoot>/.gitmodules and return submodule working-tree paths (and
+    // their ancestor directories) relative to projectRoot. Submodules outside projectRoot
+    // are dropped silently. Absent or unreadable .gitmodules yields empty sets so callers
+    // see the same shape as a non-submodule repository.
+    // <ignoreRuleRoot>/.gitmodules を解析し、projectRoot 相対の submodule ワークツリーパスと
+    // その祖先ディレクトリを返す。projectRoot 外の submodule は無視。.gitmodules が無い・
+    // 読めない場合は空集合を返し、submodule の無いリポジトリと同じ形を保つ。
+    private static (HashSet<string> Paths, HashSet<string> AncestorPaths) LoadGitSubmodulePaths(
+        string ignoreRuleRoot, string projectRoot, StringComparer pathComparer)
+    {
+        var submodulePaths = new HashSet<string>(pathComparer);
+        var ancestorPaths = new HashSet<string>(pathComparer);
+
+        var gitmodulesPath = Path.Combine(ignoreRuleRoot, ".gitmodules");
+        if (!File.Exists(gitmodulesPath))
+            return (submodulePaths, ancestorPaths);
+
+        string[] lines;
+        try
+        {
+            lines = File.ReadAllLines(gitmodulesPath);
+        }
+        catch (IOException)
+        {
+            return (submodulePaths, ancestorPaths);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return (submodulePaths, ancestorPaths);
+        }
+
+        foreach (var rawSubmodulePath in ParseSubmodulePathsFromGitmodules(lines))
+        {
+            string absolute;
+            try
+            {
+                absolute = Path.GetFullPath(Path.Combine(ignoreRuleRoot, rawSubmodulePath));
+            }
+            catch (ArgumentException)
+            {
+                continue;
+            }
+
+            var relativeToProject = NormalizeIgnorePath(Path.GetRelativePath(projectRoot, absolute));
+            if (relativeToProject.Length == 0
+                || relativeToProject == "."
+                || relativeToProject.StartsWith("../", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            submodulePaths.Add(relativeToProject);
+            var segments = relativeToProject.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 1; i < segments.Length; i++)
+                ancestorPaths.Add(string.Join('/', segments, 0, i));
+        }
+
+        return (submodulePaths, ancestorPaths);
+    }
+
+    // Tolerant .gitmodules reader: yields each declared submodule's "path = ..." value.
+    // Supports comments (# / ;), inline comments, surrounding double quotes, and
+    // ignores absolute or empty values. Quoted-string escapes are not expanded since
+    // submodule paths in practice are plain relative filesystem paths.
+    // .gitmodules を寛容に読み、各 submodule の "path = ..." 値を返す。コメント(# / ;)、
+    // インラインコメント、両端のダブルクオート、絶対パス・空値の除外をサポート。実用上の
+    // submodule パスは通常のファイル名なのでクォート内のエスケープは展開しない。
+    private static IEnumerable<string> ParseSubmodulePathsFromGitmodules(IEnumerable<string> lines)
+    {
+        var inSubmoduleSection = false;
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0)
+                continue;
+            if (line[0] == '#' || line[0] == ';')
+                continue;
+
+            if (line[0] == '[')
+            {
+                var endBracket = line.IndexOf(']');
+                if (endBracket < 0)
+                {
+                    inSubmoduleSection = false;
+                    continue;
+                }
+
+                var sectionHeader = line.Substring(1, endBracket - 1).Trim();
+                inSubmoduleSection = sectionHeader.StartsWith("submodule", StringComparison.OrdinalIgnoreCase)
+                    && sectionHeader.Length > "submodule".Length
+                    && char.IsWhiteSpace(sectionHeader["submodule".Length]);
+                continue;
+            }
+
+            if (!inSubmoduleSection)
+                continue;
+
+            var equalsIndex = line.IndexOf('=');
+            if (equalsIndex < 0)
+                continue;
+            var key = line.Substring(0, equalsIndex).Trim();
+            if (!string.Equals(key, "path", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = line[(equalsIndex + 1)..].Trim();
+            var commentIndex = value.IndexOfAny(['#', ';']);
+            if (commentIndex >= 0)
+                value = value[..commentIndex].Trim();
+            if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+                value = value[1..^1];
+            if (value.Length == 0)
+                continue;
+            if (Path.IsPathRooted(value))
+                continue;
+
+            yield return value;
+        }
     }
 
     private static string NormalizeIgnorePath(string path)

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -1983,6 +1983,160 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void ScanFiles_DescendsIntoSubmoduleHostedUnderSkipDir()
+    {
+        // .gitmodules declared submodule under a SkipDirs-named directory (e.g. vendor/foo)
+        // must remain visible: SkipDirs is overridden along the path to the submodule, but
+        // unrelated files inside the SkipDir ancestor itself stay excluded. Closes #1511.
+        // SkipDirs 名のディレクトリ配下に .gitmodules で宣言された submodule（例: vendor/foo）は
+        // 可視化される必要がある。SkipDirs は submodule までの経路でのみ上書きされ、SkipDirs
+        // 祖先自身の無関係なファイルは引き続き除外される。Closes #1511.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(Path.Combine(tempDir, "app.py"), "print('hello')");
+
+            // .gitmodules at project root declaring submodule path "vendor/foo"
+            File.WriteAllText(
+                Path.Combine(tempDir, ".gitmodules"),
+                "[submodule \"foo\"]\n\tpath = vendor/foo\n\turl = https://example.invalid/foo.git\n");
+
+            var vendorDir = Path.Combine(tempDir, "vendor");
+            Directory.CreateDirectory(vendorDir);
+            // File sitting directly in the SkipDir ancestor — must NOT be indexed
+            // SkipDirs 祖先直下のファイル — 索引されてはいけない
+            File.WriteAllText(Path.Combine(vendorDir, "vendor_dep.py"), "x = 1");
+
+            var submoduleDir = Path.Combine(vendorDir, "foo");
+            Directory.CreateDirectory(submoduleDir);
+            File.WriteAllText(Path.Combine(submoduleDir, "lib.py"), "def f(): pass");
+            Directory.CreateDirectory(Path.Combine(submoduleDir, "src"));
+            File.WriteAllText(Path.Combine(submoduleDir, "src", "nested.py"), "def g(): pass");
+
+            var indexer = new FileIndexer(tempDir);
+            var files = indexer.ScanFiles();
+
+            var rel = files.Select(f => Path.GetRelativePath(tempDir, f).Replace('\\', '/')).ToHashSet();
+            Assert.Contains("app.py", rel);
+            Assert.Contains("vendor/foo/lib.py", rel);
+            Assert.Contains("vendor/foo/src/nested.py", rel);
+            Assert.DoesNotContain("vendor/vendor_dep.py", rel);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ScanFiles_RespectsSubmoduleGitignore()
+    {
+        // Submodules brought back into the scan must still honor their own .gitignore so
+        // build artifacts inside the submodule remain excluded.
+        // 可視化された submodule も自身の .gitignore を尊重し、submodule 配下のビルド成果物などは
+        // 引き続き除外されること。
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(
+                Path.Combine(tempDir, ".gitmodules"),
+                "[submodule \"foo\"]\n\tpath = vendor/foo\n\turl = https://example.invalid/foo.git\n");
+
+            var submoduleDir = Path.Combine(tempDir, "vendor", "foo");
+            Directory.CreateDirectory(submoduleDir);
+            File.WriteAllText(Path.Combine(submoduleDir, "lib.py"), "def f(): pass");
+            File.WriteAllText(Path.Combine(submoduleDir, ".gitignore"), "generated.py\n");
+            File.WriteAllText(Path.Combine(submoduleDir, "generated.py"), "# generated");
+
+            var indexer = new FileIndexer(tempDir);
+            var files = indexer.ScanFiles();
+
+            var rel = files.Select(f => Path.GetRelativePath(tempDir, f).Replace('\\', '/')).ToHashSet();
+            Assert.Contains("vendor/foo/lib.py", rel);
+            Assert.DoesNotContain("vendor/foo/generated.py", rel);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ScanFiles_StillSkipsSkipDirWithoutMatchingSubmodule()
+    {
+        // .gitmodules declaring a submodule elsewhere must not relax SkipDirs for unrelated
+        // SkipDir-named directories. vendor/ without a declared submodule stays skipped.
+        // .gitmodules が別の場所の submodule を宣言していても、無関係な SkipDirs 名ディレクトリ
+        // (submodule が宣言されていない vendor/ 等) は引き続きスキップされること。
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(
+                Path.Combine(tempDir, ".gitmodules"),
+                "[submodule \"foo\"]\n\tpath = third_party/foo\n\turl = https://example.invalid/foo.git\n");
+
+            var submoduleDir = Path.Combine(tempDir, "third_party", "foo");
+            Directory.CreateDirectory(submoduleDir);
+            File.WriteAllText(Path.Combine(submoduleDir, "lib.py"), "def f(): pass");
+
+            var vendorDir = Path.Combine(tempDir, "vendor");
+            Directory.CreateDirectory(vendorDir);
+            File.WriteAllText(Path.Combine(vendorDir, "dep.py"), "x = 1");
+
+            var indexer = new FileIndexer(tempDir);
+            var files = indexer.ScanFiles();
+
+            var rel = files.Select(f => Path.GetRelativePath(tempDir, f).Replace('\\', '/')).ToHashSet();
+            Assert.Contains("third_party/foo/lib.py", rel);
+            Assert.DoesNotContain("vendor/dep.py", rel);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void EvaluatePathFilter_AllowsFilesUnderSubmoduleHostedInSkipDir()
+    {
+        // PathFilter must agree with the walker: files under a submodule declared in
+        // .gitmodules are not classified as ExcludedByDefaultDirectory even when an
+        // ancestor segment matches SkipDirs. This keeps update-mode (--files / --commits)
+        // consistent with full scan output.
+        // パスフィルタは walker と整合する必要がある: .gitmodules で宣言された submodule
+        // 配下のファイルは、祖先が SkipDirs に該当しても ExcludedByDefaultDirectory に
+        // 分類されない。これにより --files / --commits のような更新モードでも
+        // フルスキャンと挙動が一致する。
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(
+                Path.Combine(tempDir, ".gitmodules"),
+                "[submodule \"foo\"]\n\tpath = vendor/foo\n");
+
+            var submoduleDir = Path.Combine(tempDir, "vendor", "foo");
+            Directory.CreateDirectory(submoduleDir);
+            var libPath = Path.Combine(submoduleDir, "lib.py");
+            File.WriteAllText(libPath, "def f(): pass");
+
+            var unrelatedPath = Path.Combine(tempDir, "vendor", "dep.py");
+            File.WriteAllText(unrelatedPath, "x = 1");
+
+            var indexer = new FileIndexer(tempDir);
+            Assert.Equal(FileIndexer.PathFilterKind.None, indexer.EvaluatePathFilter(libPath).FilterKind);
+            Assert.Equal(FileIndexer.PathFilterKind.ExcludedByDefaultDirectory, indexer.EvaluatePathFilter(unrelatedPath).FilterKind);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void BuildRecord_CrlfNormalizedToLf()
     {
         // CRLF line endings in files should be normalized to LF


### PR DESCRIPTION
## Summary

- `FileIndexer` now parses repository-root `.gitmodules` and overrides `SkipDirs` along the path to each declared submodule, so submodules placed under directories like `vendor/`, `target/`, or `bin/` (e.g. Go projects' `vendor/foo`) are walked and indexed instead of being silently invisible. Cross-module reference edges between the parent project and its submodules can now be produced.
- The walker uses a "passthrough" mode inside any `SkipDirs`-named ancestor: direct files of that ancestor and unrelated sibling subdirectories stay excluded, descent continues only toward declared submodules, and each submodule's own `.gitignore` / `.cdidxignore` are honored. `EvaluatePathFilter` tracks the same state so `--files` / `--commits` update mode stays consistent with a fresh full scan.

## Test plan
- [x] `dotnet test` (full suite: 4506 passed, 3 skipped, 0 failed)
- [x] New `FileIndexerTests`:
  - [x] `ScanFiles_DescendsIntoSubmoduleHostedUnderSkipDir`
  - [x] `ScanFiles_RespectsSubmoduleGitignore`
  - [x] `ScanFiles_StillSkipsSkipDirWithoutMatchingSubmodule`
  - [x] `EvaluatePathFilter_AllowsFilesUnderSubmoduleHostedInSkipDir`
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check`

Fixes #1511