### PR TITLE
Improve status check diagnostics

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -137,6 +137,29 @@ with `cdidx . --verbose` to see `[OK  ]`, `[SKIP]`, `[DEL ]`, and `[ERR ]`
 file statuses. Use incremental refreshes after the first run; see
 [Options](#options) for `--files` and `--commits`.
 
+## CI integration
+
+Use `cdidx status --check` when a script needs one command that verifies both
+workspace freshness and readiness of query subsystems. On success, non-JSON
+`--check` exits 0 and writes no stdout. On failure, it writes one diagnostic line
+per failed check to stderr, such as `[stale] workspace_check ...` or
+`[degraded] fold_ready=false ...`.
+
+Exit codes for `status --check` are command-specific:
+
+| Exit | Meaning |
+|---|---|
+| 0 | ok |
+| 1 | stale workspace/index |
+| 2 | degraded readiness |
+| 3 | both stale and degraded |
+
+For structured automation, use `cdidx status --check --json`. The JSON payload
+includes the full status object plus `failed_checks`, an array of the checks that
+made the command fail. To check only selected readiness areas, pass
+`--check=fold,graph,hotspot,csharp`; `workspace`, `issues`, `sql`, and `newer`
+are also accepted scopes.
+
 ## Installation
 
 ### Option A: One-liner install (no .NET required)
@@ -1554,6 +1577,27 @@ cdidx search "handleRequest"
 場合は `cdidx . --verbose` で再実行すると、`[OK  ]`、`[SKIP]`、`[DEL ]`、`[ERR ]`
 のファイル別ステータスを確認できます。初回以降は差分更新を使ってください。
 `--files` と `--commits` は [オプション一覧](#オプション一覧) を参照してください。
+
+## CI 連携
+
+スクリプトから workspace の鮮度と query subsystem の readiness を一度に確認したい場合は
+`cdidx status --check` を使います。成功時、非 JSON の `--check` は exit 0 で stdout に
+何も出力しません。失敗時は `[stale] workspace_check ...` や
+`[degraded] fold_ready=false ...` のように、失敗した check ごとに stderr へ 1 行出力します。
+
+`status --check` の exit code はこのコマンド専用です:
+
+| Exit | 意味 |
+|---|---|
+| 0 | ok |
+| 1 | workspace / index が stale |
+| 2 | readiness が degraded |
+| 3 | stale と degraded の両方 |
+
+構造化された自動化では `cdidx status --check --json` を使ってください。JSON には
+完全な status object に加えて、失敗原因の配列 `failed_checks` が含まれます。
+特定の readiness だけを確認する場合は `--check=fold,graph,hotspot,csharp` を指定できます。
+`workspace`、`issues`、`sql`、`newer` も scope として受け付けます。
 
 ## インストール
 

--- a/changelog.d/unreleased/1852.changed.md
+++ b/changelog.d/unreleased/1852.changed.md
@@ -1,0 +1,17 @@
+---
+category: changed
+issues:
+  - 1852
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Models/QueryResults.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`status --check` now reports failed freshness and readiness checks (#1852)** — failed checks are surfaced as stderr diagnostics for shell use, as `failed_checks` in JSON output, and can be scoped with `--check=fold,graph,hotspot,csharp` and related status scopes.
+
+## 日本語
+
+- **`status --check` が freshness / readiness の失敗内容を返すようになりました (#1852)** — shell 向けには stderr 診断、JSON では `failed_checks` として失敗内容を示し、`--check=fold,graph,hotspot,csharp` などの scope 指定にも対応しました。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -185,7 +185,7 @@ internal static class CliFlagSchema
             new() { Name = "--with-paths", Description = "Impact: include shortest call chains per caller", Commands = Set("impact") },
             new() { Name = "--reverse", Description = "Reverse direction (show dependents)", Commands = Set("deps") },
             new() { Name = "--group-by-name", Description = "Hotspots: collapse same-name rows across files", Commands = Set("hotspots") },
-            new() { Name = "--check", Description = "Verify index matches current workspace", Commands = Set("status") },
+            new() { Name = "--check", Description = "Verify status freshness/readiness", Commands = Set("status") },
             new() { Name = "--integrity-check", Description = "Run PRAGMA integrity_check on the database", Commands = Set("db") },
             new() { Name = "--rebuild", Description = "Delete existing DB and rebuild from scratch", Commands = Set("index") },
             new() { Name = "--verbose", Description = "Show per-file status", Commands = Set("index") },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -65,7 +65,7 @@ public static class ConsoleUi
         ("map", "cdidx map [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests]"),
         ("inspect", "cdidx inspect <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--max-line-width <n>] [--exact|--exact-name]"),
         ("outline", "cdidx outline <path> [--db <path>] [--json]"),
-        ("status", "cdidx status [--db <path>] [--json] [--check]"),
+        ("status", "cdidx status [--db <path>] [--json] [--check[=workspace,fold,graph,issues,hotspot,csharp,sql,newer]]"),
         ("db", "cdidx db --integrity-check [--db <path>] [--json]"),
         ("report", "cdidx report --output <path> [--db <path>] [--json] [--log-lines <n>] [--no-log] [--include-args]"),
         ("validate", "cdidx validate [--db <path>] [--json] [--kind <kind>] [--path <glob>]"),

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -1684,11 +1684,22 @@ public static class QueryCommandRunner
                 : "";
             status.Summary = $"{status.Files} files, {status.Symbols} symbols, {status.References} refs across {status.Languages.Count} languages ({string.Join(", ", topLangs)}); index {freshness}{dirty}{degraded}";
 
+            IReadOnlyList<StatusCheckFailure> checkFailures = options.CheckWorkspace
+                ? BuildStatusCheckFailures(status, options.StatusCheckScopes)
+                : Array.Empty<StatusCheckFailure>();
+            if (options.CheckWorkspace)
+                status.FailedChecks = checkFailures.Select(f => f.Name).ToList();
+
             if (options.Json)
             {
                 Console.WriteLine(JsonSerializer.Serialize(
                     status,
                     CliJsonSerializerContextFactory.Create(jsonOptions).StatusResult));
+            }
+            else if (options.CheckWorkspace)
+            {
+                if (checkFailures.Count > 0)
+                    WriteStatusCheckDiagnostics(checkFailures);
             }
             else
             {
@@ -1803,11 +1814,7 @@ public static class QueryCommandRunner
 
             if (!options.CheckWorkspace)
                 return CommandExitCodes.Success;
-            if (status.WorkspaceCheck?.Checked != true)
-                return CommandExitCodes.FeatureUnavailable;
-            return status.WorkspaceCheck.MatchesWorkspace
-                ? CommandExitCodes.Success
-                : CommandExitCodes.StaleIndex;
+            return GetStatusCheckExitCode(checkFailures);
         });
     }
 
@@ -2783,6 +2790,7 @@ public static class QueryCommandRunner
         bool exactSubstring = false;
         bool dbPathExplicit = false;
         bool checkWorkspace = false;
+        HashSet<string>? statusCheckScopes = null;
         bool withPaths = false;
         var extraNames = new List<string>();
 
@@ -2790,6 +2798,40 @@ public static class QueryCommandRunner
         {
             parseErrors ??= [];
             parseErrors.Add(error);
+        }
+
+        void AddStatusCheckScopes(string rawScopes)
+        {
+            if (string.IsNullOrWhiteSpace(rawScopes))
+            {
+                AddParseError("Error: --check scope list cannot be empty. Use --check or --check=workspace,fold,graph,issues,hotspot,csharp,sql,newer.");
+                return;
+            }
+
+            statusCheckScopes ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var rawScope in rawScopes.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var scope = rawScope.ToLowerInvariant();
+                switch (scope)
+                {
+                    case "workspace":
+                    case "fold":
+                    case "graph":
+                    case "issues":
+                    case "hotspot":
+                    case "csharp":
+                    case "sql":
+                    case "newer":
+                        statusCheckScopes.Add(scope);
+                        break;
+                    default:
+                        AddParseError($"Error: unsupported --check scope '{rawScope}'. Use one or more of workspace, fold, graph, issues, hotspot, csharp, sql, newer.");
+                        break;
+                }
+            }
+
+            if (statusCheckScopes.Count == 0)
+                AddParseError("Error: --check scope list cannot be empty. Use --check or --check=workspace,fold,graph,issues,hotspot,csharp,sql,newer.");
         }
 
         // Track non-repeatable value-taking options that have already been observed and warn on
@@ -2809,6 +2851,13 @@ public static class QueryCommandRunner
         for (int i = 0; i < args.Length; i++)
         {
             var currentArg = args[i];
+            if (allowStatusCheck && currentArg.StartsWith("--check=", StringComparison.Ordinal))
+            {
+                checkWorkspace = true;
+                AddStatusCheckScopes(currentArg["--check=".Length..]);
+                continue;
+            }
+
             var inlineValue = TrySplitInlineOptionValue(currentArg, out var inlineOptionName)
                 ? currentArg[(inlineOptionName!.Length + 1)..]
                 : null;
@@ -3140,6 +3189,7 @@ public static class QueryCommandRunner
             ExactName = exactName,
             ExactSubstring = exactSubstring,
             CheckWorkspace = checkWorkspace,
+            StatusCheckScopes = statusCheckScopes,
             WithPaths = withPaths,
             ExtraNames = extraNames,
             ParseError = parseErrors == null ? null : string.Join(Environment.NewLine, parseErrors),
@@ -3334,6 +3384,8 @@ public static class QueryCommandRunner
             var normalizedArg = TrySplitInlineOptionValue(arg, out var inlineOptionName)
                 ? inlineOptionName!
                 : arg;
+            if (arg.StartsWith("--check=", StringComparison.Ordinal) && supported.Contains("--check"))
+                normalizedArg = "--check";
 
             if (supported.Contains(normalizedArg))
             {
@@ -3653,6 +3705,69 @@ public static class QueryCommandRunner
            || !status.CSharpMetadataTargetReady
            || !status.FoldReady
            || status.IndexNewerThanReader;
+
+    private sealed record StatusCheckFailure(string Name, bool IsStale, string Diagnostic);
+
+    private static IReadOnlyList<StatusCheckFailure> BuildStatusCheckFailures(StatusResult status, IReadOnlySet<string>? scopedChecks)
+    {
+        var failures = new List<StatusCheckFailure>();
+        var checkAll = scopedChecks is not { Count: > 0 };
+        bool Includes(string scope) => checkAll || scopedChecks!.Contains(scope);
+
+        if (Includes("workspace"))
+        {
+            if (status.WorkspaceCheck?.Checked != true)
+            {
+                failures.Add(new StatusCheckFailure("workspace_unavailable", true, "[stale] workspace_check unavailable"));
+            }
+            else if (!status.WorkspaceCheck.MatchesWorkspace)
+            {
+                var check = status.WorkspaceCheck;
+                failures.Add(new StatusCheckFailure(
+                    "workspace_stale",
+                    true,
+                    $"[stale] workspace_check reason={check.Reason} changed={check.ChangedFileCount} missing={check.MissingFileCount} unindexed={check.UnindexedFileCount}"));
+            }
+        }
+
+        if (Includes("graph") && !status.GraphTableAvailable)
+            failures.Add(new StatusCheckFailure("graph_table_available", false, "[degraded] graph_table_available=false"));
+        if (Includes("issues") && !status.IssuesTableAvailable)
+            failures.Add(new StatusCheckFailure("issues_table_available", false, "[degraded] issues_table_available=false"));
+        if (Includes("sql") && !status.SqlGraphContractReady)
+            failures.Add(new StatusCheckFailure("sql_graph_contract_ready", false, $"[degraded] sql_graph_contract_ready=false reason={status.SqlGraphContractDegradedReason ?? "unknown"}"));
+        if (Includes("hotspot") && !status.HotspotFamilyReady)
+            failures.Add(new StatusCheckFailure("hotspot_family_ready", false, $"[degraded] hotspot_family_ready=false reason={status.HotspotFamilyDegradedReason ?? "unknown"}"));
+        if (Includes("csharp") && !status.CSharpSymbolNameReady)
+            failures.Add(new StatusCheckFailure("csharp_symbol_name_ready", false, "[degraded] csharp_symbol_name_ready=false"));
+        if (Includes("csharp") && !status.CSharpMetadataTargetReady)
+            failures.Add(new StatusCheckFailure("csharp_metadata_target_ready", false, "[degraded] csharp_metadata_target_ready=false"));
+        if (Includes("fold") && !status.FoldReady)
+            failures.Add(new StatusCheckFailure("fold_ready", false, $"[degraded] fold_ready=false reason={status.FoldReadyReason ?? "unknown"}"));
+        if (Includes("newer") && status.IndexNewerThanReader)
+            failures.Add(new StatusCheckFailure("index_newer_than_reader", false, $"[degraded] index_newer_than_reader=true reason={status.IndexNewerThanReaderReason ?? "unknown"}"));
+
+        return failures;
+    }
+
+    private static void WriteStatusCheckDiagnostics(IReadOnlyList<StatusCheckFailure> failures)
+    {
+        foreach (var failure in failures)
+            Console.Error.WriteLine(failure.Diagnostic);
+    }
+
+    private static int GetStatusCheckExitCode(IReadOnlyList<StatusCheckFailure> failures)
+    {
+        var stale = failures.Any(f => f.IsStale);
+        var degraded = failures.Any(f => !f.IsStale);
+        return (stale, degraded) switch
+        {
+            (false, false) => CommandExitCodes.Success,
+            (true, false) => 1,
+            (false, true) => 2,
+            _ => 3,
+        };
+    }
 
     private static bool IsFoldOnlyReadinessDegraded(StatusResult status)
         => !status.FoldReady
@@ -4556,6 +4671,7 @@ public sealed class QueryCommandOptions
     public bool ExactName { get; init; }
     public bool ExactSubstring { get; init; }
     public bool CheckWorkspace { get; init; }
+    public IReadOnlySet<string>? StatusCheckScopes { get; init; }
     public bool WithPaths { get; init; }
     public List<string> ExtraNames { get; init; } = [];
     public string? ParseError { get; init; }

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -400,6 +400,9 @@ public class StatusResult
     [JsonPropertyName("workspace_check")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IndexFreshnessCheckResult? WorkspaceCheck { get; set; }
+    [JsonPropertyName("failed_checks")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? FailedChecks { get; set; }
     /// <summary>
     /// True when the index exposes the full reference / validation tables. False signals a
     /// degraded read (legacy or read-only DB where TryMigrateForRead could not create

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -28220,6 +28220,7 @@ jobs:
             File.WriteAllText(Path.Combine(projectRoot, "src", "app.cs"), "class App {}\n");
             var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
             TestProjectHelper.InsertIndexedFile(dbPath, "src/app.cs", "csharp", "class App {}\n");
+            MarkStatusReadinessReady(dbPath);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
                 ["--db", dbPath, "--check", "--json"],
@@ -28255,6 +28256,7 @@ jobs:
             File.WriteAllText(sourcePath, "class App {}\n");
             var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
             TestProjectHelper.InsertIndexedFile(dbPath, "src/app.cs", "csharp", "class App {}\n");
+            MarkStatusReadinessReady(dbPath);
             File.WriteAllText(sourcePath, "class App { void Run() {} }\n");
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
@@ -28265,9 +28267,10 @@ jobs:
             var json = document.RootElement;
             var check = json.GetProperty("workspace_check");
 
-            Assert.Equal(CommandExitCodes.StaleIndex, exitCode);
+            Assert.Equal(1, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.False(json.GetProperty("index_matches_workspace").GetBoolean());
+            Assert.Equal("workspace_stale", json.GetProperty("failed_checks")[0].GetString());
             Assert.True(check.GetProperty("checked").GetBoolean());
             Assert.False(check.GetProperty("matches_workspace").GetBoolean());
             Assert.Equal("changed_files", check.GetProperty("reason").GetString());
@@ -28291,6 +28294,7 @@ jobs:
             File.WriteAllText(Path.Combine(projectRoot, "src", "new.cs"), "class NewFile {}\n");
             var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
             TestProjectHelper.InsertIndexedFile(dbPath, "src/old.cs", "csharp", "class OldFile {}\n");
+            MarkStatusReadinessReady(dbPath);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
                 ["--db", dbPath, "--check", "--json"],
@@ -28299,9 +28303,10 @@ jobs:
             using var document = ParseJsonOutput(stdout);
             var check = document.RootElement.GetProperty("workspace_check");
 
-            Assert.Equal(CommandExitCodes.StaleIndex, exitCode);
+            Assert.Equal(1, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.False(document.RootElement.GetProperty("index_matches_workspace").GetBoolean());
+            Assert.Equal("workspace_stale", document.RootElement.GetProperty("failed_checks")[0].GetString());
             Assert.Equal(1, check.GetProperty("missing_file_count").GetInt32());
             Assert.Equal(1, check.GetProperty("unindexed_file_count").GetInt32());
             Assert.Equal("src/old.cs", check.GetProperty("missing_files")[0].GetString());
@@ -28339,6 +28344,7 @@ jobs:
             var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
             TestProjectHelper.InsertIndexedFile(dbPath, "src/inside.cs", "csharp", "class Inside {}\n");
             TestProjectHelper.InsertIndexedFile(dbPath, "src/outside.cs", "csharp", "class Outside {}\n");
+            MarkStatusReadinessReady(dbPath);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
                 ["--db", dbPath, "--check", "--json"],
@@ -28387,6 +28393,7 @@ jobs:
             TestProjectHelper.InsertIndexedFile(dbPath, "src/kept.cs", "csharp", "class Kept {}\n");
             TestProjectHelper.InsertIndexedFile(dbPath, "src/sparse.cs", "csharp", "class Sparse {}\n");
             TestProjectHelper.InsertIndexedFile(dbPath, "src/deleted.cs", "csharp", "class Deleted {}\n");
+            MarkStatusReadinessReady(dbPath);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
                 ["--db", dbPath, "--check", "--json"],
@@ -28395,9 +28402,10 @@ jobs:
             using var document = ParseJsonOutput(stdout);
             var check = document.RootElement.GetProperty("workspace_check");
 
-            Assert.Equal(CommandExitCodes.StaleIndex, exitCode);
+            Assert.Equal(1, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.False(document.RootElement.GetProperty("index_matches_workspace").GetBoolean());
+            Assert.Equal("workspace_stale", document.RootElement.GetProperty("failed_checks")[0].GetString());
             Assert.Equal(1, check.GetProperty("missing_file_count").GetInt32());
             Assert.Equal("src/deleted.cs", check.GetProperty("missing_files")[0].GetString());
             Assert.Equal(1, check.GetProperty("outside_sparse_cone_file_count").GetInt32());
@@ -28411,7 +28419,7 @@ jobs:
     }
 
     [Fact]
-    public void RunStatus_CheckHuman_PrintsOutsideSparseConeRow()
+    public void RunStatus_CheckHuman_SuccessKeepsOutputSilent()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_status_check_sparse_human");
         try
@@ -28427,6 +28435,7 @@ jobs:
 
             var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
             TestProjectHelper.InsertIndexedFile(dbPath, "src/sparse.cs", "csharp", "class Sparse {}\n");
+            MarkStatusReadinessReady(dbPath);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
                 ["--db", dbPath, "--check"],
@@ -28434,9 +28443,73 @@ jobs:
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
-            Assert.Contains("Outside sparse cone : 1", stdout);
-            Assert.Contains("src/sparse.cs", stdout);
-            Assert.DoesNotContain("Missing indexed files", stdout);
+            Assert.Equal(string.Empty, stdout);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunStatus_CheckHuman_WritesStaleDiagnosticToStderr()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_status_check_stderr");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            var sourcePath = Path.Combine(projectRoot, "src", "app.cs");
+            File.WriteAllText(sourcePath, "class App {}\n");
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/app.cs", "csharp", "class App {}\n");
+            MarkStatusReadinessReady(dbPath);
+            File.WriteAllText(sourcePath, "class App { void Run() {} }\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath, "--check"],
+                _jsonOptions));
+
+            Assert.Equal(1, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains("[stale] workspace_check reason=changed_files", stderr);
+            Assert.Contains("changed=1", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunStatus_CheckJsonScopedFold_ReportsOnlyFoldDegradation()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_status_check_fold_scope");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(Path.Combine(projectRoot, "src", "app.cs"), "class App {}\n");
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/app.cs", "csharp", "class App {}\n");
+            using (var db = new DbContext(dbPath))
+            {
+                using var cmd = db.Connection.CreateCommand();
+                cmd.CommandText = "PRAGMA user_version = 0";
+                cmd.ExecuteNonQuery();
+            }
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath, "--check=fold", "--json"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+            var failedChecks = json.GetProperty("failed_checks");
+
+            Assert.Equal(2, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.False(json.GetProperty("fold_ready").GetBoolean());
+            Assert.Single(failedChecks.EnumerateArray());
+            Assert.Equal("fold_ready", failedChecks[0].GetString());
         }
         finally
         {
@@ -29341,6 +29414,19 @@ jobs:
         using var db = new DbContext(dbPath);
         var writer = new DbWriter(db.Connection);
         writer.MarkGraphReady();
+    }
+
+    private static void MarkStatusReadinessReady(string dbPath)
+    {
+        using var db = new DbContext(dbPath);
+        var writer = new DbWriter(db.Connection);
+        writer.MarkGraphReady();
+        writer.MarkIssuesReady();
+        Assert.True(writer.MarkFoldReady());
+        writer.MarkCSharpSymbolNameContractReady();
+        writer.MarkMetadataTargetReady("csharp");
+        writer.MarkSqlGraphContractReady();
+        writer.MarkHotspotFamilyReady("csharp", "test");
     }
 
     // --- TryParseIso8601Since tests / TryParseIso8601Sinceテスト ---

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -28517,6 +28517,68 @@ jobs:
         }
     }
 
+    [Theory]
+    [InlineData("graph", "graph_table_available")]
+    [InlineData("issues", "issues_table_available")]
+    [InlineData("hotspot", "hotspot_family_ready")]
+    [InlineData("csharp", "csharp_symbol_name_ready")]
+    [InlineData("sql", "sql_graph_contract_ready")]
+    [InlineData("newer", "index_newer_than_reader")]
+    public void RunStatus_CheckJsonScopedReadiness_ReportsOnlyRequestedSubsystem(string scope, string expectedFailure)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject($"cdidx_query_runner_status_check_scope_{scope}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(Path.Combine(projectRoot, "src", "app.cs"), "class App {}\n");
+            File.WriteAllText(Path.Combine(projectRoot, "src", "query.sql"), "SELECT run_me();\n");
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/app.cs", "csharp", "class App {}\n");
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/query.sql", "sql", "SELECT run_me();\n");
+            MarkStatusReadinessReady(dbPath);
+            using (var db = new DbContext(dbPath))
+            {
+                var writer = new DbWriter(db.Connection);
+                switch (scope)
+                {
+                    case "graph":
+                        ExecuteNonQuery(db, $"PRAGMA user_version = {DbContext.CurrentSchemaVersion & ~DbContext.GraphReadyFlag}");
+                        break;
+                    case "issues":
+                        ExecuteNonQuery(db, $"PRAGMA user_version = {DbContext.CurrentSchemaVersion & ~DbContext.IssuesReadyFlag}");
+                        break;
+                    case "hotspot":
+                        writer.ClearHotspotFamilyReady();
+                        break;
+                    case "csharp":
+                        writer.SetMeta(DbContext.CSharpSymbolNameContractVersionMetaKey, null);
+                        break;
+                    case "sql":
+                        writer.SetMeta(DbContext.SqlGraphContractVersionMetaKey, null);
+                        break;
+                    case "newer":
+                        writer.SetMeta("fold_key_version", (NameFold.Version + 1).ToString(System.Globalization.CultureInfo.InvariantCulture));
+                        break;
+                }
+            }
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath, $"--check={scope}", "--json"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var failedChecks = document.RootElement.GetProperty("failed_checks").EnumerateArray().Select(e => e.GetString()).ToArray();
+
+            Assert.Equal(2, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal([expectedFailure], failedChecks);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Fact]
     public void RunStatus_CheckJson_UsesRepositoryRootIgnoreRulesForSubdirectoryIndex()
     {
@@ -29427,6 +29489,13 @@ jobs:
         writer.MarkMetadataTargetReady("csharp");
         writer.MarkSqlGraphContractReady();
         writer.MarkHotspotFamilyReady("csharp", "test");
+    }
+
+    private static void ExecuteNonQuery(DbContext db, string sql)
+    {
+        using var cmd = db.Connection.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
     }
 
     // --- TryParseIso8601Since tests / TryParseIso8601Sinceテスト ---


### PR DESCRIPTION
## Summary

- Add scoped `status --check=<scope>` readiness checks for workspace, graph, issues, hotspot, C#, SQL, fold, and newer-reader signals.
- Emit `failed_checks` in `status --check --json` and concise stderr diagnostics for non-JSON failing checks while keeping successful non-JSON checks silent.
- Document the CI exit-code contract and add a bilingual changelog fragment.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunStatus_Check"`
- `dotnet test CodeIndex.sln`
- `dotnet build CodeIndex.sln --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog --no-restore -- check`

## Docs and Changelog

- Updated `USER_GUIDE.md` with the CI `status --check` contract.
- Added `changelog.d/unreleased/1852.changed.md`.

## Follow-up

- Follow-up issue discovered during local dogfooding: #2234

Fixes #1852
