### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report a reproducible CodeIndex problem.
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Environment
+
+- `cdidx` version:
+- Install method: dotnet tool / local build / release binary / other
+- OS and version:
+- .NET SDK/runtime version:
+- Repository language(s):
+
+## Current behavior
+
+Describe what happened.
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Command output
+
+```text
+Paste the exact command and relevant output here.
+```
+
+## Additional context
+
+Add any related logs, index status output, screenshots, or links.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an improvement for CodeIndex.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+Describe the problem, limitation, or workflow gap.
+
+## Motivation
+
+Explain who needs this and why it matters.
+
+## Proposed solution
+
+Describe the behavior, command, API, or documentation change you want.
+
+## Alternatives considered
+
+List any workarounds or alternate designs you considered.
+
+## Additional context
+
+Add related issues, examples, links, or screenshots.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,3 +16,7 @@
 ## Issues
 
 Fixes #
+
+## Follow-up issues
+
+- None

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+- Describe the change.
+
+## Validation
+
+- [ ] Tests added or updated for changed behavior, or not needed because:
+- [ ] Relevant validation command(s) run:
+
+## Documentation and changelog
+
+- [ ] Documentation updated, or not needed because:
+- [ ] Changelog fragment added under `changelog.d/unreleased/`, or not needed because:
+- [ ] Fragment follows `.codex/workflows/changelog-fragment.md` for category, issue front matter, and bilingual sections.
+
+## Issues
+
+Fixes #

--- a/changelog.d/unreleased/1592.docs.md
+++ b/changelog.d/unreleased/1592.docs.md
@@ -10,8 +10,8 @@ affected:
 
 ## English
 
-- **Added GitHub issue and PR templates (#1592)** — new bug report, feature request, and pull request templates collect environment, reproduction, validation, documentation, and changelog-fragment details during triage.
+- **Added GitHub issue and PR templates (#1592)** — new bug report, feature request, and pull request templates collect environment, reproduction, validation, documentation, changelog-fragment, and follow-up issue details during triage.
 
 ## 日本語
 
-- **GitHub の issue / PR テンプレートを追加しました (#1592)** — bug report、feature request、pull request の各テンプレートで、トリアージ時に環境、再現手順、検証、ドキュメント、changelog fragment の情報を集められるようにしました。
+- **GitHub の issue / PR テンプレートを追加しました (#1592)** — bug report、feature request、pull request の各テンプレートで、トリアージ時に環境、再現手順、検証、ドキュメント、changelog fragment、follow-up issue の情報を集められるようにしました。

--- a/changelog.d/unreleased/1592.docs.md
+++ b/changelog.d/unreleased/1592.docs.md
@@ -1,0 +1,17 @@
+---
+category: docs
+issues:
+  - 1592
+affected:
+  - .github/ISSUE_TEMPLATE/bug_report.md
+  - .github/ISSUE_TEMPLATE/feature_request.md
+  - .github/pull_request_template.md
+---
+
+## English
+
+- **Added GitHub issue and PR templates (#1592)** — new bug report, feature request, and pull request templates collect environment, reproduction, validation, documentation, and changelog-fragment details during triage.
+
+## 日本語
+
+- **GitHub の issue / PR テンプレートを追加しました (#1592)** — bug report、feature request、pull request の各テンプレートで、トリアージ時に環境、再現手順、検証、ドキュメント、changelog fragment の情報を集められるようにしました。


### PR DESCRIPTION
## Summary

- Added GitHub issue templates for bug reports and feature requests.
- Added a pull request template with validation, documentation, and changelog-fragment checklist items.
- Added a bilingual changelog fragment for the template addition.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln`
- `git diff --cached --check`
- Adversarial review: No blocking/actionable issues found.

## Documentation and changelog

- Added `changelog.d/unreleased/1592.docs.md`.
- No `CHANGELOG.md` edit; this is an ordinary issue-fix PR using the fragment workflow.

## Notes

- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json` was attempted after merge but exited with code 143 before completion in this environment.

Fixes #1592
