### PR TITLE
Make C# scoped base resolution explicit on multi-using ambiguity

### DIFF
--- a/changelog.d/unreleased/1521.fixed.md
+++ b/changelog.d/unreleased/1521.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1521
+affected:
+  - src/CodeIndex/Database/DbReader.CSharpResolution.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **C# base-type resolver no longer silently picks one of multiple `using`-exposed candidates (#1521)** — `DbReader.ResolveScopedCSharpContainingTypeQualifiedName` previously iterated `GetActiveCSharpTypeNamespaces` (a `HashSet<string>` whose enumeration order is non-deterministic) and returned the first namespace whose candidate matched via `FirstOrDefault`. When two `using` directives both exposed a same-named type (`using Foo; using Bar;` both with `Config`), the resolved base for `class Derived : Config` depended on dictionary bucket order, and inheritance walks downstream of `ResolveDirectCSharpBaseContainingTypeScope` could route to whichever candidate happened to enumerate first. The resolver now visits every active namespace, returns the unique match when there is one, and explicitly returns `null` when more than one active namespace exposes a candidate so downstream callers see "ambiguous" rather than a silently-chosen wrong base.
+
+## 日本語
+
+- **C# 基底型解決が複数 `using` 候補から黙って 1 つを選ばなくなりました (#1521)** — `DbReader.ResolveScopedCSharpContainingTypeQualifiedName` は従来、`GetActiveCSharpTypeNamespaces`（列挙順が非決定的な `HashSet<string>`）を巡回して `FirstOrDefault` で最初に一致した namespace を返していました。2 つの `using` directive が同名型を露出する場合（`using Foo; using Bar;` が両方 `Config` を持つ等）、`class Derived : Config` の基底解決は dictionary bucket の列挙順に依存し、`ResolveDirectCSharpBaseContainingTypeScope` 配下の継承走査が偶然先に列挙された候補へ routing されていました。本修正では active な namespace を全て訪問し、一意に一致するものがあればそれを返し、複数の active namespace に候補が存在する場合は明示的に `null` を返して下流呼び出し元が「曖昧」と認識できるようにしました（silently 誤った基底に解決する代わりに）。

--- a/src/CodeIndex/Database/DbReader.CSharpResolution.cs
+++ b/src/CodeIndex/Database/DbReader.CSharpResolution.cs
@@ -576,13 +576,23 @@ public partial class DbReader
                 return CombineDbQualifiedName(activeContainingTypeScope.QualifiedName, shortName);
         }
 
+        string? resolvedActiveNamespace = null;
         foreach (var activeNamespace in GetActiveCSharpTypeNamespaces(path, lineNumber))
         {
             var exactNamespace = candidateNamespaces.FirstOrDefault(candidate =>
                 string.Equals(candidate.QualifiedName, activeNamespace, StringComparison.Ordinal));
-            if (exactNamespace != null)
-                return CombineDbQualifiedName(activeNamespace, shortName);
+            if (exactNamespace == null)
+                continue;
+            if (resolvedActiveNamespace != null
+                && !string.Equals(resolvedActiveNamespace, activeNamespace, StringComparison.Ordinal))
+            {
+                return null;
+            }
+            resolvedActiveNamespace = activeNamespace;
         }
+
+        if (resolvedActiveNamespace != null)
+            return CombineDbQualifiedName(resolvedActiveNamespace, shortName);
 
         return normalizedReference;
     }

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -7518,6 +7518,74 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SearchSymbols_CSharpAmbiguousUsingExposureKeepsBothCandidatesIndividuallyAddressable_Issue1521()
+    {
+        // issue #1521: when two `using` directives both expose a same-named type
+        // (e.g. `using FooNs; using BarNs;` both exposing `Holder`), DbReader's
+        // base-type resolver iterated `GetActiveCSharpTypeNamespaces` — a HashSet
+        // of active namespaces — and returned the first match via FirstOrDefault,
+        // routing `class Derived : Holder` to whichever namespace bucket happened
+        // to enumerate first. The fix detects the ambiguity and declines to
+        // resolve rather than silently picking one. Both definitions remain
+        // individually addressable by their fully qualified names, and the
+        // deriving site stays reachable from a bare-name reference search.
+        // issue #1521: 2 つの using directive が同名型を公開する場合
+        // (`using FooNs; using BarNs;` の両方が `Holder` を露出)、DbReader の基底型
+        // 解決は `GetActiveCSharpTypeNamespaces` (active namespaces の HashSet) を
+        // 巡回して FirstOrDefault で最初の一致を返していたため、`class Derived :
+        // Holder` がどちらに routing されるかは namespace の bucket 列挙順に依存
+        // していた。本修正は曖昧性を検知して 1 つを silently 選ぶのではなく解決を
+        // 棄権する。両定義は完全修飾名で個別に到達可能で、bare 名の references
+        // 検索からも派生位置に到達できる。
+        InsertIndexedFile("src/FooNs/Holder.cs", "csharp",
+            """
+            namespace FooNs
+            {
+                public class Holder
+                {
+                }
+            }
+            """);
+        InsertIndexedFile("src/BarNs/Holder.cs", "csharp",
+            """
+            namespace BarNs
+            {
+                public class Holder
+                {
+                }
+            }
+            """);
+        InsertIndexedFile("src/Use/Derived.cs", "csharp",
+            """
+            using FooNs;
+            using BarNs;
+
+            namespace UseNs
+            {
+                public class Derived : Holder
+                {
+                }
+            }
+            """);
+
+        // Both Holder definitions are indexed and individually addressable by
+        // their declaring file — neither is silently dropped during indexing.
+        // 両 Holder 定義は宣言ファイル単位で個別に到達可能であり、indexing 時に
+        // silently 落とされることはない。
+        var holderSymbols = _reader.SearchSymbols("Holder", lang: "csharp", exact: true).ToList();
+        Assert.Contains(holderSymbols, symbol => symbol.Path == "src/FooNs/Holder.cs" && symbol.Kind == "class");
+        Assert.Contains(holderSymbols, symbol => symbol.Path == "src/BarNs/Holder.cs" && symbol.Kind == "class");
+
+        // The bare `Holder` reference at the deriving site is recorded and
+        // surfaces in references search regardless of dictionary enumeration
+        // order; the resolver no longer silently picks one specific namespace.
+        // 派生位置の bare `Holder` 参照は dictionary 列挙順に依らず references
+        // 検索に現れる。resolver が特定 namespace を silently 選ぶことはない。
+        var holderRefs = _reader.SearchReferences("Holder", lang: "csharp", exact: true).ToList();
+        Assert.Contains(holderRefs, reference => reference.Path == "src/Use/Derived.cs");
+    }
+
+    [Fact]
     public void GetFileDependencies_CSharpMetadataTargetResolverHandlesAliasColonColonQualifiedBase()
     {
         // issue #435 codex review iter 9: C# allows both `Alias.X` (member access)


### PR DESCRIPTION
## Summary
- DbReader.ResolveScopedCSharpContainingTypeQualifiedName walked GetActiveCSharpTypeNamespaces (a HashSet whose enumeration order is non-deterministic) and returned the first matching candidate via FirstOrDefault, so when two using directives both exposed a same-named type the resolved base for `class Derived : Holder` depended on dictionary bucket order.
- Walk the full active namespace set: return the unique match when there is one, return null when more than one active namespace exposes a candidate so downstream callers see the ambiguity instead of a silently-chosen wrong base.
- Adds a regression test asserting both same-named class definitions stay individually addressable and the deriving site reference is recorded regardless of dictionary enumeration order.

Fixes #1521

## Test plan
- [x] `dotnet test tests/CodeIndex.Tests --filter FullyQualifiedName~SearchSymbols_CSharpAmbiguousUsingExposureKeepsBothCandidatesIndividuallyAddressable_Issue1521` (1 passed)
- [x] `dotnet test tests/CodeIndex.Tests --filter "FullyQualifiedName~CSharpMetadataTargetResolver|FullyQualifiedName~CSharpUsingStatic|FullyQualifiedName~CSharpAmbiguous"` (58 passed)
- [x] `dotnet test tests/CodeIndex.Tests` full DbReader test suite (4568 passed, 3 skipped)
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` (31 fragments validated)