### PR TITLE
Document extractor thread-safety contract

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -65,6 +65,12 @@ Directory scan / shared path filter (built-in skip lists + `.gitignore` / `.cdid
 
 Scoped `--files` / `--commits` refreshes reuse the same path filter as full scans. If a commit-scoped refresh includes `.gitignore` or `.cdidxignore` changes, `IndexCommandRunner` falls back to a full scan so newly ignored files are purged safely. Malformed ignore lines are reported as scan errors and skipped instead of aborting the whole run. On Windows, files and directories with Hidden or System attributes are rejected before language detection; clear those attributes before indexing project-owned sources because ignore rules cannot re-include them.
 
+### Extractor concurrency contract
+
+`SymbolExtractor` and `ReferenceExtractor` must be safe to call concurrently for different files or repeated calls on the same file content. Shared `Regex` instances and static lookup tables are initialized once by the CLR and treated as immutable after type initialization. Per-extraction state belongs in local variables, method parameters, caller-owned collections, or language-specific state objects created for that extraction call.
+
+Do not add mutable static caches, shared `StringBuilder` instances, reused `MatchCollection` enumerators, or singleton scanner state to extractor code. If a future extractor needs cross-call memoization, use an explicit thread-safe collection and add a targeted parallel regression test that proves deterministic output under concurrent calls.
+
 ### Status freshness age threshold
 
 `status --check` keeps the DB/worktree checksum comparison in `IndexFreshnessChecker`, but the user-facing age hint threshold is resolved in `QueryCommandRunner`: CLI `--stale-after <duration>` wins over `CDIDX_STALE_AFTER`, which wins over `.cdidxrc.json`'s `stale_after`, then the 24-hour default. Supported duration suffixes are `m`, `h`, and `d`. JSON output includes `stale_after_seconds` and `index_age_seconds` only for `--check`, so clients can confirm which threshold was applied without inferring it from text.

--- a/changelog.d/unreleased/1839.fixed.md
+++ b/changelog.d/unreleased/1839.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 1839
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Extractor shared-state thread-safety is now documented and regression-tested (#1839)** — symbol and reference extractor static state now carries an explicit immutability contract, and symbol extraction runs a parallel determinism test across every pattern-backed language.
+
+## 日本語
+
+- **extractor の共有 state に関する thread-safety 契約を文書化し回帰テストを追加しました (#1839)** — symbol / reference extractor の static state に immutable 運用の契約を明示し、pattern-backed な全言語で symbol extraction の並列決定性テストを実行するようにしました。

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -10,6 +10,10 @@ namespace CodeIndex.Indexer;
 /// </summary>
 public static partial class ReferenceExtractor
 {
+    // THREAD-SAFETY: Reference extraction is stateless per call. Shared Regex instances and
+    // lookup tables are initialized once and then read concurrently; language-specific state
+    // must be created per extraction call (for example via CreateState helpers) rather than
+    // stored in mutable static fields.
     internal readonly record struct CSharpMultiLineTypePatternState(
         bool WaitingForHead,
         string? PendingTypeExpression,

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -5,6 +5,9 @@ namespace CodeIndex.Indexer;
 
 internal static class LanguageReferenceExtractionSupport
 {
+    // THREAD-SAFETY: This support surface only owns immutable post-construction Regex fields.
+    // Any state accumulated while extracting references must stay in caller-provided collections
+    // or local variables so concurrent ReferenceExtractor calls cannot share mutable state.
     private static readonly Regex CppIncludeRegex = new(
         @"^(?:\s*#\s*(?:include(?:_next)?|import)\s*(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>[^\s]+))|\s*(?:export\s+)?import\s+(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>:?[A-Za-z_]\w*(?:[.:][A-Za-z_]\w*)*))\s*;)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -7,6 +7,9 @@ namespace CodeIndex.Indexer;
 
 public static partial class SymbolExtractor
 {
+    // THREAD-SAFETY: The C# scanner keeps all scan state in parameters, locals, or caller-owned
+    // collections. It may read shared Regex fields from SymbolExtractor, but must not add static
+    // mutable scanner state.
     private static void ExtractCSharpEnumMembers(long fileId, string[] rawLines, string[] enumScannerLines, string[] csharpMatchLines, List<SymbolRecord> symbols)
     {
         var enumDeclarations = symbols

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -12,6 +12,10 @@ namespace CodeIndex.Indexer;
 /// </summary>
 public static partial class SymbolExtractor
 {
+    // THREAD-SAFETY: Symbol extraction is intentionally stateless per call. Shared Regex
+    // instances and lookup tables are initialized once by the CLR and must be treated as
+    // immutable after type initialization; per-file extraction state belongs in local
+    // variables or per-call collections, never in static mutable caches.
     private const string CSharpVisibilityPattern = @"protected\s+internal|private\s+protected|public|protected|internal|private";
     // Return-type character class includes `*` so pointer and function-pointer returns
     // (`int*`, `void**`, `delegate*<int, int>`, `int*[]`) are not silently dropped.

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -1,4 +1,7 @@
 using System.Diagnostics;
+using System.Collections;
+using System.Reflection;
+using System.Text.Json;
 using CodeIndex.Indexer;
 
 namespace CodeIndex.Tests;
@@ -9,6 +12,81 @@ namespace CodeIndex.Tests;
 /// </summary>
 public class SymbolExtractorTests
 {
+    [Fact]
+    public void Extract_AllPatternLanguages_IsDeterministicUnderParallelCalls()
+    {
+        var samples = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["assembly"] = "Start:\n    call Target\nTarget:\n    ret\n",
+            ["batch"] = ":run\necho ok\n",
+            ["c"] = "int answer(void) { return 42; }\n",
+            ["cobol"] = "       IDENTIFICATION DIVISION.\n       PROGRAM-ID. HELLO.\n",
+            ["cpp"] = "namespace demo { int answer() { return 42; } }\n",
+            ["csharp"] = "namespace Demo; public class Service { public int Run() => 1; }\n",
+            ["css"] = ".card { color: red; }\n@keyframes fade { from { opacity: 0; } }\n",
+            ["dart"] = "class Service { int run() => 1; }\n",
+            ["dockerfile"] = "FROM alpine AS build\nARG VERSION=1\n",
+            ["elixir"] = "defmodule Demo do\n  def run do\n    :ok\n  end\nend\n",
+            ["fortran"] = "module demo\ncontains\nsubroutine run()\nend subroutine\nend module\n",
+            ["fsharp"] = "module Demo\nlet run x = x + 1\n",
+            ["go"] = "package demo\nfunc Run() int { return 1 }\n",
+            ["gradle"] = "task buildDocs {\n}\n",
+            ["graphql"] = "type Query { answer: Int }\nquery GetAnswer { answer }\n",
+            ["haskell"] = "module Demo where\nrun :: Int -> Int\nrun x = x + 1\n",
+            ["html"] = "<div id=\"app\"></div>\n<script>function run() { return 1; }</script>\n",
+            ["java"] = "package demo; public class Service { int run() { return 1; } }\n",
+            ["javascript"] = "export function run() { return 1; }\n",
+            ["kotlin"] = "package demo\nclass Service { fun run(): Int = 1 }\n",
+            ["lua"] = "local function run()\n  return 1\nend\n",
+            ["makefile"] = "build:\n\t@echo build\n",
+            ["objc"] = "@interface Service\n- (void)run;\n@end\n",
+            ["pascal"] = "unit Demo;\ninterface\nprocedure Run;\nimplementation\nprocedure Run; begin end;\nend.\n",
+            ["perl"] = "package Demo;\nsub run { return 1; }\n",
+            ["php"] = "<?php\nclass Service { function run() { return 1; } }\n",
+            ["powershell"] = "function Invoke-Demo { return 1 }\n",
+            ["protobuf"] = "message User { string name = 1; }\nservice Users { rpc Get(User) returns (User); }\n",
+            ["python"] = "class Service:\n    def run(self):\n        return 1\n",
+            ["r"] = "run <- function(x) {\n  x + 1\n}\n",
+            ["racket"] = "(define (run x) x)\n",
+            ["ruby"] = "class Service\n  def run\n    1\n  end\nend\n",
+            ["rust"] = "pub struct Service;\npub fn run() -> i32 { 1 }\n",
+            ["scala"] = "class Service {\n  def run(): Int = 1\n}\n",
+            ["shell"] = "run() {\n  echo ok\n}\n",
+            ["smalltalk"] = "Object subclass: #Service\nService >> run\n  ^1\n",
+            ["sql"] = "CREATE TABLE users (id int);\nCREATE PROCEDURE run AS SELECT 1;\n",
+            ["svelte"] = "<script>\n  export let name;\n  function run() { return name; }\n</script>\n",
+            ["swift"] = "class Service { func run() -> Int { 1 } }\n",
+            ["terraform"] = "resource \"local_file\" \"demo\" {\n  filename = \"demo.txt\"\n}\n",
+            ["typescript"] = "export class Service { run(): number { return 1; } }\n",
+            ["vb"] = "Public Class Service\n  Public Sub Run()\n  End Sub\nEnd Class\n",
+            ["vue"] = "<script setup lang=\"ts\">\nfunction run() { return 1 }\n</script>\n",
+            ["zig"] = "pub fn run() i32 { return 1; }\n",
+        };
+
+        var patternLanguages = GetSymbolExtractorPatternLanguages();
+        Assert.Empty(patternLanguages.Except(samples.Keys, StringComparer.Ordinal));
+
+        foreach (var (language, content) in samples)
+        {
+            var expectedJson = JsonSerializer.Serialize(SymbolExtractor.Extract(1, language, content));
+
+            Parallel.For(0, 100, _ =>
+            {
+                var actualJson = JsonSerializer.Serialize(SymbolExtractor.Extract(1, language, content));
+                Assert.Equal(expectedJson, actualJson);
+            });
+        }
+    }
+
+    private static IReadOnlyCollection<string> GetSymbolExtractorPatternLanguages()
+    {
+        var field = typeof(SymbolExtractor).GetField("PatternCache", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(field);
+
+        var patternCache = Assert.IsAssignableFrom<IDictionary>(field.GetValue(null));
+        return patternCache.Keys.Cast<string>().Order(StringComparer.Ordinal).ToArray();
+    }
+
     [Fact]
     public void Extract_Python_DetectsFunctions()
     {


### PR DESCRIPTION
## Summary

- Documented the extractor concurrency contract in `DEVELOPER_GUIDE.md`.
- Added explicit `THREAD-SAFETY` notes on the shared static-state surfaces for symbol/reference extraction.
- Added a parallel determinism regression test that exercises every `SymbolExtractor` pattern-backed language 100 times.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SymbolExtractorTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md`.
- Added changelog fragment `changelog.d/unreleased/1839.fixed.md`.

## Follow-up Candidates

- None.

Fixes #1839
