### PR TITLE
Dedupe conflicting PHPDoc @property* tags per docblock

### DIFF
--- a/changelog.d/unreleased/1541.fixed.md
+++ b/changelog.d/unreleased/1541.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 1541
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **PHPDoc `@property*` tags conflicting on the same `$name` no longer emit duplicate symbols and type references (#1541)** — within a single `/** ... */` docblock, PHP property tags (`@property`, `@property-read`, `@property-write`, plus `@phpstan-property*` / `@psalm-property*` variants) are now deduplicated by property name. The first declaration wins; subsequent tags that re-declare the same `$name` are dropped from both `SymbolExtractor` output and `ReferenceExtractor` `type_reference` edges, so conflicting documentation does not silently inflate `callers` / `impact` results. Distinct docblocks (e.g., two classes in one file) remain independent and emit their own property entries.
+
+## 日本語
+
+- **PHPDoc の `@property*` タグが同じ `$name` で衝突したときに重複シンボル/参照を吐かなくなりました (#1541)** — 単一の `/** ... */` ドックブロック内では、PHP のプロパティタグ（`@property`、`@property-read`、`@property-write`、および `@phpstan-property*` / `@psalm-property*` バリアント）をプロパティ名で重複排除するようになりました。最初の宣言を採用し、同じ `$name` を再宣言する後続のタグは `SymbolExtractor` の出力からも `ReferenceExtractor` の `type_reference` エッジからも除外されます。これにより矛盾したドキュメントが `callers` / `impact` の結果を密かに水増しすることがなくなります。別のドックブロック（例: 同一ファイル内の 2 クラス）は独立しており、それぞれ自分の `@property*` を出力します。

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -46,7 +46,7 @@ internal static class PhpReferenceExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockPropertyTypeRegex = new(
-        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?property(?:-read|-write)?\s+(?<types>\S+)",
+        @"^\s*(?:/\*\*)?\s*\*?\s*@(?>phpstan-|psalm-)?property(?:-read|-write)?\s+(?<types>\S+)(?:\s+\$(?<name>[A-Za-z_]\w*))?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex DocblockMethodReturnTypeRegex = new(
@@ -272,16 +272,31 @@ internal static class PhpReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        SymbolRecord? container)
-        => EmitDocblockTypeReferences(
-            DocblockPropertyTypeRegex,
-            originalLine,
+        SymbolRecord? container,
+        HashSet<string>? seenDocblockPropertyNames = null)
+    {
+        var match = DocblockPropertyTypeRegex.Match(originalLine);
+        if (!match.Success)
+            return;
+
+        var nameGroup = match.Groups["name"];
+        if (nameGroup.Success && seenDocblockPropertyNames != null
+            && !seenDocblockPropertyNames.Add(nameGroup.Value))
+        {
+            return;
+        }
+
+        var typesGroup = match.Groups["types"];
+        EmitDocblockTypeGroupReferences(
+            typesGroup.Value,
+            typesGroup.Index,
             references,
             seen,
             fileId,
             context,
             lineNumber,
             container);
+    }
 
     public static void EmitDocblockMethodReturnTypeReferences(
         string originalLine,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1073,6 +1073,7 @@ public static partial class ReferenceExtractor
         var sqlState = language == "sql" ? SqlReferenceExtractor.CreateState() : null;
         var csharpInDelimitedDocComment = false;
         var jvmInDelimitedDocComment = false;
+        HashSet<string>? phpDocblockPropertyNames = null;
 
         for (int i = 0; i < lines.Length; i++)
         {
@@ -1325,6 +1326,12 @@ public static partial class ReferenceExtractor
                 }
             }
 
+            if (language == "php"
+                && originalLine.IndexOf("/**", StringComparison.Ordinal) >= 0)
+            {
+                phpDocblockPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+            }
+
             if (language == "php" && originalLine.Contains("property", StringComparison.OrdinalIgnoreCase))
             {
                 var docblockContext = originalLine.Trim();
@@ -1337,8 +1344,16 @@ public static partial class ReferenceExtractor
                         fileId,
                         docblockContext,
                         lineNumber,
-                        FindInnermostContainer(containerCandidates, lineNumber));
+                        FindInnermostContainer(containerCandidates, lineNumber),
+                        phpDocblockPropertyNames);
                 }
+            }
+
+            if (language == "php"
+                && phpDocblockPropertyNames != null
+                && originalLine.IndexOf("*/", StringComparison.Ordinal) >= 0)
+            {
+                phpDocblockPropertyNames = null;
             }
 
             if (language == "php" && originalLine.Contains("@method", StringComparison.OrdinalIgnoreCase))

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -222,32 +222,42 @@ public static partial class SymbolExtractor
 
     private static void ExtractPhpDocblockPropertySymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
     {
+        HashSet<string>? seenDocblockPropertyNames = null;
         for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
         {
             var line = lines[lineIndex];
-            var match = PhpDocblockPropertyRegex.Match(line);
-            if (!match.Success)
-                continue;
+            if (line.IndexOf("/**", StringComparison.Ordinal) >= 0)
+                seenDocblockPropertyNames = new HashSet<string>(StringComparer.Ordinal);
 
-            var lineNumber = lineIndex + 1;
-            var nameGroup = match.Groups["name"];
-            AddSymbolRecord(
-                symbols,
-                cssSeenSymbols: null,
-                lineNumber,
-                new SymbolRecord
+            var match = PhpDocblockPropertyRegex.Match(line);
+            if (match.Success)
+            {
+                var lineNumber = lineIndex + 1;
+                var nameGroup = match.Groups["name"];
+                if (seenDocblockPropertyNames == null || seenDocblockPropertyNames.Add(nameGroup.Value))
                 {
-                    FileId = fileId,
-                    Kind = "property",
-                    Name = nameGroup.Value,
-                    Line = lineNumber,
-                    StartLine = lineNumber,
-                    StartColumn = nameGroup.Index,
-                    EndLine = lineNumber,
-                    Signature = line.Trim(),
-                    ReturnType = match.Groups["returnType"].Value,
-                },
-                line);
+                    AddSymbolRecord(
+                        symbols,
+                        cssSeenSymbols: null,
+                        lineNumber,
+                        new SymbolRecord
+                        {
+                            FileId = fileId,
+                            Kind = "property",
+                            Name = nameGroup.Value,
+                            Line = lineNumber,
+                            StartLine = lineNumber,
+                            StartColumn = nameGroup.Index,
+                            EndLine = lineNumber,
+                            Signature = line.Trim(),
+                            ReturnType = match.Groups["returnType"].Value,
+                        },
+                        line);
+                }
+            }
+
+            if (seenDocblockPropertyNames != null && line.IndexOf("*/", StringComparison.Ordinal) >= 0)
+                seenDocblockPropertyNames = null;
         }
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10375,6 +10375,72 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PhpDocblockProperty_DuplicateTagsForSameName_AreDeduplicated()
+    {
+        const string content = """
+            <?php
+            /**
+             * @property OwnerA $name
+             * @property OwnerB $name
+             */
+            final class Account {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "OwnerA" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "OwnerB" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_PhpDocblockProperty_OverlappingReadWriteTags_AreDeduplicated()
+    {
+        const string content = """
+            <?php
+            /**
+             * @property-read OwnerA $title
+             * @property-write OwnerB $title
+             * @phpstan-property OwnerC $title
+             */
+            final class Article {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "OwnerA" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "OwnerB" && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "OwnerC" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_PhpDocblockProperty_DistinctDocblocks_DoNotDedup()
+    {
+        const string content = """
+            <?php
+            /**
+             * @property OwnerA $name
+             */
+            final class Account {}
+
+            /**
+             * @property OwnerB $name
+             */
+            final class Profile {}
+            ?>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var references = ReferenceExtractor.Extract(1, "php", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "OwnerA" && reference.ReferenceKind == "type_reference");
+        Assert.Contains(references, reference => reference.SymbolName == "OwnerB" && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_PhpDocblockMethodReturnTypes_EmitTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12611,6 +12611,36 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_PHP_DocblockProperties_DuplicateForSameName_EmitsOnce()
+    {
+        var content = """
+            <?php
+            /**
+             * @property OwnerA $name
+             * @property OwnerB $name
+             * @property-read OwnerC $title
+             * @property-write OwnerD $title
+             */
+            class UserPresenter {}
+
+            /**
+             * @property OwnerE $name
+             */
+            class Other {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "php", content);
+        var docblockProperties = symbols.Where(s => s.Kind == "property").ToList();
+
+        Assert.Equal(3, docblockProperties.Count(s => s.Name == "name" || s.Name == "title"));
+        Assert.Single(docblockProperties, s => s.Name == "name" && s.ReturnType == "OwnerA");
+        Assert.DoesNotContain(docblockProperties, s => s.ReturnType == "OwnerB");
+        Assert.Single(docblockProperties, s => s.Name == "title" && s.ReturnType == "OwnerC");
+        Assert.DoesNotContain(docblockProperties, s => s.ReturnType == "OwnerD");
+        Assert.Single(docblockProperties, s => s.Name == "name" && s.ReturnType == "OwnerE");
+    }
+
+    [Fact]
     public void Extract_PHP_DetectsTraitAliasMethods()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Conflicting PHPDoc `@property*` tags for the same `$name` (e.g., `@property` + `@property` with different types, or overlapping `@property-read` / `@property-write`) within a single `/** ... */` docblock are now deduplicated by property name. First declaration wins; subsequent re-declarations of the same `$name` are dropped from both `SymbolExtractor` output and `ReferenceExtractor` `type_reference` edges.
- Cross-docblock independence is preserved: two classes in one file each emit their own `@property*` entries.
- Reference-side state is reset on `/**` and cleared on `*/`; symbol-side mirrors the same per-docblock scope.

## Test plan

- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` (4675 passed, 3 skipped)
- [x] New reference tests: `Extract_PhpDocblockProperty_DuplicateTagsForSameName_AreDeduplicated`, `..._OverlappingReadWriteTags_AreDeduplicated`, `..._DistinctDocblocks_DoNotDedup`
- [x] New symbol test: `Extract_PHP_DocblockProperties_DuplicateForSameName_EmitsOnce`
- [x] Existing `Extract_PhpDocblockPropertyTypes_EmitTypeReferences` and `Extract_PHP_DetectsDocblockProperties` still pass

Fixes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)
