### PR TITLE
Add query profiling for read commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 - Human `status` output translates readiness flags and `status --explain <field>`
   describes one readiness field/remediation; `status --json` keeps raw fields for
   automation, including the last full-scan unknown-extension count.
+- Read commands accept `--profile` to append SQL timing, row-count, and
+  `EXPLAIN QUERY PLAN` JSON after the normal result; `--slow-query-ms <n>` logs
+  profiled SQL statements that meet the threshold.
 - The documented `status --json` trust contract covers `fold_ready`,
   `fold_ready_reason`, `graph_table_available`, `issues_table_available`,
   `sql_graph_contract_ready`, `sql_graph_contract_degraded_reason`,
@@ -217,6 +220,9 @@ cdidx mcp
 - 人間向け `status` は readiness flag を翻訳し、`status --explain <field>` は
   個別 field の意味と対処を説明します。自動化向けの `status --json` は raw field
   と直近 full scan の未知拡張子数を維持します。
+- read 系コマンドは `--profile` で通常結果の後に SQL の時間、行数、
+  `EXPLAIN QUERY PLAN` の JSON を追加できます。`--slow-query-ms <n>` は
+  閾値以上の profiled SQL をログに記録します。
 - 文書化された `status --json` trust contract は `fold_ready`、
   `fold_ready_reason`、`graph_table_available`、`issues_table_available`、
   `sql_graph_contract_ready`、`sql_graph_contract_degraded_reason`、

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -459,6 +459,8 @@ Use `--json` for machine-readable output (AI agents):
 
 Add `--json-envelope` to wrap the per-line stream into a single document with a `metadata` block (command, `cdidx_version`, `elapsed_ms`, `db_path`, `result_count`, `exit_code`, optional `query_normalized` / `indexed_at_head_sha`) and a `results` array. The flag implies `--json` and works on every query command (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `excerpt`, `map`, `inspect`, `outline`, `status`, `validate`, `languages`, `impact`, `deps`, `unused`, `hotspots`). The flat NDJSON / array output stays the default for one release; the envelope will become the default in the next major release, at which point the flat form will be opt-in via `--json-flat`.
 
+Add `--profile` to any read command when debugging slow queries. It appends one JSON object after the normal result with `profile.phases` (`name`, `elapsed_ms`, `rows_scanned`), `profile.query_plan` (`EXPLAIN QUERY PLAN` rows), and `profile.queries` (the SQL text). Add `--slow-query-ms <n>` to log profiled SQL statements that meet the threshold to the persistent tool log.
+
 ### Search symbols (functions, classes, etc.)
 
 ```bash
@@ -2526,6 +2528,8 @@ AIエージェントがDBを直接SQL検索する場合、`sqlite3` CLIが必要
 ## 出力形式
 
 人間向けの出力では、ファイルサイズを2進単位（`KiB`、`MiB`、`GiB` など）で表示します。大きなリポジトリや `map` / `files` の一覧を読み取りやすくするためです。テキスト出力をシェルパイプラインで扱うなど、生のバイト数が必要な場合は `files` または `map` に `--bytes` を指定してください。JSON 出力（`--json`）では、機械処理向けに size フィールドを常に raw integer bytes のまま返します。
+
+遅い検索を調べる場合は、read 系コマンドに `--profile` を追加してください。通常結果の後に `profile.phases`（`name`、`elapsed_ms`、`rows_scanned`）、`profile.query_plan`（`EXPLAIN QUERY PLAN` 行）、`profile.queries`（SQL text）を含む JSON オブジェクトを 1 行追加します。`--slow-query-ms <n>` を併用すると、閾値以上の profiled SQL を persistent tool log に記録します。
 
 ## AIとの連携
 

--- a/changelog.d/unreleased/1643.added.md
+++ b/changelog.d/unreleased/1643.added.md
@@ -1,0 +1,21 @@
+---
+category: added
+issues:
+  - 1643
+affected:
+  - src/CodeIndex/Database/DbDebug.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - README.md
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Read commands can emit SQL profiles for slow-query diagnosis (#1643)** — `--profile` now appends SQL timing, row-count, and `EXPLAIN QUERY PLAN` JSON after normal read-command output, and `--slow-query-ms <n>` logs profiled SQL statements that meet the threshold.
+
+## 日本語
+
+- **read 系コマンドで遅いクエリ診断用の SQL profile を出力できるようになりました (#1643)** — `--profile` は通常の read コマンド出力の後に SQL の時間、行数、`EXPLAIN QUERY PLAN` の JSON を追加し、`--slow-query-ms <n>` は閾値以上の profiled SQL をログに記録します。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -150,6 +150,13 @@ internal static class CliFlagSchema
         "validate", "deps", "impact", "unused", "hotspots", "languages", "db", "report",
     ];
 
+    private static readonly string[] ProfileCommands =
+    [
+        "search", "definition", "references", "callers", "callees", "symbols", "files",
+        "find", "excerpt", "map", "inspect", "outline", "status", "validate", "deps",
+        "impact", "unused", "hotspots",
+    ];
+
     public static IReadOnlyList<CliFlag> All { get; } = BuildAll();
 
     private static IReadOnlyList<CliFlag> BuildAll()
@@ -158,6 +165,8 @@ internal static class CliFlagSchema
         {
             new() { Name = "--db", ValuePlaceholder = "<path>", Description = "Database path", Commands = Set(DbPathCommands) },
             new() { Name = "--json", Description = "JSON output", Commands = Set(JsonCommands) },
+            new() { Name = "--profile", Description = "Emit SQL timing and EXPLAIN QUERY PLAN profile JSON after the normal result", Commands = Set(ProfileCommands) },
+            new() { Name = "--slow-query-ms", ValuePlaceholder = "<n>", Description = "Log profiled SQL statements at or above this millisecond threshold", Commands = Set(ProfileCommands) },
             new() { Name = "--limit", ValuePlaceholder = "<n>", Description = "Max results", Commands = Set(LimitCapableCommands) },
             new() { Name = "--top", ValuePlaceholder = "<n>", Description = "Max results", Commands = Set(LimitCapableCommands) },
             new() { Name = "--lang", ValuePlaceholder = "<lang>", Description = "Filter by language", Commands = Set(LangCapableCommands) },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -582,6 +582,8 @@ public static class ConsoleUi
         Console.WriteLine("Query options:");
         Console.WriteLine("  --db <path>                Database file path (default: .cdidx/codeindex.db in current directory)");
         Console.WriteLine("  --json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)");
+        Console.WriteLine("  --profile                  Read commands: append SQL timing, row-count, and EXPLAIN QUERY PLAN JSON after the normal result");
+        Console.WriteLine("  --slow-query-ms <n>        Read commands: log profiled SQL statements that take at least <n> ms (use 0 to log every statement)");
         Console.WriteLine("  --limit <n>, --top <n>     Max results to return (default: 20)");
         Console.WriteLine("  --lang <lang>              Filter by language (aliases: bat, cmd, cshtml, razor, ts, tsx, cts, mts)");
         Console.WriteLine("  --path <glob>              Restrict matches to glob-style path patterns (* and ?)");
@@ -623,6 +625,7 @@ public static class ConsoleUi
         Console.WriteLine("  cdidx search \"auth*\"                          Prefix shorthand in literal-safe mode");
         Console.WriteLine("  cdidx search --query --path --path README.md   Search for a literal option token");
         Console.WriteLine("  cdidx search \"Run();\" --exact-substring        Case-sensitive exact substring search");
+        Console.WriteLine("  cdidx search authenticate --profile            Append SQL profile JSON for slow-query debugging");
         Console.WriteLine("  cdidx definition ResolveGitCommonDir --body   Show a symbol definition and body");
         Console.WriteLine("  cdidx references ResolveGitCommonDir          Find indexed references");
         Console.WriteLine("  cdidx references DbContext --kind instantiate Filter constructor sites by reference kind");

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -72,6 +72,7 @@ public static class QueryCommandRunner
         "--stale-after",
         "--explain",
         "--rank-by",
+        "--slow-query-ms",
     ];
     private sealed record StatusReadinessField(
         string FieldName,
@@ -152,6 +153,7 @@ public static class QueryCommandRunner
         "--group-by-name",
         "--with-paths",
         "--bytes",
+        "--profile",
     ];
     private const string FindUsage = "Usage: cdidx find <query> --path <glob> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--exclude-path <glob>] [--exclude-tests] [--before <n>] [--after <n>] [--max-line-width <n>] [--exact] [--count]\n       cdidx find --query <query> --path <glob> [...]\n       cdidx find [options] -- <query>";
     public static int RunSearch(string[] cmdArgs, JsonSerializerOptions jsonOptions)
@@ -192,7 +194,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("search", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             if (options.CountOnly)
             {
@@ -295,7 +297,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("definition", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             if (options.CountOnly)
             {
@@ -445,7 +447,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("references", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             WriteGraphReferenceKindHint("references", options.Kind, options.Json);
             var baseSqlGraphSignal = reader.GetSqlGraphContractSignal(options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests);
@@ -569,7 +571,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("callers", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             WriteGraphReferenceKindHint("callers", options.Kind, options.Json);
             var baseSqlGraphSignal = reader.GetSqlGraphContractSignal(options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests);
@@ -693,7 +695,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("callees", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             WriteGraphReferenceKindHint("callees", options.Kind, options.Json);
             var baseSqlGraphSignal = reader.GetSqlGraphContractSignal(options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests);
@@ -843,7 +845,7 @@ public static class QueryCommandRunner
             return CommandExitCodes.UsageError;
         }
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             if (options.CountOnly)
             {
@@ -962,7 +964,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("files", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             if (options.CountOnly)
             {
@@ -1062,7 +1064,7 @@ public static class QueryCommandRunner
         }
 
         var filePath = DbPathResolver.ResolveQueryFilePath(options.DbPath, options.Query, options.DbPathExplicit);
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             if (options.FocusLine.HasValue)
             {
@@ -1170,7 +1172,7 @@ public static class QueryCommandRunner
             return CommandExitCodes.UsageError;
         }
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             if (options.CountOnly)
             {
@@ -1390,7 +1392,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedPositionals("map", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             var map = reader.GetRepoMap(options.Limit, options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests);
             WorkspaceMetadataEnricher.Enrich(map, options.DbPath, options.DbPathExplicit);
@@ -1493,7 +1495,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("inspect", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             var analysis = reader.AnalyzeSymbol(options.Query, options.Limit, options.Lang, options.IncludeBody, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, exact, options.MaxLineWidth);
             var sqlGraphSignal = NarrowSqlGraphContractSignal(
@@ -1595,7 +1597,7 @@ public static class QueryCommandRunner
             return CommandExitCodes.UsageError;
 
         var filePath = DbPathResolver.ResolveQueryFilePath(options.DbPath, cmdArgs[0], options.DbPathExplicit);
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             var outline = reader.GetOutline(filePath);
             if (outline == null)
@@ -1778,7 +1780,7 @@ public static class QueryCommandRunner
             return WriteStatusReadinessExplanation(options.StatusExplainField);
         }
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             var staleAfter = (Value: DefaultStaleAfter, Error: (string?)null);
             if (options.CheckWorkspace || options.StaleAfter.HasValue)
@@ -1999,7 +2001,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("impact", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             var maxDepth = options.ContextAfterExplicit ? options.ContextAfter : 5; // --depth is parsed into ContextAfter; 0 means resolve-only
             var analysis = reader.AnalyzeImpact(options.Query, maxDepth, options.Limit, options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, options.WithPaths);
@@ -2303,7 +2305,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedPositionals("deps", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             var reverse = cmdArgs.Any(a => a == "--reverse");
             var results = reader.GetFileDependencies(options.Limit, options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, reverse);
@@ -2377,7 +2379,7 @@ public static class QueryCommandRunner
             return CommandExitCodes.UsageError;
         }
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             var baseSqlGraphSignal = reader.GetSqlGraphContractSignal(options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests);
             var zeroResultSqlGraphSignal = NarrowSqlGraphContractSignal(
@@ -2773,7 +2775,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedPositionals("unused", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             // Warn if user specified an unsupported language / 未対応言語の場合は警告
             if (options.Lang != null && !ReferenceExtractor.SupportsLanguage(options.Lang) && !options.Json)
@@ -2964,7 +2966,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedPositionals("validate", options))
             return CommandExitCodes.UsageError;
 
-        return WithDb(options.DbPath, reader =>
+        return WithDb(options, jsonOptions, reader =>
         {
             var issues = reader.GetIssues(options.Kind, options.PathPatterns);
             var issuesAvailable = reader._hasIssuesTable;
@@ -3127,6 +3129,8 @@ public static class QueryCommandRunner
         string? groupBy = null;
         bool rawBytes = false;
         bool rawKinds = false;
+        bool profile = false;
+        int? slowQueryMs = null;
         string? statusExplainField = null;
         var rankMode = ReferenceRankMode.Weighted;
         var extraNames = new List<string>();
@@ -3358,6 +3362,20 @@ public static class QueryCommandRunner
                     break;
                 case "--raw-kinds":
                     rawKinds = true;
+                    break;
+                case "--profile":
+                    profile = true;
+                    break;
+                case "--slow-query-ms":
+                    if (!TryReadRawOptionValue(args, ref i, "--slow-query-ms", inlineValue, out var slowQueryValue, out var missingSlowQueryError))
+                        AddParseError(missingSlowQueryError!);
+                    else if (TryParseNonNegativeInt(slowQueryValue!, "--slow-query-ms", out var parsedSlowQueryMs, out var slowQueryError))
+                    {
+                        WarnIfDuplicateSingleValueOption("--slow-query-ms", slowQueryValue!);
+                        slowQueryMs = parsedSlowQueryMs;
+                    }
+                    else
+                        AddParseError(slowQueryError!);
                     break;
                 case "--check":
                     if (allowStatusCheck)
@@ -3620,6 +3638,8 @@ public static class QueryCommandRunner
             GroupBy = groupBy,
             RawBytes = rawBytes,
             RawKinds = rawKinds,
+            Profile = profile,
+            SlowQueryMs = slowQueryMs,
             StatusExplainField = statusExplainField,
             RankMode = rankMode,
             ExtraNames = extraNames,
@@ -3839,8 +3859,9 @@ public static class QueryCommandRunner
     // preview 系オプションの検証はコマンド別 allowlist に寄せたため、この shim は常に null を返す。
     private static string? ValidatePreviewOptions(string commandName, string[] args, bool allowMaxLineWidth, bool allowFocusOptions) => null;
 
-    private static int WithDb(string dbPath, Func<DbReader, int> action)
+    private static int WithDb(QueryCommandOptions options, JsonSerializerOptions jsonOptions, Func<DbReader, int> action)
     {
+        var dbPath = options.DbPath;
         if (string.IsNullOrWhiteSpace(dbPath))
         {
             Console.Error.WriteLine(BuildMissingOptionValueError("--db"));
@@ -3862,12 +3883,19 @@ public static class QueryCommandRunner
         }
 
         Database.DbDebug.ResetContext();
+        var profiling = options.Profile || options.SlowQueryMs.HasValue;
+        if (profiling)
+            Database.DbDebug.BeginProfile(options.SlowQueryMs);
         try
         {
             using var db = new DbContext(dbPath);
             db.TryMigrateForRead();
             var reader = new DbReader(db);
-            return action(reader);
+            var exitCode = action(reader);
+            var profileEntries = profiling ? Database.DbDebug.EndProfile() : [];
+            if (options.Profile)
+                WriteProfilePayload(profileEntries, jsonOptions);
+            return exitCode;
         }
         catch (FtsQuerySyntaxException ex)
         {
@@ -3918,8 +3946,54 @@ public static class QueryCommandRunner
         }
         finally
         {
+            if (profiling)
+                Database.DbDebug.EndProfile();
             Database.DbDebug.ResetContext();
         }
+    }
+
+    private static void WriteProfilePayload(IReadOnlyList<QueryProfileEntry> entries, JsonSerializerOptions jsonOptions)
+    {
+        var phases = new JsonArray();
+        var queryPlan = new JsonArray();
+        var queries = new JsonArray();
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var name = "sql_" + (i + 1).ToString(CultureInfo.InvariantCulture);
+            var entry = entries[i];
+            phases.Add(new JsonObject
+            {
+                ["name"] = name,
+                ["elapsed_ms"] = Math.Round(entry.ElapsedMs, 3),
+                ["rows_scanned"] = entry.RowsScanned,
+            });
+            queries.Add(new JsonObject
+            {
+                ["name"] = name,
+                ["sql"] = entry.Sql,
+            });
+            foreach (var row in entry.QueryPlan)
+            {
+                queryPlan.Add(new JsonObject
+                {
+                    ["phase"] = name,
+                    ["id"] = row.Id,
+                    ["parent"] = row.Parent,
+                    ["not_used"] = row.NotUsed,
+                    ["detail"] = row.Detail,
+                });
+            }
+        }
+
+        Console.WriteLine(new JsonObject
+        {
+            ["profile"] = new JsonObject
+            {
+                ["phases"] = phases,
+                ["query_plan"] = queryPlan,
+                ["queries"] = queries,
+            },
+        }.ToJsonString(jsonOptions));
     }
 
     private static void WriteNumberedExcerpt(int startLine, string content)
@@ -5218,6 +5292,7 @@ public static class QueryCommandRunner
             ["--limit"] = 10_000,
             ["--snippet-lines"] = SearchSnippetFormatter.MaxSnippetLines,
             ["--max-line-width"] = LineWidthFormatter.MaxAllowedLineWidth,
+            ["--slow-query-ms"] = 3_600_000,
             ["--depth"] = 64,
             ["--before"] = 1_000,
             ["--after"] = 1_000,
@@ -5259,6 +5334,7 @@ public static class QueryCommandRunner
         ["--snippet-focus"] = "pass one of `leftmost`, `quality`, or `proximity`, e.g. `--snippet-focus quality` (default quality).",
         ["--max-line-width"] = "pass a non-negative integer (`0` disables clamping), e.g. `--max-line-width 512` (default 512).",
         ["--stale-after"] = "pass a compact positive duration, e.g. `--stale-after 30m`, `--stale-after 2h`, or `--stale-after 7d`.",
+        ["--slow-query-ms"] = "pass a non-negative millisecond threshold, e.g. `--slow-query-ms 500`; use 0 to log every profiled SQL statement.",
     };
 
     // Build a missing-value error string with optional caller-supplied hint lines first, then the
@@ -5553,6 +5629,8 @@ public sealed class QueryCommandOptions
     public string? GroupBy { get; init; }
     public bool RawBytes { get; init; }
     public bool RawKinds { get; init; }
+    public bool Profile { get; init; }
+    public int? SlowQueryMs { get; init; }
     public string? StatusExplainField { get; init; }
     public ReferenceRankMode RankMode { get; init; } = ReferenceRankMode.Weighted;
     public List<string> ExtraNames { get; init; } = [];

--- a/src/CodeIndex/Database/DbDebug.cs
+++ b/src/CodeIndex/Database/DbDebug.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Diagnostics;
 using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Database;
@@ -26,6 +27,7 @@ namespace CodeIndex.Database;
 public static class DbDebug
 {
     private const int MaxNumericChars = 64;
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<SqliteDataReader, ActiveProfile> s_activeProfiles = new();
 
     [ThreadStatic]
     private static string? _lastSql;
@@ -35,6 +37,10 @@ public static class DbDebug
     private static List<(string Name, string Value)>? _lastRow;
     [ThreadStatic]
     private static bool _hasContext;
+    [ThreadStatic]
+    private static List<QueryProfileEntry>? _profileEntries;
+    [ThreadStatic]
+    private static long? _slowQueryThresholdMs;
 
     // Process-wide gate that must be flipped by an explicit CLI flag before
     // CDIDX_DEBUG=unsafe is honored. Defaults to false so an env var alone
@@ -64,6 +70,23 @@ public static class DbDebug
     {
         Interlocked.Exchange(ref _allowUnsafeProcess, 0);
         Interlocked.Exchange(ref _unsafeDowngradeWarned, 0);
+        EndProfile();
+    }
+
+    public static bool IsProfileEnabled => _profileEntries != null;
+
+    public static void BeginProfile(long? slowQueryThresholdMs = null)
+    {
+        _profileEntries = new List<QueryProfileEntry>();
+        _slowQueryThresholdMs = slowQueryThresholdMs;
+    }
+
+    public static List<QueryProfileEntry> EndProfile()
+    {
+        var entries = _profileEntries ?? new List<QueryProfileEntry>();
+        _profileEntries = null;
+        _slowQueryThresholdMs = null;
+        return entries;
     }
 
     private enum DebugMode { Off, Redacted, Unsafe }
@@ -121,6 +144,64 @@ public static class DbDebug
         _lastParams = ps;
         _lastRow = null;
         _hasContext = true;
+    }
+
+    internal static SqliteDataReader ExecuteReader(SqliteCommand cmd)
+    {
+        if (!IsProfileEnabled)
+            return cmd.ExecuteReader();
+
+        var entry = new QueryProfileEntry(cmd.CommandText, CaptureQueryPlan(cmd));
+        _profileEntries!.Add(entry);
+
+        var sw = Stopwatch.StartNew();
+        var reader = cmd.ExecuteReader();
+        sw.Stop();
+
+        entry.AddElapsed(sw.Elapsed);
+        entry.MarkCompletedIfSlow(_slowQueryThresholdMs);
+        s_activeProfiles.Add(reader, new ActiveProfile(entry));
+        return reader;
+    }
+
+    internal static void TrackReadElapsed(SqliteDataReader reader, TimeSpan elapsed, bool rowRead)
+    {
+        if (!s_activeProfiles.TryGetValue(reader, out var active))
+            return;
+
+        active.Entry.AddElapsed(elapsed);
+        if (rowRead)
+            active.Entry.IncrementRows();
+        active.Entry.MarkCompletedIfSlow(_slowQueryThresholdMs);
+    }
+
+    private static List<QueryPlanRow> CaptureQueryPlan(SqliteCommand source)
+    {
+        var rows = new List<QueryPlanRow>();
+        try
+        {
+            using var explain = source.Connection!.CreateCommand();
+            explain.Transaction = source.Transaction;
+            explain.CommandText = "EXPLAIN QUERY PLAN " + source.CommandText;
+            foreach (SqliteParameter parameter in source.Parameters)
+                explain.Parameters.AddWithValue(parameter.ParameterName, parameter.Value ?? DBNull.Value);
+
+            using var reader = explain.ExecuteReader();
+            while (reader.Read())
+            {
+                rows.Add(new QueryPlanRow(
+                    reader.GetInt32(0),
+                    reader.GetInt32(1),
+                    reader.GetInt32(2),
+                    reader.GetString(3)));
+            }
+        }
+        catch (Exception ex)
+        {
+            rows.Add(new QueryPlanRow(-1, -1, -1, "EXPLAIN QUERY PLAN failed: " + ex.Message));
+        }
+
+        return rows;
     }
 
     internal static void SnapshotRow(SqliteDataReader reader)
@@ -241,14 +322,63 @@ internal static class DbDebugExtensions
     public static SqliteDataReader ExecuteTrackedReader(this SqliteCommand cmd)
     {
         DbDebug.TrackCommand(cmd);
-        return cmd.ExecuteReader();
+        return DbDebug.ExecuteReader(cmd);
     }
 
     public static bool TrackedRead(this SqliteDataReader reader)
     {
+        var sw = Stopwatch.StartNew();
         var ok = reader.Read();
+        sw.Stop();
+        DbDebug.TrackReadElapsed(reader, sw.Elapsed, ok);
         if (ok)
             DbDebug.SnapshotRow(reader);
         return ok;
     }
 }
+
+public sealed class QueryProfileEntry
+{
+    private long _elapsedTicks;
+    private int _rowsRead;
+    private bool _slowLogged;
+
+    internal QueryProfileEntry(string sql, List<QueryPlanRow> queryPlan)
+    {
+        Sql = sql;
+        QueryPlan = queryPlan;
+    }
+
+    public string Sql { get; }
+    public List<QueryPlanRow> QueryPlan { get; }
+    public double ElapsedMs => TimeSpan.FromTicks(Interlocked.Read(ref _elapsedTicks)).TotalMilliseconds;
+    public int RowsScanned => Volatile.Read(ref _rowsRead);
+
+    internal void AddElapsed(TimeSpan elapsed) => Interlocked.Add(ref _elapsedTicks, elapsed.Ticks);
+
+    internal void IncrementRows() => Interlocked.Increment(ref _rowsRead);
+
+    internal void MarkCompletedIfSlow(long? slowQueryThresholdMs)
+    {
+        if (!slowQueryThresholdMs.HasValue || _slowLogged)
+            return;
+
+        var elapsedMs = ElapsedMs;
+        if (elapsedMs < slowQueryThresholdMs.Value)
+            return;
+
+        _slowLogged = true;
+        try
+        {
+            CodeIndex.Cli.GlobalToolLog.Info($"slow_query elapsed_ms={elapsedMs:0.###} rows_scanned={RowsScanned} sql={Sql.Replace("\n", " ", StringComparison.Ordinal)}");
+        }
+        catch
+        {
+            // Best-effort only / ベストエフォートのみ
+        }
+    }
+}
+
+public sealed record QueryPlanRow(int Id, int Parent, int NotUsed, string Detail);
+
+internal sealed record ActiveProfile(QueryProfileEntry Entry);

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -424,7 +424,7 @@ public class DbReaderTests : IDisposable
         const string target = "TargetService";
         InsertManualReference(path, lang, containerKind: null, containerName: null, target, "call");
 
-        var (results, truncated, truncatedReason) = _reader.GetTransitiveCallers(target, maxDepth: 1, limit: 10, lang: lang);
+        var (results, truncated, truncatedReason, _, _) = _reader.GetTransitiveCallers(target, maxDepth: 1, limit: 10, lang: lang);
 
         var result = Assert.Single(results);
         Assert.Equal(path, result.Path);
@@ -448,7 +448,7 @@ public class DbReaderTests : IDisposable
             target: "TargetService",
             kind: "call");
 
-        var (results, truncated, truncatedReason) = _reader.GetTransitiveCallers("TargetService", maxDepth: 1, limit: 10, lang: "java");
+        var (results, truncated, truncatedReason, _, _) = _reader.GetTransitiveCallers("TargetService", maxDepth: 1, limit: 10, lang: "java");
 
         Assert.Empty(results);
         Assert.False(truncated);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -44,6 +44,8 @@ public class QueryCommandRunnerTests
             "--snippet-lines", $"{SearchSnippetFormatter.MaxSnippetLines}",
             "--snippet-focus", "proximity",
             "--max-line-width", "77",
+            "--profile",
+            "--slow-query-ms", "500",
             "--no-visibility-rank",
         ], jsonDefault: true);
 
@@ -68,6 +70,8 @@ public class QueryCommandRunnerTests
         Assert.Equal(SearchSnippetFormatter.MaxSnippetLines, options.SnippetLines);
         Assert.Equal(SearchSnippetFocusMode.Proximity, options.SnippetFocus);
         Assert.Equal(77, options.MaxLineWidth);
+        Assert.True(options.Profile);
+        Assert.Equal(500, options.SlowQueryMs);
         Assert.True(options.NoVisibilityRank);
     }
 
@@ -148,6 +152,58 @@ public class QueryCommandRunnerTests
             Assert.Equal(CommandExitCodes.Success, humanExitCode);
             Assert.Contains("src/private-auth.cs:1-4 [private]", humanStdout);
             Assert.Contains("1 results in 1 files", humanStderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_ProfileEmitsSqlPhasesAndQueryPlan_Issue1643()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_profile");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/auth.cs",
+                "csharp",
+                """
+                public class AuthFixture
+                {
+                    public void Authenticate() { }
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Authenticate", "--db", dbPath, "--json", "--profile", "--slow-query-ms", "0"],
+                _jsonOptions));
+            var lines = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(2, lines.Length);
+
+            using var resultDocument = JsonDocument.Parse(lines[0]);
+            Assert.Equal("src/auth.cs", resultDocument.RootElement.GetProperty("path").GetString());
+
+            using var profileDocument = JsonDocument.Parse(lines[1]);
+            var profile = profileDocument.RootElement.GetProperty("profile");
+            var phases = profile.GetProperty("phases");
+            var queryPlan = profile.GetProperty("query_plan");
+            var queries = profile.GetProperty("queries");
+
+            Assert.True(phases.GetArrayLength() > 0);
+            Assert.True(queryPlan.GetArrayLength() > 0);
+            Assert.True(queries.GetArrayLength() > 0);
+            Assert.Equal("sql_1", phases[0].GetProperty("name").GetString());
+            Assert.True(phases[0].GetProperty("elapsed_ms").GetDouble() >= 0);
+            Assert.True(phases[0].GetProperty("rows_scanned").GetInt32() >= 0);
+            Assert.False(string.IsNullOrWhiteSpace(queryPlan[0].GetProperty("detail").GetString()));
+            Assert.Contains(queries.EnumerateArray(), query =>
+                query.GetProperty("sql").GetString()?.Contains("SELECT", StringComparison.OrdinalIgnoreCase) == true);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Add `--profile` and `--slow-query-ms` to read/query commands so slow SQL can be diagnosed with timing, row counts, SQL text, and `EXPLAIN QUERY PLAN` output.
- Document the new flags in README/USER_GUIDE and add changelog fragment `changelog.d/unreleased/1643.added.md`.
- Update the latest-main `DbReaderTests` tuple deconstruction so the branch builds against the current impact return shape (Refs #2281).

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ProfileEmitsSqlPhasesAndQueryPlan_Issue1643`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~CliFlagSchemaTests`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search QueryProfileEntry --path src/CodeIndex/Database/DbDebug.cs --json --profile --slow-query-ms 0 --limit 1`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Review
- Codex adversarial review: `No blocking/actionable issues found.`

Fixes #1643
Refs #2281