### PR TITLE
Anchor PHP/Rust use-as alias parser on whitespace token boundaries (#1539)

### DIFF
--- a/changelog.d/unreleased/1539.fixed.md
+++ b/changelog.d/unreleased/1539.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1539
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Rust.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHP / Rust `use ... as ...` alias parser now anchors on whitespace token boundaries (#1539)** — the PHP group-`use` item parser and the Rust `use`-tree alias parser previously located the ` as ` separator via `IndexOf(" as ")` / `FindTopLevelKeyword(" as ")` and then sliced `item[(aliasIndex + 4)..]` unconditionally, so any whitespace variant other than a single ASCII space (tab-separated `Item\tas\tAlias`, multi-line `Result\n    as\n    IoResult`, or any path that combined tab / newline separators introduced by `TryReadRustUseStatement`) silently failed to match the keyword and the alias was either dropped entirely (PHP, falling back to the full path as the import name) or merged into the leaf name (Rust, the alias never surfaced as its own `import` occurrence). The PHP group-`use` item path now matches the alias via the new `PhpUseGroupItemAliasRegex` (`^(?<name>[\w\\]+)\s+as\s+(?<alias>\w+)$`, case-insensitive), and the Rust path uses a new `FindTopLevelAsKeyword` helper that scans for an ` as ` keyword surrounded by any whitespace (tab / space / newline) outside `{ ... }` and returns the full keyword span so the alias slice is correctly bounded.
+
+## 日本語
+
+- **PHP / Rust の `use ... as ...` エイリアスパーサが空白トークン境界で確実に分割するようになりました (#1539)** — PHP の group-`use` アイテムパーサと Rust の `use` ツリーエイリアスパーサは従来 `IndexOf(" as ")` / `FindTopLevelKeyword(" as ")` で ` as ` セパレータを探したうえで `item[(aliasIndex + 4)..]` を無条件にスライスしていたため、ASCII 半角スペース 1 個以外の空白 (タブ区切りの `Item\tas\tAlias`、改行を跨ぐ `Result\n    as\n    IoResult`、`TryReadRustUseStatement` が挿入するタブ / 改行を含むパス) ではキーワード一致に失敗し、エイリアスが完全に取りこぼされたり (PHP、フルパスがそのまま import 名にフォールバック)、リーフ名へ吸収されたまま独立した `import` として現れない (Rust) 状態になっていました。PHP の group-`use` アイテム経路は新設の `PhpUseGroupItemAliasRegex` (`^(?<name>[\w\\]+)\s+as\s+(?<alias>\w+)$`、大文字小文字区別なし) でエイリアスを捕捉し、Rust 経路は `{ ... }` の外側で任意の空白 (タブ / スペース / 改行) に囲まれた ` as ` キーワードを走査して完全なキーワード幅を返す新ヘルパー `FindTopLevelAsKeyword` を使うようになったため、エイリアススライスの境界が正しく確定します。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -35,6 +35,10 @@ public static partial class SymbolExtractor
         @"^\s*(?:[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*::)?[A-Za-z_]\w*\s+as\s+(?:(?:public|protected|private)\s+)?(?<name>(?!public\b|protected\b|private\b)[A-Za-z_]\w*)\s*;",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
+    private static readonly Regex PhpUseGroupItemAliasRegex = new(
+        @"^(?<name>[\w\\]+)\s+as\s+(?<alias>\w+)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     private static readonly Regex PhpDocblockTypeAliasRegex = new(
         @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?type\s+(?<name>[A-Za-z_]\w*)\s+(?<returnType>\S+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
@@ -61,11 +65,11 @@ public static partial class SymbolExtractor
 
                 var importedName = item;
                 var alias = string.Empty;
-                var aliasIndex = item.IndexOf(" as ", StringComparison.OrdinalIgnoreCase);
-                if (aliasIndex >= 0)
+                var aliasMatch = PhpUseGroupItemAliasRegex.Match(item);
+                if (aliasMatch.Success)
                 {
-                    importedName = item[..aliasIndex].Trim();
-                    alias = item[(aliasIndex + 4)..].Trim();
+                    importedName = aliasMatch.Groups["name"].Value;
+                    alias = aliasMatch.Groups["alias"].Value;
                 }
 
                 var symbolName = alias.Length > 0 ? alias : prefix + importedName;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Rust.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Rust.cs
@@ -244,7 +244,8 @@ public static partial class SymbolExtractor
             }
         }
 
-        var aliasIndex = FindTopLevelKeyword(text, " as ");
+        var asKeyword = FindTopLevelAsKeyword(text);
+        var aliasIndex = asKeyword.Start;
         var hasPathPrefix = !string.IsNullOrWhiteSpace(prefix);
 
         if (hasPathPrefix && text is not "self" and not "super" and not "crate" and not "*")
@@ -252,10 +253,12 @@ public static partial class SymbolExtractor
 
         if (aliasIndex >= 0)
         {
-            var alias = text[(aliasIndex + 4)..].Trim();
+            var afterKeyword = aliasIndex + asKeyword.Length;
+            var aliasTail = text[afterKeyword..];
+            var alias = aliasTail.Trim();
             if (alias.Length > 0)
             {
-                var aliasStart = bodyOffset + aliasIndex + 4 + (text[(aliasIndex + 4)..].Length - alias.Length);
+                var aliasStart = bodyOffset + afterKeyword + (aliasTail.Length - aliasTail.TrimStart().Length);
                 AddRustUseOccurrence(occurrences, alias, aliasStart, lineStarts, startLineNumber);
             }
         }
@@ -401,12 +404,15 @@ public static partial class SymbolExtractor
         return -1;
     }
 
-    private static int FindTopLevelKeyword(string text, string keyword)
+    private readonly record struct RustAsKeywordSpan(int Start, int Length);
+
+    private static RustAsKeywordSpan FindTopLevelAsKeyword(string text)
     {
         var braceDepth = 0;
-        for (var i = 0; i <= text.Length - keyword.Length; i++)
+        for (var i = 0; i < text.Length; i++)
         {
-            switch (text[i])
+            var ch = text[i];
+            switch (ch)
             {
                 case '{':
                     braceDepth++;
@@ -417,11 +423,28 @@ public static partial class SymbolExtractor
                     continue;
             }
 
-            if (braceDepth == 0 && text.AsSpan(i, keyword.Length).SequenceEqual(keyword))
-                return i;
+            if (braceDepth != 0 || !char.IsWhiteSpace(ch))
+                continue;
+
+            var asStart = i + 1;
+            while (asStart < text.Length && char.IsWhiteSpace(text[asStart]))
+                asStart++;
+
+            if (asStart + 2 > text.Length)
+                continue;
+            if (text[asStart] != 'a' || text[asStart + 1] != 's')
+                continue;
+            if (asStart + 2 >= text.Length || !char.IsWhiteSpace(text[asStart + 2]))
+                continue;
+
+            var endOfTrailingWs = asStart + 2;
+            while (endOfTrailingWs < text.Length && char.IsWhiteSpace(text[endOfTrailingWs]))
+                endOfTrailingWs++;
+
+            return new RustAsKeywordSpan(i, endOfTrailingWs - i);
         }
 
-        return -1;
+        return new RustAsKeywordSpan(-1, 0);
     }
 
     private static bool HasRustSymbol(List<SymbolRecord> symbols, long fileId, int lineNumber, string kind, string name)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12421,6 +12421,21 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_GroupUseAliasHandlesTokenBoundariesAndPathsContainingAs()
+    {
+        var content = "<?php\nuse Foo\\{Bar\\As_thing as alias, Other\\Item\tas\tAliasedItem, Plain};\n";
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var imports = symbols.Where(s => s.Kind == "import").Select(s => s.Name).ToList();
+
+        Assert.Contains("alias", imports);
+        Assert.Contains("AliasedItem", imports);
+        Assert.Contains("Foo\\Plain", imports);
+        Assert.DoesNotContain(imports, name => name.Contains(" as ", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(imports, name => name.Contains('\t'));
+    }
+
+    [Fact]
     public void Extract_PHP_DetectsClassProperties()
     {
         var content = """
@@ -13403,6 +13418,20 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Client" && s.Line == 6 && s.StartColumn == 10);
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "crate::net::server::Server as NetServer");
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "NetServer" && s.Line == 7 && s.StartColumn == 28);
+    }
+
+    [Fact]
+    public void Extract_Rust_UseAliasHandlesTokenBoundariesAndPathsContainingAs()
+    {
+        var content = "use crate::as_helpers::Inner\tas\tAliased;\nuse std::io::Result\n    as\n    IoResult;\n";
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var imports = symbols.Where(s => s.Kind == "import").Select(s => s.Name).ToList();
+
+        Assert.Contains("Aliased", imports);
+        Assert.Contains("Inner", imports);
+        Assert.Contains("IoResult", imports);
+        Assert.Contains("Result", imports);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- PHP group-`use` item parser and Rust `use`-tree alias parser previously located the ` as ` separator via `IndexOf(" as ")` / `FindTopLevelKeyword(" as ")` and unconditionally sliced `item[(aliasIndex + 4)..]`. Any whitespace variant other than a single ASCII space (tab-separated items, multi-line `Result\n    as\n    IoResult`, or any path joined with `\n` by `TryReadRustUseStatement`) silently failed to match the keyword, so the alias was either dropped (PHP fell back to the full path as the import name) or merged into the leaf name (Rust never surfaced the alias as its own `import` occurrence).
- PHP group-`use` items now match via the new `PhpUseGroupItemAliasRegex` (`^(?<name>[\w\\]+)\s+as\s+(?<alias>\w+)$`, case-insensitive); Rust uses a new `FindTopLevelAsKeyword` helper that scans for ` as ` surrounded by any whitespace outside `{ ... }` and returns the full keyword span so the alias slice is correctly bounded.
- Added bilingual changelog fragment `changelog.d/unreleased/1539.fixed.md` and new tests `Extract_PHP_GroupUseAliasHandlesTokenBoundariesAndPathsContainingAs` / `Extract_Rust_UseAliasHandlesTokenBoundariesAndPathsContainingAs` (covering tab-separated and multi-line `as` keyword variants).

Fixes #1539

## Test plan
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_PHP|FullyQualifiedName~Extract_Rust"` (96 passing, 0 failing)
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` (4655 passing, 3 skipped, 0 failing)
