### PR TITLE
Document platform support policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
     if: github.repository == 'Widthdom/CodeIndex'
     strategy:
       matrix:
+        # Keep this matrix in sync with docs/platform-support.md and install.sh
+        # unsupported-RID guidance.
+        # この matrix は docs/platform-support.md と install.sh の未対応 RID
+        # ガイダンスと同期する。
         include:
           - os: ubuntu-latest
             rid: linux-x64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ Start from the shared project guidance:
 - `DEVELOPER_GUIDE.md` for architecture, dependency policy, and build basics.
 - `TESTING_GUIDE.md` for test layout, test-writing conventions, and targeted
   test commands.
+- `docs/platform-support.md` for official release asset RIDs and unsupported
+  platform alternatives.
 - `AGENT_GUIDE.md` for repository workflow rules used by coding agents.
 
 For a normal change, create a topic branch from the latest `origin/main`.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -852,10 +852,12 @@ What `install.sh` does, in order (see `install.sh`):
 
 1. **Detect platform.** `uname -s` / `uname -m` are normalized to the
    `<os>-<arch>` RID the release workflow publishes (`linux-x64`,
-   `linux-arm64`, `osx-arm64`, `win-x64`). Alpine / musl is rejected up
-   front with an actionable error because the self-contained binary
-   links against glibc. `osx-x64` is rejected because the release matrix
-   does not ship that RID.
+   `linux-arm64`, `osx-arm64`, `win-x64`; see
+   [Platform Support](docs/platform-support.md)). Alpine / musl is
+   rejected up front with an actionable error because the self-contained
+   binary links against glibc. `osx-x64` is rejected because the release
+   matrix does not ship that RID, with NuGet global-tool and source-build
+   alternatives in the error text.
 2. **Detect existing install first.** If `INSTALL_DIR/cdidx` already
    exists, the installer caches its parsed `--version` output before any
    network work so later version-selection and repair decisions can
@@ -1354,7 +1356,7 @@ flowchart TD
 | `cdidx --version` prints `cdidx v0.0.0` | `version.json` not next to the binary in `$HOME/.local/bin/` | Re-run the fixed `install.sh`; verify `ls $HOME/.local/bin/version.json` exists |
 | `DllNotFoundException: Unable to load shared library 'e_sqlite3'` on any command | `libe_sqlite3.so` (or `.dylib`) not next to the binary | Re-run the fixed `install.sh`; verify `ls $HOME/.local/bin/libe_sqlite3.*` exists |
 | `install.sh` error: `musl-based Linux (e.g. Alpine) is not supported` | Container uses musl libc | Switch to a glibc-based image (debian/ubuntu) or install via `dotnet tool install -g cdidx` in an environment with the SDK |
-| `install.sh` error: `macOS x86_64 (Intel) binaries are not published` | Intel Mac hitting `osx-x64` RID | Run under Rosetta 2 with `osx-arm64`, or use `dotnet tool install -g cdidx` |
+| `install.sh` error: `macOS x86_64 (Intel) binaries are not published` | Intel Mac hitting `osx-x64` RID | Use `dotnet tool install -g cdidx` in a .NET SDK environment, or build from source with `dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true` |
 | `install.sh` error: `Checksum mismatch!` | Tarball tampered with or transport corrupted | Retry; if persistent, check the `sha256sums.txt` and the tarball on the release page |
 | `Error: --json is not available on this trimmed build.` | Manual/custom build reached a reflection-based `JsonSerializer` path that is not covered by source generation | Use the official `install.sh` release or NuGet/global-tool build, omit `--json`, use MCP, or add the missing DTO to `CliJsonSerializerContext` before publishing |
 | `cdidx status` shows `Files: 0` on a repo that clearly has files | Index DB never built, or pointing at the wrong `--db` | Run `cdidx <projectPath>` first; verify `.cdidx/codeindex.db` exists |
@@ -2171,7 +2173,7 @@ curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh 
 
 `install.sh` が順に行うこと（`install.sh` 参照）:
 
-1. **プラットフォーム検出。** `uname -s` / `uname -m` をリリースワークフローが publish する `<os>-<arch>` RID（`linux-x64`、`linux-arm64`、`osx-arm64`、`win-x64`）に正規化。自己完結型バイナリは glibc にリンクされているため、Alpine / musl は先頭で明示的に拒否する。リリース行列が `osx-x64` を出していないため、こちらも拒否する。
+1. **プラットフォーム検出。** `uname -s` / `uname -m` をリリースワークフローが publish する `<os>-<arch>` RID（`linux-x64`、`linux-arm64`、`osx-arm64`、`win-x64`。詳細は [プラットフォームサポート](docs/platform-support.md#プラットフォームサポート)）に正規化。自己完結型バイナリは glibc にリンクされているため、Alpine / musl は先頭で明示的に拒否する。リリース行列が `osx-x64` を出していないため、こちらも拒否し、エラー文で NuGet global tool と source build の代替手段を案内する。
 2. **既存インストールを先に検出。** `INSTALL_DIR/cdidx` が既にある場合は、ネットワークへ行く前に `--version` を解釈して保持する。これにより、後続のバージョン選択や repair 判定で「健全な一致」なのか「古い/不完全な install」なのかを区別できる。
 3. **バージョン解決。** 明示引数がある場合は `v` プレフィックス付き・無しの両方を受け付ける（`v1.8.0` / `1.8.0`）。引数なしでも GitHub API（`/repos/Widthdom/CodeIndex/releases/latest`）を叩いて latest tag を解決し、`jq` があれば `tag_name` 取得に使い、無ければ portability のため従来どおり `grep` + `sed` にフォールバックする。そのうえで健全な既存 install がその latest tag と一致している場合だけ download を skip する。壊れた `v0.0.0` install や必須隣接資産欠落 install は再インストール対象として扱う。HTTP 失敗も `403` rate limit / `404` / `5xx` / 実際の curl network error を分けて案内する。
 4. **明示バージョン指定時は再インストールまたは切り替えに進む。** 引数なし再実行も latest release を対象にするが、明示ターゲット版では、同版でも必ず再インストールへ進み、別版なら切り替えへ進む。壊れた `v0.0.0` install や、同版でも必須資産が欠けている install も置き換え対象として扱う — これは意図した挙動。
@@ -2430,7 +2432,7 @@ flowchart TD
 | `cdidx --version` が `cdidx v0.0.0` | `version.json` が `$HOME/.local/bin/` のバイナリの隣に無い | 修正後の `install.sh` を再実行。`ls $HOME/.local/bin/version.json` を確認 |
 | 任意のコマンドで `DllNotFoundException: Unable to load shared library 'e_sqlite3'` | `libe_sqlite3.so`（または `.dylib`）がバイナリの隣に無い | 修正後の `install.sh` を再実行。`ls $HOME/.local/bin/libe_sqlite3.*` を確認 |
 | `install.sh` のエラー: `musl-based Linux (e.g. Alpine) is not supported` | コンテナが musl libc を使用 | glibc ベース（debian/ubuntu）に切り替えるか、SDK のある環境で `dotnet tool install -g cdidx` を使う |
-| `install.sh` のエラー: `macOS x86_64 (Intel) binaries are not published` | Intel Mac が `osx-x64` RID に到達 | Rosetta 2 下で `osx-arm64` を使うか、`dotnet tool install -g cdidx` を使う |
+| `install.sh` のエラー: `macOS x86_64 (Intel) binaries are not published` | Intel Mac が `osx-x64` RID に到達 | .NET SDK のある環境で `dotnet tool install -g cdidx` を使うか、`dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true` で source build する |
 | `install.sh` のエラー: `Checksum mismatch!` | tarball の改ざんまたは転送時破損 | 再実行。それでも起きるならリリースページの `sha256sums.txt` と tarball を確認 |
 | `Error: --json is not available on this trimmed build.` | 手動/custom build が source generation 未対応の reflection-based `JsonSerializer` 経路に到達した | 公式 `install.sh` release または NuGet グローバルツール版を使う、`--json` を外す、MCP を使う、または publish 前に不足 DTO を `CliJsonSerializerContext` へ追加する |
 | 明らかにファイルのあるリポジトリで `cdidx status` が `Files: 0` | インデックス DB を作っていない、あるいは別の `--db` を指している | 先に `cdidx <projectPath>` を実行。`.cdidx/codeindex.db` の存在を確認 |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 |---|---|
 | [User Guide](USER_GUIDE.md) | Detailed installation, command examples, options, supported languages, MCP setup, and troubleshooting. |
 | [Cloud Bootstrap](CLOUD_BOOTSTRAP_PROMPT.md) | Install guidance for restricted cloud agent sessions. |
+| [Platform Support](docs/platform-support.md) | Official release asset RIDs, unsupported platforms, and source-build alternatives. |
 | [Developer Guide](DEVELOPER_GUIDE.md) | Architecture, implementation notes, and release workflow. |
 | [Testing Guide](TESTING_GUIDE.md) | Test conventions and validation commands. |
 | [Self-Improvement Contract](SELF_IMPROVEMENT.md) | Rules for agents improving CodeIndex itself. |
@@ -206,6 +207,7 @@ cdidx mcp
 |---|---|
 | [ユーザーガイド](USER_GUIDE.md#cdidx日本語) | 詳細なインストール、コマンド例、オプション、対応言語、MCP 設定、トラブルシュート。 |
 | [クラウドブートストラップ](CLOUD_BOOTSTRAP_PROMPT.md#日本語) | 制限されたクラウドエージェント環境でのインストール手順。 |
+| [プラットフォームサポート](docs/platform-support.md#プラットフォームサポート) | 公式リリースアセットの RID、未対応 platform、source build の代替手段。 |
 | [開発者ガイド](DEVELOPER_GUIDE.md#開発者ガイド) | アーキテクチャ、実装メモ、リリース手順。 |
 | [テストガイド](TESTING_GUIDE.md#テストガイド) | テスト規約と検証コマンド。 |
 | [自己改善コントラクト](SELF_IMPROVEMENT.md#自己改善ループ) | CodeIndex 自身を改善するエージェント向けルール。 |

--- a/changelog.d/unreleased/1871.fixed.md
+++ b/changelog.d/unreleased/1871.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 1871
+affected:
+  - install.sh
+  - docs/platform-support.md
+  - DEVELOPER_GUIDE.md
+  - README.md
+  - CONTRIBUTING.md
+  - .github/workflows/release.yml
+  - tests/CodeIndex.Tests/InstallScriptTests.cs
+---
+
+## English
+
+- **Unsupported release-asset platforms now have explicit guidance (#1871)** — `install.sh` now reports the published release RIDs and source/NuGet alternatives for unsupported architectures and Intel Mac `osx-x64`, and the platform support policy is documented.
+
+## 日本語
+
+- **公式リリースアセット未対応 platform の案内を明確化しました (#1871)** — `install.sh` は未対応 architecture と Intel Mac の `osx-x64` に対して公開済み release RID と source/NuGet の代替手段を表示し、platform support policy も文書化しました。

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,0 +1,93 @@
+# Platform Support
+
+> **[日本語版はこちら / Japanese version](#プラットフォームサポート)**
+
+This page defines the platform policy for official `cdidx` release assets.
+
+## Official Release Assets
+
+GitHub releases publish and checksum these first-class runtime identifiers:
+
+| RID | Asset | Notes |
+| --- | --- | --- |
+| `linux-x64` | `CodeIndex-linux-x64.tar.gz` | Requires glibc. Alpine/musl images are not supported by the official tarball. |
+| `linux-arm64` | `CodeIndex-linux-arm64.tar.gz` | Requires glibc. |
+| `osx-arm64` | `CodeIndex-osx-arm64.tar.gz` | Apple Silicon macOS. |
+| `win-x64` | `CodeIndex-win-x64.zip` | 64-bit Windows. |
+
+The one-line `install.sh` installer supports the Unix tarball path for Linux and
+macOS. Windows users should install from the release ZIP, use the NuGet global
+tool, or build from source.
+
+## Not Published As Release Assets
+
+The following RIDs are not currently shipped as official GitHub release assets:
+
+| RID or platform | Status | Recommended path |
+| --- | --- | --- |
+| `osx-x64` / Intel Mac | Not published | Install with `dotnet tool install -g cdidx` in a .NET SDK environment, or build from source with `dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true`. |
+| `win-x86` / 32-bit Windows | Not published | Use a 64-bit Windows environment when possible, install the NuGet global tool with the .NET SDK, or build from source for `win-x86` if you must run there. |
+| `linux-x86`, `linux-arm`, and other Linux RIDs | Not published | Use a glibc-based x64/arm64 environment, install the NuGet global tool, or build from source for the target RID. |
+| Alpine / musl Linux | Not supported by official tarballs | Use a glibc-based image such as Debian or Ubuntu, or install/build in an SDK environment that matches your deployment target. |
+
+Unsupported release-asset coverage does not mean the source code intentionally
+blocks that RID. It means the project does not currently build, test, publish,
+or checksum that binary in the release pipeline.
+
+## Requesting Another Asset
+
+Open a GitHub issue when you need an additional official release asset. Include:
+
+- the target RID;
+- where it will run, such as developer laptops, CI, enterprise fleet, or
+  container base image;
+- whether `dotnet tool install -g cdidx` or a source build is unavailable;
+- any validation constraints that would need to become part of CI.
+
+---
+
+<a id="プラットフォームサポート"></a>
+# プラットフォームサポート
+
+このページは、公式 `cdidx` リリースアセットのプラットフォーム方針を定義します。
+
+## 公式リリースアセット
+
+GitHub Releases では、次の runtime identifier を first-class として公開し、
+checksum 対象にしています。
+
+| RID | アセット | 備考 |
+| --- | --- | --- |
+| `linux-x64` | `CodeIndex-linux-x64.tar.gz` | glibc が必要です。公式 tarball は Alpine/musl image をサポートしません。 |
+| `linux-arm64` | `CodeIndex-linux-arm64.tar.gz` | glibc が必要です。 |
+| `osx-arm64` | `CodeIndex-osx-arm64.tar.gz` | Apple Silicon macOS 向けです。 |
+| `win-x64` | `CodeIndex-win-x64.zip` | 64-bit Windows 向けです。 |
+
+ワンライナーの `install.sh` は Linux と macOS の Unix tarball 経路を対象に
+しています。Windows では release ZIP、NuGet global tool、または source build
+を使ってください。
+
+## 公式アセットとして未公開のもの
+
+次の RID は、現時点では公式 GitHub release asset として公開していません。
+
+| RID / platform | 状態 | 推奨経路 |
+| --- | --- | --- |
+| `osx-x64` / Intel Mac | 未公開 | .NET SDK のある環境で `dotnet tool install -g cdidx` を使うか、`dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true` で source build してください。 |
+| `win-x86` / 32-bit Windows | 未公開 | 可能なら 64-bit Windows を使い、必要に応じて .NET SDK の NuGet global tool、または `win-x86` 向け source build を使ってください。 |
+| `linux-x86`、`linux-arm`、その他 Linux RID | 未公開 | glibc ベースの x64/arm64 環境、NuGet global tool、または対象 RID 向け source build を使ってください。 |
+| Alpine / musl Linux | 公式 tarball では非対応 | Debian / Ubuntu など glibc ベースの image を使うか、配布先に合う SDK 環境で install/build してください。 |
+
+release asset が未公開であることは、その RID を source code 側で意図的に拒否
+しているという意味ではありません。リリースパイプラインでそのバイナリを
+build、test、publish、checksum していないという意味です。
+
+## 追加アセットのリクエスト
+
+追加の公式 release asset が必要な場合は GitHub issue を作成してください。
+次の情報を含めると判断しやすくなります。
+
+- 対象 RID;
+- 開発者端末、CI、enterprise fleet、container base image などの実行場所;
+- `dotnet tool install -g cdidx` や source build が使えない理由;
+- CI に追加すべき検証条件。

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,10 @@ warn()  { printf '\033[1;33mWARN:\033[0m %s\n' "$1" >&2; }
 error() { printf '\033[1;31mERROR:\033[0m %s\n' "$1" >&2; exit 1; }
 report_error() { printf '\033[1;31mERROR:\033[0m %s\n' "$1" >&2; }
 
+published_release_rids() {
+    printf '%s' "linux-x64, linux-arm64, osx-arm64, win-x64"
+}
+
 cleanup() {
     if [ -n "$TMPDIR_CLEANUP" ]; then
         rm -rf "$TMPDIR_CLEANUP"
@@ -616,14 +620,14 @@ detect_platform() {
     case "$arch" in
         x86_64|amd64)   ARCH_NAME="x64"   ;;
         aarch64|arm64)  ARCH_NAME="arm64"  ;;
-        *)              error "Unsupported architecture: $arch (supported: x86_64, arm64)" ;;
+        *)              error "Unsupported architecture: $arch. Official release assets are published for $(published_release_rids). Other RIDs such as linux-x86, osx-x64, and win-x86 are not currently shipped. Install via 'dotnet tool install -g cdidx' with the .NET SDK, or build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r <rid> --self-contained true'. See docs/platform-support.md." ;;
     esac
 
     RID="${OS_NAME}-${ARCH_NAME}"
 
     # osx-x64 is not published / osx-x64 はリリースしていない
     if [ "$RID" = "osx-x64" ]; then
-        error "macOS x86_64 (Intel) binaries are not published. Use Rosetta 2 with osx-arm64 or install via 'dotnet tool install -g cdidx'."
+        error "macOS x86_64 (Intel) binaries are not published as CodeIndex-osx-x64.tar.gz. Install via 'dotnet tool install -g cdidx' with the .NET SDK, or build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true'. See docs/platform-support.md."
     fi
 
     # Reject musl-based Linux (e.g. Alpine) — published binaries require glibc

--- a/install.sh
+++ b/install.sh
@@ -620,14 +620,14 @@ detect_platform() {
     case "$arch" in
         x86_64|amd64)   ARCH_NAME="x64"   ;;
         aarch64|arm64)  ARCH_NAME="arm64"  ;;
-        *)              error "Unsupported architecture: $arch. Official release assets are published for $(published_release_rids). Other RIDs such as linux-x86, osx-x64, and win-x86 are not currently shipped. Install via 'dotnet tool install -g cdidx' with the .NET SDK, or build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r <rid> --self-contained true'. See docs/platform-support.md." ;;
+        *)              error "Unsupported architecture: $arch. Official release assets are published for $(published_release_rids). Other RIDs such as linux-x86, osx-x64, and win-x86 are not currently shipped. Install via 'dotnet tool install -g cdidx' with the .NET SDK, or build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r <rid> --self-contained true'. See https://github.com/${REPO}/blob/main/docs/platform-support.md." ;;
     esac
 
     RID="${OS_NAME}-${ARCH_NAME}"
 
     # osx-x64 is not published / osx-x64 はリリースしていない
     if [ "$RID" = "osx-x64" ]; then
-        error "macOS x86_64 (Intel) binaries are not published as CodeIndex-osx-x64.tar.gz. Install via 'dotnet tool install -g cdidx' with the .NET SDK, or build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true'. See docs/platform-support.md."
+        error "macOS x86_64 (Intel) binaries are not published as CodeIndex-osx-x64.tar.gz. Install via 'dotnet tool install -g cdidx' with the .NET SDK, or build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true'. See https://github.com/${REPO}/blob/main/docs/platform-support.md."
     fi
 
     # Reject musl-based Linux (e.g. Alpine) — published binaries require glibc

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -1793,6 +1793,63 @@ public sealed class InstallScriptTests : IDisposable
     }
 
     [Fact]
+    public void DetectPlatform_MacosX64_PrintsActionableUnsupportedRidGuidance()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (exitCode, _, stderr) = RunInstallerSnippet(
+            """
+            uname() {
+                case "$1" in
+                    -s) printf '%s\n' "Darwin" ;;
+                    -m) printf '%s\n' "x86_64" ;;
+                    *)  printf '%s\n' "unknown" ;;
+                esac
+            }
+
+            detect_platform
+            """,
+            enforceStrictMode: false);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("macOS x86_64 (Intel) binaries are not published as CodeIndex-osx-x64.tar.gz", stderr);
+        Assert.Contains("dotnet tool install -g cdidx", stderr);
+        Assert.Contains("dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true", stderr);
+        Assert.Contains("docs/platform-support.md", stderr);
+        Assert.DoesNotContain("Rosetta 2 with osx-arm64", stderr);
+    }
+
+    [Fact]
+    public void DetectPlatform_UnsupportedArchitecture_PrintsPublishedRidPolicyAndSourceBuildGuidance()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (exitCode, _, stderr) = RunInstallerSnippet(
+            """
+            uname() {
+                case "$1" in
+                    -s) printf '%s\n' "Linux" ;;
+                    -m) printf '%s\n' "i686" ;;
+                    *)  printf '%s\n' "unknown" ;;
+                esac
+            }
+
+            detect_platform
+            """,
+            enforceStrictMode: false);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unsupported architecture: i686", stderr);
+        Assert.Contains("linux-x64, linux-arm64, osx-arm64, win-x64", stderr);
+        Assert.Contains("linux-x86, osx-x64, and win-x86 are not currently shipped", stderr);
+        Assert.Contains("dotnet tool install -g cdidx", stderr);
+        Assert.Contains("dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r <rid> --self-contained true", stderr);
+        Assert.Contains("docs/platform-support.md", stderr);
+    }
+
+    [Fact]
     public void ResolveVersion_UsesJqWhenAvailable()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
## Summary

- Document the official release asset platform policy in `docs/platform-support.md` and link it from README, CONTRIBUTING, and developer docs.
- Make `install.sh` unsupported-architecture and Intel Mac `osx-x64` errors list the published RIDs plus NuGet/source-build alternatives.
- Add installer regression tests for the unsupported RID messages and keep the release matrix tied to the docs.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~InstallScriptTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~InstallScriptTests.DetectPlatform"`
- `dotnet test CodeIndex.sln -c Release --no-build`
- `dotnet run --project tools/CodeIndex.Changelog -- check`

## Documentation and changelog

- Added `docs/platform-support.md`.
- Updated README, CONTRIBUTING, DEVELOPER_GUIDE, and `.github/workflows/release.yml` guidance.
- Added changelog fragment `changelog.d/unreleased/1871.fixed.md`.

## Review

- Adversarial review found one actionable issue: installer errors should link to a reachable GitHub docs URL, not only a repo-relative path. Fixed in the follow-up commit.
- Re-review result: No blocking/actionable issues found.

## Follow-up candidates

- None.

Fixes #1871
