### PR TITLE
Fix C# multiline generic overload extraction

### DIFF
--- a/changelog.d/unreleased/1982.fixed.md
+++ b/changelog.d/unreleased/1982.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1982
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C# multiline generic method overloads keep distinct symbols (#1982)** — C# member extraction now merges method headers whose generic type parameter list or parameter list spans physical lines, so overloads such as `M<T>` and `M<T, U>` are both indexed with distinct signatures.
+
+## 日本語
+
+- **C# の複数行 generic メソッド overload が別々のシンボルとして残るようになりました (#1982)** — C# メンバー抽出で generic 型パラメータリストや引数リストが物理行をまたぐメソッドヘッダを結合するようにし、`M<T>` と `M<T, U>` のような overload が別々のシグネチャで index されるようにしました。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -1730,8 +1730,10 @@ public static partial class SymbolExtractor
     private static CSharpPropertyMatchCandidate BuildCSharpPropertyMatchLine(string[] lines, string[] csharpMatchLines, int startLineIndex)
     {
         var matchLine = csharpMatchLines[startLineIndex];
+        var isPropertyHeaderPrefix = CSharpPropertyHeaderPrefixRegex.IsMatch(matchLine);
+        var isMethodHeaderPrefix = CSharpMethodHeaderPrefixRegex.IsMatch(matchLine);
         if (string.IsNullOrWhiteSpace(matchLine)
-            || !CSharpPropertyHeaderPrefixRegex.IsMatch(matchLine)
+            || (!isPropertyHeaderPrefix && !isMethodHeaderPrefix)
             || HasCSharpPropertyAccessorStart(matchLine)
             || CSharpWrappedHeaderModifierLineRegex.IsMatch(matchLine))
         {
@@ -1769,7 +1771,7 @@ public static partial class SymbolExtractor
             : (int?)null;
 
         if (HasCSharpTopLevelFieldInitializer(matchLine)
-            || openBraceLineIndex >= 0 && CSharpConfirmedMemberPrefixRegex.IsMatch(matchLine))
+            || openBraceLineIndex >= 0 && IsCSharpConfirmedMemberOrMethodPrefix(matchLine))
         {
             return ContinueConfirmedCSharpPropertyMatch(
                 lines,
@@ -1833,7 +1835,7 @@ public static partial class SymbolExtractor
             }
 
             if (HasCSharpTopLevelFieldInitializer(normalizedCombined)
-                || openBraceLineIndex >= 0 && CSharpConfirmedMemberPrefixRegex.IsMatch(normalizedCombined))
+                || openBraceLineIndex >= 0 && IsCSharpConfirmedMemberOrMethodPrefix(normalizedCombined))
             {
                 return ContinueConfirmedCSharpPropertyMatch(
                     lines,
@@ -1933,6 +1935,9 @@ public static partial class SymbolExtractor
 
         return new CSharpPropertyMatchCandidate(normalizedCombined, currentLineIndex, currentLineIndex);
     }
+
+    private static bool IsCSharpConfirmedMemberOrMethodPrefix(string line)
+        => CSharpConfirmedMemberPrefixRegex.IsMatch(line) || CSharpConfirmedMethodPrefixRegex.IsMatch(line);
 
     // Prefer the raw line's `{` column (to preserve original positioning for body slicing),
     // falling back to the sanitized line only when the raw line hides the brace in a string
@@ -3331,6 +3336,9 @@ public static partial class SymbolExtractor
     // 複数行宣言も 1 つのマッチ行に結合できるようにする。複数行 const フィールド向けに
     // `const` も他の field 対応修飾子と一緒に列挙する。Closes #355.
     private static readonly Regex CSharpPropertyHeaderPrefixRegex = new($@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|volatile|unsafe|extern|const|ref(?:\s+readonly)?)\s+)*(?:{CSharpTypePattern})\s*(?:{CSharpIdentifierPattern})?\s*\{{?\s*$", RegexOptions.Compiled);
+    private static readonly Regex CSharpMethodHeaderPrefixRegex = new(
+        $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|volatile|unsafe|extern|async|file|ref(?:\s+readonly)?)\s+)*(?!{CSharpNonTypeKeywordPattern})(?:{CSharpTypePattern})\s+(?:{CSharpExplicitInterfaceQualifierPattern}\s*\.\s*)?(?:{CSharpIdentifierPattern})\s*(?:<[^{{}};=]*|{CSharpMethodTypeParameterListPattern}\([^{{}};]*)\s*$",
+        RegexOptions.Compiled);
     // Limit only the lightweight confirmation phase. Once a candidate looks like a real
     // declaration (`name =`, or a named member header before `{`), BuildCSharpPropertyMatchLine
     // switches to a linear terminator/accessor scan so long raw strings / initializers are not
@@ -3345,6 +3353,9 @@ public static partial class SymbolExtractor
     private const int CSharpPropertyMatchLookaheadCharLimit = 4096;
     private static readonly Regex CSharpConfirmedMemberPrefixRegex = new(
         $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|volatile|unsafe|extern|const|ref(?:\s+readonly)?)\s+)*(?!(?:class|struct|interface|enum|record|namespace|delegate\b(?!\*)|event|using|return|throw|yield|var|typeof|sizeof|nameof|default|if|for|foreach|while|switch|catch|lock|case|else|when|break|continue|goto|await|try|do|operator|this|base)\b)(?:{CSharpTypePattern})\s+(?:{CSharpExplicitInterfaceQualifierPattern}\s*\.\s*)?(?:{CSharpIdentifierPattern})\s*\{{?\s*$",
+        RegexOptions.Compiled);
+    private static readonly Regex CSharpConfirmedMethodPrefixRegex = new(
+        $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|volatile|unsafe|extern|async|file|ref(?:\s+readonly)?)\s+)*(?!{CSharpNonTypeKeywordPattern})(?:{CSharpTypePattern})\s+(?:{CSharpExplicitInterfaceQualifierPattern}\s*\.\s*)?(?:{CSharpIdentifierPattern})\s*{CSharpMethodTypeParameterListPattern}\([^{{}};]*\)\s*\{{?\s*$",
         RegexOptions.Compiled);
     private static readonly Regex CSharpStandaloneAccessorRegex = new(
         @"^\s*(?:(?:protected\s+internal|private\s+protected|protected|internal|private|public)\s+)*(?:readonly\s+)*(?:get|set|init)\b",

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -3337,7 +3337,7 @@ public static partial class SymbolExtractor
     // `const` も他の field 対応修飾子と一緒に列挙する。Closes #355.
     private static readonly Regex CSharpPropertyHeaderPrefixRegex = new($@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|volatile|unsafe|extern|const|ref(?:\s+readonly)?)\s+)*(?:{CSharpTypePattern})\s*(?:{CSharpIdentifierPattern})?\s*\{{?\s*$", RegexOptions.Compiled);
     private static readonly Regex CSharpMethodHeaderPrefixRegex = new(
-        $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|volatile|unsafe|extern|async|file|ref(?:\s+readonly)?)\s+)*(?!{CSharpNonTypeKeywordPattern})(?:{CSharpTypePattern})\s+(?:{CSharpExplicitInterfaceQualifierPattern}\s*\.\s*)?(?:{CSharpIdentifierPattern})\s*(?:<[^{{}};=]*|{CSharpMethodTypeParameterListPattern}\([^{{}};]*)\s*$",
+        $@"^\s*(?:(?:{CSharpVisibilityPattern})\s+|(?:static|virtual|override|abstract|sealed|new|required|partial|readonly|volatile|unsafe|extern|async|file|ref(?:\s+readonly)?)\s+)*(?!{CSharpNonTypeKeywordPattern})(?:{CSharpTypePattern})\s+(?:{CSharpExplicitInterfaceQualifierPattern}\s*\.\s*)?(?:{CSharpIdentifierPattern})\s*(?:<[^{{}};=]*|{CSharpMethodTypeParameterListPattern}\([^){{}};]*)\s*$",
         RegexOptions.Compiled);
     // Limit only the lightweight confirmation phase. Once a candidate looks like a real
     // declaration (`name =`, or a named member header before `{`), BuildCSharpPropertyMatchLine

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -8464,6 +8464,38 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_MultilineGenericMethodOverloadsKeepDistinctSignatures()
+    {
+        var content = """
+            public class Service
+            {
+                public void M<T>(
+                    T value)
+                {
+                }
+
+                public void M<T,
+                    U>(
+                    T first,
+                    U second)
+                {
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var overloads = symbols
+            .Where(s => s.Kind == "function" && s.Name == "M")
+            .OrderBy(s => s.StartLine)
+            .ToArray();
+
+        Assert.Equal(2, overloads.Length);
+        Assert.Equal("public void M<T>( T value) {", overloads[0].Signature);
+        Assert.Equal("public void M<T, U>( T first, U second) {", overloads[1].Signature);
+        Assert.NotEqual(overloads[0].Signature, overloads[1].Signature);
+    }
+
+    [Fact]
     public void Extract_CSharp_CtorRegex_StillCapturesAllValidCtorForms()
     {
         // The #349 fix tightens the ctor regex with a negative lookahead that rejects lines where


### PR DESCRIPTION
## Summary

- Merge multiline C# method headers when generic type parameter lists or parameter lists continue across physical lines.
- Preserve distinct symbols/signatures for generic overloads such as `M<T>` and `M<T, U>`.
- Add regression coverage and a bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_MultilineGenericMethodOverloadsKeepDistinctSignatures"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln -c Release --no-build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/1982.fixed.md`.
- No README/API docs update: this fixes C# symbol extraction behavior without changing CLI flags or documented command contracts.

## Review

- Adversarial review: `codex exec` attempt failed due local usage limit; manual review of `origin/main..HEAD` found no blocking/actionable issues.

## Follow-up Candidates

- None.

Fixes #1982
