### PR TITLE
Fix Razor directive scan performance

### DIFF
--- a/changelog.d/unreleased/1434.fixed.md
+++ b/changelog.d/unreleased/1434.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1434
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Razor control directive scanning no longer repeatedly walks each line (#1434)** — `.cshtml` and `.razor` reference extraction now finds control directives in a single forward pass per line, reducing indexing overhead on Razor-heavy projects with many `@if`, `@foreach`, and related blocks.
+
+## 日本語
+
+- **Razor control directive の走査で各行を繰り返しなぞらないようになりました (#1434)** — `.cshtml` / `.razor` の参照抽出は control directive を行ごとの単一 forward scan で検出するため、`@if`、`@foreach` などのブロックが多い Razor-heavy なプロジェクトで indexing 負荷が下がります。

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -8,6 +8,21 @@ internal static class LanguageReferenceExtractionSupport
     // THREAD-SAFETY: This support surface only owns immutable post-construction Regex fields.
     // Any state accumulated while extracting references must stay in caller-provided collections
     // or local variables so concurrent ReferenceExtractor calls cannot share mutable state.
+    private static readonly string[] RazorControlDirectives =
+    {
+        "@if",
+        "@foreach",
+        "@for",
+        "@while",
+        "@switch",
+        "@using",
+        "@lock",
+        "@try",
+        "@catch",
+        "@finally",
+        "@do"
+    };
+
     private static readonly Regex CppIncludeRegex = new(
         @"^(?:\s*#\s*(?:include(?:_next)?|import)\s*(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>[^\s]+))|\s*(?:export\s+)?import\s+(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>:?[A-Za-z_]\w*(?:[.:][A-Za-z_]\w*)*))\s*;)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1028,22 +1043,42 @@ internal static class LanguageReferenceExtractionSupport
 
     private static int IndexOfRazorControlDirective(char[] chars)
     {
-        var line = new string(chars);
-        foreach (var directive in new[] { "@if", "@foreach", "@for", "@while", "@switch", "@using", "@lock", "@try", "@catch", "@finally", "@do" })
+        for (var index = 0; index < chars.Length; index++)
         {
-            for (var index = line.IndexOf(directive, StringComparison.Ordinal);
-                 index >= 0;
-                 index = line.IndexOf(directive, index + directive.Length, StringComparison.Ordinal))
+            if (chars[index] != '@')
+                continue;
+
+            var beforeOk = index == 0 || char.IsWhiteSpace(chars[index - 1]) || chars[index - 1] == '}';
+            if (!beforeOk)
+                continue;
+
+            foreach (var directive in RazorControlDirectives)
             {
-                var beforeOk = index == 0 || char.IsWhiteSpace(line[index - 1]) || line[index - 1] == '}';
+                if (!CharsStartWith(chars, index, directive))
+                    continue;
+
                 var afterIndex = index + directive.Length;
-                var afterOk = afterIndex == line.Length || !IsSimpleIdentifierPart(line[afterIndex]);
+                var afterOk = afterIndex == chars.Length || !IsSimpleIdentifierPart(chars[afterIndex]);
                 if (beforeOk && afterOk)
                     return index;
             }
         }
 
         return -1;
+    }
+
+    private static bool CharsStartWith(char[] chars, int index, string value)
+    {
+        if (index + value.Length > chars.Length)
+            return false;
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (chars[index + i] != value[i])
+                return false;
+        }
+
+        return true;
     }
 
     private static bool IsRazorCodeLineInsideControl(char[] chars)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using CodeIndex.Indexer;
 using CodeIndex.Models;
 
@@ -12114,6 +12115,28 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r => r.SymbolName == "inputRef" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "person" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Value" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
+    public void Extract_RazorBlazor_ManyControlDirectives_MasksControlCodeComponents()
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < 250; i++)
+        {
+            builder.AppendLine($"<VisiblePanel{i} />");
+            builder.AppendLine($"@if (Show{i})");
+            builder.AppendLine("{");
+            builder.AppendLine($"    var hidden = \"<HiddenPanel{i} />\";");
+            builder.AppendLine("}");
+        }
+
+        var content = builder.ToString();
+        var symbols = SymbolExtractor.Extract(1, "csharp", content, "Pages/Dashboard.razor");
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols, "Pages/Dashboard.razor");
+
+        Assert.Contains(references, r => r.SymbolName == "VisiblePanel0" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "VisiblePanel249" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName.StartsWith("HiddenPanel", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Reworked Razor control directive detection to scan each line once for `@` directive candidates instead of restarting `IndexOf` searches per directive.
- Added a Razor reference extraction regression case with many control blocks to keep visible components indexed while masking components inside control-code strings.
- Added changelog fragment `changelog.d/unreleased/1434.fixed.md`.

## Validation
- `dotnet build CodeIndex.sln --configuration Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --configuration Release --no-build --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_RazorBlazor"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check origin/main..HEAD`

## Notes
- The branch was rebuilt from latest `origin/main` so the #2281 pipeline fix is included.
- A follow-up adversarial review run is currently blocked by `codex exec` usage limits. The earlier adversarial review findings about accidental upstream reversions were addressed by rebuilding the branch from `origin/main`.

## Documentation / Changelog
- No user docs changed; the CLI/API contract is unchanged.
- Changelog fragment: `changelog.d/unreleased/1434.fixed.md`

Fixes #1434