### PR TITLE
Document release tag verification and partial-failure recovery (#1551)

### DIFF
--- a/.codex/workflows/release-changelog.md
+++ b/.codex/workflows/release-changelog.md
@@ -101,3 +101,83 @@ git pull origin main
 git tag -a v1.17.0 -m "Release v1.17.0"
 git push origin v1.17.0
 ```
+
+### Verify the tag points to the merged release commit
+
+After pushing the tag, confirm it resolves to the same commit as `origin/main`.
+This catches the race where a maintainer pushed an unrelated commit to `main`
+between `git pull` and `git tag`, which would tag the wrong commit and leave a
+release whose `version.json`, `CHANGELOG.md`, and binary identity disagree.
+
+```bash
+git fetch origin --tags
+[ "$(git rev-parse v1.17.0)" = "$(git rev-parse origin/main)" ] \
+  && echo "tag OK" \
+  || { echo "tag does not match origin/main; do not announce the release" >&2; exit 1; }
+```
+
+If the rev-parse values differ, do not announce the release. Delete the tag
+locally and remotely, re-pull `main`, and re-tag from the correct commit:
+
+```bash
+git tag -d v1.17.0
+git push origin :refs/tags/v1.17.0
+git pull origin main
+git tag -a v1.17.0 -m "Release v1.17.0"
+git push origin v1.17.0
+```
+
+Then re-run the verification above before continuing.
+
+### Verify `version.json` matches the tag
+
+The release CI's install-verification step asserts that `cdidx --version` equals
+the tag name, but the tag/`version.json` consistency is also worth checking at
+the source-tree level before any artifact is built. Run this immediately after
+the tag is pushed:
+
+```bash
+git show "v1.17.0:version.json" | grep -q '"version": "1.17.0"' \
+  && echo "version.json OK" \
+  || { echo "version.json does not match tag v1.17.0" >&2; exit 1; }
+```
+
+If the check fails, the release PR most likely landed without the
+`version.json` bump from `tools/CodeIndex.Changelog prepare`. Delete the tag
+(local + remote, as above), open a follow-up PR that fixes `version.json` on
+`main`, and re-tag once it merges. Do not paper over the mismatch by editing
+the tag in place.
+
+### Partial-failure recovery
+
+The `Release` workflow has three post-tag jobs: the `release` build/publish
+matrix and two jobs that depend on it (`create-release`, `publish-nuget`).
+Failures usually only affect one of them.
+
+- **One `release` matrix lane (Linux/Windows/macOS publish) failed.**
+  Re-run the failed lane from the GitHub Actions UI. When `create-release`
+  runs afterward, its `if gh release view … then gh release upload --clobber
+  else gh release create` block uploads any missing artifacts into the
+  existing release without manual cleanup.
+- **`create-release` failed after some assets uploaded (partial release).**
+  Re-run `create-release` from the GitHub Actions UI. The job is idempotent:
+  it detects the existing release and runs `gh release upload --clobber` for
+  the missing files, then re-runs the CDN-propagation poll and `install.sh`
+  verification.
+- **`publish-nuget` failed but the GitHub release succeeded.**
+  Re-run `publish-nuget` from the GitHub Actions UI. `dotnet nuget push` uses
+  `--skip-duplicate`, so already-pushed packages are not republished. Do not
+  delete and re-tag for a NuGet-only failure — the GitHub release is
+  already public and tag deletion would invalidate it for downstream installs.
+- **Install-verification step failed (e.g. `cdidx --version` mismatch, missing
+  asset).** This means the published release is *not* usable. Investigate
+  before announcing. If the cause is a transient CDN/network blip, re-run the
+  job. If the cause is a real artifact problem, delete the GitHub release
+  (`gh release delete v1.17.0 --cleanup-tag --yes`) and start over from the
+  tag-creation step above.
+- **`CHANGELOG.md` mismatch discovered after the tag was pushed (e.g. a
+  fragment was missed, or the English/日本語 sections diverged).** Do **not**
+  delete and re-tag a public release just to fix the changelog. Land a
+  follow-up `docs:` PR against `main` and roll the correction into the next
+  release section. Note the correction in that release's notes so the audit
+  trail stays honest.

--- a/changelog.d/unreleased/1551.docs.md
+++ b/changelog.d/unreleased/1551.docs.md
@@ -1,0 +1,15 @@
+---
+category: docs
+issues:
+  - 1551
+affected:
+  - .codex/workflows/release-changelog.md
+---
+
+## English
+
+- **Documented release tag verification and partial-failure recovery (#1551)** — `.codex/workflows/release-changelog.md` now covers the post-tag steps that the workflow previously left implicit: a `git rev-parse v1.X.0 == origin/main` check that catches racing pushes to `main`, a `git show v1.X.0:version.json` consistency check so a missed `version.json` bump cannot quietly ship, and per-job recovery guidance for the `release` matrix, `create-release`, `publish-nuget`, and install-verification jobs (including the rule that `CHANGELOG.md` mismatches discovered after the tag are patched in the next release rather than fixed by deleting and re-tagging a public release).
+
+## 日本語
+
+- **リリースタグ検証と部分失敗からの復旧手順を明文化 (#1551)** — `.codex/workflows/release-changelog.md` にタグ push 後の検証手順 (`git rev-parse v1.X.0 == origin/main` で `main` への割り込み push を検出、`git show v1.X.0:version.json` で `version.json` の bump 漏れを検出) と、`release` matrix / `create-release` / `publish-nuget` / install 検証ジョブごとの部分失敗復旧手順 (公開済みリリースのタグ削除・再タグはせず、`CHANGELOG.md` の不整合は次回リリースで修正するルールを含む) を追記しました。


### PR DESCRIPTION
## Summary

`.codex/workflows/release-changelog.md` previously stopped at "push the tag," leaving the post-tag verification and partial-failure recovery steps undocumented. This PR adds three new subsections under **After the release PR merges** so a maintainer can follow the workflow end-to-end without leaving the repo/release in an inconsistent state.

- **Verify the tag points to the merged release commit** — `git rev-parse v1.X.0` vs `origin/main` check that catches a racing push to `main` between `git pull` and tag push, with the matching local+remote tag-delete recovery.
- **Verify `version.json` matches the tag** — one-line `git show v1.X.0:version.json | grep -q '"version": "1.X.0"'` consistency check, so a missed `version.json` bump from `tools/CodeIndex.Changelog prepare` cannot quietly ship. The CI install-verify already enforces `cdidx --version == tag`, but this snippet lets the maintainer fail fast at the source-tree level before artifacts build.
- **Partial-failure recovery** — per-job recovery guidance for the `release` matrix lanes, `create-release`, `publish-nuget`, and the install-verification step. Calls out that `publish-nuget` failures must not delete-and-re-tag (the GitHub release is already public), and that `CHANGELOG.md` mismatches discovered after a public tag are patched in the next release rather than fixed by deleting and re-tagging.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check` → `Validated 55 changelog fragment(s).` (the same validator the `Changelog Fragments` CI workflow runs against `.codex/workflows/release-changelog.md` and `changelog.d/**`).

The PR is documentation-only — no source code, tests, or build inputs are modified, so the full `dotnet build` / `dotnet test` suite is not run locally for this change. The `Changelog Fragments` workflow on CI will exercise the same validator on the PR.

## Documentation / changelog updates

- `.codex/workflows/release-changelog.md` — three new subsections under **After the release PR merges**.
- `changelog.d/unreleased/1551.docs.md` — bilingual fragment per `.codex/workflows/changelog-fragment.md` (no edits to `CHANGELOG.md`).

## Follow-up candidates

- None.

Fixes #1551.
