### PR TITLE
Reject overflowing before/after on the MCP excerpt tool (#1528)

### DIFF
--- a/changelog.d/unreleased/1528.fixed.md
+++ b/changelog.d/unreleased/1528.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1528
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Database/DbReader.FilesStatus.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **Reject overflowing `before` / `after` on the MCP `excerpt` tool (#1528)** — `excerpt` previously fed `before` / `after` straight into `startLine - before` and `endLine + after` without an upper bound, so `before = int.MaxValue` underflowed and an `endLine` near `int.MaxValue` overflowed before `Math.Max` / `Math.Min` could clamp; the slice path then either threw `ArgumentOutOfRangeException` (from `Enumerable.Range` with a negative count) or returned a nonsensical range. The MCP entry now caps `before` / `after` at `[0, 1000]` (mirroring the CLI `--before` / `--after` cap) and reports a clear `"before must be in [0, 1000]"` / `"after must be in [0, 1000]"` error, while `DbReader.GetExcerpt` / `GetExcerptFocusLineLength` and the MCP focus-line bounds check now perform the addition through long intermediates so a huge caller-supplied `endLine` is clamped to the real file length instead of wrapping.
+
+## 日本語
+
+- **MCP `excerpt` ツールが `before` / `after` の overflow 値を拒否するようになりました (#1528)** — `excerpt` は `before` / `after` を上限なく `startLine - before` と `endLine + after` に流していたため、`before = int.MaxValue` で underflow し、`endLine` が `int.MaxValue` 近傍だと overflow して `Math.Max` / `Math.Min` の clamp 前に範囲が壊れ、slice 経路で `Enumerable.Range` の負カウント例外を発生させたり、無意味な範囲を返したりしていました。MCP エントリで `before` / `after` を `[0, 1000]`（CLI の `--before` / `--after` 上限と一致）に制限し、`"before must be in [0, 1000]"` / `"after must be in [0, 1000]"` の明示エラーを返すようにし、`DbReader.GetExcerpt` / `GetExcerptFocusLineLength` と MCP の focus-line 境界判定では加算を long の中間値経由で行うことで、巨大な `endLine` を受け取っても実ファイル長に clamp されるようにしました。

--- a/src/CodeIndex/Database/DbReader.FilesStatus.cs
+++ b/src/CodeIndex/Database/DbReader.FilesStatus.cs
@@ -244,10 +244,17 @@ public partial class DbReader
             before = 0;
         if (after < 0)
             after = 0;
-        var requestedStart = Math.Max(1, startLine - before);
-        if (!TryLoadIndexedFileLines(path, out var lang, out var totalLines, out var lineMap, requestedStart, endLine + after))
+        // `endLine` + `after` (and `startLine` - `before`) come from untrusted MCP callers in
+        // some entry points and can overflow int when endLine is near `int.MaxValue`. Clamp via
+        // long intermediates so the subsequent `Math.Max/Min` sees the real window (#1528).
+        // 一部の MCP 経路では `endLine` + `after`（および `startLine` - `before`）が信頼できない
+        // 入力で、`int.MaxValue` 近傍の endLine だと int 加算で overflow する。long 中間で実窓を
+        // 確定させてから clamp する（#1528）。
+        var requestedStart = (int)Math.Max(1L, (long)startLine - before);
+        var requestedEndCeiling = (int)Math.Min(int.MaxValue, (long)endLine + after);
+        if (!TryLoadIndexedFileLines(path, out var lang, out var totalLines, out var lineMap, requestedStart, requestedEndCeiling))
             return null;
-        var requestedEnd = Math.Min(totalLines, endLine + after);
+        var requestedEnd = Math.Min(totalLines, requestedEndCeiling);
 
         var selectedLines = Enumerable.Range(requestedStart, requestedEnd - requestedStart + 1)
             .Where(lineMap.ContainsKey)
@@ -304,10 +311,11 @@ public partial class DbReader
         if (after < 0)
             after = 0;
 
-        var requestedStart = Math.Max(1, startLine - before);
-        if (!TryLoadIndexedFileLines(path, out _, out var totalLines, out var lineMap, requestedStart, endLine + after))
+        var requestedStart = (int)Math.Max(1L, (long)startLine - before);
+        var requestedEndCeiling = (int)Math.Min(int.MaxValue, (long)endLine + after);
+        if (!TryLoadIndexedFileLines(path, out _, out var totalLines, out var lineMap, requestedStart, requestedEndCeiling))
             return null;
-        var requestedEnd = Math.Min(totalLines, endLine + after);
+        var requestedEnd = Math.Min(totalLines, requestedEndCeiling);
 
         if (focusLine.Value < requestedStart || focusLine.Value > requestedEnd)
             return null;

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -40,6 +40,14 @@ public partial class McpServer : IDisposable
     private const string ProtocolVersion = "2025-03-26";
     private const int MaxLimit = 200;
     private const int MaxQueryLength = 1000;
+    // Per-call cap on the `before` / `after` context-line parameters accepted by `excerpt`.
+    // Without an upper bound, `int.MaxValue` previously drove `startLine - before` into underflow
+    // and `endLine + after` into overflow before `Math.Max/Min` clamped, so the slice path saw
+    // nonsensical ranges. Mirrors the CLI `--before` / `--after` cap (#1528).
+    // `excerpt` が受け取る `before` / `after` の上限。上限が無いと `int.MaxValue` で
+    // `startLine - before` が underflow、`endLine + after` が overflow し、`Math.Max/Min` で clamp
+    // する前に slice 経路が破綻していたため、CLI の `--before` / `--after` 上限と揃える（#1528）。
+    private const int MaxContextLines = 1000;
     private const int MaxLineLength = 1_000_000; // 1 MB per JSON-RPC message / 1メッセージあたり最大1MB
     // Stdio buffer for the JSON-RPC loop. Sized to fit typical large MCP payloads (e.g. batch_query)
     // in a single read so the StreamReader does not grow from its 1 KB default toward MaxLineLength.

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -993,13 +993,13 @@ public partial class McpServer
             return CreateToolErrorResponse(id, "endLine must be greater than or equal to startLine");
 
         var beforeValue = args?["before"]?.GetValue<int>();
-        if (beforeValue.HasValue && beforeValue.Value < 0)
-            return CreateToolErrorResponse(id, "before must be greater than or equal to 0");
+        if (beforeValue.HasValue && (beforeValue.Value < 0 || beforeValue.Value > MaxContextLines))
+            return CreateToolErrorResponse(id, $"before must be in [0, {MaxContextLines}]");
         var before = beforeValue ?? 0;
 
         var afterValue = args?["after"]?.GetValue<int>();
-        if (afterValue.HasValue && afterValue.Value < 0)
-            return CreateToolErrorResponse(id, "after must be greater than or equal to 0");
+        if (afterValue.HasValue && (afterValue.Value < 0 || afterValue.Value > MaxContextLines))
+            return CreateToolErrorResponse(id, $"after must be in [0, {MaxContextLines}]");
         var after = afterValue ?? 0;
 
         var focusLine = args?["focusLine"]?.GetValue<int>();
@@ -1026,8 +1026,15 @@ public partial class McpServer
                 var file = reader.GetFileByPath(path);
                 if (file != null)
                 {
-                    var requestedStart = Math.Max(1, startLine.Value - before);
-                    var requestedEnd = Math.Min(file.Lines, endLine + after);
+                    // `before` is bounded by MaxContextLines and `startLine` by `int.MaxValue`, but
+                    // `endLine` is caller-supplied: int + int can still overflow when endLine is
+                    // close to `int.MaxValue`. Use long intermediates so the clamp sees the real
+                    // window before narrowing back to int (#1528).
+                    // `before` は MaxContextLines、`startLine` は `int.MaxValue` で押さえているが、
+                    // `endLine` は呼び出し側入力で `int.MaxValue` 近傍なら int 同士の加算が overflow し得る。
+                    // long 中間変数で実窓を確定させてから int に戻す（#1528）。
+                    var requestedStart = (int)Math.Max(1L, (long)startLine.Value - before);
+                    var requestedEnd = (int)Math.Min(file.Lines, (long)endLine + after);
                     if (focusLine.Value < requestedStart || focusLine.Value > requestedEnd)
                         return CreateToolErrorResponse(id, $"focusLine ({focusLine.Value}) must be within the returned excerpt range ({requestedStart}-{requestedEnd})");
                 }

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -3071,7 +3071,7 @@ public class McpServerTests : IDisposable
         var response = _server.HandleMessage(request)!;
 
         Assert.True(response["result"]!["isError"]!.GetValue<bool>());
-        Assert.Equal("before must be greater than or equal to 0", response["result"]!["content"]![0]!["text"]!.GetValue<string>());
+        Assert.Equal("before must be in [0, 1000]", response["result"]!["content"]![0]!["text"]!.GetValue<string>());
     }
 
     [Fact]
@@ -3083,7 +3083,50 @@ public class McpServerTests : IDisposable
         var response = _server.HandleMessage(request)!;
 
         Assert.True(response["result"]!["isError"]!.GetValue<bool>());
-        Assert.Equal("after must be greater than or equal to 0", response["result"]!["content"]![0]!["text"]!.GetValue<string>());
+        Assert.Equal("after must be in [0, 1000]", response["result"]!["content"]![0]!["text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ToolsCall_Excerpt_BeforeAboveCapReturnsError()
+    {
+        InsertIndexedFile("dist/data-before-overflow.txt", "text", "line one\nline two");
+
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"excerpt","arguments":{"path":"dist/data-before-overflow.txt","startLine":1,"before":2147483647}}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.True(response["result"]!["isError"]!.GetValue<bool>());
+        Assert.Equal("before must be in [0, 1000]", response["result"]!["content"]![0]!["text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ToolsCall_Excerpt_AfterAboveCapReturnsError()
+    {
+        InsertIndexedFile("dist/data-after-overflow.txt", "text", "line one\nline two");
+
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"excerpt","arguments":{"path":"dist/data-after-overflow.txt","startLine":1,"after":2147483647}}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.True(response["result"]!["isError"]!.GetValue<bool>());
+        Assert.Equal("after must be in [0, 1000]", response["result"]!["content"]![0]!["text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ToolsCall_Excerpt_HugeEndLineDoesNotOverflow()
+    {
+        InsertIndexedFile("dist/data-endline-overflow.txt", "text", "line one\nline two\nline three");
+
+        // endLine close to int.MaxValue + bounded `after` would overflow int addition and
+        // wrap to a negative number before Math.Min clamped, masking the real file size.
+        // Validate the handler returns a sane excerpt instead (#1528).
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"excerpt","arguments":{"path":"dist/data-endline-overflow.txt","startLine":1,"endLine":2147483647,"after":1000}}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.False(response["result"]?["isError"]?.GetValue<bool>() ?? false);
+        var structured = response["result"]!["structuredContent"]!;
+        Assert.Equal("dist/data-endline-overflow.txt", structured["path"]!.GetValue<string>());
+        Assert.Equal(1, structured["startLine"]!.GetValue<int>());
+        Assert.Equal(3, structured["endLine"]!.GetValue<int>());
+        Assert.Contains("line three", structured["content"]!.GetValue<string>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- The MCP `excerpt` tool fed `before` / `after` straight into `startLine - before` and `endLine + after` without an upper bound, so `before = int.MaxValue` underflowed and an `endLine` near `int.MaxValue` overflowed before `Math.Max` / `Math.Min` could clamp. The slice path then either threw `ArgumentOutOfRangeException` (from `Enumerable.Range` with a negative count) or returned a nonsensical range.
- MCP `excerpt` now caps `before` / `after` at `[0, 1000]` (matching the CLI `--before` / `--after` cap) and returns a clear `"before must be in [0, 1000]"` / `"after must be in [0, 1000]"` error.
- The arithmetic in `DbReader.GetExcerpt`, `DbReader.GetExcerptFocusLineLength`, and the MCP focus-line bounds check is now performed through `long` intermediates so a huge caller-supplied `endLine` is clamped to the real file length instead of wrapping.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Excerpt"` — 41 / 41 pass
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests|FullyQualifiedName~DbReaderTests"` — 663 / 663 pass
- `dotnet run --project tools/CodeIndex.Changelog -- check` — 33 fragments validated

## Documentation / Changelog

- `changelog.d/unreleased/1528.fixed.md` (bilingual). No other doc updates required: README/`DEVELOPER_GUIDE.md` do not currently document the CLI `--before` / `--after` cap either, and the new MCP cap mirrors it 1:1.

## Follow-up candidates

- #1414 — MCP `find_in_file` has the same unbounded `before` / `after` pattern. Left out of scope: that issue's proposed direction (`cap and signal truncation`) differs from the `excerpt` error-on-invalid convention applied here, so the UX decision is better made in a dedicated PR.

Fixes #1528
