### PR TITLE
Take a per-database file lock during index runs (#1514)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -572,6 +572,7 @@ cdidx map --path src/ --exclude-tests --json
 | `--verbose` | `index` | Show per-file status (`[OK  ]`/`[SKIP]`/`[DEL ]`/`[ERR ]`) |
 | `--commits <id...>` | `index` | Update only files changed in specified commits. Prefer this after a normal commit because git history includes rename/delete paths. |
 | `--files <path...>` | `index` | Update only the specified files. Safe for known in-place edits or new files; old rename/delete paths are not purged unless you also list them explicitly. |
+| `--force` | `index` | Bypass the per-database index lock. Only use when you are sure no other `cdidx index` is active against the same DB; concurrent runs may corrupt the schema. |
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp |
 | `--no-dedup` | `search` | Disable overlapping-chunk deduplication for raw results |
 | `--reverse` | `deps` | Reverse lookup: show files that depend ON the matched path |
@@ -1611,6 +1612,7 @@ cdidx map --path src/ --exclude-tests --json
 | `--verbose` | `index` | ファイルごとのステータス表示（`[OK  ]`/`[SKIP]`/`[DEL ]`/`[ERR ]`） |
 | `--commits <id...>` | `index` | 指定コミットの変更ファイルのみ更新。通常のコミット後はこちらを推奨。rename/delete の旧パスも git 履歴から拾える。 |
 | `--files <path...>` | `index` | 指定ファイルのみ更新。把握している in-place 編集や新規ファイル向け。rename/delete の旧パスは明示しない限り purge されない。 |
+| `--force` | `index` | 同一 DB に対する index ロックを bypass する。他の `cdidx index` が走っていないと確信できる場合のみ使う。並行実行は schema を破壊し得る。 |
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601） |
 | `--no-dedup` | `search` | オーバーラップチャンク重複排除を無効化 |
 | `--reverse` | `deps` | 逆引き: 指定パスに依存しているファイルを表示 |

--- a/changelog.d/unreleased/1514.added.md
+++ b/changelog.d/unreleased/1514.added.md
@@ -1,0 +1,20 @@
+---
+category: added
+issues:
+  - 1514
+affected:
+  - src/CodeIndex/Cli/IndexLock.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`cdidx index` now takes a per-database file lock to block concurrent runs (#1514)** — Each `cdidx index` invocation acquires an OS-level lock on `<db>.lock` (using `FileShare.None`, the same primitive `SuggestionStore` already relies on) and writes PID / start-time / host / project metadata to a sibling `<db>.lock.info` file. A second `cdidx index` against the same database now fails fast with `Error: another cdidx index is already running on this database (PID …, started …)` and exits with `CommandExitCodes.DatabaseError` instead of silently racing through schema and data work — which previously could leave SQLite in a corrupted half-and-half state because `busy_timeout=5000` only serializes individual writes. `--dry-run` skips the lock entirely, and `--force` bypasses it with a stderr warning so CI / recovery flows remain possible without manual cleanup. Stale lockfiles from crashed processes recover automatically because the OS releases handles on process death.
+
+## 日本語
+
+- **`cdidx index` が DB ごとのファイルロックで同時実行を弾くようになりました (#1514)** — 各 `cdidx index` 実行は `<db>.lock` を OS レベルでロック（`SuggestionStore` が既に利用している `FileShare.None` と同じ仕組み）し、PID / 起動時刻 / ホスト / プロジェクトのメタデータを隣接 `<db>.lock.info` に書き出します。同じ DB に対する 2 つ目の `cdidx index` は `Error: another cdidx index is already running on this database (PID …, started …)` で即座に失敗し、`CommandExitCodes.DatabaseError` を返すようになりました。これまでは `busy_timeout=5000` が個々の write しか直列化しないため、スキーマ操作とデータ書き込みが交錯して SQLite が半端な破損状態に陥り得ました。`--dry-run` はロック取得をスキップし、`--force` は stderr に警告を出した上でロックをバイパスするため、CI や復旧フローでは手動清掃なしで実行できます。クラッシュで残された stale な lockfile は、プロセス終了時に OS がハンドルを解放するため自動で回復します。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -12,7 +12,7 @@ public static class ConsoleUi
 {
     private static readonly (string Command, string Usage)[] CommandUsageLines =
     [
-        ("index", "cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--json]"),
+        ("index", "cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--json]"),
         ("backfill-fold", "cdidx backfill-fold [--db <path>] [--json]"),
         ("index-commits", "cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json]"),
         ("index-files", "cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json]"),
@@ -369,6 +369,7 @@ public static class ConsoleUi
         Console.WriteLine("  --rebuild                  Delete existing DB and rebuild from scratch");
         Console.WriteLine("  --verbose                  Show per-file status ([OK  ]/[SKIP]/[DEL ]/[ERR ])");
         Console.WriteLine("  --dry-run                  Scan files without writing to the database");
+        Console.WriteLine("  --force                    Bypass the per-database index lock; only use when no other cdidx index is active");
         Console.WriteLine("  --json                     Output results as JSON (for AI/machine use)");
         Console.WriteLine("  --commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)");
         Console.WriteLine("  --files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed");

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -228,7 +228,41 @@ public static class IndexCommandRunner
         if (!string.IsNullOrEmpty(dbDir))
             Directory.CreateDirectory(dbDir);
 
-        using var db = new DbContext(dbPath);
+        // Acquire a process-exclusive lock so concurrent `cdidx index` runs against the
+        // same DB cannot interleave schema/data writes and corrupt the database.
+        // `--force` bypasses the check for users who knowingly accept the risk.
+        // 同一 DB に対する `cdidx index` の同時実行が schema / data 書き込みを交錯させ
+        // DB を壊さないよう排他ロックを取る。`--force` はリスクを承知の場合に bypass。
+        var lockPath = IndexLock.GetLockPath(resolvedDbPath);
+        IndexLock? indexLock = null;
+        if (!options.Force)
+        {
+            try
+            {
+                indexLock = IndexLock.Acquire(lockPath, options.ProjectPath);
+            }
+            catch (IndexLockConflictException ex)
+            {
+                var holderDescription = DescribeLockHolder(ex.Holder);
+                var message = string.IsNullOrEmpty(holderDescription)
+                    ? "another cdidx index is already running on this database"
+                    : $"another cdidx index is already running on this database ({holderDescription})";
+                return WriteCommandError(
+                    options.Json,
+                    jsonOptions,
+                    message,
+                    CommandExitCodes.DatabaseError,
+                    "Wait for the running index to finish, or pass --force to bypass the lock if you are sure no other cdidx index is active.");
+            }
+        }
+        else if (!options.Json)
+        {
+            ConsoleUi.PrintWarning("--force bypasses the index lock; concurrent cdidx index runs may corrupt the database.");
+        }
+
+        using (indexLock)
+        {
+            using var db = new DbContext(dbPath);
 
         // Capture prior readiness BEFORE we clear it. Update mode (--commits / --files) only
         // touches a subset of files, so trust bits the DB did NOT previously carry must not
@@ -294,6 +328,15 @@ public static class IndexCommandRunner
         return isUpdateMode
             ? RunUpdateMode(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorReadiness, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit)
             : RunFullScan(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit);
+        }
+    }
+
+    private static string DescribeLockHolder(IndexLockInfo? holder)
+    {
+        if (holder == null)
+            return string.Empty;
+        var startedLocal = holder.StartedAt.ToLocalTime();
+        return $"PID {holder.Pid.ToString(System.Globalization.CultureInfo.InvariantCulture)}, started {startedLocal.ToString("yyyy-MM-dd HH:mm:ss zzz", System.Globalization.CultureInfo.InvariantCulture)}";
     }
 
     public static int RunBackfillFold(string[] cmdArgs, JsonSerializerOptions jsonOptions)
@@ -403,6 +446,7 @@ public static class IndexCommandRunner
         bool verbose = false;
         bool json = false;
         bool dryRun = false;
+        bool force = false;
         string? easterEgg = null;
         int spinnerFlagCount = 0;
         bool randomSpinner = false;
@@ -427,6 +471,9 @@ public static class IndexCommandRunner
                     break;
                 case "--dry-run":
                     dryRun = true;
+                    break;
+                case "--force":
+                    force = true;
                     break;
                 case "--commits":
                     while (i + 1 < args.Length && !args[i + 1].StartsWith('-'))
@@ -482,6 +529,7 @@ public static class IndexCommandRunner
             UpdateFiles = updateFiles,
             EasterEgg = easterEgg,
             DryRun = dryRun,
+            Force = force,
         };
     }
 
@@ -2123,6 +2171,7 @@ public sealed class IndexCommandOptions
     public List<string> UpdateFiles { get; init; } = [];
     public string? EasterEgg { get; init; }
     public bool DryRun { get; init; }
+    public bool Force { get; init; }
 }
 
 public sealed class BackfillFoldCommandOptions

--- a/src/CodeIndex/Cli/IndexLock.cs
+++ b/src/CodeIndex/Cli/IndexLock.cs
@@ -1,0 +1,285 @@
+using System.Globalization;
+using System.Text;
+
+namespace CodeIndex.Cli;
+
+/// <summary>
+/// Process-exclusive lock for `cdidx index` runs against a single database file.
+/// SQLite's `busy_timeout` only serializes individual writes, so two concurrent
+/// `cdidx index` invocations could otherwise interleave schema and data work and
+/// leave the DB in a corrupted half-and-half state. The holder opens the lock
+/// file with <see cref="FileShare.None"/> for cross-process exclusion (matching
+/// the precedent in <c>SuggestionStore.WithFileLock</c>) and writes PID/start-time
+/// metadata to a sibling <c>.info</c> file so a second cdidx can identify the
+/// conflicting holder before exiting.
+/// 単一の DB ファイルに対する `cdidx index` 実行を排他化するためのロック。
+/// SQLite の `busy_timeout` は個々の write しか直列化しないため、2 つの
+/// `cdidx index` が同時に走るとスキーマ操作とデータ書き込みが交錯し DB が
+/// 破損し得る。保持者は <c>SuggestionStore.WithFileLock</c> と同じく
+/// <see cref="FileShare.None"/> でロックファイルを開いてプロセス間排他を確保し、
+/// PID と起動時刻を隣接 <c>.info</c> ファイルに書き出して、2 つ目の cdidx が
+/// 終了前に競合相手を表示できるようにする。
+/// </summary>
+internal sealed class IndexLock : IDisposable
+{
+    private readonly FileStream _stream;
+    private readonly string _lockPath;
+    private readonly string _infoPath;
+    private bool _disposed;
+
+    private IndexLock(FileStream stream, string lockPath, string infoPath)
+    {
+        _stream = stream;
+        _lockPath = lockPath;
+        _infoPath = infoPath;
+    }
+
+    /// <summary>
+    /// Resolve the lockfile path next to the resolved database path.
+    /// 解決済み DB パスの隣接ロックファイルパスを返す。
+    /// </summary>
+    public static string GetLockPath(string resolvedDbPath) => resolvedDbPath + ".lock";
+
+    /// <summary>
+    /// Resolve the metadata sidecar path next to the lockfile.
+    /// ロックファイルの隣接メタデータパスを返す。
+    /// </summary>
+    public static string GetInfoPath(string lockPath) => lockPath + ".info";
+
+    /// <summary>
+    /// Try to acquire the lock. Throws <see cref="IndexLockConflictException"/> when
+    /// another holder owns the lockfile. Stale lockfiles left by a crashed cdidx
+    /// release the OS lock automatically, so this call recovers without manual cleanup.
+    /// ロック取得を試みる。他のプロセスが保持していれば
+    /// <see cref="IndexLockConflictException"/> を投げる。クラッシュで残った lockfile は
+    /// OS が自動でロックを解放するため、手動清掃なしで回復する。
+    /// </summary>
+    public static IndexLock Acquire(string lockPath, string projectPath)
+    {
+        var dir = Path.GetDirectoryName(lockPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        var infoPath = GetInfoPath(lockPath);
+
+        FileStream stream;
+        try
+        {
+            // FileShare.None gives cross-process exclusion on every platform we
+            // support, the same approach SuggestionStore uses. The diagnostic
+            // metadata for competitors lives in a sibling .info file so we never
+            // need to relax this share mode.
+            // FileShare.None は全プラットフォームでプロセス間の排他を提供する
+            // （SuggestionStore と同じ手法）。競合相手向け診断メタデータは隣接
+            // .info ファイルに分離されるため、この共有モードを緩める必要はない。
+            stream = new FileStream(
+                lockPath,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None);
+        }
+        catch (IOException ex)
+        {
+            var holder = TryReadHolderInfo(lockPath);
+            throw new IndexLockConflictException(lockPath, holder, ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            var holder = TryReadHolderInfo(lockPath);
+            throw new IndexLockConflictException(lockPath, holder, ex);
+        }
+
+        try
+        {
+            var info = new IndexLockInfo(
+                Pid: Environment.ProcessId,
+                StartedAt: DateTime.UtcNow,
+                Host: Environment.MachineName,
+                ProjectPath: Path.GetFullPath(projectPath));
+            File.WriteAllText(infoPath, SerializeInfo(info), Encoding.UTF8);
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+
+        return new IndexLock(stream, lockPath, infoPath);
+    }
+
+    /// <summary>
+    /// Read the holder metadata if present. Returns null when the file is missing,
+    /// empty, or the metadata cannot be parsed.
+    /// 保持者メタデータを読む。ファイルが無い・空・解析不能の場合は null。
+    /// </summary>
+    public static IndexLockInfo? TryReadHolderInfo(string lockPath)
+    {
+        var infoPath = GetInfoPath(lockPath);
+        try
+        {
+            if (!File.Exists(infoPath))
+                return null;
+            // FileShare.ReadWrite mirrors what a concurrent holder might be doing
+            // (the holder may overwrite the .info on stale recovery), so a
+            // diagnostic read is never rejected for share-mode mismatch.
+            // 保持者が .info を上書きしている可能性があるため FileShare.ReadWrite で
+            // 開き、共有モード不一致で読みを失敗させない。
+            using var stream = new FileStream(
+                infoPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            var text = reader.ReadToEnd();
+            if (string.IsNullOrWhiteSpace(text))
+                return null;
+            return ParseInfo(text);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        try
+        {
+            File.Delete(_infoPath);
+        }
+        catch
+        {
+            // Best-effort. / ベストエフォート。
+        }
+
+        try
+        {
+            _stream.Dispose();
+        }
+        catch
+        {
+            // Best-effort. / ベストエフォート。
+        }
+
+        try
+        {
+            File.Delete(_lockPath);
+        }
+        catch
+        {
+            // Best-effort cleanup; a leftover empty lockfile does not block future
+            // acquires because the next Acquire opens it with OpenOrCreate.
+            // 残った空 lockfile も次回 Acquire の OpenOrCreate で再利用できる。
+        }
+    }
+
+    // --- Tiny key=value serializer (avoids touching JsonSerializerContext) ---
+    // --- 小さな key=value シリアライザ（JsonSerializerContext を触らない） ---
+
+    private static string SerializeInfo(IndexLockInfo info)
+    {
+        var sb = new StringBuilder();
+        sb.Append("pid=").Append(info.Pid.ToString(CultureInfo.InvariantCulture)).Append('\n');
+        sb.Append("started_at=").Append(info.StartedAt.ToString("o", CultureInfo.InvariantCulture)).Append('\n');
+        sb.Append("host=").Append(EscapeValue(info.Host)).Append('\n');
+        sb.Append("project=").Append(EscapeValue(info.ProjectPath)).Append('\n');
+        return sb.ToString();
+    }
+
+    private static IndexLockInfo? ParseInfo(string text)
+    {
+        int? pid = null;
+        DateTime? started = null;
+        string? host = null;
+        string? project = null;
+        foreach (var rawLine in text.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (string.IsNullOrEmpty(line))
+                continue;
+            var eq = line.IndexOf('=');
+            if (eq < 0)
+                continue;
+            var key = line[..eq];
+            var value = UnescapeValue(line[(eq + 1)..]);
+            switch (key)
+            {
+                case "pid":
+                    if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var p))
+                        pid = p;
+                    break;
+                case "started_at":
+                    if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var s))
+                        started = s;
+                    break;
+                case "host":
+                    host = value;
+                    break;
+                case "project":
+                    project = value;
+                    break;
+            }
+        }
+
+        if (pid is null || started is null)
+            return null;
+        return new IndexLockInfo(pid.Value, started.Value, host ?? string.Empty, project ?? string.Empty);
+    }
+
+    private static string EscapeValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        return value.Replace("\\", "\\\\").Replace("\n", "\\n").Replace("\r", "\\r");
+    }
+
+    private static string UnescapeValue(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        var sb = new StringBuilder(value.Length);
+        for (int i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c == '\\' && i + 1 < value.Length)
+            {
+                var next = value[++i];
+                sb.Append(next switch
+                {
+                    'n' => '\n',
+                    'r' => '\r',
+                    '\\' => '\\',
+                    _ => next,
+                });
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+        return sb.ToString();
+    }
+}
+
+internal sealed record IndexLockInfo(
+    int Pid,
+    DateTime StartedAt,
+    string Host,
+    string ProjectPath);
+
+internal sealed class IndexLockConflictException : Exception
+{
+    public string LockPath { get; }
+    public IndexLockInfo? Holder { get; }
+
+    public IndexLockConflictException(string lockPath, IndexLockInfo? holder, Exception inner)
+        : base("Another cdidx index is already running on this database.", inner)
+    {
+        LockPath = lockPath;
+        Holder = holder;
+    }
+}

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -26,7 +26,7 @@ public class ConsoleUiTests
 
         Assert.DoesNotContain("██████╗", output);
         Assert.Contains("Usage:", output);
-        Assert.Contains("cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--json]", output);
+        Assert.Contains("cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--json]", output);
         Assert.Contains("cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json]", output);
         Assert.Contains("cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json]", output);
         Assert.Contains("cdidx backfill-fold [--db <path>] [--json]", output);

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -30,6 +30,21 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void ParseArgs_ForceFlag_SetsForce()
+    {
+        var options = IndexCommandRunner.ParseArgs([".", "--force"]);
+        Assert.True(options.Force);
+        Assert.Equal(".", options.ProjectPath);
+    }
+
+    [Fact]
+    public void ParseArgs_NoForceFlag_DefaultsToFalse()
+    {
+        var options = IndexCommandRunner.ParseArgs(["."]);
+        Assert.False(options.Force);
+    }
+
+    [Fact]
     public void Run_HelpFlagReturnsSuccess()
     {
         int exitCode;
@@ -5495,5 +5510,182 @@ public class IndexCommandRunnerTests
             File.SetAttributes(dir, FileAttributes.Normal);
 
         File.SetAttributes(path, FileAttributes.Normal);
+    }
+
+    [Fact]
+    public void Run_LockHeldByAnotherHolder_RejectedWithHolderInfo()
+    {
+        var projectRoot = CreateTempProject();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_lock_held_{Guid.NewGuid():N}.db");
+        var lockPath = dbPath + ".lock";
+        var infoPath = lockPath + ".info";
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.py"), "print('hi')\n");
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+
+            // FileShare.None matches the holder mode IndexLock.Acquire uses, so a
+            // competing cdidx process gets EWOULDBLOCK on its acquire attempt.
+            // Sidecar .info file holds the metadata IndexLock.TryReadHolderInfo reads.
+            File.WriteAllText(infoPath, "pid=98765\nstarted_at=2026-05-15T10:00:00.000Z\nhost=test-host\nproject=/tmp/xyz\n");
+            using (var holder = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            {
+                var (exitCode, _, stderr) = RunAndCaptureStreams([projectRoot, "--db", dbPath]);
+
+                Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+                Assert.Contains("another cdidx index is already running", stderr);
+                Assert.Contains("PID 98765", stderr);
+                Assert.Contains("--force", stderr);
+            }
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+            if (File.Exists(infoPath))
+                File.Delete(infoPath);
+            if (File.Exists(lockPath))
+                File.Delete(lockPath);
+        }
+    }
+
+    [Fact]
+    public void Run_LockHeldByAnotherHolder_JsonIncludesHint()
+    {
+        var projectRoot = CreateTempProject();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_lock_json_{Guid.NewGuid():N}.db");
+        var lockPath = dbPath + ".lock";
+        var infoPath = lockPath + ".info";
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.py"), "print('hi')\n");
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+
+            File.WriteAllText(infoPath, "pid=12345\nstarted_at=2026-05-15T10:00:00.000Z\nhost=h\nproject=/p\n");
+            using (var holder = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            {
+                var (exitCode, json) = RunAndCaptureJson([projectRoot, "--db", dbPath, "--json"]);
+
+                Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+                Assert.Equal("error", json.GetProperty("status").GetString());
+                var message = json.GetProperty("message").GetString();
+                Assert.NotNull(message);
+                Assert.Contains("another cdidx index is already running", message);
+                Assert.Contains("PID 12345", message);
+                var hint = json.GetProperty("hint").GetString();
+                Assert.NotNull(hint);
+                Assert.Contains("--force", hint);
+            }
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+            if (File.Exists(infoPath))
+                File.Delete(infoPath);
+            if (File.Exists(lockPath))
+                File.Delete(lockPath);
+        }
+    }
+
+    [Fact]
+    public void Run_ForceFlag_BypassesLockEvenWhenHeld()
+    {
+        var projectRoot = CreateTempProject();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_lock_force_{Guid.NewGuid():N}.db");
+        var lockPath = dbPath + ".lock";
+        var infoPath = lockPath + ".info";
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.py"), "print('hi')\n");
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+
+            using (var holder = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            {
+                var (exitCode, json) = RunAndCaptureJson([projectRoot, "--db", dbPath, "--force", "--json"]);
+                Assert.Equal(CommandExitCodes.Success, exitCode);
+                Assert.Equal("success", json.GetProperty("status").GetString());
+            }
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+            if (File.Exists(infoPath))
+                File.Delete(infoPath);
+            if (File.Exists(lockPath))
+                File.Delete(lockPath);
+        }
+    }
+
+    [Fact]
+    public void Run_StaleLockFile_ReclaimedAndCleanedUpAfterSuccess()
+    {
+        var projectRoot = CreateTempProject();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_lock_stale_{Guid.NewGuid():N}.db");
+        var lockPath = dbPath + ".lock";
+        var infoPath = lockPath + ".info";
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.py"), "print('hi')\n");
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+
+            // Stale on-disk lockfile with no live holder; OS releases handles on
+            // process death so a fresh acquire must succeed and clean up after itself.
+            File.WriteAllText(lockPath, string.Empty);
+            File.WriteAllText(infoPath, "pid=99999\nstarted_at=2020-01-01T00:00:00.000Z\nhost=stale\nproject=/old\n");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--db", dbPath, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.False(File.Exists(lockPath), "lock file should be removed after a clean exit");
+            Assert.False(File.Exists(infoPath), "lock metadata sidecar should be removed after a clean exit");
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+            if (File.Exists(infoPath))
+                File.Delete(infoPath);
+            if (File.Exists(lockPath))
+                File.Delete(lockPath);
+        }
+    }
+
+    [Fact]
+    public void Run_DryRun_DoesNotAcquireLock()
+    {
+        var projectRoot = CreateTempProject();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_lock_dryrun_{Guid.NewGuid():N}.db");
+        var lockPath = dbPath + ".lock";
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.py"), "print('hi')\n");
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+
+            // Hold the lockfile while running --dry-run to prove dry-run never tries to acquire.
+            using (var holder = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            {
+                var (exitCode, json) = RunAndCaptureJson([projectRoot, "--db", dbPath, "--dry-run", "--json"]);
+                Assert.Equal(CommandExitCodes.Success, exitCode);
+                Assert.Equal("dry_run", json.GetProperty("status").GetString());
+            }
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+            if (File.Exists(lockPath))
+                File.Delete(lockPath);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a per-database file lock (`<db>.lock`, opened with `FileShare.None` to match the `SuggestionStore.WithFileLock` precedent) so a second `cdidx index` against the same DB exits with `CommandExitCodes.DatabaseError` instead of racing schema and data work. SQLite's `busy_timeout=5000` only serializes individual writes, so concurrent runs could otherwise leave the DB half-migrated.
- Holder metadata (PID / start time / host / project path) lives in a sibling `<db>.lock.info` file written by `IndexLock.Acquire`. Conflicting runs report `another cdidx index is already running on this database (PID …, started …)` plus a hint suggesting `--force`.
- `--dry-run` skips the lock entirely (the existing dry-run early return precedes the acquire site), and a new `--force` flag bypasses the lock with a stderr warning so CI / recovery flows remain possible without manual cleanup.
- Stale lockfiles from crashed processes recover automatically because the OS releases handles on process death; `IndexLock.Acquire` opens with `FileMode.OpenOrCreate` and a successful run cleans up both `.lock` and `.lock.info` on dispose.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug` — clean (0 warnings, 0 errors).
- Full solution test suite: 4559 passed / 3 skipped / 0 failed.
- New tests in `tests/CodeIndex.Tests/IndexCommandRunnerTests.cs`:
  - `ParseArgs_ForceFlag_SetsForce`, `ParseArgs_NoForceFlag_DefaultsToFalse`
  - `Run_LockHeldByAnotherHolder_RejectedWithHolderInfo` — held lock + sidecar `.info` produces `DatabaseError` with PID and `--force` hint on stderr.
  - `Run_LockHeldByAnotherHolder_JsonIncludesHint` — same path under `--json` emits `status=error`, message, and hint.
  - `Run_ForceFlag_BypassesLockEvenWhenHeld` — `--force` proceeds and writes the index even when the lockfile is held.
  - `Run_StaleLockFile_ReclaimedAndCleanedUpAfterSuccess` — stale on-disk lockfile is reclaimed and both `.lock` and `.lock.info` are gone after a clean exit.
  - `Run_DryRun_DoesNotAcquireLock` — `--dry-run` succeeds even while another process holds the lock.
- `tests/CodeIndex.Tests/ConsoleUiTests.cs` updated to expect `[--force]` in the index synopsis.
- `dotnet run --project tools/CodeIndex.Changelog -- check` — 25 fragments validated.

## Documentation / Changelog

- `changelog.d/unreleased/1514.added.md` — bilingual `added` fragment listing the new lock behavior, `--force`, and `--dry-run` exemption.
- `USER_GUIDE.md` — bilingual `--force` row added to the index options tables.
- `src/CodeIndex/Cli/ConsoleUi.cs` — synopsis and per-flag help line updated to expose `--force`.

Fixes #1514
