### PR TITLE
Document contributor workflow guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,67 @@ derivative products. See `TRADEMARKS.md`.
 
 ## Development
 
-Run:
+Start from the shared project guidance:
+
+- `DEVELOPER_GUIDE.md` for architecture, dependency policy, and build basics.
+- `TESTING_GUIDE.md` for test layout, test-writing conventions, and targeted
+  test commands.
+- `AGENT_GUIDE.md` for repository workflow rules used by coding agents.
+
+For a normal change, create a topic branch from the latest `origin/main`.
+Use a short, descriptive branch name. For issue fixes, use
+`fix-issue<issue-number>` unless the issue or maintainer asks for a different
+name.
+
+Use English commit messages. Include the relevant issue number when the change
+is tied to an issue, for example:
+
+```text
+Document contributor workflow guidance (#1590)
+```
+
+Keep changes focused and follow the existing style of the files you touch:
+
+- prefer the smallest correct change;
+- avoid unrelated refactors;
+- update docs when user-visible behavior, commands, workflows, or output
+  contracts change;
+- add or update tests when behavior changes.
+
+Before opening a pull request, run the checks that match the change. For code
+changes, the default full validation is:
 
 ```bash
 dotnet restore CodeIndex.sln
 dotnet build CodeIndex.sln -c Release
 dotnet test CodeIndex.sln -c Release
 ```
+
+Use narrower `dotnet test --filter ...` commands while iterating, then finish
+with the relevant broader validation before the PR.
+
+## Changelog Fragments
+
+User-visible, behavior-changing, install/release, documentation-contract, and
+workflow changes need a changelog fragment under `changelog.d/unreleased/`.
+Do not edit `CHANGELOG.md` for ordinary implementation PRs.
+
+Use `.codex/workflows/changelog-fragment.md` for the exact fragment format.
+Issue-based changes should use a filename like `<issue>.docs.md` or
+`<issue>.fixed.md`, include `issues:` front matter, and include both
+`## English` and `## 日本語` sections.
+
+## Pull Request Checklist
+
+Before requesting review, confirm:
+
+- the branch is based on the latest practical `origin/main`;
+- commits are focused and use English messages;
+- relevant tests/builds were run, or the PR explains why they were not needed;
+- docs were updated when behavior or workflows changed;
+- a bilingual changelog fragment was added when required;
+- issue-closing lines use `Fixes #123` in the PR body when the PR should close
+  an issue.
+
+Maintainers and coding agents should also follow `.codex/workflows/precommit.md`
+before committing.

--- a/changelog.d/unreleased/1590.docs.md
+++ b/changelog.d/unreleased/1590.docs.md
@@ -1,0 +1,15 @@
+---
+category: docs
+issues:
+  - 1590
+affected:
+  - CONTRIBUTING.md
+---
+
+## English
+
+- **CONTRIBUTING now documents the contributor workflow (#1590)** — added guidance for branch naming, commit messages, style expectations, test validation, PR checks, and the changelog-fragment workflow.
+
+## 日本語
+
+- **CONTRIBUTING に contributor workflow を明記しました (#1590)** — branch naming、commit message、style expectations、test validation、PR checks、changelog-fragment workflow の案内を追加しました。


### PR DESCRIPTION
## Summary

- Expanded `CONTRIBUTING.md` with contributor workflow guidance for branch names, commit messages, style expectations, validation, PR checks, and changelog fragments.
- Added a bilingual changelog fragment for #1590.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- `git diff --check origin/main..HEAD`
- Adversarial review of `origin/main..HEAD`: No blocking/actionable issues found.

## Documentation and Changelog

- Updated `CONTRIBUTING.md`.
- Added `changelog.d/unreleased/1590.docs.md`.

## Notes

- Full `cdidx index . --rebuild --json` was attempted after switching from the previous branch, but it produced no output for several minutes and was stopped. A targeted file refresh and post-commit `--commits HEAD` refresh both completed, but the existing local index still reports degraded readiness inherited from the interrupted rebuild.
- `AGENTS.md`, `CLAUDE.md`, and `AGENT_GUIDE.md` were not modified.

Fixes #1590
