### PR TITLE
Rank search results by symbol visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 ## Highlights
 
 - CLI-first search with human-readable and machine-oriented output.
+- Search ranking prefers public/exported symbol matches ahead of protected,
+  internal, and private matches; `--no-visibility-rank` keeps the legacy order.
 - Full-text, symbol, reference, caller/callee, dependency, map, inspect, and
   excerpt commands.
 - MCP server for AI clients such as Claude Code, Cursor, and Windsurf.
@@ -189,6 +191,8 @@ cdidx mcp
 ## 特長
 
 - CLI-first の検索。人間向け出力と機械処理向け出力に対応。
+- 検索順位は public/exported なシンボル一致を protected、internal、private より優先します。
+  従来順が必要な場合は `--no-visibility-rank` を使えます。
 - 全文検索、シンボル、参照、caller/callee、依存関係、map、inspect、excerpt
   コマンドを提供。
 - Claude Code、Cursor、Windsurf などの AI クライアント向け MCP サーバー。

--- a/changelog.d/unreleased/1868.changed.md
+++ b/changelog.d/unreleased/1868.changed.md
@@ -1,0 +1,19 @@
+---
+category: changed
+issues:
+  - 1868
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/SearchSnippetFormatter.cs
+  - README.md
+---
+
+## English
+
+- **Search ranking now prefers more visible symbol matches (#1868)** — `search` ranks public/exported symbol-bearing hits ahead of protected, internal, and private matches, exposes `visibility` in JSON results, shows non-public visibility in human output, and supports `--no-visibility-rank` for legacy ordering.
+
+## 日本語
+
+- **検索順位が visibility の高いシンボル一致を優先するようになりました (#1868)** — `search` は public/exported なシンボルを含む hit を protected、internal、private より上位にし、JSON 結果に `visibility` を出力し、人間向け出力では非 public の visibility を表示します。従来順が必要な場合は `--no-visibility-rank` を利用できます。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -179,6 +179,7 @@ internal static class CliFlagSchema
             new() { Name = "--snippet-focus", ValuePlaceholder = "<leftmost|quality|proximity>", Description = "Search snippet long-line focus mode", Commands = Set("search") },
             new() { Name = "--fts", Description = "Raw FTS5 syntax", Commands = Set("search") },
             new() { Name = "--no-dedup", Description = "Show duplicate chunks", Commands = Set("search") },
+            new() { Name = "--no-visibility-rank", Description = "Keep legacy search ranking without symbol visibility weighting", Commands = Set("search") },
             new() { Name = "--before", ValuePlaceholder = "<n>", Description = "Context lines before", Commands = Set("find", "excerpt") },
             new() { Name = "--after", ValuePlaceholder = "<n>", Description = "Context lines after", Commands = Set("find", "excerpt") },
             new() { Name = "--start", ValuePlaceholder = "<line>", Description = "Start line", Commands = Set("excerpt") },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -63,7 +63,7 @@ public static class ConsoleUi
         ("index-commits", "cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]"),
         ("index-changed-between", "cdidx index <projectPath> --changed-between <old-ref> <new-ref> [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]"),
         ("index-files", "cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]"),
-        ("search", "cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup]"),
+        ("search", "cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup] [--no-visibility-rank]"),
         ("definition", "cdidx definition <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--exact|--exact-name] [--count] [--since <datetime>]"),
         ("references", "cdidx references <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--max-line-width <n>] [--exact|--exact-name] [--count]"),
         ("callers", "cdidx callers <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--kind <kind>] [--rank-by <weighted|count|kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--exact|--exact-name] [--count]"),
@@ -933,7 +933,7 @@ public static class ConsoleUi
     }
 
     private static bool IsEnumeratedBranchScopedFlag(string flagName) =>
-        flagName is "--max-line-width" or "--snippet-lines" or "--snippet-focus" or "--fts" or "--no-dedup"
+        flagName is "--max-line-width" or "--snippet-lines" or "--snippet-focus" or "--fts" or "--no-dedup" or "--no-visibility-rank"
             or "--prefix" or "--exact-substring" or "--integrity-check" or "--check" or "--stale-after"
             or "--start" or "--end" or "--focus-line" or "--focus-column" or "--focus-length"
             or "--before" or "--after" or "--group-by-name";

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -139,6 +139,7 @@ public static class QueryCommandRunner
         "--body",
         "--count",
         "--no-dedup",
+        "--no-visibility-rank",
         "--exact",
         "--exact-name",
         "--exact-substring",
@@ -195,7 +196,7 @@ public static class QueryCommandRunner
         {
             if (options.CountOnly)
             {
-                var counts = reader.CountSearchResults(options.Query, options.Lang, options.RawFts, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, !options.NoDedup, options.Since, exact, options.Prefix);
+                var counts = reader.CountSearchResults(options.Query, options.Lang, options.RawFts, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, !options.NoDedup, options.Since, exact, options.Prefix, !options.NoVisibilityRank);
                 if (counts.Count == 0)
                 {
                     Console.WriteLine(options.Json
@@ -210,7 +211,7 @@ public static class QueryCommandRunner
                 return CommandExitCodes.Success;
             }
 
-            var results = reader.Search(options.Query, options.Limit, options.Lang, options.RawFts, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, !options.NoDedup, options.Since, exact, options.Prefix);
+            var results = reader.Search(options.Query, options.Limit, options.Lang, options.RawFts, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, !options.NoDedup, options.Since, exact, options.Prefix, !options.NoVisibilityRank);
             if (results.Count == 0)
             {
                 if (options.Json)
@@ -235,7 +236,7 @@ public static class QueryCommandRunner
             {
                 foreach (var r in results)
                 {
-                    Console.WriteLine($"{r.Path}:{r.StartLine}-{r.EndLine}");
+                    Console.WriteLine($"{r.Path}:{r.StartLine}-{r.EndLine}{FormatSearchVisibilitySuffix(r.Visibility)}");
                     var snippetLines = SearchSnippetFormatter.Format(r.Content, options.Query, options.SnippetLines, exact, options.MaxLineWidth, r.Lang, options.SnippetFocus);
                     foreach (var line in snippetLines)
                         Console.WriteLine($"  {line}");
@@ -392,6 +393,17 @@ public static class QueryCommandRunner
             }
             return CommandExitCodes.Success;
         });
+    }
+
+    private static string FormatSearchVisibilitySuffix(string? visibility)
+    {
+        if (string.IsNullOrWhiteSpace(visibility)
+            || string.Equals(visibility, "public", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        return $" [{visibility}]";
     }
 
     public static int RunReferences(string[] cmdArgs, JsonSerializerOptions jsonOptions)
@@ -3085,6 +3097,7 @@ public static class QueryCommandRunner
         bool excludeTests = false;
         DateTime? since = null;
         bool noDedup = false;
+        bool noVisibilityRank = false;
         bool exact = false;
         bool prefix = false;
         List<string>? parseErrors = null;
@@ -3279,6 +3292,9 @@ public static class QueryCommandRunner
                     break;
                 case "--no-dedup":
                     noDedup = true;
+                    break;
+                case "--no-visibility-rank":
+                    noVisibilityRank = true;
                     break;
                 case "--exact":
                     exact = true;
@@ -3572,6 +3588,7 @@ public static class QueryCommandRunner
             CountOnly = countOnly,
             Since = since,
             NoDedup = noDedup,
+            NoVisibilityRank = noVisibilityRank,
             Exact = exact,
             Prefix = prefix,
             ExactName = exactName,
@@ -5501,6 +5518,7 @@ public sealed class QueryCommandOptions
     public bool CountOnly { get; init; }
     public DateTime? Since { get; init; }
     public bool NoDedup { get; init; }
+    public bool NoVisibilityRank { get; init; }
     public bool Exact { get; init; }
     public bool Prefix { get; init; }
     public bool ExactName { get; init; }

--- a/src/CodeIndex/Cli/SearchSnippetFormatter.cs
+++ b/src/CodeIndex/Cli/SearchSnippetFormatter.cs
@@ -38,6 +38,7 @@ public static class SearchSnippetFormatter
             Query = query,
             Path = result.Path,
             Lang = result.Lang,
+            Visibility = result.Visibility,
             ChunkStartLine = result.StartLine,
             ChunkEndLine = result.EndLine,
             SnippetStartLine = excerpt.StartLine,
@@ -398,6 +399,7 @@ public sealed class CompactSearchResult
     public string Query { get; set; } = string.Empty;
     public string Path { get; set; } = string.Empty;
     public string? Lang { get; set; }
+    public string? Visibility { get; set; }
     public int ChunkStartLine { get; set; }
     public int ChunkEndLine { get; set; }
     public int SnippetStartLine { get; set; }

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -156,8 +156,10 @@ public partial class DbReader
     /// Visibility ranking: public symbols first, then protected, internal, private, unknown last.
     /// 可視性ランキング: public を最優先、次に protected、internal、private、不明は最後。
     /// </summary>
-    internal string VisibilityOrder => $@"
-        CASE lower({GetSymbolColumnSql("visibility")})
+    internal string VisibilityOrder => GetVisibilityRankSql(GetSymbolColumnSql("visibility"));
+
+    private static string GetVisibilityRankSql(string visibilitySql) => $@"
+        CASE lower({visibilitySql})
             WHEN 'public' THEN 0
             WHEN 'open' THEN 0
             WHEN 'pub' THEN 0
@@ -169,6 +171,15 @@ public partial class DbReader
             WHEN 'private' THEN 3
             WHEN 'fileprivate' THEN 3
             ELSE 4
+        END";
+
+    private static string GetVisibilityLabelSql(string visibilityRankSql) => $@"
+        CASE {visibilityRankSql}
+            WHEN 0 THEN 'public'
+            WHEN 1 THEN 'protected'
+            WHEN 2 THEN 'internal'
+            WHEN 3 THEN 'private'
+            ELSE NULL
         END";
     // Bucket ordering for files whose symbols exactly / prefix-match the ranking query.
     // Issue #1520: previously each bucket embedded a correlated `EXISTS (... lower(name) = lower(@q))`
@@ -184,20 +195,38 @@ public partial class DbReader
     internal const string PrefixSymbolMatchOrder =
         "CASE WHEN prefix_symbol_match.file_id IS NULL THEN 1 ELSE 0 END";
 
-    // Derived-table joins that supply the per-file boolean buckets referenced by the ranking
-    // ORDER BY constants above. SELECT DISTINCT keeps SQLite from flattening the subqueries
-    // back into the outer query, so each predicate runs once per query instead of once per row.
-    // 派生テーブルの SELECT DISTINCT により SQLite はサブクエリをフラット化せず、述語は 1 回だけ
-    // 評価される。
-    internal const string SearchSymbolMatchJoinsSql = @"
+    // Derived-table joins that supply the per-file match and visibility buckets referenced by
+    // search ranking. GROUP BY keeps the symbol predicates out of the outer per-hit scan while
+    // preserving the best visibility rank among matching symbols in each file.
+    // 検索順位で参照するファイル単位の一致・可視性 bucket を派生テーブルで供給する。GROUP BY により
+    // symbol 述語を外側の hit ごとの scan から切り離しつつ、ファイル内の一致シンボルの最良 visibility を保持する。
+    internal string SearchSymbolMatchJoinsSql
+    {
+        get
+        {
+            var exactVisibilityRankSql = GetVisibilityRankSql(GetSymbolColumnSql("visibility", symbolAlias: "s_exact"));
+            var prefixVisibilityRankSql = GetVisibilityRankSql(GetSymbolColumnSql("visibility", symbolAlias: "s_prefix"));
+            return $@"
         LEFT JOIN (
-            SELECT DISTINCT file_id FROM symbols
+            SELECT
+                file_id,
+                MIN({exactVisibilityRankSql}) AS visibility_order,
+                {GetVisibilityLabelSql($"MIN({exactVisibilityRankSql})")} AS visibility
+            FROM symbols s_exact
             WHERE name = @rankingQuery COLLATE NOCASE
+            GROUP BY file_id
         ) AS exact_symbol_match ON exact_symbol_match.file_id = f.id
         LEFT JOIN (
-            SELECT DISTINCT file_id FROM symbols
+            SELECT
+                file_id,
+                MIN({prefixVisibilityRankSql}) AS visibility_order,
+                {GetVisibilityLabelSql($"MIN({prefixVisibilityRankSql})")} AS visibility
+            FROM symbols s_prefix
             WHERE name LIKE @rankingQueryPrefix ESCAPE '\' COLLATE NOCASE
+            GROUP BY file_id
         ) AS prefix_symbol_match ON prefix_symbol_match.file_id = f.id";
+        }
+    }
     private const string PathTextMatchOrder = @"
         CASE
             WHEN instr(lower(f.path), lower(@rankingQuery)) > 0 THEN 0

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -70,7 +70,7 @@ public partial class DbReader
     /// Full-text search across indexed chunks using FTS5.
     /// FTS5を使ったチャンク全文検索。
     /// </summary>
-    public List<SearchResult> Search(string query, int limit = 20, string? lang = null, bool rawQuery = false, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool deduplicate = true, DateTime? since = null, bool exact = false, bool prefix = false)
+    public List<SearchResult> Search(string query, int limit = 20, string? lang = null, bool rawQuery = false, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool deduplicate = true, DateTime? since = null, bool exact = false, bool prefix = false, bool visibilityRank = true)
     {
         // Guard against empty/whitespace queries that would match everything
         // 空白のみのクエリが全件マッチするのを防止
@@ -88,7 +88,8 @@ public partial class DbReader
             // instr() による完全部分一致検索 — 大文字小文字区別、FTS5トークナイズなし
             sql = $@"
                 SELECT f.path, f.lang, c.start_line, c.end_line, c.content,
-                       0.0 AS rank
+                       0.0 AS rank,
+                       {GetSearchVisibilitySql()} AS visibility
                 FROM chunks c
                 JOIN files f ON c.file_id = f.id{SearchSymbolMatchJoinsSql}
                 WHERE instr(
@@ -101,7 +102,8 @@ public partial class DbReader
             var sanitizedQuery = rawQuery ? query : SanitizeFtsQuery(normalizedQuery, prefix);
             sql = $@"
                 SELECT f.path, f.lang, c.start_line, c.end_line, c.content,
-                       rank
+                       rank,
+                       {GetSearchVisibilitySql()} AS visibility
                 FROM fts_chunks
                 JOIN chunks c ON fts_chunks.rowid = c.id
                 JOIN files f ON c.file_id = f.id{SearchSymbolMatchJoinsSql}";
@@ -121,6 +123,7 @@ public partial class DbReader
             cmd.Parameters.AddWithValue("@exactQuery", query);
         cmd.Parameters.AddWithValue("@rankingQuery", normalizedQuery.Trim());
         cmd.Parameters.AddWithValue("@rankingQueryPrefix", $"{EscapeLikeQuery(normalizedQuery.Trim())}%");
+        cmd.Parameters.AddWithValue("@visibilityRank", visibilityRank ? 1 : 0);
         cmd.Parameters.AddWithValue("@limit", limit);
         if (lang != null)
             cmd.Parameters.AddWithValue("@lang", lang);
@@ -142,6 +145,7 @@ public partial class DbReader
                     EndLine = reader.GetInt32(3),
                     Content = reader.GetString(4),
                     Score = reader.GetDouble(5),
+                    Visibility = GetNullableString(reader, 6),
                 });
             }
         }
@@ -152,7 +156,7 @@ public partial class DbReader
         return deduplicate ? DeduplicateOverlappingResults(raw) : raw;
     }
 
-    public QueryCountResult CountSearchResults(string query, string? lang = null, bool rawQuery = false, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool deduplicate = true, DateTime? since = null, bool exact = false, bool prefix = false)
+    public QueryCountResult CountSearchResults(string query, string? lang = null, bool rawQuery = false, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool deduplicate = true, DateTime? since = null, bool exact = false, bool prefix = false, bool visibilityRank = true)
     {
         if (string.IsNullOrWhiteSpace(query))
             return new QueryCountResult(0, 0);
@@ -199,6 +203,7 @@ public partial class DbReader
             cmd.Parameters.AddWithValue("@exactQuery", query);
         cmd.Parameters.AddWithValue("@rankingQuery", normalizedQuery.Trim());
         cmd.Parameters.AddWithValue("@rankingQueryPrefix", $"{EscapeLikeQuery(normalizedQuery.Trim())}%");
+        cmd.Parameters.AddWithValue("@visibilityRank", visibilityRank ? 1 : 0);
         if (lang != null)
             cmd.Parameters.AddWithValue("@lang", lang);
         if (since != null && _fileColumns.Contains("modified"))
@@ -341,7 +346,19 @@ public partial class DbReader
 
     private static string GetSearchOrderSql()
     {
-        return $"{PathBucketOrder}, {ExactSymbolMatchOrder}, {PrefixSymbolMatchOrder}, {PathTextMatchOrder}, {ChunkTextMatchOrder}, rank, f.modified DESC, f.path";
+        return $"{PathBucketOrder}, {ExactSymbolMatchOrder}, {PrefixSymbolMatchOrder}, {SearchVisibilityOrder}, {PathTextMatchOrder}, {ChunkTextMatchOrder}, rank, f.modified DESC, f.path";
     }
+
+    private static string SearchVisibilityOrder => @"
+        CASE
+            WHEN @visibilityRank = 0 THEN 0
+            ELSE COALESCE(exact_symbol_match.visibility_order, prefix_symbol_match.visibility_order, 4)
+        END";
+
+    private static string GetSearchVisibilitySql() => @"
+        CASE
+            WHEN exact_symbol_match.visibility IS NOT NULL THEN exact_symbol_match.visibility
+            ELSE prefix_symbol_match.visibility
+        END";
 
 }

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -16,6 +16,7 @@ public class SearchResult
     public int EndLine { get; set; }
     public string Content { get; set; } = string.Empty;
     public double Score { get; set; }
+    public string? Visibility { get; set; }
 }
 
 public readonly record struct QueryCountResult(int Count, int FileCount, bool IncludesSql = false);

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -250,6 +250,42 @@ public class DbReaderTests : IDisposable
         _writer.InsertReferences(references);
     }
 
+    private void InsertSearchVisibilityFixture(string path, string visibility, DateTime modified)
+    {
+        const string content = "public class AuthFixture { void Marker() { Authenticate(); } }";
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = path,
+            Lang = "csharp",
+            Size = content.Length,
+            Lines = 1,
+            Modified = modified,
+        });
+
+        _writer.InsertChunks([new ChunkRecord
+        {
+            FileId = fileId,
+            ChunkIndex = 0,
+            StartLine = 1,
+            EndLine = 1,
+            Content = content,
+        }]);
+
+        _writer.InsertSymbols([
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = "Authenticate",
+                Line = 1,
+                StartLine = 1,
+                EndLine = 1,
+                Signature = $"{visibility} void Authenticate()",
+                Visibility = visibility,
+            }
+        ]);
+    }
+
     [Fact]
     public void Search_FindsMatchingChunks()
     {
@@ -281,6 +317,42 @@ public class DbReaderTests : IDisposable
         Assert.Equal(0, countRanked[0].ReferenceKindCounts["call"]);
         Assert.Equal(0, countRanked[0].ReferenceKindCounts["instantiate"]);
         Assert.Equal(50, countRanked[0].ReferenceKindCounts["subscribe"]);
+    }
+
+    [Fact]
+    public void Search_RanksMatchingPublicSymbolsBeforePrivateSymbols_Issue1868()
+    {
+        InsertSearchVisibilityFixture(
+            "src/private-auth.cs",
+            "private",
+            new DateTime(2025, 6, 3, 0, 0, 0, DateTimeKind.Utc));
+        InsertSearchVisibilityFixture(
+            "src/public-auth.cs",
+            "public",
+            new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var ranked = _reader.Search("Authenticate", lang: "csharp", exact: true, deduplicate: false);
+
+        Assert.Equal(["src/public-auth.cs", "src/private-auth.cs"], ranked.Select(result => result.Path).ToArray());
+        Assert.Equal(["public", "private"], ranked.Select(result => result.Visibility).ToArray());
+    }
+
+    [Fact]
+    public void Search_CanDisableVisibilityRanking_Issue1868()
+    {
+        InsertSearchVisibilityFixture(
+            "src/private-auth-legacy.cs",
+            "private",
+            new DateTime(2025, 6, 3, 0, 0, 0, DateTimeKind.Utc));
+        InsertSearchVisibilityFixture(
+            "src/public-auth-legacy.cs",
+            "public",
+            new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var legacyRanked = _reader.Search("Authenticate", lang: "csharp", exact: true, deduplicate: false, visibilityRank: false);
+
+        Assert.Equal(["src/private-auth-legacy.cs", "src/public-auth-legacy.cs"], legacyRanked.Select(result => result.Path).ToArray());
+        Assert.Equal(["private", "public"], legacyRanked.Select(result => result.Visibility).ToArray());
     }
 
     [Fact]
@@ -15099,10 +15171,10 @@ public class DbReaderTests : IDisposable
         Assert.DoesNotContain("FROM symbols", DbReader.PrefixSymbolMatchOrder, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("exact_symbol_match", DbReader.ExactSymbolMatchOrder, StringComparison.Ordinal);
         Assert.Contains("prefix_symbol_match", DbReader.PrefixSymbolMatchOrder, StringComparison.Ordinal);
-        Assert.Contains("LEFT JOIN", DbReader.SearchSymbolMatchJoinsSql, StringComparison.Ordinal);
-        Assert.Contains("SELECT DISTINCT file_id FROM symbols", DbReader.SearchSymbolMatchJoinsSql, StringComparison.Ordinal);
+        Assert.Contains("LEFT JOIN", _reader.SearchSymbolMatchJoinsSql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY file_id", _reader.SearchSymbolMatchJoinsSql, StringComparison.Ordinal);
         // The materialized lookup must stay SARGable (no `lower(name)` wrapping).
-        Assert.DoesNotContain("lower(", DbReader.SearchSymbolMatchJoinsSql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("lower(name", _reader.SearchSymbolMatchJoinsSql, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -44,6 +44,7 @@ public class QueryCommandRunnerTests
             "--snippet-lines", $"{SearchSnippetFormatter.MaxSnippetLines}",
             "--snippet-focus", "proximity",
             "--max-line-width", "77",
+            "--no-visibility-rank",
         ], jsonDefault: true);
 
         Assert.Equal("/tmp/query.db", options.DbPath);
@@ -67,6 +68,7 @@ public class QueryCommandRunnerTests
         Assert.Equal(SearchSnippetFormatter.MaxSnippetLines, options.SnippetLines);
         Assert.Equal(SearchSnippetFocusMode.Proximity, options.SnippetFocus);
         Assert.Equal(77, options.MaxLineWidth);
+        Assert.True(options.NoVisibilityRank);
     }
 
     [Fact]
@@ -111,6 +113,46 @@ public class QueryCommandRunnerTests
 
         Assert.True(options.CheckWorkspace);
         Assert.Equal(TimeSpan.FromHours(2), options.StaleAfter);
+    }
+
+    [Fact]
+    public void RunSearch_EmitsVisibilityInJsonAndHumanOutput_Issue1868()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_visibility_output");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/private-auth.cs",
+                "csharp",
+                """
+                public class AuthFixture
+                {
+                    private void Authenticate() { }
+                }
+                """);
+
+            var (jsonExitCode, jsonStdout, jsonStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Authenticate", "--db", dbPath, "--lang", "csharp", "--exact", "--json"],
+                _jsonOptions));
+            var (humanExitCode, humanStdout, humanStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Authenticate", "--db", dbPath, "--lang", "csharp", "--exact"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(jsonStdout);
+
+            Assert.Equal(CommandExitCodes.Success, jsonExitCode);
+            Assert.Equal(string.Empty, jsonStderr);
+            Assert.Equal("private", document.RootElement.GetProperty("visibility").GetString());
+            Assert.Equal(CommandExitCodes.Success, humanExitCode);
+            Assert.Contains("src/private-auth.cs:1-4 [private]", humanStdout);
+            Assert.Contains("1 results in 1 files", humanStderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/golden/search.json
+++ b/tests/CodeIndex.Tests/golden/search.json
@@ -3,6 +3,7 @@
   "query": "Add",
   "path": "src/Lib.cs",
   "lang": "csharp",
+  "visibility": "public",
   "chunk_start_line": 1,
   "chunk_end_line": 7,
   "snippet_start_line": 1,


### PR DESCRIPTION
## Summary

- Add symbol visibility as a search ranking tie-breaker, preferring public/exported matches before protected, internal, and private matches.
- Add `--no-visibility-rank` for legacy search ordering.
- Surface search result `visibility` in JSON and show non-public visibility in human output.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~DbReaderTests.Search_RanksMatchingPublicSymbolsBeforePrivateSymbols_Issue1868|FullyQualifiedName~DbReaderTests.Search_CanDisableVisibilityRanking_Issue1868|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_EmitsVisibilityInJsonAndHumanOutput_Issue1868|FullyQualifiedName~QueryCommandRunnerTests.ParseArgs_ParsesFiltersFlagsAndAcceptsMaxSnippetLines|FullyQualifiedName~JsonOutputSnapshotTests.RunSearch_JsonOutput_MatchesGolden|FullyQualifiedName~CliFlagSchemaTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln --no-restore`

## Documentation and Changelog

- Updated `README.md`.
- Added changelog fragment `changelog.d/unreleased/1868.changed.md`.

## Follow-up Candidates

- Observed `cdidx` full-scan silence/hang locally during this work; tracked separately as #2253.

Fixes #1868
