### PR TITLE
Normalize CRLF/CR to LF before file checksum (#1544)

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -57,7 +57,7 @@ files (
     lang        TEXT,                       -- detected language (e.g. "python")
     size        INTEGER,                    -- file size in bytes
     lines       INTEGER,                    -- line count
-    checksum    TEXT,                       -- SHA256 of raw file bytes
+    checksum    TEXT,                       -- SHA256 over file bytes with CRLF/CR collapsed to LF (BOM bytes preserved); cross-OS clones match while BOM add/remove still triggers re-index
     modified    DATETIME,                   -- file modification time (UTC)
     indexed_at  DATETIME DEFAULT CURRENT_TIMESTAMP
 )
@@ -1239,7 +1239,7 @@ files (
     lang        TEXT,                       -- 検出された言語（例: "python"）
     size        INTEGER,                    -- ファイルサイズ（バイト）
     lines       INTEGER,                    -- 行数
-    checksum    TEXT,                       -- ファイルraw bytesのSHA256
+    checksum    TEXT,                       -- ファイルバイトを CRLF/CR→LF に正規化した上で取った SHA256（BOM はそのまま）。これにより OS をまたいだ clone でも checksum が一致し、BOM の追加/削除は引き続き再索引のトリガーとして機能する
     modified    DATETIME,                   -- ファイル更新日時（UTC）
     indexed_at  DATETIME DEFAULT CURRENT_TIMESTAMP
 )

--- a/changelog.d/unreleased/1544.fixed.md
+++ b/changelog.d/unreleased/1544.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1544
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **File checksum now normalizes CRLF / CR to LF so cross-OS clones don't trigger spurious full reindex (#1544)** — `FileIndexer.ComputeChecksum` previously hashed the raw on-disk bytes, so the same logical file cloned on Windows (`core.autocrlf=true`, CRLF) and on Linux/macOS (LF) produced different checksums. Teams with mixed-OS developers, or workspaces shared over a NAS, saw `cdidx index` mark every file as "changed" the first time it ran on a different OS, wasting indexing time and poisoning "what files actually changed" diagnostics. The helper now collapses `\r\n` and standalone `\r` to `\n` while streaming through `IncrementalHash` (so a 10 MB file does not need an extra normalized-byte copy), and keeps BOM bytes in the hash input so BOM add / remove still flips the checksum. `DbPathResolver`'s sample-checksum sniffing now calls the same helper so it stays consistent with how the writer recorded the checksum. Added focused regressions for CRLF-vs-LF parity, BOM add/remove detection, mixed-line-ending normalization, and CR-free streaming over multi-chunk inputs; updated the BOM-stripped record test's comment to make the new contract explicit.
+
+## 日本語
+
+- **ファイルの checksum を CRLF / CR → LF 正規化してから算出するように修正 (#1544)** — これまで `FileIndexer.ComputeChecksum` はオンディスクの生バイトをそのまま SHA256 にかけていたため、Windows (`core.autocrlf=true`、CRLF) と Linux/macOS (LF) で同じ論理内容を clone しただけで checksum が一致しませんでした。混在 OS のチームや NAS 共有ワークスペースでは、別 OS で初めて `cdidx index` を走らせた瞬間に全ファイルが「変更あり」扱いとなり、再索引に時間を取られたうえ「実際にどのファイルが変わったか」の診断も汚れていました。今回ハッシュ入力に対して `\r\n` と単独 `\r` を `\n` に潰したうえで `IncrementalHash` に流し込む実装に変更し (10 MB ファイルでも正規化済みバイトのフルコピーを追加で確保しない)、BOM のバイトはハッシュ入力に残すので BOM の追加 / 削除は引き続き checksum を変化させます。`DbPathResolver` のサンプル checksum 照合も同じヘルパを呼ぶようにし、書き込み側と算出方法を揃えました。CRLF と LF の同一性、BOM 追加 / 削除の検知、混在改行の正規化、CR 無し payload を複数チャンクにまたいで処理する streaming 経路の回帰テストを追加し、BOM 剥がしテスト側のコメントも新しい契約を明示するよう更新しました。

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 
@@ -334,7 +333,11 @@ public static class DbPathResolver
                     continue;
 
                 pathExistsMatches++;
-                var checksum = ComputeChecksum(File.ReadAllBytes(absolutePath));
+                // Use the FileIndexer helper so cross-OS clones (CRLF vs LF) still match
+                // checksums recorded by an indexer running on a different OS.
+                // FileIndexer のヘルパを使い、OS をまたいだ clone (CRLF と LF) でも、
+                // 他 OS で生成された checksum と引き続き一致するようにする。
+                var checksum = FileIndexer.ComputeChecksum(File.ReadAllBytes(absolutePath));
                 if (string.Equals(checksum, sample.Checksum, StringComparison.OrdinalIgnoreCase))
                     checksumMatches++;
             }
@@ -346,12 +349,6 @@ public static class DbPathResolver
         }
 
         return new SampleMatchResult(checksumMatches, pathExistsMatches);
-    }
-
-    private static string ComputeChecksum(byte[] bytes)
-    {
-        var hash = SHA256.HashData(bytes);
-        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
     private readonly record struct SampleMatchResult(int ChecksumMatches, int PathExistsMatches);

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1936,8 +1936,21 @@ public class FileIndexer
             modifiedUtc = File.GetLastWriteTimeUtc(absolutePath);
         }
 
-        // Compute checksum from raw bytes to avoid re-encoding the string (~10MB saved for large files)
-        // 文字列の再エンコードを回避するためraw bytesからチェックサムを算出（大ファイルで約10MB節約）
+        // Compute the checksum on the byte stream after collapsing CRLF / CR to LF so
+        // a Windows clone (core.autocrlf=true) and a Linux/macOS clone of the same logical
+        // file produce identical checksums. Hashing the unnormalized raw bytes used to
+        // mark every file as "changed" the first time a developer indexed a cross-OS clone
+        // or a shared NAS workspace. BOM bytes are preserved verbatim so BOM addition /
+        // removal still flips the checksum and triggers incremental re-index. The streaming
+        // helper avoids re-encoding the UTF-8 string (~10 MB saved for large files).
+        // Closes #1544.
+        // CRLF / CR を LF に潰した上で SHA256 を取り、Windows (core.autocrlf=true) clone と
+        // Linux/macOS clone の同じ論理内容で checksum を一致させる。生バイトをそのまま
+        // ハッシュしていた以前は、cross-OS の clone や共有 NAS で全ファイルが「変更あり」
+        // 扱いとなり毎回フル再索引が走っていた。BOM はそのままハッシュ対象に残すので
+        // BOM の追加 / 削除はインクリメンタル再索引で引き続き検知できる。streaming
+        // ヘルパは UTF-8 文字列を再エンコードせずに済み、大ファイルで約 10 MB 節約する。
+        // Closes #1544.
         var checksum = ComputeChecksum(bytes);
 
         string content;
@@ -1963,9 +1976,10 @@ public class FileIndexer
         // output. Non-line-leading U+FEFF (Unicode 3.2+ ZWNBSP inside a string
         // literal, identifier, or comment — e.g. `const s = "A\uFEFFB"`) is kept
         // verbatim: stripping it would corrupt content fidelity for intentional
-        // mid-line ZWNBSP use. The raw-byte checksum is computed above and remains
-        // BOM-inclusive so incremental re-index still detects BOM add / removal.
-        // Closes #183.
+        // mid-line ZWNBSP use. The checksum computed above keeps BOM bytes in the
+        // hash input (only CRLF / CR are collapsed to LF) so incremental re-index
+        // still detects BOM add / removal. Closes #183. Cross-OS CRLF / LF parity
+        // is handled by ComputeChecksum itself; see #1544.
         // 行頭の UTF-8 BOM (U+FEFF) だけを剥がす — オフセット 0 の先頭 BOM と、
         // `\n` の直後にある BOM (ファイル連結やツール挿入で発生) が対象。先頭 BOM
         // だけでも行指向の `^\s*` 固定正規表現で BOM 付き Windows 作成ソースの
@@ -1974,8 +1988,10 @@ public class FileIndexer
         // (Unicode 3.2+ の ZWNBSP を文字列リテラル・識別子・コメントで意図的に
         // 使用しているケース、例: `const s = "A\uFEFFB"`) はそのまま保持する:
         // これを剥がすと mid-line ZWNBSP の意図的利用に対して内容が壊れる。
-        // checksum は BOM を含む生バイトから上で算出済みで、インクリメンタル更新
-        // 判定は BOM 追加 / 削除を引き続き検知する。Closes #183.
+        // checksum は上で算出済みで、ハッシュ入力に BOM をそのまま含めたまま
+        // CRLF / CR のみを LF に潰すため、BOM の追加 / 削除はインクリメンタル
+        // 再索引で引き続き検知される。Closes #183。OS をまたいだ CRLF / LF の
+        // 同一性は ComputeChecksum 自体で担保する。#1544 参照。
         content = StripLineLeadingBom(content);
         // Accurate line count: ignore trailing newline, and treat content that became
         // empty after CRLF / BOM stripping as zero lines (not `"".Split('\n') == [""]`'s
@@ -2193,12 +2209,49 @@ public class FileIndexer
     }
 
     /// <summary>
-    /// Compute SHA256 checksum from raw file bytes.
-    /// ファイルのraw bytesからSHA256チェックサムを算出する。
+    /// Compute SHA256 checksum from file bytes after collapsing CRLF / CR to LF.
+    /// Matches the line-ending normalization that BuildRecord applies to the decoded
+    /// content so cross-OS clones (Windows with core.autocrlf=true vs Linux/macOS) of the
+    /// same logical file produce the same checksum, while BOM bytes pass through unchanged
+    /// so BOM add / remove still triggers incremental re-index. Streams through
+    /// IncrementalHash with a fixed buffer so large files do not require an extra full
+    /// normalized-byte copy. Closes #1544.
+    /// CRLF / CR を LF に潰してから SHA256 を算出する。BuildRecord がデコード後 content に
+    /// 適用するのと同じ改行正規化を生バイト側でも行うので、Windows (core.autocrlf=true) と
+    /// Linux/macOS で同じ論理内容を clone した場合に checksum が一致する。BOM はそのまま
+    /// ハッシュ対象に残るので、BOM 追加 / 削除はインクリメンタル再索引で引き続き検知される。
+    /// IncrementalHash に固定バッファで投入する streaming 実装なので、大ファイルでも
+    /// 正規化後バイトのフルコピーを追加で確保しない。Closes #1544.
     /// </summary>
-    private static string ComputeChecksum(byte[] bytes)
+    internal static string ComputeChecksum(byte[] bytes)
     {
-        var hash = SHA256.HashData(bytes);
+        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        Span<byte> buffer = stackalloc byte[4096];
+        int n = 0;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            byte b = bytes[i];
+            if (b == 0x0D)
+            {
+                buffer[n++] = 0x0A;
+                if (i + 1 < bytes.Length && bytes[i + 1] == 0x0A)
+                    i++;
+            }
+            else
+            {
+                buffer[n++] = b;
+            }
+            if (n == buffer.Length)
+            {
+                hasher.AppendData(buffer);
+                n = 0;
+            }
+        }
+        if (n > 0)
+            hasher.AppendData(buffer[..n]);
+        Span<byte> hash = stackalloc byte[32];
+        if (!hasher.TryGetHashAndReset(hash, out var written) || written != hash.Length)
+            throw new InvalidOperationException("SHA256 produced an unexpected hash length");
         return Convert.ToHexString(hash).ToLowerInvariant();
     }
 

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2165,11 +2165,12 @@ public class FileIndexerTests
     {
         // Files whose on-disk bytes begin with UTF-8 BOM (EF BB BF) must have the BOM
         // stripped from the decoded content so downstream consumers never see a phantom
-        // U+FEFF glyph on line 1. The raw-byte checksum must still reflect the on-disk
-        // file (BOM included) so incremental change detection keeps working. Closes #183.
+        // U+FEFF glyph on line 1. The checksum must still reflect the BOM bytes so adding
+        // or removing the BOM keeps triggering incremental change detection. Closes #183.
         // オンディスク先頭に UTF-8 BOM (EF BB BF) を持つファイルは、デコード後の content
-        // から BOM を剥がし、下流に幽霊 U+FEFF を渡さないようにする。checksum は生バイト
-        // ベース（BOM を含む）のまま維持し、インクリメンタル更新判定が壊れないようにする。Closes #183.
+        // から BOM を剥がし、下流に幽霊 U+FEFF を渡さないようにする。checksum は BOM の
+        // バイトを含めたまま算出し、BOM 追加/削除をインクリメンタル更新判定で引き続き
+        // 検知できるようにする。Closes #183.
         var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
         try
         {
@@ -2190,11 +2191,17 @@ public class FileIndexerTests
             // 文字列オーバーロードではなくコードポイントで確認する。
             Assert.DoesNotContain('\uFEFF', content);
             Assert.Equal(2, record.Lines);
-            // Pin the backward-compatibility requirement: checksum must be SHA256 over the
-            // raw on-disk bytes (BOM included) so that adding or removing a BOM is detected
-            // as a file change by incremental re-indexing. Closes #183.
-            // 後方互換性の要件を固定: checksum は生のオンディスクバイト（BOM 含む）の
-            // SHA256 で、BOM の追加 / 削除をインクリメンタル再索引で検知できること。Closes #183.
+            // Pin the BOM-detection contract: BOM bytes feed into the checksum hash input
+            // so adding or removing a BOM still flips the checksum and triggers incremental
+            // re-index. This test's payload has no CR bytes, so the line-ending normalization
+            // added for #1544 is a no-op and the expected value still matches raw-byte SHA256.
+            // Cross-OS CRLF / LF parity is covered by BuildRecord_Checksum_CrlfAndLfMatch.
+            // Closes #183.
+            // BOM 検知契約を固定: BOM のバイトは checksum のハッシュ入力にそのまま含まれ、
+            // BOM の追加 / 削除でハッシュが変化することでインクリメンタル再索引が走る。
+            // このテストの payload には CR が無いため #1544 の改行正規化は no-op となり、
+            // 期待値は生バイトの SHA256 と一致する。OS をまたいだ CRLF / LF の同一性は
+            // BuildRecord_Checksum_CrlfAndLfMatch で担保する。Closes #183.
             var expectedChecksum = Convert.ToHexString(
                 System.Security.Cryptography.SHA256.HashData(rawBytes)).ToLowerInvariant();
             Assert.Equal(expectedChecksum, record.Checksum);
@@ -2203,6 +2210,118 @@ public class FileIndexerTests
         {
             Directory.Delete(tempDir, true);
         }
+    }
+
+    [Fact]
+    public void BuildRecord_Checksum_CrlfAndLfMatch()
+    {
+        // The same logical content cloned with CRLF line endings (Windows with
+        // core.autocrlf=true) and with LF endings (Linux/macOS) must produce the same
+        // checksum, so cross-OS clones / shared NAS workspaces do not trip incremental
+        // re-index on every file. Standalone CR (legacy Mac classic) must collapse too.
+        // Closes #1544.
+        // 同じ論理内容を CRLF (Windows core.autocrlf=true) と LF (Linux/macOS) で clone
+        // しても checksum が一致する必要がある。さもないと cross-OS clone や共有 NAS で
+        // 初回索引時に全ファイルが「変更あり」扱いとなり再索引が走ってしまう。standalone
+        // CR (旧 Mac classic) も同様に LF へ畳む。Closes #1544.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var lfPath = Path.Combine(tempDir, "lf.py");
+            var crlfPath = Path.Combine(tempDir, "crlf.py");
+            var crPath = Path.Combine(tempDir, "cr.py");
+            File.WriteAllBytes(lfPath, System.Text.Encoding.UTF8.GetBytes("line1\nline2\nline3\n"));
+            File.WriteAllBytes(crlfPath, System.Text.Encoding.UTF8.GetBytes("line1\r\nline2\r\nline3\r\n"));
+            File.WriteAllBytes(crPath, System.Text.Encoding.UTF8.GetBytes("line1\rline2\rline3\r"));
+
+            var indexer = new FileIndexer(tempDir);
+            var (lfRecord, _, _) = indexer.BuildRecord(lfPath);
+            var (crlfRecord, _, _) = indexer.BuildRecord(crlfPath);
+            var (crRecord, _, _) = indexer.BuildRecord(crPath);
+
+            Assert.Equal(lfRecord.Checksum, crlfRecord.Checksum);
+            Assert.Equal(lfRecord.Checksum, crRecord.Checksum);
+            // Spot-check the expected value: SHA256 of the LF-normalized payload, so a
+            // future regression that re-introduces raw-byte hashing fails loudly.
+            // 期待値も固定: LF 正規化後 payload の SHA256。生バイトハッシュへ戻ると
+            // 落ちるようにしておく。
+            var expected = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(
+                    System.Text.Encoding.UTF8.GetBytes("line1\nline2\nline3\n"))).ToLowerInvariant();
+            Assert.Equal(expected, lfRecord.Checksum);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BuildRecord_Checksum_BomAddRemoveStillDetected()
+    {
+        // BOM bytes (EF BB BF) must still be part of the checksum hash input so a clone
+        // that gained or lost a leading BOM is detected as changed by incremental re-index.
+        // Only CRLF / CR are collapsed; BOM passes through unchanged. Closes #1544.
+        // BOM のバイト (EF BB BF) はハッシュ入力に残し、BOM の有無が変わった clone を
+        // インクリメンタル再索引で変更として検知できるようにする。畳むのは CRLF / CR のみで
+        // BOM はそのまま通す。Closes #1544.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var bomPath = Path.Combine(tempDir, "bom.cs");
+            var noBomPath = Path.Combine(tempDir, "nobom.cs");
+            var payload = System.Text.Encoding.UTF8.GetBytes("using System;\n");
+            File.WriteAllBytes(bomPath, new byte[] { 0xEF, 0xBB, 0xBF }.Concat(payload).ToArray());
+            File.WriteAllBytes(noBomPath, payload);
+
+            var indexer = new FileIndexer(tempDir);
+            var (bomRecord, _, _) = indexer.BuildRecord(bomPath);
+            var (noBomRecord, _, _) = indexer.BuildRecord(noBomPath);
+
+            Assert.NotEqual(bomRecord.Checksum, noBomRecord.Checksum);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ComputeChecksum_MixedLineEndings_NormalizesToLf()
+    {
+        // Direct-call coverage: mixed CRLF / CR / LF lines all collapse to LF before
+        // hashing, matching the content-level normalization in BuildRecord. Pinning the
+        // helper directly catches regressions even if BuildRecord shape changes.
+        // Closes #1544.
+        // direct call の網羅: CRLF / CR / LF が混在しても全て LF に畳まれてから
+        // ハッシュ化され、BuildRecord 側の content 正規化と一致する。BuildRecord の
+        // 形が変わっても helper 単体で回帰を検知できる。Closes #1544.
+        var mixed = System.Text.Encoding.UTF8.GetBytes("a\r\nb\rc\nd\r\n");
+        var lfOnly = System.Text.Encoding.UTF8.GetBytes("a\nb\nc\nd\n");
+        Assert.Equal(
+            FileIndexer.ComputeChecksum(lfOnly),
+            FileIndexer.ComputeChecksum(mixed));
+    }
+
+    [Fact]
+    public void ComputeChecksum_LongInputWithoutCr_MatchesRawByteSha256()
+    {
+        // For CR-free payloads (the common case), the checksum must still equal raw-byte
+        // SHA256 — both as a correctness anchor for existing DBs whose stored checksums
+        // were computed from raw bytes on LF-only sources, and to confirm the streaming
+        // implementation handles inputs that span multiple AppendData chunks. Closes #1544.
+        // CR を含まない payload (一般的なケース) では checksum が生バイト SHA256 と
+        // 一致する必要がある。これは LF のみのソースで生バイトから算出された既存 DB の
+        // checksum との互換性を保ち、また streaming 実装が AppendData の複数チャンクを
+        // またぐ入力でも正しく動くことを示す。Closes #1544.
+        var payload = new byte[16 * 1024];
+        for (int i = 0; i < payload.Length; i++)
+            payload[i] = (byte)(i % 95 + 32); // printable ASCII (no CR / LF)
+        var expected = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(payload)).ToLowerInvariant();
+        Assert.Equal(expected, FileIndexer.ComputeChecksum(payload));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `FileIndexer.ComputeChecksum` now collapses CRLF / CR to LF (via `IncrementalHash` streaming) before hashing, so the same logical file cloned on Windows (CRLF) and Linux/macOS (LF) produces the same checksum and cross-OS / shared-NAS workspaces no longer trip "everything changed" reindex on first run. BOM bytes still feed into the hash so BOM add / remove keeps triggering incremental re-index.
- `DbPathResolver` sample-checksum sniffing now calls the shared helper so writer and reader agree on checksum definition.
- Bilingual changelog fragment under `changelog.d/unreleased/` and matching English/Japanese `files.checksum` column doc in `DEVELOPER_GUIDE.md`.

## Test plan

- [x] `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug` — clean build
- [x] `dotnet test … --filter "FullyQualifiedName~FileIndexerTests|FullyQualifiedName~DbPathResolverTests"` — 302/302 pass (incl. four new checksum regressions)
- [x] `dotnet test … --filter "FullyQualifiedName~IndexCommandRunnerTests|FullyQualifiedName~DbWriterTests|FullyQualifiedName~DatabaseTests"` — 154/154 pass
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` — fragment validates

Fixes #1544
