### PR TITLE
Ship CycloneDX SBOM with every GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,38 @@ jobs:
         if: ${{ !matrix.cross_compile }}
         run: dotnet test CodeIndex.sln --configuration Release --no-build --nologo
 
+      # Generate a CycloneDX SBOM once per release on the linux-x64 lane.
+      # SBOM content is RID-independent (it lists NuGet package dependencies
+      # including the bundled SQLitePCLRaw native asset), so producing it on
+      # every matrix entry would just upload identical bytes four times.
+      # Pinned to a known-stable major to avoid silent CLI surface drift from
+      # an upstream major release breaking the release workflow.
+      # SBOM はリリースごとに 1 回だけ生成すれば十分 (CycloneDX 出力は NuGet
+      # 依存ツリーと SQLitePCLRaw のネイティブアセットを列挙するので RID 間で
+      # 内容は同一)。upstream の major 変更で release workflow が黙って壊れない
+      # よう、安定メジャーをピン留めする。
+      - name: Install CycloneDX SBOM tool (linux-x64 only)
+        if: matrix.rid == 'linux-x64'
+        run: dotnet tool install --global CycloneDX --version 6.2.0
+
+      - name: Generate CycloneDX SBOM (linux-x64 only)
+        if: matrix.rid == 'linux-x64'
+        run: |
+          mkdir -p sbom
+          dotnet-CycloneDX src/CodeIndex/CodeIndex.csproj \
+            --output sbom \
+            --output-format Json \
+            --exclude-test-projects \
+            --filename cdidx.sbom.cdx.json
+          test -s sbom/cdidx.sbom.cdx.json
+
+      - name: Upload SBOM artifact (linux-x64 only)
+        if: matrix.rid == 'linux-x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: CodeIndex-sbom
+          path: sbom/cdidx.sbom.cdx.json
+
       - name: Publish (self-contained)
         run: >
           dotnet publish src/CodeIndex/CodeIndex.csproj
@@ -236,7 +268,16 @@ jobs:
       - name: Collect release files
         run: |
           mkdir -p release-files
-          find all-artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) -exec cp {} release-files/ \;
+          # Tarballs/zips are per-RID artifacts; the SBOM is a single
+          # RID-independent JSON file. Both go in release-files so
+          # sha256sums.txt covers the SBOM as well, letting supply-chain
+          # consumers verify the SBOM bytes the same way they verify the
+          # binaries.
+          # tarball/zip は RID 別の成果物、SBOM は RID 非依存の単一 JSON。
+          # どちらも release-files に集約することで sha256sums.txt が SBOM の
+          # ハッシュもカバーし、SBOM 利用側はバイナリと同じ手順で SBOM の
+          # 完全性を検証できる。
+          find all-artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.cdx.json' \) -exec cp {} release-files/ \;
           cd release-files
           sha256sum * > sha256sums.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,19 @@ jobs:
       # よう、安定メジャーをピン留めする。
       - name: Install CycloneDX SBOM tool (linux-x64 only)
         if: matrix.rid == 'linux-x64'
-        run: dotnet tool install --global CycloneDX --version 6.2.0
+        # actions/setup-dotnet@v4 does not put $HOME/.dotnet/tools on PATH
+        # automatically, so we append it via $GITHUB_PATH for every subsequent
+        # step. Without this, the next step would fail with
+        # "dotnet-CycloneDX: command not found" on GitHub-hosted runners even
+        # though the tool is installed correctly under $HOME/.dotnet/tools.
+        # actions/setup-dotnet@v4 は $HOME/.dotnet/tools を自動では PATH に
+        # 加えないため、$GITHUB_PATH 経由で明示的に追加して後続 step から
+        # `dotnet-CycloneDX` を直接呼べるようにする。これを忘れると、ツール
+        # 自体は $HOME/.dotnet/tools に正しくインストールされていても、次の
+        # step が `command not found` で落ちる。
+        run: |
+          dotnet tool install --global CycloneDX --version 6.2.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Generate CycloneDX SBOM (linux-x64 only)
         if: matrix.rid == 'linux-x64'

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -754,14 +754,17 @@ during testing or packaging.
 
 ### The moving parts
 
-Four artifacts have to end up in three correct places for `cdidx` to work:
+Four artifacts have to end up in three correct places for `cdidx` to work,
+plus one supply-chain attestation that is published next to the binaries but
+not installed:
 
 | Artifact | Origin | Final location | Required by |
 | --- | --- | --- | --- |
 | `cdidx` (trimmed self-contained single-file binary) | `dotnet publish -r <rid> --self-contained -p:PublishSingleFile=true -p:PublishTrimmed=true` in `release.yml` | `$HOME/.local/bin/cdidx` | User's `PATH` |
 | `libe_sqlite3.so` (Linux) / `libe_sqlite3.dylib` (macOS) | Native asset from the `Microsoft.Data.Sqlite` (SQLitePCLRaw) NuGet, copied into the publish output | `$HOME/.local/bin/` (next to the binary) | `SqliteConnection` static ctor → P/Invoke |
 | `version.json` | Repo root; `CodeIndex.csproj` copies it to the publish output as a `Content` item | `$HOME/.local/bin/` (next to the binary) | `ConsoleUi.LoadVersion()` via `AppContext.BaseDirectory` |
-| `sha256sums.txt` | `release.yml` computes it after packaging | Downloaded to a temp dir during install, not kept | `install.sh` integrity check |
+| `sha256sums.txt` | `release.yml` computes it after packaging (covers tarballs/zips and the SBOM) | Downloaded to a temp dir during install, not kept | `install.sh` integrity check; SBOM consumers |
+| `cdidx.sbom.cdx.json` | `release.yml` runs `dotnet CycloneDX` once on the `linux-x64` lane (content is RID-independent) and uploads it as a `CodeIndex-sbom` artifact; `create-release` copies it into `release-files/` so `sha256sums.txt` covers it | Published as a GitHub release asset; not installed on user machines | Compliance reviews (SOC2, FedRAMP-style); supply-chain scanners (Snyk, Trivy, Grype) |
 
 The first three are packaged into `CodeIndex-<rid>.tar.gz` by
 `release.yml`. A clean install has to reproduce that layout on the user's
@@ -1852,14 +1855,17 @@ Linux では `$XDG_STATE_HOME/cdidx/logs/`（未設定時は
 
 ### 構成要素
 
-`cdidx` が動作するためには、4つのアーティファクトが3つの正しい場所に収まる必要がある:
+`cdidx` が動作するためには、4つのアーティファクトが3つの正しい場所に収まる必要があり、
+さらにユーザー環境にはインストールされないがリリースには同梱されるサプライチェーン用の
+追加アセットが1つある:
 
 | アーティファクト | 由来 | 最終配置先 | 必要とする処理 |
 | --- | --- | --- | --- |
 | `cdidx`（trim 済み自己完結型シングルファイルバイナリ） | `release.yml` 内の `dotnet publish -r <rid> --self-contained -p:PublishSingleFile=true -p:PublishTrimmed=true` | `$HOME/.local/bin/cdidx` | ユーザーの `PATH` |
 | `libe_sqlite3.so`（Linux）/ `libe_sqlite3.dylib`（macOS） | `Microsoft.Data.Sqlite`（SQLitePCLRaw）NuGet のネイティブ資産。publish 出力に同梱される | `$HOME/.local/bin/`（バイナリの隣） | `SqliteConnection` 静的コンストラクタ → P/Invoke |
 | `version.json` | リポジトリルート。`CodeIndex.csproj` が `Content` として publish 出力にコピー | `$HOME/.local/bin/`（バイナリの隣） | `AppContext.BaseDirectory` 経由の `ConsoleUi.LoadVersion()` |
-| `sha256sums.txt` | `release.yml` がパッケージング後に計算 | インストール中は一時ディレクトリに保持のみ | `install.sh` の整合性チェック |
+| `sha256sums.txt` | `release.yml` がパッケージング後に計算（tarball/zip と SBOM 双方をカバー） | インストール中は一時ディレクトリに保持のみ | `install.sh` の整合性チェック / SBOM 利用側 |
+| `cdidx.sbom.cdx.json` | `release.yml` が `linux-x64` lane で 1 度だけ `dotnet CycloneDX` を実行（内容は RID 非依存）し、`CodeIndex-sbom` アーティファクトとして upload。`create-release` が `release-files/` にコピーして `sha256sums.txt` の対象に含める | GitHub release のアセットとして公開、ユーザー環境にはインストールしない | コンプライアンスレビュー（SOC2 / FedRAMP 系）/ サプライチェーンスキャナー（Snyk / Trivy / Grype） |
 
 最初の3つは `release.yml` により `CodeIndex-<rid>.tar.gz` にパッケージされる。クリーンインストールは同じレイアウトをユーザーの環境で再現する必要がある。ランタイムファイルが欠けると、後述の診断表にある症状のいずれかが発生する。
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 | [Self-Improvement Contract](SELF_IMPROVEMENT.md) | Rules for agents improving CodeIndex itself. |
 | [Integration Policy](INTEGRATION_POLICY.md) | Permitted CLI, JSON, MCP, and integration use. |
 
+## Verifying releases
+
+Every GitHub release ships the following supply-chain artifacts next to
+the per-platform `CodeIndex-<rid>.tar.gz` / `.zip` binaries:
+
+| Asset | Purpose |
+|---|---|
+| `sha256sums.txt` | SHA-256 of every release asset (including the SBOM). `install.sh` uses it to verify the downloaded tarball before placing anything under `$HOME/.local/bin/`. |
+| `cdidx.sbom.cdx.json` | CycloneDX 1.x JSON Software Bill of Materials covering every NuGet dependency (including the bundled `SQLitePCLRaw` native asset) so compliance reviewers (SOC2, FedRAMP-style) and scanners (Snyk, Trivy, Grype) can audit transitive dependencies without re-deriving them from `.deps.json`. |
+
+Quick check after downloading both files from the release page:
+
+```bash
+sha256sum --check sha256sums.txt --ignore-missing
+jq '.metadata.component.name, .components | length' cdidx.sbom.cdx.json
+```
+
 ## License and Fair Source Use
 
 CodeIndex and official `cdidx` binaries are source-available / Fair Source-style software
@@ -152,6 +169,24 @@ cdidx mcp
 | [テストガイド](TESTING_GUIDE.md#テストガイド) | テスト規約と検証コマンド。 |
 | [自己改善コントラクト](SELF_IMPROVEMENT.md#自己改善ループ) | CodeIndex 自身を改善するエージェント向けルール。 |
 | [統合ポリシー](INTEGRATION_POLICY.md) | CLI、JSON、MCP、各種統合で許可される利用。 |
+
+## リリース成果物の検証
+
+各 GitHub release では、プラットフォーム別の
+`CodeIndex-<rid>.tar.gz` / `.zip` バイナリと並んで、サプライチェーン関連の
+成果物を同梱しています。
+
+| アセット | 用途 |
+|---|---|
+| `sha256sums.txt` | 各リリースアセット（SBOM を含む）の SHA-256。`install.sh` は `$HOME/.local/bin/` に何も書き込む前に tarball をこのファイルで検証します。 |
+| `cdidx.sbom.cdx.json` | CycloneDX 1.x JSON 形式の Software Bill of Materials。同梱の `SQLitePCLRaw` ネイティブアセットを含む全 NuGet 依存を列挙するため、SOC2 / FedRAMP 系のコンプライアンスレビューや Snyk / Trivy / Grype などのスキャナーが `.deps.json` から再構築せずに推移的依存を監査できます。 |
+
+リリースページから両ファイルをダウンロードしたあとの簡易チェック例:
+
+```bash
+sha256sum --check sha256sums.txt --ignore-missing
+jq '.metadata.component.name, .components | length' cdidx.sbom.cdx.json
+```
 
 ## ライセンスと Fair Source の扱い
 

--- a/changelog.d/unreleased/1553.added.md
+++ b/changelog.d/unreleased/1553.added.md
@@ -1,0 +1,18 @@
+---
+category: added
+issues:
+  - 1553
+affected:
+  - .github/workflows/release.yml
+  - tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+  - README.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Releases now ship a CycloneDX SBOM (`cdidx.sbom.cdx.json`) (#1553)** — every `v*` GitHub release publishes a CycloneDX 1.x JSON Software Bill of Materials alongside the per-platform `CodeIndex-<rid>.tar.gz` / `.zip` binaries and the existing `sha256sums.txt`. The SBOM is generated once per release on the `linux-x64` lane via the pinned `dotnet CycloneDX` global tool against `src/CodeIndex/CodeIndex.csproj` with `--exclude-test-projects`, uploaded as a `CodeIndex-sbom` build artifact, copied into `release-files/` so `sha256sums.txt` covers its hash, and shipped as a release asset. The SBOM enumerates every NuGet dependency (including the bundled `Microsoft.Data.Sqlite` / `SQLitePCLRaw` graph and the native `e_sqlite3` asset), so enterprise consumers can run SOC2 / FedRAMP-style compliance reviews and supply-chain scanners (Snyk, Trivy, Grype) without re-deriving the dependency graph from the .NET-specific `.deps.json`. `README.md` adds a "Verifying releases" section that documents the SBOM location and a `sha256sum --check` quick-verify command, and `DEVELOPER_GUIDE.md` adds the SBOM to the release "moving parts" table.
+
+## 日本語
+
+- **リリースに CycloneDX SBOM (`cdidx.sbom.cdx.json`) を同梱するようになりました (#1553)** — すべての `v*` GitHub release で、プラットフォーム別の `CodeIndex-<rid>.tar.gz` / `.zip` バイナリおよび従来の `sha256sums.txt` と並んで CycloneDX 1.x JSON 形式の Software Bill of Materials を公開します。SBOM はピン留めした `dotnet CycloneDX` グローバルツールを `src/CodeIndex/CodeIndex.csproj` に対して `--exclude-test-projects` 付きで `linux-x64` lane でのみ 1 度だけ実行して生成し、`CodeIndex-sbom` ビルドアーティファクトとしてアップロード、`release-files/` にコピーして `sha256sums.txt` の対象に含めた上で release アセットとして配布します。SBOM は同梱の `Microsoft.Data.Sqlite` / `SQLitePCLRaw` 依存ツリーおよびネイティブ資産 `e_sqlite3` を含むすべての NuGet 依存を列挙するため、エンタープライズ利用者は .NET 固有の `.deps.json` から依存グラフを再構築することなく、SOC2 / FedRAMP 系のコンプライアンスレビューや Snyk / Trivy / Grype 等のサプライチェーンスキャナーを実行できます。`README.md` には SBOM の所在と `sha256sum --check` による簡易検証コマンドを記載した「Verifying releases / リリース成果物の検証」セクションを追加し、`DEVELOPER_GUIDE.md` のリリース構成要素テーブルにも SBOM を追加しています。

--- a/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
@@ -15,6 +15,45 @@ public class ReleaseWorkflowTests
         Assert.Contains("'\"version\":'", workflow);
     }
 
+    // Issue #1553: releases must ship a CycloneDX SBOM so enterprise consumers
+    // (SOC2/FedRAMP reviewers, Snyk/Trivy/Grype scanners) can verify transitive
+    // dependencies and bundled SQLitePCLRaw native assets without re-deriving
+    // them from .deps.json. The workflow contract is: generate one SBOM per
+    // release on the linux-x64 lane (content is RID-independent), upload it as
+    // an artifact, copy it into release-files so sha256sums.txt covers it, and
+    // ship it alongside the tarballs/zips on the GitHub release.
+    // Issue #1553 対応: リリースに CycloneDX SBOM を同梱し、SOC2/FedRAMP 等の
+    // コンプライアンスレビューや Snyk/Trivy/Grype 等のスキャナーが .deps.json
+    // から再構築せずに推移的依存と SQLitePCLRaw ネイティブアセットを検証できる
+    // ようにする。workflow 契約は、RID 非依存内容のため linux-x64 lane で 1 回
+    // だけ生成し、artifact として upload、release-files にコピーして
+    // sha256sums.txt の対象に含め、tarball/zip と一緒に GitHub release に同梱、
+    // という流れである。
+    [Fact]
+    public void ReleaseWorkflow_GeneratesCycloneDxSbomAndShipsItAsReleaseAsset()
+    {
+        var workflow = File.ReadAllText(Path.Combine(GetRepositoryRoot(), ".github", "workflows", "release.yml"));
+
+        // Pin the global tool to a known version so an upstream major release
+        // cannot silently shift the CLI surface (flag renames have happened
+        // between v4 -> v5 -> v6: `--json` was removed in favor of
+        // `--output-format Json`). 6.x is the current stable major and
+        // supports the modern `-o / -fn / -F / -t` flag surface.
+        // upstream の major リリースで CLI フラグが silent に変わるのを防ぐ
+        // ため、global tool をバージョン固定する (`--json` は v4→v5 で廃止され
+        // `--output-format Json` に置き換わったように、major 間で flag が
+        // 変更されている)。6.x は現行の安定 major で、`-o / -fn / -F / -t`
+        // 系のモダンフラグを備える。
+        Assert.Contains("dotnet tool install --global CycloneDX --version 6.2.0", workflow);
+        Assert.Contains("dotnet-CycloneDX src/CodeIndex/CodeIndex.csproj", workflow);
+        Assert.Contains("--output-format Json", workflow);
+        Assert.Contains("--exclude-test-projects", workflow);
+        Assert.Contains("cdidx.sbom.cdx.json", workflow);
+        Assert.Contains("CodeIndex-sbom", workflow);
+        Assert.Contains("matrix.rid == 'linux-x64'", workflow);
+        Assert.Contains("'*.cdx.json'", workflow);
+    }
+
     private static string GetRepositoryRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## Summary

- Generate a CycloneDX 1.x JSON SBOM (`cdidx.sbom.cdx.json`) once per release on the `linux-x64` matrix lane via the pinned `dotnet-CycloneDX` global tool (`--version 6.2.0`, `--output-format Json`, `--exclude-test-projects`), upload it as the `CodeIndex-sbom` artifact, copy it into `release-files/` so `sha256sums.txt` covers its hash, and ship it as a release asset alongside the per-RID tarballs/zips. Extend the asset-collection glob in `create-release` to also match `*.cdx.json`.
- The SBOM enumerates every NuGet dependency (including the bundled `Microsoft.Data.Sqlite` / `SQLitePCLRaw` graph and the native `e_sqlite3` asset), so SOC2 / FedRAMP-style compliance reviews and supply-chain scanners (Snyk, Trivy, Grype) can audit transitive dependencies without re-deriving them from the .NET-specific `.deps.json`. The CycloneDX tool only runs on the CI release runner and never lands in the shipped binary, so the production runtime-dependency policy is unchanged.
- Append `$HOME/.dotnet/tools` to `$GITHUB_PATH` in the install step because `actions/setup-dotnet@v4` does not put the global-tools directory on PATH for subsequent steps on GitHub-hosted runners.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReleaseWorkflowTests"` — passes (2/2).
- New test `ReleaseWorkflow_GeneratesCycloneDxSbomAndShipsItAsReleaseAsset` asserts the pinned `--version 6.2.0`, the `dotnet-CycloneDX src/CodeIndex/CodeIndex.csproj` invocation, the modern `--output-format Json` and `--exclude-test-projects` flag surface, the stable filename `cdidx.sbom.cdx.json`, the `CodeIndex-sbom` artifact name, the `matrix.rid == 'linux-x64'` gate, and the `*.cdx.json` glob clause in `create-release`, so accidental flag drift (e.g. `--json` → `--output-format Json` between CycloneDX majors) or removal of the SBOM step fails CI loudly.
- End-to-end SBOM generation is exercised only by the release workflow itself (it requires the GitHub Actions runner environment); the actual artifact will appear on the next `v*` tag.

## Documentation / Changelog

- Changelog fragment: `changelog.d/unreleased/1553.added.md` (bilingual `added` category).
- `README.md` (English + Japanese): new "Verifying releases / リリース成果物の検証" section documenting the SBOM location, intended consumers, and a `sha256sum --check` quick-verify command.
- `DEVELOPER_GUIDE.md` (English + Japanese): release "moving parts" table extended with the SBOM row alongside the existing per-RID binaries and `sha256sums.txt`.

## Follow-up candidates

- None identified for this PR. (Future work could add an SPDX SBOM in addition to CycloneDX, or sign release assets via Sigstore / cosign, but those are out of scope for #1553 which asks specifically for a CycloneDX or SPDX SBOM.)

Fixes #1553
