### PR TITLE
Fix C# generic constraint references

### DIFF
--- a/changelog.d/unreleased/2084.fixed.md
+++ b/changelog.d/unreleased/2084.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2084
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# generic constraints now index multi-line `where` type references (#2084)** — `where` clauses split across lines now emit `type_reference` edges for constraint types while suppressing generic type parameters and special constraint keywords.
+
+## 日本語
+
+- **C# generic 制約の複数行 `where` 型参照を index するようになりました (#2084)** — 複数行に分かれた `where` 句でも constraint 型の `type_reference` を出し、generic 型パラメータや特殊 constraint keyword は参照として出さないようにしました。

--- a/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.cs
@@ -5,6 +5,7 @@ using CSharpFunctionValueReceiverNameRecord = CodeIndex.Indexer.ReferenceExtract
 using CSharpMultiLineTypePatternState = CodeIndex.Indexer.ReferenceExtractor.CSharpMultiLineTypePatternState;
 using CSharpUsingAliasRecord = CodeIndex.Indexer.ReferenceExtractor.CSharpUsingAliasRecord;
 using CSharpUsingStaticRecord = CodeIndex.Indexer.ReferenceExtractor.CSharpUsingStaticRecord;
+using CSharpWhereConstraintState = CodeIndex.Indexer.ReferenceExtractor.CSharpWhereConstraintState;
 
 namespace CodeIndex.Indexer;
 
@@ -134,6 +135,7 @@ internal static class CSharpReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn,
         SymbolRecord? container,
+        CSharpWhereConstraintState pendingWhereConstraint,
         ref CSharpMultiLineTypePatternState pendingCSharpMultiLineTypePattern)
         => ReferenceExtractor.EmitCSharpTypePositionReferences(
             preparedLine,
@@ -150,6 +152,7 @@ internal static class CSharpReferenceExtractor
             lineNumber,
             resolveContainerForColumn,
             container,
+            pendingWhereConstraint,
             ref pendingCSharpMultiLineTypePattern);
 
     public static bool HasTrailingIsAsTypePatternIntro(string preparedLine, string originalLine)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -550,19 +550,78 @@ public static partial class ReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        Func<int, SymbolRecord?> resolveContainerForColumn)
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string> declarationGenericParameterNames,
+        CSharpWhereConstraintState pendingWhereConstraint)
     {
-        var genericParameterNames = new HashSet<string>(StringComparer.Ordinal);
-        foreach (Match match in CSharpWhereClauseRegex.Matches(line))
+        if (declarationGenericParameterNames.Count > 0)
         {
+            pendingWhereConstraint.HeaderGenericParameterNames.Clear();
+            pendingWhereConstraint.HeaderGenericParameterNames.UnionWith(declarationGenericParameterNames);
+        }
+
+        var searchStart = 0;
+        if (pendingWhereConstraint.Active)
+        {
+            var nextWhereMatch = CSharpWhereClauseRegex.Match(line);
+            var nextWhere = nextWhereMatch.Success ? nextWhereMatch.Index : -1;
+            var pendingEnd = FindTypeListTerminator(line, allowArrow: true);
+            if (nextWhere >= 0 && (pendingEnd < 0 || nextWhere < pendingEnd))
+                pendingEnd = nextWhere;
+            if (pendingEnd < 0)
+                pendingEnd = line.Length;
+
+            EmitCSharpWhereConstraintSegments(
+                line,
+                0,
+                pendingEnd,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn,
+                pendingWhereConstraint.IgnoredSegments);
+
+            if (pendingEnd < line.Length && nextWhere >= 0 && nextWhere == pendingEnd)
+            {
+                searchStart = nextWhere;
+            }
+            else if (pendingEnd < line.Length)
+            {
+                pendingWhereConstraint.Active = false;
+                pendingWhereConstraint.HeaderGenericParameterNames.Clear();
+                pendingWhereConstraint.IgnoredSegments.Clear();
+                return;
+            }
+            else
+            {
+                return;
+            }
+
+            pendingWhereConstraint.Active = false;
+            pendingWhereConstraint.IgnoredSegments.Clear();
+        }
+
+        var lineWhereMatches = CSharpWhereClauseRegex.Matches(line);
+        var sawWhereMatch = false;
+        var lineWhereNames = new HashSet<string>(pendingWhereConstraint.HeaderGenericParameterNames, StringComparer.Ordinal);
+        lineWhereNames.UnionWith(declarationGenericParameterNames);
+        foreach (Match match in lineWhereMatches)
+        {
+            if (match.Index < searchStart)
+                continue;
+            sawWhereMatch = true;
             var nameGroup = match.Groups["name"];
             if (nameGroup.Success && nameGroup.Value.Length > 0)
-                genericParameterNames.Add(nameGroup.Value);
+                lineWhereNames.Add(nameGroup.Value);
         }
-        genericParameterNames.UnionWith(CSharpWhereConstraintIgnoredSegments);
+        lineWhereNames.UnionWith(CSharpWhereConstraintIgnoredSegments);
 
-        foreach (Match match in CSharpWhereClauseRegex.Matches(line))
+        foreach (Match match in lineWhereMatches)
         {
+            if (match.Index < searchStart)
+                continue;
             int listStart = match.Index + match.Length;
             var remaining = line.Substring(listStart);
             var nextWhereMatch = CSharpWhereClauseRegex.Match(remaining);
@@ -572,25 +631,69 @@ public static partial class ReferenceExtractor
                 end = nextWhere;
             if (end < 0)
                 end = remaining.Length;
-            var constraintList = remaining.Substring(0, end);
-            foreach (var (segmentStart, segmentLength) in SplitTopLevelCommaSpans(constraintList))
+            EmitCSharpWhereConstraintSegments(
+                line,
+                listStart,
+                end,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn,
+                lineWhereNames);
+
+            if (listStart + end >= line.Length && nextWhere < 0 && FindTypeListTerminator(remaining, allowArrow: true) < 0)
             {
-                var rawSegment = constraintList.Substring(segmentStart, segmentLength).Trim();
-                if (rawSegment.Length == 0 || rawSegment.Contains('('))
-                    continue;
-                var absoluteStart = listStart + segmentStart + CountLeadingWhitespace(constraintList, segmentStart, segmentLength);
-                AddTypeExpressionSegments(
-                    references,
-                    seen,
-                    fileId,
-                    rawSegment,
-                    absoluteStart,
-                    context,
-                    lineNumber,
-                    resolveContainerForColumn(absoluteStart),
-                    "csharp",
-                    genericParameterNames);
+                pendingWhereConstraint.Active = true;
+                pendingWhereConstraint.IgnoredSegments.Clear();
+                pendingWhereConstraint.IgnoredSegments.UnionWith(lineWhereNames);
             }
+            else
+            {
+                pendingWhereConstraint.HeaderGenericParameterNames.Clear();
+            }
+        }
+
+        if (!sawWhereMatch && FindTypeListTerminator(line, allowArrow: true) >= 0)
+        {
+            pendingWhereConstraint.HeaderGenericParameterNames.Clear();
+        }
+    }
+
+    private static void EmitCSharpWhereConstraintSegments(
+        string line,
+        int listStart,
+        int listLength,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn,
+        IReadOnlySet<string> ignoredSegments)
+    {
+        if (listLength <= 0)
+            return;
+
+        var constraintList = line.Substring(listStart, listLength);
+        foreach (var (segmentStart, segmentLength) in SplitTopLevelCommaSpans(constraintList))
+        {
+            var rawSegment = constraintList.Substring(segmentStart, segmentLength).Trim();
+            if (rawSegment.Length == 0 || rawSegment.Contains('('))
+                continue;
+            var absoluteStart = listStart + segmentStart + CountLeadingWhitespace(constraintList, segmentStart, segmentLength);
+            AddTypeExpressionSegments(
+                references,
+                seen,
+                fileId,
+                rawSegment,
+                absoluteStart,
+                context,
+                lineNumber,
+                resolveContainerForColumn(absoluteStart),
+                "csharp",
+                ignoredSegments);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -554,11 +554,7 @@ public static partial class ReferenceExtractor
         IReadOnlySet<string> declarationGenericParameterNames,
         CSharpWhereConstraintState pendingWhereConstraint)
     {
-        if (declarationGenericParameterNames.Count > 0)
-        {
-            pendingWhereConstraint.HeaderGenericParameterNames.Clear();
-            pendingWhereConstraint.HeaderGenericParameterNames.UnionWith(declarationGenericParameterNames);
-        }
+        UpdateCSharpWhereHeaderGenericParameterNames(line, declarationGenericParameterNames, pendingWhereConstraint);
 
         var searchStart = 0;
         if (pendingWhereConstraint.Active)
@@ -659,6 +655,95 @@ public static partial class ReferenceExtractor
         {
             pendingWhereConstraint.HeaderGenericParameterNames.Clear();
         }
+    }
+
+    private static void UpdateCSharpWhereHeaderGenericParameterNames(
+        string line,
+        IReadOnlySet<string> declarationGenericParameterNames,
+        CSharpWhereConstraintState pendingWhereConstraint)
+    {
+        if (declarationGenericParameterNames.Count > 0)
+        {
+            pendingWhereConstraint.CollectingHeaderGenericParameters = false;
+            pendingWhereConstraint.HeaderGenericParameterDepth = 0;
+            pendingWhereConstraint.HeaderGenericParameterText = string.Empty;
+            pendingWhereConstraint.HeaderGenericParameterNames.Clear();
+            pendingWhereConstraint.HeaderGenericParameterNames.UnionWith(declarationGenericParameterNames);
+            return;
+        }
+
+        if (pendingWhereConstraint.Active)
+            return;
+
+        if (pendingWhereConstraint.CollectingHeaderGenericParameters)
+        {
+            pendingWhereConstraint.HeaderGenericParameterText += " " + line.Trim();
+            pendingWhereConstraint.HeaderGenericParameterDepth += CountCSharpGenericParameterAngleDelta(line);
+            if (pendingWhereConstraint.HeaderGenericParameterDepth <= 0)
+            {
+                pendingWhereConstraint.HeaderGenericParameterNames.Clear();
+                pendingWhereConstraint.HeaderGenericParameterNames.UnionWith(
+                    CollectCSharpGenericParameterNamesFromClause(pendingWhereConstraint.HeaderGenericParameterText, 0));
+                pendingWhereConstraint.CollectingHeaderGenericParameters = false;
+                pendingWhereConstraint.HeaderGenericParameterDepth = 0;
+                pendingWhereConstraint.HeaderGenericParameterText = string.Empty;
+            }
+
+            return;
+        }
+
+        var genericOpen = FindPotentialCSharpGenericDeclarationOpen(line);
+        if (genericOpen < 0)
+            return;
+
+        var genericClose = FindMatchingChar(line, genericOpen, '<', '>');
+        if (genericClose > genericOpen)
+        {
+            pendingWhereConstraint.HeaderGenericParameterNames.Clear();
+            pendingWhereConstraint.HeaderGenericParameterNames.UnionWith(
+                CollectCSharpGenericParameterNamesFromClause(line, genericOpen));
+            return;
+        }
+
+        pendingWhereConstraint.CollectingHeaderGenericParameters = true;
+        pendingWhereConstraint.HeaderGenericParameterDepth = CountCSharpGenericParameterAngleDelta(line[genericOpen..]);
+        pendingWhereConstraint.HeaderGenericParameterText = line[genericOpen..].Trim();
+    }
+
+    private static int FindPotentialCSharpGenericDeclarationOpen(string line)
+    {
+        var whereIndex = line.IndexOf(" where ", StringComparison.Ordinal);
+        for (var index = 0; index < line.Length; index++)
+        {
+            if (line[index] != '<')
+                continue;
+            if (whereIndex >= 0 && index > whereIndex)
+                return -1;
+
+            var before = line[..index].TrimEnd();
+            if (before.Length == 0)
+                continue;
+            if (!IsTypeExpressionIdentifierPart("csharp", before[^1]))
+                continue;
+
+            return index;
+        }
+
+        return -1;
+    }
+
+    private static int CountCSharpGenericParameterAngleDelta(string text)
+    {
+        var depth = 0;
+        foreach (var c in text)
+        {
+            if (c == '<')
+                depth++;
+            else if (c == '>')
+                depth--;
+        }
+
+        return depth;
     }
 
     private static void EmitCSharpWhereConstraintSegments(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -21,6 +21,12 @@ public static partial class ReferenceExtractor
         int PendingTypeLineNumber,
         string? PendingContext,
         SymbolRecord? PendingContainer);
+    internal sealed class CSharpWhereConstraintState
+    {
+        public bool Active { get; set; }
+        public HashSet<string> HeaderGenericParameterNames { get; } = new(StringComparer.Ordinal);
+        public HashSet<string> IgnoredSegments { get; } = new(StringComparer.Ordinal);
+    }
     private static readonly HashSet<string> SupportedLanguages =
     [
         "python", "javascript", "typescript", "csharp", "go", "rust",
@@ -1096,6 +1102,7 @@ public static partial class ReferenceExtractor
         var references = new List<ReferenceRecord>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var pendingCSharpMultiLineTypePattern = default(CSharpMultiLineTypePatternState);
+        var pendingCSharpWhereConstraint = language == "csharp" ? new CSharpWhereConstraintState() : null;
         var sqlState = language == "sql" ? SqlReferenceExtractor.CreateState() : null;
         var csharpInDelimitedDocComment = false;
         var jvmInDelimitedDocComment = false;
@@ -1784,6 +1791,7 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     ResolveContainerForCall,
                     container,
+                    pendingCSharpWhereConstraint!,
                     ref pendingCSharpMultiLineTypePattern);
 
                 if (CSharpReferenceExtractor.HasTrailingIsAsTypePatternIntro(preparedLine, originalLine))
@@ -3685,11 +3693,21 @@ public static partial class ReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn,
         SymbolRecord? container,
+        CSharpWhereConstraintState pendingWhereConstraint,
         ref CSharpMultiLineTypePatternState pendingCSharpMultiLineTypePattern)
     {
         var csharpGenericParameterNames = CollectCSharpGenericParameterNamesForDeclaration(preparedLine);
         TryEmitCSharpBaseListReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, csharpGenericParameterNames);
-        EmitCSharpWhereConstraintReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitCSharpWhereConstraintReferences(
+            preparedLine,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn,
+            csharpGenericParameterNames,
+            pendingWhereConstraint);
         EmitDeclarationTypeReferences("csharp", preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, csharpGenericParameterNames);
 
         foreach (Match match in CSharpIsAsTypeTestRegex.Matches(preparedLine))

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -26,6 +26,9 @@ public static partial class ReferenceExtractor
         public bool Active { get; set; }
         public HashSet<string> HeaderGenericParameterNames { get; } = new(StringComparer.Ordinal);
         public HashSet<string> IgnoredSegments { get; } = new(StringComparer.Ordinal);
+        public bool CollectingHeaderGenericParameters { get; set; }
+        public int HeaderGenericParameterDepth { get; set; }
+        public string HeaderGenericParameterText { get; set; } = string.Empty;
     }
     private static readonly HashSet<string> SupportedLanguages =
     [
@@ -617,7 +620,7 @@ public static partial class ReferenceExtractor
     };
     private static readonly HashSet<string> CSharpWhereConstraintIgnoredSegments = new(StringComparer.Ordinal)
     {
-        "allows", "notnull", "ref", "unmanaged",
+        "allows", "default", "notnull", "ref", "unmanaged",
     };
     private static readonly Dictionary<string, HashSet<string>> LanguageBuiltInTypeNames = new(StringComparer.Ordinal)
     {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20407,10 +20407,11 @@ public class ReferenceExtractorTests
     {
         const string content = """
             interface IContract {}
-            class Demo<TValue, TKey, TBuffer>
+            class Demo<TValue, TKey, TBuffer, TDefault>
                 where TValue : unmanaged, IContract
                 where TKey : notnull
                 where TBuffer : IContract, allows ref struct
+                where TDefault : default
             {
             }
             """;
@@ -20419,7 +20420,7 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "IContract" && r.ReferenceKind == "type_reference");
-        Assert.DoesNotContain(references, r => (r.SymbolName is "allows" or "ref" or "unmanaged" or "notnull") && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => (r.SymbolName is "allows" or "default" or "ref" or "unmanaged" or "notnull") && r.ReferenceKind == "type_reference");
     }
 
     [Fact]
@@ -20432,7 +20433,9 @@ public class ReferenceExtractorTests
             interface IAuditable {}
             namespace Domain.Models { class Entity {} }
 
-            class Demo<TValue, TKey>
+            class Demo<
+                TValue,
+                TKey>
                 where TValue :
                     global::Domain.Models.Entity,
                     IContract<TKey>,

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -20423,6 +20423,36 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpMultiLineWhereConstraints_CapturesConstraintTypeReferences()
+    {
+        const string content = """
+            using System.Collections.Generic;
+
+            interface IContract<T> {}
+            interface IAuditable {}
+            namespace Domain.Models { class Entity {} }
+
+            class Demo<TValue, TKey>
+                where TValue :
+                    global::Domain.Models.Entity,
+                    IContract<TKey>,
+                    IAuditable,
+                    new()
+                where TKey : notnull
+            {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Entity" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "IContract" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "IAuditable" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => (r.SymbolName is "TValue" or "TKey" or "notnull" or "new") && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpGenericSignatures_DoNotEmitTypeParameterReferences()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Add C# `where` constraint state so multi-line constraint lists emit `type_reference` edges for real constraint types.
- Suppress generic type parameters and C# special constraint keywords, including `default`, in constraint references.
- Add regression coverage for multi-line generic headers and multi-line constraint lists.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation and changelog

- Added `changelog.d/unreleased/2084.fixed.md`.
- No README or guide update was needed; this changes extracted reference coverage without changing CLI/MCP command syntax or documented output shape.

## Follow-up candidates

- Existing full-scan stall is tracked by #2300.

Fixes #2084
