### PR TITLE
docs: consolidate agent guidance into AGENT_GUIDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,5 @@
 # Codex Entry Point
 
-Read `AGENT_GUIDE.md` first. It is the shared source of truth for CodeIndex agent behavior, including the code search and safety policy that forbids `grep`/`rg`/`find`/etc. in favor of the locally built `cdidx` binary.
+Read `AGENT_GUIDE.md`. It is the single source of truth for agent behavior in this repository, including the code search and safety policy (no `grep`/`rg`/`find`/etc., use the locally built `cdidx`), the workflow index, and all repository, commit, review, and PR rules.
 
-For task-specific procedures, read the relevant workflow in `.codex/workflows/`:
-
-- issue fixing: `.codex/workflows/issue-fix.md`
-- changelog fragments: `.codex/workflows/changelog-fragment.md`
-- release changelog: `.codex/workflows/release-changelog.md`
-- adversarial review: `.codex/workflows/adversarial-review.md`
-- commit checks: `.codex/workflows/precommit.md`
-- PR finalization and CI checks: `.codex/workflows/pr-finalize.md`
-- related/new issue scope control: `.codex/workflows/issue-scope.md`
-
-Do not duplicate workflow or policy rules in this file. Update `AGENT_GUIDE.md` or the relevant workflow file instead.
+**Do not add new rules, policy, workflow pointers, or contract notes to this file.** This file is a thin redirect and must stay that way. Put new content in `AGENT_GUIDE.md` (or in the relevant `.codex/workflows/*.md` workflow). Codex-specific guidance, if any, goes under `Tool-Specific Notes` in `AGENT_GUIDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Codex Entry Point
 
-Read `AGENT_GUIDE.md`. It is the single source of truth for agent behavior in this repository, including the code search and safety policy (no `grep`/`rg`/`find`/etc., use the locally built `cdidx`), the workflow index, and all repository, commit, review, and PR rules.
+Read `AGENT_GUIDE.md`. It is the single source of truth for agent behavior in this repository, including the search/indexing policy, the workflow index, tool-specific notes, and all repository, commit, review, PR, status, and reference-extraction rules.
 
-**Do not add new rules, policy, workflow pointers, or contract notes to this file.** This file is a thin redirect and must stay that way. Put new content in `AGENT_GUIDE.md` (or in the relevant `.codex/workflows/*.md` workflow). Codex-specific guidance, if any, goes under `Tool-Specific Notes` in `AGENT_GUIDE.md`.
+**Do not add new rules, policy, workflow pointers, or contract notes to this file.** This file is a thin redirect and must stay that way. Put new content in `AGENT_GUIDE.md` (or in the relevant `.codex/workflows/*.md` workflow). Codex-specific guidance goes under `Tool-Specific Notes` in `AGENT_GUIDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Codex Entry Point
 
-Read `AGENT_GUIDE.md` first. It is the shared source of truth for CodeIndex agent behavior.
+Read `AGENT_GUIDE.md` first. It is the shared source of truth for CodeIndex agent behavior, including the code search and safety policy that forbids `grep`/`rg`/`find`/etc. in favor of the locally built `cdidx` binary.
 
 For task-specific procedures, read the relevant workflow in `.codex/workflows/`:
 
@@ -12,24 +12,4 @@ For task-specific procedures, read the relevant workflow in `.codex/workflows/`:
 - PR finalization and CI checks: `.codex/workflows/pr-finalize.md`
 - related/new issue scope control: `.codex/workflows/issue-scope.md`
 
-Do not duplicate workflow rules in this file. Update the shared files instead.
-
-## Code search and safety policy
-
-For CodeIndex work, dogfood the project-built CodeIndex binary.
-
-Do not use grep, rg, ripgrep, ag, ack, find, fd, locate, git grep, Python scripts,
-or a globally installed cdidx for code search or repository discovery.
-
-Use:
-
-`dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll`
-
-Examples:
-
-- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search SymbolExtractor`
-- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll symbols --lang csharp`
-- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll inspect src/CodeIndex/Indexer/SymbolExtractor.cs`
-
-This instruction is a workflow rule. Enforcement is provided separately by the
-Claude and Codex guard hooks.
+Do not duplicate workflow or policy rules in this file. Update `AGENT_GUIDE.md` or the relevant workflow file instead.

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -18,12 +18,19 @@ For implementation tasks:
 
 ## Search and Indexing Rules
 
-For code search, do not use `grep`, `rg`, `python`, or a globally installed `cdidx`.
-Use the locally built CodeIndex binary from this repository:
+For CodeIndex work, dogfood the project-built CodeIndex binary.
+
+Do not use `grep`, `rg`, `ripgrep`, `ag`, `ack`, `find`, `fd`, `locate`, `git grep`, Python scripts, or a globally installed `cdidx` for code search or repository discovery. Use the locally built CodeIndex binary from this repository:
 
 ```bash
 dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll
 ```
+
+Examples:
+
+- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search SymbolExtractor`
+- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll symbols --lang csharp`
+- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll inspect src/CodeIndex/Indexer/SymbolExtractor.cs`
 
 Before implementation, first check whether the local index already matches the current workspace:
 
@@ -33,7 +40,15 @@ dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json
 
 If the command exits `0` and reports `index_matches_workspace: true`, you may trust the existing `.cdidx/codeindex.db` without rebuilding it. If it exits with stale-index status or reports mismatched `workspace_check` counts, refresh the local index as documented by the project guidance. If the exact index-refresh command is documented elsewhere, use that documented command instead of inventing a new one.
 
-This rule applies to code search and repository understanding. It does not forbid Git commands, build tools, test runners, package managers, or small shell checks that are not being used to search implementation code.
+This rule applies to code search and repository understanding. It does not forbid Git commands, build tools, test runners, package managers, or small shell checks that are not being used to search implementation code. Enforcement of forbidden tools is provided separately by the Claude and Codex guard hooks.
+
+## Tool-Specific Notes
+
+### Claude Code
+
+- Follow the repository-tracked `.claude/settings.json` and `.claude/hooks/bash-guard.py` policy files when running in Claude Code.
+- Do not edit those policy files during ordinary implementation work unless the task is explicitly about Claude Code guard behavior.
+- For shell search and navigation, prefer the built-in Grep / Glob tools or the locally built `cdidx` binary described above.
 
 ## Scope Rules
 
@@ -94,6 +109,19 @@ Reviews must focus on blocking/actionable issues, not nitpicks.
 
 Follow `.codex/workflows/pr-finalize.md`.
 CI watching must be bounded. Do not loop indefinitely.
+
+## Status Contract
+
+- `status --json` and related JSON/MCP payloads currently expose the trust fields documented in `README.md` and `DEVELOPER_GUIDE.md`, including `fold_ready`, `fold_ready_reason`, `graph_table_available`, `issues_table_available`, `sql_graph_contract_ready`, `sql_graph_contract_degraded_reason`, `hotspot_family_ready`, `hotspot_family_degraded_reason`, `csharp_symbol_name_ready`, `csharp_metadata_target_ready`, `indexed_head_commit`, `worktree_head_changed`, `index_writer_version`, `index_newer_than_reader`, and `index_newer_than_reader_reason`.
+- When `fold_ready` is the only degraded readiness bit, the CLI also adds `degraded_reason`, `recommended_action`, and `alternative_action`.
+- `index_writer_version` records the `cdidx` version that last wrote to the DB (stamped into `codeindex_meta` as `cdidx_writer_version` on every full scan, update, and MCP index). `index_newer_than_reader` flips to `true` whenever any persisted numeric contract stamp in `codeindex_meta` (or unknown `PRAGMA user_version` readiness bits) exceeds the current binary's compiled maximum, so an older CLI re-opening a DB written by a newer CLI degrades loudly with an audit trail instead of silently dropping back to text-search fallbacks. `index_newer_than_reader_reason` enumerates the specific newer-than-reader stamps.
+- `status` also surfaces indexed-HEAD freshness via `indexed_head_sha`, `indexed_head_branch`, `indexed_head_timestamp`, and `commits_ahead_of_indexed_head`. They are stamped by `cdidx index` on every successful run (full scan AND partial update, distinct from `indexed_head_commit` which is full-scan only) on a best-effort basis (never blocks an otherwise-successful index) and omitted on non-git workspaces, detached HEAD (branch only), or legacy DBs created before this contract.
+- Keep `README.md`, `DEVELOPER_GUIDE.md`, and this file synchronized if this contract changes.
+
+## Reference Extraction
+
+- Dockerfile multi-stage builds now emit `call`-kind reference edges for `FROM <stage> AS <new>` and `COPY --from=<stage>` when the source name matches a named stage in the same file, so `callers` and `impact` can follow stage dependencies instead of treating intermediate stages as unused.
+- Rust macro invocations (`name!(...)` / `name![...]` / `name!{...}`) now emit `call`-kind reference edges, while the `macro_rules!` declaration keyword remains suppressed so macro definitions do not double-count as calls.
 
 ## When You Cannot Complete an Operation
 

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -3,18 +3,29 @@
 This file is the shared, authoritative agent guide for CodeIndex.
 It is used by Codex, Claude Code, and any other coding agent working in this repository.
 
-`AGENTS.md` and `CLAUDE.md` are entry points only. Do not duplicate full workflows there.
-When this guide and an entry-point file disagree, this guide wins unless the difference is explicitly tool-specific.
+`AGENTS.md` and `CLAUDE.md` are thin entry points only; they just redirect here. **Any new rule, policy, workflow pointer, or contract note must be added to this file (or to a `.codex/workflows/*.md` workflow), not to `AGENTS.md` or `CLAUDE.md`.** Tool-specific guidance goes under `Tool-Specific Notes` in this file. When this guide and an entry-point file disagree, this guide wins.
 
 ## Read Order
 
 For implementation tasks:
 
-1. Read the agent entry point for your tool, if one was loaded automatically.
+1. Read the agent entry point for your tool, if one was loaded automatically (`AGENTS.md` for Codex, `CLAUDE.md` for Claude Code). Those files are thin entry points and only point here.
 2. Read this file.
-3. Read the relevant workflow in `.codex/workflows/`.
+3. Read the relevant workflow in `.codex/workflows/` (see the Workflow Index below).
 4. Read project-specific files referenced by that workflow, such as `SELF_IMPROVEMENT.md`, `DEVELOPER_GUIDE.md`, or `TESTING_GUIDE.md`.
 5. Read only the additional source files needed for the task.
+
+## Workflow Index
+
+Task-specific procedures live in `.codex/workflows/`. The directory is a shared workflow library for all coding agents, not only Codex.
+
+- issue fixing: `.codex/workflows/issue-fix.md`
+- changelog fragments: `.codex/workflows/changelog-fragment.md`
+- release changelog: `.codex/workflows/release-changelog.md`
+- adversarial review: `.codex/workflows/adversarial-review.md`
+- commit checks: `.codex/workflows/precommit.md`
+- PR finalization and CI checks: `.codex/workflows/pr-finalize.md`
+- related/new issue scope control: `.codex/workflows/issue-scope.md`
 
 ## Search and Indexing Rules
 
@@ -79,7 +90,7 @@ When editing changelog content, verify that both English and Japanese entries ar
 ## Documentation Rules
 
 - Treat documentation as part of the feature contract, not as optional cleanup.
-- If a change affects user-visible behavior, CLI/MCP output, flags, error messages, install/release behavior, or contributor/agent workflow, update the matching docs in the same change. For CodeIndex this usually means `README.md`, `DEVELOPER_GUIDE.md`, `TESTING_GUIDE.md`, `SELF_IMPROVEMENT.md`, `INTEGRATION_POLICY.md`, `CLAUDE.md`, `AGENT_GUIDE.md`, or the relevant `.codex/workflows/*.md` file.
+- If a change affects user-visible behavior, CLI/MCP output, flags, error messages, install/release behavior, or contributor/agent workflow, update the matching docs in the same change. For CodeIndex this usually means `README.md`, `DEVELOPER_GUIDE.md`, `TESTING_GUIDE.md`, `SELF_IMPROVEMENT.md`, `INTEGRATION_POLICY.md`, `AGENT_GUIDE.md`, or the relevant `.codex/workflows/*.md` file. Do not put agent workflow or policy content in `AGENTS.md` / `CLAUDE.md`; they are thin entry points.
 - Do not open or merge a PR with a user-visible change unless the required docs and changelog updates are present, or the PR body explicitly explains why no docs/changelog change is needed.
   - Changelog entries are required for user-visible or behavior-changing work. For ordinary implementation PRs, write the changelog entry as a bilingual fragment under `changelog.d/unreleased/`; do not update `CHANGELOG.md` directly as the default path.
   - Use issue-based fragment names and `issues:` front matter only when the work is actually tied to GitHub issues. For non-issue work, use a `+<slug>.<category>.md` fragment and omit `issues` entirely. Never write `issues: null` or `issues: []`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # Claude Code Entry Point
 
-Read `AGENT_GUIDE.md`. It is the single source of truth for agent behavior in this repository, including Claude Code-specific notes, the search/indexing policy, the workflow index, and all status and reference-extraction contracts.
+Read `AGENT_GUIDE.md`. It is the single source of truth for agent behavior in this repository, including the search/indexing policy, the workflow index, tool-specific notes, and all repository, commit, review, PR, status, and reference-extraction rules.
 
 **Do not add new rules, policy, workflow pointers, or contract notes to this file.** This file is a thin redirect and must stay that way. Put new content in `AGENT_GUIDE.md` (or in the relevant `.codex/workflows/*.md` workflow). Claude Code-specific guidance goes under `Tool-Specific Notes > Claude Code` in `AGENT_GUIDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,5 @@
 # Claude Code Entry Point
 
-Read `AGENT_GUIDE.md` first. It is the shared source of truth for CodeIndex agent behavior, including Claude Code-specific notes, the search/indexing policy, and the status and reference-extraction contracts.
+Read `AGENT_GUIDE.md`. It is the single source of truth for agent behavior in this repository, including Claude Code-specific notes, the search/indexing policy, the workflow index, and all status and reference-extraction contracts.
 
-For task-specific procedures, read the relevant workflow in `.codex/workflows/`:
-
-- issue fixing: `.codex/workflows/issue-fix.md`
-- changelog fragments: `.codex/workflows/changelog-fragment.md`
-- release changelog: `.codex/workflows/release-changelog.md`
-- adversarial review: `.codex/workflows/adversarial-review.md`
-- commit checks: `.codex/workflows/precommit.md`
-- PR finalization and CI checks: `.codex/workflows/pr-finalize.md`
-- related/new issue scope control: `.codex/workflows/issue-scope.md`
-
-The `.codex/workflows/` directory is a shared workflow library for all coding agents, not only Codex.
-
-Do not duplicate workflow or policy rules in this file. Update `AGENT_GUIDE.md` or the relevant workflow file instead.
+**Do not add new rules, policy, workflow pointers, or contract notes to this file.** This file is a thin redirect and must stay that way. Put new content in `AGENT_GUIDE.md` (or in the relevant `.codex/workflows/*.md` workflow). Claude Code-specific guidance goes under `Tool-Specific Notes > Claude Code` in `AGENT_GUIDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude Code Entry Point
 
-Read `AGENT_GUIDE.md` first. It is the shared source of truth for CodeIndex agent behavior.
+Read `AGENT_GUIDE.md` first. It is the shared source of truth for CodeIndex agent behavior, including Claude Code-specific notes, the search/indexing policy, and the status and reference-extraction contracts.
 
 For task-specific procedures, read the relevant workflow in `.codex/workflows/`:
 
@@ -14,21 +14,4 @@ For task-specific procedures, read the relevant workflow in `.codex/workflows/`:
 
 The `.codex/workflows/` directory is a shared workflow library for all coding agents, not only Codex.
 
-## Claude Code Notes
-
-- Follow the repository-tracked `.claude/settings.json` and `.claude/hooks/bash-guard.py` policy files when running in Claude Code.
-- Do not edit those policy files during ordinary implementation work unless the task is explicitly about Claude Code guard behavior.
-- For shell search and navigation, prefer the built-in Grep / Glob tools or the locally built `cdidx` binary described in `AGENT_GUIDE.md`.
-
-## Status Contract
-
-- `status --json` and related JSON/MCP payloads currently expose the trust fields documented in `README.md` and `DEVELOPER_GUIDE.md`, including `fold_ready`, `fold_ready_reason`, `graph_table_available`, `issues_table_available`, `sql_graph_contract_ready`, `sql_graph_contract_degraded_reason`, `hotspot_family_ready`, `hotspot_family_degraded_reason`, `csharp_symbol_name_ready`, `csharp_metadata_target_ready`, `indexed_head_commit`, `worktree_head_changed`, `index_writer_version`, `index_newer_than_reader`, and `index_newer_than_reader_reason`.
-- When `fold_ready` is the only degraded readiness bit, the CLI also adds `degraded_reason`, `recommended_action`, and `alternative_action`.
-- `index_writer_version` records the `cdidx` version that last wrote to the DB (stamped into `codeindex_meta` as `cdidx_writer_version` on every full scan, update, and MCP index). `index_newer_than_reader` flips to `true` whenever any persisted numeric contract stamp in `codeindex_meta` (or unknown `PRAGMA user_version` readiness bits) exceeds the current binary's compiled maximum, so an older CLI re-opening a DB written by a newer CLI degrades loudly with an audit trail instead of silently dropping back to text-search fallbacks. `index_newer_than_reader_reason` enumerates the specific newer-than-reader stamps.
-- `status` also surfaces indexed-HEAD freshness via `indexed_head_sha`, `indexed_head_branch`, `indexed_head_timestamp`, and `commits_ahead_of_indexed_head`. They are stamped by `cdidx index` on every successful run (full scan AND partial update, distinct from `indexed_head_commit` which is full-scan only) on a best-effort basis (never blocks an otherwise-successful index) and omitted on non-git workspaces, detached HEAD (branch only), or legacy DBs created before this contract.
-- Keep the three docs synchronized if this contract changes.
-
-## Reference Extraction
-
-- Dockerfile multi-stage builds now emit `call`-kind reference edges for `FROM <stage> AS <new>` and `COPY --from=<stage>` when the source name matches a named stage in the same file, so `callers` and `impact` can follow stage dependencies instead of treating intermediate stages as unused.
-- Rust macro invocations (`name!(...)` / `name![...]` / `name!{...}`) now emit `call`-kind reference edges, while the `macro_rules!` declaration keyword remains suppressed so macro definitions do not double-count as calls.
+Do not duplicate workflow or policy rules in this file. Update `AGENT_GUIDE.md` or the relevant workflow file instead.


### PR DESCRIPTION
## Summary
- `AGENT_GUIDE.md` is the single source of truth. The header now states explicitly that any new rule, policy, workflow pointer, or contract note must land here (or in a `.codex/workflows/*.md` workflow), not in `AGENTS.md` / `CLAUDE.md`.
- Moved into `AGENT_GUIDE.md`: the shared `Workflow Index` (previously duplicated in both entry-point files), the full forbidden-tool list and example invocations from `AGENTS.md`'s `Code search and safety policy`, and the `Status Contract`, `Reference Extraction`, and Claude Code-specific notes from `CLAUDE.md` (the latter under a new `Tool-Specific Notes > Claude Code` subsection).
- Reduced `CLAUDE.md` and `AGENTS.md` to bare redirects: one sentence pointing to `AGENT_GUIDE.md`, plus an explicit "do not add new rules here" guardrail so the entry points cannot quietly re-fatten over time.
- Removed `CLAUDE.md` from the `Documentation Rules` "matching docs" example list and added a line stating agent workflow/policy content does not belong in `AGENTS.md` / `CLAUDE.md`.

## Rationale
`AGENT_GUIDE.md` already declared itself the shared source of truth and `AGENTS.md` / `CLAUDE.md` as entry points, but those two files had accumulated workflow/policy content and a duplicated workflow index. This change makes the actual layout match the stated contract and adds explicit forward-guidance so future updates land in one place.

## Notes
- No code or runtime behavior changes; pure documentation reorganization.
- `Status Contract` cross-reference note updated to explicitly list `README.md`, `DEVELOPER_GUIDE.md`, and `AGENT_GUIDE.md` (replacing the implicit `CLAUDE.md` reference).
- No `changelog.d/unreleased/` fragment added: agent-facing docs reshuffle with no user-visible behavior change.

## Test plan
- [ ] Confirm `CLAUDE.md` and `AGENTS.md` are bare redirects with no workflow/policy bullets.
- [ ] Confirm `AGENT_GUIDE.md` contains `Workflow Index`, `Search and Indexing Rules`, `Tool-Specific Notes`, `Status Contract`, and `Reference Extraction` sections, and that the header explicitly forbids adding new rules to the entry-point files.
- [ ] Spot-check other docs (`USER_GUIDE.md`, `CLOUD_BOOTSTRAP_PROMPT.md`, `.codex/workflows/README.md`, `.codex/config.toml`) -- references to `CLAUDE.md` / `AGENTS.md` still resolve (files still exist, just thinner).

Generated with Claude Code.
