### PR TITLE
Document first index timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,22 @@ and [cdidx vs VS Code workspace index](USER_GUIDE.md#cdidx-vs-vs-code-workspace-
 ## Quick Start
 
 ```bash
+# Install is usually seconds.
 curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash
+
+# First index: ~30-60s on small repos; minutes or longer on 100k-file trees.
+# Add --verbose to see each file status while it runs.
 cdidx .
 cdidx status --check --json
 cdidx search "handleRequest"
 cdidx definition UserService
 cdidx mcp
 ```
+
+During indexing, the terminal shows `Scanning...`, `Indexing...`, and a
+`67.0% [28/42]`-style progress line. For later edits, refresh incrementally
+with `--files` or `--commits` instead of rebuilding; see
+[Quick Start](USER_GUIDE.md#quick-start).
 
 Use `cdidx` when a repository will be searched repeatedly from terminals,
 scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
@@ -148,13 +157,22 @@ details.
 ## すぐに試す
 
 ```bash
+# インストールは通常数秒で終わります。
 curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash
+
+# 初回 index は小規模 repo で約30-60秒、100kファイル級では数分以上かかることがあります。
+# 実行中のファイル別ステータスを見たい場合は --verbose を付けてください。
 cdidx .
 cdidx status --check --json
 cdidx search "handleRequest"
 cdidx definition UserService
 cdidx mcp
 ```
+
+インデックス中は `Scanning...`、`Indexing...`、`67.0% [28/42]` のような
+進捗行が表示されます。編集後は再構築ではなく `--files` や `--commits` で
+差分更新できます。詳細は [クイックスタート](USER_GUIDE.md#クイックスタート)
+を参照してください。
 
 ターミナル、スクリプト、CI、AI ツールから同じリポジトリを繰り返し検索する
 場合は `cdidx` が向いています。1回限りのテキスト検索には `rg` が向いています。

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -113,11 +113,14 @@ If you need deterministic, scriptable retrieval outside an IDE (or across multip
 
 For implementation details (schema, indexing pipeline, MCP behavior), see [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md).
 
-## 30-Second Quick Start
+## First Query Quick Start
 
 ```bash
-# One-liner install (no .NET required)
+# One-liner install (no .NET required; usually seconds)
 curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash
+
+# First index: ~30-60s on small repos; minutes or longer on 100k-file trees.
+# Add --verbose to see each file status while it runs.
 cdidx .
 cdidx search "handleRequest"
 ```
@@ -127,6 +130,12 @@ That is the whole loop:
 1. `cdidx .` builds or refreshes `.cdidx/codeindex.db`
 2. `cdidx search ...` returns results from the local index
 3. after edits, refresh with `cdidx . --files path/to/file.cs` or `cdidx . --commits HEAD`
+
+During indexing, interactive terminals show `Scanning...`, `Indexing...`, and
+a `67.0% [28/42]`-style progress line. If a large first index looks slow, rerun
+with `cdidx . --verbose` to see `[OK  ]`, `[SKIP]`, `[DEL ]`, and `[ERR ]`
+file statuses. Use incremental refreshes after the first run; see
+[Options](#options) for `--files` and `--commits`.
 
 ## Installation
 
@@ -260,6 +269,11 @@ cdidx ./myproject
 cdidx ./myproject --rebuild     # full rebuild from scratch
 cdidx ./myproject --verbose     # show per-file details
 ```
+
+The first index does the expensive work once. Expect roughly 30-60 seconds on
+small repositories, and minutes or longer on very large monorepos with around
+100k files. Interactive terminals keep a live spinner and progress bar; use
+`--verbose` when you want per-file status while waiting.
 
 By default, `cdidx index` stores the database in `<projectPath>/.cdidx/codeindex.db`, even if you run the command from another directory.
 Indexing keeps the built-in skip lists (`node_modules`, `bin`, `obj`, lockfiles, etc.) and also honors user `.gitignore` plus optional `.cdidxignore` rules across full scans, `--files`, and `--commits` updates. On Windows, paths marked with the Hidden or System attribute are skipped before language detection so broad scans do not enter OS-owned caches such as `System Volume Information` or `$Recycle.Bin`; clear those attributes before indexing project-owned source files because ignore rules only exclude additional paths. When the project is inside Git, ignore matching follows the repository's `core.ignorecase` setting, even when the indexed project path is a subdirectory inside that repo; repo-root and other ancestor `.gitignore` files above that subdirectory still apply, and `--commits` resolves changed paths from the repository root before narrowing them back to the indexed project root. `**` only gets Git-style special handling in the documented path forms rather than as an unrestricted cross-directory wildcard. If an update refresh includes ignore-file changes, cdidx automatically falls back to a full scan so newly ignored files are purged safely. Invalid ignore lines are skipped with a warning instead of aborting the whole run, while unreadable ignore files fail closed for that directory scope so cdidx does not index with incomplete rules.
@@ -1427,11 +1441,14 @@ CodeIndex は source-available / Fair Source-style software であり、OSI-appr
 
 実装の詳細（スキーマ、索引パイプライン、MCP挙動）は [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md#開発者ガイド) を参照してください。
 
-## 30秒で試す
+## 最初の検索を試す
 
 ```bash
-# .NET 不要のワンライナーインストール
+# .NET 不要のワンライナーインストール（通常は数秒）
 curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash
+
+# 初回 index は小規模 repo で約30-60秒、100kファイル級では数分以上かかることがあります。
+# 実行中のファイル別ステータスを見たい場合は --verbose を付けてください。
 cdidx .
 cdidx search "handleRequest"
 ```
@@ -1441,6 +1458,12 @@ cdidx search "handleRequest"
 1. `cdidx .` で `.cdidx/codeindex.db` を作成または更新
 2. `cdidx search ...` でローカルインデックスを検索
 3. 編集後は `cdidx . --files path/to/file.cs` や `cdidx . --commits HEAD` で差分更新
+
+インデックス中、interactive terminal では `Scanning...`、`Indexing...`、
+`67.0% [28/42]` のような進捗行が表示されます。大きな初回 index が遅く見える
+場合は `cdidx . --verbose` で再実行すると、`[OK  ]`、`[SKIP]`、`[DEL ]`、`[ERR ]`
+のファイル別ステータスを確認できます。初回以降は差分更新を使ってください。
+`--files` と `--commits` は [オプション一覧](#オプション一覧) を参照してください。
 
 ## インストール
 
@@ -1565,6 +1588,11 @@ cdidx ./myproject
 cdidx ./myproject --rebuild     # 完全再構築
 cdidx ./myproject --verbose     # ファイルごとの詳細表示
 ```
+
+初回 index は重い処理を一度だけ実行します。小規模リポジトリでは約30-60秒、
+100kファイル級の大規模 monorepo では数分以上かかることがあります。
+interactive terminal では spinner と progress bar が動き続けます。待っている間に
+ファイル別ステータスを確認したい場合は `--verbose` を使ってください。
 
 `cdidx index` は、別ディレクトリから実行しても、デフォルトでは `<projectPath>/.cdidx/codeindex.db` にDBを保存します。
 

--- a/changelog.d/unreleased/1589.docs.md
+++ b/changelog.d/unreleased/1589.docs.md
@@ -1,0 +1,16 @@
+---
+category: docs
+issues:
+  - 1589
+affected:
+  - README.md
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Quickstart now sets first-index expectations (#1589)** — the README and user guide call out install time, first-index time on small versus large repositories, `--verbose` progress details, and incremental refresh options.
+
+## 日本語
+
+- **Quickstart で初回 index の所要時間目安を明記しました (#1589)** — README とユーザーガイドで、インストール時間、小規模/大規模リポジトリの初回 index 時間、`--verbose` の進捗詳細、差分更新の選択肢を案内するようにしました。


### PR DESCRIPTION
## Summary

- Add first-index time expectations to the README and user guide quickstarts.
- Document `--verbose` and the live progress-line format so large first indexes do not look hung.
- Point users toward `--files` and `--commits` incremental refreshes after the first index.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog

- Updated `README.md`
- Updated `USER_GUIDE.md`
- Added changelog fragment `changelog.d/unreleased/1589.docs.md`

## Follow-up candidates

- None.

Fixes #1589
