### PR TITLE
Stop snippet line clamp from slicing UTF-16 surrogate pairs (#1522)

### DIFF
--- a/changelog.d/unreleased/1522.fixed.md
+++ b/changelog.d/unreleased/1522.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1522
+affected:
+  - src/CodeIndex/Database/LineWidthFormatter.cs
+  - tests/CodeIndex.Tests/LineWidthFormatterTests.cs
+---
+
+## English
+
+- **Snippet line clamp no longer slices in the middle of a UTF-16 surrogate pair (#1522)** — `LineWidthFormatter.ClampLine` previously substringed by raw UTF-16 code-unit count, so a line ending in a non-BMP character (e.g. 👍 U+1F44D) could leave an orphaned high surrogate at the boundary, rendered as U+FFFD in CLI / JSON `snippet` output. The clamp now backs up by one code unit when the proposed boundary would split a surrogate pair, preserving the full character on both head and focus-window slices.
+
+## 日本語
+
+- **スニペットの行クランプが UTF-16 サロゲートペアの途中で切られなくなりました (#1522)** — `LineWidthFormatter.ClampLine` は UTF-16 のコードユニット数で部分文字列を取っていたため、行末に非 BMP 文字 (例: 👍 U+1F44D) があると high surrogate だけが残り、CLI / JSON の `snippet` 出力で U+FFFD に化けることがありました。クランプは境界がサロゲートペアを分断する場合に 1 コードユニット戻るようになり、先頭クランプとフォーカス窓クランプの両方で文字を保持します。

--- a/src/CodeIndex/Database/LineWidthFormatter.cs
+++ b/src/CodeIndex/Database/LineWidthFormatter.cs
@@ -53,9 +53,9 @@ public static class LineWidthFormatter
         var suffix = BuildMarker(line.Length - maxLineWidth);
         var visibleWidth = maxLineWidth - suffix.Length;
         if (visibleWidth <= 0)
-            return new ClampedTextResult(line[..maxLineWidth], true);
+            return new ClampedTextResult(line[..SafeSliceEnd(line, maxLineWidth)], true);
 
-        return new ClampedTextResult(line[..visibleWidth] + suffix, true);
+        return new ClampedTextResult(line[..SafeSliceEnd(line, visibleWidth)] + suffix, true);
     }
 
     private static ClampedTextResult ClampAroundFocus(string line, int maxLineWidth, int focusColumn, int focusLength)
@@ -71,7 +71,12 @@ public static class LineWidthFormatter
             var suffix = end < line.Length ? BuildMarker(line.Length - end) : string.Empty;
             var visibleWidth = maxLineWidth - prefix.Length - suffix.Length;
             if (visibleWidth <= 0)
-                return new ClampedTextResult(line.Substring(focusStart, Math.Min(maxLineWidth, line.Length - focusStart)), true);
+            {
+                var safeFocusStart = SafeSliceStart(line, focusStart);
+                var fallbackLength = Math.Min(maxLineWidth, line.Length - safeFocusStart);
+                var safeFallbackEnd = SafeSliceEnd(line, safeFocusStart + fallbackLength);
+                return new ClampedTextResult(line[safeFocusStart..safeFallbackEnd], true);
+            }
 
             var desiredCenter = focusStart + ((focusEnd - focusStart) / 2);
             start = Math.Max(0, desiredCenter - (visibleWidth / 2));
@@ -90,9 +95,31 @@ public static class LineWidthFormatter
             }
         }
 
-        var finalPrefix = start > 0 ? BuildMarker(start) : string.Empty;
-        var finalSuffix = end < line.Length ? BuildMarker(line.Length - end) : string.Empty;
-        return new ClampedTextResult(finalPrefix + line[start..end] + finalSuffix, true);
+        var safeStart = SafeSliceStart(line, start);
+        var safeEnd = SafeSliceEnd(line, end);
+        var finalPrefix = safeStart > 0 ? BuildMarker(safeStart) : string.Empty;
+        var finalSuffix = safeEnd < line.Length ? BuildMarker(line.Length - safeEnd) : string.Empty;
+        return new ClampedTextResult(finalPrefix + line[safeStart..safeEnd] + finalSuffix, true);
+    }
+
+    // Avoid slicing in the middle of a UTF-16 surrogate pair so output stays valid UTF-16
+    // and non-BMP characters (e.g. emoji like U+1F44D) survive line clamping without becoming U+FFFD.
+    private static int SafeSliceEnd(string line, int desiredEnd)
+    {
+        if (desiredEnd <= 0)
+            return 0;
+        if (desiredEnd >= line.Length)
+            return line.Length;
+        return char.IsLowSurrogate(line[desiredEnd]) ? desiredEnd - 1 : desiredEnd;
+    }
+
+    private static int SafeSliceStart(string line, int desiredStart)
+    {
+        if (desiredStart <= 0)
+            return 0;
+        if (desiredStart >= line.Length)
+            return line.Length;
+        return char.IsLowSurrogate(line[desiredStart]) ? desiredStart + 1 : desiredStart;
     }
 
     private static string BuildMarker(int elidedChars) =>

--- a/tests/CodeIndex.Tests/LineWidthFormatterTests.cs
+++ b/tests/CodeIndex.Tests/LineWidthFormatterTests.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using CodeIndex.Database;
+
+namespace CodeIndex.Tests;
+
+public class LineWidthFormatterTests
+{
+    private const string ThumbsUp = "\U0001F44D";
+
+    [Fact]
+    public void ClampLine_DoesNotSplitHeadSliceSurrogatePair()
+    {
+        // A run of non-BMP code points where the head-clamp boundary
+        // would naturally land on a low surrogate without the fix.
+        var line = string.Concat(Enumerable.Repeat(ThumbsUp, 100));
+
+        var result = LineWidthFormatter.ClampLine(line, maxLineWidth: 21);
+
+        Assert.True(result.Truncated);
+        AssertNoOrphanedSurrogate(result.Text);
+        Assert.DoesNotContain('�', result.Text);
+    }
+
+    [Fact]
+    public void ClampLine_DoesNotSplitTrailingSurrogatePairBeforeMarker()
+    {
+        var prefix = new string('a', 50);
+        var suffix = new string('b', 50);
+        // Place the emoji where the head-slice boundary would split it.
+        var line = prefix + ThumbsUp + suffix;
+
+        var result = LineWidthFormatter.ClampLine(line, maxLineWidth: 62);
+
+        Assert.True(result.Truncated);
+        AssertNoOrphanedSurrogate(result.Text);
+        Assert.DoesNotContain('�', result.Text);
+    }
+
+    [Fact]
+    public void ClampLine_KeepsFocusedSurrogatePairIntact()
+    {
+        var prefix = new string('a', 200);
+        var suffix = new string('b', 200);
+        var line = prefix + ThumbsUp + suffix;
+        var focusColumn = prefix.Length + 1;
+
+        var result = LineWidthFormatter.ClampLine(line, maxLineWidth: 64, focusColumn: focusColumn, focusLength: 2);
+
+        Assert.True(result.Truncated);
+        AssertNoOrphanedSurrogate(result.Text);
+        Assert.DoesNotContain('�', result.Text);
+        Assert.Contains(ThumbsUp, result.Text);
+    }
+
+    [Fact]
+    public void ClampLine_TightBudgetStillProducesValidUtf16()
+    {
+        var prefix = new string('a', 60);
+        var suffix = new string('b', 60);
+        var line = prefix + ThumbsUp + suffix;
+        var focusColumn = prefix.Length + 1;
+
+        var result = LineWidthFormatter.ClampLine(line, maxLineWidth: 4, focusColumn: focusColumn, focusLength: 2);
+
+        Assert.True(result.Truncated);
+        AssertNoOrphanedSurrogate(result.Text);
+        Assert.DoesNotContain('�', result.Text);
+    }
+
+    [Fact]
+    public void ClampLine_SurrogatePairAtVeryStartIsPreserved()
+    {
+        var line = ThumbsUp + new string('a', 100);
+
+        var result = LineWidthFormatter.ClampLine(line, maxLineWidth: 20);
+
+        Assert.True(result.Truncated);
+        AssertNoOrphanedSurrogate(result.Text);
+        Assert.StartsWith(ThumbsUp, result.Text);
+    }
+
+    private static void AssertNoOrphanedSurrogate(string text)
+    {
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (char.IsHighSurrogate(c))
+            {
+                Assert.True(i + 1 < text.Length, "trailing high surrogate without low surrogate");
+                Assert.True(char.IsLowSurrogate(text[i + 1]), "high surrogate not followed by low surrogate");
+                i++;
+            }
+            else
+            {
+                Assert.False(char.IsLowSurrogate(c), "orphaned low surrogate");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `LineWidthFormatter.ClampLine` substringed the line by raw UTF-16 code-unit count, so a clamp boundary landing between a high and low surrogate left an orphaned high surrogate in the CLI / JSON `snippet` output, rendered as U+FFFD.
- Add `SafeSliceEnd` / `SafeSliceStart` helpers that back the slice off the low-surrogate side of a pair, and apply them to both the head-clamp and the focus-window paths in `LineWidthFormatter` (`src/CodeIndex/Database/LineWidthFormatter.cs:51` and `:61`).
- Add `LineWidthFormatterTests` covering head-clamp, focus-window, very-tight-budget fallback, and leading-emoji cases against orphaned surrogates.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release` (4455 passed, 3 skipped — `PerformanceTests` only)
- `dotnet run --project tools/CodeIndex.Changelog -c Release -- check`

## Documentation / Changelog

- `changelog.d/unreleased/1522.fixed.md` (bilingual fragment).

Fixes #1522