### PR TITLE
Add opt-in JSONL metrics emission for CLI and MCP (#1549)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -595,6 +595,7 @@ cdidx map --path src/ --exclude-tests --json
 | `--reverse` | `deps` | Reverse lookup: show files that depend ON the matched path |
 | `--top <n>` | Query commands | Alias for `--limit` |
 | `--color <when>` | All commands | Control ANSI color output. Accepts `auto` (default), `always`, or `never`. Precedence: `--color` flag > `CLICOLOR_FORCE` > `NO_COLOR` > `CLICOLOR=0` > TTY auto-detect. Use `--color=always` to keep colored kind labels through a pager such as `cdidx symbols Foo \| less -R`; use `--color=never` (or `NO_COLOR=1`) to suppress ANSI even on a TTY. |
+| `--metrics <path>` | All commands (and MCP tool calls) | Append one JSONL metrics record per CLI command / MCP tool call to `<path>`. The `CDIDX_METRICS=<path>` environment variable provides the same destination as a fallback when the flag is not passed. Best-effort: any IO failure (missing directory, read-only mount, etc.) is swallowed silently and never breaks the underlying command. |
 
 If a query itself begins with `-`, pass it as `--query <query>` or `-- <query>`. If an option value itself begins with `--`, pass it as `--opt=<value>` rather than a separated value, for example `--path=--json-dir` or `--db=--tmp.db`.
 
@@ -655,6 +656,35 @@ If a query fails with a SQLite reader error such as `The data is NULL at ordinal
 | (none of the above) | — | Fall back to the default TTY check |
 
 `CLICOLOR_FORCE` has the highest precedence, then `NO_COLOR`, then `CLICOLOR=0`. An empty `NO_COLOR` (e.g. `NO_COLOR=` exported with no value) is ignored, matching the no-color.org specification.
+
+### Metrics emission
+
+Pass `--metrics <path>` (or set `CDIDX_METRICS=<path>` in the environment) to make `cdidx` append one JSON-lines record per CLI command and per MCP tool call. The flag wins over the environment variable when both are present. The destination file is opened in append mode, so multiple cdidx invocations writing to the same path interleave cleanly. Emission is best-effort: any IO failure (missing directory, unwritable mount, etc.) is swallowed silently and never breaks the underlying command.
+
+Each record is a single JSON object on its own line with these fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `timestamp` | string (ISO 8601 with offset) | When the command / tool call started |
+| `tool` | string | CLI subcommand (`search`, `index`, …) or MCP tool name |
+| `source` | string | `cli` for CLI invocations, `mcp` for MCP tool calls |
+| `elapsed_ms` | number | Wall-clock duration in milliseconds (3 decimal places) |
+| `exit_code` | number | CLI exit code; `0` for successful MCP tool calls, `1` for tool calls that threw |
+| `language` | string (optional) | `--lang` / `language` argument, when present and known |
+| `bytes_read` | number (optional) | Reserved for future per-call IO accounting |
+| `bytes_written` | number (optional) | Reserved for future per-call IO accounting |
+| `wal_checkpoint_ms` | number (optional) | Reserved for future WAL checkpoint timing |
+| `files_indexed` | number (optional) | Reserved for future per-index file counts |
+| `error` | string (optional) | Short error category, when the command failed in a way worth tagging |
+
+Optional fields are omitted from the JSON when null so future consumers can grow new columns without breaking older parsers. The file is local-only and uses the relaxed JSON encoder so timestamps stay human-readable in `tail` / `grep` workflows.
+
+Example output:
+
+```jsonl
+{"timestamp":"2026-05-16T09:00:01.1234567+00:00","tool":"search","source":"cli","elapsed_ms":221.574,"exit_code":0,"language":"csharp"}
+{"timestamp":"2026-05-16T09:00:02.4567890+00:00","tool":"definition","source":"mcp","elapsed_ms":18.402,"exit_code":0}
+```
 
 ## How it works
 
@@ -1684,6 +1714,7 @@ cdidx map --path src/ --exclude-tests --json
 | `--reverse` | `deps` | 逆引き: 指定パスに依存しているファイルを表示 |
 | `--top <n>` | クエリ系 | `--limit` のエイリアス |
 | `--color <when>` | 全コマンド | ANSI カラー出力の制御。`auto`（既定）、`always`、`never` を受け付ける。優先順位: `--color` フラグ > `CLICOLOR_FORCE` > `NO_COLOR` > `CLICOLOR=0` > TTY 自動判定。`cdidx symbols Foo \| less -R` のような pager pipe でも色を維持したい場合は `--color=always`、TTY 上でも ANSI を抑止したい場合は `--color=never`（または `NO_COLOR=1`）を指定する。 |
+| `--metrics <path>` | 全コマンド（および MCP ツール呼び出し） | CLI コマンド / MCP ツール呼び出し 1 回ごとに JSONL レコードを 1 行ずつ `<path>` に追記する。フラグ未指定時のフォールバックとして `CDIDX_METRICS=<path>` 環境変数でも同じ出力先を指定できる。Best-effort のため、ディレクトリが無い・read-only マウント等の IO 失敗は黙って握り潰し、本体コマンドを壊さない。 |
 
 クエリ自体が `-` で始まる場合は `--query <query>` または `-- <query>` で渡してください。オプション値自体が `--` で始まる場合は、分離形式ではなく `--opt=<value>` で渡します。たとえば `--path=--json-dir` や `--db=--tmp.db` のように指定します。
 
@@ -1742,6 +1773,35 @@ MCP ツールで catch-all まで突き抜けた例外（想定外の SQLite 例
 | 上記いずれも未設定 | — | 既定の TTY 判定にフォールバック |
 
 優先順位は `CLICOLOR_FORCE` → `NO_COLOR` → `CLICOLOR=0` の順です。値が空の `NO_COLOR`（例: `NO_COLOR=` のみ export）は no-color.org の仕様に従い無視されます。
+
+### メトリクス出力
+
+`--metrics <path>` を渡す（または環境変数 `CDIDX_METRICS=<path>` を設定する）と、`cdidx` は CLI コマンド 1 回・MCP ツール呼び出し 1 回ごとに 1 行の JSON レコードを指定パスへ追記します。両方指定されている場合はフラグが優先されます。出力先は append モードで開かれるため、複数の cdidx 実行が同じファイルへ書いてもきれいにインターリーブされます。出力は best-effort で、ディレクトリ不在・書き込み不可マウントなどの IO 失敗は黙って握り潰し、本体コマンドを壊しません。
+
+各レコードは独立した行に 1 つの JSON オブジェクトとして書き出され、フィールドは次の通りです。
+
+| フィールド | 型 | 意味 |
+|---|---|---|
+| `timestamp` | string（オフセット付き ISO 8601） | コマンド / ツール呼び出しの開始時刻 |
+| `tool` | string | CLI サブコマンド（`search`、`index` …）または MCP ツール名 |
+| `source` | string | CLI 呼び出しは `cli`、MCP ツール呼び出しは `mcp` |
+| `elapsed_ms` | number | ウォールクロック経過ミリ秒（小数 3 桁） |
+| `exit_code` | number | CLI 終了コード。MCP は成功時 `0`、ツール内で例外が出た場合 `1` |
+| `language` | string（任意） | `--lang` / `language` 引数が指定され言語が判定できた場合に付与 |
+| `bytes_read` | number（任意） | 将来の per-call IO 計測用に予約 |
+| `bytes_written` | number（任意） | 将来の per-call IO 計測用に予約 |
+| `wal_checkpoint_ms` | number（任意） | 将来の WAL チェックポイント時間計測用に予約 |
+| `files_indexed` | number（任意） | 将来の index 当たり処理ファイル数用に予約 |
+| `error` | string（任意） | タグ付けに値する失敗時の短いエラーカテゴリ |
+
+任意フィールドは値が null のとき JSON から省略されるため、後でフィールドを追加しても古いパーサを壊しません。ファイルはローカル専用で、`tail` / `grep` ワークフローでも timestamp が人間可読のまま残るよう relaxed エンコーダを使用します。
+
+出力例:
+
+```jsonl
+{"timestamp":"2026-05-16T09:00:01.1234567+00:00","tool":"search","source":"cli","elapsed_ms":221.574,"exit_code":0,"language":"csharp"}
+{"timestamp":"2026-05-16T09:00:02.4567890+00:00","tool":"definition","source":"mcp","elapsed_ms":18.402,"exit_code":0}
+```
 
 ## 動作の仕組み
 

--- a/changelog.d/unreleased/1549.added.md
+++ b/changelog.d/unreleased/1549.added.md
@@ -1,0 +1,19 @@
+---
+category: added
+issues:
+  - 1549
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/MetricsSink.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/MetricsSinkTests.cs
+---
+
+## English
+
+- **Opt-in JSONL metrics emission for CLI + MCP (#1549)** — `cdidx` now accepts a `--metrics <path>` flag (or the `CDIDX_METRICS` env var) and appends one JSON-lines record per CLI command and per MCP tool call to that path. Each record carries `timestamp`, `tool`, `source` (`cli` / `mcp`), `elapsed_ms`, `exit_code`, and — when known — `language`, so latency regressions or throughput drops can be detected from logs alone without re-running queries. Metrics emission is best-effort: a missing directory, an unwritable path, or any IO failure is swallowed silently and never breaks the underlying command. Optional fields (`bytes_read`, `bytes_written`, `wal_checkpoint_ms`, `files_indexed`, `error`) are omitted when null so future consumers can grow new columns without breaking older parsers.
+
+## 日本語
+
+- **CLI / MCP 向けのオプトイン JSONL メトリクス出力 (#1549)** — `cdidx` に `--metrics <path>` フラグ（または `CDIDX_METRICS` 環境変数）を追加し、CLI コマンドおよび MCP ツール呼び出し 1 回ごとに 1 行の JSON レコードを指定パスへ追記します。各レコードは `timestamp` / `tool` / `source`（`cli` / `mcp`）/ `elapsed_ms` / `exit_code` を含み、判明していれば `language` も付与されるので、クエリを再実行せずともログだけからレイテンシ退行やスループット低下を検出できます。メトリクス出力は best-effort で、ディレクトリが無い・書き込めない・その他 IO 失敗があっても黙って握り潰され、本体コマンドを壊しません。オプション項目（`bytes_read` / `bytes_written` / `wal_checkpoint_ms` / `files_indexed` / `error`）は null のとき出力されないため、後でフィールドを追加しても古いパーサを壊しません。

--- a/scripts/metrics-summary.py
+++ b/scripts/metrics-summary.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Summarize a cdidx --metrics JSONL file.
+
+Reports count, p50, p95, p99, and max elapsed_ms per (source, tool) pair so you
+can spot latency regressions or throughput drops from a captured log without
+re-running queries. Pass the JSONL path as the only argument; reads from stdin
+when no argument is provided.
+
+cdidx の --metrics JSONL ファイルを集計するサンプルスクリプト。
+(source, tool) 別に count / p50 / p95 / p99 / max の elapsed_ms を表示する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        return math.nan
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    k = (len(sorted_values) - 1) * (pct / 100.0)
+    lower = math.floor(k)
+    upper = math.ceil(k)
+    if lower == upper:
+        return sorted_values[int(k)]
+    return sorted_values[lower] + (sorted_values[upper] - sorted_values[lower]) * (k - lower)
+
+
+def _iter_records(stream: Iterable[str]) -> Iterable[dict]:
+    for raw in stream:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(f"warn: skipping malformed line: {exc}", file=sys.stderr)
+
+
+def summarize(records: Iterable[dict]) -> list[dict]:
+    buckets: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for rec in records:
+        elapsed = rec.get("elapsed_ms")
+        if not isinstance(elapsed, (int, float)):
+            continue
+        key = (rec.get("source") or "?", rec.get("tool") or "?")
+        buckets[key].append(float(elapsed))
+
+    rows: list[dict] = []
+    for (source, tool), values in sorted(buckets.items()):
+        values.sort()
+        rows.append({
+            "source": source,
+            "tool": tool,
+            "count": len(values),
+            "p50_ms": round(_percentile(values, 50), 3),
+            "p95_ms": round(_percentile(values, 95), 3),
+            "p99_ms": round(_percentile(values, 99), 3),
+            "max_ms": round(values[-1], 3),
+        })
+    return rows
+
+
+def _print_table(rows: list[dict]) -> None:
+    if not rows:
+        print("(no records)")
+        return
+    headers = ["source", "tool", "count", "p50_ms", "p95_ms", "p99_ms", "max_ms"]
+    widths = [max(len(h), *(len(str(r[h])) for r in rows)) for h in headers]
+    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+    print(fmt.format(*headers))
+    print(fmt.format(*("-" * w for w in widths)))
+    for r in rows:
+        print(fmt.format(*(r[h] for h in headers)))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize cdidx --metrics JSONL output")
+    parser.add_argument("path", nargs="?", help="Path to JSONL file (defaults to stdin)")
+    parser.add_argument("--json", action="store_true", help="Emit summary rows as JSON")
+    args = parser.parse_args()
+
+    if args.path and args.path != "-":
+        with Path(args.path).open("r", encoding="utf-8") as fh:
+            rows = summarize(_iter_records(fh))
+    else:
+        rows = summarize(_iter_records(sys.stdin))
+
+    if args.json:
+        json.dump(rows, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        _print_table(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -390,6 +390,7 @@ public static class ConsoleUi
         Console.WriteLine("  --commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)");
         Console.WriteLine("  --files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed");
         Console.WriteLine("  --color <when>             Color output: `auto` (default), `always`, or `never`; flag wins over `CLICOLOR_FORCE` / `NO_COLOR` / `CLICOLOR` env vars, which win over TTY auto-detect");
+        Console.WriteLine("  --metrics <path>           Append one JSONL record per CLI command / MCP tool call to <path> (also honors CDIDX_METRICS=<path>)");
         Console.WriteLine("  --help, -h                 Show this help message");
         Console.WriteLine("  --version, -V              Show version information");
         Console.WriteLine("  --license                  Show licensing, trademark, and commercial-use summary");

--- a/src/CodeIndex/Cli/MetricsSink.cs
+++ b/src/CodeIndex/Cli/MetricsSink.cs
@@ -128,10 +128,13 @@ internal static class MetricsSink
         using (var jw = new Utf8JsonWriter(buffer, new JsonWriterOptions
         {
             Indented = false,
-            // ISO-8601 timestamps contain `+` for the timezone offset, which the default
-            // strict encoder rewrites to `+`. Use the relaxed encoder so the JSONL is
-            // human-readable in tail / grep workflows; the file is local-only.
-            // ISO-8601 timestamp の `+` を `+` にエスケープせず人間可読のまま残すため relaxed エンコーダを使う。
+            // The default strict encoder escapes characters the JSON spec does not
+            // strictly require to be literal (e.g. the `+` in ISO-8601 timezone
+            // offsets becomes a unicode escape). Use the relaxed encoder so the
+            // JSONL stays human-readable in tail / grep workflows; the file is
+            // local-only.
+            // strict encoder は ISO-8601 timestamp の `+` 等まで unicode escape
+            // するため、ローカル前提の JSONL が tail / grep で読みづらくなる。relaxed encoder で人間可読のまま残す。
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         }))
         {

--- a/src/CodeIndex/Cli/MetricsSink.cs
+++ b/src/CodeIndex/Cli/MetricsSink.cs
@@ -1,0 +1,179 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Threading;
+
+namespace CodeIndex.Cli;
+
+/// <summary>
+/// Opt-in JSONL metrics emitter. Resolves the destination from an explicit `--metrics` CLI
+/// path or the `CDIDX_METRICS` environment variable and writes one record per CLI command
+/// (and per MCP tool call) so maintainers can detect latency regressions or throughput
+/// drops without reproducing them by hand. Best-effort: any IO failure is swallowed so
+/// metrics emission cannot break the underlying command (#1549).
+/// オプトインのJSONLメトリクス出力。`--metrics` または `CDIDX_METRICS` から出力先を解決し、
+/// CLIコマンドおよびMCPツール呼び出しごとに1レコードを書き出す。IO失敗時はベストエフォートで
+/// 黙って無視し、メトリクス出力がコマンド本体を壊さないようにする (#1549)。
+/// </summary>
+internal static class MetricsSink
+{
+    private static readonly AsyncLocal<Session?> CurrentSession = new();
+    internal const string EnvVarName = "CDIDX_METRICS";
+
+    internal static IDisposable? TryStart(string? explicitPath)
+    {
+        var path = ResolvePath(explicitPath);
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        try
+        {
+            var fullPath = Path.GetFullPath(path);
+            var directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            var stream = new FileStream(fullPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+            var writer = new StreamWriter(stream, new UTF8Encoding(false))
+            {
+                AutoFlush = true,
+            };
+            var session = new Session(writer, fullPath);
+            CurrentSession.Value = session;
+            return session;
+        }
+        catch
+        {
+            // Best-effort: a metrics sink that cannot open its file must not block the command.
+            // メトリクス出力先が開けなくても本体コマンドはブロックしない。
+            CurrentSession.Value = null;
+            return null;
+        }
+    }
+
+    internal static bool IsActive => CurrentSession.Value is not null;
+
+    internal static void Record(MetricsEvent evt)
+    {
+        var session = CurrentSession.Value;
+        session?.Write(evt);
+    }
+
+    internal static string? ResolvePath(string? explicitPath)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitPath))
+            return explicitPath;
+
+        var envValue = Environment.GetEnvironmentVariable(EnvVarName);
+        return string.IsNullOrWhiteSpace(envValue) ? null : envValue;
+    }
+
+    internal sealed class Session : IDisposable
+    {
+        private readonly object _gate = new();
+        private readonly StreamWriter _writer;
+        private bool _disposed;
+
+        public Session(StreamWriter writer, string path)
+        {
+            _writer = writer;
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public void Write(MetricsEvent evt)
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+
+                try
+                {
+                    _writer.WriteLine(SerializeEvent(evt));
+                }
+                catch
+                {
+                    // Best-effort only / ベストエフォートのみ
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+                CurrentSession.Value = null;
+                try
+                {
+                    _writer.Dispose();
+                }
+                catch
+                {
+                    // Best-effort only / ベストエフォートのみ
+                }
+            }
+        }
+    }
+
+    internal static string SerializeEvent(MetricsEvent evt)
+    {
+        using var buffer = new MemoryStream();
+        using (var jw = new Utf8JsonWriter(buffer, new JsonWriterOptions
+        {
+            Indented = false,
+            // ISO-8601 timestamps contain `+` for the timezone offset, which the default
+            // strict encoder rewrites to `+`. Use the relaxed encoder so the JSONL is
+            // human-readable in tail / grep workflows; the file is local-only.
+            // ISO-8601 timestamp の `+` を `+` にエスケープせず人間可読のまま残すため relaxed エンコーダを使う。
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        }))
+        {
+            jw.WriteStartObject();
+            jw.WriteString("timestamp", evt.Timestamp.ToString("O", CultureInfo.InvariantCulture));
+            jw.WriteString("tool", evt.Tool);
+            jw.WriteString("source", evt.Source);
+            jw.WriteNumber("elapsed_ms", Math.Round(evt.ElapsedMs, 3));
+            jw.WriteNumber("exit_code", evt.ExitCode);
+            if (evt.Language is { } lang)
+                jw.WriteString("language", lang);
+            if (evt.BytesRead is { } br)
+                jw.WriteNumber("bytes_read", br);
+            if (evt.BytesWritten is { } bw)
+                jw.WriteNumber("bytes_written", bw);
+            if (evt.WalCheckpointMs is { } wal)
+                jw.WriteNumber("wal_checkpoint_ms", Math.Round(wal, 3));
+            if (evt.FilesIndexed is { } fi)
+                jw.WriteNumber("files_indexed", fi);
+            if (evt.Error is { } err)
+                jw.WriteString("error", err);
+            jw.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+}
+
+/// <summary>
+/// Structured metrics record emitted to the JSONL sink. Optional fields are omitted from
+/// the payload when null so consumers can grow new fields without breaking older parsers.
+/// JSONLシンクに出力する構造化メトリクスレコード。null フィールドは出力しないので、
+/// 新しいフィールドを追加しても古いパーサを壊さない。
+/// </summary>
+internal sealed record MetricsEvent(
+    DateTimeOffset Timestamp,
+    string Tool,
+    string Source,
+    double ElapsedMs,
+    int ExitCode,
+    string? Language = null,
+    long? BytesRead = null,
+    long? BytesWritten = null,
+    double? WalCheckpointMs = null,
+    int? FilesIndexed = null,
+    string? Error = null);

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CodeIndex.Database;
@@ -21,19 +22,35 @@ internal static class ProgramRunner
             return CommandExitCodes.UsageError;
         }
 
+        if (!TryConsumeMetricsFlag(ref args, out var metricsPath, out var metricsError))
+        {
+            Console.Error.WriteLine(metricsError);
+            Console.Error.WriteLine("Hint: pass `--metrics <path>` (e.g. `--metrics out.jsonl`).");
+            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.UsageError} metrics_flag_invalid=true");
+            return CommandExitCodes.UsageError;
+        }
+
+        using var metricsSession = MetricsSink.TryStart(metricsPath);
+
         TryConsumeDebugUnsafeFlag(ref args);
+
+        var commandStopwatch = Stopwatch.StartNew();
+        var commandStartTimestamp = DateTimeOffset.UtcNow;
 
         if (args.Length == 0 || args[0] is "--help" or "-h")
         {
             ConsoleUi.PrintUsage(showBanner: args.Length > 0);
-            GlobalToolLog.Info($"command_complete exit_code={(args.Length == 0 ? CommandExitCodes.UsageError : CommandExitCodes.Success)} help_or_usage=true");
-            return args.Length == 0 ? CommandExitCodes.UsageError : CommandExitCodes.Success;
+            var helpExit = args.Length == 0 ? CommandExitCodes.UsageError : CommandExitCodes.Success;
+            GlobalToolLog.Info($"command_complete exit_code={helpExit} help_or_usage=true");
+            EmitCommandMetric("help", args, commandStartTimestamp, commandStopwatch, helpExit);
+            return helpExit;
         }
 
         if (args[0] is "--version" or "-V")
         {
             Console.WriteLine($"cdidx v{appVersion}");
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} version_only=true");
+            EmitCommandMetric("version", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
             return CommandExitCodes.Success;
         }
 
@@ -41,6 +58,7 @@ internal static class ProgramRunner
         {
             ConsoleUi.PrintLicenseSummary();
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} license_only=true");
+            EmitCommandMetric("license", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
             return CommandExitCodes.Success;
         }
 
@@ -48,6 +66,7 @@ internal static class ProgramRunner
         {
             var exitCode = RunCompletions(args[1..]);
             GlobalToolLog.Info($"command_complete exit_code={exitCode} command=completions");
+            EmitCommandMetric("completions", args, commandStartTimestamp, commandStopwatch, exitCode);
             return exitCode;
         }
 
@@ -55,6 +74,7 @@ internal static class ProgramRunner
         {
             ConsoleUi.PrintUsage(showBanner: true);
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} subcommand_help=true");
+            EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
             return CommandExitCodes.Success;
         }
 
@@ -63,6 +83,7 @@ internal static class ProgramRunner
         {
             ConsoleUi.PrintEasterEggMessage(easterEgg);
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} easter_egg={easterEgg}");
+            EmitCommandMetric("easter_egg", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
             return CommandExitCodes.Success;
         }
 
@@ -72,6 +93,7 @@ internal static class ProgramRunner
             {
                 var mcpExitCode = RunMcp(args[1..], appVersion);
                 GlobalToolLog.Info($"command_complete exit_code={mcpExitCode} command=mcp");
+                EmitCommandMetric("mcp", args, commandStartTimestamp, commandStopwatch, mcpExitCode);
                 return mcpExitCode;
             }
 
@@ -121,6 +143,7 @@ internal static class ProgramRunner
                 };
             }
             GlobalToolLog.Info($"command_complete exit_code={exitCode} command={commandName}");
+            EmitCommandMetric(commandName, args, commandStartTimestamp, commandStopwatch, exitCode);
             return exitCode;
         }
         catch (Exception ex)
@@ -128,10 +151,12 @@ internal static class ProgramRunner
             if (JsonOutputFailure.TryHandle(ex, out var exitCode))
             {
                 GlobalToolLog.Error($"command_complete exit_code={exitCode} handled_exception={ex.GetType().Name}: {ex.Message}");
+                EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, exitCode, ex.GetType().Name);
                 return exitCode;
             }
 
             GlobalToolLog.Error($"unhandled_exception type={ex.GetType().FullName}: {ex}");
+            EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, CommandExitCodes.DatabaseError, ex.GetType().Name);
             throw;
         }
     }
@@ -244,6 +269,103 @@ internal static class ProgramRunner
             args = kept.ToArray();
         }
         return seen;
+    }
+
+    // Strip `--metrics <path>` / `--metrics=<path>` from the global args before subcommand
+    // parsing so any command (CLI or MCP) inherits the same JSONL metrics sink without
+    // each subcommand re-declaring the flag. Falls back to the CDIDX_METRICS env var when
+    // the explicit flag is absent. Anything after `--` is left untouched to preserve
+    // subcommand query-escape semantics (#1549).
+    // サブコマンド解析前に `--metrics <path>` / `--metrics=<path>` を取り除き、CLI/MCPいずれの
+    // コマンドでも同じJSONLシンクを継承させる。明示フラグが無い場合は CDIDX_METRICS 環境変数に
+    // フォールバック。`--` 以降はサブコマンドのクエリエスケープ意味論を保つため触らない (#1549)。
+    internal static bool TryConsumeMetricsFlag(ref string[] args, out string? path, out string error)
+    {
+        path = null;
+        error = string.Empty;
+        if (args.Length == 0)
+            return true;
+
+        var kept = new List<string>(args.Length);
+        string? requested = null;
+        var passthrough = false;
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (passthrough)
+            {
+                kept.Add(arg);
+                continue;
+            }
+            if (arg == "--")
+            {
+                passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+
+            string? rawValue = null;
+            if (arg == "--metrics")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    error = "Error: --metrics requires a path value (use `--metrics <path>` or `--metrics=<path>`).";
+                    return false;
+                }
+                rawValue = args[++i];
+            }
+            else if (arg.StartsWith("--metrics=", StringComparison.Ordinal))
+            {
+                rawValue = arg.Substring("--metrics=".Length);
+            }
+            else
+            {
+                kept.Add(arg);
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                error = "Error: --metrics requires a non-empty path value.";
+                return false;
+            }
+            requested = rawValue;
+        }
+
+        path = requested;
+        args = kept.ToArray();
+        return true;
+    }
+
+    internal static void EmitCommandMetric(string tool, string[] args, DateTimeOffset startTimestamp, Stopwatch stopwatch, int exitCode, string? error = null)
+    {
+        if (!MetricsSink.IsActive)
+            return;
+
+        stopwatch.Stop();
+        MetricsSink.Record(new MetricsEvent(
+            Timestamp: startTimestamp,
+            Tool: tool,
+            Source: "cli",
+            ElapsedMs: stopwatch.Elapsed.TotalMilliseconds,
+            ExitCode: exitCode,
+            Language: TryParseLanguageFromArgs(args),
+            Error: error));
+    }
+
+    internal static string? TryParseLanguageFromArgs(string[] args)
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (arg == "--")
+                return null;
+            if (arg == "--lang" && i + 1 < args.Length)
+                return args[i + 1];
+            if (arg.StartsWith("--lang=", StringComparison.Ordinal))
+                return arg.Substring("--lang=".Length);
+        }
+        return null;
     }
 
     internal static JsonSerializerOptions CreateDefaultJsonOptions() => new()

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -250,6 +250,9 @@ public partial class McpServer : IDisposable
             return CreateErrorResponse(hasId: true, id: id, code: -32602, message: "Missing tool name");
 
         Database.DbDebug.ResetContext();
+        var metricsStartedAt = DateTimeOffset.UtcNow;
+        var metricsStopwatch = System.Diagnostics.Stopwatch.StartNew();
+        string? metricsError = null;
         try
         {
             return toolName switch
@@ -295,12 +298,46 @@ public partial class McpServer : IDisposable
             // パスや索引内容が漏れる（#1530）。
             Console.Error.WriteLine(BuildToolErrorLog(toolName, ex.Message));
             Database.DbDebug.DumpToStderr(ex);
+            metricsError = ex.GetType().Name;
             return CreateToolErrorResponse(true, id, BuildSanitizedToolErrorMessage(toolName, ex));
         }
         finally
         {
             Database.DbDebug.ResetContext();
+            if (MetricsSink.IsActive)
+            {
+                metricsStopwatch.Stop();
+                MetricsSink.Record(new MetricsEvent(
+                    Timestamp: metricsStartedAt,
+                    Tool: toolName,
+                    Source: "mcp",
+                    ElapsedMs: metricsStopwatch.Elapsed.TotalMilliseconds,
+                    ExitCode: metricsError == null ? 0 : 1,
+                    Language: TryReadStringArg(args, "language") ?? TryReadStringArg(args, "lang"),
+                    Error: metricsError));
+            }
         }
+    }
+
+    private static string? TryReadStringArg(JsonNode? args, string key)
+    {
+        if (args is null)
+            return null;
+
+        try
+        {
+            var node = args[key];
+            if (node is null)
+                return null;
+            if (node is JsonValue value && value.TryGetValue<string>(out var stringValue))
+                return string.IsNullOrWhiteSpace(stringValue) ? null : stringValue;
+        }
+        catch
+        {
+            // Best-effort: any oddity in argument shape just suppresses the language hint.
+            // ベストエフォート: 引数形状が不正でも language ヒントを抑止するだけ。
+        }
+        return null;
     }
 
     internal static string BuildOversizedMessageLog(int lineLength) =>

--- a/tests/CodeIndex.Tests/MetricsSinkTests.cs
+++ b/tests/CodeIndex.Tests/MetricsSinkTests.cs
@@ -1,0 +1,258 @@
+using System.Text.Json;
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+[Collection("SQLite pool sensitive")]
+public class MetricsSinkTests
+{
+    [Fact]
+    public void TryConsumeMetricsFlag_StripsSeparatedFormAndReturnsPath()
+    {
+        var args = new[] { "search", "--metrics", "/tmp/metrics.jsonl", "foo" };
+
+        Assert.True(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
+        Assert.Empty(error);
+        Assert.Equal("/tmp/metrics.jsonl", path);
+        Assert.Equal(new[] { "search", "foo" }, args);
+    }
+
+    [Fact]
+    public void TryConsumeMetricsFlag_StripsEqualsFormAndReturnsPath()
+    {
+        var args = new[] { "search", "--metrics=/tmp/m.jsonl", "foo" };
+
+        Assert.True(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
+        Assert.Empty(error);
+        Assert.Equal("/tmp/m.jsonl", path);
+        Assert.Equal(new[] { "search", "foo" }, args);
+    }
+
+    [Fact]
+    public void TryConsumeMetricsFlag_MissingValue_ReturnsUsageError()
+    {
+        var args = new[] { "search", "--metrics" };
+
+        Assert.False(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
+        Assert.Null(path);
+        Assert.Contains("--metrics requires a path value", error);
+    }
+
+    [Fact]
+    public void TryConsumeMetricsFlag_EmptyEqualsValue_ReturnsUsageError()
+    {
+        var args = new[] { "search", "--metrics=" };
+
+        Assert.False(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
+        Assert.Null(path);
+        Assert.Contains("non-empty path value", error);
+    }
+
+    [Fact]
+    public void TryConsumeMetricsFlag_AfterDoubleDash_PreservesQueryEscape()
+    {
+        // `--` is the query-escape sentinel for subcommands; tokens after it must stay
+        // literal so a `cdidx search -- --metrics=foo` query string is not consumed.
+        var args = new[] { "search", "--", "--metrics=foo" };
+
+        Assert.True(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
+        Assert.Null(path);
+        Assert.Empty(error);
+        Assert.Equal(new[] { "search", "--", "--metrics=foo" }, args);
+    }
+
+    [Fact]
+    public void TryParseLanguageFromArgs_ReturnsValueWhenPresent()
+    {
+        Assert.Equal("csharp", ProgramRunner.TryParseLanguageFromArgs(["search", "foo", "--lang", "csharp"]));
+        Assert.Equal("python", ProgramRunner.TryParseLanguageFromArgs(["symbols", "--lang=python"]));
+        Assert.Null(ProgramRunner.TryParseLanguageFromArgs(["search", "foo"]));
+        Assert.Null(ProgramRunner.TryParseLanguageFromArgs(["search", "--", "--lang=csharp"]));
+    }
+
+    [Fact]
+    public void Run_WithMetricsFlag_AppendsJsonlRecordForEachInvocation()
+    {
+        var metricsPath = Path.Combine(Path.GetTempPath(), $"cdidx_metrics_{Guid.NewGuid():N}.jsonl");
+        try
+        {
+            var (exitCode, _, _) = CaptureConsole(() => ProgramRunner.Run(
+                ["--metrics", metricsPath, "definitely-not-a-command"],
+                appVersion: "1.10.0"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            var lines = File.ReadAllLines(metricsPath);
+            Assert.Single(lines);
+
+            using var doc = JsonDocument.Parse(lines[0]);
+            var root = doc.RootElement;
+            Assert.Equal("definitely-not-a-command", root.GetProperty("tool").GetString());
+            Assert.Equal("cli", root.GetProperty("source").GetString());
+            Assert.Equal(CommandExitCodes.UsageError, root.GetProperty("exit_code").GetInt32());
+            Assert.True(root.GetProperty("elapsed_ms").GetDouble() >= 0);
+            Assert.True(root.TryGetProperty("timestamp", out _));
+            Assert.False(root.TryGetProperty("language", out _));
+        }
+        finally
+        {
+            if (File.Exists(metricsPath))
+                File.Delete(metricsPath);
+        }
+    }
+
+    [Fact]
+    public void Run_WithEnvVarFallback_StillEmitsMetrics()
+    {
+        var metricsPath = Path.Combine(Path.GetTempPath(), $"cdidx_metrics_env_{Guid.NewGuid():N}.jsonl");
+        var original = Environment.GetEnvironmentVariable(MetricsSink.EnvVarName);
+        try
+        {
+            Environment.SetEnvironmentVariable(MetricsSink.EnvVarName, metricsPath);
+
+            var (exitCode, _, _) = CaptureConsole(() => ProgramRunner.Run(
+                ["definitely-not-a-command", "--lang", "csharp"],
+                appVersion: "1.10.0"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            var lines = File.ReadAllLines(metricsPath);
+            Assert.Single(lines);
+
+            using var doc = JsonDocument.Parse(lines[0]);
+            var root = doc.RootElement;
+            Assert.Equal("definitely-not-a-command", root.GetProperty("tool").GetString());
+            Assert.Equal("csharp", root.GetProperty("language").GetString());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MetricsSink.EnvVarName, original);
+            if (File.Exists(metricsPath))
+                File.Delete(metricsPath);
+        }
+    }
+
+    [Fact]
+    public void Run_WithoutMetricsConfiguration_DoesNotCreateFile()
+    {
+        // Sanity check: with no --metrics flag and no env var, MetricsSink stays inert and
+        // the command completes normally without writing anywhere.
+        // フラグも環境変数も無い場合は MetricsSink は無効のまま、ファイルも作成されない。
+        var original = Environment.GetEnvironmentVariable(MetricsSink.EnvVarName);
+        try
+        {
+            Environment.SetEnvironmentVariable(MetricsSink.EnvVarName, null);
+            Assert.False(MetricsSink.IsActive);
+
+            var (exitCode, _, _) = CaptureConsole(() => ProgramRunner.Run(
+                ["definitely-not-a-command"],
+                appVersion: "1.10.0"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.False(MetricsSink.IsActive);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MetricsSink.EnvVarName, original);
+        }
+    }
+
+    [Fact]
+    public void Run_InvalidMetricsFlag_ReportsUsageError()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            ["--metrics"],
+            appVersion: "1.10.0"));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("--metrics requires a path value", stderr);
+    }
+
+    [Fact]
+    public void Run_WithMetricsFlag_BadDirectory_DoesNotBreakCommand()
+    {
+        // A metrics path under a non-writable / non-existent location must not break the
+        // underlying command — sink failure is best-effort and silently degrades.
+        // 書き込めない場所でも本体コマンドは継続する。
+        var badPath = Path.Combine("/", "definitely-not-a-real-mount", "metrics.jsonl");
+        var (exitCode, _, _) = CaptureConsole(() => ProgramRunner.Run(
+            ["--metrics", badPath, "definitely-not-a-command"],
+            appVersion: "1.10.0"));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+    }
+
+    [Fact]
+    public void SerializeEvent_OmitsNullOptionalFields()
+    {
+        var evt = new MetricsEvent(
+            Timestamp: new DateTimeOffset(2026, 5, 16, 0, 0, 0, TimeSpan.Zero),
+            Tool: "search",
+            Source: "cli",
+            ElapsedMs: 12.5,
+            ExitCode: 0);
+
+        var json = MetricsSink.SerializeEvent(evt);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("search", root.GetProperty("tool").GetString());
+        Assert.Equal("cli", root.GetProperty("source").GetString());
+        Assert.Equal(12.5, root.GetProperty("elapsed_ms").GetDouble());
+        Assert.Equal(0, root.GetProperty("exit_code").GetInt32());
+        Assert.False(root.TryGetProperty("language", out _));
+        Assert.False(root.TryGetProperty("bytes_read", out _));
+        Assert.False(root.TryGetProperty("bytes_written", out _));
+        Assert.False(root.TryGetProperty("wal_checkpoint_ms", out _));
+        Assert.False(root.TryGetProperty("files_indexed", out _));
+        Assert.False(root.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public void SerializeEvent_IncludesAllOptionalFieldsWhenSet()
+    {
+        var evt = new MetricsEvent(
+            Timestamp: new DateTimeOffset(2026, 5, 16, 0, 0, 0, TimeSpan.Zero),
+            Tool: "index",
+            Source: "cli",
+            ElapsedMs: 1234.5,
+            ExitCode: 0,
+            Language: "csharp",
+            BytesRead: 4096,
+            BytesWritten: 8192,
+            WalCheckpointMs: 1.234,
+            FilesIndexed: 42,
+            Error: null);
+
+        var json = MetricsSink.SerializeEvent(evt);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("csharp", root.GetProperty("language").GetString());
+        Assert.Equal(4096, root.GetProperty("bytes_read").GetInt64());
+        Assert.Equal(8192, root.GetProperty("bytes_written").GetInt64());
+        Assert.Equal(1.234, root.GetProperty("wal_checkpoint_ms").GetDouble());
+        Assert.Equal(42, root.GetProperty("files_indexed").GetInt32());
+        Assert.False(root.TryGetProperty("error", out _));
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CaptureConsole(Func<int> action)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            try
+            {
+                Console.SetOut(stdout);
+                Console.SetError(stderr);
+                return (action(), stdout.ToString(), stderr.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `--metrics <path>` (with `CDIDX_METRICS=<path>` env-var fallback) that appends one JSON-lines record per CLI command and per MCP tool call, carrying `timestamp` / `tool` / `source` / `elapsed_ms` / `exit_code` plus `language` when known. Optional fields (`bytes_read`, `bytes_written`, `wal_checkpoint_ms`, `files_indexed`, `error`) are reserved on the schema and omitted from the JSON when null so future consumers can grow new columns without breaking older parsers.
- Emission is best-effort: a missing directory, an unwritable mount, or any IO failure is swallowed silently and never breaks the underlying command.
- Adds `scripts/metrics-summary.py`, a tiny analysis sample that reports p50 / p95 / p99 / max latency per `(source, tool)` straight from the JSONL so latency regressions are visible without re-running queries.
- Adds USER_GUIDE.md docs (EN + JP) and a bilingual changelog fragment.

Fixes #1549

## Test plan
- [x] `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug` succeeds (no warnings)
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~MetricsSinkTests"` — 13 / 13 pass
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` — 4721 / 4721 pass (3 skipped perf tests)
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` — fragments validate
- [x] Smoke-tested `--metrics out.jsonl` against `status` and `search` from a freshly built binary; the JSONL records emit one well-formed line per invocation
- [x] Smoke-tested `scripts/metrics-summary.py` against synthetic JSONL; p50 / p95 / p99 / max are computed per `(source, tool)`