### PR TITLE
Fix report shell completions

### DIFF
--- a/changelog.d/unreleased/2196.fixed.md
+++ b/changelog.d/unreleased/2196.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2196
+affected:
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/CliFlagSchemaTests.cs
+---
+
+## English
+
+- **Report command completions now expose report-specific flags (#2196)** — bash, zsh, and fish completions now suggest `report` options such as `--output`, `--log-lines`, `--no-log`, and `--include-args`, including the `-o` short alias for `--output`.
+
+## 日本語
+
+- **`report` コマンドの補完で report 固有フラグを提示するようになりました (#2196)** — bash / zsh / fish の補完で `--output`、`--log-lines`、`--no-log`、`--include-args` などの `report` 用オプションを提示し、`--output` の短縮形 `-o` も補完します。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -19,6 +19,7 @@ namespace CodeIndex.Cli;
 internal sealed record CliFlag
 {
     public required string Name { get; init; }
+    public string? ShortName { get; init; }
     public string? ValuePlaceholder { get; init; }
     public required string Description { get; init; }
 
@@ -203,7 +204,7 @@ internal static class CliFlagSchema
             new() { Name = "--files", ValuePlaceholder = "<path>", Description = "Update only the specified files", Commands = Set("index") },
             new() { Name = "--watch", Description = "Continuous reindex on file changes (rejects --commits / --changed-between / --files / --dry-run)", Commands = Set("index") },
             new() { Name = "--debounce", ValuePlaceholder = "<ms>", Description = "Watch only: coalesce file events into one update after <ms> of quiet (default 500)", Commands = Set("index") },
-            new() { Name = "--output", ValuePlaceholder = "<path>", Description = "Output bundle path", Commands = Set("report") },
+            new() { Name = "--output", ShortName = "-o", ValuePlaceholder = "<path>", Description = "Output bundle path", Commands = Set("report") },
             new() { Name = "--no-log", Description = "Exclude global tool log from bundle", Commands = Set("report") },
             new() { Name = "--include-args", Description = "Include args in bundle log", Commands = Set("report") },
             new() { Name = "--log-lines", ValuePlaceholder = "<n>", Description = "Number of log lines to include in bundle", Commands = Set("report") },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -846,7 +846,7 @@ public static class ConsoleUi
     // generic catch-all となるよう揃える。テストもこの並びを前提にしている。
     private static readonly string[] EnumeratedCompletionCommands =
     [
-        "find", "excerpt", "references", "inspect", "hotspots", "status", "db", "search",
+        "find", "excerpt", "references", "inspect", "hotspots", "status", "db", "report", "search",
     ];
 
     // Generic-branch representative set: union of completion flags from these commands populates
@@ -877,7 +877,7 @@ public static class ConsoleUi
         sb.Append("    fi\n");
         sb.Append("\n");
         sb.Append("    case \"$prev\" in\n");
-        sb.Append("        --db|--path|--exclude-path) COMPREPLY=($(compgen -f -- \"$cur\")) ;;\n");
+        sb.Append("        --db|--path|--exclude-path|--output|-o) COMPREPLY=($(compgen -f -- \"$cur\")) ;;\n");
         sb.Append($"        --lang) COMPREPLY=($(compgen -W \"{langs}\" -- \"$cur\")) ;;\n");
         sb.Append("        --kind) COMPREPLY=($(compgen -W \"function class struct interface enum property event delegate namespace import\" -- \"$cur\")) ;;\n");
         sb.Append("        *)\n");
@@ -905,7 +905,11 @@ public static class ConsoleUi
         // schema のフラグに `--help` を加え、`find` のみ `--` end-of-options マーカーも露出させる。
         var tokens = new List<string>();
         foreach (var flag in CliFlagSchema.GetCompletionFlagsForCommand(command))
+        {
             tokens.Add(flag.Name);
+            if (flag.ShortName is not null)
+                tokens.Add(flag.ShortName);
+        }
         tokens.Add("--help");
         if (command == "find")
             tokens.Add("--");
@@ -925,7 +929,11 @@ public static class ConsoleUi
                 if (IsEnumeratedBranchScopedFlag(flag.Name))
                     continue;
                 if (seen.Add(flag.Name))
+                {
                     tokens.Add(flag.Name);
+                    if (flag.ShortName is not null)
+                        tokens.Add(flag.ShortName);
+                }
             }
         }
         tokens.Add("--help");
@@ -980,7 +988,7 @@ public static class ConsoleUi
     {
         var args = new List<string>();
         foreach (var flag in CliFlagSchema.GetCompletionFlagsForCommand(command))
-            args.Add(FormatZshArgument(flag, langs));
+            args.AddRange(FormatZshArguments(flag, langs));
         // Append a trailing positional placeholder so zsh suggests path/query completion after
         // the flags — but only for commands that actually accept a positional argument. `status`,
         // `db`, `hotspots`, etc. would reject anything typed there, so emitting no placeholder
@@ -1008,18 +1016,25 @@ public static class ConsoleUi
                 if (IsEnumeratedBranchScopedFlag(flag.Name))
                     continue;
                 if (seen.Add(flag.Name))
-                    args.Add(FormatZshArgument(flag, langs));
+                    args.AddRange(FormatZshArguments(flag, langs));
             }
         }
         args.Add("'*:query'");
         return args;
     }
 
-    private static string FormatZshArgument(CliFlag flag, string langs)
+    private static IEnumerable<string> FormatZshArguments(CliFlag flag, string langs)
+    {
+        yield return FormatZshArgument(flag.Name, flag, langs);
+        if (flag.ShortName is not null)
+            yield return FormatZshArgument(flag.ShortName, flag, langs);
+    }
+
+    private static string FormatZshArgument(string name, CliFlag flag, string langs)
     {
         var desc = flag.Description.Replace("'", "''");
         if (!flag.IsValueBearing)
-            return $"'{flag.Name}[{desc}]'";
+            return $"'{name}[{desc}]'";
 
         var valueSpec = flag.ValuePlaceholder switch
         {
@@ -1037,7 +1052,7 @@ public static class ConsoleUi
             "<stdio|http>" => "transport:(stdio http)",
             _ => "value",
         };
-        return $"'{flag.Name}[{desc}]:{valueSpec}'";
+        return $"'{name}[{desc}]:{valueSpec}'";
     }
 
     private static void AppendZshArguments(StringBuilder sb, IReadOnlyList<string> args)
@@ -1080,6 +1095,7 @@ public static class ConsoleUi
             // トークン順は旧スクリプトと同じ `-l name (-r)? (-a) -d` を維持する。
             // ConsoleUiTests の fish 抽出正規表現が -l の直前に値マーカーを期待していないため。
             var requiresArg = flag.IsValueBearing ? " -r" : "";
+            var shortName = flag.ShortName is null ? "" : $" -s {flag.ShortName.TrimStart('-')}";
             var description = name switch
             {
                 "group-by-name" => "Collapse same-name rows across files",
@@ -1093,7 +1109,7 @@ public static class ConsoleUi
                 _ => "",
             };
             description = description.Replace("'", "\\'");
-            lines.Add($"complete -c cdidx -n '__fish_seen_subcommand_from {commands}' -l {name}{requiresArg}{argSpec} -d '{description}'");
+            lines.Add($"complete -c cdidx -n '__fish_seen_subcommand_from {commands}' -l {name}{shortName}{requiresArg}{argSpec} -d '{description}'");
         }
         return string.Join(Environment.NewLine, lines);
     }

--- a/tests/CodeIndex.Tests/CliFlagSchemaTests.cs
+++ b/tests/CodeIndex.Tests/CliFlagSchemaTests.cs
@@ -61,6 +61,11 @@ public class CliFlagSchemaTests
         {
             Assert.StartsWith("--", flag.Name);
             Assert.True(seen.Add(flag.Name), $"Duplicate flag in schema: {flag.Name}");
+            if (flag.ShortName is not null)
+            {
+                Assert.StartsWith("-", flag.ShortName);
+                Assert.DoesNotContain("--", flag.ShortName);
+            }
         }
     }
 
@@ -144,6 +149,8 @@ public class CliFlagSchemaTests
             var flags = ExtractBashSubcommandFlags(script, command);
             var allowed = CliFlagSchema.GetCompletionFlagsForCommand(command)
                 .Select(f => f.Name).ToHashSet(StringComparer.Ordinal);
+            foreach (var shortName in CliFlagSchema.GetCompletionFlagsForCommand(command).Select(f => f.ShortName).OfType<string>())
+                allowed.Add(shortName);
             allowed.Add("--help");
             if (command == "find")
                 allowed.Add("--");
@@ -209,7 +216,7 @@ public class CliFlagSchemaTests
     // ConsoleUi 側の EnumeratedCompletionCommands に対応する一覧。
     private static readonly string[] EnumeratedBashBranches =
     [
-        "find", "excerpt", "references", "inspect", "hotspots", "status", "db", "search",
+        "find", "excerpt", "references", "inspect", "hotspots", "status", "db", "report", "search",
     ];
 
     private static IReadOnlyList<string> GetConsoleUiCommands()

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -408,6 +408,32 @@ public class ConsoleUiTests
         }
     }
 
+    [Fact]
+    public void PrintCompletions_ReportFlagSetsMatchAcrossShells()
+    {
+        var bashScript = ConsoleUi.GetCompletionScript("bash");
+        var zshScript = ConsoleUi.GetCompletionScript("zsh");
+        var fishScript = ConsoleUi.GetCompletionScript("fish");
+        var bashReport = ExtractBashSubcommandFlags(bashScript, "report", "search");
+        var zshReport = ExtractZshSubcommandFlags(zshScript, "report", "search");
+        var fishReport = ExtractFishSubcommandFlags(fishScript, "report");
+
+        // --help is universal in bash but is not enumerated by the zsh/fish scripts.
+        bashReport.Remove("help");
+
+        var expected = new SortedSet<string>(StringComparer.Ordinal)
+        {
+            "db", "json", "output", "log-lines", "no-log", "include-args",
+        };
+        Assert.Equal(expected, bashReport);
+        Assert.Equal(expected, zshReport);
+        Assert.Equal(expected, fishReport);
+
+        Assert.Contains("-o", ExtractBetween(bashScript, "[ \"$cmd\" = \"report\" ]; then", "[ \"$cmd\" = \"search\" ]; then"));
+        Assert.Contains("'-o[Output bundle path]:file:_files'", ExtractBetween(zshScript, "[[ $subcmd == report ]]; then", "[[ $subcmd == search ]]; then"));
+        Assert.Contains("-l output -s o -r", fishScript);
+    }
+
     private static SortedSet<string> ExtractBashSubcommandFlags(string script, string subcommand, string nextSubcommand)
     {
         var startMarker = $"[ \"$cmd\" = \"{subcommand}\" ]; then";


### PR DESCRIPTION
## Summary

- Add `report` to the bash/zsh per-command completion branches so it no longer falls through to the generic flag set.
- Surface the `--output` short alias `-o` from the shared flag schema across bash, zsh, and fish completions.
- Add regression coverage for report completion parity and the `-o` alias.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests|FullyQualifiedName~CliFlagSchemaTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- `dotnet build CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/2196.fixed.md`

## Follow-up Candidates

- Existing index refresh hang/degraded-index issue observed locally: #2234 / #2253.

Fixes #2196
