### PR TITLE
Add required property signature regression test

### DIFF
--- a/changelog.d/unreleased/1456.fixed.md
+++ b/changelog.d/unreleased/1456.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1456
+affected:
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C# required property signatures are covered by regression tests (#1456)** — `public required` properties now have explicit coverage proving `required` and `init` remain in extracted signatures.
+
+## 日本語
+
+- **C# の required プロパティシグネチャを回帰テストで保護しました (#1456)** — `public required` プロパティで、抽出シグネチャに `required` と `init` が残ることを明示的に検証するようになりました。

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -8099,6 +8099,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_RequiredProperties_PreserveRequiredAndInitInSignature()
+    {
+        var content = """
+            public class User
+            {
+                public required string Name { get; init; }
+                public required int Age { get; set; }
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var name = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "Name"));
+        var age = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "Age"));
+
+        Assert.Equal("public required string Name { get; init; }", name.Signature);
+        Assert.Equal("public required int Age { get; set; }", age.Signature);
+    }
+
+    [Fact]
     public void Extract_CSharp_DetectsNoVisibilityMembers()
     {
         // Classes/methods without explicit visibility (internal by default)


### PR DESCRIPTION
## Summary
- Add regression coverage for C# `required` properties so extracted signatures preserve both `required` and `init`.
- Add a bilingual changelog fragment for #1456.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_RequiredProperties_PreserveRequiredAndInitInSignature"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog
- Changelog fragment: `changelog.d/unreleased/1456.fixed.md`
- No documentation update needed; this adds regression coverage for the existing C# signature extraction contract.

Fixes #1456
