### PR TITLE
Add report --output for redacted bug-report bundles (#1552)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -552,6 +552,24 @@ cdidx map --path src/ --exclude-tests --json
 
 `map` is the fastest way to orient both a human and an AI agent before deeper queries. Use it to get languages, modules, hot files, and likely entrypoints, then narrow with `inspect`, `search`, or `definition`. For the full freshness and metadata contract of `status --json`, `map --json`, `inspect --json`, and MCP `analyze_symbol`, see [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md).
 
+### Build a bug-report bundle
+
+```bash
+cdidx report --output report.tgz
+cdidx report --output report.tgz --json
+```
+
+`cdidx report --output <path>` packages a redacted `.tar.gz` you can attach to a GitHub issue. The bundle includes the cdidx version, .NET runtime, OS / process architecture, and a `schema.txt` listing each SQLite table with its row count (no user content). It also tails the recent cdidx lifecycle log (`stderr-yyyyMMdd.log`), with `cwd=` and `args=` lines replaced by `[redacted]` so working-directory paths and literal query strings never leave your machine.
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--output <path>` / `-o <path>` | (required) | Destination `.tar.gz`. The directory is created if missing. |
+| `--db <path>` | `.cdidx/codeindex.db` | Override the database whose schema is summarized. If absent, `schema.txt` records that no DB was found. |
+| `--log-lines <n>` | `200` | How many trailing lifecycle-log lines to include (`0` disables the tail). |
+| `--no-log` | | Skip the lifecycle log entirely. |
+| `--include-args` | | Keep literal `cwd=` and `args=` values in the log tail (opt-in; share only with trusted recipients). |
+| `--json` | | Print a stable summary envelope (`output_path`, `version`, `files`, `schema_tables`, `log_lines_included`, `log_included`, `db_included`, `db_path`) instead of the human-friendly output. |
+
 ## Options
 
 | Option | Applies to | Description |
@@ -1667,6 +1685,24 @@ cdidx map --path src/ --exclude-tests --json
 ```
 
 `map` は、人と AI のどちらにも最短で全体像を渡すための入口です。言語、モジュール、ホットなファイル、推定エントリポイントを把握したら、`inspect`、`search`、`definition` に進んでください。`status --json`、`map --json`、`inspect --json`、MCP `analyze_symbol` の詳細なメタデータ契約は [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md#開発者ガイド) にまとめています。
+
+### バグ報告用バンドルを作る
+
+```bash
+cdidx report --output report.tgz
+cdidx report --output report.tgz --json
+```
+
+`cdidx report --output <path>` は GitHub Issue に添付できる匿名化済み `.tar.gz` を生成します。バンドルには cdidx のバージョン、.NET ランタイム、OS / プロセスアーキテクチャ、各 SQLite テーブル名と整数の行数のみを記録した `schema.txt`（ユーザコンテンツは含まれません）が入ります。さらに直近のライフサイクルログ（`stderr-yyyyMMdd.log`）の末尾も含まれますが、`cwd=` と `args=` 行は `[redacted]` に置換されるため、作業ディレクトリのパスや具体的なクエリ文字列が端末から外に出ることはありません。
+
+| フラグ | 既定値 | 効果 |
+|---|---|---|
+| `--output <path>` / `-o <path>` | （必須） | 出力先 `.tar.gz`。親ディレクトリが無ければ作成します。 |
+| `--db <path>` | `.cdidx/codeindex.db` | スキーマ要約対象の DB を上書きします。存在しなければ `schema.txt` に「DB が見つからなかった」旨が記録されます。 |
+| `--log-lines <n>` | `200` | ライフサイクルログ末尾を何行含めるか（`0` で末尾を含めません）。 |
+| `--no-log` | | ライフサイクルログを完全に省略します。 |
+| `--include-args` | | ログ末尾の `cwd=` / `args=` 値を伏字化せずそのまま含めます（信頼できる相手にだけ使用してください）。 |
+| `--json` | | 人間向け出力の代わりに、安定したサマリ JSON（`output_path` / `version` / `files` / `schema_tables` / `log_lines_included` / `log_included` / `db_included` / `db_path`）を出力します。 |
 
 ## オプション一覧
 

--- a/changelog.d/unreleased/1552.added.md
+++ b/changelog.d/unreleased/1552.added.md
@@ -1,0 +1,21 @@
+---
+category: added
+issues:
+  - 1552
+affected:
+  - src/CodeIndex/Cli/ReportCommandRunner.cs
+  - src/CodeIndex/Cli/GlobalToolLog.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **New `cdidx report --output <path>` command builds a redacted bug-report bundle (#1552)** — until now, asking a user "please share what cdidx version, OS, and DB schema you are on" required them to gather and redact several pieces by hand, and there was no commonly-shaped artifact to attach to a GitHub issue. `cdidx report --output report.tgz` now emits a deterministic `.tar.gz` containing `metadata.json` (cdidx version, .NET runtime, OS / process architecture, generated-at UTC), `version.txt`, `env.txt`, `schema.txt` (SQLite table names and integer row counts only — no user content), and a `log/stderr-recent.log` tail of the cdidx lifecycle log. By default the tail's `cwd=` and `args=` lines are replaced with `[redacted]` so working-directory paths and literal query strings never leave the user's machine; `--include-args` is an explicit opt-in for trusted recipients, and `--no-log` omits the log entirely. Supporting flags `--db <path>` (override schema source), `--log-lines <n>` (tail size, default 200), and `--json` (stable summary envelope including `output_path`, `version`, `files`, `schema_tables`, `log_lines_included`, `log_included`, `db_included`, `db_path`) round out the contract. Exit codes follow the existing convention: `0` on success, `1` for usage errors, `3` when the bundle cannot be written. The command never reads indexed source content — only table names and row counts — so the bundle is safe to attach to public issues for repos where the source itself is sensitive.
+
+## 日本語
+
+- **`cdidx report --output <path>` で匿名化されたバグ報告バンドルを生成できるようになりました (#1552)** — これまで「cdidx のバージョン・OS・DB スキーマを送ってください」と頼むには、ユーザが手動で複数の情報を集めて伏字化する必要があり、GitHub Issue に貼り付けやすい標準フォーマットも存在しませんでした。`cdidx report --output report.tgz` は `metadata.json` (cdidx バージョン、.NET ランタイム、OS / プロセスアーキテクチャ、生成 UTC)、`version.txt`、`env.txt`、`schema.txt` (SQLite テーブル名と整数の行数のみ — ユーザコンテンツは含まない)、ライフサイクルログ末尾の `log/stderr-recent.log` を含む決定的な `.tar.gz` を生成します。既定ではログ末尾の `cwd=` と `args=` 行を `[redacted]` に置換するため、作業ディレクトリのパスや具体的なクエリ文字列がユーザ端末から出ることはありません。信頼できる相手に渡す場合のみ `--include-args` で literal を残せ、`--no-log` でログを完全に除外できます。補助フラグとして `--db <path>` (スキーマソース上書き)、`--log-lines <n>` (末尾行数、既定 200)、`--json` (`output_path` / `version` / `files` / `schema_tables` / `log_lines_included` / `log_included` / `db_included` / `db_path` を含む安定サマリエンベロープ) も提供します。終了コードは既存の規約に沿って成功時 `0`、usage error 時 `1`、バンドル書き込み失敗時 `3` です。本コマンドはインデックス対象のソース内容を一切読み取らず (テーブル名と行数のみ)、ソース自体に機微情報を含むリポジトリでも公開 Issue に安心して添付できます。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -44,6 +44,7 @@ public static class ConsoleUi
         ("outline", "cdidx outline <path> [--db <path>] [--json]"),
         ("status", "cdidx status [--db <path>] [--json] [--check]"),
         ("db", "cdidx db --integrity-check [--db <path>] [--json]"),
+        ("report", "cdidx report --output <path> [--db <path>] [--json] [--log-lines <n>] [--no-log] [--include-args]"),
         ("validate", "cdidx validate [--db <path>] [--json] [--kind <kind>] [--path <glob>]"),
         ("impact", "cdidx impact <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--depth <n>] [--count] [--with-paths]"),
         ("deps", "cdidx deps [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--reverse]"),
@@ -371,6 +372,7 @@ public static class ConsoleUi
         Console.WriteLine("  outline <path>             Show the symbol outline of a single file");
         Console.WriteLine("  status                     Show database statistics; add --check to verify DB/worktree match");
         Console.WriteLine("  db --integrity-check       Run SQLite `PRAGMA integrity_check` and report findings");
+        Console.WriteLine("  report --output <path>     Build a redacted crash-repro tarball (.tgz) for bug reports");
         Console.WriteLine("  validate                   Report encoding issues (U+FFFD, BOM, null bytes, mixed line endings, UTF-16 BOM, likely non-UTF8)");
         Console.WriteLine("  impact <query>             Show transitive callers; type queries may return heuristic file-level dependency hints");
         Console.WriteLine("  deps                       Show file-level dependency edges from the reference graph");
@@ -560,7 +562,7 @@ public static class ConsoleUi
     [
         "index", "backfill-fold", "search", "definition", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
-        "validate", "deps", "impact", "unused", "hotspots", "languages", "mcp", "db", "license",
+        "validate", "deps", "impact", "unused", "hotspots", "languages", "mcp", "db", "report", "license",
     ];
 
     /// <summary>

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -73,6 +73,16 @@ internal static class GlobalToolLog
             || normalized.Contains("/tests/CodeIndex.Tests/bin/", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Resolve the lifecycle-log directory cdidx writes to, using the same precedence
+    /// as <see cref="TryStart"/>. Exposed to `cdidx report` so the bug-report bundle
+    /// can locate recent stderr log files without duplicating the platform-fallback
+    /// logic.
+    /// `cdidx report` 用に <see cref="TryStart"/> と同じ優先順位で
+    /// ライフサイクルログのディレクトリ解決を公開する。
+    /// </summary>
+    internal static string ResolveLogDirectoryForReport() => ResolveLogDirectory();
+
     private static string ResolveLogDirectory()
     {
         var overrideDirectory = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -30,6 +30,16 @@ internal sealed record DbIntegrityCheckJsonResult(
     [property: JsonPropertyName("ok")] bool Ok,
     [property: JsonPropertyName("issues")] List<string> Issues);
 
+internal sealed record ReportBundleSummary(
+    [property: JsonPropertyName("output_path")] string OutputPath,
+    [property: JsonPropertyName("version")] string Version,
+    [property: JsonPropertyName("files")] int Files,
+    [property: JsonPropertyName("schema_tables")] int SchemaTables,
+    [property: JsonPropertyName("log_lines_included")] int LogLinesIncluded,
+    [property: JsonPropertyName("log_included")] bool LogIncluded,
+    [property: JsonPropertyName("db_included")] bool DbIncluded,
+    [property: JsonPropertyName("db_path")] string? DbPath);
+
 internal sealed record QueryCountJsonResult(
     [property: JsonPropertyName("count")] int Count);
 
@@ -226,6 +236,7 @@ internal sealed record GroupedSymbolHotspotJsonResult(
 [JsonSerializable(typeof(RepoLanguageResult))]
 [JsonSerializable(typeof(RepoMapResult))]
 [JsonSerializable(typeof(RepoModuleResult))]
+[JsonSerializable(typeof(ReportBundleSummary))]
 [JsonSerializable(typeof(SearchHighlight))]
 [JsonSerializable(typeof(SearchResult))]
 [JsonSerializable(typeof(StatusResult))]

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -137,6 +137,7 @@ internal static class ProgramRunner
                     "index" => IndexCommandRunner.Run(subArgs, jsonOptions),
                     "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, jsonOptions),
                     "db" => DbCommandRunner.RunIntegrityCheck(subArgs, jsonOptions),
+                    "report" => ReportCommandRunner.Run(subArgs, jsonOptions, appVersion),
                     _ when IsProjectPathArg(commandName)
                         => IndexCommandRunner.Run(args, jsonOptions),
                     _ => ShowError(args, $"Unknown command: {commandName}")

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -1,0 +1,443 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Cli;
+
+/// <summary>
+/// Runs `cdidx report --output <path>`, which bundles a redacted crash-repro
+/// tarball (`.tar.gz`) containing the cdidx version, OS / .NET runtime info,
+/// the schema table list with row counts, and recent lifecycle log lines.
+/// User-content fields (paths, query strings, args) are redacted by default.
+/// `cdidx report --output <path>` を実行する。バージョン、OS / .NET ランタイム情報、
+/// スキーマのテーブル一覧と行数、最近のライフサイクルログを含む匿名化済み
+/// tarball (`.tar.gz`) を作る。パス・クエリ文字列・args 等のユーザコンテンツは
+/// 既定で伏字化する。
+/// </summary>
+public static class ReportCommandRunner
+{
+    internal const int DefaultLogLines = 200;
+    internal const string RedactedPlaceholder = "[redacted]";
+
+    public static int Run(string[] cmdArgs, JsonSerializerOptions jsonOptions, string? appVersion = null)
+    {
+        var options = ParseArgs(cmdArgs);
+        if (options.ShowHelp)
+        {
+            ConsoleUi.PrintUsage();
+            return CommandExitCodes.Success;
+        }
+
+        if (options.ParseError != null)
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                options.ParseError,
+                CommandExitCodes.UsageError,
+                "Run `cdidx report --help` to see the supported command shape.",
+                CommandErrorCodes.UsageError);
+
+        if (string.IsNullOrWhiteSpace(options.OutputPath))
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                "report requires --output <path>",
+                CommandExitCodes.UsageError,
+                "Pass `--output report.tgz` (or another writable path) to choose where the redacted bundle is written.",
+                CommandErrorCodes.UsageError);
+
+        try
+        {
+            var resolvedVersion = appVersion ?? ConsoleUi.LoadVersion();
+            var bundle = BuildBundle(options, resolvedVersion);
+            WriteBundle(options.OutputPath!, bundle);
+
+            var summary = new ReportBundleSummary(
+                Path.GetFullPath(options.OutputPath!),
+                resolvedVersion,
+                bundle.Files.Count,
+                bundle.SchemaTables.Count,
+                bundle.LogLinesIncluded,
+                bundle.LogIncluded,
+                bundle.DbIncluded,
+                bundle.DbPath);
+
+            if (options.Json)
+            {
+                var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
+                Console.WriteLine(JsonSerializer.Serialize(summary, jsonContext.ReportBundleSummary));
+            }
+            else
+            {
+                Console.WriteLine("Bug report bundle");
+                Console.WriteLine($"  output       : {summary.OutputPath}");
+                Console.WriteLine($"  cdidx        : v{summary.Version}");
+                Console.WriteLine($"  files        : {summary.Files}");
+                Console.WriteLine($"  schema rows  : {summary.SchemaTables}");
+                Console.WriteLine($"  log lines    : {(summary.LogIncluded ? summary.LogLinesIncluded.ToString() : "skipped")}");
+                Console.WriteLine($"  schema source: {(summary.DbIncluded ? summary.DbPath : "(no DB found)")}");
+                Console.WriteLine();
+                Console.WriteLine("Attach the tarball to the GitHub issue. Path lists, query strings, and");
+                Console.WriteLine("`args=` log lines are redacted by default; rerun with `--include-args` to");
+                Console.WriteLine("include literal command-line arguments only when you trust the recipient.");
+            }
+            return CommandExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            if (JsonOutputFailure.TryHandle(ex, out var exitCode))
+                return exitCode;
+
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                $"failed to build report: {ex.Message}",
+                CommandExitCodes.DatabaseError,
+                "Retry `cdidx report --output <path>`. If this persists, check that the output directory is writable.",
+                CommandErrorCodes.DbError);
+        }
+    }
+
+    internal static ReportBundle BuildBundle(ReportCommandOptions options, string version)
+    {
+        var bundle = new ReportBundle();
+        var nowUtc = DateTimeOffset.UtcNow;
+
+        var metadata = new ReportMetadata(
+            Version: version,
+            GeneratedAtUtc: nowUtc.ToString("O"),
+            DotNetRuntimeVersion: Environment.Version.ToString(),
+            FrameworkDescription: RuntimeInformation.FrameworkDescription,
+            OsDescription: RuntimeInformation.OSDescription,
+            OsArchitecture: RuntimeInformation.OSArchitecture.ToString(),
+            ProcessArchitecture: RuntimeInformation.ProcessArchitecture.ToString(),
+            IsLittleEndian: BitConverter.IsLittleEndian);
+        var metaJson = JsonSerializer.Serialize(metadata, ReportMetadataJsonContext.Default.ReportMetadata);
+        bundle.AddText("metadata.json", metaJson);
+
+        bundle.AddText("version.txt", $"cdidx v{version}\n");
+        bundle.AddText(
+            "env.txt",
+            string.Join('\n',
+                $"cdidx-version: {version}",
+                $"generated-at-utc: {nowUtc:O}",
+                $"dotnet-runtime: {Environment.Version}",
+                $"framework: {RuntimeInformation.FrameworkDescription}",
+                $"os: {RuntimeInformation.OSDescription}",
+                $"os-architecture: {RuntimeInformation.OSArchitecture}",
+                $"process-architecture: {RuntimeInformation.ProcessArchitecture}",
+                "") + "\n");
+
+        var (schemaText, tables, dbPath, dbIncluded) = BuildSchemaSummary(options.DbPath);
+        bundle.SchemaTables = tables;
+        bundle.DbIncluded = dbIncluded;
+        bundle.DbPath = dbPath;
+        bundle.AddText("schema.txt", schemaText);
+
+        bundle.LogIncluded = options.IncludeLog;
+        bundle.LogLinesIncluded = 0;
+        if (options.IncludeLog && options.LogLines > 0)
+        {
+            var logText = BuildRecentLogTail(options.LogLines, options.IncludeArgs, out var linesIncluded);
+            bundle.LogLinesIncluded = linesIncluded;
+            bundle.AddText("log/stderr-recent.log", logText);
+        }
+
+        bundle.AddText("README.md", BuildReadme(version, options.IncludeLog, options.IncludeArgs));
+        return bundle;
+    }
+
+    internal static string BuildReadme(string version, bool includeLog, bool includeArgs)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# cdidx bug-report bundle");
+        sb.AppendLine();
+        sb.AppendLine($"Generated by cdidx v{version}. Attach this tarball to the GitHub issue you are filing at");
+        sb.AppendLine("<https://github.com/Widthdom/CodeIndex/issues>.");
+        sb.AppendLine();
+        sb.AppendLine("## Contents");
+        sb.AppendLine();
+        sb.AppendLine("- `metadata.json` — version, OS, .NET runtime info (machine-readable).");
+        sb.AppendLine("- `version.txt` — cdidx version only.");
+        sb.AppendLine("- `env.txt` — human-readable OS / runtime summary.");
+        sb.AppendLine("- `schema.txt` — list of SQLite tables and row counts (no user content).");
+        if (includeLog)
+        {
+            sb.AppendLine("- `log/stderr-recent.log` — last N lines of the cdidx lifecycle log");
+            sb.AppendLine(includeArgs
+                ? "  (includes literal `args=` lines; rerun without `--include-args` to redact them)."
+                : "  (`args=` lines are redacted; rerun with `--include-args` to keep them literal).");
+        }
+        else
+        {
+            sb.AppendLine("- (log skipped via `--no-log`)");
+        }
+        sb.AppendLine();
+        sb.AppendLine("## Redactions");
+        sb.AppendLine();
+        sb.AppendLine("- Indexed source content, file paths, query strings, and `args=` lines are not included by default.");
+        sb.AppendLine("- Schema reporting only emits table names and integer row counts.");
+        return sb.ToString();
+    }
+
+    internal static (string Text, List<ReportSchemaTable> Tables, string? DbPath, bool DbIncluded) BuildSchemaSummary(string dbPath)
+    {
+        if (!File.Exists(dbPath))
+        {
+            var missingText = $"no SQLite index found at: {dbPath}\nRun `cdidx index <projectPath>` first if you want schema details attached.\n";
+            return (missingText, new List<ReportSchemaTable>(), dbPath, false);
+        }
+
+        var tables = new List<ReportSchemaTable>();
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadOnly,
+        }.ConnectionString;
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+
+        var tableNames = new List<string>();
+        using (var listCmd = connection.CreateCommand())
+        {
+            listCmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name";
+            using var reader = listCmd.ExecuteReader();
+            while (reader.Read())
+                tableNames.Add(reader.GetString(0));
+        }
+
+        foreach (var name in tableNames)
+        {
+            long rowCount;
+            try
+            {
+                using var countCmd = connection.CreateCommand();
+                countCmd.CommandText = $"SELECT COUNT(*) FROM \"{name.Replace("\"", "\"\"")}\"";
+                rowCount = Convert.ToInt64(countCmd.ExecuteScalar());
+            }
+            catch (SqliteException)
+            {
+                rowCount = -1;
+            }
+            tables.Add(new ReportSchemaTable(name, rowCount));
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"database: {Path.GetFullPath(dbPath)}");
+        sb.AppendLine($"tables  : {tables.Count}");
+        sb.AppendLine();
+        sb.AppendLine("name | row_count");
+        sb.AppendLine("-----|----------");
+        foreach (var t in tables)
+            sb.AppendLine($"{t.Name} | {(t.RowCount < 0 ? "(unreadable)" : t.RowCount.ToString())}");
+
+        return (sb.ToString(), tables, dbPath, true);
+    }
+
+    internal static string BuildRecentLogTail(int maxLines, bool includeArgs, out int linesIncluded)
+    {
+        linesIncluded = 0;
+        var logDir = GlobalToolLog.ResolveLogDirectoryForReport();
+        if (string.IsNullOrWhiteSpace(logDir) || !Directory.Exists(logDir))
+            return $"no cdidx lifecycle log directory found (looked at: {logDir ?? "<unknown>"}).\n";
+
+        var logFiles = new DirectoryInfo(logDir)
+            .EnumerateFiles("stderr-*.log", SearchOption.TopDirectoryOnly)
+            .OrderByDescending(f => f.Name, StringComparer.Ordinal)
+            .ToList();
+        if (logFiles.Count == 0)
+            return $"no cdidx lifecycle log files found in: {logDir}\n";
+
+        var collected = new LinkedList<string>();
+        foreach (var file in logFiles)
+        {
+            if (collected.Count >= maxLines)
+                break;
+            string[] lines;
+            try
+            {
+                lines = File.ReadAllLines(file.FullName);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+            for (var i = lines.Length - 1; i >= 0 && collected.Count < maxLines; i--)
+                collected.AddFirst(lines[i]);
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"# cdidx lifecycle log (last {collected.Count} lines, newest last)");
+        sb.AppendLine($"# source directory: {logDir}");
+        sb.AppendLine();
+        foreach (var line in collected)
+        {
+            sb.AppendLine(includeArgs ? line : RedactSensitiveFields(line));
+        }
+        linesIncluded = collected.Count;
+        return sb.ToString();
+    }
+
+    internal static string RedactSensitiveFields(string line)
+    {
+        var redacted = RedactKeyValue(line, "args=");
+        redacted = RedactKeyValue(redacted, "cwd=");
+        return redacted;
+    }
+
+    private static string RedactKeyValue(string line, string key)
+    {
+        var idx = line.IndexOf(key, StringComparison.Ordinal);
+        if (idx < 0)
+            return line;
+        return line[..(idx + key.Length)] + RedactedPlaceholder;
+    }
+
+    private static void WriteBundle(string outputPath, ReportBundle bundle)
+    {
+        var dir = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        using var gz = new GZipStream(fileStream, CompressionLevel.Optimal);
+        using var tar = new TarWriter(gz, TarEntryFormat.Pax, leaveOpen: true);
+
+        foreach (var (name, bytes) in bundle.Files)
+        {
+            var entry = new PaxTarEntry(TarEntryType.RegularFile, name)
+            {
+                DataStream = new MemoryStream(bytes, writable: false),
+                Mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead,
+                ModificationTime = DateTimeOffset.UtcNow,
+            };
+            tar.WriteEntry(entry);
+        }
+    }
+
+    internal static ReportCommandOptions ParseArgs(string[] args)
+    {
+        var options = new ReportCommandOptions
+        {
+            DbPath = Path.Combine(".cdidx", "codeindex.db"),
+            LogLines = DefaultLogLines,
+            IncludeLog = true,
+            IncludeArgs = false,
+        };
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--db" when i + 1 < args.Length:
+                    options.DbPath = args[++i];
+                    break;
+                case "--db":
+                    options.ParseError = "--db requires a value";
+                    break;
+                case "--output" or "-o" when i + 1 < args.Length:
+                    options.OutputPath = args[++i];
+                    break;
+                case "--output" or "-o":
+                    options.ParseError = "--output requires a value";
+                    break;
+                case "--json":
+                    options.Json = true;
+                    break;
+                case "--no-log":
+                    options.IncludeLog = false;
+                    break;
+                case "--include-args":
+                    options.IncludeArgs = true;
+                    break;
+                case "--log-lines" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], out var parsedLines) || parsedLines < 0)
+                        options.ParseError = $"--log-lines requires a non-negative integer, got '{args[i]}'";
+                    else
+                        options.LogLines = parsedLines;
+                    break;
+                case "--log-lines":
+                    options.ParseError = "--log-lines requires a value";
+                    break;
+                case "--help" or "-h":
+                    options.ShowHelp = true;
+                    return options;
+                default:
+                    if (args[i].StartsWith('-'))
+                        options.ParseError = $"report does not support option: '{args[i]}'";
+                    else
+                        options.ParseError = $"report does not accept positional arguments: '{args[i]}'";
+                    break;
+            }
+
+            if (options.ParseError != null)
+                break;
+        }
+
+        return options;
+    }
+
+    private static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode, string? hint = null, string? errorCode = null)
+    {
+        if (json)
+            Console.WriteLine(JsonSerializer.Serialize(
+                new CommandErrorJsonResult("error", message, hint, errorCode),
+                CliJsonSerializerContextFactory.Create(jsonOptions).CommandErrorJsonResult));
+        else
+        {
+            var prefix = errorCode is null ? "Error" : $"Error [{errorCode}]";
+            Console.Error.WriteLine($"{prefix}: {message}");
+            if (hint != null)
+                Console.Error.WriteLine($"Hint: {hint}");
+        }
+        return exitCode;
+    }
+}
+
+internal sealed class ReportCommandOptions
+{
+    public string DbPath { get; set; } = string.Empty;
+    public string? OutputPath { get; set; }
+    public bool Json { get; set; }
+    public bool ShowHelp { get; set; }
+    public bool IncludeLog { get; set; } = true;
+    public bool IncludeArgs { get; set; }
+    public int LogLines { get; set; } = ReportCommandRunner.DefaultLogLines;
+    public string? ParseError { get; set; }
+}
+
+internal sealed class ReportBundle
+{
+    public List<(string Name, byte[] Bytes)> Files { get; } = new();
+    public List<ReportSchemaTable> SchemaTables { get; set; } = new();
+    public bool LogIncluded { get; set; }
+    public bool DbIncluded { get; set; }
+    public string? DbPath { get; set; }
+    public int LogLinesIncluded { get; set; }
+
+    public void AddText(string name, string content) =>
+        Files.Add((name, Encoding.UTF8.GetBytes(content)));
+}
+
+internal sealed record ReportSchemaTable(string Name, long RowCount);
+
+internal sealed record ReportMetadata(
+    string Version,
+    string GeneratedAtUtc,
+    string DotNetRuntimeVersion,
+    string FrameworkDescription,
+    string OsDescription,
+    string OsArchitecture,
+    string ProcessArchitecture,
+    bool IsLittleEndian);
+
+[System.Text.Json.Serialization.JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = System.Text.Json.Serialization.JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+[System.Text.Json.Serialization.JsonSerializable(typeof(ReportMetadata))]
+internal partial class ReportMetadataJsonContext : System.Text.Json.Serialization.JsonSerializerContext;

--- a/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
@@ -1,0 +1,399 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using CodeIndex.Cli;
+using CodeIndex.Database;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Tests;
+
+/// <summary>
+/// Tests for `cdidx report --output <path>` (issue #1552). The command must
+/// produce a redacted `.tar.gz` containing version + OS + schema + a tail of
+/// the lifecycle log, while never embedding indexed source content or unredacted
+/// command-line arguments.
+/// `cdidx report --output <path>` のテスト (issue #1552)。匿名化された
+/// tarball にバージョン・OS・スキーマ・ログ末尾のみが入り、ソース内容や
+/// 生の引数が混入しないことを担保する。
+/// </summary>
+[Collection("SQLite pool sensitive")]
+public class ReportCommandRunnerTests
+{
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    [Fact]
+    public void ParseArgs_OutputFlagCapturesValue()
+    {
+        var options = ReportCommandRunner.ParseArgs(["--output", "bundle.tgz"]);
+
+        Assert.Equal("bundle.tgz", options.OutputPath);
+        Assert.Null(options.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_ShortOutputAliasCapturesValue()
+    {
+        var options = ReportCommandRunner.ParseArgs(["-o", "bundle.tgz"]);
+
+        Assert.Equal("bundle.tgz", options.OutputPath);
+    }
+
+    [Fact]
+    public void ParseArgs_NoLogTurnsOffLogInclusion()
+    {
+        var options = ReportCommandRunner.ParseArgs(["--output", "x.tgz", "--no-log"]);
+
+        Assert.False(options.IncludeLog);
+    }
+
+    [Fact]
+    public void ParseArgs_IncludeArgsOptsInToLiteralLog()
+    {
+        var options = ReportCommandRunner.ParseArgs(["--output", "x.tgz", "--include-args"]);
+
+        Assert.True(options.IncludeArgs);
+    }
+
+    [Fact]
+    public void ParseArgs_LogLinesParsesPositive()
+    {
+        var options = ReportCommandRunner.ParseArgs(["--output", "x.tgz", "--log-lines", "50"]);
+
+        Assert.Equal(50, options.LogLines);
+        Assert.Null(options.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_LogLinesNegativeReportsError()
+    {
+        var options = ReportCommandRunner.ParseArgs(["--output", "x.tgz", "--log-lines", "-3"]);
+
+        Assert.NotNull(options.ParseError);
+        Assert.Contains("non-negative", options.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_UnknownOptionRecordsParseError()
+    {
+        var options = ReportCommandRunner.ParseArgs(["--bogus"]);
+
+        Assert.NotNull(options.ParseError);
+        Assert.Contains("--bogus", options.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_PositionalArgRecordsParseError()
+    {
+        var options = ReportCommandRunner.ParseArgs(["extra"]);
+
+        Assert.NotNull(options.ParseError);
+        Assert.Contains("positional", options.ParseError);
+    }
+
+    [Fact]
+    public void Run_MissingOutputFlag_ReturnsUsageError()
+    {
+        var (exitCode, _, stderr) = RunAndCaptureStreams([]);
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("--output", stderr);
+    }
+
+    [Fact]
+    public void Run_MissingOutputFlag_JsonShapeIncludesHint()
+    {
+        var (exitCode, json) = RunAndCaptureJson(["--json"]);
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal("error", json.GetProperty("status").GetString());
+        Assert.Contains("--output", json.GetProperty("message").GetString());
+        Assert.Contains("--output", json.GetProperty("hint").GetString());
+    }
+
+    [Fact]
+    public void Run_NoDbAndNoLog_StillProducesBundleWithMetadata()
+    {
+        var workDir = CreateWorkDir();
+        try
+        {
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var missingDb = Path.Combine(workDir, "missing.db");
+
+            var (exitCode, _, _) = RunAndCaptureStreams([
+                "--output", output,
+                "--db", missingDb,
+                "--no-log",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.True(File.Exists(output));
+
+            var entries = ReadTarGzEntries(output);
+            Assert.Contains("metadata.json", entries.Keys);
+            Assert.Contains("version.txt", entries.Keys);
+            Assert.Contains("env.txt", entries.Keys);
+            Assert.Contains("schema.txt", entries.Keys);
+            Assert.Contains("README.md", entries.Keys);
+            Assert.DoesNotContain("log/stderr-recent.log", entries.Keys);
+
+            var schemaText = Encoding.UTF8.GetString(entries["schema.txt"]);
+            Assert.Contains("no SQLite index found", schemaText);
+        }
+        finally
+        {
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void Run_WithRealDb_SchemaTxtListsTablesAndRowCounts()
+    {
+        var workDir = CreateWorkDir();
+        var dbPath = Path.Combine(workDir, "codeindex.db");
+        try
+        {
+            using (var db = new DbContext(dbPath))
+                db.InitializeSchema();
+            SqliteConnection.ClearAllPools();
+
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var (exitCode, _, _) = RunAndCaptureStreams([
+                "--output", output,
+                "--db", dbPath,
+                "--no-log",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var entries = ReadTarGzEntries(output);
+            var schemaText = Encoding.UTF8.GetString(entries["schema.txt"]);
+            Assert.Contains("tables", schemaText);
+            Assert.Contains("files", schemaText);
+            Assert.Contains("symbols", schemaText);
+            Assert.Contains("row_count", schemaText);
+            Assert.DoesNotContain("no SQLite index found", schemaText);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void Run_WithLogDirOverride_IncludesRedactedTail()
+    {
+        var workDir = CreateWorkDir();
+        var logDir = Path.Combine(workDir, "logs");
+        Directory.CreateDirectory(logDir);
+        File.WriteAllText(
+            Path.Combine(logDir, "stderr-20260516.log"),
+            string.Join('\n',
+                "2026-05-16T03:00:00Z [INFO] session_start pid=1 version=1.21.0",
+                "2026-05-16T03:00:00Z [INFO] cwd=/Users/widthdom/secret",
+                "2026-05-16T03:00:00Z [INFO] args=query \"SELECT * FROM secret\"",
+                "2026-05-16T03:00:01Z [ERROR] sample error",
+                ""));
+
+        var previousLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+        try
+        {
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var (exitCode, _, _) = RunAndCaptureStreams([
+                "--output", output,
+                "--db", Path.Combine(workDir, "missing.db"),
+                "--log-lines", "20",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var entries = ReadTarGzEntries(output);
+            Assert.True(entries.ContainsKey("log/stderr-recent.log"));
+            var logText = Encoding.UTF8.GetString(entries["log/stderr-recent.log"]);
+            Assert.Contains("args=[redacted]", logText);
+            Assert.Contains("cwd=[redacted]", logText);
+            Assert.DoesNotContain("/Users/widthdom/secret", logText);
+            Assert.DoesNotContain("SELECT * FROM secret", logText);
+            Assert.Contains("session_start", logText);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", previousLogDir);
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void Run_IncludeArgs_PreservesLiteralArgsAndCwd()
+    {
+        var workDir = CreateWorkDir();
+        var logDir = Path.Combine(workDir, "logs");
+        Directory.CreateDirectory(logDir);
+        File.WriteAllText(
+            Path.Combine(logDir, "stderr-20260516.log"),
+            "2026-05-16T03:00:00Z [INFO] cwd=/tmp/keep-this\n2026-05-16T03:00:00Z [INFO] args=index .\n");
+
+        var previousLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+        try
+        {
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var (exitCode, _, _) = RunAndCaptureStreams([
+                "--output", output,
+                "--db", Path.Combine(workDir, "missing.db"),
+                "--log-lines", "20",
+                "--include-args",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var entries = ReadTarGzEntries(output);
+            var logText = Encoding.UTF8.GetString(entries["log/stderr-recent.log"]);
+            Assert.Contains("cwd=/tmp/keep-this", logText);
+            Assert.Contains("args=index .", logText);
+            Assert.DoesNotContain("[redacted]", logText);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", previousLogDir);
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void Run_JsonMode_PrintsSummaryEnvelope()
+    {
+        var workDir = CreateWorkDir();
+        try
+        {
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var (exitCode, json) = RunAndCaptureJson([
+                "--output", output,
+                "--db", Path.Combine(workDir, "missing.db"),
+                "--no-log",
+                "--json",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(Path.GetFullPath(output), json.GetProperty("output_path").GetString());
+            Assert.True(json.GetProperty("files").GetInt32() >= 4);
+            Assert.False(json.GetProperty("log_included").GetBoolean());
+            Assert.False(json.GetProperty("db_included").GetBoolean());
+        }
+        finally
+        {
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsCwdLine()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "2026-05-16T03:00:00Z [INFO] cwd=/private/foo/secret-project");
+
+        Assert.Contains("cwd=[redacted]", redacted);
+        Assert.DoesNotContain("/private/foo/secret-project", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsArgsLine()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "2026-05-16T03:00:00Z [INFO] args=query \"SELECT * FROM secret\"");
+
+        Assert.Contains("args=[redacted]", redacted);
+        Assert.DoesNotContain("SELECT * FROM secret", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_LinesWithoutSensitiveKeysPassThrough()
+    {
+        var line = "2026-05-16T03:00:00Z [INFO] session_start pid=1 version=1.21.0";
+        var redacted = ReportCommandRunner.RedactSensitiveFields(line);
+
+        Assert.Equal(line, redacted);
+    }
+
+    private (int ExitCode, string StdOut, string StdErr) RunAndCaptureStreams(string[] args)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            using var outWriter = new StringWriter();
+            using var errWriter = new StringWriter();
+            try
+            {
+                Console.SetOut(outWriter);
+                Console.SetError(errWriter);
+                var exitCode = ReportCommandRunner.Run(args, _jsonOptions, appVersion: "test");
+                return (exitCode, outWriter.ToString(), errWriter.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    private (int ExitCode, JsonElement Json) RunAndCaptureJson(string[] args)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            using var writer = new StringWriter();
+            try
+            {
+                Console.SetOut(writer);
+                var exitCode = ReportCommandRunner.Run(args, _jsonOptions, appVersion: "test");
+                using var document = JsonDocument.Parse(writer.ToString());
+                return (exitCode, document.RootElement.Clone());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+
+    private static string CreateWorkDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cdidx_report_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup for tests / テスト用ベストエフォート削除。
+        }
+    }
+
+    private static Dictionary<string, byte[]> ReadTarGzEntries(string path)
+    {
+        var entries = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        using var fileStream = File.OpenRead(path);
+        using var gz = new GZipStream(fileStream, CompressionMode.Decompress);
+        using var tar = new TarReader(gz);
+        while (tar.GetNextEntry() is { } entry)
+        {
+            if (entry.EntryType != TarEntryType.RegularFile)
+                continue;
+            using var buffer = new MemoryStream();
+            entry.DataStream?.CopyTo(buffer);
+            entries[entry.Name] = buffer.ToArray();
+        }
+        return entries;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `report --output <path>` subcommand that builds a redacted `.tar.gz` for bug reports.
- The bundle contains `metadata.json` (version, .NET runtime, OS / process architecture, generated-at UTC), `version.txt`, `env.txt`, `schema.txt` (each SQLite table with its row count — no user content), `README.md`, and optionally `log/stderr-recent.log` (the lifecycle log tail).
- Lifecycle-log `cwd=` and `args=` lines are replaced with `[redacted]` by default; `--include-args` is an explicit opt-in.
- Supporting flags: `--db <path>`, `--log-lines <n>` (default 200), `--no-log`, `--json` (stable summary envelope including `output_path`, `version`, `files`, `schema_tables`, `log_lines_included`, `log_included`, `db_included`, `db_path`).
- Exit codes follow the existing convention: `0` success, `1` usage error, `3` bundle write failure.

## Validation

- `dotnet build CodeIndex.sln -c Release` — clean (0 warnings, 0 errors).
- `dotnet test CodeIndex.sln -c Release` — 4771 passed, 3 skipped, 0 failed (18 of the passes are new `ReportCommandRunnerTests`).
- Smoke tests of the locally built binary: human output, `--json` summary envelope, missing `--output` error envelope, and tarball entry list.
- `dotnet run --project tools/CodeIndex.Changelog -- check` — 57 fragments validated.

## Documentation / Changelog

- `USER_GUIDE.md` (English + 日本語) — added a "Build a bug-report bundle" / 「バグ報告用バンドルを作る」 section with the full flag table.
- `changelog.d/unreleased/1552.added.md` — bilingual fragment with `category: added`, `issues: [1552]`, and the affected file list.

## Test plan

- [x] Build clean (Debug + Release)
- [x] Full test suite green
- [x] `cdidx report --output report.tgz --no-log` smoke test (human output)
- [x] `cdidx report --output report.tgz --json` smoke test (summary envelope)
- [x] `cdidx report --json` (missing `--output`) returns usage-error envelope
- [x] Tarball entries verified via `tar -tzf`
- [x] Schema redaction verified (table names + integer counts only)
- [x] `cwd=` / `args=` redaction verified via unit tests
- [x] `--include-args` opt-in verified via unit test

## Follow-ups

- #2196 — bash/zsh/fish completion templates do not enumerate the new `report` flags.

Fixes #1552
