### PR TITLE
[codex] Fix shebang binary probe handling

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -32,7 +32,7 @@ The test project mirrors the production areas closely.
 - `ChunkSplitterTests.cs`, `SymbolExtractorTests.cs`, `ReferenceExtractorTests.cs`, `SearchSnippetFormatterTests.cs`, `DbPathResolverTests.cs`, `ConsoleUiTests.cs`
   Pure or mostly pure behavior tests with in-memory inputs.
 - `FileIndexerTests.cs`
-  File scanning, language detection, and record-building behavior.
+  File scanning, language detection, and record-building behavior, including extensionless shebang detection's 256-byte first-line cap and binary/NUL-byte rejection.
 - `DatabaseTests.cs`, `DbReaderTests.cs`
   SQLite schema, write paths, migrations, and query behavior.
 - `LegacySchemaMigrationTests.cs`
@@ -202,7 +202,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 - `ChunkSplitterTests.cs`、`SymbolExtractorTests.cs`、`ReferenceExtractorTests.cs`、`SearchSnippetFormatterTests.cs`、`DbPathResolverTests.cs`、`ConsoleUiTests.cs`
   インメモリ入力中心の、純粋またはほぼ純粋な振る舞いのテスト。
 - `FileIndexerTests.cs`
-  ファイル走査、言語判定、レコード構築のテスト。
+  ファイル走査、言語判定、レコード構築のテスト。拡張子なし shebang 判定の「先頭物理行 256 byte 上限」と binary/NUL byte 除外も含みます。
 - `DatabaseTests.cs`、`DbReaderTests.cs`
   SQLite スキーマ、書き込み経路、マイグレーション、クエリ挙動のテスト。
 - `LegacySchemaMigrationTests.cs`

--- a/changelog.d/unreleased/1587.fixed.md
+++ b/changelog.d/unreleased/1587.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1587
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Extensionless shebang probing now rejects binary-like inputs before parsing (#1587)** — shebang detection now reads only the first physical line within a documented 256-byte cap, rejects NUL-containing probes such as ELF/Mach-O/PE headers, and ignores over-cap first lines instead of silently parsing minified or malformed data as scripts.
+
+## 日本語
+
+- **拡張子なし shebang 判定が解析前に binary らしい入力を除外するようになりました (#1587)** — shebang 判定は文書化した 256 byte 上限内の先頭物理行だけを読み、ELF/Mach-O/PE header のような NUL を含む probe を拒否し、上限超過の先頭行は minified / malformed data として黙って script 解析しないようになりました。

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -353,6 +353,10 @@ public class FileIndexer
 
     // Maximum file size to index (10 MB) / インデックス対象の最大ファイルサイズ (10 MB)
     private const long MaxFileSize = 10 * 1024 * 1024;
+    // Extensionless shebang detection reads at most the first physical line within this
+    // byte cap. NUL bytes or a line that reaches the cap without LF/CR are treated as
+    // unsupported so binary executables and minified data are not parsed as scripts.
+    private const int ShebangProbeByteLimit = 256;
 
     private readonly string _projectRoot;
     private readonly string _ignoreRuleRoot;
@@ -2466,6 +2470,8 @@ public class FileIndexer
     /// <summary>
     /// Try to infer a language from an extensionless script shebang.
     /// This is a cheap fallback used only after extension and exact-filename checks fail.
+    /// It reads at most <see cref="ShebangProbeByteLimit"/> bytes from the first line;
+    /// NUL bytes and over-cap first lines are treated as non-scripts.
     /// 拡張子・完全一致ファイル名で判定できない場合だけ、拡張子なしスクリプトの shebang から言語を推定する。
     /// </summary>
     private static LanguageDetectionResult TryDetectLanguageFromShebang(string filePath)
@@ -2479,13 +2485,24 @@ public class FileIndexer
             if (!stream.CanRead)
                 return new LanguageDetectionResult(FileProbeStatus.ProbeFailed, null);
 
-            Span<byte> buffer = stackalloc byte[256];
+            Span<byte> buffer = stackalloc byte[ShebangProbeByteLimit];
             var bytesRead = stream.Read(buffer);
             if (bytesRead <= 0)
                 return new LanguageDetectionResult(FileProbeStatus.Unsupported, null);
 
-            var firstLine = Encoding.UTF8.GetString(buffer[..bytesRead])
-                .Split(['\r', '\n'], 2)[0];
+            var bytes = buffer[..bytesRead];
+            if (bytes.Contains((byte)0))
+                return new LanguageDetectionResult(FileProbeStatus.Unsupported, null);
+
+            var lineEnd = bytes.IndexOfAny((byte)'\r', (byte)'\n');
+            if (lineEnd < 0)
+            {
+                if (bytesRead == ShebangProbeByteLimit)
+                    return new LanguageDetectionResult(FileProbeStatus.Unsupported, null);
+                lineEnd = bytesRead;
+            }
+
+            var firstLine = new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(bytes[..lineEnd]);
 
             if (firstLine.StartsWith('\uFEFF'))
                 firstLine = firstLine[1..];
@@ -2518,6 +2535,10 @@ public class FileIndexer
         catch (UnauthorizedAccessException)
         {
             return new LanguageDetectionResult(FileProbeStatus.ProbeFailed, null);
+        }
+        catch (DecoderFallbackException)
+        {
+            return new LanguageDetectionResult(FileProbeStatus.Unsupported, null);
         }
     }
 

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -292,6 +292,46 @@ public class FileIndexerTests
         }
     }
 
+    [Theory]
+    [InlineData("elf", new byte[] { 0x7F, (byte)'E', (byte)'L', (byte)'F', 0x02, 0x01, 0x01, 0x00 })]
+    [InlineData("macho", new byte[] { 0xCF, 0xFA, 0xED, 0xFE, 0x07, 0x00, 0x00, 0x01 })]
+    [InlineData("pe", new byte[] { (byte)'M', (byte)'Z', 0x90, 0x00, 0x03, 0x00, 0x00, 0x00 })]
+    [InlineData("data", new byte[] { (byte)'#', (byte)'!', (byte)'/', (byte)'b', (byte)'i', (byte)'n', (byte)'/', (byte)'s', (byte)'h', 0x00 })]
+    public void DetectLanguage_ExtensionlessBinaryLikeFiles_ReturnsNull(string fileName, byte[] bytes)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var path = Path.Combine(tempDir, fileName);
+            File.WriteAllBytes(path, bytes);
+
+            Assert.Null(FileIndexer.DetectLanguage(path));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void DetectLanguage_ExtensionlessOverCapShebangLine_ReturnsNull()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var path = Path.Combine(tempDir, "tool");
+            File.WriteAllText(path, "#!/usr/bin/env " + new string('x', 256));
+
+            Assert.Null(FileIndexer.DetectLanguage(path));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
     [Fact]
     public void DetectLanguage_ExtensionlessNonScript_ReturnsNull()
     {


### PR DESCRIPTION
## Summary

- Add a documented 256-byte first-line cap for extensionless shebang probing.
- Reject NUL-containing probe buffers before shebang parsing so binary-like ELF/Mach-O/PE inputs are not treated as scripts.
- Add FileIndexer regression coverage plus TESTING_GUIDE and changelog fragment updates.

## Documentation and changelog

- Updated `TESTING_GUIDE.md` for the shebang probe cap and binary/NUL-byte rejection coverage.
- Added changelog fragment `changelog.d/unreleased/1587.fixed.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests"`
- `dotnet test`
- `dotnet run --no-restore --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --rebuild --json`
- Adversarial review: No blocking/actionable issues found.

## Follow-up candidates

- None.

Fixes #1587