### PR TITLE
Add --palette flag and capability detection for ANSI color output (#1569)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -614,6 +614,7 @@ cdidx report --output report.tgz --json
 | `--reverse` | `deps` | Reverse lookup: show files that depend ON the matched path |
 | `--top <n>` | Query commands | Alias for `--limit` |
 | `--color <when>` | All commands | Control ANSI color output. Accepts `auto` (default), `always`, or `never`. Precedence: `--color` flag > `CLICOLOR_FORCE` > `NO_COLOR` > `CLICOLOR=0` > TTY auto-detect. Use `--color=always` to keep colored kind labels through a pager such as `cdidx symbols Foo \| less -R`; use `--color=never` (or `NO_COLOR=1`) to suppress ANSI even on a TTY. |
+| `--palette <name>` | All commands | Choose the ANSI palette used when color output is enabled. Accepts `basic` (8-color SGR 30–37, the default fallback for minimal SSH/CI terminals), `256` (256-color `\x1b[38;5;Nm`), or `truecolor` (24-bit RGB `\x1b[38;2;R;G;Bm`). Precedence: `--palette` flag > `CDIDX_COLOR_PALETTE` env var > `COLORTERM` / `TERM` auto-detect. The basic palette avoids `\x1b[90m` (bright-black / dim), which is unreadable on many minimal terminals. |
 | `--metrics <path>` | All commands (and MCP tool calls) | Append one JSONL metrics record per CLI command / MCP tool call to `<path>`. The `CDIDX_METRICS=<path>` environment variable provides the same destination as a fallback when the flag is not passed. Best-effort: any IO failure (missing directory, read-only mount, etc.) is swallowed silently and never breaks the underlying command. |
 
 If a query itself begins with `-`, pass it as `--query <query>` or `-- <query>`. If an option value itself begins with `--`, pass it as `--opt=<value>` rather than a separated value, for example `--path=--json-dir` or `--db=--tmp.db`.
@@ -675,6 +676,22 @@ If a query fails with a SQLite reader error such as `The data is NULL at ordinal
 | (none of the above) | — | Fall back to the default TTY check |
 
 `CLICOLOR_FORCE` has the highest precedence, then `NO_COLOR`, then `CLICOLOR=0`. An empty `NO_COLOR` (e.g. `NO_COLOR=` exported with no value) is ignored, matching the no-color.org specification.
+
+#### Palette selection
+
+When color is enabled, `cdidx` picks an ANSI palette so the same kind labels stay readable on minimal SSH/CI terminals and on truecolor-capable terminals alike. The `--palette` flag and `CDIDX_COLOR_PALETTE` environment variable override auto-detection:
+
+| Source | Value | Effect |
+|---|---|---|
+| `--palette` flag | `basic` \| `8` \| `16` \| `ansi` | Force the 8-color SGR palette (30–37); avoids `\x1b[90m` (bright-black / dim), which is unreadable on many minimal SSH/CI terminals |
+| `--palette` flag | `256` \| `color256` \| `8bit` | Force the 256-color palette (`\x1b[38;5;Nm`) |
+| `--palette` flag | `truecolor` \| `24bit` \| `rgb` | Force the 24-bit RGB palette (`\x1b[38;2;R;G;Bm`) |
+| `CDIDX_COLOR_PALETTE` env var | same value set as above | Same as `--palette` when the flag is not passed |
+| `COLORTERM` env var | `truecolor` \| `24bit` | Auto-detect truecolor |
+| `TERM` env var | contains `256color` | Auto-detect 256-color |
+| (none of the above) | — | Fall back to the basic 8-color palette |
+
+Precedence: `--palette` flag > `CDIDX_COLOR_PALETTE` > `COLORTERM` / `TERM` auto-detect. `NO_COLOR` / `--color=never` consistently suppress ANSI escapes across every palette, so opting out of color always wins over palette selection.
 
 ### Metrics emission
 
@@ -1814,6 +1831,7 @@ cdidx report --output report.tgz --json
 | `--reverse` | `deps` | 逆引き: 指定パスに依存しているファイルを表示 |
 | `--top <n>` | クエリ系 | `--limit` のエイリアス |
 | `--color <when>` | 全コマンド | ANSI カラー出力の制御。`auto`（既定）、`always`、`never` を受け付ける。優先順位: `--color` フラグ > `CLICOLOR_FORCE` > `NO_COLOR` > `CLICOLOR=0` > TTY 自動判定。`cdidx symbols Foo \| less -R` のような pager pipe でも色を維持したい場合は `--color=always`、TTY 上でも ANSI を抑止したい場合は `--color=never`（または `NO_COLOR=1`）を指定する。 |
+| `--palette <name>` | 全コマンド | カラー出力が有効なときに用いる ANSI パレットを選択する。`basic`（標準8色 SGR 30–37、最小 SSH/CI 端末向けの既定フォールバック）、`256`（256色 `\x1b[38;5;Nm`）、`truecolor`（24ビット RGB `\x1b[38;2;R;G;Bm`）を受け付ける。優先順位: `--palette` フラグ > `CDIDX_COLOR_PALETTE` 環境変数 > `COLORTERM` / `TERM` 自動判定。`basic` パレットは最小端末で読みにくい `\x1b[90m`（暗灰 / dim）を避ける。 |
 | `--metrics <path>` | 全コマンド（および MCP ツール呼び出し） | CLI コマンド / MCP ツール呼び出し 1 回ごとに JSONL レコードを 1 行ずつ `<path>` に追記する。フラグ未指定時のフォールバックとして `CDIDX_METRICS=<path>` 環境変数でも同じ出力先を指定できる。Best-effort のため、ディレクトリが無い・read-only マウント等の IO 失敗は黙って握り潰し、本体コマンドを壊さない。 |
 
 クエリ自体が `-` で始まる場合は `--query <query>` または `-- <query>` で渡してください。オプション値自体が `--` で始まる場合は、分離形式ではなく `--opt=<value>` で渡します。たとえば `--path=--json-dir` や `--db=--tmp.db` のように指定します。
@@ -1873,6 +1891,22 @@ MCP ツールで catch-all まで突き抜けた例外（想定外の SQLite 例
 | 上記いずれも未設定 | — | 既定の TTY 判定にフォールバック |
 
 優先順位は `CLICOLOR_FORCE` → `NO_COLOR` → `CLICOLOR=0` の順です。値が空の `NO_COLOR`（例: `NO_COLOR=` のみ export）は no-color.org の仕様に従い無視されます。
+
+#### パレット選択
+
+カラー出力が有効なとき、`cdidx` は最小 SSH/CI 端末でも truecolor 対応端末でも同じシンボル種別ラベルが読みやすくなる ANSI パレットを選択します。`--palette` フラグおよび `CDIDX_COLOR_PALETTE` 環境変数で自動判定を上書きできます:
+
+| 設定元 | 値 | 動作 |
+|---|---|---|
+| `--palette` フラグ | `basic` \| `8` \| `16` \| `ansi` | 標準8色 SGR (30–37) を強制。最小 SSH/CI 端末で読みにくい `\x1b[90m`（暗灰 / dim）を避ける |
+| `--palette` フラグ | `256` \| `color256` \| `8bit` | 256色パレット (`\x1b[38;5;Nm`) を強制 |
+| `--palette` フラグ | `truecolor` \| `24bit` \| `rgb` | 24ビット RGB パレット (`\x1b[38;2;R;G;Bm`) を強制 |
+| `CDIDX_COLOR_PALETTE` 環境変数 | 上記と同じ値 | フラグが未指定のときに `--palette` と同じ意味で適用 |
+| `COLORTERM` 環境変数 | `truecolor` \| `24bit` | truecolor として自動判定 |
+| `TERM` 環境変数 | `256color` を含む | 256色として自動判定 |
+| 上記いずれも無し | — | 標準8色 (basic) にフォールバック |
+
+優先順位は `--palette` フラグ → `CDIDX_COLOR_PALETTE` → `COLORTERM` / `TERM` 自動判定の順です。`NO_COLOR` / `--color=never` はパレット選択に関わらず ANSI エスケープを抑止し、色をオフにする選択が常に優先されます。
 
 ### メトリクス出力
 

--- a/changelog.d/unreleased/1569.added.md
+++ b/changelog.d/unreleased/1569.added.md
@@ -1,0 +1,19 @@
+---
+category: added
+issues:
+  - 1569
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`--palette` flag and `CDIDX_COLOR_PALETTE` env var pick the ANSI palette; `basic` no longer emits unreadable `\x1b[90m` dim (#1569)** — `ColorizeKind` previously hard-coded 8 ANSI colors plus `\x1b[90m` (bright-black / dim) without inspecting terminal capability, so SSH and CI terminals that render dim as invisible silently lost the `namespace` and `import` labels, and truecolor-capable terminals saw the same coarse 16-color rendering. `cdidx` now resolves a palette via `--palette basic|256|truecolor` (with aliases `8`/`16`/`ansi`, `color256`/`8bit`, `24bit`/`rgb`) and a matching `CDIDX_COLOR_PALETTE` environment variable, falling back to `COLORTERM=truecolor|24bit` and `TERM=*256color*` auto-detection and finally to the safer `basic` palette. The basic palette is now strictly 8-color (SGR 30–37): `namespace` and `import` use white (`\x1b[37m`) instead of `\x1b[90m`, so minimal terminals stay readable. The 256-color and truecolor palettes emit higher-contrast `\x1b[38;5;Nm` / `\x1b[38;2;R;G;Bm` codes on capable terminals. `NO_COLOR` / `--color=never` continue to suppress ANSI escapes across every palette.
+
+## 日本語
+
+- **`--palette` フラグと `CDIDX_COLOR_PALETTE` 環境変数で ANSI パレットを選択でき、`basic` では読めない `\x1b[90m` の dim を出力しなくなりました (#1569)** — これまで `ColorizeKind` は端末の能力を確認せずに ANSI 8色＋ `\x1b[90m`（暗灰 / dim）をハードコードしていたため、dim が見えにくい SSH / CI 端末では `namespace` / `import` のラベルが事実上消え、truecolor 対応端末でも同じ 16色の粗い表示しか得られませんでした。今後は `--palette basic|256|truecolor`（エイリアス `8`/`16`/`ansi`、`color256`/`8bit`、`24bit`/`rgb` も可）と対応する `CDIDX_COLOR_PALETTE` 環境変数で明示的にパレットを選べ、未指定時は `COLORTERM=truecolor|24bit` / `TERM=*256color*` を自動判定し、最終的により安全な `basic` にフォールバックします。`basic` パレットは厳密に 8色 (SGR 30–37) のみを使い、`namespace` / `import` は `\x1b[90m` ではなく白 (`\x1b[37m`) を使うため、最小端末でも可読性を保てます。256色 / truecolor パレットは対応端末で高コントラストな `\x1b[38;5;Nm` / `\x1b[38;2;R;G;Bm` を出力します。`NO_COLOR` / `--color=never` は全パレットで引き続き ANSI を抑止します。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -20,6 +20,28 @@ public enum ColorMode
 }
 
 /// <summary>
+/// ANSI color palette to use when color output is enabled. <see cref="Basic"/>
+/// stays within the 8 standard SGR colors (30–37) and avoids the bright-black
+/// dim escape (<c>\x1b[90m</c>), which is unreadable on many SSH/CI terminals.
+/// <see cref="Color256"/> uses 256-color codes (`\x1b[38;5;Nm`) for higher
+/// contrast on capable terminals. <see cref="Truecolor"/> uses 24-bit RGB
+/// (`\x1b[38;2;R;G;Bm`) for terminals that advertise truecolor via
+/// <c>COLORTERM=truecolor|24bit</c>.
+/// 色出力で使用する ANSI パレット。Basic は標準8色のみで `\x1b[90m`（dim）を
+/// 避け、SSH / CI 端末でも可読性を確保する。Color256 / Truecolor はそれぞれ
+/// 256色 / 24ビットRGB を用い、対応端末で高コントラストを実現する。
+/// </summary>
+public enum ColorPalette
+{
+    /// <summary>Standard 8-color ANSI palette (30–37); avoids dim (`\x1b[90m`).</summary>
+    Basic = 0,
+    /// <summary>256-color ANSI palette (`\x1b[38;5;Nm`).</summary>
+    Color256 = 1,
+    /// <summary>24-bit RGB / truecolor palette (`\x1b[38;2;R;G;Bm`).</summary>
+    Truecolor = 2,
+}
+
+/// <summary>
 /// Console UI helpers: spinner, progress bar, banner, and easter egg messages.
 /// コンソールUIヘルパー: スピナー、プログレスバー、バナー、イースターエッグメッセージ。
 /// </summary>
@@ -430,6 +452,7 @@ public static class ConsoleUi
         Console.WriteLine("  --commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)");
         Console.WriteLine("  --files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed");
         Console.WriteLine("  --color <when>             Color output: `auto` (default), `always`, or `never`; flag wins over `CLICOLOR_FORCE` / `NO_COLOR` / `CLICOLOR` env vars, which win over TTY auto-detect");
+        Console.WriteLine("  --palette <name>           ANSI palette: `basic` (8-color, default fallback), `256`, or `truecolor`; flag wins over `CDIDX_COLOR_PALETTE` env var, which wins over `COLORTERM` / `TERM` auto-detect");
         Console.WriteLine("  --metrics <path>           Append one JSONL record per CLI command / MCP tool call to <path> (also honors CDIDX_METRICS=<path>)");
         Console.WriteLine("  --help, -h                 Show this help message");
         Console.WriteLine("  --version, -V              Show version information");
@@ -883,6 +906,7 @@ _cdidx";
     // --- Helpers / ヘルパー ---
 
     private static ColorMode _colorMode = ColorMode.Auto;
+    private static ColorPalette? _explicitPalette;
 
     /// <summary>
     /// Set the active color-output mode. <see cref="ColorMode.Always"/> and
@@ -894,6 +918,94 @@ _cdidx";
     public static void SetColorMode(ColorMode mode) => _colorMode = mode;
 
     internal static ColorMode GetColorMode() => _colorMode;
+
+    /// <summary>
+    /// Override the active ANSI palette. <c>null</c> restores auto-detection
+    /// via <c>COLORTERM</c> / <c>TERM</c> / <c>CDIDX_COLOR_PALETTE</c>.
+    /// </summary>
+    public static void SetColorPalette(ColorPalette? palette) => _explicitPalette = palette;
+
+    internal static ColorPalette? GetExplicitColorPalette() => _explicitPalette;
+
+    /// <summary>
+    /// Parse a user-supplied `--palette` value. Accepts `basic`, `256`,
+    /// `color256`, `truecolor`, and `24bit` (case-insensitive). Returns false
+    /// on any other value.
+    /// `--palette` 値を解析する。`basic` / `256` / `truecolor` などを許可する。
+    /// </summary>
+    public static bool TryParseColorPalette(string? value, out ColorPalette palette)
+    {
+        switch (value?.Trim().ToLowerInvariant())
+        {
+            case "basic":
+            case "8":
+            case "16":
+            case "ansi":
+                palette = ColorPalette.Basic;
+                return true;
+            case "256":
+            case "color256":
+            case "8bit":
+                palette = ColorPalette.Color256;
+                return true;
+            case "truecolor":
+            case "24bit":
+            case "rgb":
+                palette = ColorPalette.Truecolor;
+                return true;
+            default:
+                palette = ColorPalette.Basic;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Resolve the palette to use. Honors the explicit override set via
+    /// <see cref="SetColorPalette"/> first, then falls back to the
+    /// <c>CDIDX_COLOR_PALETTE</c> environment variable, then to capability
+    /// detection from <c>COLORTERM</c> / <c>TERM</c>.
+    /// </summary>
+    public static ColorPalette ResolveColorPalette()
+    {
+        if (_explicitPalette is { } explicitPalette)
+            return explicitPalette;
+
+        var envPalette = Environment.GetEnvironmentVariable("CDIDX_COLOR_PALETTE");
+        if (!string.IsNullOrWhiteSpace(envPalette) && TryParseColorPalette(envPalette, out var parsed))
+            return parsed;
+
+        return DetectColorPalette();
+    }
+
+    /// <summary>
+    /// Detect the terminal palette from the <c>COLORTERM</c> and <c>TERM</c>
+    /// environment variables. <c>COLORTERM=truecolor</c> / <c>COLORTERM=24bit</c>
+    /// → <see cref="ColorPalette.Truecolor"/>. <c>TERM</c> containing
+    /// <c>256color</c> (e.g. <c>xterm-256color</c>, <c>screen-256color</c>) →
+    /// <see cref="ColorPalette.Color256"/>. Otherwise <see cref="ColorPalette.Basic"/>.
+    /// </summary>
+    internal static ColorPalette DetectColorPalette()
+    {
+        var colorTerm = Environment.GetEnvironmentVariable("COLORTERM");
+        if (!string.IsNullOrEmpty(colorTerm))
+        {
+            var ct = colorTerm.Trim().ToLowerInvariant();
+            if (ct == "truecolor" || ct == "24bit")
+                return ColorPalette.Truecolor;
+        }
+
+        var term = Environment.GetEnvironmentVariable("TERM");
+        if (!string.IsNullOrEmpty(term))
+        {
+            var t = term.ToLowerInvariant();
+            if (t.Contains("256color", StringComparison.Ordinal))
+                return ColorPalette.Color256;
+            if (t.Contains("truecolor", StringComparison.Ordinal) || t.Contains("direct", StringComparison.Ordinal))
+                return ColorPalette.Truecolor;
+        }
+
+        return ColorPalette.Basic;
+    }
 
     /// <summary>
     /// Parse a user-supplied `--color` value. Accepts `auto`, `always`, and
@@ -931,25 +1043,64 @@ _cdidx";
         var padded = padWidth > 0 ? kind.PadRight(padWidth) : kind;
         if (ShouldUseColor())
         {
-            var color = kind switch
-            {
-                "class" => "\x1b[36m",      // cyan / シアン
-                "struct" => "\x1b[36m",     // cyan / シアン
-                "interface" => "\x1b[34m",  // blue / 青
-                "enum" => "\x1b[35m",       // magenta / マゼンタ
-                "function" => "\x1b[33m",   // yellow / 黄
-                "property" => "\x1b[32m",   // green / 緑
-                "event" => "\x1b[31m",      // red / 赤
-                "delegate" => "\x1b[35m",   // magenta / マゼンタ
-                "namespace" => "\x1b[90m",  // dim / 暗灰
-                "import" => "\x1b[90m",     // dim / 暗灰
-                _ => "",
-            };
+            var color = GetKindColorCode(kind, ResolveColorPalette());
             if (color.Length > 0)
                 return $"{color}{padded}\x1b[0m";
         }
         return padded;
     }
+
+    // Per-palette SGR introducer for a given symbol kind. Basic stays within
+    // the 8 standard ANSI colors (30–37) and intentionally avoids
+    // `\x1b[90m` (bright-black / dim), which is unreadable on many minimal
+    // SSH / CI terminals; namespace / import fall back to plain white (37).
+    // 各パレットでのシンボル種別ごとの SGR コード。Basic は標準8色のみで
+    // dim (`\x1b[90m`) を避け、SSH/CI 端末でも可読性を確保する。
+    internal static string GetKindColorCode(string kind, ColorPalette palette) => palette switch
+    {
+        ColorPalette.Truecolor => kind switch
+        {
+            "class" => "\x1b[38;2;102;217;239m",     // bright cyan
+            "struct" => "\x1b[38;2;102;217;239m",
+            "interface" => "\x1b[38;2;102;160;255m",  // bright blue
+            "enum" => "\x1b[38;2;215;110;215m",       // bright magenta
+            "function" => "\x1b[38;2;255;215;75m",    // gold yellow
+            "property" => "\x1b[38;2;160;230;100m",   // bright green
+            "event" => "\x1b[38;2;255;100;100m",      // bright red
+            "delegate" => "\x1b[38;2;215;110;215m",
+            "namespace" => "\x1b[38;2;180;180;180m",  // light gray (readable on dark + light bg)
+            "import" => "\x1b[38;2;180;180;180m",
+            _ => "",
+        },
+        ColorPalette.Color256 => kind switch
+        {
+            "class" => "\x1b[38;5;81m",     // cyan
+            "struct" => "\x1b[38;5;81m",
+            "interface" => "\x1b[38;5;75m",  // blue
+            "enum" => "\x1b[38;5;213m",      // magenta
+            "function" => "\x1b[38;5;221m",  // gold
+            "property" => "\x1b[38;5;120m",  // green
+            "event" => "\x1b[38;5;203m",     // salmon red
+            "delegate" => "\x1b[38;5;213m",
+            "namespace" => "\x1b[38;5;245m", // medium gray (not as dim as 90m)
+            "import" => "\x1b[38;5;245m",
+            _ => "",
+        },
+        _ => kind switch
+        {
+            "class" => "\x1b[36m",      // cyan / シアン
+            "struct" => "\x1b[36m",     // cyan / シアン
+            "interface" => "\x1b[34m",  // blue / 青
+            "enum" => "\x1b[35m",       // magenta / マゼンタ
+            "function" => "\x1b[33m",   // yellow / 黄
+            "property" => "\x1b[32m",   // green / 緑
+            "event" => "\x1b[31m",      // red / 赤
+            "delegate" => "\x1b[35m",   // magenta / マゼンタ
+            "namespace" => "\x1b[37m",  // white (instead of dim 90m) / 白（dim 回避）
+            "import" => "\x1b[37m",     // white (instead of dim 90m) / 白（dim 回避）
+            _ => "",
+        },
+    };
 
     internal static bool ShouldUseInteractiveConsole()
     {

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -23,6 +23,14 @@ internal static class ProgramRunner
             return CommandExitCodes.UsageError;
         }
 
+        if (!TryConsumePaletteFlag(ref args, out var paletteError))
+        {
+            Console.Error.WriteLine(paletteError);
+            Console.Error.WriteLine("Hint: use one of `basic`, `256`, `truecolor`.");
+            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.UsageError} palette_flag_invalid=true");
+            return CommandExitCodes.UsageError;
+        }
+
         if (!TryConsumeMetricsFlag(ref args, out var metricsPath, out var metricsError))
         {
             Console.Error.WriteLine(metricsError);
@@ -224,6 +232,71 @@ internal static class ProgramRunner
 
         if (requested.HasValue)
             ConsoleUi.SetColorMode(requested.Value);
+        args = kept.ToArray();
+        return true;
+    }
+
+    // Strip `--palette <name>` / `--palette=<name>` from `args` before
+    // subcommand parsing. Mirrors `TryConsumeColorFlag` so any subcommand
+    // (CLI or MCP) inherits the chosen ANSI palette without re-parsing.
+    // Anything after `--` is passed through verbatim so subcommand
+    // query-escape semantics are preserved (#1569).
+    internal static bool TryConsumePaletteFlag(ref string[] args, out string error)
+    {
+        error = string.Empty;
+        ConsoleUi.SetColorPalette(null);
+        if (args.Length == 0)
+            return true;
+
+        var kept = new List<string>(args.Length);
+        ColorPalette? requested = null;
+        var passthrough = false;
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+
+            if (passthrough)
+            {
+                kept.Add(arg);
+                continue;
+            }
+            if (arg == "--")
+            {
+                passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+
+            string? rawValue = null;
+            if (arg == "--palette")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    error = "Error: --palette requires a value (one of `basic`, `256`, `truecolor`).";
+                    return false;
+                }
+                rawValue = args[++i];
+            }
+            else if (arg.StartsWith("--palette=", StringComparison.Ordinal))
+            {
+                rawValue = arg.Substring("--palette=".Length);
+            }
+            else
+            {
+                kept.Add(arg);
+                continue;
+            }
+
+            if (!ConsoleUi.TryParseColorPalette(rawValue, out var palette))
+            {
+                error = $"Error: invalid --palette value `{rawValue}`.";
+                return false;
+            }
+            requested = palette;
+        }
+
+        if (requested.HasValue)
+            ConsoleUi.SetColorPalette(requested.Value);
         args = kept.ToArray();
         return true;
     }

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -555,11 +555,22 @@ public class ConsoleUiTests
             var originalNoColor = Environment.GetEnvironmentVariable("NO_COLOR");
             var originalCliColor = Environment.GetEnvironmentVariable("CLICOLOR");
             var originalCliColorForce = Environment.GetEnvironmentVariable("CLICOLOR_FORCE");
+            var originalColorTerm = Environment.GetEnvironmentVariable("COLORTERM");
+            var originalTerm = Environment.GetEnvironmentVariable("TERM");
+            var originalPaletteEnv = Environment.GetEnvironmentVariable("CDIDX_COLOR_PALETTE");
+            var originalPalette = ConsoleUi.GetExplicitColorPalette();
             try
             {
                 Environment.SetEnvironmentVariable("NO_COLOR", noColor);
                 Environment.SetEnvironmentVariable("CLICOLOR", cliColor);
                 Environment.SetEnvironmentVariable("CLICOLOR_FORCE", cliColorForce);
+                // These ANSI-code assertions predate the palette feature and assume
+                // the 8-color basic palette; pin it explicitly so the host's
+                // COLORTERM/TERM cannot upgrade the palette mid-test.
+                Environment.SetEnvironmentVariable("COLORTERM", null);
+                Environment.SetEnvironmentVariable("TERM", null);
+                Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", null);
+                ConsoleUi.SetColorPalette(ColorPalette.Basic);
                 action();
             }
             finally
@@ -567,6 +578,10 @@ public class ConsoleUiTests
                 Environment.SetEnvironmentVariable("NO_COLOR", originalNoColor);
                 Environment.SetEnvironmentVariable("CLICOLOR", originalCliColor);
                 Environment.SetEnvironmentVariable("CLICOLOR_FORCE", originalCliColorForce);
+                Environment.SetEnvironmentVariable("COLORTERM", originalColorTerm);
+                Environment.SetEnvironmentVariable("TERM", originalTerm);
+                Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", originalPaletteEnv);
+                ConsoleUi.SetColorPalette(originalPalette);
             }
         }
     }
@@ -671,13 +686,221 @@ public class ConsoleUiTests
         Assert.Contains("CLICOLOR_FORCE", output);
     }
 
+    [Fact]
+    public void PrintUsage_DocumentsPaletteFlag()
+    {
+        var output = CaptureUsageOutput(showBanner: false);
+        Assert.Contains("--palette <name>", output);
+        Assert.Contains("`basic`", output);
+        Assert.Contains("`256`", output);
+        Assert.Contains("`truecolor`", output);
+        Assert.Contains("COLORTERM", output);
+        Assert.Contains("CDIDX_COLOR_PALETTE", output);
+    }
+
+    [Theory]
+    [InlineData("basic", ColorPalette.Basic)]
+    [InlineData("BASIC", ColorPalette.Basic)]
+    [InlineData("8", ColorPalette.Basic)]
+    [InlineData("16", ColorPalette.Basic)]
+    [InlineData("ansi", ColorPalette.Basic)]
+    [InlineData("256", ColorPalette.Color256)]
+    [InlineData("color256", ColorPalette.Color256)]
+    [InlineData("8bit", ColorPalette.Color256)]
+    [InlineData("truecolor", ColorPalette.Truecolor)]
+    [InlineData("24bit", ColorPalette.Truecolor)]
+    [InlineData("rgb", ColorPalette.Truecolor)]
+    [InlineData(" Truecolor ", ColorPalette.Truecolor)]
+    public void TryParseColorPalette_KnownValue_ReturnsTrue(string value, ColorPalette expected)
+    {
+        Assert.True(ConsoleUi.TryParseColorPalette(value, out var palette));
+        Assert.Equal(expected, palette);
+    }
+
+    [Theory]
+    [InlineData("on")]
+    [InlineData("none")]
+    [InlineData("fancy")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryParseColorPalette_UnknownValue_ReturnsFalse(string? value)
+    {
+        Assert.False(ConsoleUi.TryParseColorPalette(value, out _));
+    }
+
+    [Fact]
+    public void ColorizeKind_BasicPalette_DoesNotEmitDimEscape()
+    {
+        // The dim escape `\x1b[90m` (bright black) is unreadable on many
+        // minimal SSH / CI terminals; the basic palette must avoid it (#1569).
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        ConsoleUi.SetColorMode(ColorMode.Always);
+        ConsoleUi.SetColorPalette(ColorPalette.Basic);
+
+        foreach (var kind in new[] { "namespace", "import", "class", "function" })
+        {
+            var output = ConsoleUi.ColorizeKind(kind);
+            Assert.DoesNotContain("\x1b[90m", output);
+        }
+    }
+
+    [Fact]
+    public void ColorizeKind_Color256Palette_EmitsExtendedSgrCodes()
+    {
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        ConsoleUi.SetColorMode(ColorMode.Always);
+        ConsoleUi.SetColorPalette(ColorPalette.Color256);
+
+        var output = ConsoleUi.ColorizeKind("class");
+        Assert.StartsWith("\x1b[38;5;", output);
+        Assert.EndsWith("\x1b[0m", output);
+    }
+
+    [Fact]
+    public void ColorizeKind_TruecolorPalette_EmitsRgbSgrCodes()
+    {
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        ConsoleUi.SetColorMode(ColorMode.Always);
+        ConsoleUi.SetColorPalette(ColorPalette.Truecolor);
+
+        var output = ConsoleUi.ColorizeKind("class");
+        Assert.StartsWith("\x1b[38;2;", output);
+        Assert.EndsWith("\x1b[0m", output);
+    }
+
+    [Fact]
+    public void ResolveColorPalette_ExplicitOverrideWins()
+    {
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        Environment.SetEnvironmentVariable("COLORTERM", "truecolor");
+        Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", "256");
+        ConsoleUi.SetColorPalette(ColorPalette.Basic);
+
+        Assert.Equal(ColorPalette.Basic, ConsoleUi.ResolveColorPalette());
+    }
+
+    [Fact]
+    public void ResolveColorPalette_EnvVarWinsOverDetection()
+    {
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        Environment.SetEnvironmentVariable("COLORTERM", "truecolor");
+        Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", "basic");
+        ConsoleUi.SetColorPalette(null);
+
+        Assert.Equal(ColorPalette.Basic, ConsoleUi.ResolveColorPalette());
+    }
+
+    [Fact]
+    public void ResolveColorPalette_ColorTermTruecolor_DetectedAsTruecolor()
+    {
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        Environment.SetEnvironmentVariable("COLORTERM", "truecolor");
+        Environment.SetEnvironmentVariable("TERM", "xterm");
+        ConsoleUi.SetColorPalette(null);
+
+        Assert.Equal(ColorPalette.Truecolor, ConsoleUi.ResolveColorPalette());
+    }
+
+    [Fact]
+    public void ResolveColorPalette_ColorTerm24bit_DetectedAsTruecolor()
+    {
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        Environment.SetEnvironmentVariable("COLORTERM", "24bit");
+        Environment.SetEnvironmentVariable("TERM", "xterm");
+        ConsoleUi.SetColorPalette(null);
+
+        Assert.Equal(ColorPalette.Truecolor, ConsoleUi.ResolveColorPalette());
+    }
+
+    [Fact]
+    public void ResolveColorPalette_Term256color_DetectedAsColor256()
+    {
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        Environment.SetEnvironmentVariable("COLORTERM", null);
+        Environment.SetEnvironmentVariable("TERM", "xterm-256color");
+        ConsoleUi.SetColorPalette(null);
+
+        Assert.Equal(ColorPalette.Color256, ConsoleUi.ResolveColorPalette());
+    }
+
+    [Fact]
+    public void ResolveColorPalette_MinimalTerm_FallsBackToBasic()
+    {
+        using var env = new ColorEnvironmentScope();
+        using var pal = new ColorPaletteScope();
+        Environment.SetEnvironmentVariable("COLORTERM", null);
+        Environment.SetEnvironmentVariable("TERM", "xterm");
+        ConsoleUi.SetColorPalette(null);
+
+        Assert.Equal(ColorPalette.Basic, ConsoleUi.ResolveColorPalette());
+    }
+
+    [Fact]
+    public void ColorizeKind_NoColorRequested_SuppressesAllPalettes()
+    {
+        // NO_COLOR must consistently suppress ANSI escapes across every palette
+        // so users opting out via the env standard get clean output regardless
+        // of `--palette` (#1569).
+        foreach (var palette in new[] { ColorPalette.Basic, ColorPalette.Color256, ColorPalette.Truecolor })
+        {
+            using var env = new ColorEnvironmentScope();
+            using var pal = new ColorPaletteScope();
+            Environment.SetEnvironmentVariable("NO_COLOR", "1");
+            ConsoleUi.SetColorPalette(palette);
+
+            var output = ConsoleUi.ColorizeKind("class");
+            Assert.DoesNotContain('\x1b', output);
+            Assert.Equal("class", output);
+        }
+    }
+
+    private sealed class ColorPaletteScope : IDisposable
+    {
+        private readonly ColorPalette? _original;
+        private readonly string? _originalEnv;
+        private readonly string? _originalColorTerm;
+        private readonly string? _originalTerm;
+
+        public ColorPaletteScope()
+        {
+            _original = ConsoleUi.GetExplicitColorPalette();
+            _originalEnv = Environment.GetEnvironmentVariable("CDIDX_COLOR_PALETTE");
+            _originalColorTerm = Environment.GetEnvironmentVariable("COLORTERM");
+            _originalTerm = Environment.GetEnvironmentVariable("TERM");
+            Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", null);
+            Environment.SetEnvironmentVariable("COLORTERM", null);
+            Environment.SetEnvironmentVariable("TERM", null);
+            ConsoleUi.SetColorPalette(null);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", _originalEnv);
+            Environment.SetEnvironmentVariable("COLORTERM", _originalColorTerm);
+            Environment.SetEnvironmentVariable("TERM", _originalTerm);
+            ConsoleUi.SetColorPalette(_original);
+        }
+    }
+
     private sealed class ColorEnvironmentScope : IDisposable
     {
         private readonly bool _lockTaken;
         private readonly string? _originalNoColor;
         private readonly string? _originalForce;
         private readonly string? _originalCliColor;
+        private readonly string? _originalColorTerm;
+        private readonly string? _originalTerm;
+        private readonly string? _originalPaletteEnv;
         private readonly ColorMode _originalMode;
+        private readonly ColorPalette? _originalPalette;
 
         public ColorEnvironmentScope()
         {
@@ -686,10 +909,18 @@ public class ConsoleUiTests
             _originalNoColor = Environment.GetEnvironmentVariable("NO_COLOR");
             _originalForce = Environment.GetEnvironmentVariable("CLICOLOR_FORCE");
             _originalCliColor = Environment.GetEnvironmentVariable("CLICOLOR");
+            _originalColorTerm = Environment.GetEnvironmentVariable("COLORTERM");
+            _originalTerm = Environment.GetEnvironmentVariable("TERM");
+            _originalPaletteEnv = Environment.GetEnvironmentVariable("CDIDX_COLOR_PALETTE");
             _originalMode = ConsoleUi.GetColorMode();
+            _originalPalette = ConsoleUi.GetExplicitColorPalette();
             Environment.SetEnvironmentVariable("NO_COLOR", null);
             Environment.SetEnvironmentVariable("CLICOLOR_FORCE", null);
             Environment.SetEnvironmentVariable("CLICOLOR", null);
+            Environment.SetEnvironmentVariable("COLORTERM", null);
+            Environment.SetEnvironmentVariable("TERM", null);
+            Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", null);
+            ConsoleUi.SetColorPalette(null);
         }
 
         public void Dispose()
@@ -697,7 +928,11 @@ public class ConsoleUiTests
             Environment.SetEnvironmentVariable("NO_COLOR", _originalNoColor);
             Environment.SetEnvironmentVariable("CLICOLOR_FORCE", _originalForce);
             Environment.SetEnvironmentVariable("CLICOLOR", _originalCliColor);
+            Environment.SetEnvironmentVariable("COLORTERM", _originalColorTerm);
+            Environment.SetEnvironmentVariable("TERM", _originalTerm);
+            Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", _originalPaletteEnv);
             ConsoleUi.SetColorMode(_originalMode);
+            ConsoleUi.SetColorPalette(_originalPalette);
             if (_lockTaken)
                 Monitor.Exit(TestConsoleLock.Gate);
         }

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -297,6 +297,123 @@ public class ProgramRunnerTests
         Assert.Contains("Hint:", stderr);
     }
 
+    [Theory]
+    [InlineData(new[] { "--palette=truecolor", "status" }, ColorPalette.Truecolor, new[] { "status" })]
+    [InlineData(new[] { "status", "--palette", "256" }, ColorPalette.Color256, new[] { "status" })]
+    [InlineData(new[] { "search", "--palette=basic", "foo" }, ColorPalette.Basic, new[] { "search", "foo" })]
+    public void TryConsumePaletteFlag_StripsFlagAndSetsPalette(string[] input, ColorPalette expected, string[] expectedKept)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var original = ConsoleUi.GetExplicitColorPalette();
+            try
+            {
+                var args = input;
+                Assert.True(ProgramRunner.TryConsumePaletteFlag(ref args, out var error));
+                Assert.Empty(error);
+                Assert.Equal(expected, ConsoleUi.GetExplicitColorPalette());
+                Assert.Equal(expectedKept, args);
+            }
+            finally
+            {
+                ConsoleUi.SetColorPalette(original);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryConsumePaletteFlag_NoFlag_ClearsExplicitOverride()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var original = ConsoleUi.GetExplicitColorPalette();
+            try
+            {
+                ConsoleUi.SetColorPalette(ColorPalette.Truecolor);
+                var args = new[] { "status" };
+                Assert.True(ProgramRunner.TryConsumePaletteFlag(ref args, out var error));
+                Assert.Empty(error);
+                Assert.Null(ConsoleUi.GetExplicitColorPalette());
+                Assert.Equal(new[] { "status" }, args);
+            }
+            finally
+            {
+                ConsoleUi.SetColorPalette(original);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryConsumePaletteFlag_InvalidValue_ReturnsError()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var original = ConsoleUi.GetExplicitColorPalette();
+            try
+            {
+                var args = new[] { "search", "--palette=fancy" };
+                Assert.False(ProgramRunner.TryConsumePaletteFlag(ref args, out var error));
+                Assert.Contains("fancy", error);
+            }
+            finally
+            {
+                ConsoleUi.SetColorPalette(original);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryConsumePaletteFlag_MissingValue_ReturnsError()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var original = ConsoleUi.GetExplicitColorPalette();
+            try
+            {
+                var args = new[] { "search", "--palette" };
+                Assert.False(ProgramRunner.TryConsumePaletteFlag(ref args, out var error));
+                Assert.Contains("requires a value", error);
+            }
+            finally
+            {
+                ConsoleUi.SetColorPalette(original);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryConsumePaletteFlag_AfterDoubleDash_PreservesQueryEscape()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var original = ConsoleUi.GetExplicitColorPalette();
+            try
+            {
+                var args = new[] { "search", "--", "--palette=truecolor" };
+                Assert.True(ProgramRunner.TryConsumePaletteFlag(ref args, out var error));
+                Assert.Empty(error);
+                Assert.Null(ConsoleUi.GetExplicitColorPalette());
+                Assert.Equal(new[] { "search", "--", "--palette=truecolor" }, args);
+            }
+            finally
+            {
+                ConsoleUi.SetColorPalette(original);
+            }
+        }
+    }
+
+    [Fact]
+    public void Run_InvalidPaletteValue_ReturnsUsageError()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            ["--palette=fancy", "status"],
+            appVersion: "1.10.0"));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("invalid --palette value `fancy`", stderr);
+        Assert.Contains("Hint:", stderr);
+    }
+
     [Fact]
     public void Run_Version_HumanOutput_IncludesBuildMetadata()
     {


### PR DESCRIPTION
## Summary
- `ColorizeKind` previously hard-coded 8 ANSI colors plus `\x1b[90m` (bright-black/dim) without checking terminal capability, so remote-session and CI terminals silently dropped `namespace` and `import` labels and truecolor-capable terminals saw the same coarse 16-color rendering.
- Adds `--palette basic|256|truecolor` CLI flag (with aliases `8`/`16`/`ansi`, `color256`/`8bit`, `24bit`/`rgb`) and `CDIDX_COLOR_PALETTE` env var; auto-detects via `COLORTERM=truecolor|24bit` and `TERM=*256color*`, falling back to `basic`.
- Basic palette is now strictly 8-color (SGR 30-37) -- `namespace`/`import` use white (`\x1b[37m`) instead of dim; 256-color and truecolor palettes emit higher-contrast SGR codes on capable terminals. `NO_COLOR` / `--color=never` continue to suppress ANSI across every palette.

Fixes #1569

## Test plan
- [x] `dotnet test` -- 4904 passed, 3 skipped (perf tests)
- [x] Targeted unit tests for `TryParseColorPalette`, `ResolveColorPalette` (explicit > env > `COLORTERM` > `TERM` > basic), and per-palette `ColorizeKind` SGR output
- [x] Tests assert basic palette emits no `\x1b[90m`
- [x] `NO_COLOR` suppression verified across all three palettes
- [x] Usage output documents `--palette <name>`
- [x] Bilingual changelog fragment (`changelog.d/unreleased/1569.added.md`)
- [x] `USER_GUIDE.md` (EN + JP) documents the flag, env var, and detection precedence
- [x] Codex adversarial review: no blocking/actionable issues

Generated with Claude Code.
