### PR TITLE
Fix reference ranking SQL for #2163

### DIFF
--- a/changelog.d/unreleased/2163.fixed.md
+++ b/changelog.d/unreleased/2163.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2163
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Reference search ranking no longer lowers reference names in SQL (#2163)** — the `references` ordering buckets now use `COLLATE NOCASE` comparisons instead of `lower(r.symbol_name)`, keeping the emitted SQL aligned with the SARGable reference-name query predicates.
+
+## 日本語
+
+- **reference 検索の ranking が SQL 内で reference 名を lower しないようになりました (#2163)** — `references` の並び替え bucket は `lower(r.symbol_name)` ではなく `COLLATE NOCASE` 比較を使うようになり、SARGable な reference 名クエリ述語と SQL 形状が揃いました。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -1386,7 +1386,7 @@ public partial class DbReader
             FROM logical_references r";
         }
         if (includeOrdering)
-            sql += $" ORDER BY CASE WHEN @preferExactCase = 1 AND r.symbol_name = @rawQuery THEN 0 ELSE 1 END, {(referenceKind == null ? GetPathBucketOrderSql("r.path") : PathBucketOrder)}, CASE WHEN lower(r.symbol_name) = lower(@rankingQuery) THEN 0 ELSE 1 END, CASE WHEN lower(r.symbol_name) LIKE lower(@rankingQueryPrefix) ESCAPE '\\' THEN 0 ELSE 1 END, {(referenceKind == null ? "r.path" : "f.path")}, r.line, r.column_number, r.reference_kind, r.symbol_name LIMIT @limit OFFSET @offset";
+            sql += $" ORDER BY CASE WHEN @preferExactCase = 1 AND r.symbol_name = @rawQuery THEN 0 ELSE 1 END, {(referenceKind == null ? GetPathBucketOrderSql("r.path") : PathBucketOrder)}, CASE WHEN r.symbol_name = @rankingQuery COLLATE NOCASE THEN 0 ELSE 1 END, CASE WHEN r.symbol_name COLLATE NOCASE LIKE @rankingQueryPrefix ESCAPE '\\' THEN 0 ELSE 1 END, {(referenceKind == null ? "r.path" : "f.path")}, r.line, r.column_number, r.reference_kind, r.symbol_name LIMIT @limit OFFSET @offset";
 
         cmd.CommandText = sql;
         if (query != null)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text;
 using CodeIndex.Database;
 using CodeIndex.Indexer;
@@ -66,6 +67,17 @@ public class DbReaderTests : IDisposable
 
         Assert.Equal(1, counts.Count);
         Assert.Equal(1, counts.FileCount);
+    }
+
+    [Fact]
+    public void CreateSearchReferencesCommand_RanksWithoutLoweringReferenceNames()
+    {
+        using var cmd = CreateSearchReferencesCommandForSql("FetchData");
+        var sql = cmd.CommandText;
+
+        Assert.DoesNotContain("lower(r.symbol_name)", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("r.symbol_name = @rankingQuery COLLATE NOCASE", sql, StringComparison.Ordinal);
+        Assert.Contains("r.symbol_name COLLATE NOCASE LIKE @rankingQueryPrefix ESCAPE '\\'", sql, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -221,6 +233,29 @@ public class DbReaderTests : IDisposable
         SymbolExtractor.ApplyFamilyScope(symbols, familyScopeKey ?? FileIndexer.DeriveFallbackFamilyScopeKey(path));
         _writer.InsertSymbols(symbols);
         _writer.InsertReferences(ReferenceExtractor.Extract(fileId, lang, normalized, symbols));
+    }
+
+    private SqliteCommand CreateSearchReferencesCommandForSql(string query)
+    {
+        var method = typeof(DbReader).GetMethod(
+            "CreateSearchReferencesCommand",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        return Assert.IsType<SqliteCommand>(method!.Invoke(
+            _reader,
+            [
+                query,
+                20,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                0,
+                true,
+            ]));
     }
 
     private void InsertManualReferences(string path, string containerName, string target, string kind, int count)


### PR DESCRIPTION
## Summary

- Replaced the remaining `references` ORDER BY `lower(r.symbol_name)` ranking buckets with `COLLATE NOCASE` comparisons.
- Added a DbReader regression test that asserts the emitted references SQL no longer contains `lower(r.symbol_name)`.
- Added the bilingual changelog fragment for #2163.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~DbReaderTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` remains degraded because the earlier full scan stall left unrelated files unindexed; tracked separately in #2300.

## Documentation and Changelog

- Added `changelog.d/unreleased/2163.fixed.md`.
- No README or guide changes were required; this preserves observable ranking while changing only the SQL shape.

## Follow-up

- Full scan stall observed during local validation: #2300.

Fixes #2163
