### PR TITLE
Stop re-registering SQL user functions on every DbReader construction (#1564)

### DIFF
--- a/changelog.d/unreleased/1564.changed.md
+++ b/changelog.d/unreleased/1564.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+issues:
+  - 1564
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **`DbReader` no longer re-registers SQL user functions on every construction (#1564)** — the ~20 SQL user functions (`sql_leaf_name`, `sql_normalize_name_folded`, `sql_resolve_reference_name`, etc.) are already registered once per connection by `DbContext`, so dropping the redundant call from the `DbReader` constructor removes wasted CPU on hot MCP/CLI paths that build a short-lived reader per request. Constructing a `DbReader` from a warm `DbContext.Connection` is now decoupled from the SQL function-table size.
+
+## 日本語
+
+- **`DbReader` のコンストラクタが SQL ユーザー関数を毎回再登録しなくなりました (#1564)** — `sql_leaf_name` / `sql_normalize_name_folded` / `sql_resolve_reference_name` を含む約 20 個の SQL ユーザー関数は `DbContext` が接続オープン時に一度だけ登録するため、`DbReader` コンストラクタからの再登録呼び出しを削除しました。MCP/CLI の hot path でリクエストごとに短命な reader を作るケースで無駄な CPU 消費を減らし、`DbReader` の構築コストを SQL 関数テーブルのサイズから切り離します。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -256,7 +256,11 @@ public partial class DbReader
     public DbReader(SqliteConnection connection, bool isReadOnly = false)
     {
         _conn = connection;
-        DbContext.RegisterConnectionFunctions(_conn);
+        // SQL user functions are registered once per connection by `DbContext` when the
+        // connection is opened. Re-registering on every `DbReader` construction wasted CPU
+        // on hot MCP/CLI paths that build a short-lived reader per request (#1564).
+        // SQL ユーザー関数は接続オープン時に `DbContext` が一度だけ登録するため、
+        // ここでの再登録は不要 (#1564)。
         _isReadOnly = isReadOnly;
         _fileColumns = LoadColumns("files");
         _symbolColumns = LoadColumns("symbols");

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -6142,19 +6142,18 @@ public class McpServerTests : IDisposable
             Assert.True(secondResponse["result"]!["structuredContent"]!["fold_ready"]!.GetValue<bool>());
             Assert.Null(secondResponse["result"]!["structuredContent"]!["fold_ready_reason"]);
 
-            using var verify = new SqliteConnection($"Data Source={dbPath}");
-            verify.Open();
-            using var userVerCmd = verify.CreateCommand();
+            using var verify = new DbContext(dbPath);
+            using var userVerCmd = verify.Connection.CreateCommand();
             userVerCmd.CommandText = "PRAGMA user_version";
             var userVersion = (long)userVerCmd.ExecuteScalar()!;
             Assert.NotEqual(0, userVersion & DbContext.FoldReadyFlag);
 
-            using var versionCmd = verify.CreateCommand();
+            using var versionCmd = verify.Connection.CreateCommand();
             versionCmd.CommandText = "SELECT value FROM codeindex_meta WHERE key = 'fold_key_version'";
             var storedVersion = versionCmd.ExecuteScalar() as string;
             Assert.Equal(NameFold.Version.ToString(), storedVersion);
 
-            var reader = new DbReader(verify);
+            var reader = new DbReader(verify.Connection, verify.IsReadOnly);
             Assert.Single(reader.SearchSymbols(new[] { "STRASSE" }, limit: 10, exact: true));
         }
         finally


### PR DESCRIPTION
## Summary

- Drop the redundant `DbContext.RegisterConnectionFunctions(_conn)` call from `DbReader`'s constructor. `DbContext` already registers the ~20 SQL user functions exactly once per connection in every constructor path (lines 131, 155, 175 of `src/CodeIndex/Database/DbContext.cs`), so the per-`DbReader` re-registration was idempotent but wasted CPU on hot MCP/CLI paths that build a short-lived reader per request.
- Update `McpServerTests.ToolsCall_Index_RestampsFoldReadyWhenFoldKeyVersionMismatchesButAllRowsAreRewritten` — the one site that constructed a `DbReader` from a raw `SqliteConnection` — to route the verification path through `DbContext`, matching the new contract that connections handed to `DbReader` are already registered.
- Bilingual changelog fragment at `changelog.d/unreleased/1564.changed.md` (category: `changed`).

## Validation

- `dotnet build CodeIndex.sln -c Release` — succeeds.
- `dotnet test CodeIndex.sln -c Release --no-build` — 4817 passed, 3 skipped, 0 failed.
- `dotnet run --project tools/CodeIndex.Changelog -- check` — 68 fragments validated.
- Codex adversarial review (`codex exec review --uncommitted`) — no blocking/actionable findings.

## Documentation / Changelog

- `changelog.d/unreleased/1564.changed.md` (bilingual, category: `changed`).
- No README / DEVELOPER_GUIDE / AGENT_GUIDE update needed: this is an internal performance refactor with no change to CLI/MCP user-facing surface.

Fixes #1564
