### PR TITLE
Add project-local .cdidxrc.json configuration file (#1571)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -737,6 +737,38 @@ Over-quota tool calls receive a structured JSON-RPC `-32000` error:
 
 Inside `batch_query`, each inner slot is also checked against the inner tool's bucket. Over-quota slots surface `error_category: "rate_limited"` and `retry_after_ms` directly in the per-slot result without failing the rest of the batch.
 
+### Project-local configuration file (`.cdidxrc.json`)
+
+You can check a `.cdidxrc.json` file into a repository to set per-project defaults instead of relying on shell-profile or CI env vars (#1571). On startup `cdidx` walks upward from the current working directory looking for the first `.cdidxrc.json`, validates its schema, and materializes recognized keys as process environment variables — so every existing env-var consumer picks them up without further changes.
+
+Precedence is **CLI flag > environment variable > config file > built-in default**. A config-file value is applied only when the matching env var is not already set in the process, so a value the user already exported in the shell or CI always wins. A malformed file (invalid JSON, unknown key, wrong type) is a hard error: cdidx exits `1` with the file path and the offending field; set `CDIDX_DISABLE_CONFIG_FILE=1` to bypass the file entirely.
+
+Secrets are intentionally **not** loadable from the file: `CDIDX_GITHUB_TOKEN`, `CDIDX_MCP_AUTH_TOKEN`, and `CDIDX_MCP_HTTP_TOKEN` are env-only so tokens never get checked into version control.
+
+Supported schema (snake_case keys; every key is optional):
+
+```jsonc
+{
+  "$schema": "https://github.com/Widthdom/CodeIndex",
+  "debug": "1",                          // → CDIDX_DEBUG
+  "metrics_path": "./.cdidx/metrics.jsonl", // → CDIDX_METRICS
+  "disable_persistent_log": true,        // → CDIDX_DISABLE_PERSISTENT_LOG=1
+  "global_tool_log_dir": "./.cdidx/logs", // → CDIDX_GLOBAL_TOOL_LOG_DIR
+  "mcp": {
+    "tools": {
+      "allow": ["search", "definition", "references"], // → CDIDX_MCP_TOOLS_ALLOW
+      "deny":  ["index", "backfill_fold"]              // → CDIDX_MCP_TOOLS_DENY
+    },
+    "rate_limit": {
+      "rps":   5,  // → CDIDX_MCP_RATE_LIMIT_RPS
+      "burst": 10  // → CDIDX_MCP_RATE_LIMIT_BURST
+    }
+  }
+}
+```
+
+JSON5-style line comments (`//`) and trailing commas are accepted so the file stays human-editable. The optional `$schema` key is ignored at runtime; it is honored only so editors that recognize JSON Schema references can offer completion. Setting `disable_persistent_log` to `false` is a no-op (absence already means "logging enabled") — only `true` exports `CDIDX_DISABLE_PERSISTENT_LOG=1`.
+
 ## How it works
 
 cdidx scans your project directory, applies the built-in skip lists plus user `.gitignore` / `.cdidxignore` rules, splits each remaining source file into overlapping chunks, and stores everything in a SQLite database with FTS5 full-text search. Incremental mode (default) first purges database entries for files that no longer exist on disk, then checks each file's last-modified timestamp against the database — only files whose timestamp exactly matches are skipped, and any difference (newer or older) triggers re-indexing. Newly appeared files are indexed as new entries. The same path filter is reused for scoped `--files` / `--commits` refreshes, commit-based refreshes automatically switch to a full scan when ignore files changed, and Git-managed workspaces follow the repository's `core.ignorecase` setting when evaluating ignore rules. This means re-indexing after a branch switch only processes the files that actually differ unless ignore rules themselves changed.
@@ -1944,6 +1976,38 @@ MCP ツールで catch-all まで突き抜けた例外（想定外の SQLite 例
 ```
 
 `batch_query` の内側スロットも各内側ツールのバケットで判定されます。超過したスロットはバッチ全体を失敗させずに、スロット結果に `error_category: "rate_limited"` と `retry_after_ms` を含めて返します。
+
+### プロジェクト固有の設定ファイル (`.cdidxrc.json`)
+
+シェルプロファイルや CI の環境変数に頼らず、プロジェクトごとの既定値を `.cdidxrc.json` ファイルとしてリポジトリにチェックインできます (#1571)。`cdidx` は起動時にカレントディレクトリから上方向に最初の `.cdidxrc.json` を探索し、スキーマを検証してから既知のキーをプロセス環境変数として注入します。これにより、既存の環境変数コンシューマはコード変更なしに同じ値を受け取れます。
+
+優先順位は **CLI フラグ > 環境変数 > 設定ファイル > 組み込み既定値** です。設定ファイル由来の値は、対応する環境変数がプロセスで未設定の場合にのみ適用されるため、シェルや CI で既に export されている値が常に優先されます。不正なファイル（無効な JSON、未知のキー、型違い）は hard error として扱われ、cdidx はファイルパスと該当フィールドを示して終了コード `1` で終了します。完全にバイパスしたい場合は `CDIDX_DISABLE_CONFIG_FILE=1` を設定してください。
+
+シークレットは意図的に**ファイルから読み込めません**。`CDIDX_GITHUB_TOKEN` / `CDIDX_MCP_AUTH_TOKEN` / `CDIDX_MCP_HTTP_TOKEN` は環境変数専用としており、トークンがバージョン管理に混入するのを防ぎます。
+
+対応スキーマ（snake_case、すべて任意）:
+
+```jsonc
+{
+  "$schema": "https://github.com/Widthdom/CodeIndex",
+  "debug": "1",                          // → CDIDX_DEBUG
+  "metrics_path": "./.cdidx/metrics.jsonl", // → CDIDX_METRICS
+  "disable_persistent_log": true,        // → CDIDX_DISABLE_PERSISTENT_LOG=1
+  "global_tool_log_dir": "./.cdidx/logs", // → CDIDX_GLOBAL_TOOL_LOG_DIR
+  "mcp": {
+    "tools": {
+      "allow": ["search", "definition", "references"], // → CDIDX_MCP_TOOLS_ALLOW
+      "deny":  ["index", "backfill_fold"]              // → CDIDX_MCP_TOOLS_DENY
+    },
+    "rate_limit": {
+      "rps":   5,  // → CDIDX_MCP_RATE_LIMIT_RPS
+      "burst": 10  // → CDIDX_MCP_RATE_LIMIT_BURST
+    }
+  }
+}
+```
+
+人手で編集しやすいよう JSON5 形式の行コメント（`//`）と末尾カンマを許容します。任意の `$schema` キーはランタイムでは無視され、JSON Schema 参照をサポートするエディタが補完を提供するためだけに認識されます。`disable_persistent_log` を `false` に設定しても何も起きません（不在のままで "ログ有効" が既定）— `true` の場合のみ `CDIDX_DISABLE_PERSISTENT_LOG=1` を export します。
 
 ## 動作の仕組み
 

--- a/changelog.d/unreleased/1571.added.md
+++ b/changelog.d/unreleased/1571.added.md
@@ -1,0 +1,18 @@
+---
+category: added
+issues:
+  - 1571
+affected:
+  - src/CodeIndex/Cli/CdidxConfigFile.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/CdidxConfigFileTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Project-local configuration via `.cdidxrc.json` (#1571)** — `cdidx` now walks upward from the current working directory (like `.editorconfig`) for a `.cdidxrc.json` file and materializes recognized keys as process environment variables on startup so every existing env-var consumer picks them up unchanged. Precedence is CLI flag > environment variable > config file > built-in default: the loader only writes a value when the matching env var is not already set, so anything the user already exported in a shell or CI still wins. The schema is strict (snake_case keys; unknown keys are a hard usage error), accepts JSON5 line comments and trailing commas, and recognizes `debug`, `metrics_path`, `disable_persistent_log`, `global_tool_log_dir`, plus nested `mcp.tools.allow` / `mcp.tools.deny` and `mcp.rate_limit.rps` / `mcp.rate_limit.burst`. Secrets (`CDIDX_GITHUB_TOKEN`, `CDIDX_MCP_AUTH_TOKEN`, `CDIDX_MCP_HTTP_TOKEN`) are intentionally env-only so tokens never get checked into version control. A malformed file fails fast with the path and offending field, and `CDIDX_DISABLE_CONFIG_FILE=1` bypasses the lookup entirely.
+
+## 日本語
+
+- **`.cdidxrc.json` によるプロジェクト固有設定 (#1571)** — `cdidx` は起動時にカレントディレクトリから（`.editorconfig` のように）上方向へ `.cdidxrc.json` を探索し、既知のキーをプロセス環境変数として注入するようになりました。これにより、既存の環境変数コンシューマは変更なしに同じ値を受け取れます。優先順位は CLI フラグ > 環境変数 > 設定ファイル > 組み込み既定値で、ローダーは対応する環境変数が未設定のときだけ値を書き込みます。シェルや CI で既に export 済みの値は常に優先されます。スキーマは厳格（snake_case、未知のキーは usage error）で JSON5 行コメントと末尾カンマを許容し、`debug` / `metrics_path` / `disable_persistent_log` / `global_tool_log_dir` と、入れ子の `mcp.tools.allow` / `mcp.tools.deny` および `mcp.rate_limit.rps` / `mcp.rate_limit.burst` を認識します。シークレット（`CDIDX_GITHUB_TOKEN` / `CDIDX_MCP_AUTH_TOKEN` / `CDIDX_MCP_HTTP_TOKEN`）はトークンがバージョン管理に混入しないよう意図的に環境変数専用です。不正なファイルはパスと該当フィールドを示して即座に失敗し、`CDIDX_DISABLE_CONFIG_FILE=1` で探索全体をバイパスできます。

--- a/src/CodeIndex/Cli/CdidxConfigFile.cs
+++ b/src/CodeIndex/Cli/CdidxConfigFile.cs
@@ -1,0 +1,303 @@
+using System.Text.Json;
+
+namespace CodeIndex.Cli;
+
+/// <summary>
+/// Project-local configuration file (`.cdidxrc.json`) loader (#1571). Walks upward from a
+/// starting directory looking for the first `.cdidxrc.json`, validates its schema, and
+/// materializes recognized keys as process environment variables so the existing env-var
+/// consumers (debug, metrics, MCP tool/rate-limit gates, persistent log) pick them up
+/// without further changes. A real environment variable always wins over a config-file
+/// value, which yields the documented precedence: CLI &gt; env &gt; config file &gt; defaults.
+/// Secrets (`CDIDX_GITHUB_TOKEN`, `CDIDX_MCP_AUTH_TOKEN`, `CDIDX_MCP_HTTP_TOKEN`) are
+/// intentionally NOT loadable from the config file to keep tokens out of version control.
+/// プロジェクトローカル設定ファイル `.cdidxrc.json` のローダー (#1571)。指定ディレクトリから
+/// 上方向に走査して最初に見つかった `.cdidxrc.json` をスキーマ検証し、認識済みキーを
+/// プロセス環境変数として展開する。既存の env-var 消費側（debug / metrics / MCP ツール ＆
+/// レート制限ゲート / 永続ログ）は追加変更なしに継承する。実際の環境変数は常に config
+/// ファイル値より優先し、結果として「CLI &gt; env &gt; config file &gt; 既定」の優先順位を満たす。
+/// 秘匿値 (`CDIDX_GITHUB_TOKEN`, `CDIDX_MCP_AUTH_TOKEN`, `CDIDX_MCP_HTTP_TOKEN`) は
+/// バージョン管理に漏れないよう、意図的に config ファイルからは読まない。
+/// </summary>
+internal static class CdidxConfigFile
+{
+    internal const string FileName = ".cdidxrc.json";
+    internal const string DisableEnvVar = "CDIDX_DISABLE_CONFIG_FILE";
+
+    private static readonly IReadOnlyList<string> KnownTopLevelKeys = new[]
+    {
+        "$schema",
+        "debug",
+        "metrics_path",
+        "disable_persistent_log",
+        "global_tool_log_dir",
+        "mcp",
+    };
+
+    private static readonly IReadOnlyList<string> KnownMcpKeys = new[] { "tools", "rate_limit" };
+    private static readonly IReadOnlyList<string> KnownMcpToolsKeys = new[] { "allow", "deny" };
+    private static readonly IReadOnlyList<string> KnownMcpRateLimitKeys = new[] { "rps", "burst" };
+
+    internal sealed record LoadResult(string? Path, string? Error)
+    {
+        internal bool Loaded => Path is not null && Error is null;
+        internal bool Failed => Error is not null;
+    }
+
+    /// <summary>
+    /// Walk upward from <paramref name="startingDirectory"/> looking for `.cdidxrc.json`. When
+    /// found, parse it and materialize recognized keys into the process environment (only when
+    /// the matching env var is currently unset). Returns a result describing what happened so
+    /// callers can surface validation errors. No-op when `CDIDX_DISABLE_CONFIG_FILE=1` is set.
+    /// </summary>
+    internal static LoadResult LoadAndApply(string startingDirectory)
+        => LoadAndApply(startingDirectory, Environment.GetEnvironmentVariable, Environment.SetEnvironmentVariable);
+
+    internal static LoadResult LoadAndApply(
+        string startingDirectory,
+        Func<string, string?> envReader,
+        Action<string, string?> envWriter)
+    {
+        if (string.Equals(envReader(DisableEnvVar), "1", StringComparison.Ordinal))
+            return new LoadResult(Path: null, Error: null);
+
+        var path = FindConfigFile(startingDirectory);
+        if (path is null)
+            return new LoadResult(Path: null, Error: null);
+
+        string text;
+        try
+        {
+            text = File.ReadAllText(path);
+        }
+        catch (Exception ex)
+        {
+            return new LoadResult(Path: path, Error: $"[cdidx] Failed to read {FileName} at {path}: {ex.Message}");
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(text, new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+            });
+        }
+        catch (JsonException ex)
+        {
+            return new LoadResult(Path: path, Error: $"[cdidx] Invalid JSON in {path}: {ex.Message}");
+        }
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return new LoadResult(Path: path, Error: $"[cdidx] {path}: top-level value must be a JSON object.");
+
+            if (TryFindUnknownKey(root, KnownTopLevelKeys, out var unknownTopKey))
+                return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `{unknownTopKey}`. Supported keys: {string.Join(", ", KnownTopLevelKeys.Where(k => k != "$schema"))}.");
+
+            var pending = new List<(string EnvName, string Value)>();
+
+            if (root.TryGetProperty("debug", out var debug))
+            {
+                if (!TryReadString(debug, "debug", path, out var value, out var err))
+                    return new LoadResult(Path: path, Error: err);
+                pending.Add(("CDIDX_DEBUG", value!));
+            }
+
+            if (root.TryGetProperty("metrics_path", out var metrics))
+            {
+                if (!TryReadString(metrics, "metrics_path", path, out var value, out var err))
+                    return new LoadResult(Path: path, Error: err);
+                pending.Add(("CDIDX_METRICS", value!));
+            }
+
+            if (root.TryGetProperty("disable_persistent_log", out var disableLog))
+            {
+                if (disableLog.ValueKind != JsonValueKind.True && disableLog.ValueKind != JsonValueKind.False)
+                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `disable_persistent_log` must be a boolean.");
+                if (disableLog.GetBoolean())
+                    pending.Add(("CDIDX_DISABLE_PERSISTENT_LOG", "1"));
+            }
+
+            if (root.TryGetProperty("global_tool_log_dir", out var logDir))
+            {
+                if (!TryReadString(logDir, "global_tool_log_dir", path, out var value, out var err))
+                    return new LoadResult(Path: path, Error: err);
+                pending.Add(("CDIDX_GLOBAL_TOOL_LOG_DIR", value!));
+            }
+
+            if (root.TryGetProperty("mcp", out var mcp))
+            {
+                if (mcp.ValueKind != JsonValueKind.Object)
+                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp` must be a JSON object.");
+                if (TryFindUnknownKey(mcp, KnownMcpKeys, out var unknownMcpKey))
+                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.{unknownMcpKey}`. Supported keys: {string.Join(", ", KnownMcpKeys)}.");
+
+                if (mcp.TryGetProperty("tools", out var tools))
+                {
+                    if (tools.ValueKind != JsonValueKind.Object)
+                        return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp.tools` must be a JSON object.");
+                    if (TryFindUnknownKey(tools, KnownMcpToolsKeys, out var unknownToolsKey))
+                        return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.tools.{unknownToolsKey}`. Supported keys: {string.Join(", ", KnownMcpToolsKeys)}.");
+
+                    if (tools.TryGetProperty("allow", out var allow))
+                    {
+                        if (!TryReadStringArray(allow, "mcp.tools.allow", path, out var value, out var err))
+                            return new LoadResult(Path: path, Error: err);
+                        if (value!.Length > 0)
+                            pending.Add(("CDIDX_MCP_TOOLS_ALLOW", string.Join(",", value)));
+                    }
+
+                    if (tools.TryGetProperty("deny", out var deny))
+                    {
+                        if (!TryReadStringArray(deny, "mcp.tools.deny", path, out var value, out var err))
+                            return new LoadResult(Path: path, Error: err);
+                        if (value!.Length > 0)
+                            pending.Add(("CDIDX_MCP_TOOLS_DENY", string.Join(",", value)));
+                    }
+                }
+
+                if (mcp.TryGetProperty("rate_limit", out var rateLimit))
+                {
+                    if (rateLimit.ValueKind != JsonValueKind.Object)
+                        return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp.rate_limit` must be a JSON object.");
+                    if (TryFindUnknownKey(rateLimit, KnownMcpRateLimitKeys, out var unknownRlKey))
+                        return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.rate_limit.{unknownRlKey}`. Supported keys: {string.Join(", ", KnownMcpRateLimitKeys)}.");
+
+                    if (rateLimit.TryGetProperty("rps", out var rps))
+                    {
+                        if (!TryReadNumberAsString(rps, "mcp.rate_limit.rps", path, out var value, out var err))
+                            return new LoadResult(Path: path, Error: err);
+                        pending.Add(("CDIDX_MCP_RATE_LIMIT_RPS", value!));
+                    }
+
+                    if (rateLimit.TryGetProperty("burst", out var burst))
+                    {
+                        if (!TryReadNumberAsString(burst, "mcp.rate_limit.burst", path, out var value, out var err))
+                            return new LoadResult(Path: path, Error: err);
+                        pending.Add(("CDIDX_MCP_RATE_LIMIT_BURST", value!));
+                    }
+                }
+            }
+
+            // Apply only when the matching env var is not already set, preserving the
+            // documented precedence (real env wins over config-file value).
+            foreach (var (name, value) in pending)
+            {
+                if (string.IsNullOrEmpty(envReader(name)))
+                    envWriter(name, value);
+            }
+
+            return new LoadResult(Path: path, Error: null);
+        }
+    }
+
+    private static string? FindConfigFile(string startingDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(startingDirectory))
+            return null;
+
+        DirectoryInfo? current;
+        try
+        {
+            current = new DirectoryInfo(Path.GetFullPath(startingDirectory));
+        }
+        catch
+        {
+            return null;
+        }
+
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, FileName);
+            if (File.Exists(candidate))
+                return candidate;
+            current = current.Parent;
+        }
+        return null;
+    }
+
+    private static bool TryFindUnknownKey(JsonElement obj, IReadOnlyList<string> knownKeys, out string? unknown)
+    {
+        foreach (var property in obj.EnumerateObject())
+        {
+            var matched = false;
+            for (var i = 0; i < knownKeys.Count; i++)
+            {
+                if (string.Equals(knownKeys[i], property.Name, StringComparison.Ordinal))
+                {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched)
+            {
+                unknown = property.Name;
+                return true;
+            }
+        }
+        unknown = null;
+        return false;
+    }
+
+    private static bool TryReadString(JsonElement element, string key, string path, out string? value, out string? error)
+    {
+        value = null;
+        error = null;
+        if (element.ValueKind != JsonValueKind.String)
+        {
+            error = $"[cdidx] {path}: `{key}` must be a string.";
+            return false;
+        }
+        var raw = element.GetString();
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            error = $"[cdidx] {path}: `{key}` must be a non-empty string.";
+            return false;
+        }
+        value = raw;
+        return true;
+    }
+
+    private static bool TryReadStringArray(JsonElement element, string key, string path, out string[]? value, out string? error)
+    {
+        value = null;
+        error = null;
+        if (element.ValueKind != JsonValueKind.Array)
+        {
+            error = $"[cdidx] {path}: `{key}` must be an array of strings.";
+            return false;
+        }
+        var collected = new List<string>(element.GetArrayLength());
+        foreach (var item in element.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String)
+            {
+                error = $"[cdidx] {path}: `{key}` must contain only strings.";
+                return false;
+            }
+            var raw = item.GetString();
+            if (string.IsNullOrWhiteSpace(raw))
+                continue;
+            collected.Add(raw);
+        }
+        value = collected.ToArray();
+        return true;
+    }
+
+    private static bool TryReadNumberAsString(JsonElement element, string key, string path, out string? value, out string? error)
+    {
+        value = null;
+        error = null;
+        if (element.ValueKind != JsonValueKind.Number)
+        {
+            error = $"[cdidx] {path}: `{key}` must be a number.";
+            return false;
+        }
+        value = element.GetRawText();
+        return true;
+    }
+}

--- a/src/CodeIndex/Cli/CdidxConfigFile.cs
+++ b/src/CodeIndex/Cli/CdidxConfigFile.cs
@@ -183,11 +183,14 @@ internal static class CdidxConfigFile
                 }
             }
 
-            // Apply only when the matching env var is not already set, preserving the
-            // documented precedence (real env wins over config-file value).
+            // Apply only when the matching env var is not present (null), preserving the
+            // documented precedence (real env wins over config-file value). An explicit
+            // empty string still counts as "set" because several existing consumers
+            // (e.g. RateLimiterOptions.FromEnvironment) treat empty as "feature off",
+            // so a user clearing a checked-in value must be able to override with `export FOO=`.
             foreach (var (name, value) in pending)
             {
-                if (string.IsNullOrEmpty(envReader(name)))
+                if (envReader(name) is null)
                     envWriter(name, value);
             }
 

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -9,10 +9,26 @@ namespace CodeIndex.Cli;
 
 internal static class ProgramRunner
 {
-    internal static int Run(string[] args, JsonSerializerOptions? jsonOptions = null, string? appVersion = null)
+    internal static int Run(string[] args, JsonSerializerOptions? jsonOptions = null, string? appVersion = null, string? configStartDirectory = null)
     {
         appVersion ??= ConsoleUi.LoadVersion();
+
+        // Load project-local `.cdidxrc.json` before anything else reads env vars so log
+        // location, debug mode, and MCP gates honor the file (#1571). Hard-fail on
+        // validation errors so silent typos cannot quietly change behavior.
+        // 環境変数を読む処理より先に `.cdidxrc.json` を読み込み、ログ位置 / debug / MCP ゲート
+        // などが config を反映できるようにする (#1571)。スキーマ違反は黙って無視せず exit する。
+        var configResult = CdidxConfigFile.LoadAndApply(configStartDirectory ?? Environment.CurrentDirectory);
+        if (configResult.Failed)
+        {
+            Console.Error.WriteLine(configResult.Error);
+            Console.Error.WriteLine($"Hint: fix or remove `{CdidxConfigFile.FileName}`, or set `{CdidxConfigFile.DisableEnvVar}=1` to bypass it.");
+            return CommandExitCodes.UsageError;
+        }
+
         using var globalToolLog = GlobalToolLog.TryStart(args, appVersion);
+        if (configResult.Loaded)
+            GlobalToolLog.Info($"config_file_loaded path={configResult.Path}");
         jsonOptions ??= CreateDefaultJsonOptions();
 
         if (!TryConsumeColorFlag(ref args, out var colorError))

--- a/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
+++ b/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
@@ -78,6 +78,27 @@ public class CdidxConfigFileTests
     }
 
     [Fact]
+    public void LoadAndApply_EmptyEnvVarStillCountsAsSet()
+    {
+        // Empty-string env vars are not "unset" — RateLimiterOptions.FromEnvironment and
+        // similar consumers treat empty as "feature off", so an explicit `export FOO=`
+        // must defeat a checked-in config value (real env wins, per documented precedence).
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"),
+                """{ "metrics_path": "/from/config.jsonl" }""");
+
+            var env = new TestEnvironment(initial: new() { ["CDIDX_METRICS"] = "" });
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Loaded);
+            Assert.False(env.Writes.ContainsKey("CDIDX_METRICS"));
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
     public void LoadAndApply_WalksUpwardFromStartingDirectory()
     {
         var root = CreateTempDir();

--- a/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
+++ b/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
@@ -1,0 +1,307 @@
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+public class CdidxConfigFileTests
+{
+    [Fact]
+    public void LoadAndApply_NoFile_NoOp()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.False(result.Loaded);
+            Assert.False(result.Failed);
+            Assert.Null(result.Path);
+            Assert.Empty(env.Writes);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_MaterializesKnownKeysIntoEnvironment()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"), """
+                {
+                  "debug": "1",
+                  "metrics_path": "/tmp/m.jsonl",
+                  "disable_persistent_log": true,
+                  "global_tool_log_dir": "/tmp/logs",
+                  "mcp": {
+                    "tools": { "allow": ["search", "definition"], "deny": ["index"] },
+                    "rate_limit": { "rps": 5, "burst": 10 }
+                  }
+                }
+                """);
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Loaded);
+            Assert.Null(result.Error);
+            Assert.Equal("1", env.Writes["CDIDX_DEBUG"]);
+            Assert.Equal("/tmp/m.jsonl", env.Writes["CDIDX_METRICS"]);
+            Assert.Equal("1", env.Writes["CDIDX_DISABLE_PERSISTENT_LOG"]);
+            Assert.Equal("/tmp/logs", env.Writes["CDIDX_GLOBAL_TOOL_LOG_DIR"]);
+            Assert.Equal("search,definition", env.Writes["CDIDX_MCP_TOOLS_ALLOW"]);
+            Assert.Equal("index", env.Writes["CDIDX_MCP_TOOLS_DENY"]);
+            Assert.Equal("5", env.Writes["CDIDX_MCP_RATE_LIMIT_RPS"]);
+            Assert.Equal("10", env.Writes["CDIDX_MCP_RATE_LIMIT_BURST"]);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_RealEnvVarWinsOverConfigFile()
+    {
+        // Precedence contract: CLI > env > config file > defaults. The loader must NOT
+        // overwrite a value the user has already set in the process environment.
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"),
+                """{ "metrics_path": "/from/config.jsonl" }""");
+
+            var env = new TestEnvironment(initial: new() { ["CDIDX_METRICS"] = "/from/env.jsonl" });
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Loaded);
+            Assert.False(env.Writes.ContainsKey("CDIDX_METRICS"));
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_WalksUpwardFromStartingDirectory()
+    {
+        var root = CreateTempDir();
+        try
+        {
+            var nested = Path.Combine(root, "a", "b", "c");
+            Directory.CreateDirectory(nested);
+            File.WriteAllText(Path.Combine(root, ".cdidxrc.json"),
+                """{ "debug": "config-value" }""");
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(nested, env.Read, env.Write);
+
+            Assert.True(result.Loaded);
+            Assert.Equal(Path.Combine(root, ".cdidxrc.json"), result.Path);
+            Assert.Equal("config-value", env.Writes["CDIDX_DEBUG"]);
+        }
+        finally { TestProjectHelper.DeleteDirectory(root); }
+    }
+
+    [Fact]
+    public void LoadAndApply_DisabledByEnvVar_SkipsLoad()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"),
+                """{ "debug": "1" }""");
+
+            var env = new TestEnvironment(initial: new() { ["CDIDX_DISABLE_CONFIG_FILE"] = "1" });
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.False(result.Loaded);
+            Assert.False(result.Failed);
+            Assert.Empty(env.Writes);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_MalformedJson_ReturnsError()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"), "{ not-json");
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Failed);
+            Assert.Contains("Invalid JSON", result.Error);
+            Assert.Empty(env.Writes);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_UnknownTopLevelKey_ReturnsError()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"),
+                """{ "github_token": "secret" }""");
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Failed);
+            Assert.Contains("github_token", result.Error);
+            Assert.Empty(env.Writes);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_UnknownNestedMcpKey_ReturnsError()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"),
+                """{ "mcp": { "tools": { "bogus": [] } } }""");
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Failed);
+            Assert.Contains("mcp.tools.bogus", result.Error);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_WrongType_ReturnsError()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"),
+                """{ "disable_persistent_log": "yes" }""");
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Failed);
+            Assert.Contains("must be a boolean", result.Error);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_AllowsSchemaKeyAndComments()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"), """
+                {
+                  // editor link
+                  "$schema": "https://example/cdidxrc.schema.json",
+                  "debug": "1",
+                }
+                """);
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Loaded);
+            Assert.Null(result.Error);
+            Assert.Equal("1", env.Writes["CDIDX_DEBUG"]);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void LoadAndApply_DisabledPersistentLog_FalseIsNoOp()
+    {
+        // When `disable_persistent_log: false`, the loader must NOT set the env var:
+        // absence already means "logging enabled" (the historical default). Writing "0"
+        // would behave the same as "1" because `GlobalToolLog.ShouldEnable` only treats
+        // exact "1" as disable, but a future change could broaden that check, so we
+        // assert the contract holds today.
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"),
+                """{ "disable_persistent_log": false }""");
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.LoadAndApply(dir, env.Read, env.Write);
+
+            Assert.True(result.Loaded);
+            Assert.False(env.Writes.ContainsKey("CDIDX_DISABLE_PERSISTENT_LOG"));
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void Run_MalformedConfigFile_FailsWithUsageError()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"), "{ not-json");
+
+            var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                ["definitely-not-a-command"],
+                appVersion: "1.21.0",
+                configStartDirectory: dir));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Contains("Invalid JSON", stderr);
+            Assert.Contains("CDIDX_DISABLE_CONFIG_FILE", stderr);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    private static string CreateTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cdidx_config_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CaptureConsole(Func<int> action)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            try
+            {
+                Console.SetOut(stdout);
+                Console.SetError(stderr);
+                return (action(), stdout.ToString(), stderr.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    private sealed class TestEnvironment
+    {
+        private readonly Dictionary<string, string?> _env;
+        public Dictionary<string, string?> Writes { get; } = new(StringComparer.Ordinal);
+
+        public TestEnvironment(Dictionary<string, string?>? initial = null)
+        {
+            _env = new(initial ?? new(), StringComparer.Ordinal);
+        }
+
+        public string? Read(string name) => _env.TryGetValue(name, out var v) ? v : null;
+
+        public void Write(string name, string? value)
+        {
+            _env[name] = value;
+            Writes[name] = value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a project-local `.cdidxrc.json` loader (`src/CodeIndex/Cli/CdidxConfigFile.cs`) that walks upward from the current working directory like `.editorconfig`, validates a strict snake_case schema (with JSON5 line comments and trailing commas), and materializes recognized keys as process environment variables on startup. Recognized keys cover `debug`, `metrics_path`, `disable_persistent_log`, `global_tool_log_dir`, `mcp.tools.allow`, `mcp.tools.deny`, `mcp.rate_limit.rps`, `mcp.rate_limit.burst`.
- Preserve the documented precedence `CLI flag > env > config file > defaults`: the loader writes a value only when the matching env var is **null** (an explicit empty `export FOO=` still counts as "set", so users can defeat a checked-in value). Secrets (`CDIDX_GITHUB_TOKEN`, `CDIDX_MCP_AUTH_TOKEN`, `CDIDX_MCP_HTTP_TOKEN`) are intentionally env-only so tokens never get checked into version control.
- Hard-fail with a usage exit code on validation errors (path + offending field shown). Bypass the entire lookup with `CDIDX_DISABLE_CONFIG_FILE=1`. Loader runs before `GlobalToolLog.TryStart` so log location, debug mode, and the MCP gates honor the file.
- Covered by 13 new unit tests (schema validation, walk-up search, real-env-wins precedence including the empty-env override case, opt-out, JSON5 / `$schema` handling, malformed-file integration through `ProgramRunner.Run`), USER_GUIDE.md sections in English + 日本語, and a bilingual changelog fragment.

Fixes #1571

## Test plan

- [x] `dotnet build CodeIndex.sln -c Release` (0 warnings, 0 errors)
- [x] `dotnet test CodeIndex.sln -c Release --no-build` (4955 passed, 0 failed, 3 skipped performance tests)
- [x] `dotnet run --project tools/CodeIndex.Changelog -- check` (75 fragments validated)
- [x] Codex adversarial review: both round-1 findings addressed (`origin/main` merged so the diff no longer naively reverts #1569; loader now uses `is null` instead of `IsNullOrEmpty` with a dedicated regression test). Round-2 only re-flagged branch staleness as new mainline commits landed during review — mechanical, resolved by a second merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
