### PR TITLE
Materialize search ranking EXISTS subqueries into derived-table JOINs (#1520)

### DIFF
--- a/changelog.d/unreleased/1520.fixed.md
+++ b/changelog.d/unreleased/1520.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1520
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Stop re-evaluating ranking subqueries per FTS hit (#1520)** — `cdidx search` previously embedded two correlated `EXISTS (SELECT 1 FROM symbols ...)` subqueries inside the `ORDER BY` of the FTS query. SQLite re-ran each one per result row before applying `--limit`, and the `lower(name) = lower(@q)` / `lower(name) LIKE lower(@prefix)` predicates were not SARGable, so the planner fell back to a full scan of `symbols` — turning a fast FTS hit into an O(N×M) sort on large indexes (most painful for MCP sessions that accumulate many small searches). The two ranking buckets are now sourced from a pair of `LEFT JOIN (SELECT DISTINCT file_id FROM symbols WHERE name = @q COLLATE NOCASE ...)` derived tables that run once per query and reach the existing `idx_symbols_name_nocase` / `idx_symbols_name_folded` indexes, so the observable ranking is unchanged but the query plan no longer carries a correlated scalar subquery.
+
+## 日本語
+
+- **search ランキングの相関サブクエリを 1 クエリ 1 回に縮約 (#1520)** — `cdidx search` の `ORDER BY` には `EXISTS (SELECT 1 FROM symbols ...)` が 2 本埋め込まれており、`--limit` 適用前に各 FTS ヒットごとに再評価されていました。さらに `lower(name) = lower(@q)` / `lower(name) LIKE lower(@prefix)` は SARGable でなく、プランナは `symbols` の全件スキャンに退避するため、大規模 index ではソートが O(N×M) に膨張していました (多数の小さな検索を重ねる MCP セッションで特に顕著)。2 つのランキングバケットは、`LEFT JOIN (SELECT DISTINCT file_id FROM symbols WHERE name = @q COLLATE NOCASE ...)` 形式の派生テーブル経由で 1 クエリ 1 回だけ評価され、既存の `idx_symbols_name_nocase` / `idx_symbols_name_folded` を利用するようになりました。可視ランキングは従来通りで、相関スカラサブクエリは EXPLAIN QUERY PLAN から消えます。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -167,26 +167,34 @@ public partial class DbReader
             WHEN 'fileprivate' THEN 3
             ELSE 4
         END";
-    private const string ExactSymbolMatchOrder = @"
-        CASE
-            WHEN EXISTS (
-                SELECT 1
-                FROM symbols sx
-                WHERE sx.file_id = f.id
-                  AND lower(sx.name) = lower(@rankingQuery)
-            ) THEN 0
-            ELSE 1
-        END";
-    private const string PrefixSymbolMatchOrder = @"
-        CASE
-            WHEN EXISTS (
-                SELECT 1
-                FROM symbols sx
-                WHERE sx.file_id = f.id
-                  AND lower(sx.name) LIKE lower(@rankingQueryPrefix) ESCAPE '\'
-            ) THEN 0
-            ELSE 1
-        END";
+    // Bucket ordering for files whose symbols exactly / prefix-match the ranking query.
+    // Issue #1520: previously each bucket embedded a correlated `EXISTS (... lower(name) = lower(@q))`
+    // subquery inside ORDER BY. SQLite re-evaluated it per FTS hit, and `lower(col)` defeated the
+    // `idx_symbols_name_nocase` / `idx_symbols_name_folded` indexes, producing an O(N*M) plan that
+    // degraded `cdidx search` latency on large indexes. The bucket value is now sourced from a
+    // dedicated LEFT JOIN against a derived table that pre-aggregates matching `file_id`s exactly
+    // once per query, using SARGable `name COLLATE NOCASE` / `name LIKE ... COLLATE NOCASE`
+    // predicates so the planner can use the existing indexes.
+    // バケット順位は LEFT JOIN 結果の NULL 判定だけで決まり、`f.id` ごとの再評価は不要。
+    internal const string ExactSymbolMatchOrder =
+        "CASE WHEN exact_symbol_match.file_id IS NULL THEN 1 ELSE 0 END";
+    internal const string PrefixSymbolMatchOrder =
+        "CASE WHEN prefix_symbol_match.file_id IS NULL THEN 1 ELSE 0 END";
+
+    // Derived-table joins that supply the per-file boolean buckets referenced by the ranking
+    // ORDER BY constants above. SELECT DISTINCT keeps SQLite from flattening the subqueries
+    // back into the outer query, so each predicate runs once per query instead of once per row.
+    // 派生テーブルの SELECT DISTINCT により SQLite はサブクエリをフラット化せず、述語は 1 回だけ
+    // 評価される。
+    internal const string SearchSymbolMatchJoinsSql = @"
+        LEFT JOIN (
+            SELECT DISTINCT file_id FROM symbols
+            WHERE name = @rankingQuery COLLATE NOCASE
+        ) AS exact_symbol_match ON exact_symbol_match.file_id = f.id
+        LEFT JOIN (
+            SELECT DISTINCT file_id FROM symbols
+            WHERE name LIKE @rankingQueryPrefix ESCAPE '\' COLLATE NOCASE
+        ) AS prefix_symbol_match ON prefix_symbol_match.file_id = f.id";
     private const string PathTextMatchOrder = @"
         CASE
             WHEN instr(lower(f.path), lower(@rankingQuery)) > 0 THEN 0

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -298,7 +298,7 @@ public partial class DbReader
                 SELECT f.path, f.lang, c.start_line, c.end_line, c.content,
                        0.0 AS rank
                 FROM chunks c
-                JOIN files f ON c.file_id = f.id
+                JOIN files f ON c.file_id = f.id{SearchSymbolMatchJoinsSql}
                 WHERE instr(
                     {GetExactSearchTextSql("c.content", "f.lang")},
                     {GetExactSearchTextSql("@exactQuery", "f.lang")}
@@ -307,12 +307,12 @@ public partial class DbReader
         else
         {
             var sanitizedQuery = rawQuery ? query : SanitizeFtsQuery(normalizedQuery);
-            sql = @"
+            sql = $@"
                 SELECT f.path, f.lang, c.start_line, c.end_line, c.content,
                        rank
                 FROM fts_chunks
                 JOIN chunks c ON fts_chunks.rowid = c.id
-                JOIN files f ON c.file_id = f.id";
+                JOIN files f ON c.file_id = f.id{SearchSymbolMatchJoinsSql}";
             sql += " WHERE fts_chunks MATCH @query";
             cmd.Parameters.AddWithValue("@query", sanitizedQuery);
         }
@@ -376,7 +376,7 @@ public partial class DbReader
                 SELECT f.path, c.start_line, c.end_line,
                        0.0 AS rank
                 FROM chunks c
-                JOIN files f ON c.file_id = f.id
+                JOIN files f ON c.file_id = f.id{SearchSymbolMatchJoinsSql}
                 WHERE instr(
                     {GetExactSearchTextSql("c.content", "f.lang")},
                     {GetExactSearchTextSql("@exactQuery", "f.lang")}
@@ -385,12 +385,12 @@ public partial class DbReader
         else
         {
             var sanitizedQuery = rawQuery ? query : SanitizeFtsQuery(normalizedQuery);
-            sql = @"
+            sql = $@"
                 SELECT f.path, c.start_line, c.end_line,
                        rank
                 FROM fts_chunks
                 JOIN chunks c ON fts_chunks.rowid = c.id
-                JOIN files f ON c.file_id = f.id";
+                JOIN files f ON c.file_id = f.id{SearchSymbolMatchJoinsSql}";
             sql += " WHERE fts_chunks MATCH @query";
             cmd.Parameters.AddWithValue("@query", sanitizedQuery);
         }

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -14218,6 +14218,127 @@ public class DbReaderTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Search_RanksFilesWithExactSymbolMatchBeforeFilesWithout_Issue1520()
+    {
+        // Issue #1520: the search ORDER BY uses a per-file "exact symbol match" bucket so that
+        // FTS hits inside files where a symbol named exactly like the query exists float above
+        // files where the query only appears textually. Pin the observable ordering after
+        // materializing the EXISTS predicate into a derived-table LEFT JOIN.
+        // Issue #1520: ORDER BY のシンボル一致バケットをサブクエリ→LEFT JOIN 化したため、
+        // ランキングが従来通りに維持されることを観測ベースで pin する。
+        const string token = "rank_match_token_1520";
+        InsertIndexedFile(
+            "src/rank_text_only.py",
+            "python",
+            $"# bare mention only\nresult = {token}\n");
+        InsertIndexedFile(
+            "src/rank_symbol_hit.py",
+            "python",
+            $"def {token}():\n    return None\n");
+
+        var results = _reader.Search(token);
+
+        Assert.True(results.Count >= 2);
+        var symbolHitIndex = results.FindIndex(r => r.Path == "src/rank_symbol_hit.py");
+        var textOnlyIndex = results.FindIndex(r => r.Path == "src/rank_text_only.py");
+        Assert.True(symbolHitIndex >= 0, "file with the exact-symbol match should appear in results");
+        Assert.True(textOnlyIndex >= 0, "file with the textual-only match should appear in results");
+        Assert.True(symbolHitIndex < textOnlyIndex,
+            $"file with the exact-symbol match ranked at {symbolHitIndex} should precede textual-only at {textOnlyIndex}");
+    }
+
+    [Fact]
+    public void Search_RanksFilesWithPrefixSymbolMatchBeforeFilesWithout_Issue1520()
+    {
+        // Issue #1520: prefix bucket must still favor files that own a symbol whose name starts
+        // with the query (e.g. `auth*` matches an `authenticate` function declaration) over
+        // files that only contain the literal substring in chunk text.
+        // Issue #1520: prefix バケットも、シンボル名が query で始まるファイルを優先する挙動を維持する。
+        const string prefix = "prefix1520";
+        InsertIndexedFile(
+            "src/prefix_text_only.py",
+            "python",
+            $"# textual mention: {prefix}_lookup is just a string here.\n");
+        InsertIndexedFile(
+            "src/prefix_symbol_hit.py",
+            "python",
+            $"def {prefix}_handler():\n    return None\n");
+
+        var results = _reader.Search(prefix);
+
+        Assert.True(results.Count >= 2);
+        var symbolHitIndex = results.FindIndex(r => r.Path == "src/prefix_symbol_hit.py");
+        var textOnlyIndex = results.FindIndex(r => r.Path == "src/prefix_text_only.py");
+        Assert.True(symbolHitIndex >= 0);
+        Assert.True(textOnlyIndex >= 0);
+        Assert.True(symbolHitIndex < textOnlyIndex,
+            $"file with the prefix-symbol match ranked at {symbolHitIndex} should precede textual-only at {textOnlyIndex}");
+    }
+
+    [Fact]
+    public void SearchRankingBuckets_DoNotEmbedCorrelatedExistsInOrderBy_Issue1520()
+    {
+        // Issue #1520: the ranking constants must not embed a correlated EXISTS subquery
+        // against `symbols` that references the outer `f.id`. Such a subquery is re-evaluated
+        // per FTS hit before the LIMIT, turning a fast search into an O(N x M) sort.
+        // Issue #1520: ranking 定数に外側 f.id を参照する EXISTS を埋め戻していないことを固定する。
+        Assert.DoesNotContain("EXISTS", DbReader.ExactSymbolMatchOrder, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("EXISTS", DbReader.PrefixSymbolMatchOrder, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("FROM symbols", DbReader.ExactSymbolMatchOrder, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("FROM symbols", DbReader.PrefixSymbolMatchOrder, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("exact_symbol_match", DbReader.ExactSymbolMatchOrder, StringComparison.Ordinal);
+        Assert.Contains("prefix_symbol_match", DbReader.PrefixSymbolMatchOrder, StringComparison.Ordinal);
+        Assert.Contains("LEFT JOIN", DbReader.SearchSymbolMatchJoinsSql, StringComparison.Ordinal);
+        Assert.Contains("SELECT DISTINCT file_id FROM symbols", DbReader.SearchSymbolMatchJoinsSql, StringComparison.Ordinal);
+        // The materialized lookup must stay SARGable (no `lower(name)` wrapping).
+        Assert.DoesNotContain("lower(", DbReader.SearchSymbolMatchJoinsSql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Search_OrderByPlanDoesNotReScanSymbolsPerRow_Issue1520()
+    {
+        // Issue #1520: EXPLAIN QUERY PLAN of the full search SQL must show the ranking
+        // subqueries materialized once instead of re-scanning `symbols` correlated by `f.id`.
+        // Modern SQLite reports a single "MATERIALIZE" or "CO-ROUTINE" step for SELECT DISTINCT
+        // subqueries in FROM; the regression would surface a "CORRELATED SCALAR SUBQUERY"
+        // (or repeated "SEARCH symbols ... USING INDEX idx_symbols_file") instead.
+        // Issue #1520: EXPLAIN QUERY PLAN に CORRELATED SCALAR SUBQUERY が現れないことを固定する。
+        const string sql = @"
+            SELECT f.path, f.lang, c.start_line, c.end_line, c.content, rank
+            FROM fts_chunks
+            JOIN chunks c ON fts_chunks.rowid = c.id
+            JOIN files f ON c.file_id = f.id
+            LEFT JOIN (
+                SELECT DISTINCT file_id FROM symbols
+                WHERE name = @rankingQuery COLLATE NOCASE
+            ) AS exact_symbol_match ON exact_symbol_match.file_id = f.id
+            LEFT JOIN (
+                SELECT DISTINCT file_id FROM symbols
+                WHERE name LIKE @rankingQueryPrefix ESCAPE '\' COLLATE NOCASE
+            ) AS prefix_symbol_match ON prefix_symbol_match.file_id = f.id
+            WHERE fts_chunks MATCH @query
+            ORDER BY
+                CASE WHEN exact_symbol_match.file_id IS NULL THEN 1 ELSE 0 END,
+                CASE WHEN prefix_symbol_match.file_id IS NULL THEN 1 ELSE 0 END,
+                rank
+            LIMIT 10";
+
+        using var cmd = _db.Connection.CreateCommand();
+        cmd.CommandText = "EXPLAIN QUERY PLAN " + sql;
+        cmd.Parameters.AddWithValue("@query", "authenticate");
+        cmd.Parameters.AddWithValue("@rankingQuery", "authenticate");
+        cmd.Parameters.AddWithValue("@rankingQueryPrefix", "authenticate%");
+
+        var plan = new StringBuilder();
+        using (var reader = cmd.ExecuteReader())
+            while (reader.Read())
+                plan.AppendLine(reader.GetString(3));
+
+        var planText = plan.ToString();
+        Assert.DoesNotContain("CORRELATED", planText);
+    }
+
     private static SqliteConnection CreateLegacyReferenceConnection(string legacyPath)
     {
         var db = new DbContext(legacyPath);


### PR DESCRIPTION
## Summary

- `cdidx search` previously embedded two correlated `EXISTS (SELECT 1 FROM symbols WHERE file_id = f.id AND lower(name) = lower(@q))` subqueries inside the `ORDER BY`. SQLite re-ran them per FTS hit before `--limit`, and the `lower(...)` wrappers defeated `idx_symbols_name_nocase` / `idx_symbols_name_folded`, producing the O(N×M) sort path described in the issue.
- Replaced the two ranking buckets with `LEFT JOIN (SELECT DISTINCT file_id FROM symbols WHERE name = @q COLLATE NOCASE)` derived tables that run once per query and stay SARGable so the planner can use the existing nocase / folded indexes. `ORDER BY` now reads `CASE WHEN exact_symbol_match.file_id IS NULL THEN 1 ELSE 0 END` (and the prefix twin). Visible ranking is unchanged.
- The exact-mode (`instr`) `search` path and `CountSearchResults` both share the same joins, since they reuse `GetSearchOrderSql()`.

## Validation

- `dotnet build CodeIndex.sln` — clean.
- `dotnet test tests/CodeIndex.Tests --filter "FullyQualifiedName~Issue1520"` — 4 passed.
- `dotnet test tests/CodeIndex.Tests --filter "FullyQualifiedName~DbReaderTests"` — 425 passed.
- `dotnet test tests/CodeIndex.Tests --filter "FullyQualifiedName~QueryCommandRunnerTests|FullyQualifiedName~McpServerTests|FullyQualifiedName~PerformanceTests"` — 1192 passed (3 skipped, perf-gated).
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` (full suite) — 4571 passed (3 skipped).

## EXPLAIN QUERY PLAN

The four new tests in `tests/CodeIndex.Tests/DbReaderTests.cs`:

- `Search_RanksFilesWithExactSymbolMatchBeforeFilesWithout_Issue1520`
- `Search_RanksFilesWithPrefixSymbolMatchBeforeFilesWithout_Issue1520`
- `SearchRankingBuckets_DoNotEmbedCorrelatedExistsInOrderBy_Issue1520`
- `Search_OrderByPlanDoesNotReScanSymbolsPerRow_Issue1520`

pin both the observable ranking and the absence of `CORRELATED` in the EXPLAIN QUERY PLAN for the new SQL shape (the regression marker for the issue).

## Docs / Changelog

- `changelog.d/unreleased/1520.fixed.md` — bilingual fragment.

## Follow-up candidates

- Reference-ranking SQL in `DbReader.cs` still uses `lower(r.symbol_name) = lower(@rankingQuery)` inside `ORDER BY` (not a correlated subquery like #1520, but a non-SARGable pattern divergent from the rest of the file after this PR). Tracked separately in #2163 — not in this PR's scope.

Fixes #1520
