### PR TITLE
Clarify README opening positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
 ![License](https://img.shields.io/badge/License-FSL--1.1--ALv2-orange)
 ![SQLite](https://img.shields.io/badge/SQLite-FTS5-003B57?logo=sqlite&logoColor=white)
 
-**AI-native local code search for terminal and MCP workflows.**
+**CLI code indexing and MCP search for local repositories.**
 
-`cdidx` indexes a repository into a local SQLite FTS5 database, then answers
+`cdidx` is a command-line code indexer and MCP server that builds a local
+SQLite index of your repository so humans and AI agents can run fast
 full-text, symbol, dependency, and inspection queries without repeatedly
-rescanning the same tree. It is built for humans and AI agents that need small,
-structured code context from local repositories.
+rescanning the same tree.
 
 ## Why cdidx
 
@@ -122,12 +122,12 @@ details.
 ![License](https://img.shields.io/badge/License-FSL--1.1--ALv2-orange)
 ![SQLite](https://img.shields.io/badge/SQLite-FTS5-003B57?logo=sqlite&logoColor=white)
 
-**ターミナルと MCP ワークフロー向けの、AI ネイティブなローカルコード検索です。**
+**ローカルリポジトリ向けの CLI コードインデックスと MCP 検索です。**
 
-`cdidx` はリポジトリをローカル SQLite FTS5 データベースにインデックスし、
-同じツリーを何度も読み直さずに全文検索、シンボル、依存関係、inspect
-クエリへ応答します。人間と AI エージェントの両方が、ローカルリポジトリから
-小さく構造化されたコード文脈を取り出すためのツールです。
+`cdidx` はコマンドラインのコードインデクサー兼 MCP サーバーで、リポジトリの
+ローカル SQLite index を作成します。人間と AI エージェントは、同じツリーを
+何度も読み直さずに、高速な全文検索、シンボル、依存関係、inspect クエリを
+実行できます。
 
 ## なぜ cdidx なのか
 

--- a/changelog.d/unreleased/1588.docs.md
+++ b/changelog.d/unreleased/1588.docs.md
@@ -1,0 +1,15 @@
+---
+category: docs
+issues:
+  - 1588
+affected:
+  - README.md
+---
+
+## English
+
+- **README now identifies cdidx before describing its storage model (#1588)** — The opening copy now states that cdidx is a command-line code indexer and MCP server before mentioning the local SQLite index.
+
+## 日本語
+
+- **README が storage model より先に cdidx の正体を説明するようになりました (#1588)** — 冒頭文でローカル SQLite index に触れる前に、cdidx がコマンドラインのコードインデクサー兼 MCP サーバーであることを明示しました。


### PR DESCRIPTION
## Summary

- Rewrite the README opening copy so new readers first learn that `cdidx` is a command-line code indexer and MCP server.
- Mirror the same positioning in the Japanese README section.

## Validation

- `dotnet build`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and Changelog

- Updated `README.md`.
- Added changelog fragment `changelog.d/unreleased/1588.docs.md`.

## Review

- Codex adversarial review found an unrelated changelog deletion in an earlier branch base; the branch was recreated from the latest `origin/main` and the final diff is limited to `README.md` and `changelog.d/unreleased/1588.docs.md`.
- No remaining blocking/actionable issue after the fix.

## Follow-up Candidates

- None.

Fixes #1588
