### PR TITLE
Add regression coverage for directory scan failure propagation

### DIFF
--- a/changelog.d/unreleased/1586.fixed.md
+++ b/changelog.d/unreleased/1586.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1586
+affected:
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Directory scan failure propagation is now covered by regression tests (#1586)** — nested permission failures are verified to keep parent directories out of the fully scanned set, preventing purge code from treating incomplete subtree scans as authoritative.
+
+## 日本語
+
+- **ディレクトリ走査失敗の伝播を回帰テストで固定しました (#1586)** — ネストした permission failure が発生した場合に親ディレクトリを fully scanned 扱いにしないことを検証し、不完全なサブツリー走査を purge 処理が authoritative とみなさないようにしました。

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -1109,6 +1109,48 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void ScanFilesDetailed_DoesNotMarkParentsFullyScannedWhenNestedDirectoryFails()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        var srcDir = Path.Combine(tempDir, "src");
+        var blockedDir = Path.Combine(srcDir, "blocked");
+        UnixFileMode? originalMode = null;
+        try
+        {
+            Directory.CreateDirectory(blockedDir);
+            File.WriteAllText(Path.Combine(tempDir, "keep.py"), "print('keep')");
+            File.WriteAllText(Path.Combine(srcDir, "service.py"), "print('service')");
+            File.WriteAllText(Path.Combine(blockedDir, "secret.py"), "print('secret')");
+            originalMode = File.GetUnixFileMode(blockedDir);
+            SetUnixPermissions(blockedDir, UnixFileMode.None);
+
+            var indexer = new FileIndexer(tempDir);
+            var result = indexer.ScanFilesDetailed();
+            var files = result.Files
+                .Select(path => Path.GetRelativePath(tempDir, path).Replace('\\', '/'))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.Equal(["keep.py", "src/service.py"], files);
+            Assert.Contains(result.Errors, error => error.Path == "src/blocked" && error.Message == "Could not scan directory due to permissions.");
+            Assert.Contains("", result.ListedDirectories);
+            Assert.DoesNotContain("", result.FullyScannedDirectories);
+            Assert.DoesNotContain("src", result.FullyScannedDirectories);
+            Assert.DoesNotContain("src/blocked", result.FullyScannedDirectories);
+        }
+        finally
+        {
+            if (originalMode.HasValue && Directory.Exists(blockedDir))
+                SetUnixPermissions(blockedDir, originalMode.Value);
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void ScanFiles_RespectsRootAnchoredGitignorePatterns()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

- Add regression coverage for nested directory scan failures so parent directories are not treated as fully scanned when a child directory cannot be enumerated.
- Add a bilingual unreleased changelog fragment for #1586.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation and Changelog

- Added `changelog.d/unreleased/1586.fixed.md`.
- No README or developer guide update was needed because this locks existing scan/purge safety behavior without changing user-facing CLI or MCP contracts.

## Review

- Adversarial review: No blocking/actionable issues found.

Fixes #1586
