### PR TITLE
Treat offsetless ISO 8601 timestamps as UTC (#1545)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -589,7 +589,7 @@ cdidx map --path src/ --exclude-tests --json
 | `--commits <id...>` | `index` | Update only files changed in specified commits. Prefer this after a normal commit because git history includes rename/delete paths. |
 | `--files <path...>` | `index` | Update only the specified files. Safe for known in-place edits or new files; old rename/delete paths are not purged unless you also list them explicitly. |
 | `--force` | `index` | Bypass the per-database index lock. Only use when you are sure no other `cdidx index` is active against the same DB; concurrent runs may corrupt the schema. |
-| `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp |
+| `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp. Offsetless values (e.g. `2024-01-01T00:00:00`) are treated as UTC so the same flag resolves to the same instant in every timezone; append `Z` or an explicit offset (`+09:00`) to be explicit. |
 | `--no-dedup` | `search` | Disable overlapping-chunk deduplication for raw results |
 | `--reverse` | `deps` | Reverse lookup: show files that depend ON the matched path |
 | `--top <n>` | Query commands | Alias for `--limit` |
@@ -1677,7 +1677,7 @@ cdidx map --path src/ --exclude-tests --json
 | `--commits <id...>` | `index` | 指定コミットの変更ファイルのみ更新。通常のコミット後はこちらを推奨。rename/delete の旧パスも git 履歴から拾える。 |
 | `--files <path...>` | `index` | 指定ファイルのみ更新。把握している in-place 編集や新規ファイル向け。rename/delete の旧パスは明示しない限り purge されない。 |
 | `--force` | `index` | 同一 DB に対する index ロックを bypass する。他の `cdidx index` が走っていないと確信できる場合のみ使う。並行実行は schema を破壊し得る。 |
-| `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601） |
+| `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601）。オフセットなしの値（例: `2024-01-01T00:00:00`）は UTC として解釈されるため、どのタイムゾーンから呼び出しても同じ UTC 時点になります。明示したい場合は末尾に `Z` または `+09:00` 等のオフセットを付与してください。 |
 | `--no-dedup` | `search` | オーバーラップチャンク重複排除を無効化 |
 | `--reverse` | `deps` | 逆引き: 指定パスに依存しているファイルを表示 |
 | `--top <n>` | クエリ系 | `--limit` のエイリアス |

--- a/changelog.d/unreleased/1545.fixed.md
+++ b/changelog.d/unreleased/1545.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 1545
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Stop silently shifting offsetless ISO 8601 timestamps by the local timezone (#1545)** — `DbReader.ParseDateTimeValue` previously parsed string timestamps via `DateTime.TryParse` (which defaults to `AssumeLocal`) and then re-stamped the result as `DateTimeKind.Utc` via `SpecifyKind`, so an offset-bearing column value (e.g. `2025-06-04T15:00:00+09:00`) was first converted to local wall-clock time and then relabeled UTC, drifting `MAX(indexed_at)` / `MAX(modified)` freshness by the reader's local TZ offset. `QueryCommandRunner.TryParseIso8601Since` had the symmetric bug for `--since` inputs: offsetless values were parsed with `DateTimeStyles.AssumeLocal`, so two teammates issuing `--since 2024-01-01T00:00:00` in Tokyo and New York filtered against different logical UTC moments. Both parsers now use `DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal` (DB-side via `DateTime.TryParse` with `CultureInfo.InvariantCulture`; CLI-side via the existing `DateTimeOffset.TryParseExact` path), so offsetless inputs are anchored at UTC and timestamps with an explicit `Z` / `+09:00` offset convert correctly. `USER_GUIDE.md` documents the new convention so callers can opt into a non-UTC interpretation by appending `Z` or an explicit offset.
+
+## 日本語
+
+- **オフセットなし ISO 8601 タイムスタンプがローカルタイムゾーンぶん黙ってずれる挙動を修正しました (#1545)** — `DbReader.ParseDateTimeValue` は従来、文字列タイムスタンプを `DateTime.TryParse`（既定で `AssumeLocal`）で解析した後に `SpecifyKind` で `DateTimeKind.Utc` を上書きしていたため、オフセット付きの列値（例: `2025-06-04T15:00:00+09:00`）は一度ローカル時刻に変換されてから UTC として再ラベルされ、`MAX(indexed_at)` / `MAX(modified)` の鮮度が読み出し側のローカル TZ オフセットぶんずれていました。`QueryCommandRunner.TryParseIso8601Since` も対称な不具合を抱えており、`--since` 入力がオフセットなしのとき `DateTimeStyles.AssumeLocal` で解析されるため、東京とニューヨークの利用者が同じ `--since 2024-01-01T00:00:00` を指定しても異なる UTC 時点で絞り込まれていました。両パーサーを `DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal` 経由（DB 側は `DateTime.TryParse` + `CultureInfo.InvariantCulture`、CLI 側は既存の `DateTimeOffset.TryParseExact` 経路）に揃え、オフセットなしの入力は UTC に固定、`Z` や `+09:00` 等のオフセット付き入力は正しく変換されるようにしました。`USER_GUIDE.md` にもこの取り決めを記載し、明示的に非 UTC で解釈させたい場合は `Z` または明示オフセットを付与するよう案内しています。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4494,13 +4494,16 @@ public static class QueryCommandRunner
     /// <summary>
     /// Parse a --since value using invariant ISO 8601 formats only.
     /// Rejects ambiguous locale-dependent formats like MM/dd/yyyy.
-    /// Offsetless inputs are treated as local time (matching prior behavior).
+    /// Offsetless inputs are treated as UTC so the same `--since 2024-01-01T00:00:00`
+    /// resolves to the same logical UTC moment regardless of the caller's timezone
+    /// (Issue #1545). Append `Z` or an explicit offset (`+09:00`) to opt out.
     /// ISO 8601形式のみで--since値をパースする。MM/dd/yyyyなどロケール依存の曖昧な形式は拒否する。
-    /// オフセットなしの入力はローカル時刻として扱う（従来の動作を維持）。
+    /// オフセットなしの入力はUTCとして扱い、呼び出し側のタイムゾーンに依らず同じUTC時点になる
+    /// （Issue #1545）。明示的にオフセットを付けたい場合は `Z` または `+09:00` 等を付与する。
     /// </summary>
     internal static bool TryParseIso8601Since(string value, out DateTime result)
     {
-        if (DateTimeOffset.TryParseExact(value, Iso8601Formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var dto))
+        if (DateTimeOffset.TryParseExact(value, Iso8601Formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dto))
         {
             result = dto.UtcDateTime;
             return true;

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -1,5 +1,6 @@
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -1866,12 +1867,19 @@ public partial class DbReader
     internal static int GetInt32OrFallback(SqliteDataReader reader, int ordinal, int fallbackOrdinal)
         => reader.IsDBNull(ordinal) ? reader.GetInt32(fallbackOrdinal) : reader.GetInt32(ordinal);
 
+    // Offsetless timestamps stored by SQLite (e.g. CURRENT_TIMESTAMP, or a UTC DateTime written
+    // through Microsoft.Data.Sqlite) are treated as UTC. Parsing offsetless input via
+    // DateTime.TryParse defaults to AssumeLocal, so without AssumeUniversal|AdjustToUniversal
+    // the value would silently shift by the local TZ offset before being re-stamped as UTC,
+    // which is the cross-TZ drift Issue #1545 describes.
+    // SQLiteが保存するオフセットなしのタイムスタンプはUTC扱い。AssumeUniversal|AdjustToUniversalを
+    // 付けないとローカル時刻として解釈→UTCにリラベルで暗黙にズレるため、Issue #1545対応として明示する。
     private static DateTime? ParseDateTimeValue(object value)
     {
         return value switch
         {
             DateTime dateTime => dateTime.Kind == DateTimeKind.Utc ? dateTime : DateTime.SpecifyKind(dateTime, DateTimeKind.Utc),
-            string text when DateTime.TryParse(text, out var parsed) => parsed.Kind == DateTimeKind.Utc ? parsed : DateTime.SpecifyKind(parsed, DateTimeKind.Utc),
+            string text when DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed) => parsed,
             _ => null,
         };
     }

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -10671,6 +10671,33 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void GetRepoMap_TreatsStoredTimestampsAsUtc_NotLocalRelabelled()
+    {
+        // Issue #1545: timestamps stored in SQLite (whether offsetless or with an explicit
+        // offset) must round-trip to a single canonical UTC instant. Previously the offset-
+        // bearing string was first converted to local time by DateTime.TryParse and then
+        // re-stamped as UTC, drifting freshness by the caller's local TZ offset.
+        // Issue #1545: SQLite に保存された日時（オフセット有無問わず）は同一の UTC 時点へ
+        // ラウンドトリップする必要がある。旧実装は DateTime.TryParse が一旦ローカルへ変換し、
+        // SpecifyKind(Utc) で再ラベルしていたため、呼び出し側のローカル TZ ぶんずれていた。
+        InsertIndexedFile("src/Program.cs", "csharp", "public class Program {}\n",
+            modified: new DateTime(2025, 6, 2, 0, 0, 0, DateTimeKind.Utc));
+
+        using var cmd = _db.Connection.CreateCommand();
+        cmd.CommandText = "UPDATE files SET indexed_at = @ts WHERE path = 'src/Program.cs'";
+        // Offset-bearing literal: 2025-06-04T15:00:00+09:00 == 2025-06-04T06:00:00Z /
+        // オフセット付き値: 2025-06-04T15:00:00+09:00 == 2025-06-04T06:00:00Z
+        cmd.Parameters.AddWithValue("@ts", "2025-06-04T15:00:00+09:00");
+        cmd.ExecuteNonQuery();
+
+        var file = _reader.GetFileByPath("src/Program.cs");
+        Assert.NotNull(file);
+        Assert.NotNull(file!.IndexedAt);
+        Assert.Equal(new DateTime(2025, 6, 4, 6, 0, 0, DateTimeKind.Utc), file.IndexedAt!.Value);
+        Assert.Equal(DateTimeKind.Utc, file.IndexedAt!.Value.Kind);
+    }
+
+    [Fact]
     public void GetFileByPath_ReturnsExactMatchWithFullMetadata()
     {
         // Seed data: src/api.js — Size=800, Lines=50, Modified=2025-06-01, 2 symbols (ApiClient, fetchData)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -29379,13 +29379,25 @@ jobs:
     }
 
     [Fact]
-    public void TryParseIso8601Since_DateOnlyTreatedAsLocalTime()
+    public void TryParseIso8601Since_DateOnlyTreatedAsUtc()
     {
-        // Offsetless dates are treated as local time, matching prior DateTime.TryParse behavior /
-        // オフセットなしの日付はローカル時刻として扱う（従来のDateTime.TryParseの動作と一致）
+        // Issue #1545: offsetless inputs resolve to the same UTC instant in every timezone, so
+        // teammates running the same `--since 2024-06-15` query agree on the cutoff. Append `Z`
+        // or an explicit offset to opt out.
+        // Issue #1545: オフセットなしの入力はどのタイムゾーンでも同じUTC時点になり、`--since 2024-06-15`
+        // が地域差で揺れない。明示したい場合は `Z` または `+09:00` を付ける。
         QueryCommandRunner.TryParseIso8601Since("2024-06-15", out var result);
-        var expected = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeZoneInfo.Local.GetUtcOffset(new DateTime(2024, 6, 15))).UtcDateTime;
-        Assert.Equal(expected, result);
+        Assert.Equal(new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc), result);
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+
+    [Fact]
+    public void TryParseIso8601Since_OffsetlessTimestampTreatedAsUtc()
+    {
+        // Issue #1545: offsetless date-times must not shift by the caller's local TZ offset.
+        // Issue #1545: オフセットなしの日時はローカルTZオフセットの分だけずれてはならない。
+        QueryCommandRunner.TryParseIso8601Since("2024-06-15T12:00:00", out var result);
+        Assert.Equal(new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc), result);
         Assert.Equal(DateTimeKind.Utc, result.Kind);
     }
 
@@ -29419,9 +29431,9 @@ jobs:
             ["search", "foo", "--since", "2024-01-02"], jsonDefault: false);
         Assert.Null(options.ParseError);
         Assert.NotNull(options.Since);
-        // Offsetless date → local midnight → UTC / オフセットなし → ローカル深夜 → UTC
-        var expected = new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeZoneInfo.Local.GetUtcOffset(new DateTime(2024, 1, 2))).UtcDateTime;
-        Assert.Equal(expected, options.Since.Value);
+        // Issue #1545: offsetless date → UTC midnight, independent of caller TZ /
+        // Issue #1545: オフセットなし → UTC深夜（呼び出し側TZに依存しない）
+        Assert.Equal(new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc), options.Since.Value);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `DbReader.ParseDateTimeValue` no longer parses string timestamps via `DateTime.TryParse` default (`AssumeLocal`) and then re-stamps them `Utc`; it uses `CultureInfo.InvariantCulture` + `DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal`, so offset-bearing column values convert correctly and offsetless values anchor at UTC.
- `QueryCommandRunner.TryParseIso8601Since` switches from `DateTimeStyles.AssumeLocal` to `DateTimeStyles.AssumeUniversal`, so the same `--since 2024-01-01T00:00:00` resolves to the same UTC instant regardless of caller timezone.
- `USER_GUIDE.md` documents the new convention (both EN / JA), and a bilingual fragment is added under `changelog.d/unreleased/`.

Fixes #1545

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~TryParseIso8601Since|...~ParseArgs_AcceptsSinceWithIsoDate|...~GetRepoMap_TreatsStoredTimestampsAsUtc|...~GetRepoMap_KeepsScopedFreshnessAndAddsWorkspaceFreshness"` → 25 passed
- [x] `dotnet test ... --filter "FullyQualifiedName~DbReaderTests|FullyQualifiedName~QueryCommandRunnerTests"` → 1396 passed
- [x] `dotnet test ... --filter "FullyQualifiedName~McpServerTests|FullyQualifiedName~Status"` → 297 passed
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` → validated 49 fragments