### PR TITLE
Honor NO_COLOR / CLICOLOR / CLICOLOR_FORCE for ANSI output

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -614,6 +614,19 @@ If a query fails with a SQLite reader error such as `The data is NULL at ordinal
   CDIDX_DEBUG=unsafe cdidx unused       # raw content, local only / 生テキスト、ローカルのみ
   ```
 
+### Color output
+
+`cdidx` colorizes symbol-kind labels with ANSI escapes only when stdout is an interactive terminal. The standard `NO_COLOR` (https://no-color.org), `CLICOLOR`, and `CLICOLOR_FORCE` environment variables override that decision so CI logs and scripts stay clean:
+
+| Variable | Value | Effect |
+|---|---|---|
+| `CLICOLOR_FORCE` | any non-empty value other than `0` | Force ANSI color on, even when stdout is not a TTY |
+| `NO_COLOR` | any non-empty value | Disable ANSI color regardless of TTY status |
+| `CLICOLOR` | `0` | Disable ANSI color regardless of TTY status |
+| (none of the above) | — | Fall back to the default TTY check |
+
+`CLICOLOR_FORCE` has the highest precedence, then `NO_COLOR`, then `CLICOLOR=0`. An empty `NO_COLOR` (e.g. `NO_COLOR=` exported with no value) is ignored, matching the no-color.org specification.
+
 ## How it works
 
 cdidx scans your project directory, applies the built-in skip lists plus user `.gitignore` / `.cdidxignore` rules, splits each remaining source file into overlapping chunks, and stores everything in a SQLite database with FTS5 full-text search. Incremental mode (default) first purges database entries for files that no longer exist on disk, then checks each file's last-modified timestamp against the database — only files whose timestamp exactly matches are skipped, and any difference (newer or older) triggers re-indexing. Newly appeared files are indexed as new entries. The same path filter is reused for scoped `--files` / `--commits` refreshes, commit-based refreshes automatically switch to a full scan when ignore files changed, and Git-managed workspaces follow the repository's `core.ignorecase` setting when evaluating ignore rules. This means re-indexing after a branch switch only processes the files that actually differ unless ignore rules themselves changed.
@@ -1661,6 +1674,19 @@ cdidx map --path src/ --exclude-tests --json
 CDIDX_DEBUG=1 cdidx unused            # テキスト伏字化
 CDIDX_DEBUG=unsafe cdidx unused       # 生テキスト、ローカルのみ
 ```
+
+### カラー出力
+
+`cdidx` はシンボル種別ラベルに ANSI エスケープを付けますが、これは stdout がインタラクティブな端末の場合のみです。CI ログやスクリプトが ANSI で汚れないよう、標準的な `NO_COLOR`（https://no-color.org）、`CLICOLOR`、`CLICOLOR_FORCE` の環境変数で挙動を上書きできます。
+
+| 変数 | 値 | 効果 |
+|---|---|---|
+| `CLICOLOR_FORCE` | `0` 以外の非空値 | TTY でなくても ANSI カラーを強制 ON |
+| `NO_COLOR` | 任意の非空値 | TTY 判定に関わらず ANSI カラーを無効化 |
+| `CLICOLOR` | `0` | TTY 判定に関わらず ANSI カラーを無効化 |
+| 上記いずれも未設定 | — | 既定の TTY 判定にフォールバック |
+
+優先順位は `CLICOLOR_FORCE` → `NO_COLOR` → `CLICOLOR=0` の順です。値が空の `NO_COLOR`（例: `NO_COLOR=` のみ export）は no-color.org の仕様に従い無視されます。
 
 ## 動作の仕組み
 

--- a/changelog.d/unreleased/1523.added.md
+++ b/changelog.d/unreleased/1523.added.md
@@ -1,0 +1,17 @@
+---
+category: added
+issues:
+  - 1523
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Honor `NO_COLOR` / `CLICOLOR` / `CLICOLOR_FORCE` for ANSI color output (#1523)** — `cdidx` now disables ANSI color when `NO_COLOR` (any non-empty value, per https://no-color.org) or `CLICOLOR=0` is set, and forces color on when `CLICOLOR_FORCE` is set to a non-empty value other than `0`. `CLICOLOR_FORCE` takes precedence over `NO_COLOR`. CI logs that exported `NO_COLOR=1` no longer accumulate escape sequences in symbol-kind output.
+
+## 日本語
+
+- **ANSI カラー出力で `NO_COLOR` / `CLICOLOR` / `CLICOLOR_FORCE` を尊重 (#1523)** — `NO_COLOR`（https://no-color.org に従い、空でない任意の値）または `CLICOLOR=0` が指定されている場合、`cdidx` は ANSI カラーを無効化するようになりました。`CLICOLOR_FORCE` に `0` 以外の非空値を指定すれば TTY でなくてもカラーを強制できます。優先順位は `CLICOLOR_FORCE` > `NO_COLOR` > `CLICOLOR=0` の順です。これにより `NO_COLOR=1` を export した CI ログにシンボル種別出力のエスケープシーケンスが残らなくなります。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -825,13 +825,17 @@ _cdidx";
 
     /// <summary>
     /// Colorize a symbol kind name with ANSI escape codes for terminal output.
-    /// Degrades to plain text when output is redirected (not a terminal).
-    /// シンボル種別名をANSIエスケープコードで色付けする。出力がリダイレクトされている場合は無色テキスト。
+    /// Degrades to plain text when output is redirected (not a terminal) or when
+    /// the user opts out of color via NO_COLOR / CLICOLOR=0. CLICOLOR_FORCE forces
+    /// color on regardless of TTY status.
+    /// シンボル種別名をANSIエスケープコードで色付けする。リダイレクト時、または
+    /// NO_COLOR / CLICOLOR=0 で色を無効化された場合は無色テキスト。
+    /// CLICOLOR_FORCE が指定された場合は TTY でなくても色を付ける。
     /// </summary>
     public static string ColorizeKind(string kind, int padWidth = 0)
     {
         var padded = padWidth > 0 ? kind.PadRight(padWidth) : kind;
-        if (ShouldUseInteractiveConsole())
+        if (ShouldUseColor())
         {
             var color = kind switch
             {
@@ -862,6 +866,42 @@ _cdidx";
         // Console.IsOutputRedirected stays false even though interactive terminal
         // behavior would be unsafe. Treat UTF-16 Console.Out as redirected capture.
         return !Console.Out.Encoding.Equals(Encoding.Unicode);
+    }
+
+    /// <summary>
+    /// Decide whether ANSI color escapes should be emitted, honoring the standard
+    /// NO_COLOR (https://no-color.org) and CLICOLOR / CLICOLOR_FORCE conventions.
+    /// Precedence (highest first):
+    ///   1. CLICOLOR_FORCE (any non-empty value other than "0") — force color on.
+    ///   2. NO_COLOR (any non-empty value) — color off.
+    ///   3. CLICOLOR=0 — color off.
+    ///   4. Otherwise fall back to <see cref="ShouldUseInteractiveConsole"/>.
+    /// ANSI 色エスケープを出力するかを判定する。NO_COLOR / CLICOLOR /
+    /// CLICOLOR_FORCE の慣習に従い、TTY 判定より優先する。
+    /// </summary>
+    internal static bool ShouldUseColor()
+    {
+        if (IsForceColorRequested())
+            return true;
+        if (IsNoColorRequested())
+            return false;
+        return ShouldUseInteractiveConsole();
+    }
+
+    private static bool IsForceColorRequested()
+    {
+        var force = Environment.GetEnvironmentVariable("CLICOLOR_FORCE");
+        return !string.IsNullOrEmpty(force) && force != "0";
+    }
+
+    private static bool IsNoColorRequested()
+    {
+        var noColor = Environment.GetEnvironmentVariable("NO_COLOR");
+        if (!string.IsNullOrEmpty(noColor))
+            return true;
+
+        var cliColor = Environment.GetEnvironmentVariable("CLICOLOR");
+        return cliColor == "0";
     }
 
     /// <summary>

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -381,6 +381,110 @@ public class ConsoleUiTests
         }
     }
 
+    [Fact]
+    public void ColorizeKind_NoColorEnvVar_DisablesAnsiEscapes()
+    {
+        WithColorEnvironment(noColor: "1", cliColor: null, cliColorForce: null, () =>
+        {
+            Assert.False(ConsoleUi.ShouldUseColor());
+            var output = ConsoleUi.ColorizeKind("function");
+            Assert.Equal("function", output);
+            Assert.DoesNotContain('\x1b', output);
+        });
+    }
+
+    [Fact]
+    public void ColorizeKind_NoColorEmpty_LeavesDefaultBehavior()
+    {
+        // Per https://no-color.org, only a non-empty NO_COLOR disables color.
+        // 規約に従い、空の NO_COLOR は色を抑制せず、TTY 判定にフォールバックする。
+        WithColorEnvironment(noColor: string.Empty, cliColor: null, cliColorForce: null, () =>
+        {
+            Assert.Equal(ConsoleUi.ShouldUseInteractiveConsole(), ConsoleUi.ShouldUseColor());
+        });
+    }
+
+    [Fact]
+    public void ColorizeKind_CliColorZero_DisablesAnsiEscapes()
+    {
+        WithColorEnvironment(noColor: null, cliColor: "0", cliColorForce: null, () =>
+        {
+            Assert.False(ConsoleUi.ShouldUseColor());
+            var output = ConsoleUi.ColorizeKind("class", padWidth: 6);
+            Assert.Equal("class ", output);
+            Assert.DoesNotContain('\x1b', output);
+        });
+    }
+
+    [Fact]
+    public void ColorizeKind_CliColorOne_DoesNotOverrideTtyDetection()
+    {
+        // CLICOLOR=1 is the conventional default and must not override TTY detection.
+        // CLICOLOR=1 は慣習的なデフォルトであり、TTY 判定を上書きしない。
+        WithColorEnvironment(noColor: null, cliColor: "1", cliColorForce: null, () =>
+        {
+            Assert.Equal(ConsoleUi.ShouldUseInteractiveConsole(), ConsoleUi.ShouldUseColor());
+        });
+    }
+
+    [Fact]
+    public void ColorizeKind_CliColorForce_ForcesAnsiEvenWithoutTty()
+    {
+        WithColorEnvironment(noColor: null, cliColor: null, cliColorForce: "1", () =>
+        {
+            Assert.True(ConsoleUi.ShouldUseColor());
+            var output = ConsoleUi.ColorizeKind("function");
+            Assert.StartsWith("\x1b[33m", output);
+            Assert.EndsWith("\x1b[0m", output);
+        });
+    }
+
+    [Fact]
+    public void ColorizeKind_CliColorForceZero_DoesNotForceColor()
+    {
+        // CLICOLOR_FORCE=0 must not force color on; behavior falls back to TTY detection.
+        // CLICOLOR_FORCE=0 は色を強制せず、TTY 判定にフォールバックする。
+        WithColorEnvironment(noColor: null, cliColor: null, cliColorForce: "0", () =>
+        {
+            Assert.Equal(ConsoleUi.ShouldUseInteractiveConsole(), ConsoleUi.ShouldUseColor());
+        });
+    }
+
+    [Fact]
+    public void ColorizeKind_CliColorForceBeatsNoColor()
+    {
+        // CLICOLOR_FORCE has the highest precedence so users can override a
+        // global NO_COLOR for a single command.
+        // CLICOLOR_FORCE は NO_COLOR より優先され、単発で色を有効化できる。
+        WithColorEnvironment(noColor: "1", cliColor: "0", cliColorForce: "1", () =>
+        {
+            Assert.True(ConsoleUi.ShouldUseColor());
+        });
+    }
+
+    private static void WithColorEnvironment(string? noColor, string? cliColor, string? cliColorForce, Action action)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalNoColor = Environment.GetEnvironmentVariable("NO_COLOR");
+            var originalCliColor = Environment.GetEnvironmentVariable("CLICOLOR");
+            var originalCliColorForce = Environment.GetEnvironmentVariable("CLICOLOR_FORCE");
+            try
+            {
+                Environment.SetEnvironmentVariable("NO_COLOR", noColor);
+                Environment.SetEnvironmentVariable("CLICOLOR", cliColor);
+                Environment.SetEnvironmentVariable("CLICOLOR_FORCE", cliColorForce);
+                action();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("NO_COLOR", originalNoColor);
+                Environment.SetEnvironmentVariable("CLICOLOR", originalCliColor);
+                Environment.SetEnvironmentVariable("CLICOLOR_FORCE", originalCliColorForce);
+            }
+        }
+    }
+
     [Theory]
     [InlineData("serach", "search")]
     [InlineData("statu", "status")]


### PR DESCRIPTION
## Summary

- Adds a `ShouldUseColor` gate in `ConsoleUi` that follows the [no-color.org](https://no-color.org) standard plus the BSD `CLICOLOR` / `CLICOLOR_FORCE` conventions:
  - `CLICOLOR_FORCE` (non-empty, non-zero) forces ANSI color on regardless of TTY.
  - `NO_COLOR` (any non-empty value) disables ANSI color regardless of TTY.
  - `CLICOLOR=0` disables ANSI color regardless of TTY.
  - Otherwise the existing TTY check (`ShouldUseInteractiveConsole`) applies.
- `ColorizeKind` now consults `ShouldUseColor`. Spinner / progress-bar interactivity stays gated on `Console.IsOutputRedirected` and is unchanged.
- Documents the precedence in both English and Japanese sections of `USER_GUIDE.md` and adds a bilingual `changelog.d/unreleased/1523.added.md` fragment.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug` — succeeded.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~ConsoleUiTests"` — 38 / 38 passed.
- `dotnet test CodeIndex.sln -c Debug` (full suite) — 4585 / 4585 passed (3 perf tests skipped as usual).
- `dotnet run --project tools/CodeIndex.Changelog -- check` — validated 29 fragments.

## Documentation / changelog

- `USER_GUIDE.md` — new "Color output" / "カラー出力" subsections covering the precedence table.
- `changelog.d/unreleased/1523.added.md` — bilingual fragment.

Fixes #1523
