### PR TITLE
Fix type-reference container lookup scaling

### DIFF
--- a/changelog.d/unreleased/1433.fixed.md
+++ b/changelog.d/unreleased/1433.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1433
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# type-reference extraction now reuses line-ordered container lookup state (#1433)** — reference extraction avoids rewalking every candidate container for repeated source-ordered lookup requests, reducing superlinear indexing cost on large generated files with many type-position tokens.
+
+## 日本語
+
+- **C# の型参照抽出で行順のコンテナ探索状態を再利用するようになりました (#1433)** — 参照抽出が source-order の探索要求ごとに候補コンテナ全体を歩き直さないようになり、多数の型位置トークンを含む大きな生成ファイルでの超線形なインデックスコストを抑えます。

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -51,6 +51,77 @@ public static partial class ReferenceExtractor
         return null;
     }
 
+    internal sealed class InnermostContainerResolver
+    {
+        private readonly IReadOnlyList<SymbolRecord> candidates;
+        private readonly List<(SymbolRecord Symbol, int SpanLength, int OriginalIndex)> candidatesByStart;
+        private readonly SortedSet<ActiveContainer> activeContainers = new();
+        private int nextCandidateIndex;
+        private int currentLine;
+        private int? cachedLine;
+        private SymbolRecord? cachedContainer;
+
+        internal InnermostContainerResolver(IReadOnlyList<SymbolRecord> candidates)
+        {
+            this.candidates = candidates;
+            candidatesByStart = candidates
+                .Select((symbol, index) => (Symbol: symbol, SpanLength: GetContainerSpanLength(symbol), OriginalIndex: index))
+                .OrderBy(item => item.Symbol.BodyStartLine!.Value)
+                .ThenBy(item => item.Symbol.BodyEndLine!.Value)
+                .ThenBy(item => item.SpanLength)
+                .ThenBy(item => item.OriginalIndex)
+                .ToList();
+        }
+
+        internal SymbolRecord? Find(int lineNumber)
+        {
+            if (cachedLine == lineNumber)
+                return cachedContainer;
+
+            if (lineNumber < currentLine)
+                return Cache(lineNumber, FindInnermostContainer(candidates, lineNumber));
+
+            AdvanceTo(lineNumber);
+            return Cache(lineNumber, activeContainers.Count == 0 ? null : activeContainers.Min.Symbol);
+        }
+
+        private void AdvanceTo(int lineNumber)
+        {
+            while (nextCandidateIndex < candidatesByStart.Count
+                   && candidatesByStart[nextCandidateIndex].Symbol.BodyStartLine!.Value <= lineNumber)
+            {
+                var candidate = candidatesByStart[nextCandidateIndex];
+                activeContainers.Add(new ActiveContainer(candidate.Symbol, candidate.SpanLength, candidate.OriginalIndex));
+                nextCandidateIndex++;
+            }
+
+            activeContainers.RemoveWhere(active => active.Symbol.BodyEndLine!.Value < lineNumber);
+            currentLine = lineNumber;
+        }
+
+        private SymbolRecord? Cache(int lineNumber, SymbolRecord? container)
+        {
+            cachedLine = lineNumber;
+            cachedContainer = container;
+            return container;
+        }
+
+        private static int GetContainerSpanLength(SymbolRecord symbol) =>
+            (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine);
+
+        private readonly record struct ActiveContainer(SymbolRecord Symbol, int SpanLength, int OriginalIndex) : IComparable<ActiveContainer>
+        {
+            public int CompareTo(ActiveContainer other)
+            {
+                var spanComparison = SpanLength.CompareTo(other.SpanLength);
+                if (spanComparison != 0)
+                    return spanComparison;
+
+                return OriginalIndex.CompareTo(other.OriginalIndex);
+            }
+        }
+    }
+
     private static bool CanAttachCSharpXmlDocCommentToNextDeclaration(
         SymbolRecord? innermostContainer,
         IReadOnlyList<SymbolRecord>? scopeCandidates,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1012,6 +1012,7 @@ public static partial class ReferenceExtractor
                                || symbol.Kind == "property"))
             .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
             .ToList();
+        var containerResolver = new InnermostContainerResolver(containerCandidates);
         var csharpXmlDocAttachmentScopeCandidates = language == "csharp"
             ? symbols
                 .Where(symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null
@@ -1117,7 +1118,7 @@ public static partial class ReferenceExtractor
             {
                 if (!phpLineContainerResolved)
                 {
-                    phpLineContainer = FindInnermostContainer(containerCandidates, lineNumber);
+                    phpLineContainer = containerResolver.Find(lineNumber);
                     phpLineContainerResolved = true;
                 }
 
@@ -1140,7 +1141,7 @@ public static partial class ReferenceExtractor
                 var csharpDocCommentText = originalLine[csharpDocCommentStartIndex..csharpDocCommentEndExclusive];
                 if (csharpDocCommentText.IndexOf("cref=\"", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
-                    var innermostContainer = FindInnermostContainer(containerCandidates, lineNumber);
+                    var innermostContainer = containerResolver.Find(lineNumber);
                     var sameLineDeclarationStartColumn = GetCSharpSameLineDocumentedDeclarationStartColumn(
                         originalLine,
                         csharpDocCommentEndExclusive,
@@ -1512,7 +1513,7 @@ public static partial class ReferenceExtractor
             List<SqlReferenceExtractor.DefinitionLeafSpan>? sqlDefinitionLeafSpans = null;
             if (language == "sql")
                 sqlDefinitionLeafSpansByLine?.TryGetValue(lineNumber, out sqlDefinitionLeafSpans);
-            var container = FindInnermostContainer(containerCandidates, lineNumber);
+            var container = containerResolver.Find(lineNumber);
 
             // Per-line Java same-line ctor synthesis. When `public Leaf(){super(0); doWork();}`
             // is entirely on one line, SymbolExtractor does not emit a function symbol for the

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1,4 +1,5 @@
 using CodeIndex.Indexer;
+using CodeIndex.Models;
 
 namespace CodeIndex.Tests;
 
@@ -8,6 +9,25 @@ namespace CodeIndex.Tests;
 /// </summary>
 public class ReferenceExtractorTests
 {
+    [Fact]
+    public void InnermostContainerResolver_ForwardScan_UpdatesAtNestedContainerBoundaries()
+    {
+        var outer = Container("outer", "class", 1, 100);
+        var method = Container("method", "function", 10, 90);
+        var local = Container("local", "function", 20, 25);
+        var later = Container("later", "function", 60, 70);
+        var candidates = new[] { local, later, method, outer };
+        var resolver = new ReferenceExtractor.InnermostContainerResolver(candidates);
+
+        Assert.Same(method, resolver.Find(12));
+        Assert.Same(local, resolver.Find(20));
+        Assert.Same(local, resolver.Find(20));
+        Assert.Same(method, resolver.Find(26));
+        Assert.Same(later, resolver.Find(65));
+        Assert.Same(method, resolver.Find(80));
+        Assert.Same(local, resolver.Find(22));
+    }
+
     [Fact]
     public void Extract_PythonCall_AssignsCallerContainer()
     {
@@ -29839,4 +29859,15 @@ public class ReferenceExtractorTests
             && r.ContainerKind == "function"
             && r.ContainerName == "render");
     }
+
+    private static SymbolRecord Container(string name, string kind, int startLine, int endLine) =>
+        new()
+        {
+            Name = name,
+            Kind = kind,
+            StartLine = startLine,
+            EndLine = endLine,
+            BodyStartLine = startLine,
+            BodyEndLine = endLine,
+        };
 }


### PR DESCRIPTION
## Summary

- Add a line-ordered innermost container resolver for reference extraction.
- Route repeated per-line container lookups through the resolver while preserving the existing smallest-span container selection.
- Add a focused resolver boundary test.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter FullyQualifiedName~ReferenceExtractorTests`
- `dotnet test CodeIndex.sln -c Release`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: no blocking/actionable issues found.

## Documentation / Changelog

- Added changelog fragment `changelog.d/unreleased/1433.fixed.md`.
- No README or guide updates were needed because this is an internal performance fix with no CLI/API contract change.

Fixes #1433
