### PR TITLE
Relax InstallScript extraction budget

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -40,6 +40,8 @@ The test project mirrors the production areas closely.
   End-to-end upgrade path: seeds a pre-column legacy DB, opens it through `TryMigrateForRead`, and exercises the read paths that touch nullable symbol ordinals (outline, symbol search, nearby, unused, analyze bundle) to lock in the real-world failure mode behind #58 / #49.
 - `IndexCommandRunnerTests.cs`, `QueryCommandRunnerTests.cs`, `ProgramCliTests.cs`, `InstallScriptTests.cs`
   CLI parsing, command execution, and installer behavior. `ProgramCliTests.cs` covers top-level entrypoint behavior that must be exercised through a subprocess, while `InstallScriptTests.cs` runs focused bash snippets against `install.sh` in library mode to lock in release-installer regressions without performing real network installs.
+- `SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget`
+  is a coarse runaway guard for the real `InstallScriptTests.cs` C# extraction fixture. Its wall-clock budget is intentionally broader than a benchmark so slower or noisy CI hosts do not fail the suite for ordinary variance.
 - `McpServerTests.cs`
   MCP JSON-RPC behavior and tool outputs.
 - `GitHelperTests.cs`
@@ -213,6 +215,8 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
   エンドツーエンドのアップグレード経路: カラム追加前のレガシー DB を用意し、`TryMigrateForRead` 経由で開いてから NULL になりうるシンボル列を触る read path（outline、シンボル検索、近傍、unused、analyze バンドル）を一通り叩き、#58 / #49 の実機失敗モードを固定する。
 - `IndexCommandRunnerTests.cs`、`QueryCommandRunnerTests.cs`、`ProgramCliTests.cs`、`InstallScriptTests.cs`
   CLI の引数解析、コマンド実行、installer 挙動のテスト。`ProgramCliTests.cs` はグローバル引数の解釈や完全な CLI 起動フローのように subprocess 経由で確認すべき Program エントリポイント挙動を扱い、`InstallScriptTests.cs` は `install.sh` を library mode で source した bash snippet を実行して、実ネットワーク install を行わずに release installer の回帰を固定する。
+- `SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget`
+  は実ファイル `InstallScriptTests.cs` を C# 抽出に通す coarse な runaway guard です。wall-clock の予算は benchmark より意図的に広く取り、遅い / 混雑した CI host で通常の揺れだけにより suite が失敗しないようにしています。
 - `McpServerTests.cs`
   MCP の JSON-RPC 挙動とツール出力のテスト。
 - `GitHelperTests.cs`

--- a/changelog.d/unreleased/2285.internal.md
+++ b/changelog.d/unreleased/2285.internal.md
@@ -1,0 +1,16 @@
+---
+category: internal
+issues:
+  - 2285
+affected:
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Relaxed the C# InstallScript extraction runaway guard (#2285)** — the real `InstallScriptTests.cs` fixture still exercises the #447 raw-string/heredoc regression shape, but the wall-clock budget now allows slower or noisy CI hosts instead of failing on ordinary variance.
+
+## 日本語
+
+- **C# InstallScript 抽出の runaway guard を緩和しました (#2285)** — 実ファイル `InstallScriptTests.cs` による #447 の raw-string/heredoc 回帰形状は引き続き検証しつつ、wall-clock 予算を広げて遅い / 混雑した CI host の通常の揺れで失敗しないようにしました。

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -22787,10 +22787,12 @@ public class SymbolExtractorTests
         // issue #447 regression: the real InstallScriptTests fixture previously drove C#
         // symbol extraction into super-linear CPU time. Use the repository's current copy so
         // the regression test keeps exercising the same realistic raw-string + heredoc shape
-        // that broke self-indexing, but keep the budget generous enough for slower CI hosts.
+        // that broke self-indexing. This is a coarse runaway guard, not a tight benchmark, so
+        // keep the budget generous enough for slower or noisy CI hosts.
         // issue #447 回帰: 実ファイル InstallScriptTests.cs が C# シンボル抽出を super-linear に
         // 悪化させていた。自己ホストを壊した raw-string + heredoc の実形を継続的に踏むため、
-        // リポジトリ内の現行ファイルをそのまま使う。時間予算は遅い CI でも耐えるよう広めに取る。
+        // リポジトリ内の現行ファイルをそのまま使う。これは厳密な benchmark ではなく runaway
+        // guard なので、時間予算は遅い / 混雑した CI でも耐えるよう広めに取る。
         var path = Path.Combine(GetRepositoryRoot(), "tests", "CodeIndex.Tests", "InstallScriptTests.cs");
         var content = File.ReadAllText(path);
 
@@ -22801,8 +22803,8 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "InstallScriptTests");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Main_WithoutExplicitVersion_DoesNotShortCircuitBrokenZeroVersionInstall");
         Assert.True(
-            stopwatch.Elapsed < TimeSpan.FromSeconds(10),
-            $"InstallScriptTests.cs extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < 10s.");
+            stopwatch.Elapsed < TimeSpan.FromSeconds(20),
+            $"InstallScriptTests.cs extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < 20s.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Relax the C# `InstallScriptTests.cs` extraction runaway guard from 10s to 20s so normal slow/noisy CI variance no longer fails the suite.
- Document that this fixture is a coarse runaway guard rather than a benchmark.
- Add an unreleased bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `git diff --check origin/main..HEAD`

## Documentation / Changelog

- Updated `TESTING_GUIDE.md`.
- Added `changelog.d/unreleased/2285.internal.md`.

## Review

- Adversarial review performed for `origin/main..HEAD`: no blocking/actionable issues found after recreating the branch on latest `origin/main`.
- Separate `codex exec` review attempt was blocked by usage limit, so the review was completed in-session using the repository workflow.

## Follow-up Candidates

- None.

Fixes #2285
