### PR TITLE
Fix index elapsed duration display

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ cdidx mcp
 ```
 
 During indexing, the terminal shows `Scanning...`, `Indexing...`, and a
-`67.0% [28/42]`-style progress line. For later edits, refresh incrementally
-with `--files` or `--commits` instead of rebuilding; see
+`67.0% [28/42]`-style progress line, then a unit-labelled elapsed time such as
+`2.4s` or `5m 42s`. For later edits, refresh incrementally with `--files` or
+`--commits` instead of rebuilding; see
 [Quick Start](USER_GUIDE.md#quick-start).
 
 Use `cdidx` when a repository will be searched repeatedly from terminals,
@@ -172,8 +173,9 @@ cdidx mcp
 ```
 
 インデックス中は `Scanning...`、`Indexing...`、`67.0% [28/42]` のような
-進捗行が表示されます。編集後は再構築ではなく `--files` や `--commits` で
-差分更新できます。詳細は [クイックスタート](USER_GUIDE.md#クイックスタート)
+進捗行が表示され、最後に `2.4s` や `5m 42s` のような単位付き経過時間が出ます。
+編集後は再構築ではなく `--files` や `--commits` で差分更新できます。詳細は
+[クイックスタート](USER_GUIDE.md#クイックスタート)
 を参照してください。
 
 ターミナル、スクリプト、CI、AI ツールから同じリポジトリを繰り返し検索する

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -268,6 +268,7 @@ cdidx --version
 cdidx ./myproject
 cdidx ./myproject --rebuild     # full rebuild from scratch
 cdidx ./myproject --verbose     # show per-file details
+cdidx ./myproject --duration-format seconds  # show elapsed time as seconds
 cdidx ./myproject --watch       # stay running and reindex on file changes
 cdidx ./myproject --watch --debounce 200   # coalesce bursts within a 200 ms window
 ```
@@ -307,10 +308,12 @@ Done.
   Hotspots : ready
   C# names : ready
   Fold     : ready
-  Elapsed  : 00:00:02
+  Elapsed  : 2.4s
 ```
 
 During long-running indexing on an interactive terminal, `Indexing...` stays live as a spinner instead of dropping to a fixed line until the next 50-file progress update. Warnings still print immediately, but the spinner resumes right after each warning so the run does not look frozen. When stdout is redirected (for example `cdidx . > out.txt`), cdidx prints a single `Indexing...` line to stdout, keeps warnings on stderr, and emits only line-based progress updates to stdout.
+
+Human output formats elapsed index time with unit labels by default: milliseconds under 1 second, seconds under 1 minute, minutes/seconds under 1 hour, and hours/minutes/seconds after that. Use `--duration-format seconds` for decimal seconds or `--duration-format hms` for the legacy `HH:MM:SS` display. JSON output continues to expose raw `elapsed_ms` for machine consumers.
 
 Machine-readable output also reports the post-run readiness bits directly:
 
@@ -628,6 +631,7 @@ cdidx report --output report.tgz --json
 | `--commits <id...>` | `index` | Update only files changed in specified commits. Prefer this after a normal commit because git history includes rename/delete paths. |
 | `--files <path...>` | `index` | Update only the specified files. Safe for known in-place edits or new files; old rename/delete paths are not purged unless you also list them explicitly. |
 | `--force` | `index` | Bypass the per-database index lock. Only use when you are sure no other `cdidx index` is active against the same DB; concurrent runs may corrupt the schema. |
+| `--duration-format <auto\|seconds\|hms>` | `index` | Choose human elapsed-time display for index summaries. `auto` (default) uses unit labels; `seconds` emits decimal seconds; `hms` keeps `HH:MM:SS`. JSON always keeps raw `elapsed_ms`. |
 | `--watch` | `index` | After the initial scan completes, stay running and reindex incrementally as files change (FileSystemWatcher / inotify / FSEvents). Rejects `--commits`, `--files`, and `--dry-run` because the loop already drives continuous incremental updates. |
 | `--debounce <ms>` | `index` (watch only) | Coalesce bursts of file events into a single update after `<ms>` of quiet (non-negative integer; default: 500). Invalid values emit a warning and are ignored. |
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp. Offsetless values (e.g. `2024-01-01T00:00:00`) are treated as UTC so the same flag resolves to the same instant in every timezone; append `Z` or an explicit offset (`+09:00`) to be explicit. |
@@ -1677,6 +1681,7 @@ cdidx --version
 cdidx ./myproject
 cdidx ./myproject --rebuild     # 完全再構築
 cdidx ./myproject --verbose     # ファイルごとの詳細表示
+cdidx ./myproject --duration-format seconds  # 経過時間を秒で表示
 cdidx ./myproject --watch       # 初回スキャン後も常駐して変更を反映
 cdidx ./myproject --watch --debounce 200   # 200 ms のデバウンス窓でまとめて反映
 ```
@@ -1714,10 +1719,12 @@ Done.
   Hotspots: ready
   C# names: ready
   Fold    : ready
-  Elapsed : 00:00:02
+  Elapsed : 2.4s
 ```
 
 対話ターミナルで長時間インデックスするときも、`Indexing...` は次の 50 ファイル更新まで固定文字列に落ちず、スピナーとして動き続けます。警告はその場で表示されますが、各警告の直後にスピナーが再開するため、処理が止まったようには見えません。stdout をリダイレクトしている場合（例: `cdidx . > out.txt`）は、stdout には `Indexing...` を 1 回だけ出し、警告は stderr に分離したまま、stdout には行単位の進捗だけを出します。
+
+human 出力の index 経過時間は既定で単位付きになります。1 秒未満はミリ秒、1 分未満は秒、1 時間未満は分/秒、それ以上は時/分/秒です。`--duration-format seconds` で小数秒、`--duration-format hms` で従来の `HH:MM:SS` 表示にできます。JSON 出力は機械向けに raw の `elapsed_ms` を維持します。
 
 機械向けの `--json` 出力でも、実行後の readiness bit がそのまま返ります:
 
@@ -2039,6 +2046,7 @@ cdidx report --output report.tgz --json
 | `--commits <id...>` | `index` | 指定コミットの変更ファイルのみ更新。通常のコミット後はこちらを推奨。rename/delete の旧パスも git 履歴から拾える。 |
 | `--files <path...>` | `index` | 指定ファイルのみ更新。把握している in-place 編集や新規ファイル向け。rename/delete の旧パスは明示しない限り purge されない。 |
 | `--force` | `index` | 同一 DB に対する index ロックを bypass する。他の `cdidx index` が走っていないと確信できる場合のみ使う。並行実行は schema を破壊し得る。 |
+| `--duration-format <auto\|seconds\|hms>` | `index` | index summary の human 経過時間表示を選ぶ。`auto`（既定）は単位付き、`seconds` は小数秒、`hms` は `HH:MM:SS` を維持。JSON は常に raw の `elapsed_ms` を返す。 |
 | `--watch` | `index` | 初回スキャン完了後もプロセスを残し、ファイル変更を検知して差分更新を繰り返す（FileSystemWatcher / inotify / FSEvents）。連続的な差分更新を内蔵しているため `--commits` / `--files` / `--dry-run` との併用は拒否する。 |
 | `--debounce <ms>` | `index`（`--watch` 専用） | 一連のイベントを `<ms>` の静止後に 1 つの更新へ集約する（0 以上の整数。既定: 500）。不正な値は警告を出して無視する。 |
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601）。オフセットなしの値（例: `2024-01-01T00:00:00`）は UTC として解釈されるため、どのタイムゾーンから呼び出しても同じ UTC 時点になります。明示したい場合は末尾に `Z` または `+09:00` 等のオフセットを付与してください。 |

--- a/changelog.d/unreleased/1853.fixed.md
+++ b/changelog.d/unreleased/1853.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 1853
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - README.md
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Index summaries now show elapsed time with unit labels (#1853)** — human `cdidx index` output uses readable duration labels by default and adds `--duration-format auto|seconds|hms` for explicit display preferences while keeping JSON `elapsed_ms` unchanged.
+
+## 日本語
+
+- **index summary の経過時間に単位が付くようになりました (#1853)** — human 向けの `cdidx index` 出力は既定で読みやすい単位付き duration を表示し、明示的な表示設定用に `--duration-format auto|seconds|hms` を追加しました。JSON の `elapsed_ms` は従来どおりです。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -191,6 +191,7 @@ internal static class CliFlagSchema
             new() { Name = "--verbose", Description = "Show per-file status", Commands = Set("index") },
             new() { Name = "--dry-run", Description = "Scan files without writing", Commands = Set("index") },
             new() { Name = "--force", Description = "Bypass the per-database index lock", Commands = Set("index") },
+            new() { Name = "--duration-format", ValuePlaceholder = "<auto|seconds|hms>", Description = "Index elapsed time display format", Commands = Set("index") },
             new() { Name = "--commits", ValuePlaceholder = "<id>", Description = "Update files changed in given git commits", Commands = Set("index") },
             new() { Name = "--files", ValuePlaceholder = "<path>", Description = "Update only the specified files", Commands = Set("index") },
             new() { Name = "--watch", Description = "Continuous reindex on file changes (rejects --commits / --files / --dry-run)", Commands = Set("index") },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -1,5 +1,6 @@
 using CodeIndex.Database;
 using CodeIndex.Indexer;
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 
@@ -41,6 +42,13 @@ public enum ColorPalette
     Truecolor = 2,
 }
 
+public enum DurationOutputFormat
+{
+    Auto = 0,
+    Seconds = 1,
+    Hms = 2,
+}
+
 /// <summary>
 /// Console UI helpers: spinner, progress bar, banner, and easter egg messages.
 /// コンソールUIヘルパー: スピナー、プログレスバー、バナー、イースターエッグメッセージ。
@@ -49,10 +57,10 @@ public static class ConsoleUi
 {
     private static readonly (string Command, string Usage)[] CommandUsageLines =
     [
-        ("index", "cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--json] [--watch [--debounce <ms>]]"),
+        ("index", "cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--json] [--duration-format <auto|seconds|hms>] [--watch [--debounce <ms>]]"),
         ("backfill-fold", "cdidx backfill-fold [--db <path>] [--json]"),
-        ("index-commits", "cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json]"),
-        ("index-files", "cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json]"),
+        ("index-commits", "cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]"),
+        ("index-files", "cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]"),
         ("search", "cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup]"),
         ("definition", "cdidx definition <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--exact|--exact-name] [--count] [--since <datetime>]"),
         ("references", "cdidx references <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--max-line-width <n>] [--exact|--exact-name] [--count]"),
@@ -89,6 +97,55 @@ public static class ConsoleUi
     ];
 
     // --- Spinner / スピナー ---
+
+    public static string FormatDuration(TimeSpan duration, DurationOutputFormat format = DurationOutputFormat.Auto)
+    {
+        if (duration < TimeSpan.Zero)
+            duration = TimeSpan.Zero;
+
+        return format switch
+        {
+            DurationOutputFormat.Seconds => FormatDurationAsSeconds(duration),
+            DurationOutputFormat.Hms => FormatDurationAsHms(duration),
+            _ => FormatDurationAuto(duration),
+        };
+    }
+
+    private static string FormatDurationAuto(TimeSpan duration)
+    {
+        if (duration < TimeSpan.FromSeconds(1))
+            return string.Create(CultureInfo.InvariantCulture, $"{Math.Floor(duration.TotalMilliseconds):0}ms");
+
+        if (duration < TimeSpan.FromMinutes(1))
+            return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalSeconds:0.0}s");
+
+        var totalSeconds = (long)Math.Floor(duration.TotalSeconds);
+        if (duration < TimeSpan.FromHours(1))
+        {
+            var minutes = totalSeconds / 60;
+            var seconds = totalSeconds % 60;
+            return string.Create(CultureInfo.InvariantCulture, $"{minutes}m {seconds}s");
+        }
+
+        var hours = totalSeconds / 3600;
+        var remainder = totalSeconds % 3600;
+        var remMinutes = remainder / 60;
+        var remSeconds = remainder % 60;
+        return string.Create(CultureInfo.InvariantCulture, $"{hours}h {remMinutes}m {remSeconds}s");
+    }
+
+    private static string FormatDurationAsSeconds(TimeSpan duration)
+        => string.Create(CultureInfo.InvariantCulture, $"{duration.TotalSeconds:0.0}s");
+
+    private static string FormatDurationAsHms(TimeSpan duration)
+    {
+        var totalSeconds = (long)Math.Floor(duration.TotalSeconds);
+        var hours = totalSeconds / 3600;
+        var remainder = totalSeconds % 3600;
+        var minutes = remainder / 60;
+        var seconds = remainder % 60;
+        return string.Create(CultureInfo.InvariantCulture, $"{hours:00}:{minutes:00}:{seconds:00}");
+    }
 
     /// <summary>
     /// Start spinner on a background thread, returns CancellationTokenSource to stop it.
@@ -459,6 +516,7 @@ public static class ConsoleUi
         Console.WriteLine("  --dry-run                  Scan files without writing to the database");
         Console.WriteLine("  --force                    Bypass the per-database index lock; only use when no other cdidx index is active");
         Console.WriteLine("  --json                     Output results as JSON (for AI/machine use)");
+        Console.WriteLine("  --duration-format <format> Index elapsed time format: `auto` (default), `seconds`, or `hms`; JSON keeps raw elapsed_ms");
         Console.WriteLine("  --commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)");
         Console.WriteLine("  --files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed");
         Console.WriteLine("  --watch                    After the initial scan, stay running and reindex on file changes (FileSystemWatcher / inotify / FSEvents); rejects --commits / --files / --dry-run");

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -499,6 +499,7 @@ public static class IndexCommandRunner
         bool force = false;
         bool watch = false;
         int? watchDebounceMs = null;
+        var durationFormat = DurationOutputFormat.Auto;
         string? easterEgg = null;
         int spinnerFlagCount = 0;
         bool randomSpinner = false;
@@ -541,6 +542,12 @@ public static class IndexCommandRunner
                         Console.Error.WriteLine($"Warning: invalid --debounce value '{args[i + 1]}' (ignored; must be a non-negative integer in milliseconds) / 不正な --debounce 値 '{args[i + 1]}'（無視。ミリ秒の0以上の整数を指定）");
                         i++;
                     }
+                    break;
+                case "--duration-format" when i + 1 < args.Length:
+                    durationFormat = ParseDurationFormat(args[++i], durationFormat);
+                    break;
+                case var option when option.StartsWith("--duration-format=", StringComparison.Ordinal):
+                    durationFormat = ParseDurationFormat(option["--duration-format=".Length..], durationFormat);
                     break;
                 case "--commits":
                     while (i + 1 < args.Length && !args[i + 1].StartsWith('-'))
@@ -603,7 +610,25 @@ public static class IndexCommandRunner
             Force = force,
             Watch = watch,
             WatchDebounceMs = watchDebounceMs,
+            DurationFormat = durationFormat,
         };
+    }
+
+    private static DurationOutputFormat ParseDurationFormat(string value, DurationOutputFormat fallback)
+    {
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "auto" => DurationOutputFormat.Auto,
+            "seconds" => DurationOutputFormat.Seconds,
+            "hms" => DurationOutputFormat.Hms,
+            _ => WarnInvalidDurationFormat(value, fallback),
+        };
+    }
+
+    private static DurationOutputFormat WarnInvalidDurationFormat(string value, DurationOutputFormat fallback)
+    {
+        Console.Error.WriteLine($"Warning: invalid --duration-format value '{value}' (ignored; use auto, seconds, or hms) / 不正な --duration-format 値 '{value}'（無視。auto, seconds, hms のいずれかを指定）");
+        return fallback;
     }
 
     private static string? AbsolutizePathOption(string? value)
@@ -1362,7 +1387,7 @@ public static class IndexCommandRunner
             Console.WriteLine($"  C# names : {(csharpSymbolNameReadyAfter ? "ready" : "degraded")}");
             Console.WriteLine($"  C# meta  : {(csharpMetadataTargetReadyAfter ? "ready" : "degraded")}");
             Console.WriteLine($"  Fold     : {(foldReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Elapsed  : {stopwatch.Elapsed:hh\\:mm\\:ss}");
+            Console.WriteLine($"  Elapsed  : {ConsoleUi.FormatDuration(stopwatch.Elapsed, options.DurationFormat)}");
             Console.WriteLine();
             if (errors > 0)
                 ConsoleUi.PrintWarning($"Some files failed to update. Fix the reported files or permissions, then rerun `cdidx index \"{projectRoot}\"` to restore a fully ready index.");
@@ -2228,7 +2253,7 @@ public static class IndexCommandRunner
             Console.WriteLine($"  C# names : {(csharpSymbolNameReadyAfter ? "ready" : "degraded")}");
             Console.WriteLine($"  C# meta  : {(csharpMetadataTargetReadyAfter ? "ready" : "degraded")}");
             Console.WriteLine($"  Fold     : {(foldReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Elapsed  : {stopwatch.Elapsed:hh\\:mm\\:ss}");
+            Console.WriteLine($"  Elapsed  : {ConsoleUi.FormatDuration(stopwatch.Elapsed, options.DurationFormat)}");
             Console.WriteLine();
             if (errors > 0)
                 ConsoleUi.PrintWarning($"Some files failed to index. Fix the reported files or permissions, then rerun `cdidx index \"{projectRoot}\"` to restore a fully ready index.");
@@ -2445,6 +2470,7 @@ public sealed class IndexCommandOptions
     public bool Force { get; init; }
     public bool Watch { get; init; }
     public int? WatchDebounceMs { get; init; }
+    public DurationOutputFormat DurationFormat { get; init; } = DurationOutputFormat.Auto;
 }
 
 public sealed class BackfillFoldCommandOptions

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -27,9 +27,9 @@ public class ConsoleUiTests
 
         Assert.DoesNotContain("██████╗", output);
         Assert.Contains("Usage:", output);
-        Assert.Contains("cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--json]", output);
-        Assert.Contains("cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json]", output);
-        Assert.Contains("cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json]", output);
+        Assert.Contains("cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--json] [--duration-format <auto|seconds|hms>]", output);
+        Assert.Contains("cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]", output);
+        Assert.Contains("cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]", output);
         Assert.Contains("cdidx backfill-fold [--db <path>] [--json]", output);
         Assert.Contains("cdidx license", output);
         Assert.Contains("cdidx references <query>|--query <query>|-- <query>", output);
@@ -48,6 +48,7 @@ public class ConsoleUiTests
         Assert.Contains("--count                    Count only; search/definition/references/callers/callees/symbols/files/find/unused ignore --limit, impact/hotspots still use visible page counts", output);
         Assert.Contains("--commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)", output);
         Assert.Contains("--files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed", output);
+        Assert.Contains("--duration-format <format> Index elapsed time format: `auto` (default), `seconds`, or `hms`; JSON keeps raw elapsed_ms", output);
         Assert.Contains("cdidx excerpt <path> --start <line> [--end <line>] [--before <n>] [--after <n>] [--max-line-width <n>] [--focus-line <line>] [--focus-column <n>] [--focus-length <n>] [--db <path>] [--json]", output);
         Assert.Contains("--focus-column <n>         excerpt: column to keep centered when clamping (must be within the focused line)", output);
         Assert.Contains("--focus-line <line>        excerpt: line whose focused column should stay visible", output);
@@ -114,6 +115,30 @@ public class ConsoleUiTests
         var frames = ConsoleUi.GetSpinnerFrames(null);
 
         Assert.Equal(["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"], frames);
+    }
+
+    [Theory]
+    [InlineData(0, "0ms")]
+    [InlineData(999, "999ms")]
+    [InlineData(1_000, "1.0s")]
+    [InlineData(59_900, "59.9s")]
+    [InlineData(60_000, "1m 0s")]
+    [InlineData(3_599_000, "59m 59s")]
+    [InlineData(3_600_000, "1h 0m 0s")]
+    [InlineData(86_400_000, "24h 0m 0s")]
+    [InlineData(360_061_000, "100h 1m 1s")]
+    public void FormatDuration_Auto_UsesUnitLabels(int milliseconds, string expected)
+    {
+        Assert.Equal(expected, ConsoleUi.FormatDuration(TimeSpan.FromMilliseconds(milliseconds)));
+    }
+
+    [Fact]
+    public void FormatDuration_ExplicitFormats_RespectUserPreference()
+    {
+        var duration = TimeSpan.FromMilliseconds(65_432);
+
+        Assert.Equal("65.4s", ConsoleUi.FormatDuration(duration, DurationOutputFormat.Seconds));
+        Assert.Equal("00:01:05", ConsoleUi.FormatDuration(duration, DurationOutputFormat.Hms));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -89,6 +89,40 @@ public class IndexCommandRunnerTests
         }
     }
 
+    [Theory]
+    [InlineData("--duration-format", "auto", DurationOutputFormat.Auto)]
+    [InlineData("--duration-format", "seconds", DurationOutputFormat.Seconds)]
+    [InlineData("--duration-format", "hms", DurationOutputFormat.Hms)]
+    [InlineData("--duration-format=hms", null, DurationOutputFormat.Hms)]
+    public void ParseArgs_DurationFormatFlag_ParsesValue(string flag, string? value, DurationOutputFormat expected)
+    {
+        string[] args = value is null
+            ? [".", flag]
+            : [".", flag, value];
+
+        var options = IndexCommandRunner.ParseArgs(args);
+
+        Assert.Equal(expected, options.DurationFormat);
+    }
+
+    [Fact]
+    public void ParseArgs_DurationFormatFlag_InvalidValue_IsIgnored()
+    {
+        var originalErr = Console.Error;
+        using var stderr = new StringWriter();
+        try
+        {
+            Console.SetError(stderr);
+            var options = IndexCommandRunner.ParseArgs([".", "--duration-format", "bogus"]);
+            Assert.Equal(DurationOutputFormat.Auto, options.DurationFormat);
+            Assert.Contains("invalid --duration-format value", stderr.ToString());
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+
     [Fact]
     public void ParseArgs_AbsolutizesRelativeProjectPath()
     {


### PR DESCRIPTION
## Summary

- Add unit-labelled `cdidx index` elapsed-time formatting for human output.
- Add `--duration-format auto|seconds|hms` for explicit display preferences while keeping JSON `elapsed_ms` unchanged.
- Update README, USER_GUIDE, help/completion schema, tests, and changelog fragment.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests|FullyQualifiedName~IndexCommandRunnerTests|FullyQualifiedName~CliFlagSchemaTests"`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: No blocking/actionable issues found.

## Documentation and Changelog

- Updated `README.md` and `USER_GUIDE.md`.
- Added changelog fragment `changelog.d/unreleased/1853.fixed.md`.

## Notes

- Local `cdidx index . --commits HEAD --json` succeeded after the commit. A local full `cdidx . --json` attempt remained silent for over a minute and was stopped; this appears to be an environment/index maintenance issue outside this PR's behavior change.

Fixes #1853
