### PR TITLE
Add db --integrity-check subcommand (#1517)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -327,6 +327,16 @@ cdidx backfill-fold
 
 This recomputes `name_folded` / `*_folded` columns from the existing DB rows and stamps `fold_ready` without reparsing source files. The target must already be an existing CodeIndex DB; blank or missing paths are rejected instead of creating a new database.
 
+If you suspect the SQLite file itself is corrupted (queries crashing with a SQLite error, unexpected `database disk image is malformed` messages), you can probe it explicitly:
+
+```bash
+cdidx db --integrity-check                              # run PRAGMA integrity_check
+cdidx db --integrity-check --db ./.cdidx/codeindex.db   # point at a specific DB
+cdidx db --integrity-check --json                       # machine-readable result
+```
+
+This opens the database read-only, runs SQLite's `PRAGMA integrity_check`, and prints whether the file is `ok` or lists the failures. Exit codes are stable for scripting: `0` clean, `2` (NotFound) when the file does not exist, `3` (DatabaseError) when corruption is detected. SQLite does not offer a general-purpose repair primitive — if the check fails, recover by rebuilding with `cdidx index <projectPath> --rebuild`.
+
 ### Search code
 
 ```bash
@@ -1360,6 +1370,16 @@ cdidx backfill-fold
 ```
 
 これは既存 DB 行から `name_folded` / `*_folded` 列を再計算し、ソース再解析なしで `fold_ready` を stamp します。対象は既存の CodeIndex DB に限られ、空のDBや存在しないパスを指定しても新規作成せず拒否します。
+
+SQLite ファイル自体が破損していると疑われる場合（クエリが SQLite エラーで落ちる、`database disk image is malformed` といったメッセージが出る等）には、整合性を明示的に確認できます:
+
+```bash
+cdidx db --integrity-check                              # PRAGMA integrity_check を実行
+cdidx db --integrity-check --db ./.cdidx/codeindex.db   # 特定 DB を指定
+cdidx db --integrity-check --json                       # 機械可読な結果
+```
+
+DB を read-only で開いて SQLite の `PRAGMA integrity_check` を実行し、`ok` か、検出された破損行の一覧を出力します。終了コードは安定しており、`0` = 健全、`2` (NotFound) = ファイル無し、`3` (DatabaseError) = 破損検出です。SQLite には汎用的な修復プリミティブが無いため、チェックが失敗した場合は `cdidx index <projectPath> --rebuild` で再構築するのが推奨復旧手段です。
 
 ### コード検索
 

--- a/changelog.d/unreleased/1517.added.md
+++ b/changelog.d/unreleased/1517.added.md
@@ -1,0 +1,19 @@
+---
+category: added
+issues:
+  - 1517
+affected:
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+---
+
+## English
+
+- **New `cdidx db --integrity-check` command surfaces SQLite corruption explicitly (#1517)** — previously the only way to confirm a `.cdidx/codeindex.db` was healthy was to wait for a query to crash with a SQLite error, and there was no human- or JSON-friendly probe for CI / oncall workflows. `cdidx db --integrity-check [--db <path>] [--json]` now opens the database read-only, runs `PRAGMA integrity_check`, and reports the result with a stable contract: exit `0` and `ok=true` for a clean database, exit `3` (DatabaseError) with the pragma's diagnostic rows for a corrupted one, exit `2` (NotFound) when the file does not exist (with a hint to run `cdidx index <projectPath>` first), and exit `1` for usage mistakes. Bash / zsh / fish completions and the `--help` output list the new subcommand alongside its `--db`, `--json`, and `--integrity-check` flags. A `--repair` mode is intentionally out of scope for this change — SQLite has no general-purpose repair primitive, so the recommended recovery remains `cdidx index <projectPath> --rebuild`, and the corruption hint now points users there.
+
+## 日本語
+
+- **`cdidx db --integrity-check` コマンドで SQLite 破損を明示的に検出できるようになりました (#1517)** — これまで `.cdidx/codeindex.db` が健全か確認する唯一の方法はクエリが SQLite エラーで落ちるのを待つことで、CI / オンコール向けに human / JSON 出力で扱える整合性チェックがありませんでした。`cdidx db --integrity-check [--db <path>] [--json]` は DB を read-only で開いて `PRAGMA integrity_check` を実行し、結果を安定した契約で返します: 健全なら exit `0` と `ok=true`、破損していれば exit `3` (DatabaseError) と pragma の検出行、ファイルが無ければ exit `2` (NotFound) と `cdidx index <projectPath>` を案内するヒント、使い方の誤りには exit `1` を返します。bash / zsh / fish 補完と `--help` 出力も新しいサブコマンドおよび `--db` / `--json` / `--integrity-check` フラグを表示します。本変更には `--repair` モードは含まれていません — SQLite には汎用的な修復プリミティブがないため、推奨される復旧手段は引き続き `cdidx index <projectPath> --rebuild` であり、破損時のヒントもそこへ誘導します。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -29,6 +29,7 @@ public static class ConsoleUi
         ("inspect", "cdidx inspect <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--max-line-width <n>] [--exact|--exact-name]"),
         ("outline", "cdidx outline <path> [--db <path>] [--json]"),
         ("status", "cdidx status [--db <path>] [--json] [--check]"),
+        ("db", "cdidx db --integrity-check [--db <path>] [--json]"),
         ("validate", "cdidx validate [--db <path>] [--json] [--kind <kind>] [--path <glob>]"),
         ("impact", "cdidx impact <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--depth <n>] [--count]"),
         ("deps", "cdidx deps [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--reverse]"),
@@ -355,6 +356,7 @@ public static class ConsoleUi
         Console.WriteLine("  inspect <query>            Bundle definition, graph, and nearby symbol context");
         Console.WriteLine("  outline <path>             Show the symbol outline of a single file");
         Console.WriteLine("  status                     Show database statistics; add --check to verify DB/worktree match");
+        Console.WriteLine("  db --integrity-check       Run SQLite `PRAGMA integrity_check` and report findings");
         Console.WriteLine("  validate                   Report encoding issues (U+FFFD, BOM, null bytes, mixed line endings)");
         Console.WriteLine("  impact <query>             Show transitive callers; type queries may return heuristic file-level dependency hints");
         Console.WriteLine("  deps                       Show file-level dependency edges from the reference graph");
@@ -540,7 +542,7 @@ public static class ConsoleUi
     [
         "index", "backfill-fold", "search", "definition", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
-        "validate", "deps", "impact", "unused", "hotspots", "languages", "mcp", "license",
+        "validate", "deps", "impact", "unused", "hotspots", "languages", "mcp", "db", "license",
     ];
 
     /// <summary>
@@ -620,6 +622,8 @@ public static class ConsoleUi
                 COMPREPLY=($(compgen -W ""--db --json --limit --lang --kind --path --exclude-path --exclude-tests --count --group-by-name --help"" -- ""$cur""))
             elif [ ""$cmd"" = ""status"" ]; then
                 COMPREPLY=($(compgen -W ""--db --json --check --help"" -- ""$cur""))
+            elif [ ""$cmd"" = ""db"" ]; then
+                COMPREPLY=($(compgen -W ""--db --json --integrity-check --help"" -- ""$cur""))
             elif [ ""$cmd"" = ""search"" ]; then
                 COMPREPLY=($(compgen -W ""--db --json --limit --top --lang --path --exclude-path --exclude-tests --count --fts --snippet-lines --max-line-width --since --no-dedup --exact --exact-substring --help"" -- ""$cur""))
             else
@@ -728,6 +732,11 @@ _cdidx() {{
                     '--db[Database path]:file:_files' \
                     '--json[JSON output]' \
                     '--check[Verify index matches current workspace]'
+            elif [[ $subcmd == db ]]; then
+                _arguments \
+                    '--db[Database path]:file:_files' \
+                    '--json[JSON output]' \
+                    '--integrity-check[Run PRAGMA integrity_check on the database]'
             elif [[ $subcmd == search ]]; then
                 _arguments \
                     '--db[Database path]:file:_files' \
@@ -784,6 +793,9 @@ _cdidx";
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find excerpt map inspect outline status' -l db -r -d 'Database path'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find excerpt map inspect outline status' -l json -d 'JSON output'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from status' -l check -d 'Verify index matches current workspace'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from db' -l db -r -d 'Database path'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from db' -l json -d 'JSON output'");
+        lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from db' -l integrity-check -d 'Run PRAGMA integrity_check on the database'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l limit -r -d 'Max results'");
         lines.Add($"complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l lang -r -a '{GetCompletionLangs()}' -d 'Filter by language'");
         lines.Add("complete -c cdidx -n '__fish_seen_subcommand_from search definition references callers callees symbols files find' -l count -d 'Count only'");

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Cli;
+
+/// <summary>
+/// Runs `db` subcommands that operate directly on the SQLite file (integrity check, etc.).
+/// SQLite ファイル本体に対する `db` サブコマンド（整合性チェックなど）を実行する。
+/// </summary>
+public static class DbCommandRunner
+{
+    public static int RunIntegrityCheck(string[] cmdArgs, JsonSerializerOptions jsonOptions)
+    {
+        var options = ParseArgs(cmdArgs);
+        if (options.ShowHelp)
+        {
+            ConsoleUi.PrintUsage();
+            return CommandExitCodes.Success;
+        }
+
+        if (options.ParseError != null)
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                options.ParseError,
+                CommandExitCodes.UsageError,
+                "Run `cdidx db --integrity-check --help` to see the supported command shape.");
+
+        if (!options.IntegrityCheck)
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                "db requires a mode flag",
+                CommandExitCodes.UsageError,
+                "Pass `--integrity-check` to run `PRAGMA integrity_check` on the database.");
+
+        var dbPath = options.DbPath;
+        var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
+        if (!isUri && !File.Exists(dbPath))
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                $"database not found: {dbPath}",
+                CommandExitCodes.NotFound,
+                "Point `--db` at an existing `codeindex.db`, or run `cdidx index <projectPath>` first to create one.");
+
+        try
+        {
+            var issues = RunIntegrityCheckPragma(dbPath);
+            var ok = issues.Count == 1 && string.Equals(issues[0], "ok", StringComparison.Ordinal);
+            var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
+
+            if (options.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(
+                    new DbIntegrityCheckJsonResult(
+                        Path.GetFullPath(isUri ? dbPath : dbPath),
+                        ok,
+                        ok ? new List<string>() : issues),
+                    jsonContext.DbIntegrityCheckJsonResult));
+            }
+            else
+            {
+                Console.WriteLine("Integrity check");
+                Console.WriteLine($"  database: {Path.GetFullPath(isUri ? dbPath : dbPath)}");
+                Console.WriteLine($"  result  : {(ok ? "ok" : "corrupted")}");
+                if (!ok)
+                {
+                    Console.WriteLine($"  issues  : {issues.Count} row(s)");
+                    foreach (var line in issues)
+                        Console.WriteLine($"    - {line}");
+                    Console.WriteLine();
+                    Console.Error.WriteLine("Error: SQLite reported integrity_check failures.");
+                    Console.Error.WriteLine("Hint: rebuild with `cdidx index <projectPath> --rebuild` to discard the corrupted DB and start fresh.");
+                }
+            }
+
+            return ok ? CommandExitCodes.Success : CommandExitCodes.DatabaseError;
+        }
+        catch (Exception ex)
+        {
+            if (JsonOutputFailure.TryHandle(ex, out var exitCode))
+                return exitCode;
+
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                $"failed to run integrity check: {ex.Message}",
+                CommandExitCodes.DatabaseError,
+                "Retry `cdidx db --integrity-check`. If this persists, the DB may be unreadable; rebuild with `cdidx index <projectPath> --rebuild`.");
+        }
+    }
+
+    // PRAGMA integrity_check returns a single row `"ok"` when the file passes every consistency
+    // probe, otherwise it returns up to N rows of corruption findings. The pragma itself only
+    // reads the database, so a read-only connection is sufficient and avoids the WAL-mode
+    // pragma side effects of the normal DbContext open path.
+    // PRAGMA integrity_check は問題が無ければ 1 行の `"ok"` を、破損があれば最大 N 行の検出結果を返す。
+    // 読み取りのみのため read-only 接続で十分で、DbContext の WAL モード設定副作用を避けられる。
+    private static List<string> RunIntegrityCheckPragma(string dbPath)
+    {
+        var connectionString = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
+            ? $"Data Source={dbPath}"
+            : new SqliteConnectionStringBuilder
+            {
+                DataSource = dbPath,
+                Mode = SqliteOpenMode.ReadOnly,
+            }.ConnectionString;
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA integrity_check";
+        using var reader = cmd.ExecuteReader();
+        var rows = new List<string>();
+        while (reader.Read())
+        {
+            var raw = reader.IsDBNull(0) ? string.Empty : reader.GetString(0);
+            rows.Add(raw);
+        }
+        return rows.Count > 0 ? rows : new List<string> { "ok" };
+    }
+
+    internal static DbCommandOptions ParseArgs(string[] args)
+    {
+        var dbPath = Path.Combine(".cdidx", "codeindex.db");
+        var json = false;
+        var integrityCheck = false;
+        string? parseError = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--db" when i + 1 < args.Length:
+                    dbPath = args[++i];
+                    break;
+                case "--db":
+                    parseError = "--db requires a value";
+                    break;
+                case "--json":
+                    json = true;
+                    break;
+                case "--integrity-check":
+                    integrityCheck = true;
+                    break;
+                case "--help" or "-h":
+                    return new DbCommandOptions { ShowHelp = true, DbPath = dbPath, Json = json };
+                default:
+                    if (args[i].StartsWith('-'))
+                        parseError = $"db does not support option: '{args[i]}'";
+                    else
+                        parseError = $"db does not accept positional arguments: '{args[i]}'";
+                    break;
+            }
+
+            if (parseError != null)
+                break;
+        }
+
+        return new DbCommandOptions
+        {
+            DbPath = dbPath,
+            Json = json,
+            IntegrityCheck = integrityCheck,
+            ParseError = parseError,
+        };
+    }
+
+    private static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode, string? hint = null)
+    {
+        if (json)
+            Console.WriteLine(JsonSerializer.Serialize(
+                new CommandErrorJsonResult("error", message, hint),
+                CliJsonSerializerContextFactory.Create(jsonOptions).CommandErrorJsonResult));
+        else
+        {
+            Console.Error.WriteLine($"Error: {message}");
+            if (hint != null)
+                Console.Error.WriteLine($"Hint: {hint}");
+        }
+        return exitCode;
+    }
+}
+
+internal sealed class DbCommandOptions
+{
+    public string DbPath { get; init; } = string.Empty;
+    public bool Json { get; init; }
+    public bool ShowHelp { get; init; }
+    public bool IntegrityCheck { get; init; }
+    public string? ParseError { get; init; }
+}

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -24,6 +24,11 @@ internal sealed record CommandErrorJsonResult(
     [property: JsonPropertyName("message")] string Message,
     [property: JsonPropertyName("hint")] string? Hint);
 
+internal sealed record DbIntegrityCheckJsonResult(
+    [property: JsonPropertyName("db_path")] string DbPath,
+    [property: JsonPropertyName("ok")] bool Ok,
+    [property: JsonPropertyName("issues")] List<string> Issues);
+
 internal sealed record QueryCountJsonResult(
     [property: JsonPropertyName("count")] int Count);
 
@@ -169,6 +174,7 @@ internal sealed record GroupedSymbolHotspotJsonResult(
 [JsonSerializable(typeof(CliJsonMessage))]
 [JsonSerializable(typeof(CompactSearchResult))]
 [JsonSerializable(typeof(CommandErrorJsonResult))]
+[JsonSerializable(typeof(DbIntegrityCheckJsonResult))]
 [JsonSerializable(typeof(DefinitionResult))]
 [JsonSerializable(typeof(Dictionary<string, int>))]
 [JsonSerializable(typeof(Dictionary<string, long>))]

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -87,6 +87,7 @@ internal static class ProgramRunner
                 "hotspots" => QueryCommandRunner.RunHotspots(args[1..], jsonOptions),
                 "index" => IndexCommandRunner.Run(args[1..], jsonOptions),
                 "backfill-fold" => IndexCommandRunner.RunBackfillFold(args[1..], jsonOptions),
+                "db" => DbCommandRunner.RunIntegrityCheck(args[1..], jsonOptions),
                 _ when IsProjectPathArg(args[0])
                     => IndexCommandRunner.Run(args, jsonOptions),
                 _ => ShowError(args, $"Unknown command: {args[0]}")

--- a/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
@@ -1,0 +1,222 @@
+using System.Text.Json;
+using CodeIndex.Cli;
+using CodeIndex.Database;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Tests;
+
+/// <summary>
+/// Tests for `cdidx db --integrity-check` (issue #1517).
+/// `cdidx db --integrity-check` のテスト (issue #1517)。
+/// </summary>
+[Collection("SQLite pool sensitive")]
+public class DbCommandRunnerTests
+{
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    [Fact]
+    public void ParseArgs_IntegrityCheckFlagSetsFlag()
+    {
+        var options = DbCommandRunner.ParseArgs(["--integrity-check"]);
+
+        Assert.True(options.IntegrityCheck);
+        Assert.Null(options.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_HelpFlagSetsShowHelp()
+    {
+        var options = DbCommandRunner.ParseArgs(["--help"]);
+
+        Assert.True(options.ShowHelp);
+    }
+
+    [Fact]
+    public void ParseArgs_UnknownOptionRecordsParseError()
+    {
+        var options = DbCommandRunner.ParseArgs(["--bogus"]);
+
+        Assert.NotNull(options.ParseError);
+        Assert.Contains("--bogus", options.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_PositionalArgRecordsParseError()
+    {
+        var options = DbCommandRunner.ParseArgs(["something"]);
+
+        Assert.NotNull(options.ParseError);
+        Assert.Contains("positional", options.ParseError);
+    }
+
+    [Fact]
+    public void Run_WithoutModeFlag_ReturnsUsageError()
+    {
+        var (exitCode, _, stderr) = RunAndCaptureStreams([]);
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("db requires a mode flag", stderr);
+        Assert.Contains("--integrity-check", stderr);
+    }
+
+    [Fact]
+    public void Run_WithUnknownOption_ReturnsUsageError()
+    {
+        var (exitCode, _, stderr) = RunAndCaptureStreams(["--bogus"]);
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("--bogus", stderr);
+    }
+
+    [Fact]
+    public void Run_MissingDb_ReturnsNotFoundWithHint()
+    {
+        var missingDb = Path.Combine(Path.GetTempPath(), $"cdidx_db_missing_{Guid.NewGuid():N}.db");
+
+        var (exitCode, _, stderr) = RunAndCaptureStreams(["--integrity-check", "--db", missingDb]);
+
+        Assert.Equal(CommandExitCodes.NotFound, exitCode);
+        Assert.Contains("database not found", stderr);
+        Assert.Contains("cdidx index <projectPath>", stderr);
+    }
+
+    [Fact]
+    public void Run_MissingDb_JsonShapeIncludesHint()
+    {
+        var missingDb = Path.Combine(Path.GetTempPath(), $"cdidx_db_missing_{Guid.NewGuid():N}.db");
+
+        var (exitCode, json) = RunAndCaptureJson(["--integrity-check", "--db", missingDb, "--json"]);
+
+        Assert.Equal(CommandExitCodes.NotFound, exitCode);
+        Assert.Equal("error", json.GetProperty("status").GetString());
+        Assert.Contains("database not found", json.GetProperty("message").GetString());
+        Assert.Contains("cdidx index <projectPath>", json.GetProperty("hint").GetString());
+    }
+
+    [Fact]
+    public void Run_CleanDb_ReturnsOk()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_clean_{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = new DbContext(dbPath))
+                db.InitializeSchema();
+            SqliteConnection.ClearAllPools();
+
+            var (exitCode, stdout, _) = RunAndCaptureStreams(["--integrity-check", "--db", dbPath]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Contains("Integrity check", stdout);
+            Assert.Contains("ok", stdout);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void Run_CleanDb_JsonReportsOkTrueAndEmptyIssues()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_clean_json_{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = new DbContext(dbPath))
+                db.InitializeSchema();
+            SqliteConnection.ClearAllPools();
+
+            var (exitCode, json) = RunAndCaptureJson(["--integrity-check", "--db", dbPath, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.True(json.GetProperty("ok").GetBoolean());
+            Assert.Equal(0, json.GetProperty("issues").GetArrayLength());
+            Assert.Equal(Path.GetFullPath(dbPath), json.GetProperty("db_path").GetString());
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void Run_CorruptedDb_ReturnsDatabaseError()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_corrupt_{Guid.NewGuid():N}.db");
+        try
+        {
+            // Write bytes that begin with a valid SQLite header so the file is recognized
+            // as a database, then garbage after that triggers an integrity_check failure.
+            // SQLite ヘッダで始めつつ後続をゴミにすることで integrity_check に検出させる。
+            var header = System.Text.Encoding.ASCII.GetBytes("SQLite format 3\0");
+            var bytes = new byte[4096];
+            Array.Copy(header, bytes, header.Length);
+            for (var i = header.Length; i < bytes.Length; i++)
+                bytes[i] = 0xFF;
+            File.WriteAllBytes(dbPath, bytes);
+
+            var (exitCode, _, stderr) = RunAndCaptureStreams(["--integrity-check", "--db", dbPath]);
+
+            // Either the pragma raises an exception (caught as DatabaseError) or it returns
+            // non-"ok" rows; both paths must produce DatabaseError, never Success.
+            // PRAGMA が例外を投げるか non-"ok" 行を返すかのいずれでも DatabaseError を返すべき。
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            Assert.NotEmpty(stderr);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    private (int ExitCode, string StdOut, string StdErr) RunAndCaptureStreams(string[] args)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            using var outWriter = new StringWriter();
+            using var errWriter = new StringWriter();
+            try
+            {
+                Console.SetOut(outWriter);
+                Console.SetError(errWriter);
+                var exitCode = DbCommandRunner.RunIntegrityCheck(args, _jsonOptions);
+                return (exitCode, outWriter.ToString(), errWriter.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    private (int ExitCode, JsonElement Json) RunAndCaptureJson(string[] args)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            using var writer = new StringWriter();
+            try
+            {
+                Console.SetOut(writer);
+                var exitCode = DbCommandRunner.RunIntegrityCheck(args, _jsonOptions);
+                using var document = JsonDocument.Parse(writer.ToString());
+                return (exitCode, document.RootElement.Clone());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1517

## Summary
- Adds `cdidx db --integrity-check [--db <path>] [--json]`, which opens the SQLite file read-only and runs `PRAGMA integrity_check` so users (and CI / oncall scripts) can confirm `.cdidx/codeindex.db` is healthy without waiting for a query to crash.
- Stable exit codes for scripting: `0` clean, `2` (NotFound) when the file is missing, `3` (DatabaseError) when the pragma reports issues, `1` (UsageError) for bad invocations. `--json` returns `{db_path, ok, issues}` (and the existing `CommandErrorJsonResult` shape on error).
- Updates `--help`, the `Commands` array used by suggestions, and bash/zsh/fish completions to surface the new subcommand and its `--db`, `--json`, and `--integrity-check` flags.
- Documents the new recovery workflow in `USER_GUIDE.md` (English + 日本語) next to the existing `backfill-fold` block, including the explicit guidance that recovery from a failed check is still `cdidx index <projectPath> --rebuild`.
- Adds a bilingual changelog fragment at `changelog.d/unreleased/1517.added.md`.

`--repair` is intentionally out of scope: SQLite has no general-purpose repair primitive, so the existing rebuild path remains the recommended recovery and the corruption hint already routes users there.

## Test plan
- [x] `dotnet build CodeIndex.sln -c Release` — clean (only the offline `NU1900` warning).
- [x] `dotnet test CodeIndex.sln -c Release` — 4563 passed, 3 skipped (perf tests), 0 failed.
- [x] `dotnet test --filter "FullyQualifiedName~DbCommandRunnerTests"` — 11 new tests cover: arg parsing (help / unknown / positional / `--integrity-check`), missing mode flag, unknown option, missing DB (human + JSON shapes), clean DB (human + JSON with `ok=true`, empty `issues`, absolute `db_path`), and a corrupted DB returning `DatabaseError`.
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` — fragment validates.
