### PR TITLE
Stream-cap FileIndexer reads to close FileInfo/ReadAllBytes TOCTOU (#1529)

### DIFF
--- a/changelog.d/unreleased/1529.fixed.md
+++ b/changelog.d/unreleased/1529.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1529
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Close TOCTOU between `FileInfo.Length` and `ReadAllBytes` in `FileIndexer.BuildRecordWithRawBytes` (#1529)** — `BuildRecordWithRawBytes` previously checked `FileInfo.Length` against `MaxFileSize` (10 MB) and then re-opened the file via `File.ReadAllBytes`, leaving a stat / read window where an auto-generated file (build output, log capture) or an adversarial writer could grow from a small size to multi-GB between the two syscalls and force the indexer into an OOM-sized allocation that bypassed the documented cap. The method now opens the path once through a single `FileStream` (`FileShare.Read`), validates `stream.Length` against `MaxFileSize` on that open handle, and streams the bytes into a `MemoryStream` accumulator whose running total is capped at `MaxFileSize`, so a concurrent appender that keeps writing during the read still throws `InvalidOperationException` (`"File too large (> 10 MB limit; grew during read)"`) instead of allocating beyond the ceiling. `FileRecord.Size` and `FileRecord.Modified` now come from the bytes actually read and the post-open `File.GetLastWriteTimeUtc`, so downstream consumers (status, freshness checks, MCP) see the same payload size the indexer ingested rather than a racy `FileInfo.Length` snapshot.
+
+## 日本語
+
+- **`FileIndexer.BuildRecordWithRawBytes` の `FileInfo.Length` / `ReadAllBytes` 間 TOCTOU を塞ぎました (#1529)** — `BuildRecordWithRawBytes` は従来 `FileInfo.Length` を `MaxFileSize` (10 MB) と比較した後で `File.ReadAllBytes` がファイルを開き直していたため、2 つの syscall の間に自動生成ファイル (ビルド出力やログ追記) や悪意ある書き込み主体がファイルを小サイズから数 GB まで肥大化させ、上限を素通りして OOM 級の確保を強制できる stat / read ウィンドウが残っていました。修正後は 1 本の `FileStream` (`FileShare.Read`) でパスを 1 度だけ開き、そのハンドル経由で `stream.Length` を `MaxFileSize` と照合し、バイト列を `MemoryStream` アキュムレータへ流し込みながら累積バイト数を `MaxFileSize` で打ち切るため、読み込み中に並行追記が続いても上限を超える確保は発生せず、`InvalidOperationException` (`"File too large (> 10 MB limit; grew during read)"`) を投げて停止します。`FileRecord.Size` と `FileRecord.Modified` は実際に読み込んだバイト数とオープン後の `File.GetLastWriteTimeUtc` から作成するため、status / freshness check / MCP などの下流は競合しうる `FileInfo.Length` のスナップショットではなく、インデクサが実際に取り込んだペイロード長を確認できます。

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1882,16 +1882,59 @@ public class FileIndexer
             throw new InvalidOperationException("Only regular files can be indexed");
 
         var relativePath = Path.GetRelativePath(_projectRoot, absolutePath);
-        var info = new FileInfo(absolutePath);
 
-        // Skip files exceeding size limit to avoid OutOfMemoryException
-        // OOM防止のためサイズ上限を超えるファイルをスキップ
-        if (info.Length > MaxFileSize)
-            throw new InvalidOperationException($"File too large ({info.Length / 1024 / 1024} MB > {MaxFileSize / 1024 / 1024} MB limit)");
+        // Read raw bytes through a single FileStream and cap the accumulated payload at
+        // MaxFileSize so a file that grew between the size probe and the read can no
+        // longer bypass the cap. Splitting `FileInfo.Length` from `File.ReadAllBytes`
+        // left a TOCTOU window where an attacker (or any build/log emitter rapidly
+        // appending to a generated file) could grow a 1 MB file to multi-GB between
+        // stat and read and force the indexer into an OOM-sized allocation; reading
+        // through one open handle removes the second stat call, and the read loop's
+        // running total guarantees we never accumulate more than MaxFileSize bytes
+        // regardless of how aggressively a concurrent writer extends the file.
+        // ファイルを 1 本の FileStream で開き、MaxFileSize を上限として累積バッファを
+        // 制限することで、サイズ確認と読み込みの間にファイルが肥大化しても上限を
+        // 回避できないようにする。`FileInfo.Length` と `File.ReadAllBytes` を分離して
+        // いた従来実装では、stat と read の間に攻撃者 (もしくは自動生成ファイルを高速
+        // に追記し続けるビルド/ログ系) が 1 MB のファイルを数 GB まで肥大化させて
+        // インデクサに巨大確保を強制できる TOCTOU 経路があったが、1 本のオープン
+        // ハンドルで読むことで 2 回目の stat を排除し、ループ側の総バイト数チェック
+        // により並行追記がどれほど激しくても MaxFileSize 以上の確保は発生しない。
+        byte[] bytes;
+        long sizeBytes;
+        DateTime modifiedUtc;
+        using (var stream = new FileStream(
+            absolutePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            useAsync: false))
+        {
+            var initialLength = stream.Length;
+            if (initialLength > MaxFileSize)
+                throw new InvalidOperationException($"File too large ({initialLength / 1024 / 1024} MB > {MaxFileSize / 1024 / 1024} MB limit)");
 
-        // Read raw bytes and decode UTF-8; detect invalid sequences
-        // 生バイト読み込み後UTF-8デコード、不正シーケンスを検出
-        var bytes = File.ReadAllBytes(absolutePath);
+            // Pre-size the accumulator to the observed length but cap initial capacity
+            // at MaxFileSize so a tampered Length cannot force a huge up-front allocation.
+            // 初期容量は観測した長さに合わせるが MaxFileSize で打ち切り、Length を偽装
+            // されても巨大な事前確保を起こさないようにする。
+            var initialCapacity = (int)Math.Min(initialLength, MaxFileSize);
+            using var accumulator = new MemoryStream(initialCapacity);
+            var buffer = new byte[81920];
+            long total = 0;
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                total += read;
+                if (total > MaxFileSize)
+                    throw new InvalidOperationException($"File too large (> {MaxFileSize / 1024 / 1024} MB limit; grew during read)");
+                accumulator.Write(buffer, 0, read);
+            }
+            bytes = accumulator.ToArray();
+            sizeBytes = total;
+            modifiedUtc = File.GetLastWriteTimeUtc(absolutePath);
+        }
 
         // Compute checksum from raw bytes to avoid re-encoding the string (~10MB saved for large files)
         // 文字列の再エンコードを回避するためraw bytesからチェックサムを算出（大ファイルで約10MB節約）
@@ -1952,10 +1995,10 @@ public class FileIndexer
         {
             Path = NormalizePathSeparators(relativePath),
             Lang = TryDetectLanguage(absolutePath, content).Language,
-            Size = info.Length,
+            Size = sizeBytes,
             Lines = lineCount,
             Checksum = checksum,
-            Modified = info.LastWriteTimeUtc,
+            Modified = modifiedUtc,
         };
 
         return (record, content, bytes, warning);

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2360,6 +2360,72 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void BuildRecord_AcceptsFileAtSizeLimitBoundary()
+    {
+        // Regression for #1529: the TOCTOU fix reads through one FileStream and caps the
+        // accumulator at MaxFileSize. A file at exactly 10 MB must still be accepted so
+        // the boundary contract documented by the oversize test stays symmetric (>10MB
+        // throws, ==10MB succeeds).
+        // #1529 のリグレッション: TOCTOU 修正で 1 本の FileStream を通して MaxFileSize で
+        // 累積バッファを打ち切る実装にした際、ちょうど 10 MB のファイルは引き続き受け
+        // 入れる必要がある (>10MB が throw / ==10MB が成功という対称契約を維持)。
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var filePath = Path.Combine(tempDir, "boundary.py");
+            // Exactly MaxFileSize bytes — ASCII so UTF-8 decode succeeds without warning.
+            // ちょうど MaxFileSize バイト — ASCII なら UTF-8 デコードで警告無く成功する。
+            var data = new byte[10 * 1024 * 1024];
+            for (int i = 0; i < data.Length; i++)
+                data[i] = (byte)'a';
+            File.WriteAllBytes(filePath, data);
+
+            var indexer = new FileIndexer(tempDir);
+            var (record, content, _) = indexer.BuildRecord(filePath);
+
+            Assert.Equal(data.Length, record.Size);
+            Assert.Equal(data.Length, content.Length);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BuildRecord_RecordSizeReflectsBytesActuallyRead()
+    {
+        // Regression for #1529: with the FileStream-based read path, record.Size must
+        // come from the bytes streamed through the open handle rather than from a
+        // separate FileInfo.Length stat. Asserting record.Size against the byte count
+        // documents the contract that downstream consumers (status, freshness checks)
+        // see the same value the indexer actually ingested.
+        // #1529 のリグレッション: FileStream ベースの読み込み経路では record.Size は
+        // 別途取得した FileInfo.Length ではなく、オープンしたハンドル経由で実際に読み
+        // 込んだバイト数を反映しなければならない。`record.Size` をバイト数と突き合わ
+        // せることで、status や freshness check の下流が実際に取り込まれた値と一致
+        // することを契約として固定する。
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var filePath = Path.Combine(tempDir, "sized.py");
+            var payload = "print('hello world')\n"u8.ToArray();
+            File.WriteAllBytes(filePath, payload);
+
+            var indexer = new FileIndexer(tempDir);
+            var (record, _, _) = indexer.BuildRecord(filePath);
+
+            Assert.Equal(payload.Length, record.Size);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void BuildRecord_ExtensionlessShebangScriptUsesDetectedLanguage()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

- `FileIndexer.BuildRecordWithRawBytes` checked `FileInfo.Length` against `MaxFileSize` and then re-opened the file via `File.ReadAllBytes`, leaving a stat / read TOCTOU window where a file that grew from a small size to multi-GB between the two syscalls could bypass the 10 MB cap and force an OOM-sized allocation.
- The method now opens the path once through a single `FileStream` (`FileShare.Read`), validates `stream.Length` against `MaxFileSize` on the open handle, and streams bytes into a `MemoryStream` accumulator whose running total is capped at `MaxFileSize`. A concurrent writer that keeps extending the file during the read now throws `"File too large (> 10 MB limit; grew during read)"` instead of allocating beyond the cap.
- `FileRecord.Size` / `FileRecord.Modified` now come from the bytes actually read and a post-open `File.GetLastWriteTimeUtc` so downstream consumers (status, freshness checks, MCP) see the same payload size the indexer ingested rather than a racy `FileInfo.Length` snapshot.

Fixes #1529

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test CodeIndex.sln --no-build` — 4636 passed, 3 skipped, 0 failed
- `dotnet run --project tools/CodeIndex.Changelog -- check` — 38 fragments validated

## Documentation / Changelog

- `changelog.d/unreleased/1529.fixed.md` (bilingual fragment for `category: fixed`)

## Test plan

- [x] New `BuildRecord_AcceptsFileAtSizeLimitBoundary` — file at exactly 10 MB still succeeds
- [x] New `BuildRecord_RecordSizeReflectsBytesActuallyRead` — `record.Size` matches actual byte count
- [x] Existing `BuildRecord_ThrowsForOversizedFile` — 10 MB + 1 byte still throws `InvalidOperationException`

## Follow-up candidates

None.
