### PR TITLE
Detect UTF-16 BOMs and aggregate non-UTF8 encodings in FileIndexer (#1540)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1053,7 +1053,7 @@ Once configured, the AI can directly call these tools:
 | `unused_symbols` | Find symbols defined but never referenced, with confidence buckets for dead-code triage |
 | `symbol_hotspots` | Find high-impact symbols; unique names use codebase-wide counts, duplicate-name families fall back conservatively |
 | `batch_query` | Execute multiple queries in a single call (MCP only, max 10) |
-| `validate` | Report encoding issues (U+FFFD, BOM, null bytes, mixed/CR-only line endings) |
+| `validate` | Report encoding issues (U+FFFD, BOM, null bytes, mixed/CR-only line endings, UTF-16 BOM detection, likely non-UTF8 encodings) |
 | `languages` | List all supported languages, file extensions, and capabilities |
 | `ping` | Lightweight connection check |
 | `index` | Index or re-index a project directory |
@@ -2130,7 +2130,7 @@ OpenAI Codex CLI (`codex.json` または `~/.codex/config.json`):
 | `unused_symbols` | 定義されているが参照されていないシンボルを bucket 付きで検索（デッドコード検出向け） |
 | `symbol_hotspots` | 影響の大きいシンボルを検索。一意名は codebase 全体件数、同名ファミリーは保守的に縮退 |
 | `batch_query` | 複数クエリを1回で実行（MCP専用、最大10件） |
-| `validate` | エンコーディング問題（U+FFFD、BOM、null バイト、改行混在 / CR-only 行末）を報告 |
+| `validate` | エンコーディング問題（U+FFFD、BOM、null バイト、改行混在 / CR-only 行末、UTF-16 BOM 検出、UTF-8 以外と推定されるエンコーディング）を報告 |
 | `languages` | 対応言語一覧を拡張子・機能付きで表示 |
 | `ping` | 軽量な接続確認 |
 | `index` | プロジェクトのインデックス作成・更新 |

--- a/changelog.d/unreleased/1540.fixed.md
+++ b/changelog.d/unreleased/1540.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 1540
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Mcp/McpToolDefinitions.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Detect UTF-16 BOMs and aggregate likely non-UTF8 encodings in `FileIndexer` (#1540)** — `BuildRecordWithRawBytes` previously assumed UTF-8 input and only fell back to a UTF-8 replacement-mode decode when `throwOnInvalidBytes` tripped, so UTF-16 LE/BE source files (BOM `FF FE` / `FE FF`) and BOM-less SHIFT_JIS / GBK / ISO-8859-1 / Latin-1 files were silently mangled into runs of `U+FFFD` and `NUL` characters that hid every symbol they declared. The decoder now BOM-detects UTF-16 LE and UTF-16 BE (excluding the UTF-32 LE prefix `FF FE 00 00`) and decodes those bytes through `UnicodeEncoding` so symbols, references, and search hits stay intact for `cdidx` users on mixed-encoding repos. `ValidateContent` adds two new issue kinds visible from `cdidx validate` and the MCP `validate` tool: `utf16_bom` is emitted exactly once for UTF-16 BOM-decoded files (and suppresses the raw-byte heuristics `bom` / `null_byte` / `mixed_line_endings`, which would otherwise misfire on UTF-16 LE's per-character NUL bytes and `0D 00 0A 00` CRLF), and `non_utf8_likely` collapses a high `U+FFFD` ratio (≥1 % with at least 5 occurrences in the decoded content) into one aggregate issue with the actual count, total chars, and percentage, so a fully mojibake file no longer produces hundreds of near-duplicate `replacement_char` rows that drown the diagnostic. The per-line `replacement_char` emission still runs for low-ratio files so genuine point defects (one stray byte in an otherwise-UTF-8 source) remain actionable, and `cdidx validate --kind utf16_bom` / `--kind non_utf8_likely` now filter the new categories from CLI and MCP.
+
+## 日本語
+
+- **`FileIndexer` で UTF-16 BOM 検出と UTF-8 以外と推定されるエンコーディングの集約を実装しました (#1540)** — `BuildRecordWithRawBytes` は従来入力を UTF-8 と仮定し、`throwOnInvalidBytes` が発火した場合のみ UTF-8 置換モードへフォールバックしていたため、UTF-16 LE/BE ソース (BOM `FF FE` / `FE FF`) や BOM 無しの SHIFT_JIS / GBK / ISO-8859-1 / Latin-1 ファイルは大量の `U+FFFD` / `NUL` 文字に化けて、ファイル内で宣言されたシンボルがそのまま消失していました。デコーダは UTF-16 LE / UTF-16 BE の BOM を検出して (UTF-32 LE の prefix `FF FE 00 00` は除外) `UnicodeEncoding` でデコードするようになり、混在エンコーディングのリポジトリでも `cdidx` が symbol / references / search hits を取り逃さなくなりました。`ValidateContent` には `cdidx validate` と MCP `validate` ツールから見える 2 種類の新しい issue kind を追加しています: UTF-16 BOM 経由でデコードしたファイルには `utf16_bom` を 1 件だけ出し、UTF-16 LE の文字ごとに現れる NUL バイトや `0D 00 0A 00` の CRLF を誤検出してしまう生バイトのヒューリスティクス (`bom` / `null_byte` / `mixed_line_endings`) を抑止します。さらに `non_utf8_likely` は、デコード後の content における `U+FFFD` 比率が 1 % 以上かつ件数 5 以上のとき、その件数・全文字数・割合を込めて 1 件のアグリゲートに集約し、丸ごと文字化けしたファイルが per-line `replacement_char` 行の数百件で診断を埋め尽くす状況を防ぎます。比率がしきい値未満のファイルでは従来の per-line `replacement_char` 検出を引き続き走らせ、UTF-8 ベースのソースに数バイトだけ混入した点の不具合も見逃しません。`cdidx validate --kind utf16_bom` / `--kind non_utf8_likely` で CLI と MCP の両経路から新カテゴリを絞り込めます。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -371,7 +371,7 @@ public static class ConsoleUi
         Console.WriteLine("  outline <path>             Show the symbol outline of a single file");
         Console.WriteLine("  status                     Show database statistics; add --check to verify DB/worktree match");
         Console.WriteLine("  db --integrity-check       Run SQLite `PRAGMA integrity_check` and report findings");
-        Console.WriteLine("  validate                   Report encoding issues (U+FFFD, BOM, null bytes, mixed line endings)");
+        Console.WriteLine("  validate                   Report encoding issues (U+FFFD, BOM, null bytes, mixed line endings, UTF-16 BOM, likely non-UTF8)");
         Console.WriteLine("  impact <query>             Show transitive callers; type queries may return heuristic file-level dependency hints");
         Console.WriteLine("  deps                       Show file-level dependency edges from the reference graph");
         Console.WriteLine("  unused                     Find symbols defined but never referenced (dead code)");

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1955,15 +1955,38 @@ public class FileIndexer
 
         string content;
         string? warning = null;
-        try
+        // BOM-based encoding detection: UTF-16 LE/BE source files are otherwise mangled
+        // by the UTF-8 decoder (every other byte is U+FFFD or NUL), silently dropping
+        // every symbol they declare. UTF-32 LE shares the first two bytes with UTF-16 LE
+        // (FF FE [00 00]), so we exclude that prefix from the UTF-16 LE path rather than
+        // misclassify a UTF-32 LE file as UTF-16 LE with embedded NULs. Closes #1540.
+        // BOM ベースのエンコーディング検出: UTF-16 LE/BE のソースファイルは UTF-8
+        // デコーダで毎バイト U+FFFD / NUL に変換され、ファイル内のシンボルが丸ごと
+        // 消える。UTF-32 LE は UTF-16 LE と先頭 2 バイトを共有する (FF FE [00 00])
+        // ため、UTF-16 LE 経路から除外し UTF-8 fallback に流す。Closes #1540.
+        if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
         {
-            content = new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(bytes);
+            content = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: false)
+                .GetString(bytes);
         }
-        catch (DecoderFallbackException)
+        else if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE
+                 && !(bytes.Length >= 4 && bytes[2] == 0x00 && bytes[3] == 0x00))
         {
-            // Fall back to replacement mode but warn / 置換モードにフォールバックし警告
-            content = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(bytes);
-            warning = $"{relativePath}: contains invalid UTF-8 bytes (replaced with U+FFFD)";
+            content = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: false)
+                .GetString(bytes);
+        }
+        else
+        {
+            try
+            {
+                content = new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(bytes);
+            }
+            catch (DecoderFallbackException)
+            {
+                // Fall back to replacement mode but warn / 置換モードにフォールバックし警告
+                content = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(bytes);
+                warning = $"{relativePath}: contains invalid UTF-8 bytes (replaced with U+FFFD)";
+            }
         }
         // Normalize line endings to LF / 改行をLFに正規化
         content = content.Replace("\r\n", "\n").Replace("\r", "\n");
@@ -2093,119 +2116,207 @@ public class FileIndexer
     {
         var issues = new List<FileIssue>();
 
-        // U+FFFD replacement characters baked into the file / ファイルに焼き付いたU+FFFD置換文字
-        for (int i = 0; i < content.Length; i++)
+        // UTF-16 BOM-detected files are decoded as UTF-16 in BuildRecordWithRawBytes, so the
+        // raw-byte heuristics for `bom` / `null_byte` / `mixed_line_endings` would all misfire
+        // (every UTF-16 LE character ASCII point looks like a NUL byte; CRLF appears as 0D 00
+        // 0A 00). Emit a single `utf16_bom` issue instead so `validate` clearly explains the
+        // file was decoded via UTF-16. The content-side U+FFFD check still runs so genuine
+        // invalid surrogate pairs are reported. Closes #1540.
+        // UTF-16 BOM 検出ファイルは BuildRecordWithRawBytes で UTF-16 デコード済みのため、
+        // 生バイト系の `bom` / `null_byte` / `mixed_line_endings` 判定はすべて誤検出する
+        // (UTF-16 LE では ASCII 部の片バイトが NUL、CRLF は 0D 00 0A 00)。代わりに
+        // `utf16_bom` 1 件を出して `validate` が「UTF-16 として解釈した」ことを示し、
+        // 不正サロゲートペアに備え content 側 U+FFFD 走査は継続する。Closes #1540.
+        var hasUtf16BeBom = rawBytes.Length >= 2 && rawBytes[0] == 0xFE && rawBytes[1] == 0xFF;
+        var hasUtf16LeBom = rawBytes.Length >= 2 && rawBytes[0] == 0xFF && rawBytes[1] == 0xFE
+            && !(rawBytes.Length >= 4 && rawBytes[2] == 0x00 && rawBytes[3] == 0x00);
+        var isUtf16 = hasUtf16BeBom || hasUtf16LeBom;
+
+        if (isUtf16)
         {
-            if (content[i] == '\uFFFD')
+            issues.Add(new FileIssue
             {
-                // Find line number / 行番号を特定
-                var lineNum = content[..i].Count(c => c == '\n') + 1;
+                Path = relativePath,
+                Kind = "utf16_bom",
+                Line = 1,
+                Message = hasUtf16BeBom
+                    ? "UTF-16 BE BOM detected (decoded as UTF-16)"
+                    : "UTF-16 LE BOM detected (decoded as UTF-16)",
+            });
+        }
+
+        // Aggregate signal: when a large fraction of the decoded content is U+FFFD, the file
+        // most likely uses a non-UTF8 encoding without a BOM (SHIFT_JIS / GBK / ISO-8859-1).
+        // Emit one `non_utf8_likely` issue and suppress the per-line `replacement_char`
+        // emission below so a mangled mojibake file does not produce hundreds of near-duplicate
+        // issues that drown the actual diagnostic. The minimum count of 5 avoids tripping on
+        // tiny stub files that happen to contain a single bad byte. Closes #1540.
+        // 集約シグナル: デコード後の content に U+FFFD が大量にあるファイルは BOM 無し
+        // 非 UTF-8 (SHIFT_JIS / GBK / ISO-8859-1) の可能性が高い。`non_utf8_likely` 1 件
+        // を出し下の `replacement_char` 行単位出力は抑止する。1% 閾値だけだと大ファイル
+        // で数百件の重複が出てしまい本来の診断を埋もれさせるためアグリゲートで代替。
+        // 最低 5 件しきい値で、たまたま 1 byte 壊れた小さなスタブを誤検出しないように。
+        // Closes #1540.
+        const double NonUtf8LikelyRatioThreshold = 0.01;
+        const int NonUtf8LikelyMinCount = 5;
+        var fffdCount = CountReplacementChars(content);
+        var nonUtf8Likely = fffdCount >= NonUtf8LikelyMinCount
+            && content.Length > 0
+            && (double)fffdCount / content.Length >= NonUtf8LikelyRatioThreshold;
+        if (nonUtf8Likely)
+        {
+            var ratioPercent = 100.0 * fffdCount / content.Length;
+            issues.Add(new FileIssue
+            {
+                Path = relativePath,
+                Kind = "non_utf8_likely",
+                Line = 0,
+                Message = $"Likely non-UTF8 encoding ({fffdCount} U+FFFD over {content.Length} chars, {ratioPercent:F1}%); source may be SHIFT_JIS, GBK, ISO-8859-1, or UTF-16 without BOM",
+            });
+        }
+
+        // U+FFFD replacement characters baked into the file / ファイルに焼き付いたU+FFFD置換文字
+        // Skip the per-line emission when `non_utf8_likely` already fired so a mojibake file
+        // does not produce hundreds of near-duplicate `replacement_char` issues.
+        // `non_utf8_likely` が出た場合は重複を抑え 1 件のアグリゲートに集約する。
+        if (!nonUtf8Likely)
+        {
+            for (int i = 0; i < content.Length; i++)
+            {
+                if (content[i] == '\uFFFD')
+                {
+                    // Find line number / 行番号を特定
+                    var lineNum = content[..i].Count(c => c == '\n') + 1;
+                    issues.Add(new FileIssue
+                    {
+                        Path = relativePath,
+                        Kind = "replacement_char",
+                        Line = lineNum,
+                        Message = $"U+FFFD replacement character at line {lineNum}",
+                    });
+                    // Skip to next line to avoid reporting every char on the same line
+                    // 同じ行の連続報告を避けるため次の行までスキップ
+                    var nextNewline = content.IndexOf('\n', i);
+                    if (nextNewline >= 0) i = nextNewline;
+                }
+            }
+        }
+
+        // Raw-byte heuristics: skip for UTF-16-decoded files because every UTF-16 LE ASCII
+        // codepoint looks like a NUL byte and CRLF appears as 0D 00 0A 00, so `bom` /
+        // `null_byte` / `mixed_line_endings` / `cr_only_line_endings` would all misfire.
+        // UTF-16 デコード経路では生バイト列が NUL バイトと 0D 00 0A 00 で埋まり、`bom` /
+        // `null_byte` / `mixed_line_endings` / `cr_only_line_endings` がすべて誤検出する
+        // ためスキップする。
+        if (!isUtf16)
+        {
+            // BOM marker / BOMマーカー
+            if (rawBytes.Length >= 3 && rawBytes[0] == 0xEF && rawBytes[1] == 0xBB && rawBytes[2] == 0xBF)
+            {
                 issues.Add(new FileIssue
                 {
                     Path = relativePath,
-                    Kind = "replacement_char",
-                    Line = lineNum,
-                    Message = $"U+FFFD replacement character at line {lineNum}",
+                    Kind = "bom",
+                    Line = 1,
+                    Message = "UTF-8 BOM marker detected",
                 });
-                // Skip to next line to avoid reporting every char on the same line
-                // 同じ行の連続報告を避けるため次の行までスキップ
-                var nextNewline = content.IndexOf('\n', i);
-                if (nextNewline >= 0) i = nextNewline;
             }
-        }
 
-        // BOM marker / BOMマーカー
-        if (rawBytes.Length >= 3 && rawBytes[0] == 0xEF && rawBytes[1] == 0xBB && rawBytes[2] == 0xBF)
-        {
-            issues.Add(new FileIssue
+            // NULL bytes (likely binary content) / NULLバイト（バイナリ混入の可能性）
+            if (rawBytes.Any(b => b == 0))
             {
-                Path = relativePath,
-                Kind = "bom",
-                Line = 1,
-                Message = "UTF-8 BOM marker detected",
-            });
-        }
-
-        // NULL bytes (likely binary content) / NULLバイト（バイナリ混入の可能性）
-        if (rawBytes.Any(b => b == 0))
-        {
-            issues.Add(new FileIssue
-            {
-                Path = relativePath,
-                Kind = "null_byte",
-                Line = 0,
-                Message = "File contains NULL bytes (possible binary content)",
-            });
-        }
-
-        // Line-ending classification — check raw bytes before LF normalization so
-        // bare CR (legacy Mac) and three-way mixes are not silently flattened by
-        // the `\r\n` → `\n` then `\r` → `\n` pass in BuildRecordWithRawBytes.
-        // 改行コードの判定 — LF 正規化前の rawBytes で確認。BuildRecordWithRawBytes が
-        // `\r\n`→`\n`、`\r`→`\n` の順で潰してしまうため、生バイトで CR-only (旧 Mac)
-        // と 3 種混在を見分ける。
-        var hasCrlf = false;
-        var hasLfOnly = false;
-        var hasCrOnly = false;
-        for (int i = 0; i < rawBytes.Length; i++)
-        {
-            if (rawBytes[i] == 0x0D)
-            {
-                if (i + 1 < rawBytes.Length && rawBytes[i + 1] == 0x0A)
+                issues.Add(new FileIssue
                 {
-                    hasCrlf = true;
-                    i++; // skip the LF after CR
+                    Path = relativePath,
+                    Kind = "null_byte",
+                    Line = 0,
+                    Message = "File contains NULL bytes (possible binary content)",
+                });
+            }
+
+            // Line-ending classification — check raw bytes before LF normalization so
+            // bare CR (legacy Mac) and three-way mixes are not silently flattened by
+            // the `\r\n` → `\n` then `\r` → `\n` pass in BuildRecordWithRawBytes.
+            // 改行コードの判定 — LF 正規化前の rawBytes で確認。BuildRecordWithRawBytes が
+            // `\r\n`→`\n`、`\r`→`\n` の順で潰してしまうため、生バイトで CR-only (旧 Mac)
+            // と 3 種混在を見分ける。
+            var hasCrlf = false;
+            var hasLfOnly = false;
+            var hasCrOnly = false;
+            for (int i = 0; i < rawBytes.Length; i++)
+            {
+                if (rawBytes[i] == 0x0D)
+                {
+                    if (i + 1 < rawBytes.Length && rawBytes[i + 1] == 0x0A)
+                    {
+                        hasCrlf = true;
+                        i++; // skip the LF after CR
+                    }
+                    else
+                    {
+                        hasCrOnly = true;
+                    }
                 }
+                else if (rawBytes[i] == 0x0A)
+                {
+                    hasLfOnly = true;
+                }
+            }
+            var distinctEndingTypes = (hasCrlf ? 1 : 0) + (hasLfOnly ? 1 : 0) + (hasCrOnly ? 1 : 0);
+            if (distinctEndingTypes >= 3)
+            {
+                issues.Add(new FileIssue
+                {
+                    Path = relativePath,
+                    Kind = "mixed_line_endings_three_way",
+                    Line = 0,
+                    Message = "Mixed line endings (CRLF, LF, and CR)",
+                });
+            }
+            else if (distinctEndingTypes == 2)
+            {
+                string description;
+                if (hasCrlf && hasLfOnly)
+                    description = "CRLF and LF";
+                else if (hasCrlf && hasCrOnly)
+                    description = "CRLF and CR";
                 else
+                    description = "LF and CR";
+                issues.Add(new FileIssue
                 {
-                    hasCrOnly = true;
-                }
+                    Path = relativePath,
+                    Kind = "mixed_line_endings",
+                    Line = 0,
+                    Message = $"Mixed line endings ({description})",
+                });
             }
-            else if (rawBytes[i] == 0x0A)
+            else if (hasCrOnly)
             {
-                hasLfOnly = true;
+                issues.Add(new FileIssue
+                {
+                    Path = relativePath,
+                    Kind = "cr_only_line_endings",
+                    Line = 0,
+                    Message = "CR-only line endings (legacy Mac)",
+                });
             }
-        }
-        var distinctEndingTypes = (hasCrlf ? 1 : 0) + (hasLfOnly ? 1 : 0) + (hasCrOnly ? 1 : 0);
-        if (distinctEndingTypes >= 3)
-        {
-            issues.Add(new FileIssue
-            {
-                Path = relativePath,
-                Kind = "mixed_line_endings_three_way",
-                Line = 0,
-                Message = "Mixed line endings (CRLF, LF, and CR)",
-            });
-        }
-        else if (distinctEndingTypes == 2)
-        {
-            string description;
-            if (hasCrlf && hasLfOnly)
-                description = "CRLF and LF";
-            else if (hasCrlf && hasCrOnly)
-                description = "CRLF and CR";
-            else
-                description = "LF and CR";
-            issues.Add(new FileIssue
-            {
-                Path = relativePath,
-                Kind = "mixed_line_endings",
-                Line = 0,
-                Message = $"Mixed line endings ({description})",
-            });
-        }
-        else if (hasCrOnly)
-        {
-            issues.Add(new FileIssue
-            {
-                Path = relativePath,
-                Kind = "cr_only_line_endings",
-                Line = 0,
-                Message = "CR-only line endings (legacy Mac)",
-            });
         }
 
         return issues;
+    }
+
+    /// <summary>
+    /// Count U+FFFD replacement characters in decoded content.
+    /// デコード済みcontent内のU+FFFD置換文字数を計上する。
+    /// </summary>
+    private static int CountReplacementChars(string content)
+    {
+        var count = 0;
+        for (int i = 0; i < content.Length; i++)
+        {
+            if (content[i] == '�') count++;
+        }
+        return count;
     }
 
     /// <summary>

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -321,13 +321,13 @@ public partial class McpServer
                 ReadOnlyAnnotations()),
             CreateToolDefinition(
                 "validate",
-                "Report encoding issues found during indexing: U+FFFD replacement chars, BOM markers, null bytes, mixed/CR-only line endings. / インデックス時に検出したエンコーディング問題を報告。",
+                "Report encoding issues found during indexing: U+FFFD replacement chars, BOM markers, null bytes, mixed/CR-only line endings, UTF-16 BOM detection, likely non-UTF8 encodings. / インデックス時に検出したエンコーディング問題を報告。",
                 new JsonObject
                 {
                     ["type"] = "object",
                     ["properties"] = new JsonObject
                     {
-                        ["kind"] = new JsonObject { ["type"] = "string", ["description"] = "Filter by issue kind (replacement_char, bom, null_byte, mixed_line_endings, mixed_line_endings_three_way, cr_only_line_endings)" },
+                        ["kind"] = new JsonObject { ["type"] = "string", ["description"] = "Filter by issue kind (replacement_char, bom, null_byte, mixed_line_endings, mixed_line_endings_three_way, cr_only_line_endings, utf16_bom, non_utf8_likely)" },
                         ["path"] = new JsonObject { ["oneOf"] = new JsonArray { new JsonObject { ["type"] = "string" }, new JsonObject { ["type"] = "array", ["items"] = new JsonObject { ["type"] = "string" } } }, ["description"] = "Filter to paths containing this text. Accepts a single string or an array; multiple values are OR'd together." }
                     }
                 },

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2387,6 +2387,172 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void BuildRecord_Utf16LeBomFile_DecodedAsUtf16()
+    {
+        // Files written as UTF-16 LE with BOM (FF FE) must be decoded via UTF-16, not
+        // through the UTF-8 fallback that mangles every other byte into U+FFFD / NUL.
+        // Closes #1540.
+        // UTF-16 LE BOM (FF FE) 付きで書かれたソースは UTF-8 fallback ではなく UTF-16 で
+        // デコードしなければならない。UTF-8 経路では 1 バイトおきに U+FFFD / NUL に
+        // 化けてシンボル抽出が壊れる。Closes #1540.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var filePath = Path.Combine(tempDir, "utf16le.cs");
+            var payload = "using System;\nnamespace Utf16Le;\n";
+            var rawBytes = new byte[] { 0xFF, 0xFE }
+                .Concat(System.Text.Encoding.Unicode.GetBytes(payload))
+                .ToArray();
+            File.WriteAllBytes(filePath, rawBytes);
+
+            var indexer = new FileIndexer(tempDir);
+            var (_, content, _, warning) = indexer.BuildRecordWithRawBytes(filePath);
+
+            Assert.Null(warning);
+            Assert.Contains("namespace Utf16Le;", content);
+            Assert.DoesNotContain('�', content);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BuildRecord_Utf16BeBomFile_DecodedAsUtf16()
+    {
+        // UTF-16 BE BOM (FE FF) must also be decoded via UTF-16 BE so files authored on
+        // big-endian Windows or by legacy tooling keep their symbols intact. Closes #1540.
+        // UTF-16 BE BOM (FE FF) も UTF-16 BE でデコードし、ビッグエンディアン Windows
+        // やレガシツール由来のソースが壊れないようにする。Closes #1540.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var filePath = Path.Combine(tempDir, "utf16be.cs");
+            var payload = "using System;\nnamespace Utf16Be;\n";
+            var rawBytes = new byte[] { 0xFE, 0xFF }
+                .Concat(System.Text.Encoding.BigEndianUnicode.GetBytes(payload))
+                .ToArray();
+            File.WriteAllBytes(filePath, rawBytes);
+
+            var indexer = new FileIndexer(tempDir);
+            var (_, content, _, warning) = indexer.BuildRecordWithRawBytes(filePath);
+
+            Assert.Null(warning);
+            Assert.Contains("namespace Utf16Be;", content);
+            Assert.DoesNotContain('�', content);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ValidateContent_Utf16LeBomFile_EmitsUtf16BomNotRawByteIssues()
+    {
+        // When a file decodes via UTF-16 LE, the raw bytes are full of NULs (every ASCII
+        // codepoint) and the CRLF heuristic sees 0D 00 0A 00. ValidateContent must skip the
+        // `bom` / `null_byte` / `mixed_line_endings` paths and emit a single `utf16_bom`
+        // issue instead. Closes #1540.
+        // UTF-16 LE デコード経路では生バイト列に大量の NUL が並び、CRLF 判定は 0D 00 0A 00
+        // を見て誤検出する。ValidateContent は `bom` / `null_byte` / `mixed_line_endings`
+        // を出さず `utf16_bom` 1 件に集約する。Closes #1540.
+        var payload = "using System;\nclass C { }\n";
+        var rawBytes = new byte[] { 0xFF, 0xFE }
+            .Concat(System.Text.Encoding.Unicode.GetBytes(payload))
+            .ToArray();
+        // Simulate the content that BuildRecordWithRawBytes would produce.
+        var content = payload;
+
+        var issues = FileIndexer.ValidateContent("utf16le.cs", rawBytes, content);
+
+        Assert.Contains(issues, i => i.Kind == "utf16_bom");
+        Assert.DoesNotContain(issues, i => i.Kind == "bom");
+        Assert.DoesNotContain(issues, i => i.Kind == "null_byte");
+        Assert.DoesNotContain(issues, i => i.Kind == "mixed_line_endings");
+        Assert.DoesNotContain(issues, i => i.Kind == "replacement_char");
+        Assert.DoesNotContain(issues, i => i.Kind == "non_utf8_likely");
+    }
+
+    [Fact]
+    public void ValidateContent_HighFffdRatio_EmitsAggregateNonUtf8Likely()
+    {
+        // A file decoded with many U+FFFD characters (mojibake from SHIFT_JIS / GBK / Latin-1
+        // misread as UTF-8) must collapse to one `non_utf8_likely` aggregate issue, not
+        // hundreds of per-line `replacement_char` issues that drown the diagnostic. Closes #1540.
+        // SHIFT_JIS / GBK / ISO-8859-1 を UTF-8 で読んで化けた content は per-line
+        // `replacement_char` で埋め尽くすのではなく `non_utf8_likely` 1 件に集約する。
+        // Closes #1540.
+        // Build content with > 1% U+FFFD ratio and many lines.
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < 50; i++)
+        {
+            sb.Append("alpha � beta\n");
+        }
+        var content = sb.ToString();
+        // Raw bytes do not matter here for non_utf8_likely (it reads `content`), so use
+        // ASCII-safe bytes that won't trip the raw-byte heuristics.
+        var rawBytes = System.Text.Encoding.UTF8.GetBytes("placeholder\n");
+
+        var issues = FileIndexer.ValidateContent("garbled.cs", rawBytes, content);
+
+        Assert.Contains(issues, i => i.Kind == "non_utf8_likely");
+        // Per-line replacement_char emission must be suppressed when the aggregate fires.
+        // アグリゲートが出た場合は per-line replacement_char を抑止する。
+        Assert.DoesNotContain(issues, i => i.Kind == "replacement_char");
+    }
+
+    [Fact]
+    public void ValidateContent_LowFffdRatio_KeepsPerLineReplacementCharIssues()
+    {
+        // Below the aggregate threshold (a few stray U+FFFD in an otherwise clean file),
+        // the existing per-line `replacement_char` issues must still fire so genuine point
+        // defects (one stray byte in an otherwise-UTF-8 file) remain actionable. Closes #1540.
+        // 集約しきい値未満 (大半が正しく UTF-8 で書かれた中に数文字だけ U+FFFD が残る)
+        // の場合は従来の per-line `replacement_char` を出し続け、点の不具合を見逃さない。
+        // Closes #1540.
+        // 4 U+FFFD chars in a long file → far below 1% ratio AND below the minimum-count
+        // floor of 5, so the aggregate must not fire.
+        var sb = new System.Text.StringBuilder();
+        sb.Append("line1 clean\n");
+        sb.Append("line2 has � here\n");
+        sb.Append("line3 has � here\n");
+        for (int i = 0; i < 200; i++) sb.Append("filler ascii ascii ascii\n");
+        sb.Append("trailing �\n");
+        sb.Append("another �\n");
+        var content = sb.ToString();
+        var rawBytes = System.Text.Encoding.UTF8.GetBytes("placeholder\n");
+
+        var issues = FileIndexer.ValidateContent("partial.cs", rawBytes, content);
+
+        Assert.DoesNotContain(issues, i => i.Kind == "non_utf8_likely");
+        Assert.Contains(issues, i => i.Kind == "replacement_char");
+    }
+
+    [Fact]
+    public void ValidateContent_Utf32LePrefix_NotMisclassifiedAsUtf16()
+    {
+        // UTF-32 LE shares the first two bytes with UTF-16 LE (FF FE 00 00). The detector
+        // must exclude this prefix so a UTF-32 LE file does not get tagged with `utf16_bom`
+        // and skip the raw-byte heuristics that would otherwise catch its NUL pattern.
+        // Closes #1540.
+        // UTF-32 LE は UTF-16 LE と先頭 2 バイトを共有する (FF FE 00 00)。この prefix を
+        // 検出器から除外し、UTF-32 LE を `utf16_bom` と誤判定して NUL バイトの生バイト
+        // ヒューリスティクスを飛ばさないようにする。Closes #1540.
+        var rawBytes = new byte[] { 0xFF, 0xFE, 0x00, 0x00, 0x41, 0x00, 0x00, 0x00 };
+        // The content passed in does not matter much — what matters is that the validator
+        // does not emit `utf16_bom`. We pass an ASCII placeholder.
+        var content = "A";
+
+        var issues = FileIndexer.ValidateContent("utf32le.txt", rawBytes, content);
+
+        Assert.DoesNotContain(issues, i => i.Kind == "utf16_bom");
+    }
+
+    [Fact]
     public void StripLineLeadingBom_BomFreeContent_ReturnsSameInstance()
     {
         // BOM-free content (the dominant case) must hit the fast path and


### PR DESCRIPTION
## Summary

- BOM-detect UTF-16 LE / UTF-16 BE in `BuildRecordWithRawBytes` (excluding the UTF-32 LE prefix `FF FE 00 00`) so non-UTF-8 source files keep their symbols instead of decoding into runs of `U+FFFD` and `NUL`.
- Add two new `validate` issue kinds — `utf16_bom` (single issue per UTF-16-decoded file; suppresses the raw-byte `bom` / `null_byte` / `mixed_line_endings` / `cr_only_line_endings` heuristics that misfire on UTF-16's per-character NULs) and `non_utf8_likely` (aggregate when >= 5 U+FFFD chars and >= 1 % of decoded content; suppresses per-line `replacement_char` to keep mojibake diagnostics readable).
- Update the MCP `validate` tool description / kind filter, the CLI `validate` help text, and both English / Japanese `USER_GUIDE.md` tables.

Fixes #1540

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj` — succeeds, 0 warnings, 0 errors.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` — 4712 passed, 3 skipped (performance tests), 0 failed.
- 6 new tests in `tests/CodeIndex.Tests/FileIndexerTests.cs` covering UTF-16 LE / BE decoding, the `utf16_bom` raw-byte-heuristic suppression, the `non_utf8_likely` aggregate, the per-line `replacement_char` fall-through for low-ratio files, and the UTF-32 LE prefix exclusion.
- Adversarial review against `origin/main..HEAD`: no blocking/actionable issues found.

## Documentation / changelog

- Bilingual changelog fragment: `changelog.d/unreleased/1540.fixed.md`.
- `USER_GUIDE.md` English and Japanese `validate` table entries updated to mention UTF-16 BOM detection and likely non-UTF8 encodings.
- `src/CodeIndex/Cli/ConsoleUi.cs` `validate` help line updated.
- `src/CodeIndex/Mcp/McpToolDefinitions.cs` `validate` tool description and `kind` filter enumeration updated to include `utf16_bom` and `non_utf8_likely`.

## Follow-ups

None.

Generated with Claude Code (claude.com/claude-code)
