### PR TITLE
Fix C++ template specialization extraction

### DIFF
--- a/changelog.d/unreleased/1944.fixed.md
+++ b/changelog.d/unreleased/1944.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1944
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C++ template specialization and instantiation sites are now distinguished (#1944)** — `cdidx` records explicit and partial template specializations as `specialization` symbols and emits `instantiate` references for explicit template instantiations and template-id declaration sites.
+
+## 日本語
+
+- **C++ template specialization / instantiation 箇所を区別するようになりました (#1944)** — `cdidx` は明示 / 部分 template specialization を `specialization` シンボルとして記録し、明示的な template instantiation と template-id 宣言箇所に `instantiate` 参照を出力します。

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -164,6 +164,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex CppExplicitTemplateInstantiationRegex = new(
         @"\b(?:extern\s+)?template\s+(?:class|struct)\s+(?<type>[^;]+);",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CppTemplateIdDeclarationRegex = new(
+        @"(?<!template\s)(?<!class\s)(?<!struct\s)(?<type>(?:[A-Za-z_]\w*\s*::\s*)*[A-Z_]\w*)\s*<(?<args>[^;{}]+)>\s*(?:[*&]\s*)?[A-Za-z_]\w*\s*(?:[=;{,)]|\[[^\]]*\])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex CppTemplateParameterDefaultTypeRegex = new(
         @"\b(?:typename|class)\s+[A-Za-z_]\w*\s*=\s*(?<type>(?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*(?:\s*<[^,>]+>)?(?:\s*[*&])?)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -1576,7 +1579,22 @@ internal static class LanguageReferenceExtractionSupport
         foreach (Match match in CppExplicitTemplateInstantiationRegex.Matches(preparedLine))
         {
             var group = match.Groups["type"];
+            var typeName = LastCppQualifiedSegment(group.Value);
+            var typeStart = group.Index + group.Value.LastIndexOf(typeName, StringComparison.Ordinal);
+            ReferenceExtractor.AddReference(references, seen, fileId, typeName, typeStart, "instantiate", context, lineNumber, resolveContainerForColumn(typeStart));
             ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, group.Value, group.Index, context, lineNumber, resolveContainerForColumn(group.Index), language);
+        }
+
+        foreach (Match match in CppTemplateIdDeclarationRegex.Matches(preparedLine))
+        {
+            if (IsCppTemplateDeclarationOrSpecializationLine(preparedLine, match.Index))
+                continue;
+
+            var group = match.Groups["type"];
+            var typeName = LastCppQualifiedSegment(group.Value);
+            var typeStart = group.Index + group.Value.LastIndexOf(typeName, StringComparison.Ordinal);
+            ReferenceExtractor.AddReference(references, seen, fileId, typeName, typeStart, "instantiate", context, lineNumber, resolveContainerForColumn(typeStart));
+            ReferenceExtractor.AddTypeExpressionSegments(references, seen, fileId, match.Groups["args"].Value, match.Groups["args"].Index, context, lineNumber, resolveContainerForColumn(match.Groups["args"].Index), language);
         }
 
         foreach (Match match in CppTemplateParameterDefaultTypeRegex.Matches(preparedLine))
@@ -4988,6 +5006,13 @@ internal static class LanguageReferenceExtractionSupport
             text = text[..genericIndex].TrimEnd();
         var separator = text.LastIndexOf("::", StringComparison.Ordinal);
         return separator >= 0 ? text[(separator + 2)..].Trim() : text;
+    }
+
+    private static bool IsCppTemplateDeclarationOrSpecializationLine(string line, int matchIndex)
+    {
+        var prefix = line[..Math.Clamp(matchIndex, 0, line.Length)].TrimStart();
+        return prefix.StartsWith("template", StringComparison.Ordinal)
+            || prefix.StartsWith("export template", StringComparison.Ordinal);
     }
 
     private static string LastQualifiedSegment(string value)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2002,7 +2002,7 @@ public static partial class SymbolExtractor
 
     private static readonly HashSet<string> ContainerKinds =
     [
-        "class", "struct", "interface", "namespace", "enum", "heading"
+        "class", "struct", "interface", "namespace", "enum", "heading", "specialization"
     ];
 
     /// <summary>

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1446,6 +1446,8 @@ public static partial class SymbolExtractor
             new("import", new Regex(CppFunctionStartBlacklistPattern + @"(?:export\s+)?import\s+(?:<(?<name>[^>\r\n]+)>|""(?<name>[^""\r\n]+)""|(?<name>:?[A-Za-z_]\w*(?:[.:][A-Za-z_]\w*)*))\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
             new("namespace", new Regex(CppFunctionStartBlacklistPattern + @"inline\s+namespace\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("interface", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + @"(?:export\s+)?concept\s+(?<name>\w+)\b", RegexOptions.Compiled), BodyStyle.None),
+            new("specialization", new Regex(CppFunctionStartBlacklistPattern + @"\s*template\s*<[^>]*>\s*(?:class|struct|union)\s+(?<name>(?:[A-Za-z_]\w*::)*[A-Za-z_]\w*)\s*<[^;{}]+>", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
+            new("specialization", new Regex(CppFunctionStartBlacklistPattern + @"\s*template\s*<>\s*" + CppAttributePrefixPattern + @"(?:extern\s+""(?:C|C\+\+)""\s*)?" + CppAttributePrefixPattern + @"(?:(?<returnType>(?:(?:" + CppFunctionReturnTypeAtomPattern + @")[\s*&]+)+))?(?:(?:[\w:<>]+\s*::\s*)+)?" + CFunctionNameBlacklistPattern + @"(?<name>~?\w+|operator(?:\s*\(\)|\s*\[\]|\s*[^\s(]+(?:\s+[^\s(]+)?))\s*<[^>\r\n]+>\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
             new("function", new Regex(CppFunctionStartBlacklistPattern + CppTemplatePrefixPattern + CppAttributePrefixPattern + @"(?:extern\s+""(?:C|C\+\+)""\s*)?" + CppAttributePrefixPattern + @"(?:(?<returnType>(?:(?:" + CppFunctionReturnTypeAtomPattern + @")[\s*&]+)+))?(?:(?:[\w:<>]+\s*::\s*)+)?" + CFunctionNameBlacklistPattern + @"(?<name>~?\w+|operator(?:\s*\(\)|\s*\[\]|\s*[^\s(]+(?:\s+[^\s(]+)?))(?:\s*<[^>]+>)?\s*\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
             // Type alias / 型エイリアス
             new("import", new Regex(CppFunctionStartBlacklistPattern + @"using\s+enum\s+(?<name>(?:[A-Za-z_]\w*::)*[A-Za-z_]\w*)\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
@@ -3017,6 +3019,12 @@ public static partial class SymbolExtractor
                             fortranProcedureNames = names.Where(static candidate => candidate.Length > 0).ToList();
                     }
 
+                    if (lang == "cpp"
+                        && IsCppTemplateSpecializationSymbol(kind, name, signature, lines, i))
+                    {
+                        kind = "specialization";
+                    }
+
                     var suppressJavaStatementSymbol = false;
                     if (lang == "java" && pattern.Kind == "function")
                     {
@@ -3272,6 +3280,7 @@ public static partial class SymbolExtractor
                                         BodyStartLine = bodyStartLine,
                                         BodyEndLine = bodyEndLine,
                                     Signature = signature,
+                                    FamilyKey = lang == "cpp" && kind == "specialization" ? name : null,
                                     Visibility = TryGetGroup(match, pattern.VisibilityGroup),
                                     ReturnType = NormalizeMetadata(rawReturnType),
                                 },
@@ -8797,6 +8806,39 @@ public static partial class SymbolExtractor
             return true;
 
         return segment.All(static ch => ch == '_' || char.IsLetterOrDigit(ch));
+    }
+
+    private static bool IsCppTemplateSpecializationSymbol(
+        string kind,
+        string name,
+        string signature,
+        IReadOnlyList<string> lines,
+        int lineIndex)
+    {
+        if (kind is not ("class" or "struct" or "union" or "function"))
+            return false;
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(signature))
+            return false;
+        if (!signature.Contains(name + "<", StringComparison.Ordinal))
+            return false;
+
+        var trimmedSignature = signature.TrimStart();
+        if (trimmedSignature.StartsWith("template", StringComparison.Ordinal)
+            || trimmedSignature.StartsWith("export template", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        for (var previousLineIndex = lineIndex - 1; previousLineIndex >= 0; previousLineIndex--)
+        {
+            var previous = lines[previousLineIndex].Trim();
+            if (previous.Length == 0)
+                continue;
+            return previous.StartsWith("template", StringComparison.Ordinal)
+                || previous.StartsWith("export template", StringComparison.Ordinal);
+        }
+
+        return false;
     }
 
     private static string StripVisualBasicIdentifierEscapes(string segment) =>

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10768,6 +10768,29 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CppTemplateInstantiationSites_CaptureInstantiationReferences()
+    {
+        const string content = """
+            template class Box<int>;
+            extern template struct ns::Cache<Key>;
+
+            void Run() {
+              Box<User> box;
+              ns::Cache<Key> cache{};
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cpp", content);
+        var references = ReferenceExtractor.Extract(1, "cpp", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Box" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "Cache" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Key" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "ns" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CppTypedefAliases_CaptureTargetTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15420,6 +15420,33 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CppTemplateSpecializations_DistinguishesDeclarationSites()
+    {
+        var content = """
+            template <typename T>
+            class Box {};
+
+            template<>
+            class Box<int> {};
+
+            template <typename U>
+            class Box<U*> {};
+
+            template<>
+            void Save<int>(int value) {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cpp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Box");
+        var specializations = symbols.Where(s => s.Kind == "specialization" && s.Name == "Box").ToList();
+        Assert.Equal(2, specializations.Count);
+        Assert.All(specializations, s => Assert.Equal("Box", s.FamilyKey));
+        Assert.Contains(symbols, s => s.Kind == "specialization" && s.Name == "Save" && s.ReturnType == "void");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Signature?.Contains("Box<int>", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
     public void Extract_Cpp_DetectsClassBodyMembers()
     {
         // C++: constructors, destructors, operator overloads / C++: コンストラクタ、デストラクタ、演算子オーバーロード


### PR DESCRIPTION
## Summary

- Record C++ explicit and partial template specialization declarations as `specialization` symbols instead of ordinary class/function symbols.
- Emit `instantiate` references for explicit template instantiation declarations and template-id declaration sites such as `Box<User> box;`.
- Keep specialization symbols usable as containers and add focused regression coverage.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CppTemplateSpecializations_DistinguishesDeclarationSites|FullyQualifiedName~ReferenceExtractorTests.Extract_CppTemplateInstantiationSites_CaptureInstantiationReferences"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet test CodeIndex.sln`
- `dotnet build CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and Changelog

- Added `changelog.d/unreleased/1944.fixed.md`.
- No README or guide update was required; this is extractor behavior covered by tests and the changelog fragment.

## Review

- Adversarial review found one actionable issue: specialization symbols needed to remain container-capable. Fixed in `382d3711`.
- Attempted `codex exec review --base origin/main`, but the Codex CLI stopped with a usage-limit error before completing.

Fixes #1944