### PR TITLE
Lock CLI numeric flag parsing to InvariantCulture (#1543)

### DIFF
--- a/changelog.d/unreleased/1543.fixed.md
+++ b/changelog.d/unreleased/1543.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1543
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerInvariantCultureTests.cs
+---
+
+## English
+
+- **CLI numeric flag parsing is now locked to `CultureInfo.InvariantCulture` (#1543)** — `QueryCommandRunner` previously called `int.TryParse(value, out var x)` for `--limit` / `--top` / `--before` / `--after` / `--max-line-width` and for the shared `TryParsePositiveInt` / `TryParseNonNegativeInt` helpers, which leaks the runtime culture's `NumberFormatInfo` (notably `NegativeSign`) into parsing decisions and lets the same `cdidx --limit X` command drift across machines with different locales (or across future locale-aware CLR changes). Every CLI numeric `TryParse` now passes `NumberStyles.Integer, CultureInfo.InvariantCulture` so the parse contract is anchored to ASCII digits and the ASCII `-` sign regardless of `LANG` / `CurrentCulture`.
+
+## 日本語
+
+- **CLI の数値フラグ parsing が `CultureInfo.InvariantCulture` に固定されました (#1543)** — `QueryCommandRunner` は従来 `--limit` / `--top` / `--before` / `--after` / `--max-line-width` および共通ヘルパー `TryParsePositiveInt` / `TryParseNonNegativeInt` で `int.TryParse(value, out var x)` を呼んでおり、ランタイムの `NumberFormatInfo`（特に `NegativeSign`）が parse 判定に漏れていたため、同じ `cdidx --limit X` コマンドがロケールの異なるマシンで（あるいは将来の CLR ロケール対応変更で）挙動 drift する余地がありました。CLI の数値 `TryParse` をすべて `NumberStyles.Integer, CultureInfo.InvariantCulture` 経由に統一し、`LANG` / `CurrentCulture` に依存せず ASCII 数字と ASCII `-` 符号に parse 契約を固定します。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -1203,21 +1203,21 @@ public static class QueryCommandRunner
                     value = args[i + 1];
                     i++;
                 }
-                if ((arg == "--limit" || arg == "--top") && (!int.TryParse(value, out var limit) || limit <= 0))
+                if ((arg == "--limit" || arg == "--top") && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var limit) || limit <= 0))
                     return $"Error: {arg} requires a positive integer, got '{value}'";
                 if ((arg == "--limit" || arg == "--top")
-                    && int.TryParse(value, out var limitCeil)
+                    && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var limitCeil)
                     && NumericFlagUpperBounds.TryGetValue("--limit", out var limitMax)
                     && limitCeil > limitMax)
                     return $"Error: --limit must be less than or equal to {limitMax}, got '{value}'.";
-                if (arg == "--max-line-width" && (!int.TryParse(value, out var widthValue) || widthValue < 0))
+                if (arg == "--max-line-width" && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var widthValue) || widthValue < 0))
                     return $"Error: {arg} requires a non-negative integer, got '{value}'";
-                if (arg == "--max-line-width" && int.TryParse(value, out var widthCeil) && widthCeil > LineWidthFormatter.MaxAllowedLineWidth)
+                if (arg == "--max-line-width" && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var widthCeil) && widthCeil > LineWidthFormatter.MaxAllowedLineWidth)
                     return $"Error: --max-line-width must be less than or equal to {LineWidthFormatter.MaxAllowedLineWidth} (got '{value}').";
-                if ((arg == "--before" || arg == "--after") && (!int.TryParse(value, out var context) || context < 0))
+                if ((arg == "--before" || arg == "--after") && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var context) || context < 0))
                     return $"Error: {arg} requires a non-negative integer, got '{value}'";
                 if ((arg == "--before" || arg == "--after")
-                    && int.TryParse(value, out var contextCeil)
+                    && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var contextCeil)
                     && NumericFlagUpperBounds.TryGetValue(arg, out var contextMax)
                     && contextCeil > contextMax)
                     return $"Error: {arg} must be less than or equal to {contextMax}, got '{value}'.";
@@ -4281,7 +4281,7 @@ public static class QueryCommandRunner
         if (string.Equals(optionName, "--max-line-width", StringComparison.Ordinal))
             return TryParseNonNegativeInt(rawValue, optionName, out value, out error);
 
-        if (!int.TryParse(rawValue, out value) || value <= 0)
+        if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out value) || value <= 0)
         {
             value = 0;
             error = $"Error: {optionName} requires a positive integer, got '{rawValue}'. Hint: retry with `{optionName} 1` or another positive integer.";
@@ -4301,7 +4301,7 @@ public static class QueryCommandRunner
 
     private static bool TryParseNonNegativeInt(string rawValue, string optionName, out int value, out string? error)
     {
-        if (!int.TryParse(rawValue, out value) || value < 0)
+        if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out value) || value < 0)
         {
             value = 0;
             error = $"Error: {optionName} requires a non-negative integer, got '{rawValue}'. Hint: retry with `{optionName} 0` or another non-negative integer.";

--- a/tests/CodeIndex.Tests/QueryCommandRunnerInvariantCultureTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerInvariantCultureTests.cs
@@ -1,0 +1,127 @@
+using System.Globalization;
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+// Regression lock for #1543: CLI numeric flag parsing must run under
+// CultureInfo.InvariantCulture so the same `cdidx --limit X` command behaves
+// identically on machines with different runtime cultures (and stays stable
+// across future CLR locale-aware changes). The test installs a quirky current
+// culture whose NegativeSign is U+2212 ("−") instead of ASCII "-" — under the
+// old culture-leaking code that custom NegativeSign would alter how int.TryParse
+// reads dashes from CLI tokens; with InvariantCulture pinned, the parser must
+// stay anchored on the ASCII contract regardless of LANG.
+// #1543 の回帰ロック: CLI の数値フラグ parsing は CultureInfo.InvariantCulture に
+// 固定し、ロケールが異なるマシンでも `cdidx --limit X` が同一に振る舞う（将来の
+// CLR ロケール対応変更にも耐える）こと。テストは NegativeSign を U+2212 ("−") に
+// 差し替えた quirky culture を CurrentCulture に設定する。culture-leak していた旧
+// コードでは int.TryParse のダッシュ解釈がこの custom NegativeSign に引きずられる
+// が、InvariantCulture 固定後は LANG に依存せず ASCII 契約に留まる。
+public class QueryCommandRunnerInvariantCultureTests
+{
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("de-DE")]
+    [InlineData("tr-TR")]
+    [InlineData("fa-IR")]
+    public void ParseArgs_NumericFlagsParseIdenticallyAcrossCultures(string cultureName)
+    {
+        using var _ = new CultureScope(new CultureInfo(cultureName));
+
+        var options = QueryCommandRunner.ParseArgs(
+            [
+                "RunSearch",
+                "--limit", "7",
+                "--before", "2",
+                "--after", "3",
+                "--max-line-width", "77",
+            ],
+            jsonDefault: false,
+            allowNamedQuery: true);
+
+        Assert.Null(options.ParseError);
+        Assert.Equal(7, options.Limit);
+        Assert.Equal(2, options.ContextBefore);
+        Assert.Equal(3, options.ContextAfter);
+        Assert.Equal(77, options.MaxLineWidth);
+    }
+
+    [Fact]
+    public void ParseArgs_NegativeLimitRejectedUnderQuirkyNegativeSignCulture()
+    {
+        using var _ = new CultureScope(BuildQuirkyNegativeSignCulture());
+
+        var options = QueryCommandRunner.ParseArgs(
+            ["RunSearch", "--limit", "-5"],
+            jsonDefault: false,
+            allowNamedQuery: true);
+
+        Assert.NotNull(options.ParseError);
+        Assert.Contains("--limit requires a positive integer", options.ParseError);
+        Assert.Contains("got '-5'", options.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_AsciiHyphenInBeforeFlagRejectedUnderQuirkyNegativeSignCulture()
+    {
+        using var _ = new CultureScope(BuildQuirkyNegativeSignCulture());
+
+        var options = QueryCommandRunner.ParseArgs(
+            ["RunSearch", "--before", "-1"],
+            jsonDefault: false,
+            allowNamedQuery: true);
+
+        Assert.NotNull(options.ParseError);
+        Assert.Contains("--before requires a non-negative integer", options.ParseError);
+        Assert.Contains("got '-1'", options.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_QuirkyNegativeSignCulturePreservesPositiveLimitParse()
+    {
+        // Positive ASCII digits must parse to the same integer regardless of the
+        // current culture's NegativeSign. This guards the "no drift between users"
+        // contract from #1543 for the most common positive-flag case.
+        // 正の ASCII 数字は、CurrentCulture の NegativeSign が何であれ同じ整数として
+        // parse されなければならない。これは #1543 の "ユーザー間で挙動が drift しない"
+        // 契約の中で最も一般的な正の値ケースを担保する。
+        using var _ = new CultureScope(BuildQuirkyNegativeSignCulture());
+
+        var options = QueryCommandRunner.ParseArgs(
+            ["RunSearch", "--limit", "42", "--max-line-width", "0"],
+            jsonDefault: false,
+            allowNamedQuery: true);
+
+        Assert.Null(options.ParseError);
+        Assert.Equal(42, options.Limit);
+        Assert.Equal(0, options.MaxLineWidth);
+    }
+
+    private static CultureInfo BuildQuirkyNegativeSignCulture()
+    {
+        var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        culture.NumberFormat.NegativeSign = "−";
+        culture.NumberFormat.PositiveSign = "➕";
+        return culture;
+    }
+
+    private sealed class CultureScope : IDisposable
+    {
+        private readonly CultureInfo _originalCulture;
+        private readonly CultureInfo _originalUiCulture;
+
+        public CultureScope(CultureInfo culture)
+        {
+            _originalCulture = CultureInfo.CurrentCulture;
+            _originalUiCulture = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+        }
+
+        public void Dispose()
+        {
+            CultureInfo.CurrentCulture = _originalCulture;
+            CultureInfo.CurrentUICulture = _originalUiCulture;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Pin every CLI numeric `int.TryParse` in `QueryCommandRunner` (`--limit` / `--top` / `--before` / `--after` / `--max-line-width`, plus the shared `TryParsePositiveInt` / `TryParseNonNegativeInt` helpers) to `NumberStyles.Integer, CultureInfo.InvariantCulture` so the parse contract no longer leaks `CurrentCulture.NumberFormat.NegativeSign` and behaves identically across locales / future locale-aware CLR changes.
- Add `QueryCommandRunnerInvariantCultureTests` to lock the cross-culture contract for `--limit` / `--before` / `--after` / `--max-line-width`, including a synthetic culture whose `NegativeSign` is U+2212.
- Add bilingual changelog fragment under `changelog.d/unreleased/1543.fixed.md`.

## Test plan
- [x] `dotnet build CodeIndex.sln -c Debug`
- [x] `dotnet test ... --filter FullyQualifiedName~QueryCommandRunnerInvariantCultureTests` (7/7 passing)
- [x] `dotnet test ... --filter FullyQualifiedName~QueryCommandRunner` (966/966 passing)
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` (47 fragments validated)

Fixes #1543