### PR TITLE
Add property-based tests for parser-heavy paths (#1572)

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -21,8 +21,9 @@ Use the full suite by default. Use targeted filters only while iterating locally
 - Framework: xUnit
 - Target framework: `net8.0`
 - Main test project: `tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
-- Common direct test-only packages: `Microsoft.NET.Test.Sdk`, `xunit`, `xunit.runner.visualstudio`, `coverlet.collector`, `Microsoft.Data.Sqlite`
+- Common direct test-only packages: `Microsoft.NET.Test.Sdk`, `xunit`, `xunit.runner.visualstudio`, `coverlet.collector`, `Microsoft.Data.Sqlite`, `FsCheck.Xunit`
 - These test-only packages are separate from the production dependency rule in `src/CodeIndex`, which still allows only `Microsoft.Data.Sqlite` at runtime.
+- `FsCheck.Xunit` is reserved for property-based tests that assert universal invariants (never-throws contracts, idempotence, "output is parseable by downstream consumer") across randomly generated inputs. Use it to complement, not replace, the example-based `[Fact]` / `[Theory]` tests — pick FsCheck when the property is a universally quantified claim, and an example test when a specific concrete case is the contract.
 - Test parallelism: enabled by default across independent test classes. Tests that touch process-global state such as SQLite pool resets, environment variables, or current-directory overrides must use an explicit non-parallel collection, and tests that swap `Console.Out` / `Console.Error` must lock on `TestConsoleLock.Gate`.
 
 ## Test Layout
@@ -59,6 +60,8 @@ The test project mirrors the production areas closely.
   Database corruption recovery and graceful degradation behavior.
 - `JsonOutputSnapshotTests.cs`, `JsonOutputSnapshotHelper.cs`
   Golden-file regression fixtures for the CLI `--json` output contracts (issue #1548). Each test runs one command (`status`, `search`, `references`, `impact`, `excerpt`) against a deterministic in-memory fixture, normalizes volatile fields (timestamps, absolute paths, commit SHAs, FTS5 scores), and diffs against the matching file under `tests/CodeIndex.Tests/golden/`. Renames, removals, reordered arrays, or new keys fail the snapshot so the contract change is forced to land alongside an intentional golden update. See "JSON `--json` output snapshots" below for the update procedure.
+- `PropertyBasedParserTests.cs`
+  FsCheck-driven property tests for parser-heavy paths called out in issue #1572: `ArgHelper.WantsHelp` and `ProgramRunner.IsProjectPathArg` never throw on arbitrary inputs; `FileIndexer.NormalizePathSeparators` is idempotent under double application; the literal-safe FTS5 sanitizer (`DbReader.SanitizeFtsQuery`) always emits a query that a real in-memory FTS5 virtual table can parse. They complement, not replace, the example-based tests in `ArgHelperTests.cs` / `QueryCommandRunnerTests.cs`.
 - `TestProjectHelper.cs`, `TestConsoleLock.cs`
   Shared test helpers.
 
@@ -191,8 +194,9 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 - フレームワーク: xUnit
 - 対象フレームワーク: `net8.0`
 - メインのテストプロジェクト: `tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
-- 主な直接参照の test-only package: `Microsoft.NET.Test.Sdk`、`xunit`、`xunit.runner.visualstudio`、`coverlet.collector`、`Microsoft.Data.Sqlite`
+- 主な直接参照の test-only package: `Microsoft.NET.Test.Sdk`、`xunit`、`xunit.runner.visualstudio`、`coverlet.collector`、`Microsoft.Data.Sqlite`、`FsCheck.Xunit`
 - これらの test-only package は `src/CodeIndex` の本番依存ルールとは別であり、runtime 側は引き続き `Microsoft.Data.Sqlite` のみを許容する。
+- `FsCheck.Xunit` はランダム生成入力に対する普遍的不変条件（never-throws、idempotence、"出力が downstream consumer で parse 可能" 等）を表明する property-based テスト専用です。例ベースの `[Fact]` / `[Theory]` を置き換えるのではなく補完するもので、普遍量化された主張なら FsCheck、特定の具体ケースが契約なら例ベースという形で使い分けてください。
 - テスト並列実行: 独立したテストクラス間ではデフォルトで有効です。SQLite pool の解放、環境変数の変更、カレントディレクトリの上書きのような process-global 状態を触るテストは、明示的な non-parallel collection に入れてください。`Console.Out` / `Console.Error` を差し替えるテストは `TestConsoleLock.Gate` で lock してください。
 
 ## テスト構成
@@ -229,6 +233,8 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
   DB破損からの復旧とグレースフル劣化のテスト。
 - `JsonOutputSnapshotTests.cs`、`JsonOutputSnapshotHelper.cs`
   CLI の `--json` 出力契約に対するゴールデンファイル回帰フィクスチャ (issue #1548)。各テストは `status` / `search` / `references` / `impact` / `excerpt` を決定的なインメモリ fixture に対して実行し、揺らぐフィールド（timestamp、絶対パス、commit SHA、FTS5 score など）を正規化したうえで `tests/CodeIndex.Tests/golden/` 配下のファイルと差分比較します。フィールドの rename / 削除 / 並び替え / 新規追加が起きると snapshot が失敗するため、契約変更は意図的な golden 更新と同じ PR で揃えざるを得ません。更新手順は下記「JSON `--json` 出力 snapshot」を参照してください。
+- `PropertyBasedParserTests.cs`
+  issue #1572 で挙げられたパーサー系経路に対する FsCheck 駆動の property テスト: `ArgHelper.WantsHelp` と `ProgramRunner.IsProjectPathArg` が任意入力で例外を投げないこと、`FileIndexer.NormalizePathSeparators` が二重適用で idempotent であること、literal-safe な FTS5 サニタイザ (`DbReader.SanitizeFtsQuery`) が常にインメモリ FTS5 仮想テーブルで parse 可能なクエリを出力すること。`ArgHelperTests.cs` / `QueryCommandRunnerTests.cs` の例ベーステストを置き換えるものではなく補完します。
 - `TestProjectHelper.cs`、`TestConsoleLock.cs`
   共有テストヘルパー。
 

--- a/changelog.d/unreleased/1572.added.md
+++ b/changelog.d/unreleased/1572.added.md
@@ -1,0 +1,18 @@
+---
+category: added
+issues:
+  - 1572
+affected:
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - tests/CodeIndex.Tests/CodeIndex.Tests.csproj
+  - tests/CodeIndex.Tests/PropertyBasedParserTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Property-based tests for parser-heavy paths (#1572)** — added an FsCheck.Xunit test suite (`PropertyBasedParserTests`) that asserts universal invariants on the parser surfaces called out in the issue: `ArgHelper.WantsHelp` never throws on arbitrary `string[]`, `ProgramRunner.IsProjectPathArg` never throws on any non-null token, `FileIndexer.NormalizePathSeparators` is idempotent under double application, and the literal-safe FTS5 sanitizer (`DbReader.SanitizeFtsQuery`) always emits a query that an in-memory FTS5 virtual table actually accepts. The sanitizer's visibility was relaxed from `private` to `internal` so the property test can reach it across the existing `InternalsVisibleTo` boundary.
+
+## 日本語
+
+- **パーサー系コードに対する property-based テストを追加 (#1572)** — issue で指摘されていたパーサー表面に普遍的な不変条件を表明する FsCheck.Xunit テストスイート (`PropertyBasedParserTests`) を追加しました。`ArgHelper.WantsHelp` が任意の `string[]` で例外を投げないこと、`ProgramRunner.IsProjectPathArg` が任意の非 null トークンで例外を投げないこと、`FileIndexer.NormalizePathSeparators` が二重適用に対して idempotent であること、そして literal-safe な FTS5 サニタイザ (`DbReader.SanitizeFtsQuery`) が常にインメモリ FTS5 仮想テーブルで実際に受理されるクエリを生成することを property として表明します。サニタイザの可視性は既存の `InternalsVisibleTo` 境界からテストが届くよう `private` から `internal` に緩めました。

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -19,7 +19,7 @@ public partial class DbReader
     /// <paramref name="prefix"/> が true の場合、すべてのトークンを FTS5 prefix phrase として扱い、
     /// unicode61 が単一トークンにまとめる CJK のようなスクリプトでも opt-in で wildcard マッチさせる。
     /// </summary>
-    private static string SanitizeFtsQuery(string query, bool prefix)
+    internal static string SanitizeFtsQuery(string query, bool prefix)
     {
         // Escape double quotes inside the query, then wrap each whitespace-separated
         // token in double quotes so FTS5 treats them as literal phrases. A trailing

--- a/tests/CodeIndex.Tests/CodeIndex.Tests.csproj
+++ b/tests/CodeIndex.Tests/CodeIndex.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/tests/CodeIndex.Tests/PropertyBasedParserTests.cs
+++ b/tests/CodeIndex.Tests/PropertyBasedParserTests.cs
@@ -66,13 +66,16 @@ public class PropertyBasedParserTests
     /// special characters (double quotes, asterisks, operator keywords, embedded
     /// control chars) the user typed. We verify by feeding the sanitized output into
     /// a real in-memory FTS5 table and asserting no syntax-error SqliteException
-    /// surfaces.
+    /// surfaces. We additionally require that the sanitizer did NOT collapse the
+    /// non-whitespace input to the empty-token fallback <c>"\"\""</c> — otherwise a
+    /// regression that aggressively stripped all input would pass vacuously.
     /// </summary>
     [Property(MaxTest = 200, EndSize = 64)]
     public Property SanitizeFtsQuery_EmitsParseableFts5(NonWhiteSpaceString query, bool prefix)
     {
         var sanitized = DbReader.SanitizeFtsQuery(query.Item, prefix);
-        return TryRunFts5Match(sanitized).ToProperty();
+        var nonTrivial = sanitized.Length > 2 && sanitized != "\"\"";
+        return (nonTrivial && TryRunFts5Match(sanitized)).ToProperty();
     }
 
     private static bool TryRunFts5Match(string match)

--- a/tests/CodeIndex.Tests/PropertyBasedParserTests.cs
+++ b/tests/CodeIndex.Tests/PropertyBasedParserTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using CodeIndex.Cli;
+using CodeIndex.Database;
+using CodeIndex.Indexer;
+using FsCheck;
+using FsCheck.Xunit;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace CodeIndex.Tests;
+
+/// <summary>
+/// Property-based tests for parser-heavy paths (issue #1572). Existing example-based
+/// tests already lock in hand-picked cases; these complement them by asserting
+/// universal invariants — never-throws contracts, idempotence, and "the output is
+/// always parseable by the downstream consumer" — across the random inputs that
+/// FsCheck generates (empty strings, control chars, surrogate halves, embedded
+/// special characters, long strings).
+/// </summary>
+public class PropertyBasedParserTests
+{
+    /// <summary>
+    /// CLI parser contract: <see cref="ArgHelper.WantsHelp"/> must not throw on
+    /// any <c>string[]</c> shape. Catches accidental indexer or null-deref regressions
+    /// in the single-value-flag skip logic when callers pass unusual token sequences.
+    /// </summary>
+    [Property(MaxTest = 200, EndSize = 64)]
+    public bool ArgHelper_WantsHelp_NeverThrows(NonNull<string>[] tokens)
+    {
+        var args = (tokens ?? Array.Empty<NonNull<string>>())
+            .Select(t => t.Item)
+            .ToArray();
+        _ = ArgHelper.WantsHelp(args.AsSpan());
+        return true;
+    }
+
+    /// <summary>
+    /// <see cref="ProgramRunner.IsProjectPathArg"/> must not throw for any non-null
+    /// string. The top-level CLI dispatcher uses it on arbitrary argv tokens, so any
+    /// exception here would surface as a startup crash.
+    /// </summary>
+    [Property(MaxTest = 200)]
+    public bool IsProjectPathArg_NeverThrows(NonNull<string> arg)
+    {
+        _ = ProgramRunner.IsProjectPathArg(arg.Item);
+        return true;
+    }
+
+    /// <summary>
+    /// PathOps contract from issue #1572: separator normalization must be idempotent
+    /// — applying it twice must equal applying it once — so callers can re-normalize
+    /// already-normalized DB-stored paths without drift.
+    /// </summary>
+    [Property(MaxTest = 200)]
+    public bool NormalizePathSeparators_IsIdempotent(NonNull<string> path)
+    {
+        var once = FileIndexer.NormalizePathSeparators(path.Item);
+        var twice = FileIndexer.NormalizePathSeparators(once);
+        return once == twice;
+    }
+
+    /// <summary>
+    /// FTS5 builder contract from issue #1572: the literal-safe sanitizer must always
+    /// produce a string that the FTS5 MATCH grammar can parse, regardless of what
+    /// special characters (double quotes, asterisks, operator keywords, embedded
+    /// control chars) the user typed. We verify by feeding the sanitized output into
+    /// a real in-memory FTS5 table and asserting no syntax-error SqliteException
+    /// surfaces.
+    /// </summary>
+    [Property(MaxTest = 200, EndSize = 64)]
+    public Property SanitizeFtsQuery_EmitsParseableFts5(NonWhiteSpaceString query, bool prefix)
+    {
+        var sanitized = DbReader.SanitizeFtsQuery(query.Item, prefix);
+        return TryRunFts5Match(sanitized).ToProperty();
+    }
+
+    private static bool TryRunFts5Match(string match)
+    {
+        using var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using (var create = conn.CreateCommand())
+        {
+            create.CommandText = "CREATE VIRTUAL TABLE fts USING fts5(c);";
+            create.ExecuteNonQuery();
+        }
+        using var query = conn.CreateCommand();
+        query.CommandText = "SELECT count(*) FROM fts WHERE fts MATCH @q";
+        query.Parameters.AddWithValue("@q", match);
+        try
+        {
+            query.ExecuteScalar();
+            return true;
+        }
+        catch (SqliteException ex) when (
+            ex.Message.Contains("fts5: syntax error", StringComparison.OrdinalIgnoreCase) ||
+            ex.Message.Contains("unterminated string", StringComparison.OrdinalIgnoreCase) ||
+            ex.Message.Contains("no such column", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/packages.lock.json
+++ b/tests/CodeIndex.Tests/packages.lock.json
@@ -8,6 +8,16 @@
         "resolved": "6.0.0",
         "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
       },
+      "FsCheck.Xunit": {
+        "type": "Direct",
+        "requested": "[2.16.6, )",
+        "resolved": "2.16.6",
+        "contentHash": "Gd8xOmsHCfi5NR3tDWTia8VGc81jgA+ca7n8RCzdPnYUlG1/WbAy2WG9PGM9DFP4ft23JeO7+9xpE/7kqujVBw==",
+        "dependencies": {
+          "FsCheck": "[2.16.6]",
+          "xunit.extensibility.execution": "[2.2.0, 3.0.0)"
+        }
+      },
       "Microsoft.Data.Sqlite": {
         "type": "Direct",
         "requested": "[10.0.5, )",
@@ -45,6 +55,44 @@
         "requested": "[2.5.3, )",
         "resolved": "2.5.3",
         "contentHash": "HFFL6O+QLEOfs555SqHii48ovVa4CqGYanY+B32BjLpPptdE+wEJmCFNXlLHdEOD5LYeayb9EroaUpydGpcybg=="
+      },
+      "FsCheck": {
+        "type": "Transitive",
+        "resolved": "2.16.6",
+        "contentHash": "8yQlt7HgoigIXIoe7ZouNh551rypxp4WtQnqBlpB9a7gf4IkpdMSnEzsnJS/gFmeNtIf9hEJ37celeCq/6FuHA==",
+        "dependencies": {
+          "FSharp.Core": "4.2.3"
+        }
+      },
+      "FSharp.Core": {
+        "type": "Transitive",
+        "resolved": "4.2.3",
+        "contentHash": "PthzJd0cY9L7+mPHoMB0B9Z9moR4oO1rU5RDrVW44cfMm0R9AYFf+F3BsuTvP9clr9w/Wa0wbSfEwbJV8sV80A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Console": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Linq.Queryable": "4.0.1",
+          "System.Net.Requests": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Parallel": "4.0.1",
+          "System.Threading.Thread": "4.0.0",
+          "System.Threading.ThreadPool": "4.0.10",
+          "System.Threading.Timer": "4.0.1"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -539,6 +587,21 @@
           "System.Threading": "4.3.0"
         }
       },
+      "System.Linq.Queryable": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "Yn/WfYe9RoRfmSLvUt2JerP0BTGGykCZkQPgojaxgzF2N0oPo+/AhB8TXOpdCcNlrG3VRtsamtK2uzsp3cqRVw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.3",
@@ -588,6 +651,26 @@
           "System.Runtime.Handles": "4.3.0"
         }
       },
+      "System.Net.Requests": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "vxGt7C0cZixN+VqoSW4Yakc1Y9WknmxauDqzxgpw/FnBdz4kQNN51l4wxdXX5VY1xjqy//+G+4CvJWp1+f+y6Q==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Net.Http": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
       "System.Net.Sockets": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -599,6 +682,17 @@
           "System.Net.Primitives": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Net.WebHeaderCollection": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "XX2TIAN+wBSAIV51BU2FvvXMdstUa8b0FBSZmDWjZdwUMmggQSifpTOZ5fNH20z9ZCg2fkV1L5SsZnpO2RQDRQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
         }
       },
       "System.ObjectModel": {
@@ -972,6 +1066,38 @@
           "System.Collections": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "7Pc9t25bcynT9FpMvkUw4ZjYwUiGup/5cJFW72/5MgCG+np2cfVUMdh29u8d7onxX7d8PS3J+wL73zQRqkdrSA==",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Thread": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "gIdJqDXlOr5W9zeqFErLw3dsOsiShSCYtF9SEHitACycmvNvY8odf9kiKvp6V7aibc8C4HzzNBkWXjyfn7plbQ==",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.0.10",
+        "contentHash": "IMXgB5Vf/5Qw1kpoVgJMOvUO1l32aC+qC3OaIZjWJOjvcxuxNWOK2ZTWWYXfij22NHxT2j1yWX5vlAeQWld9vA==",
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1"
         }
       },
       "System.Threading.Timer": {


### PR DESCRIPTION
## Summary
- Adds an `FsCheck.Xunit` property-based test suite (`PropertyBasedParserTests`) that asserts universal invariants on the parser surfaces called out in #1572:
  - `ArgHelper.WantsHelp` never throws on arbitrary `string[]`.
  - `ProgramRunner.IsProjectPathArg` never throws on any non-null token.
  - `FileIndexer.NormalizePathSeparators` is idempotent under double application.
  - `DbReader.SanitizeFtsQuery` always emits a string that a real in-memory FTS5 virtual table actually accepts (verified by binding the sanitized output to `CREATE VIRTUAL TABLE fts USING fts5(c)` and running `WHERE fts MATCH @q`). The property also rejects vacuous output (sanitizer collapsing all non-whitespace input to the empty-token fallback), so a regression that aggressively strips input can't pass the property silently.
- Sole production-code change: `DbReader.SanitizeFtsQuery` visibility relaxed from `private` to `internal` so the property test can reach it across the existing `InternalsVisibleTo CodeIndex.Tests` boundary. No behavior change.
- Documents the new test file and the `FsCheck.Xunit` policy (use for universal invariants; do not use to replace targeted example-based tests) in `TESTING_GUIDE.md` (EN + JA), and ships a bilingual `changelog.d/unreleased/1572.added.md` fragment.

Fixes #1572

## Test plan
- [x] `dotnet restore CodeIndex.sln --locked-mode` — passes (lock file regenerated for `FsCheck.Xunit` 2.16.6 and its transitive closure).
- [x] `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` — full suite: 4925 passed / 0 failed / 3 skipped (the 3 `PerformanceTests` skip on this host as designed).
- [x] `dotnet test --filter "FullyQualifiedName~PropertyBasedParserTests"` — all 4 properties pass (200 runs each).
- [x] Adversarial review (codex) — surfaced one vacuous-success path; addressed in the second commit.
