### PR TITLE
Absolutize index paths and detect cwd drift (#1577)

### DIFF
--- a/changelog.d/unreleased/1577.fixed.md
+++ b/changelog.d/unreleased/1577.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1577
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **`cdidx index` now absolutizes paths at the option-parsing boundary and surfaces cwd drift (#1577)** — `projectPath` and `--db` are normalized with `Path.GetFullPath` inside `IndexCommandRunner.ParseArgs` (file URIs pass through unchanged), and the runner snapshots `Environment.CurrentDirectory` at startup so it can warn when an embedded host, signal handler, or future plugin changed the cwd by the time the final write happens. Both `index --json` finalize payloads expose `cwd_drift_detected`, `cwd_at_start`, `cwd_at_finalize`, and `cwd_drift_notice` so automation can react to the drift, and the human path prints a matching warning.
+
+## 日本語
+
+- **`cdidx index` がオプション解析境界でパスを絶対化し、cwd ドリフトを通知するようになりました (#1577)** — `IndexCommandRunner.ParseArgs` 内で `projectPath` と `--db` を `Path.GetFullPath` で正規化（`file:` URI はそのまま）し、起動時に `Environment.CurrentDirectory` を記録します。これにより、埋め込みホストやシグナルハンドラ、将来のプラグインが最終書き込み時点までに cwd を変更した場合、`index --json` の最終ペイロードに `cwd_drift_detected` / `cwd_at_start` / `cwd_at_finalize` / `cwd_drift_notice` を出力し、人間向け出力にも警告を表示します。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -31,6 +31,11 @@ public static class IndexCommandRunner
             return CommandExitCodes.UsageError;
         }
 
+        // Snapshot cwd alongside the already-absolutized options so the finalize step can
+        // detect mid-run drift (embedded host, signal handler, future plugin) and warn the
+        // operator. Failure to read cwd (e.g. it was deleted out from under us) is best-effort
+        // -- we just skip the drift warning rather than block the run. Issue #1577.
+        var initialCwd = TryCaptureCurrentDirectory();
         var dbPath = DbPathResolver.ResolveForIndex(options.ProjectPath, options.DbPath);
         var stopwatch = Stopwatch.StartNew();
         var isUpdateMode = options.Commits.Count > 0 || options.UpdateFiles.Count > 0;
@@ -330,8 +335,8 @@ public static class IndexCommandRunner
         var projectRoot = Path.GetFullPath(options.ProjectPath);
 
         return isUpdateMode
-            ? RunUpdateMode(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorReadiness, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit)
-            : RunFullScan(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit);
+            ? RunUpdateMode(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorReadiness, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd)
+            : RunFullScan(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd);
         }
     }
 
@@ -531,8 +536,12 @@ public static class IndexCommandRunner
 
         return new IndexCommandOptions
         {
-            ProjectPath = projectPath,
-            DbPath = dbPath,
+            // Absolutize critical paths at the option-parsing boundary so a cwd shift after
+            // this point (embedded host, signal handler, future plugin) cannot silently break
+            // relative-path math in FileIndexer / GitHelper / DbPathResolver. Issue #1577.
+            // オプション解析の境界で絶対化し、以降の cwd 変化で相対パス計算が崩れないようにする。
+            ProjectPath = AbsolutizePathOption(projectPath),
+            DbPath = AbsolutizeDbPathOption(dbPath),
             Rebuild = rebuild,
             Verbose = verbose,
             Json = json,
@@ -542,6 +551,61 @@ public static class IndexCommandRunner
             DryRun = dryRun,
             Force = force,
         };
+    }
+
+    private static string? AbsolutizePathOption(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return value;
+        try
+        {
+            return Path.GetFullPath(value);
+        }
+        catch
+        {
+            return value;
+        }
+    }
+
+    private static string? AbsolutizeDbPathOption(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return value;
+        if (value.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+            return value;
+        return AbsolutizePathOption(value);
+    }
+
+    internal static string? TryCaptureCurrentDirectory()
+    {
+        try
+        {
+            return Environment.CurrentDirectory;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Build a warning message when the process cwd at the final write step differs from
+    /// the cwd captured at the option-parsing boundary. Returns null when the two cwds
+    /// are equal or either snapshot is missing. Issue #1577.
+    /// </summary>
+    internal static string? BuildCwdDriftNotice(string? initialCwd, string? currentCwd)
+    {
+        if (string.IsNullOrEmpty(initialCwd) || string.IsNullOrEmpty(currentCwd))
+            return null;
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (string.Equals(initialCwd, currentCwd, comparison))
+            return null;
+        return $"Process working directory changed during index (was {initialCwd}, now {currentCwd}). "
+            + "Index/query paths were absolutized at the option-parsing boundary so this run "
+            + "is unaffected, but later code paths that depend on Environment.CurrentDirectory "
+            + "may misbehave. Restore the original working directory or re-resolve relative paths.";
     }
 
     private static BackfillFoldCommandOptions ParseBackfillFoldArgs(string[] args)
@@ -602,7 +666,8 @@ public static class IndexCommandRunner
         IReadOnlyDictionary<string, string?> currentHotspotFamilyMarkerFingerprints,
         string? priorIndexedProjectRoot,
         string? priorIndexedHeadCommit,
-        string? currentHeadCommit)
+        string? currentHeadCommit,
+        string? initialCwd)
     {
         var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
         var currentSqlGraphContractVersion = DbContext.SqlGraphContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
@@ -682,7 +747,8 @@ public static class IndexCommandRunner
                 currentHotspotFamilyMarkerFingerprints,
                 priorIndexedProjectRoot,
                 priorIndexedHeadCommit,
-                currentHeadCommit);
+                currentHeadCommit,
+                initialCwd);
         }
 
         if (!options.Json)
@@ -1148,6 +1214,18 @@ public static class IndexCommandRunner
         if (errors == 0)
             StampIndexedHeadMetadata(writer, projectRoot);
         stopwatch.Stop();
+        // Detect cwd drift between option-parsing and finalize. Paths used in this run are
+        // already absolute, but a drifted cwd is a strong signal that an embedded host or
+        // signal handler mutated process state -- surface it so the operator can correct
+        // their hosting code. Issue #1577.
+        var finalCwd = TryCaptureCurrentDirectory();
+        var cwdDriftNotice = BuildCwdDriftNotice(initialCwd, finalCwd);
+        var cwdDriftDetected = cwdDriftNotice != null;
+        if (cwdDriftDetected)
+        {
+            warningList.Add(new CliJsonMessage("<process_cwd>", cwdDriftNotice!));
+            warnings++;
+        }
         var (totalFiles, totalChunks, totalSymbols, totalReferences) = writer.GetCounts();
         var signalReader = new DbReader(writer.Connection);
         var sqlGraphContractSignalAfter = signalReader.GetSqlGraphContractSignal(lang: null);
@@ -1203,6 +1281,10 @@ public static class IndexCommandRunner
                 DegradedReason = foldOnlyRemediation?.DegradedReason,
                 RecommendedAction = foldOnlyRemediation?.RecommendedAction,
                 AlternativeAction = foldOnlyRemediation?.AlternativeAction,
+                CwdDriftDetected = cwdDriftDetected,
+                CwdAtStart = initialCwd,
+                CwdAtFinalize = finalCwd,
+                CwdDriftNotice = cwdDriftNotice,
                 Errors = errorList.Count > 0 ? errorList : null,
                 Warnings = warningList.Count > 0 ? warningList : null,
                 ElapsedMs = stopwatch.ElapsedMilliseconds,
@@ -1236,6 +1318,8 @@ public static class IndexCommandRunner
                 ConsoleUi.PrintWarning($"Some files failed to update. Fix the reported files or permissions, then rerun `cdidx index \"{projectRoot}\"` to restore a fully ready index.");
             if (!graphTableAvailableAfter || !issuesTableAvailableAfter || !sqlGraphContractReadyAfter || !hotspotFamilyReadyAfter || !csharpSymbolNameReadyAfter || !csharpMetadataTargetReadyAfter || !foldReadyAfter)
                 ConsoleUi.PrintWarning(GetIndexReadinessWarning(graphTableAvailableAfter, issuesTableAvailableAfter, sqlGraphContractReadyAfter, hotspotFamilyReadyAfter, csharpSymbolNameReadyAfter, csharpMetadataTargetReadyAfter, foldReadyAfter, foldReadyReasonAfter, projectRoot, resolvedDbPath));
+            if (cwdDriftDetected)
+                ConsoleUi.PrintWarning(cwdDriftNotice!);
         }
 
         return CommandExitCodes.Success;
@@ -1547,7 +1631,8 @@ public static class IndexCommandRunner
         IReadOnlyDictionary<string, string?> currentHotspotFamilyMarkerFingerprints,
         string? priorIndexedProjectRoot,
         string? priorIndexedHeadCommit,
-        string? currentHeadCommit)
+        string? currentHeadCommit,
+        string? initialCwd)
     {
         var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
         _ = priorMetadataTargetCsharp; // full-scan resolver runs unconditionally on success / 成功時に常に再解決するため不要
@@ -1959,6 +2044,17 @@ public static class IndexCommandRunner
             StampIndexedHeadMetadata(writer, projectRoot);
         }
         stopwatch.Stop();
+        // Detect cwd drift between option-parsing and finalize. See RunUpdateMode for the
+        // rationale; the warning is informational because we already absolutized paths.
+        // Issue #1577.
+        var finalCwd = TryCaptureCurrentDirectory();
+        var cwdDriftNotice = BuildCwdDriftNotice(initialCwd, finalCwd);
+        var cwdDriftDetected = cwdDriftNotice != null;
+        if (cwdDriftDetected)
+        {
+            warningList.Add(new CliJsonMessage("<process_cwd>", cwdDriftNotice!));
+            warnings++;
+        }
         var (totalFiles, totalChunks, totalSymbols, totalReferences) = writer.GetCounts();
         var signalReader = new DbReader(writer.Connection);
         var sqlGraphContractSignalAfter = signalReader.GetSqlGraphContractSignal(lang: null);
@@ -2018,6 +2114,10 @@ public static class IndexCommandRunner
                 PriorIndexedHeadCommit = priorIndexedHeadCommit,
                 CurrentHeadCommit = currentHeadCommit,
                 HeadChangeNotice = headChangeNotice,
+                CwdDriftDetected = cwdDriftDetected,
+                CwdAtStart = initialCwd,
+                CwdAtFinalize = finalCwd,
+                CwdDriftNotice = cwdDriftNotice,
                 Errors = errorList.Count > 0 ? errorList : null,
                 Warnings = warningList.Count > 0 ? warningList : null,
                 ElapsedMs = stopwatch.ElapsedMilliseconds,
@@ -2049,6 +2149,8 @@ public static class IndexCommandRunner
                 ConsoleUi.PrintWarning($"Some files failed to index. Fix the reported files or permissions, then rerun `cdidx index \"{projectRoot}\"` to restore a fully ready index.");
             if (!graphTableAvailableAfter || !issuesTableAvailableAfter || !sqlGraphContractReadyAfter || !hotspotFamilyReadyAfter || !csharpSymbolNameReadyAfter || !csharpMetadataTargetReadyAfter || !foldReadyAfter)
                 ConsoleUi.PrintWarning(GetIndexReadinessWarning(graphTableAvailableAfter, issuesTableAvailableAfter, sqlGraphContractReadyAfter, hotspotFamilyReadyAfter, csharpSymbolNameReadyAfter, csharpMetadataTargetReadyAfter, foldReadyAfter, foldReadyReasonAfter, projectRoot, resolvedDbPath));
+            if (cwdDriftDetected)
+                ConsoleUi.PrintWarning(cwdDriftNotice!);
         }
 
         return CommandExitCodes.Success;

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -121,6 +121,10 @@ internal sealed class IndexUpdateJsonResult
     public string? DegradedReason { get; init; }
     public string? RecommendedAction { get; init; }
     public string? AlternativeAction { get; init; }
+    public bool CwdDriftDetected { get; init; }
+    public string? CwdAtStart { get; init; }
+    public string? CwdAtFinalize { get; init; }
+    public string? CwdDriftNotice { get; init; }
     public List<CliJsonMessage>? Errors { get; init; }
     public List<CliJsonMessage>? Warnings { get; init; }
     public long ElapsedMs { get; init; }
@@ -150,6 +154,10 @@ internal sealed class IndexFullScanJsonResult
     public string? PriorIndexedHeadCommit { get; init; }
     public string? CurrentHeadCommit { get; init; }
     public string? HeadChangeNotice { get; init; }
+    public bool CwdDriftDetected { get; init; }
+    public string? CwdAtStart { get; init; }
+    public string? CwdAtFinalize { get; init; }
+    public string? CwdDriftNotice { get; init; }
     public List<CliJsonMessage>? Errors { get; init; }
     public List<CliJsonMessage>? Warnings { get; init; }
     public long ElapsedMs { get; init; }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -34,7 +34,9 @@ public class IndexCommandRunnerTests
     {
         var options = IndexCommandRunner.ParseArgs([".", "--force"]);
         Assert.True(options.Force);
-        Assert.Equal(".", options.ProjectPath);
+        Assert.NotNull(options.ProjectPath);
+        Assert.True(Path.IsPathRooted(options.ProjectPath));
+        Assert.Equal(Path.GetFullPath("."), options.ProjectPath);
     }
 
     [Fact]
@@ -42,6 +44,57 @@ public class IndexCommandRunnerTests
     {
         var options = IndexCommandRunner.ParseArgs(["."]);
         Assert.False(options.Force);
+    }
+
+    [Fact]
+    public void ParseArgs_AbsolutizesRelativeProjectPath()
+    {
+        var options = IndexCommandRunner.ParseArgs(["./sub/path"]);
+        Assert.NotNull(options.ProjectPath);
+        Assert.True(Path.IsPathRooted(options.ProjectPath));
+        Assert.Equal(Path.GetFullPath("./sub/path"), options.ProjectPath);
+    }
+
+    [Fact]
+    public void ParseArgs_AbsolutizesRelativeDbPath()
+    {
+        var options = IndexCommandRunner.ParseArgs([".", "--db", "./.cdidx/codeindex.db"]);
+        Assert.NotNull(options.DbPath);
+        Assert.True(Path.IsPathRooted(options.DbPath));
+        Assert.Equal(Path.GetFullPath("./.cdidx/codeindex.db"), options.DbPath);
+    }
+
+    [Fact]
+    public void ParseArgs_PreservesFileUriDbPath()
+    {
+        var uri = "file:///tmp/example.db?immutable=1";
+        var options = IndexCommandRunner.ParseArgs([".", "--db", uri]);
+        Assert.Equal(uri, options.DbPath);
+    }
+
+    [Fact]
+    public void BuildCwdDriftNotice_ReturnsNullWhenCwdUnchanged()
+    {
+        var notice = IndexCommandRunner.BuildCwdDriftNotice("/tmp/project", "/tmp/project");
+        Assert.Null(notice);
+    }
+
+    [Fact]
+    public void BuildCwdDriftNotice_ReturnsNullWhenEitherSnapshotMissing()
+    {
+        Assert.Null(IndexCommandRunner.BuildCwdDriftNotice(null, "/tmp/project"));
+        Assert.Null(IndexCommandRunner.BuildCwdDriftNotice("/tmp/project", null));
+        Assert.Null(IndexCommandRunner.BuildCwdDriftNotice(string.Empty, "/tmp/project"));
+    }
+
+    [Fact]
+    public void BuildCwdDriftNotice_DescribesDriftWhenCwdChanged()
+    {
+        var notice = IndexCommandRunner.BuildCwdDriftNotice("/tmp/project", "/tmp/other");
+        Assert.NotNull(notice);
+        Assert.Contains("/tmp/project", notice);
+        Assert.Contains("/tmp/other", notice);
+        Assert.Contains("working directory changed", notice);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Resolves the "working-directory drift mid-process not detected; relative-path math can break" issue by tightening path handling at the option-parsing boundary and surfacing cwd drift during `index` runs.

- **Absolutize at the boundary** — `IndexCommandRunner.ParseArgs` now normalizes `projectPath` and `--db` with `Path.GetFullPath` (via two small helpers). `file:` URIs for `--db` pass through unchanged so the existing `DbPathResolver.NormalizeDbPath` path keeps working. Downstream code no longer depends on the live `Environment.CurrentDirectory` for those paths.
- **Detect cwd drift** — `Run` snapshots `Environment.CurrentDirectory` at startup via `TryCaptureCurrentDirectory` and threads the snapshot through `RunUpdateMode` / `RunFullScan`. At finalize, `BuildCwdDriftNotice` compares against the current cwd (case-insensitive on Windows). If it changed, both finalize paths append a structured warning entry and the human-output path emits `ConsoleUi.PrintWarning`.
- **Structured JSON** — `IndexUpdateJsonResult` and `IndexFullScanJsonResult` gain `CwdDriftDetected`, `CwdAtStart`, `CwdAtFinalize`, `CwdDriftNotice` so automation can branch on the drift just like the existing `HeadChanged`/`HeadChangeNotice` pattern.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj` — 0 warnings, 0 errors.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` — 5042 passed, 0 failed, 3 skipped (perf gates).
- `dotnet run --project tools/CodeIndex.Changelog -- check` — Validated 81 fragments.
- Codex adversarial review on `--commit 825014c6`: no blocking/actionable issues.

## Documentation / Changelog

- `changelog.d/unreleased/1577.fixed.md` — bilingual fragment (English + 日本語) describing the new behavior and the new `index --json` fields.
- No `CHANGELOG.md` edits (per the fragment-driven release process).
- No `AGENT.md` / `CLAUDE.md` / `AGENT_GUIDE.md` edits.

## Follow-up candidates

None identified. Implementation is scoped strictly to #1577; no naturally-related issues surfaced during review.

Fixes #1577
