### PR TITLE
Surface structured Code/Category/Path/Hint on hot-path failures (#1580)

### DIFF
--- a/changelog.d/unreleased/1580.fixed.md
+++ b/changelog.d/unreleased/1580.fixed.md
@@ -1,0 +1,22 @@
+---
+category: fixed
+issues:
+  - 1580
+affected:
+  - src/CodeIndex/CodeIndexException.cs
+  - src/CodeIndex/Cli/CodeIndexExceptionFormatter.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **Hot-path failures now surface a structured Code / Category / Path / Hint instead of a bare `InvalidOperationException` (#1580)** — `CodeIndexException` carries a stable error code, a category, the offending DB or file path, and a recovery hint; CLI prints `Error [Code]: …` plus `Path:` / `Hint:` lines (or a populated `path` / `category` field in `--json` envelopes), and the MCP catch-all echoes `[Code/Category] path='…' hint='…'` so clients can branch on the stable code without parsing message text. The SQLite retry helper now also wraps the final busy attempt instead of rethrowing a raw `SqliteException`, so `cdidx index` against a locked database fails with `E002_DB_LOCKED` and the database path instead of a terse generic message.
+
+## 日本語
+
+- **ホットパスの失敗が `InvalidOperationException` ではなく構造化された Code / Category / Path / Hint を返すようになりました (#1580)** — `CodeIndexException` は既存の `Exxx` 分類を流用した安定したエラーコード、カテゴリ、失敗した DB / ファイルパス、回復のためのヒントを保持します。CLI は `Error [Exxx]: …` に加えて `Path:` / `Hint:` 行を出力し、`--json` エンベロープには `path` / `category` が入ります。MCP の catch-all も `[Code/Category] path=… hint=…` を返すため、クライアントはメッセージ文字列を解析せずに安定したコードで分岐できます。SQLite の retry helper は最終試行の busy エラーも構造化例外で包むようになったため、ロック中の DB に `cdidx index` した際は素の `SqliteException` ではなく `E002_DB_LOCKED` と DB パスが返ります。

--- a/src/CodeIndex/Cli/CodeIndexExceptionFormatter.cs
+++ b/src/CodeIndex/Cli/CodeIndexExceptionFormatter.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+
+namespace CodeIndex.Cli;
+
+/// <summary>
+/// Uniform CLI formatter for <see cref="CodeIndexException"/> so the structured
+/// fields (Code, Category, Path, Hint) end up on stderr (or, when --json was
+/// requested, in a <see cref="CommandErrorJsonResult"/> envelope on stdout)
+/// instead of being lost behind a generic stack trace (#1580).
+/// CodeIndexException 用の CLI 出力フォーマッタ。stderr または --json 時の構造化エンベロープ
+/// に Code / Category / Path / Hint を一律な形で出すことで、汎用スタックトレース越しに
+/// 構造化情報が失われないようにする (#1580)。
+/// </summary>
+internal static class CodeIndexExceptionFormatter
+{
+    public static void Write(CodeIndexException ex, string[] args, JsonSerializerOptions jsonOptions)
+    {
+        if (HasJsonFlag(args))
+        {
+            var payload = new CommandErrorJsonResult(
+                Status: "error",
+                Message: ex.Message,
+                Hint: ex.Hint,
+                ErrorCode: ex.Code,
+                Path: ex.Path,
+                Category: ex.Category);
+            Console.WriteLine(JsonSerializer.Serialize(
+                payload,
+                CliJsonSerializerContextFactory.Create(jsonOptions).CommandErrorJsonResult));
+            return;
+        }
+
+        // Keep human output close to the existing `Error [Exxx]: ...` shape that
+        // QueryCommandRunner / IndexCommandRunner already emit so downstream
+        // parsers do not need a second format.
+        // 既存の `Error [Exxx]: ...` 形に揃え、parser の差分を最小化する。
+        Console.Error.WriteLine($"Error [{ex.Code}]: {ex.Message}");
+        if (!string.IsNullOrEmpty(ex.Path))
+            Console.Error.WriteLine($"Path: {ex.Path}");
+        if (!string.IsNullOrEmpty(ex.Hint))
+            Console.Error.WriteLine($"Hint: {ex.Hint}");
+    }
+
+    internal static bool HasJsonFlag(string[] args)
+    {
+        foreach (var arg in args)
+        {
+            if (arg == "--")
+                return false;
+            if (arg == "--json")
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -23,7 +23,9 @@ internal sealed record CommandErrorJsonResult(
     [property: JsonPropertyName("status")] string Status,
     [property: JsonPropertyName("message")] string Message,
     [property: JsonPropertyName("hint")] string? Hint,
-    [property: JsonPropertyName("error_code")] string? ErrorCode = null);
+    [property: JsonPropertyName("error_code")] string? ErrorCode = null,
+    [property: JsonPropertyName("path")] string? Path = null,
+    [property: JsonPropertyName("category")] string? Category = null);
 
 internal sealed record DbIntegrityCheckJsonResult(
     [property: JsonPropertyName("db_path")] string DbPath,

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -172,6 +172,18 @@ internal static class ProgramRunner
             EmitCommandMetric(commandName, args, commandStartTimestamp, commandStopwatch, exitCode);
             return exitCode;
         }
+        catch (CodeIndexException ex)
+        {
+            // Issue #1580: surface Code, Path, Category, and Hint uniformly so
+            // users can tell which file failed and automation has a stable
+            // signal to branch on instead of parsing free-form messages.
+            // #1580: 失敗ファイル / 構造化フィールドを CLI で一律に表示する。
+            var exitCode = MapCodeIndexExceptionExitCode(ex.Code);
+            CodeIndexExceptionFormatter.Write(ex, args, jsonOptions);
+            GlobalToolLog.Error($"command_complete exit_code={exitCode} code_index_exception code={ex.Code} category={ex.Category} path={ex.Path}");
+            EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, exitCode, ex.Code);
+            return exitCode;
+        }
         catch (Exception ex)
         {
             if (JsonOutputFailure.TryHandle(ex, out var exitCode))
@@ -189,6 +201,21 @@ internal static class ProgramRunner
 
     internal static bool IsProjectPathArg(string arg) =>
         !arg.StartsWith('-') && (Directory.Exists(arg) || arg.Contains('/') || arg.Contains('\\') || arg == ".");
+
+    internal static int MapCodeIndexExceptionExitCode(string code) => code switch
+    {
+        CommandErrorCodes.DbNotFound => CommandExitCodes.NotFound,
+        CommandErrorCodes.DbLocked => CommandExitCodes.DatabaseError,
+        CommandErrorCodes.DbNotWritable => CommandExitCodes.DatabaseError,
+        CommandErrorCodes.DbIntegrityFailed => CommandExitCodes.DatabaseError,
+        CommandErrorCodes.SchemaTooNew => CommandExitCodes.DatabaseError,
+        CommandErrorCodes.TempStoreExhausted => CommandExitCodes.DatabaseError,
+        CommandErrorCodes.DbError => CommandExitCodes.DatabaseError,
+        CommandErrorCodes.DirectoryNotFound => CommandExitCodes.NotFound,
+        CommandErrorCodes.FeatureUnavailable => CommandExitCodes.FeatureUnavailable,
+        CommandErrorCodes.UsageError => CommandExitCodes.UsageError,
+        _ => CommandExitCodes.DatabaseError,
+    };
 
     internal static bool TryConsumeColorFlag(ref string[] args, out string error)
     {

--- a/src/CodeIndex/CodeIndexException.cs
+++ b/src/CodeIndex/CodeIndexException.cs
@@ -1,0 +1,71 @@
+namespace CodeIndex;
+
+/// <summary>
+/// Base exception for CodeIndex hot-path failures that need to surface a
+/// stable machine-readable Code, a Category (Database, Filesystem, ...),
+/// the offending file/DB Path, and an optional recovery Hint. CLI and MCP
+/// formatters route on these fields so users see the offending path and
+/// automation can branch on Code/Category without parsing free-form
+/// Message text (#1580).
+/// 機械可読な Code / Category / Path / Hint を伴う CodeIndex のホットパス例外。
+/// CLI と MCP のフォーマッタはこれらのフィールドを参照して構造化エラーを返し、
+/// ユーザーは失敗したパスを認識でき、自動化側は Message を文字列解析しなくても
+/// 分岐できる (#1580)。
+///
+/// IMPORTANT (#1530 / #1580 contract): the <c>Path</c> and <c>Hint</c> fields
+/// are echoed verbatim to MCP clients by <c>McpServer.BuildSanitizedToolErrorMessage</c>
+/// and <c>BuildSanitizedLoopErrorMessage</c>. The <c>BuildSanitizedToolErrorMessage</c>
+/// sanitizer for #1530 strips <c>ex.Message</c> precisely because user-bound
+/// SQLite parameters or matched content can leak into it; <see cref="CodeIndexException"/>
+/// fields bypass that sanitizer. Throwers MUST only populate <c>Path</c> and
+/// <c>Hint</c> with tool-defined strings (DB paths, file paths, fixed recovery
+/// copy). Never echo a search query, SQL parameter binding, or other
+/// user-supplied content into these fields.
+/// 重要 (#1530 / #1580 規約): <c>Path</c> / <c>Hint</c> は MCP 出力に素通しされる。
+/// #1530 は <c>ex.Message</c> を MCP に出さないことで SQL バインド値や検索結果の
+/// 漏えいを封じている。CodeIndexException の構造化フィールドはその sanitizer を
+/// 通らないため、ツールが固定した DB パス / ファイルパス / 回復メッセージ以外
+/// （ユーザー検索文字列・SQL バインド値・マッチ内容など）を Path / Hint に
+/// 載せてはならない。
+/// </summary>
+public class CodeIndexException : Exception
+{
+    public string Code { get; }
+    public string Category { get; }
+    public string? Path { get; }
+    public string? Hint { get; }
+
+    public CodeIndexException(
+        string code,
+        string category,
+        string message,
+        string? path = null,
+        string? hint = null,
+        Exception? innerException = null)
+        : base(BuildMessage(message, path), innerException)
+    {
+        Code = code ?? throw new ArgumentNullException(nameof(code));
+        Category = category ?? throw new ArgumentNullException(nameof(category));
+        Path = path;
+        Hint = hint;
+    }
+
+    private static string BuildMessage(string message, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            throw new ArgumentException("message must be non-empty", nameof(message));
+        return string.IsNullOrWhiteSpace(path) ? message : $"{message} (path: {path})";
+    }
+}
+
+/// <summary>
+/// Stable Category labels used by <see cref="CodeIndexException"/>. Treated like
+/// the <c>CommandErrorCodes</c> taxonomy: published values stay published.
+/// CodeIndexException で使う安定した Category ラベル。一度公開した値は変更しない。
+/// </summary>
+public static class CodeIndexExceptionCategory
+{
+    public const string Database = "database";
+    public const string Filesystem = "filesystem";
+    public const string Indexer = "indexer";
+}

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -1,3 +1,4 @@
+using CodeIndex.Cli;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 
@@ -87,7 +88,8 @@ public class DbContext : IDisposable
             using var connection = OpenSqliteConnectionWithRetry(
                 () => createConnection(openTarget),
                 openConnection,
-                sleep);
+                sleep,
+                dbPath: dbPath);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = "SELECT name FROM sqlite_master WHERE type = 'table'";
@@ -159,7 +161,8 @@ public class DbContext : IDisposable
             _connection = OpenSqliteConnectionWithRetry(
                 () => new SqliteConnection(builder.ConnectionString),
                 static connection => connection.Open(),
-                static milliseconds => System.Threading.Thread.Sleep(milliseconds));
+                static milliseconds => System.Threading.Thread.Sleep(milliseconds),
+                dbPath: dbPath);
             Execute("PRAGMA busy_timeout=5000");
             RegisterConnectionFunctions(_connection);
 
@@ -207,9 +210,14 @@ public class DbContext : IDisposable
         Func<SqliteConnection> createConnection,
         Action<SqliteConnection> openConnection,
         Action<int>? sleep = null,
-        int maxOpenAttempts = 5)
+        int maxOpenAttempts = 5,
+        string? dbPath = null)
     {
+        if (maxOpenAttempts <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxOpenAttempts), maxOpenAttempts, "Must be at least 1.");
+
         SqliteConnection? connection = null;
+        SqliteException? lastBusyError = null;
         for (var attempt = 1; attempt <= maxOpenAttempts; attempt++)
         {
             connection?.Dispose();
@@ -219,9 +227,16 @@ public class DbContext : IDisposable
                 openConnection(connection);
                 return connection;
             }
-            catch (SqliteException ex) when (IsTransientBusyError(ex) && attempt < maxOpenAttempts)
+            catch (SqliteException ex) when (IsTransientBusyError(ex))
             {
-                sleep?.Invoke(50 * attempt);
+                // #1580: capture the busy error on every attempt — including the
+                // last — so the end-of-loop throw can wrap it in a structured
+                // CodeIndexException instead of leaking SqliteException to callers
+                // (which previously made the bottom `throw` unreachable).
+                // #1580: 末尾の throw を必ず通すために busy エラーを全試行で捕捉する。
+                lastBusyError = ex;
+                if (attempt < maxOpenAttempts)
+                    sleep?.Invoke(50 * attempt);
             }
             catch
             {
@@ -229,8 +244,19 @@ public class DbContext : IDisposable
                 throw;
             }
         }
+        connection?.Dispose();
 
-        throw new InvalidOperationException("Failed to open SQLite connection.");
+        // Issue #1580: surface the DB path and a recovery hint instead of a bare
+        // `InvalidOperationException("Failed to ...")` so the caller (CLI / MCP) can
+        // tell which database failed and which retry knob to suggest.
+        // #1580: 失敗した DB のパスとリカバリ手順を構造化して投げる。
+        throw new CodeIndexException(
+            code: CommandErrorCodes.DbLocked,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Failed to open SQLite connection after retries.",
+            path: dbPath,
+            hint: "Another process holds a write lock on the database. If another cdidx index is running, wait for it to finish; otherwise check for other SQLite clients (e.g. backup tools, DB browsers) accessing the file, then retry.",
+            innerException: lastBusyError);
     }
 
     // Detect whether a SQLite URI explicitly requests read-only semantics. Only URIs that

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -139,7 +139,7 @@ public class DbContext : IDisposable
                 _connection = new SqliteConnection($"Data Source={dbPath}");
                 _connection.Open();
                 Execute("PRAGMA busy_timeout=5000");
-                RegisterConnectionFunctions(_connection);
+                RegisterConnectionFunctionsWithRetry(_connection);
                 _isReadOnly = true;
                 return;
             }
@@ -164,7 +164,7 @@ public class DbContext : IDisposable
                 static milliseconds => System.Threading.Thread.Sleep(milliseconds),
                 dbPath: dbPath);
             Execute("PRAGMA busy_timeout=5000");
-            RegisterConnectionFunctions(_connection);
+            RegisterConnectionFunctionsWithRetry(_connection);
 
             // Enable WAL mode and verify it was applied / WALモードを有効にし適用を確認
             var journalMode = ExecuteScalar("PRAGMA journal_mode=WAL");
@@ -184,7 +184,7 @@ public class DbContext : IDisposable
             _connection?.Dispose();
             _connection = OpenReadOnly(dbPath);
             Execute("PRAGMA busy_timeout=5000");
-            RegisterConnectionFunctions(_connection);
+            RegisterConnectionFunctionsWithRetry(_connection);
             _isReadOnly = true;
         }
 
@@ -451,6 +451,29 @@ public class DbContext : IDisposable
             "sql_allow_leaf_fallback_at",
             (string? symbolName, string? context, string? containerName, long? columnNumber) =>
                 SqlNameResolver.AllowLeafFallbackAtColumn(symbolName, context, containerName, ToNullableInt(columnNumber)) ? 1 : 0);
+    }
+
+    private static void RegisterConnectionFunctionsWithRetry(
+        SqliteConnection connection,
+        Action<int>? sleep = null,
+        int maxAttempts = 5)
+    {
+        if (maxAttempts <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxAttempts), maxAttempts, "Must be at least 1.");
+
+        sleep ??= static milliseconds => System.Threading.Thread.Sleep(milliseconds);
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                RegisterConnectionFunctions(connection);
+                return;
+            }
+            catch (SqliteException ex) when (IsTransientBusyError(ex) && attempt < maxAttempts)
+            {
+                sleep(50 * attempt);
+            }
+        }
     }
 
     /// <summary>

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -1158,16 +1158,39 @@ public partial class McpServer : IDisposable
     // Wire-safe error body for the tool catch-all. Mentions the tool and the
     // exception type so the client can branch (retry vs. surface to user)
     // while keeping bound values or matched content out of the response (#1530).
+    // For CodeIndexException (#1580) the Code / Category / Path / Hint fields
+    // are author-controlled and therefore safe to echo verbatim, so the client
+    // gets the structured failure metadata it needs without re-introducing the
+    // ex.Message leak vector #1530 closed.
     // ツール catch-all のワイヤー向け本文。クライアントが分岐できるよう tool 名と
-    // 例外型は残し、バインド値や一致内容は含めない（#1530）。
-    internal static string BuildSanitizedToolErrorMessage(string toolName, Exception ex) =>
-        $"Error executing {toolName} ({ex.GetType().Name}). See cdidx server stderr for details.";
+    // 例外型は残し、バインド値や一致内容は含めない（#1530）。CodeIndexException (#1580)
+    // の Code / Category / Path / Hint は実装側で固定したフィールドなのでそのまま転写し、
+    // #1530 で封じた ex.Message 漏れを再現させずに失敗詳細をクライアントへ届ける。
+    internal static string BuildSanitizedToolErrorMessage(string toolName, Exception ex)
+    {
+        if (ex is CodeIndexException codeIndexEx)
+            return $"Error executing {toolName} ({ex.GetType().Name}) [{codeIndexEx.Code}/{codeIndexEx.Category}]{BuildPathFragment(codeIndexEx)}{BuildHintFragment(codeIndexEx)}. See cdidx server stderr for details.";
+        return $"Error executing {toolName} ({ex.GetType().Name}). See cdidx server stderr for details.";
+    }
 
     // Wire-safe error body for the JSON-RPC loop catch-all. Same rationale as
-    // the tool catch-all (#1530).
-    // JSON-RPC ループ catch-all のワイヤー向け本文。理由はツール catch-all と同じ（#1530）。
-    internal static string BuildSanitizedLoopErrorMessage(Exception ex) =>
-        $"Internal error ({ex.GetType().Name}). See cdidx server stderr for details.";
+    // the tool catch-all (#1530, #1580).
+    // JSON-RPC ループ catch-all のワイヤー向け本文。理由はツール catch-all と同じ（#1530, #1580）。
+    internal static string BuildSanitizedLoopErrorMessage(Exception ex)
+    {
+        if (ex is CodeIndexException codeIndexEx)
+            return $"Internal error ({ex.GetType().Name}) [{codeIndexEx.Code}/{codeIndexEx.Category}]{BuildPathFragment(codeIndexEx)}{BuildHintFragment(codeIndexEx)}. See cdidx server stderr for details.";
+        return $"Internal error ({ex.GetType().Name}). See cdidx server stderr for details.";
+    }
+
+    // Quote so paths/hints with spaces stay one token. Single quotes are kept
+    // for human readability — this is a display contract, not a shell-parsing one.
+    // 空白を含む path / hint が 2 トークンに見えないよう単引用符でラップする。
+    private static string BuildPathFragment(CodeIndexException ex) =>
+        string.IsNullOrEmpty(ex.Path) ? string.Empty : $" path='{ex.Path}'";
+
+    private static string BuildHintFragment(CodeIndexException ex) =>
+        string.IsNullOrEmpty(ex.Hint) ? string.Empty : $" hint='{ex.Hint}'";
 
     // Tool implementations are in McpToolHandlers.cs / ツール実装は McpToolHandlers.cs に分離
 

--- a/tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
+++ b/tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
@@ -1,0 +1,257 @@
+using System.Reflection;
+using System.Text.Json;
+using CodeIndex;
+using CodeIndex.Cli;
+using CodeIndex.Database;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Tests;
+
+/// <summary>
+/// Coverage for the <see cref="CodeIndexException"/> base type and the CLI / MCP
+/// formatters that surface its <c>Code / Category / Path / Hint</c> fields uniformly (#1580).
+/// CodeIndexException と、その <c>Code / Category / Path / Hint</c> を一律に出す
+/// CLI / MCP フォーマッタのカバレッジ (#1580)。
+/// </summary>
+[Collection("SQLite pool sensitive")]
+public class CodeIndexExceptionTests
+{
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    [Fact]
+    public void Constructor_PathProvided_AppendsPathToMessage()
+    {
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbLocked,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Failed to open SQLite connection after retries.",
+            path: "/tmp/cdidx.db",
+            hint: "Close other cdidx invocations.");
+
+        Assert.Equal(CommandErrorCodes.DbLocked, ex.Code);
+        Assert.Equal(CodeIndexExceptionCategory.Database, ex.Category);
+        Assert.Equal("/tmp/cdidx.db", ex.Path);
+        Assert.Equal("Close other cdidx invocations.", ex.Hint);
+        Assert.Contains("Failed to open SQLite connection", ex.Message);
+        Assert.Contains("/tmp/cdidx.db", ex.Message);
+    }
+
+    [Fact]
+    public void Constructor_NoPath_LeavesMessageUntouched()
+    {
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbError,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Generic failure.");
+
+        Assert.Equal("Generic failure.", ex.Message);
+        Assert.Null(ex.Path);
+        Assert.Null(ex.Hint);
+    }
+
+    [Fact]
+    public void Constructor_NullCode_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CodeIndexException(
+            code: null!,
+            category: CodeIndexExceptionCategory.Database,
+            message: "msg"));
+    }
+
+    [Fact]
+    public void Constructor_NullCategory_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CodeIndexException(
+            code: CommandErrorCodes.DbError,
+            category: null!,
+            message: "msg"));
+    }
+
+    [Fact]
+    public void Constructor_EmptyMessage_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new CodeIndexException(
+            code: CommandErrorCodes.DbError,
+            category: CodeIndexExceptionCategory.Database,
+            message: "   "));
+    }
+
+    [Fact]
+    public void Constructor_InnerException_IsPreserved()
+    {
+        var inner = new InvalidOperationException("inner");
+
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbError,
+            category: CodeIndexExceptionCategory.Database,
+            message: "outer",
+            innerException: inner);
+
+        Assert.Same(inner, ex.InnerException);
+    }
+
+    [Fact]
+    public void Formatter_NoJsonFlag_WritesHumanLines()
+    {
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbLocked,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Failed to open SQLite connection after retries.",
+            path: "/var/cdidx/state.db",
+            hint: "Wait for the other indexer to finish.");
+
+        var (stdout, stderr) = CaptureConsole(() =>
+            CodeIndexExceptionFormatter.Write(ex, ["status"], _jsonOptions));
+
+        Assert.Empty(stdout);
+        Assert.Contains("[E002_DB_LOCKED]", stderr);
+        Assert.Contains("Failed to open SQLite connection", stderr);
+        Assert.Contains("Path: /var/cdidx/state.db", stderr);
+        Assert.Contains("Hint: Wait for the other indexer to finish.", stderr);
+    }
+
+    [Fact]
+    public void Formatter_NoJsonFlag_OmitsPathAndHintLinesWhenAbsent()
+    {
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbError,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Generic failure.");
+
+        var (_, stderr) = CaptureConsole(() =>
+            CodeIndexExceptionFormatter.Write(ex, ["status"], _jsonOptions));
+
+        Assert.Contains("[E008_DB_ERROR]", stderr);
+        Assert.DoesNotContain("Path:", stderr);
+        Assert.DoesNotContain("Hint:", stderr);
+    }
+
+    [Fact]
+    public void Formatter_JsonFlag_EmitsStructuredEnvelope()
+    {
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbLocked,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Failed to open SQLite connection after retries.",
+            path: "/var/cdidx/state.db",
+            hint: "Wait for the other indexer to finish.");
+
+        var (stdout, stderr) = CaptureConsole(() =>
+            CodeIndexExceptionFormatter.Write(ex, ["status", "--json"], _jsonOptions));
+
+        Assert.Empty(stderr);
+        using var doc = JsonDocument.Parse(stdout);
+        var root = doc.RootElement;
+        Assert.Equal("error", root.GetProperty("status").GetString());
+        Assert.Equal("E002_DB_LOCKED", root.GetProperty("error_code").GetString());
+        Assert.Equal("database", root.GetProperty("category").GetString());
+        Assert.Equal("/var/cdidx/state.db", root.GetProperty("path").GetString());
+        Assert.Equal("Wait for the other indexer to finish.", root.GetProperty("hint").GetString());
+        Assert.Contains("Failed to open SQLite connection", root.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public void HasJsonFlag_RespectsDoubleDashBoundary()
+    {
+        Assert.False(CodeIndexExceptionFormatter.HasJsonFlag(["status"]));
+        Assert.True(CodeIndexExceptionFormatter.HasJsonFlag(["status", "--json"]));
+        Assert.False(CodeIndexExceptionFormatter.HasJsonFlag(["status", "--", "--json"]));
+    }
+
+    [Fact]
+    public void OpenSqliteConnectionWithRetry_ZeroAttempts_ThrowsArgumentOutOfRange()
+    {
+        // Guard the degenerate maxOpenAttempts=0 case so the bottom CodeIndexException
+        // is never thrown with a null inner exception (would mask the misuse).
+        // maxOpenAttempts=0 で末尾の throw に落ちると inner exception が null になり
+        // 呼び出しミスを隠してしまうため、入口で ArgumentOutOfRange を投げる。
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            DbContext.OpenSqliteConnectionWithRetry(
+                () => new SqliteConnection("Data Source=:memory:"),
+                static _ => { },
+                sleep: null,
+                maxOpenAttempts: 0));
+    }
+
+    [Fact]
+    public void OpenSqliteConnectionWithRetry_ExhaustedRetries_RaisesCodeIndexExceptionWithPath()
+    {
+        // #1580: when the busy retry loop exhausts, the caller must get the DB path,
+        // a stable error Code, and a recovery Hint — not a bare InvalidOperationException.
+        // #1580: retry 枯渇時は path / Code / Hint を含む CodeIndexException を投げる。
+        const string dbPath = "/tmp/cdidx_retry_exhaust.db";
+        var sleeps = new List<int>();
+        var attempts = 0;
+
+        var ex = Assert.Throws<CodeIndexException>(() =>
+            DbContext.OpenSqliteConnectionWithRetry(
+                () => new SqliteConnection("Data Source=:memory:"),
+                _ =>
+                {
+                    attempts++;
+                    throw CreateTransientBusyException();
+                },
+                sleep: sleeps.Add,
+                maxOpenAttempts: 3,
+                dbPath: dbPath));
+
+        Assert.Equal(CommandErrorCodes.DbLocked, ex.Code);
+        Assert.Equal(CodeIndexExceptionCategory.Database, ex.Category);
+        Assert.Equal(dbPath, ex.Path);
+        Assert.False(string.IsNullOrEmpty(ex.Hint));
+        Assert.Contains(dbPath, ex.Message);
+        Assert.IsType<SqliteException>(ex.InnerException);
+        Assert.Equal(3, attempts);
+    }
+
+    private static SqliteException CreateTransientBusyException()
+    {
+        var exception = Activator.CreateInstance(
+            typeof(SqliteException),
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: ["busy", 5],
+            culture: null) as SqliteException;
+        return exception ?? throw new InvalidOperationException("Failed to create SqliteException for retry test.");
+    }
+
+    [Theory]
+    [InlineData(CommandErrorCodes.DbNotFound, CommandExitCodes.NotFound)]
+    [InlineData(CommandErrorCodes.DirectoryNotFound, CommandExitCodes.NotFound)]
+    [InlineData(CommandErrorCodes.DbLocked, CommandExitCodes.DatabaseError)]
+    [InlineData(CommandErrorCodes.DbNotWritable, CommandExitCodes.DatabaseError)]
+    [InlineData(CommandErrorCodes.DbIntegrityFailed, CommandExitCodes.DatabaseError)]
+    [InlineData(CommandErrorCodes.SchemaTooNew, CommandExitCodes.DatabaseError)]
+    [InlineData(CommandErrorCodes.TempStoreExhausted, CommandExitCodes.DatabaseError)]
+    [InlineData(CommandErrorCodes.DbError, CommandExitCodes.DatabaseError)]
+    [InlineData(CommandErrorCodes.FeatureUnavailable, CommandExitCodes.FeatureUnavailable)]
+    [InlineData(CommandErrorCodes.UsageError, CommandExitCodes.UsageError)]
+    [InlineData("E999_UNKNOWN", CommandExitCodes.DatabaseError)]
+    public void MapCodeIndexExceptionExitCode_MapsKnownCodesToTaxonomy(string code, int expectedExitCode)
+    {
+        Assert.Equal(expectedExitCode, ProgramRunner.MapCodeIndexExceptionExitCode(code));
+    }
+
+    private static (string stdout, string stderr) CaptureConsole(Action body)
+    {
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            body();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+        return (stdout.ToString(), stderr.ToString());
+    }
+}

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -698,6 +698,67 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void BuildSanitizedToolErrorMessage_CodeIndexException_EchoesStructuredFields()
+    {
+        // Issue #1580: CodeIndexException carries author-controlled Code / Category /
+        // Path / Hint values, so the MCP catch-all must surface them so clients can
+        // branch on Code without parsing free-form messages. The free-form `Message`
+        // text built by CodeIndexException itself (which already includes the path
+        // suffix) still must not be echoed verbatim, to keep #1530 closed for the
+        // database message body.
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbLocked,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Failed to open SQLite connection.",
+            path: "/var/cdidx/state.db",
+            hint: "Close other cdidx invocations.");
+
+        var message = McpServer.BuildSanitizedToolErrorMessage("search", ex);
+
+        Assert.Contains("Error executing search", message);
+        Assert.Contains(nameof(CodeIndexException), message);
+        Assert.Contains("[E002_DB_LOCKED/database]", message);
+        Assert.Contains("path='/var/cdidx/state.db'", message);
+        Assert.Contains("hint='Close other cdidx invocations.'", message);
+        Assert.Contains("server stderr", message);
+    }
+
+    [Fact]
+    public void BuildSanitizedLoopErrorMessage_CodeIndexException_EchoesStructuredFields()
+    {
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbLocked,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Failed to open SQLite connection.",
+            path: "/var/cdidx/state.db",
+            hint: "Close other cdidx invocations.");
+
+        var message = McpServer.BuildSanitizedLoopErrorMessage(ex);
+
+        Assert.Contains("Internal error", message);
+        Assert.Contains(nameof(CodeIndexException), message);
+        Assert.Contains("[E002_DB_LOCKED/database]", message);
+        Assert.Contains("path='/var/cdidx/state.db'", message);
+        Assert.Contains("hint='Close other cdidx invocations.'", message);
+        Assert.Contains("server stderr", message);
+    }
+
+    [Fact]
+    public void BuildSanitizedToolErrorMessage_CodeIndexException_NoPathNoHint_OmitsFragments()
+    {
+        var ex = new CodeIndexException(
+            code: CommandErrorCodes.DbError,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Generic failure.");
+
+        var message = McpServer.BuildSanitizedToolErrorMessage("status", ex);
+
+        Assert.Contains("[E008_DB_ERROR/database]", message);
+        Assert.DoesNotContain("path=", message);
+        Assert.DoesNotContain("hint=", message);
+    }
+
+    [Fact]
     public void ToolsCall_ReusesDbContextAcrossInvocations()
     {
         // #1494: every MCP tool call used to construct a fresh DbContext (and reopen the


### PR DESCRIPTION
## Summary
- Introduce `CodeIndexException` base type with stable `Code`, `Category`, `Path`, `Hint` fields and replace bare `InvalidOperationException` in `DbContext.OpenSqliteConnectionWithRetry`; the SQLite busy-retry helper now wraps the final attempt's `SqliteException` as inner exception so callers always get a structured error with the DB path.
- CLI surfaces the fields uniformly (`Error [Exxx]: ...` + `Path:` / `Hint:` stderr lines, or `path` / `category` snake_case fields in `--json` envelopes via the extended `CommandErrorJsonResult`); `ProgramRunner` maps known error codes to the existing `CommandExitCodes` taxonomy.
- MCP catch-all (`BuildSanitizedToolErrorMessage` / `BuildSanitizedLoopErrorMessage`) echoes `[Code/Category] path='...' hint='...'` while preserving #1530 sanitization for non-`CodeIndexException` paths; Path/Hint are quoted so values with spaces stay tokenized.
- Fix pre-existing unreachability bug: the retry helper's `when (... && attempt < maxOpenAttempts)` predicate caused the final busy error to fall through the unrestricted `catch { throw; }`, making the bottom throw unreachable. Now the predicate gates only the sleep call. Added `ArgumentOutOfRangeException` guard for `maxOpenAttempts <= 0`.

Fixes #1580

## Test plan
- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` — 5079 passed, 3 skipped (perf), 0 failed
- [x] New `CodeIndexExceptionTests` covers constructor null/empty/path/hint paths, formatter human + JSON output, `HasJsonFlag` `--` boundary, exit-code map (11 inline data rows), and end-to-end retry-exhaust → `CodeIndexException` with path/hint/inner exception
- [x] `OpenSqliteConnectionWithRetry_ZeroAttempts_ThrowsArgumentOutOfRange` covers the new guard
- [x] New `McpServerTests` assertions verify the `[Code/Category] path='...' hint='...'` quoted format reaches sanitized MCP error envelopes
- [x] Codex adversarial review performed — findings on doc clarity (MCP path/hint echoed verbatim), `null`/whitespace path handling, broadened busy-retry hint wording, quoted MCP path/hint formatting, and `maxOpenAttempts <= 0` guard all addressed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
