### PR TITLE
Negotiate MCP protocolVersion in initialize (#1554)

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1100,6 +1100,17 @@ Piping `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` into
   `serverInfo.name`, `serverInfo.version` (read via
   `ConsoleUi.LoadVersion()` — the same `version.json` source), and the
   long `instructions` string that guides AI clients on tool selection.
+- `protocolVersion` is **negotiated**, not hardcoded (#1554). The server
+  maintains `McpServer.SupportedProtocolVersions` (newest first:
+  `2025-03-26`, `2024-11-05`), reads the client's requested
+  `protocolVersion` from `initialize` params, and either echoes the
+  supported version back (handshake success), falls back to the newest
+  supported version when the client omits or sends a non-string value,
+  or rejects with a structured JSON-RPC `-32602` whose `error.data`
+  carries `requestedVersion` and `supportedVersions`. This keeps future
+  MCP spec bumps visible as actionable handshake failures instead of
+  silently desynced wire formats. Bump the array deliberately and keep
+  `ProtocolVersion` aligned with its first entry.
 
 Because MCP uses a distinct serialization strategy, it is the most
 robust smoke test for "is the binary runnable at all?" — it stresses
@@ -2074,6 +2085,7 @@ sequenceDiagram
 - `McpServer` が stdin/stdout を持ち、JSON-RPC 2.0 フレームを解析する。
 - レスポンス構築は `JsonSerializer.Serialize<T>(...)` ではなく、`System.Text.Json.Nodes.JsonObject` / `JsonArray` を**手組み**する。これが、トリミング済みバイナリでリフレクションベースのシリアライズが無効でも MCP パスが動き続ける理由。
 - `initialize` レスポンスは `protocolVersion`、`capabilities`、`serverInfo.name`、`serverInfo.version`（`ConsoleUi.LoadVersion()` — `version.json` が源）、および AI クライアントにツール選択を案内する長い `instructions` 文字列を返す。
+- `protocolVersion` は**ハードコードではなく交渉**で決まる（#1554）。サーバーは `McpServer.SupportedProtocolVersions`（新しい順: `2025-03-26`, `2024-11-05`）を保持し、`initialize` パラメータからクライアント要求バージョンを読み取って、対応集合にあればそれを返し（合意）、未指定／非文字列なら既定の最新バージョンに fallback し、対応外なら `error.data` に `requestedVersion` と `supportedVersions` を入れた JSON-RPC `-32602` で拒否する。これにより将来 MCP 仕様が改訂されても、wire format が黙ってずれるのではなく actionable な handshake 失敗として表面化する。配列を新バージョンで更新する際は `ProtocolVersion` を先頭エントリと揃えて意図的に bump する。
 
 MCP は独立したシリアライズ戦略（オブジェクトを JSON などの転送形式に変換する方式のこと。CLI の `--json` 側は .NET 標準の `JsonSerializer` に任せる方式、MCP 側は `JsonObject` を手で組み立てる方式と、別の手段を採っている）を採るため、「そもそもバイナリは走るのか?」を確かめる最も頑健なスモークテスト（デプロイや起動直後に行う、基本動作だけを短時間で確認する簡易テストのこと。詳細な正しさではなく「煙が出ていないか＝致命的に壊れていないか」を見るためこの名で呼ばれる）となる — .NET ホスト、`Program.Main`、CLI ルーティング、`ConsoleUi.LoadVersion()` に負荷をかけるが、SQLite には触れない（`search` など MCP の*ツール呼び出し*は SQLite に触れるが、`initialize` 単独では触れない）。
 

--- a/changelog.d/unreleased/1554.changed.md
+++ b/changelog.d/unreleased/1554.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+issues:
+  - 1554
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP `protocolVersion` negotiation in `initialize` (#1554)** — `cdidx mcp` no longer ignores the `protocolVersion` field that the client sends in the `initialize` request. The server now maintains a `SupportedProtocolVersions` set (`2025-03-26`, `2024-11-05`) and echoes the client's requested version when it is supported, falls back to the newest server version when the client omits or sends a non-string value, and rejects unsupported versions with a structured JSON-RPC `-32602` error whose `error.data` carries `requestedVersion` and `supportedVersions`. This means future MCP spec bumps surface as a clear handshake failure with actionable guidance instead of a silent wire-format mismatch.
+
+## 日本語
+
+- **MCP `initialize` の `protocolVersion` 交渉 (#1554)** — `cdidx mcp` は `initialize` 要求でクライアントが送る `protocolVersion` フィールドを無視しなくなりました。サーバーは対応バージョン集合 `SupportedProtocolVersions`（`2025-03-26` / `2024-11-05`）を保持し、要求バージョンがその集合にあればそれを返し、未指定や非文字列の場合は最新の既定バージョンに fallback します。対応外バージョンが要求された場合は、JSON-RPC `-32602` を構造化エラーとして返し、`error.data` に `requestedVersion` と `supportedVersions` を含めて報告します。これにより、将来 MCP 仕様が改訂されても無言の wire format ミスマッチではなく、actionable な handshake 失敗としてクライアントに伝わります。

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -11,7 +11,9 @@ namespace CodeIndex.Mcp;
 /// <summary>
 /// MCP (Model Context Protocol) server over stdin/stdout using JSON-RPC 2.0.
 /// stdin/stdout上のJSON-RPC 2.0によるMCPサーバー。
-/// Protocol version: 2024-11-05
+/// Supported protocol versions: see <see cref="SupportedProtocolVersions"/> (negotiated per
+/// `initialize` request, #1554).
+/// 対応プロトコルバージョン: <see cref="SupportedProtocolVersions"/> 参照（`initialize` ごとに交渉, #1554）。
 /// </summary>
 public partial class McpServer : IDisposable
 {
@@ -37,7 +39,21 @@ public partial class McpServer : IDisposable
     private bool _sharedDbReadMigrated;
     private bool _disposed;
 
+    // Preferred MCP protocol version returned when the client does not pin one. This is the
+    // newest entry in `SupportedProtocolVersions` and must stay in lockstep with that array.
+    // 既定の MCP プロトコルバージョン。クライアントが指定しなかった場合に返す値で、
+    // `SupportedProtocolVersions` の先頭（最新）と一致させる。
     private const string ProtocolVersion = "2025-03-26";
+    // MCP protocol versions this server can speak, newest first. Issue #1554: the
+    // `initialize` response used to advertise a single hardcoded version and ignored the
+    // client's requested `protocolVersion`, so any spec bump silently desynced clients and
+    // servers. Negotiation walks this set so older clients on `2024-11-05` keep working and
+    // unknown future versions surface as a structured `-32602` instead of a misleading echo.
+    // このサーバーが話せる MCP プロトコルバージョン（新しい順）。Issue #1554: 旧実装は
+    // ハードコードした 1 つのバージョンだけを返し、クライアントが要求した `protocolVersion`
+    // を無視していたため、仕様改訂のたびに無言で互換が崩れていた。`2024-11-05` の旧クライアント
+    // を引き続きサポートしつつ、未知バージョンは構造化された `-32602` で明示的に拒否する。
+    internal static readonly string[] SupportedProtocolVersions = { "2025-03-26", "2024-11-05" };
     private const int MaxLimit = 200;
     private const int MaxQueryLength = 1000;
     // Upper bound on the `impact_analysis` `maxDepth` argument. Deep monorepos can have
@@ -212,9 +228,23 @@ public partial class McpServer : IDisposable
     /// </summary>
     private JsonNode HandleInitialize(JsonNode? id, JsonNode? _params)
     {
+        var negotiated = NegotiateProtocolVersion(_params, out var requestedVersion);
+        if (negotiated == null)
+        {
+            // No overlap between the client's requested version and this server's supported
+            // set. Issue #1554: respond with structured `-32602` (invalid params) carrying the
+            // requested + supported versions in `error.data` so clients can branch on it
+            // instead of guessing why the handshake silently failed.
+            // クライアント要求バージョンとサーバー対応集合に重なりがない場合。Issue #1554:
+            // クライアントが分岐判定できるよう、`error.data` に要求バージョンと対応バージョン
+            // を入れた -32602 (invalid params) を返す。
+            Console.Error.WriteLine(BuildUnsupportedProtocolLog(requestedVersion));
+            return CreateUnsupportedProtocolError(id, requestedVersion);
+        }
+
         var result = new JsonObject
         {
-            ["protocolVersion"] = ProtocolVersion,
+            ["protocolVersion"] = negotiated,
             ["capabilities"] = new JsonObject
             {
                 ["tools"] = new JsonObject
@@ -232,6 +262,88 @@ public partial class McpServer : IDisposable
             ["instructions"] = BuildInstructions()
         };
         return CreateSuccessResponse(true, id, result);
+    }
+
+    /// <summary>
+    /// Resolve the protocol version to advertise back to the client. Returns the version
+    /// string on success and `null` when the client pinned an unsupported version.
+    /// Issue #1554: the previous handshake hardcoded a single version, so a future MCP
+    /// spec bump would silently break clients. The negotiation now mirrors the MCP spec:
+    /// echo the client's requested version when it is in our supported set, fall back to
+    /// the preferred version when no version was supplied, and surface a structured error
+    /// when there is no overlap (no silent downgrade so clients cannot mistakenly proceed
+    /// against an unsupported wire format).
+    /// クライアントに返すプロトコルバージョンを決める。成功時はバージョン文字列、
+    /// クライアントが対応外バージョンを指定した場合は `null` を返す。Issue #1554:
+    /// 旧実装はハードコードした 1 つのバージョンだけを返していたため、将来の仕様改訂で
+    /// 無言で互換が壊れる。本ロジックは MCP 仕様準拠で、要求バージョンが対応集合にあれば
+    /// それをそのまま返し、未指定なら既定バージョンを返し、重なりが無い場合は構造化エラー
+    /// を返す（黙ってダウングレードしないことでクライアントが誤った wire format で進むのを防ぐ）。
+    /// </summary>
+    internal static string? NegotiateProtocolVersion(JsonNode? initializeParams, out string? requestedVersion)
+    {
+        requestedVersion = null;
+        if (initializeParams is JsonObject obj
+            && obj.TryGetPropertyValue("protocolVersion", out var node)
+            && node is JsonValue value
+            && value.TryGetValue<string>(out var versionString)
+            && !string.IsNullOrWhiteSpace(versionString))
+        {
+            requestedVersion = versionString;
+            foreach (var supported in SupportedProtocolVersions)
+            {
+                if (string.Equals(supported, versionString, StringComparison.Ordinal))
+                    return supported;
+            }
+            return null;
+        }
+
+        // Field absent / null / malformed: fall back to the preferred version so clients
+        // that omit the field (or send a non-string sentinel) keep working as before.
+        // 未指定 / null / 不正型: 既定バージョンに fallback して既存クライアントの互換を保つ。
+        return ProtocolVersion;
+    }
+
+    private static JsonObject CreateUnsupportedProtocolError(JsonNode? id, string? requestedVersion)
+    {
+        var supportedArray = new JsonArray();
+        foreach (var supported in SupportedProtocolVersions)
+            supportedArray.Add(JsonValue.Create(supported));
+
+        var data = new JsonObject
+        {
+            ["supportedVersions"] = supportedArray
+        };
+        if (requestedVersion != null)
+            data["requestedVersion"] = requestedVersion;
+
+        var error = new JsonObject
+        {
+            ["code"] = -32602,
+            ["message"] = BuildUnsupportedProtocolMessage(requestedVersion),
+            ["data"] = data
+        };
+        var response = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["error"] = error,
+            ["id"] = id is null ? JsonNode.Parse("null") : JsonNode.Parse(id.ToJsonString())
+        };
+        return response;
+    }
+
+    internal static string BuildUnsupportedProtocolMessage(string? requestedVersion)
+    {
+        var supported = string.Join(", ", SupportedProtocolVersions);
+        var requested = string.IsNullOrEmpty(requestedVersion) ? "(unspecified)" : requestedVersion;
+        return $"Unsupported MCP protocolVersion '{requested}'. Server supports: {supported}.";
+    }
+
+    internal static string BuildUnsupportedProtocolLog(string? requestedVersion)
+    {
+        var supported = string.Join(", ", SupportedProtocolVersions);
+        var requested = string.IsNullOrEmpty(requestedVersion) ? "(unspecified)" : requestedVersion;
+        return $"[cdidx-mcp] Rejecting initialize: client requested protocolVersion '{requested}', server supports {supported}. Upgrade the server or pin a supported version on the client.";
     }
 
     // Tool definitions are in McpToolDefinitions.cs / ツール定義は McpToolDefinitions.cs に分離

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -119,14 +119,121 @@ public class McpServerTests : IDisposable
     [Fact]
     public void Initialize_ReturnsProtocolVersion()
     {
+        // Issue #1554: negotiation echoes back the client's requested protocolVersion when
+        // it is in the server's supported set, instead of hardcoding the server's preferred
+        // version. The legacy `2024-11-05` client is still supported, so the response should
+        // mirror what the client asked for.
+        // Issue #1554: 交渉ロジックはサーバー対応集合にあるクライアント要求バージョンを
+        // そのまま返すようにした。レガシー `2024-11-05` クライアントは引き続きサポートする
+        // ため、レスポンスは要求された値と一致する。
         var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test"}}}""")!;
         var response = _server.HandleMessage(request)!;
 
         Assert.Equal("2.0", response["jsonrpc"]!.GetValue<string>());
         Assert.Equal(1, response["id"]!.GetValue<int>());
-        Assert.Equal("2025-03-26", response["result"]!["protocolVersion"]!.GetValue<string>());
+        Assert.Equal("2024-11-05", response["result"]!["protocolVersion"]!.GetValue<string>());
         Assert.Equal("cdidx", response["result"]!["serverInfo"]!["name"]!.GetValue<string>());
         Assert.Equal(ConsoleUi.LoadVersion(), response["result"]!["serverInfo"]!["version"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Initialize_RequestedCurrentProtocolVersion_EchoesBack()
+    {
+        // Issue #1554: when the client pins the current preferred version, the server
+        // must echo it (the client and server agree, no fallback needed).
+        // Issue #1554: クライアントが現行の優先バージョンを指定した場合、サーバーは
+        // そのまま返す（合意済みなので fallback 不要）。
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.Equal("2025-03-26", response["result"]!["protocolVersion"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Initialize_NoProtocolVersion_UsesPreferred()
+    {
+        // Issue #1554: empty params still works — the negotiation falls back to the server's
+        // preferred (newest) version so existing clients that never sent the field keep
+        // working unchanged.
+        // Issue #1554: params が空でも動作する — 既定の優先バージョン（最新）に fallback
+        // することで、protocolVersion を送らない既存クライアントの互換を保つ。
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.Equal("2025-03-26", response["result"]!["protocolVersion"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Initialize_UnsupportedProtocolVersion_ReturnsInvalidParamsError()
+    {
+        // Issue #1554: an unsupported requested version must NOT silently downgrade to the
+        // server's preferred version — that hid mismatches and made future spec bumps
+        // observably break clients. Instead the handshake returns -32602 with structured
+        // data so clients can branch on the failure and report a precise diagnostic.
+        // Issue #1554: 未対応の要求バージョンを黙ってダウングレードしてはならない
+        // （ミスマッチを覆い隠してしまうため）。-32602 と構造化データを返し、クライアントが
+        // 失敗判定して正確な診断を出せるようにする。
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2099-01-01"}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.Null(response["result"]);
+        var error = response["error"]!;
+        Assert.Equal(-32602, error["code"]!.GetValue<int>());
+        Assert.Contains("2099-01-01", error["message"]!.GetValue<string>());
+        Assert.Contains("2025-03-26", error["message"]!.GetValue<string>());
+
+        var data = error["data"]!;
+        Assert.Equal("2099-01-01", data["requestedVersion"]!.GetValue<string>());
+        var supported = data["supportedVersions"]!.AsArray()
+            .Select(n => n!.GetValue<string>())
+            .ToArray();
+        Assert.Equal(McpServer.SupportedProtocolVersions, supported);
+    }
+
+    [Fact]
+    public void Initialize_MalformedProtocolVersion_FallsBackToPreferred()
+    {
+        // Non-string `protocolVersion` (e.g. number, null, object) is treated the same as
+        // "field absent": fall back to the preferred version. Erroring would break tolerant
+        // clients that send `null` when no preference exists, while a silent fallback only
+        // kicks in for genuinely malformed inputs and not for the strict-mismatch path.
+        // 非文字列の `protocolVersion`（数値・null・オブジェクト）は「未指定」と同じ扱いで
+        // 既定の優先バージョンに fallback する。null を許容するクライアントとの互換を残しつつ、
+        // 厳格な不一致ケース（文字列だが対応外）には引き続き -32602 を返せる。
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":42}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.Equal("2025-03-26", response["result"]!["protocolVersion"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void SupportedProtocolVersions_IsNewestFirstAndIncludesPreferred()
+    {
+        // The preferred version must be the newest entry; ordering matters for future
+        // additions because clients may rely on the listed order as a "newest-first" hint.
+        // 既定の優先バージョンは先頭でなければならない。クライアントが「先頭が最新」と
+        // して扱う可能性があるため、順序の保証は明示的に必要。
+        Assert.NotEmpty(McpServer.SupportedProtocolVersions);
+        Assert.Equal("2025-03-26", McpServer.SupportedProtocolVersions[0]);
+        Assert.Contains("2024-11-05", McpServer.SupportedProtocolVersions);
+    }
+
+    [Fact]
+    public void BuildUnsupportedProtocolMessage_MentionsRequestedAndSupported()
+    {
+        var msg = McpServer.BuildUnsupportedProtocolMessage("2099-01-01");
+        Assert.Contains("2099-01-01", msg);
+        foreach (var supported in McpServer.SupportedProtocolVersions)
+            Assert.Contains(supported, msg);
+    }
+
+    [Fact]
+    public void BuildUnsupportedProtocolLog_IsActionable()
+    {
+        var log = McpServer.BuildUnsupportedProtocolLog("2099-01-01");
+        Assert.Contains("Rejecting initialize", log);
+        Assert.Contains("2099-01-01", log);
+        Assert.Contains("Upgrade the server or pin a supported version", log);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds `protocolVersion` negotiation to the MCP `initialize` handshake, replacing the previously hardcoded version that ignored whatever the client requested.
- Maintains `McpServer.SupportedProtocolVersions` (newest first: `2025-03-26`, `2024-11-05`) and echoes the client's requested version when supported, falls back to the newest server version when the client omits or sends a non-string value, and rejects unsupported versions with a structured JSON-RPC `-32602` whose `error.data` carries `requestedVersion` and `supportedVersions`.
- Updates DEVELOPER_GUIDE (English + Japanese), the `McpServer` XML doc, and adds a bilingual changelog fragment.

## Test plan
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` — 4748 passed, 3 skipped (perf-only), 0 failed.
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` — fragment validates.
- [x] Adversarial review on the diff; addressed the one finding (stale class-level XML comment).

Fixes #1554
