### PR TITLE
Fix backfill_fold check-then-stamp race that left NULL-folded rows under fold_ready=true (#1535)

### DIFF
--- a/changelog.d/unreleased/1535.fixed.md
+++ b/changelog.d/unreleased/1535.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1535
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+---
+
+## English
+
+- **`backfill_fold` no longer stamps `fold_ready=true` when a concurrent writer slipped in a NULL-folded row (#1535)** — `DbWriter.MarkFoldReady` now re-verifies `AllFoldedColumnsBackfilled` inside the same `BEGIN IMMEDIATE` transaction that flips the FoldReady bit and writes `fold_key_version` / `fold_key_fingerprint`, and returns `false` (writing nothing) if the re-verify fails. Previously the MCP `backfill_fold` handler, the `cdidx backfill-fold` CLI, the `cdidx index` full-scan / partial-update restamp paths, and the MCP `index_project` full-scan restamp path all ran the verify and the stamp as separate statements, so a parallel `cdidx index` could insert fresh rows between the two and leave `fold_ready=true` with some `name_folded` / `*_folded` columns still NULL — silently underreporting on `--exact` Unicode searches. All five call sites now surface the same retry-friendly error message they already use for legacy NULL rows, so readers degrade to the NOCASE fallback until `backfill_fold` is re-run successfully.
+
+## 日本語
+
+- **`backfill_fold` が concurrent writer による NULL 行差し込みで `fold_ready=true` を誤って立てなくなりました (#1535)** — `DbWriter.MarkFoldReady` は FoldReady bit を立てる `BEGIN IMMEDIATE` トランザクション内で `AllFoldedColumnsBackfilled` を再検証するようになり、再検証に失敗した場合は何も書かずに `false` を返します。これまで MCP の `backfill_fold` ハンドラ、`cdidx backfill-fold` CLI、`cdidx index` のフルスキャン / 部分更新の restamp 経路、および MCP の `index_project` フルスキャン restamp 経路は検証と stamp を別ステートメントで実行していたため、並列で動く `cdidx index` がその隙間に行を挿入すると、`name_folded` / `*_folded` が NULL のまま `fold_ready=true` が立ち、`--exact` の Unicode 検索が静かに取りこぼす可能性がありました。5 つの呼び出し元は legacy NULL 行と同じ retry 案内のエラーを返すようになり、`backfill_fold` を再実行して成功するまで reader は NOCASE fallback に降格します。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -385,7 +385,11 @@ public static class IndexCommandRunner
                 || storedFoldFingerprint != currentFoldFingerprint;
 
             var (symbols, symbolReferences) = writer.BackfillFoldedColumns(rewriteAll);
-            var verified = writer.AllFoldedColumnsBackfilled();
+            // MarkFoldReady re-verifies inside a BEGIN IMMEDIATE so a concurrent writer cannot
+            // insert NULL-folded rows between the verify and the stamp. Issue #1535.
+            // MarkFoldReady は BEGIN IMMEDIATE 内で再検証するため、concurrent writer による
+            // NULL 行差し込みで fold_ready が嘘になるのを防ぐ。Issue #1535。
+            var verified = writer.MarkFoldReady();
             if (!verified)
             {
                 return WriteCommandError(
@@ -396,7 +400,6 @@ public static class IndexCommandRunner
                     "Retry `cdidx backfill-fold`. If the DB still does not verify, rebuild it with `cdidx index <projectPath> --rebuild`.");
             }
 
-            writer.MarkFoldReady();
             var userVersionAfter = db.GetUserVersion();
 
             if (options.Json)
@@ -1125,8 +1128,11 @@ public static class IndexCommandRunner
                 && priorFoldVersion == currentFoldVersion
                 && priorFoldFingerprint == currentFoldFingerprint)
             {
-                writer.MarkFoldReady();
-                foldReadyAfter = true;
+                // MarkFoldReady re-verifies inside BEGIN IMMEDIATE; a concurrent NULL-folded
+                // insert during this restamp window leaves foldReadyAfter=false. Issue #1535.
+                // MarkFoldReady は BEGIN IMMEDIATE 内で再検証する。restamp 窓の concurrent
+                // 書き込みで NULL 行が残った場合は foldReadyAfter=false のまま。Issue #1535。
+                foldReadyAfter = writer.MarkFoldReady();
             }
             writer.WriteCdidxWriterVersion(ConsoleUi.LoadVersion());
         }
@@ -1886,8 +1892,18 @@ public static class IndexCommandRunner
             // user_version だけ落ちた current DB もここで回復させる。
             if (backfillReady && (skipped == 0 || canRestampExistingFoldTrust))
             {
-                writer.MarkFoldReady();
-                foldReadyAfter = true;
+                // MarkFoldReady re-verifies inside BEGIN IMMEDIATE; if a concurrent writer slipped
+                // in a NULL-folded row between the upfront check and this stamp, the stamp is
+                // skipped and we degrade to the legacy reason instead of silent misadvertisement.
+                // Issue #1535.
+                // BEGIN IMMEDIATE 内で再検証するため、concurrent writer による NULL 差し込みで
+                // stamp は失敗し、silent な fold-trust 誤広告ではなく legacy 理由に降格する。Issue #1535。
+                foldReadyAfter = writer.MarkFoldReady();
+                if (!foldReadyAfter)
+                {
+                    backfillReady = false;
+                    foldReadyReasonAfter = GetFoldReadyReason(false, foldVersionMatchesCurrent, foldFingerprintMatchesCurrent);
+                }
             }
             else
                 foldReadyReasonAfter = GetFoldReadyReason(backfillReady, foldVersionMatchesCurrent, foldFingerprintMatchesCurrent);

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -828,14 +828,70 @@ public class DbWriter
     /// Readers require the bit, a version match, and a fingerprint match before trusting
     /// folded columns, so both intentional fold changes and runtime ICU / invariant-casing
     /// drift degrade safely to NOCASE until `--rebuild`. Issue #97.
+    ///
+    /// Re-verifies <see cref="AllFoldedColumnsBackfilled"/> inside a BEGIN IMMEDIATE
+    /// transaction so a concurrent writer cannot insert NULL-folded rows between the
+    /// caller's pre-check and this stamp. Returns false (and writes nothing) when the
+    /// re-verify fails, so callers can surface a friendly retry message instead of
+    /// silently advertising fold-trust to readers. Issue #1535.
     /// FoldReady bit + fold_key_version + fold_key_fingerprint を書く。runtime drift を含む
     /// silent mismatch を防ぎ、ズレた場合は `--rebuild` まで NOCASE fallback に降格する。
+    /// BEGIN IMMEDIATE で囲んだうえで再検証し、concurrent writer による NULL 行差し込みで
+    /// fold_ready が嘘になるのを防ぐ。Issue #1535。
     /// </summary>
-    public void MarkFoldReady()
+    /// <returns>True when the bit was actually stamped; false when re-verification failed.</returns>
+    public bool MarkFoldReady()
     {
-        SetReadyBit(DbContext.FoldReadyFlag);
-        SetMeta("fold_key_version", NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture));
-        SetMeta("fold_key_fingerprint", NameFold.Fingerprint());
+        bool ownTransaction = !IsInTransaction();
+        if (ownTransaction)
+            Execute("BEGIN IMMEDIATE");
+        try
+        {
+            if (!AllFoldedColumnsBackfilled())
+            {
+                if (ownTransaction)
+                {
+                    Execute("COMMIT");
+                    ownTransaction = false;
+                }
+                return false;
+            }
+
+            // Inline the SetReadyBit body. SetReadyBit opens its own BEGIN IMMEDIATE
+            // when not already in a DbWriter-tracked transaction, but our raw
+            // BEGIN IMMEDIATE above is not tracked in _transactionDepth, so a direct
+            // SetReadyBit call would attempt a nested BEGIN IMMEDIATE and fail.
+            // SetReadyBit は _transactionDepth ベースでしか外側 transaction を見ないため、
+            // 生 BEGIN IMMEDIATE 内では呼べない。内容を inline 展開する。
+            int current;
+            using (var read = _conn.CreateCommand())
+            {
+                read.CommandText = "PRAGMA user_version";
+                var raw = read.ExecuteScalar();
+                current = raw is long l ? (int)l : (raw is int i ? i : 0);
+            }
+            int next = current | DbContext.FoldReadyFlag;
+            if (next != current)
+                Execute($"PRAGMA user_version = {next}");
+
+            SetMeta("fold_key_version", NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            SetMeta("fold_key_fingerprint", NameFold.Fingerprint());
+
+            if (ownTransaction)
+            {
+                Execute("COMMIT");
+                ownTransaction = false;
+            }
+            return true;
+        }
+        catch
+        {
+            if (ownTransaction)
+            {
+                try { Execute("ROLLBACK"); } catch { /* best effort */ }
+            }
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1753,8 +1753,15 @@ public partial class McpServer
             var canRestampExistingFoldTrust = foldVersionMatchesCurrent && foldFingerprintMatchesCurrent;
             if (backfillReady && (skipped == 0 || canRestampExistingFoldTrust))
             {
-                writer.MarkFoldReady();
-                foldReadyAfter = true;
+                // MarkFoldReady re-verifies inside BEGIN IMMEDIATE; a concurrent NULL-folded
+                // insert during this restamp window leaves foldReadyAfter=false and degrades
+                // to the legacy "missing_fold_backfill" reason instead of silent misadvertise.
+                // Issue #1535.
+                // BEGIN IMMEDIATE 内で再検証する。concurrent NULL 差し込みで stamp が失敗した
+                // 場合は missing_fold_backfill に降格する。Issue #1535。
+                foldReadyAfter = writer.MarkFoldReady();
+                if (!foldReadyAfter)
+                    foldReadyReason = "missing_fold_backfill";
             }
             else if (!backfillReady)
             {
@@ -1874,11 +1881,14 @@ public partial class McpServer
             var rewriteAll = storedFoldVersion != currentFoldVersion
                 || storedFoldFingerprint != currentFoldFingerprint;
             var (symbols, symbolReferences) = writer.BackfillFoldedColumns(rewriteAll);
-            var verified = writer.AllFoldedColumnsBackfilled();
+            // MarkFoldReady wraps its own re-verification in BEGIN IMMEDIATE, so a concurrent
+            // writer cannot insert NULL-folded rows between the verify and the stamp. Issue #1535.
+            // MarkFoldReady は BEGIN IMMEDIATE 内で再検証するため、concurrent writer による
+            // NULL 行差し込みで fold_ready が嘘になるのを防ぐ。Issue #1535。
+            var verified = writer.MarkFoldReady();
             if (!verified)
-                return CreateToolErrorResponse(id, "Folded-name backfill verification failed: some rows still have NULL folded values.");
+                return CreateToolErrorResponse(id, "Folded-name backfill verification failed: some rows still have NULL folded values. Re-run backfill_fold.");
 
-            writer.MarkFoldReady();
             var userVersionAfter = db.GetUserVersion();
 
             var payload = new JsonObject

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -508,6 +508,59 @@ public class DatabaseTests : IDisposable
         Assert.Equal(1, files);
     }
 
+    [Fact]
+    public void MarkFoldReady_StampsFoldReadyWhenAllRowsBackfilled()
+    {
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/fold_ok.py", Lang = "python", Size = 30, Lines = 3,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertSymbols([
+            new SymbolRecord { FileId = fileId, Kind = "function", Name = "Straße", Line = 1, StartLine = 1, EndLine = 1 },
+        ]);
+
+        var stamped = _writer.MarkFoldReady();
+
+        Assert.True(stamped);
+        Assert.Equal(DbContext.FoldReadyFlag, _db.GetUserVersion() & DbContext.FoldReadyFlag);
+    }
+
+    [Fact]
+    public void MarkFoldReady_LeavesFoldReadyUnsetWhenNullFoldedRowExists()
+    {
+        // Reproduces issue #1535: a concurrent writer inserting a NULL-folded row between
+        // an upfront verify and the FoldReady stamp can leave readers on the fold path with
+        // some rows still NULL. The fix re-verifies inside MarkFoldReady's BEGIN IMMEDIATE so
+        // this stamp is skipped and readers stay on NOCASE until backfill_fold is re-run.
+        // issue #1535 の再現: 上位の verify 後に concurrent writer が NULL 行を差し込んだ場合、
+        // 修正後の MarkFoldReady は再検証で stamp を取りやめ、reader を NOCASE に保つ。
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/fold_partial.py", Lang = "python", Size = 30, Lines = 3,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertSymbols([
+            new SymbolRecord { FileId = fileId, Kind = "function", Name = "Straße", Line = 1, StartLine = 1, EndLine = 1 },
+        ]);
+
+        // Simulate a concurrent NULL-folded insert that slipped in after the caller's
+        // upfront AllFoldedColumnsBackfilled check returned true.
+        // 上位の verify 直後に concurrent writer が NULL 行を入れたシナリオを再現する。
+        using (var cmd = _db.Connection.CreateCommand())
+        {
+            cmd.CommandText = "UPDATE symbols SET name_folded = NULL";
+            cmd.ExecuteNonQuery();
+        }
+
+        var stamped = _writer.MarkFoldReady();
+
+        Assert.False(stamped);
+        Assert.Equal(0, _db.GetUserVersion() & DbContext.FoldReadyFlag);
+        Assert.Null(_db.GetMetaString("fold_key_version"));
+        Assert.Null(_db.GetMetaString("fold_key_fingerprint"));
+    }
+
     public void Dispose()
     {
         _db.Dispose();


### PR DESCRIPTION
## Summary

- `DbWriter.MarkFoldReady` now re-verifies `AllFoldedColumnsBackfilled` inside the same `BEGIN IMMEDIATE` transaction that flips `FoldReadyFlag` and writes `fold_key_version` / `fold_key_fingerprint`, and returns `false` (writing nothing) when the re-verify fails.
- Five call sites (MCP `backfill_fold` handler, `backfill-fold` CLI subcommand, `index` full-scan / partial-update restamp paths, and MCP `index_project` full-scan restamp path) now use the bool return so a concurrent indexer inserting NULL-folded rows between the upfront verify and the stamp degrades to NOCASE fallback with the existing retry-friendly error message instead of silently advertising `fold_ready=true`.
- Bilingual changelog fragment added at `changelog.d/unreleased/1535.fixed.md`.

Fixes #1535.

## Test plan

- [x] dotnet build CodeIndex.sln
- [x] dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj — 4647 passed, 3 skipped (perf tests).
- [x] New MarkFoldReady_StampsFoldReadyWhenAllRowsBackfilled and MarkFoldReady_LeavesFoldReadyUnsetWhenNullFoldedRowExists tests cover both branches of the new atomic re-verification.
- [x] Changelog fragment validated with the bilingual ChangelogTool check step.