### PR TITLE
Handle filesystem DB errors during indexing

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -57,7 +57,7 @@ The test project mirrors the production areas closely.
 - `PerformanceTests.cs`
   Large-scale data benchmarks (10K+ files). Skip-by-default; run manually with `--filter`.
 - `DbRecoveryTests.cs`
-  Database corruption recovery and graceful degradation behavior.
+  Database corruption recovery and graceful degradation behavior. Filesystem setup failures for `cdidx index` (read-only DB files and unwritable DB parent directories) are covered in `IndexCommandRunnerTests.cs` so they exercise the same CLI JSON/stderr boundary users see.
 - `JsonOutputSnapshotTests.cs`, `JsonOutputSnapshotHelper.cs`
   Golden-file regression fixtures for the CLI `--json` output contracts (issue #1548). Each test runs one command (`status`, `search`, `references`, `impact`, `excerpt`) against a deterministic in-memory fixture, normalizes volatile fields (timestamps, absolute paths, commit SHAs, FTS5 scores), and diffs against the matching file under `tests/CodeIndex.Tests/golden/`. Renames, removals, reordered arrays, or new keys fail the snapshot so the contract change is forced to land alongside an intentional golden update. See "JSON `--json` output snapshots" below for the update procedure.
 - `PropertyBasedParserTests.cs`
@@ -230,7 +230,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 - `PerformanceTests.cs`
   大規模データベンチマーク（10K+ファイル）。デフォルトSkip。`--filter` で手動実行。
 - `DbRecoveryTests.cs`
-  DB破損からの復旧とグレースフル劣化のテスト。
+  DB破損からの復旧とグレースフル劣化のテスト。`cdidx index` の filesystem setup failure（read-only DB file や書き込み不可の DB 親ディレクトリ）は、ユーザーが見る CLI JSON/stderr 境界を通すため `IndexCommandRunnerTests.cs` で扱います。
 - `JsonOutputSnapshotTests.cs`、`JsonOutputSnapshotHelper.cs`
   CLI の `--json` 出力契約に対するゴールデンファイル回帰フィクスチャ (issue #1548)。各テストは `status` / `search` / `references` / `impact` / `excerpt` を決定的なインメモリ fixture に対して実行し、揺らぐフィールド（timestamp、絶対パス、commit SHA、FTS5 score など）を正規化したうえで `tests/CodeIndex.Tests/golden/` 配下のファイルと差分比較します。フィールドの rename / 削除 / 並び替え / 新規追加が起きると snapshot が失敗するため、契約変更は意図的な golden 更新と同じ PR で揃えざるを得ません。更新手順は下記「JSON `--json` 出力 snapshot」を参照してください。
 - `PropertyBasedParserTests.cs`

--- a/changelog.d/unreleased/1822.fixed.md
+++ b/changelog.d/unreleased/1822.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1822
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Filesystem database failures now return structured index errors (#1822)** - `cdidx index` now reports read-only database files and unwritable database parent directories as `E004_DB_NOT_WRITABLE` errors instead of allowing raw filesystem or SQLite exceptions to reach stderr.
+
+## 日本語
+
+- **filesystem 由来の database failure が構造化された index error を返すようになりました (#1822)** - `cdidx index` は read-only database file や書き込み不可の database parent directory を、raw filesystem / SQLite 例外を stderr に出す代わりに `E004_DB_NOT_WRITABLE` として報告します。

--- a/changelog.d/unreleased/1822.fixed.md
+++ b/changelog.d/unreleased/1822.fixed.md
@@ -3,6 +3,7 @@ category: fixed
 issues:
   - 1822
 affected:
+  - src/CodeIndex/Cli/IndexLock.cs
   - src/CodeIndex/Cli/IndexCommandRunner.cs
   - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
   - TESTING_GUIDE.md

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -303,9 +303,6 @@ public static class IndexCommandRunner
                 }
                 catch (IndexLockConflictException ex)
                 {
-                    if (ex.Holder == null && ex.InnerException is { } inner && IsDatabaseFilesystemError(inner))
-                        return WriteDatabaseFilesystemError(options.Json, jsonOptions, resolvedDbPath, inner);
-
                     var holderDescription = DescribeLockHolder(ex.Holder);
                     var message = string.IsNullOrEmpty(holderDescription)
                         ? "another cdidx index is already running on this database"

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using CodeIndex.Database;
 using CodeIndex.Indexer;
+using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Cli;
 
@@ -280,47 +281,52 @@ public static class IndexCommandRunner
             return CommandExitCodes.Success;
         }
 
-        var dbDir = Path.GetDirectoryName(dbPath);
-        if (!string.IsNullOrEmpty(dbDir))
-            Directory.CreateDirectory(dbDir);
-
-        // Acquire a process-exclusive lock so concurrent `cdidx index` runs against the
-        // same DB cannot interleave schema/data writes and corrupt the database.
-        // `--force` bypasses the check for users who knowingly accept the risk.
-        // 同一 DB に対する `cdidx index` の同時実行が schema / data 書き込みを交錯させ
-        // DB を壊さないよう排他ロックを取る。`--force` はリスクを承知の場合に bypass。
-        var lockPath = IndexLock.GetLockPath(resolvedDbPath);
-        IndexLock? indexLock = null;
-        if (!options.Force)
-        {
-            try
-            {
-                indexLock = IndexLock.Acquire(lockPath, options.ProjectPath);
-            }
-            catch (IndexLockConflictException ex)
-            {
-                var holderDescription = DescribeLockHolder(ex.Holder);
-                var message = string.IsNullOrEmpty(holderDescription)
-                    ? "another cdidx index is already running on this database"
-                    : $"another cdidx index is already running on this database ({holderDescription})";
-                return WriteCommandError(
-                    options.Json,
-                    jsonOptions,
-                    message,
-                    CommandExitCodes.DatabaseError,
-                    "Wait for the running index to finish, or pass --force to bypass the lock if you are sure no other cdidx index is active.",
-                    CommandErrorCodes.DbLocked);
-            }
-        }
-        else if (!options.Json)
-        {
-            ConsoleUi.PrintWarning("--force bypasses the index lock; concurrent cdidx index runs may corrupt the database.");
-        }
-
         int initialExitCode;
-        using (indexLock)
+        try
         {
-            using var db = new DbContext(dbPath);
+            var dbDir = Path.GetDirectoryName(dbPath);
+            if (!string.IsNullOrEmpty(dbDir))
+                Directory.CreateDirectory(dbDir);
+
+            // Acquire a process-exclusive lock so concurrent `cdidx index` runs against the
+            // same DB cannot interleave schema/data writes and corrupt the database.
+            // `--force` bypasses the check for users who knowingly accept the risk.
+            // 同一 DB に対する `cdidx index` の同時実行が schema / data 書き込みを交錯させ
+            // DB を壊さないよう排他ロックを取る。`--force` はリスクを承知の場合に bypass。
+            var lockPath = IndexLock.GetLockPath(resolvedDbPath);
+            IndexLock? indexLock = null;
+            if (!options.Force)
+            {
+                try
+                {
+                    indexLock = IndexLock.Acquire(lockPath, options.ProjectPath);
+                }
+                catch (IndexLockConflictException ex)
+                {
+                    if (ex.Holder == null && ex.InnerException is { } inner && IsDatabaseFilesystemError(inner))
+                        return WriteDatabaseFilesystemError(options.Json, jsonOptions, resolvedDbPath, inner);
+
+                    var holderDescription = DescribeLockHolder(ex.Holder);
+                    var message = string.IsNullOrEmpty(holderDescription)
+                        ? "another cdidx index is already running on this database"
+                        : $"another cdidx index is already running on this database ({holderDescription})";
+                    return WriteCommandError(
+                        options.Json,
+                        jsonOptions,
+                        message,
+                        CommandExitCodes.DatabaseError,
+                        "Wait for the running index to finish, or pass --force to bypass the lock if you are sure no other cdidx index is active.",
+                        CommandErrorCodes.DbLocked);
+                }
+            }
+            else if (!options.Json)
+            {
+                ConsoleUi.PrintWarning("--force bypasses the index lock; concurrent cdidx index runs may corrupt the database.");
+            }
+
+            using (indexLock)
+            {
+                using var db = new DbContext(dbPath);
 
         // Capture prior readiness BEFORE we clear it. Update mode (--commits / --files) only
         // touches a subset of files, so trust bits the DB did NOT previously carry must not
@@ -386,6 +392,11 @@ public static class IndexCommandRunner
         initialExitCode = isUpdateMode
             ? RunUpdateMode(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorReadiness, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd)
             : RunFullScan(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd);
+            }
+        }
+        catch (Exception ex) when (IsDatabaseFilesystemError(ex))
+        {
+            return WriteDatabaseFilesystemError(options.Json, jsonOptions, resolvedDbPath, ex);
         }
 
         if (!options.Watch || initialExitCode != CommandExitCodes.Success)
@@ -1832,6 +1843,20 @@ public static class IndexCommandRunner
         }
         return exitCode;
     }
+
+    private static int WriteDatabaseFilesystemError(bool json, JsonSerializerOptions jsonOptions, string dbPath, Exception ex) =>
+        WriteCommandError(
+            json,
+            jsonOptions,
+            $"database write failed for {dbPath}: {CollapseLineBreaks(ex.Message)}",
+            CommandExitCodes.DatabaseError,
+            "Check that the database file and parent directory exist and are writable, then retry `cdidx index`.",
+            CommandErrorCodes.DbNotWritable);
+
+    private static bool IsDatabaseFilesystemError(Exception ex) =>
+        ex is UnauthorizedAccessException
+        || ex is IOException
+        || ex is SqliteException { SqliteErrorCode: 8 or 10 or 14 };
 
     private static int RunFullScan(
         DbWriter writer,

--- a/src/CodeIndex/Cli/IndexLock.cs
+++ b/src/CodeIndex/Cli/IndexLock.cs
@@ -86,6 +86,9 @@ internal sealed class IndexLock : IDisposable
         catch (UnauthorizedAccessException ex)
         {
             var holder = TryReadHolderInfo(lockPath);
+            if (holder == null)
+                throw;
+
             throw new IndexLockConflictException(lockPath, holder, ex);
         }
 

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -6270,6 +6270,41 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_LockHeldWithoutHolderInfo_ReportsDbLocked()
+    {
+        var projectRoot = CreateTempProject();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_lock_no_info_{Guid.NewGuid():N}.db");
+        var lockPath = dbPath + ".lock";
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.py"), "print('hi')\n");
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+
+            using (var holder = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            {
+                var (exitCode, json) = RunAndCaptureJson([projectRoot, "--db", dbPath, "--json"]);
+
+                Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+                Assert.Equal("error", json.GetProperty("status").GetString());
+                Assert.Equal(CommandErrorCodes.DbLocked, json.GetProperty("error_code").GetString());
+                Assert.Contains("another cdidx index is already running", json.GetProperty("message").GetString());
+                Assert.Contains("--force", json.GetProperty("hint").GetString());
+            }
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+            if (File.Exists(lockPath + ".info"))
+                File.Delete(lockPath + ".info");
+            if (File.Exists(lockPath))
+                File.Delete(lockPath);
+        }
+    }
+
+    [Fact]
     public void Run_ForceFlag_BypassesLockEvenWhenHeld()
     {
         var projectRoot = CreateTempProject();

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -1476,6 +1476,112 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_ReadOnlyDbFile_ReturnsDatabaseErrorWithoutStackTrace()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { }\n");
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            SqliteConnection.ClearAllPools();
+            SetUnixPermissions(dbPath, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
+            File.SetLastWriteTimeUtc(Path.Combine(projectRoot, "app.cs"), DateTime.UtcNow.AddSeconds(2));
+
+            var (exitCode, stdout, stderr) = RunCliInSubprocess([projectRoot, "--files", "app.cs", "--json"], projectRoot);
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            AssertNoRawStackTrace(stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var json = document.RootElement;
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.DbNotWritable, json.GetProperty("error_code").GetString());
+            Assert.Contains(dbPath, json.GetProperty("message").GetString());
+            Assert.Contains("writable", json.GetProperty("hint").GetString());
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                SetUnixPermissions(dbPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_MissingCdidxDirectoryInReadOnlyProject_ReturnsDatabaseErrorWithoutStackTrace()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { }\n");
+            SetUnixPermissions(projectRoot, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            var (exitCode, stdout, stderr) = RunCliInSubprocess([projectRoot, "--json"], projectRoot);
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            AssertNoRawStackTrace(stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var json = document.RootElement;
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.DbNotWritable, json.GetProperty("error_code").GetString());
+            Assert.Contains(Path.Combine(projectRoot, ".cdidx", "codeindex.db"), json.GetProperty("message").GetString());
+            Assert.Contains("writable", json.GetProperty("hint").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(projectRoot))
+                SetUnixPermissions(projectRoot, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_ExplicitDbInReadOnlyParent_ReturnsDatabaseErrorWithoutStackTrace()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        var dbParent = Path.Combine(Path.GetTempPath(), $"cdidx_readonly_db_parent_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dbParent);
+        var dbPath = Path.Combine(dbParent, "codeindex.db");
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { }\n");
+            SetUnixPermissions(dbParent, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            var (exitCode, stdout, stderr) = RunCliInSubprocess([projectRoot, "--db", dbPath, "--json"], projectRoot);
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            AssertNoRawStackTrace(stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var json = document.RootElement;
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.DbNotWritable, json.GetProperty("error_code").GetString());
+            Assert.Contains(dbPath, json.GetProperty("message").GetString());
+            Assert.Contains("writable", json.GetProperty("hint").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(dbParent))
+                SetUnixPermissions(dbParent, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            DeleteDirectory(projectRoot);
+            if (Directory.Exists(dbParent))
+                DeleteDirectory(dbParent);
+        }
+    }
+
+    [Fact]
     public void RunBackfillFold_BackfillsLegacyRowsAndStampsFoldReady()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_backfill_fold_{Guid.NewGuid():N}.db");
@@ -5932,6 +6038,15 @@ public class IndexCommandRunnerTests
         }
 
         return count;
+    }
+
+    private static void AssertNoRawStackTrace(string stderr)
+    {
+        Assert.DoesNotContain("Unhandled exception", stderr);
+        Assert.DoesNotContain("System.UnauthorizedAccessException", stderr);
+        Assert.DoesNotContain("Microsoft.Data.Sqlite.SqliteException", stderr);
+        Assert.DoesNotContain(" at CodeIndex.", stderr);
+        Assert.DoesNotContain(".cs:line ", stderr);
     }
 
     [UnsupportedOSPlatform("windows")]


### PR DESCRIPTION
## Summary

- Map `cdidx index` database setup/open filesystem failures to structured `E004_DB_NOT_WRITABLE` errors.
- Add regression coverage for read-only DB files, unwritable default `.cdidx` creation, unwritable explicit DB parent directories, and holderless lock conflicts.
- Update test guidance and add changelog fragment `changelog.d/unreleased/1822.fixed.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests.Run_ReadOnlyDbFile_ReturnsDatabaseErrorWithoutStackTrace|FullyQualifiedName~IndexCommandRunnerTests.Run_MissingCdidxDirectoryInReadOnlyProject_ReturnsDatabaseErrorWithoutStackTrace|FullyQualifiedName~IndexCommandRunnerTests.Run_ExplicitDbInReadOnlyParent_ReturnsDatabaseErrorWithoutStackTrace|FullyQualifiedName~IndexCommandRunnerTests.Run_LockHeldWithoutHolderInfo_ReportsDbLocked|FullyQualifiedName~IndexCommandRunnerTests.Run_LockHeldByAnotherHolder_JsonIncludesHint|FullyQualifiedName~IndexCommandRunnerTests.Run_LockHeldByAnotherHolder_RejectedWithHolderInfo"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests"`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Cli/IndexLock.cs src/CodeIndex/Cli/IndexCommandRunner.cs tests/CodeIndex.Tests/IndexCommandRunnerTests.cs changelog.d/unreleased/1822.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Updated `TESTING_GUIDE.md`.
- Added `changelog.d/unreleased/1822.fixed.md`.

## Follow-up Candidates

- Existing #2253 tracks the local full-scan hang observed while refreshing the index; no new issue was created.

Fixes #1822
