### PR TITLE
Add suggestion attribution metadata

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -561,6 +561,7 @@ The `suggest_improvement` MCP tool allows AI agents to report gaps or errors.
 - Description text (natural language, validated by SourceCodeDetector)
 - Context text (natural language, validated by SourceCodeDetector)
 - cdidx version string
+- Attribution metadata: `created_by_agent`, `session_id`, `client_version`, `mcp_client_name`, `mcp_client_version`, and optional `tool_invocation_context`
 - SHA256 suggestion hash (for deduplication)
 
 ### What is NOT included in the payload by design
@@ -572,7 +573,7 @@ The `suggest_improvement` MCP tool allows AI agents to report gaps or errors.
 
 ### Heuristic source code guard (not a security boundary)
 
-The description and context fields pass through `SourceCodeDetector` before storage and optional GitHub submission. This heuristic rejects common pasted code patterns (multi-line blocks, fenced code, import runs, function definitions) but intentionally allows short inline code examples so gap descriptions remain useful. It is **not a security boundary** — a determined agent could bypass it. The guard is a best-effort filter to catch accidental code inclusion, not a guarantee that no code-like text will ever be transmitted.
+The description, context, and optional tool invocation context fields pass through `SourceCodeDetector` before storage and optional GitHub submission. This heuristic rejects common pasted code patterns (multi-line blocks, fenced code, import runs, function definitions) but intentionally allows short inline code examples so gap descriptions remain useful. It is **not a security boundary** — a determined agent could bypass it. The guard is a best-effort filter to catch accidental code inclusion, not a guarantee that no code-like text will ever be transmitted.
 
 ### SourceCodeDetector design
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1402,7 +1402,7 @@ When both are set, the allowlist wins. `tools/list` only advertises enabled tool
 
 ### AI Feedback
 
-cdidx includes a `suggest_improvement` MCP tool for AI agents that hit gaps or bugs. Suggestions are saved locally to `.cdidx/suggestions.json`, and are sent to GitHub only when the user explicitly provides `CDIDX_GITHUB_TOKEN`. Payload details and source-code leak guardrails are documented in the [Developer Guide](DEVELOPER_GUIDE.md#ai-feedback-implementation).
+cdidx includes a `suggest_improvement` MCP tool for AI agents that hit gaps or bugs. Suggestions are saved locally to `.cdidx/suggestions.json`, and are sent to GitHub only when the user explicitly provides `CDIDX_GITHUB_TOKEN`. New records also store attribution metadata: the MCP `initialize.clientInfo` name/version when available, an opaque cdidx session id, the cdidx version that recorded the suggestion, and optional natural-language `toolInvocationContext` supplied by the caller. Payload details and source-code leak guardrails are documented in the [Developer Guide](DEVELOPER_GUIDE.md#ai-feedback-implementation).
 
 ## Troubleshooting
 
@@ -2860,7 +2860,7 @@ stdio トランスポートはバイト単位で挙動が変わらないため�
 
 ### AIフィードバック
 
-cdidx には、AI エージェントがギャップや不具合に気づいたときに使える `suggest_improvement` MCP ツールがあります。提案は `.cdidx/suggestions.json` にローカル保存され、`CDIDX_GITHUB_TOKEN` を明示設定した場合に限って GitHub へ送信されます。ペイロード詳細とソースコード漏えいガードは [DEVELOPER_GUIDE.md#aiフィードバックの実装](DEVELOPER_GUIDE.md#aiフィードバックの実装) にまとめています。
+cdidx には、AI エージェントがギャップや不具合に気づいたときに使える `suggest_improvement` MCP ツールがあります。提案は `.cdidx/suggestions.json` にローカル保存され、`CDIDX_GITHUB_TOKEN` を明示設定した場合に限って GitHub へ送信されます。新規レコードには attribution metadata も保存されます。取得可能な場合は MCP `initialize.clientInfo` の name/version、不透明な cdidx セッション ID、提案を記録した cdidx バージョン、呼び出し元が任意で渡す自然言語の `toolInvocationContext` が含まれます。ペイロード詳細とソースコード漏えいガードは [DEVELOPER_GUIDE.md#aiフィードバックの実装](DEVELOPER_GUIDE.md#aiフィードバックの実装) にまとめています。
 
 ## トラブルシューティング
 

--- a/changelog.d/unreleased/1873.added.md
+++ b/changelog.d/unreleased/1873.added.md
@@ -1,0 +1,21 @@
+---
+category: added
+issues:
+  - 1873
+affected:
+  - src/CodeIndex/Models/SuggestionRecord.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Mcp/McpToolDefinitions.cs
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - DEVELOPER_GUIDE.md
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Suggestion records now capture agent attribution metadata (#1873)** — `suggest_improvement` records the MCP client name/version, an opaque cdidx session id, the cdidx version, and optional natural-language invocation context so accumulated suggestions can be correlated by agent and session.
+
+## 日本語
+
+- **Suggestion record にエージェント attribution metadata を記録するようになりました (#1873)** — `suggest_improvement` は MCP クライアント名/version、不透明な cdidx セッション ID、cdidx バージョン、任意の自然言語 invocation context を保存し、蓄積した提案をエージェントやセッション単位で追跡できるようにしました。

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -16,6 +16,7 @@ namespace CodeIndex.Cli;
 ///   - Language name (e.g. "typescript")
 ///   - Description text (validated by SourceCodeDetector to not contain code)
 ///   - Context text (also validated)
+///   - Attribution metadata captured from MCP initialize/client context
 ///   - cdidx version and suggestion hash
 ///
 /// このクラスはAIフィードバックシステムの一部である。構造化されたギャップ記述のみを
@@ -24,6 +25,7 @@ namespace CodeIndex.Cli;
 ///   - 言語名（例: "typescript"）
 ///   - 説明テキスト（SourceCodeDetector によりコードが含まれないことを検証済み）
 ///   - コンテキストテキスト（同様に検証済み）
+///   - MCP initialize / client context から取得した attribution metadata
 ///   - cdidx バージョンと提案ハッシュ
 ///
 /// GitHub Issues are only created when the user has explicitly configured
@@ -208,6 +210,9 @@ internal static class GitHubIssueReporter
         // GitHub に公開する前に除去し、コード的な内容が外部リポジトリに到達することを防ぐ。
         var scrubbedDescription = ScrubInlineCode(record.Description);
         var scrubbedContext = record.Context != null ? ScrubInlineCode(record.Context) : null;
+        var scrubbedToolInvocationContext = record.ToolInvocationContext != null
+            ? ScrubInlineCode(record.ToolInvocationContext)
+            : null;
 
         // Build the issue body — structured fields only, with code scrubbed.
         // Issue 本文を構築 — 構造化フィールドのみ、コードは除去済み。
@@ -223,6 +228,13 @@ internal static class GitHubIssueReporter
         body.AppendLine();
         body.AppendLine("## Context");
         body.AppendLine(scrubbedContext ?? "N/A");
+        body.AppendLine();
+        body.AppendLine("## Attribution");
+        body.AppendLine($"Created by: {record.CreatedByAgent}");
+        body.AppendLine($"Session: {record.SessionId}");
+        body.AppendLine($"MCP client: {record.McpClientName ?? "N/A"}");
+        body.AppendLine($"MCP client version: {record.McpClientVersion ?? "N/A"}");
+        body.AppendLine($"Tool invocation context: {scrubbedToolInvocationContext ?? "N/A"}");
         body.AppendLine();
         body.AppendLine("---");
         body.AppendLine($"_Submitted by cdidx v{version}. Hash: `{record.Hash}`_");

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -213,8 +213,10 @@ public class SuggestionStore
 
         try
         {
-            return JsonSerializer.Deserialize<List<SuggestionRecord>>(json, s_readOptions)
-                   ?? new List<SuggestionRecord>();
+            var records = JsonSerializer.Deserialize<List<SuggestionRecord>>(json, s_readOptions)
+                          ?? new List<SuggestionRecord>();
+            NormalizeAttributionDefaults(records);
+            return records;
         }
         catch (JsonException)
         {
@@ -225,6 +227,19 @@ public class SuggestionStore
         }
         // IOException is NOT caught here — it propagates to the caller (fail-closed).
         // IOException はここでキャッチしない — 呼び出し元に伝播する（fail-closed）。
+    }
+
+    private static void NormalizeAttributionDefaults(List<SuggestionRecord> records)
+    {
+        foreach (var record in records)
+        {
+            if (string.IsNullOrWhiteSpace(record.CreatedByAgent))
+                record.CreatedByAgent = "unknown";
+            if (string.IsNullOrWhiteSpace(record.SessionId))
+                record.SessionId = "unknown";
+            if (string.IsNullOrWhiteSpace(record.ClientVersion))
+                record.ClientVersion = "unknown";
+        }
     }
 
     /// <summary>

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -81,6 +81,9 @@ public partial class McpServer : IDisposable
     // にする。`initialize` 毎に上書きすることで再接続時に caller identity が追随する。
     private string? _clientName;
     private string? _clientVersion;
+    // Opaque per-server-instance session id copied into suggestion attribution records (#1873).
+    // #1873 の提案 attribution 用に保存する、サーバーインスタンス単位の不透明セッションID。
+    private readonly string _sessionId = Guid.NewGuid().ToString("D");
     // Caller identity used to key the per-(tool, caller) rate limiter. Captured from the
     // `clientInfo.name` field of the `initialize` request when the client supplies it, so
     // shared / networked MCP deployments can attribute and throttle individual clients
@@ -249,6 +252,12 @@ public partial class McpServer : IDisposable
     /// テストがレート制限のキーを検証するために公開する。
     /// </summary>
     internal string CurrentCaller => _caller;
+
+    /// <summary>
+    /// Opaque session id used for suggestion attribution records (#1873).
+    /// 提案 attribution レコードに使う不透明セッションID (#1873)。
+    /// </summary>
+    internal string CurrentSessionId => _sessionId;
 
     /// <summary>
     /// Cap configured for concurrent in-flight tool calls (#1567). Surfaced for tests so

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -455,7 +455,8 @@ public partial class McpServer
                         },
                         ["language"] = new JsonObject { ["type"] = "string", ["description"] = "Programming language this applies to (optional)" },
                         ["description"] = new JsonObject { ["type"] = "string", ["description"] = "What gap or improvement you observed, or what error occurred (NOT source code)" },
-                        ["context"] = new JsonObject { ["type"] = "string", ["description"] = "What you were trying to do when you noticed the gap (NOT source code)" }
+                        ["context"] = new JsonObject { ["type"] = "string", ["description"] = "What you were trying to do when you noticed the gap (NOT source code)" },
+                        ["toolInvocationContext"] = new JsonObject { ["type"] = "string", ["description"] = "Natural-language context for the current tool invocation or workflow (optional, NOT source code)" }
                     },
                     ["required"] = new JsonArray { "category", "description" }
                 },

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -2274,9 +2274,12 @@ public partial class McpServer
         // 2. Validate optional parameters / 任意パラメータのバリデーション
         var language = args?["language"]?.GetValue<string>();
         var context = args?["context"]?.GetValue<string>();
+        var toolInvocationContext = args?["toolInvocationContext"]?.GetValue<string>();
 
         if (context != null && context.Length > MaxContextLength)
             return CreateToolErrorResponse(id, $"Context too long ({context.Length} chars, max {MaxContextLength})");
+        if (toolInvocationContext != null && toolInvocationContext.Length > MaxContextLength)
+            return CreateToolErrorResponse(id, $"Tool invocation context too long ({toolInvocationContext.Length} chars, max {MaxContextLength})");
 
         // 3. Source code leak detection — reject if code is detected
         //    ソースコード漏洩検出 — コードが検出されたら拒否
@@ -2285,6 +2288,8 @@ public partial class McpServer
 
         if (context != null && SourceCodeDetector.ContainsSourceCode(context))
             return CreateToolErrorResponse(id, "Context appears to contain source code. Please describe what you were trying to do without including code.");
+        if (toolInvocationContext != null && SourceCodeDetector.ContainsSourceCode(toolInvocationContext))
+            return CreateToolErrorResponse(id, "Tool invocation context appears to contain source code. Please describe the invocation without including code.");
 
         // 4. Compute dedup hash / 重複排除ハッシュを計算
         var hash = SuggestionStore.ComputeHash(category, language, description);
@@ -2316,6 +2321,12 @@ public partial class McpServer
             Context = context,
             Hash = hash,
             CreatedAt = DateTime.UtcNow,
+            CreatedByAgent = ResolveSuggestionAgent(),
+            SessionId = _sessionId,
+            ClientVersion = _version,
+            McpClientName = _clientName,
+            McpClientVersion = _clientVersion,
+            ToolInvocationContext = toolInvocationContext,
         };
 
         // Build GitHub submission callback (null if no token configured).
@@ -2360,6 +2371,11 @@ public partial class McpServer
         if (result.GitHubIssueUrl != null)
             payload["github_issue_url"] = result.GitHubIssueUrl;
         return CreateToolResult(id, "Suggestion recorded. Thank you for the feedback.", payload);
+    }
+
+    private string ResolveSuggestionAgent()
+    {
+        return string.IsNullOrWhiteSpace(_caller) ? "unknown" : _caller;
     }
 
 }

--- a/src/CodeIndex/Models/SuggestionRecord.cs
+++ b/src/CodeIndex/Models/SuggestionRecord.cs
@@ -45,6 +45,24 @@ public class SuggestionRecord
     /// <summary>UTC timestamp when the suggestion was recorded / 提案が記録されたUTCタイムスタンプ</summary>
     public DateTime CreatedAt { get; set; }
 
+    /// <summary>Agent or client identity that created the suggestion / 提案を作成したエージェントまたはクライアントID</summary>
+    public string CreatedByAgent { get; set; } = "unknown";
+
+    /// <summary>Opaque cdidx MCP session identifier / cdidx MCP セッションの不透明ID</summary>
+    public string SessionId { get; set; } = "unknown";
+
+    /// <summary>cdidx version that recorded the suggestion / 提案を記録した cdidx バージョン</summary>
+    public string ClientVersion { get; set; } = "unknown";
+
+    /// <summary>MCP client name from initialize.clientInfo, when available / initialize.clientInfo 由来の MCP クライアント名（取得可能な場合）</summary>
+    public string? McpClientName { get; set; }
+
+    /// <summary>MCP client version from initialize.clientInfo, when available / initialize.clientInfo 由来の MCP クライアントバージョン（取得可能な場合）</summary>
+    public string? McpClientVersion { get; set; }
+
+    /// <summary>Optional natural-language invocation context supplied by the caller / 呼び出し元が渡す任意の自然言語コンテキスト</summary>
+    public string? ToolInvocationContext { get; set; }
+
     /// <summary>Whether the suggestion has been submitted to GitHub / GitHubに送信済みか</summary>
     public bool SubmittedToGitHub { get; set; }
 

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -221,6 +221,11 @@ public class GitHubIssueReporterTests : IDisposable
             Assert.Equal(2, handler.RequestCount);
             Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
             Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+            var postedJson = Assert.Single(handler.RequestBodies);
+            Assert.Contains("codex/5.0", postedJson);
+            Assert.Contains("session-123", postedJson);
+            Assert.Contains("MCP client: codex", postedJson);
+            Assert.Contains("Tool invocation context: Investigating suggestion triage", postedJson);
         }
         finally
         {
@@ -295,6 +300,12 @@ public class GitHubIssueReporterTests : IDisposable
             Description = description,
             Hash = SuggestionStore.ComputeHash("other", null, description),
             CreatedAt = new DateTime(2026, 5, 15, 0, 0, 0, DateTimeKind.Utc),
+            CreatedByAgent = "codex/5.0",
+            SessionId = "session-123",
+            ClientVersion = "1.0.0-test",
+            McpClientName = "codex",
+            McpClientVersion = "5.0",
+            ToolInvocationContext = "Investigating suggestion triage",
         };
     }
 
@@ -315,8 +326,10 @@ public class GitHubIssueReporterTests : IDisposable
     {
         private readonly List<(Func<HttpRequestMessage, bool> Match, HttpResponseMessage Response)> _responses = new();
         private readonly List<HttpRequestMessage> _requests = new();
+        private readonly List<string> _requestBodies = new();
 
         public IReadOnlyList<HttpRequestMessage> Requests => _requests;
+        public IReadOnlyList<string> RequestBodies => _requestBodies;
         public int RequestCount => _requests.Count;
 
         public void AddResponse(Func<HttpRequestMessage, bool> match, HttpResponseMessage response)
@@ -327,6 +340,8 @@ public class GitHubIssueReporterTests : IDisposable
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             _requests.Add(request);
+            if (request.Content != null)
+                _requestBodies.Add(request.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult());
             foreach (var entry in _responses)
             {
                 if (entry.Match(request))

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -6940,6 +6940,42 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void SuggestImprovement_RecordsClientAttributionFromInitialize()
+    {
+        _server.HandleMessage(JsonNode.Parse(
+            """{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"clientInfo":{"name":"codex","version":"5.0"}}}""")!);
+        var uniqueDesc = $"Attribution metadata regression {Guid.NewGuid():N}";
+        var json = new JsonObject
+        {
+            ["jsonrpc"] = "2.0", ["id"] = 1,
+            ["method"] = "tools/call",
+            ["params"] = new JsonObject
+            {
+                ["name"] = "suggest_improvement",
+                ["arguments"] = new JsonObject
+                {
+                    ["category"] = "other",
+                    ["description"] = uniqueDesc,
+                    ["toolInvocationContext"] = "Investigating suggestion triage"
+                }
+            }
+        };
+
+        _server.HandleMessage((JsonNode)json);
+
+        var cdidxDir = Path.GetDirectoryName(_dbPath)!;
+        var dbName = Path.GetFileNameWithoutExtension(_dbPath);
+        var stored = new SuggestionStore(cdidxDir, dbName).LoadAll()
+            .Single(s => s.Description == uniqueDesc);
+        Assert.Equal("codex/5.0", stored.CreatedByAgent);
+        Assert.Equal(_server.CurrentSessionId, stored.SessionId);
+        Assert.Equal(ConsoleUi.LoadVersion(), stored.ClientVersion);
+        Assert.Equal("codex", stored.McpClientName);
+        Assert.Equal("5.0", stored.McpClientVersion);
+        Assert.Equal("Investigating suggestion triage", stored.ToolInvocationContext);
+    }
+
+    [Fact]
     public void SuggestImprovement_DuplicateSubmission_ReturnsDuplicate()
     {
         var uniqueDesc = $"Add support for Zig language {Guid.NewGuid():N}";

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -150,6 +150,12 @@ public class SuggestionStoreTests : IDisposable
             Context = "Searching for arrow functions",
             Hash = SuggestionStore.ComputeHash("crash_report", "typescript", "NullReferenceException during search"),
             CreatedAt = new DateTime(2026, 4, 12, 10, 0, 0, DateTimeKind.Utc),
+            CreatedByAgent = "codex/5",
+            SessionId = "session-123",
+            ClientVersion = "1.2.3",
+            McpClientName = "codex",
+            McpClientVersion = "5",
+            ToolInvocationContext = "MCP regression triage",
             SubmittedToGitHub = false,
             GitHubIssueUrl = null,
         };
@@ -164,8 +170,39 @@ public class SuggestionStoreTests : IDisposable
         Assert.Equal("NullReferenceException during search", r.Description);
         Assert.Equal("Searching for arrow functions", r.Context);
         Assert.Equal(record.Hash, r.Hash);
+        Assert.Equal("codex/5", r.CreatedByAgent);
+        Assert.Equal("session-123", r.SessionId);
+        Assert.Equal("1.2.3", r.ClientVersion);
+        Assert.Equal("codex", r.McpClientName);
+        Assert.Equal("5", r.McpClientVersion);
+        Assert.Equal("MCP regression triage", r.ToolInvocationContext);
         Assert.False(r.SubmittedToGitHub);
         Assert.Null(r.GitHubIssueUrl);
+    }
+
+    [Fact]
+    public void LoadAll_LegacyRecordsDefaultMissingAttribution()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "suggestions-codeindex.json"),
+            """
+            [
+              {
+                "category": "other",
+                "description": "Legacy suggestion without attribution",
+                "hash": "abc123",
+                "created_at": "2026-04-12T10:00:00Z"
+              }
+            ]
+            """);
+
+        var loaded = _store.LoadAll();
+
+        Assert.Single(loaded);
+        Assert.Equal("unknown", loaded[0].CreatedByAgent);
+        Assert.Equal("unknown", loaded[0].SessionId);
+        Assert.Equal("unknown", loaded[0].ClientVersion);
+        Assert.Null(loaded[0].McpClientName);
+        Assert.Null(loaded[0].McpClientVersion);
     }
 
     // --- MarkSubmitted tests / MarkSubmitted テスト ---


### PR DESCRIPTION
## Summary

- Add attribution fields to `SuggestionRecord` for agent identity, session id, cdidx version, MCP client name/version, and optional invocation context.
- Populate attribution from MCP `initialize.clientInfo` and the current MCP session when `suggest_improvement` records a suggestion.
- Preserve legacy suggestions by defaulting missing attribution fields to `unknown`, and document the new payload contract.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SuggestionStoreTests|FullyQualifiedName~GitHubIssueReporterTests|FullyQualifiedName~McpServerTests.SuggestImprovement"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget"` after one full-suite timing-threshold failure
- `dotnet test CodeIndex.sln` rerun passed

## Documentation and Changelog

- Updated `USER_GUIDE.md` and `DEVELOPER_GUIDE.md`.
- Added changelog fragment `changelog.d/unreleased/1873.added.md`.

## Follow-up Candidates

- None.

Fixes #1873
