### PR TITLE
Fix release install verification and dirty version stamp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,10 +400,20 @@ jobs:
           test -f "$CDIDX_INSTALL_DIR/LICENSES/Apache-2.0.txt"
 
           # --version must reflect the tag, not the v0.0.0 fallback.
+          # Since #1550 `cdidx --version` is `cdidx v<ver>` optionally
+          # followed by a ` (commit <sha>, built <date>, <clean|dirty>)`
+          # build-metadata suffix, so anchor on the `cdidx <tag>` prefix
+          # instead of an exact match — a wrong version still fails because
+          # the suffix can only ever follow a space.
           EXPECTED="cdidx ${TAG_NAME}"
           ACTUAL="$("$CDIDX_INSTALL_DIR/cdidx" --version)"
-          [ "$ACTUAL" = "$EXPECTED" ] \
-            || { echo "Version mismatch: expected '$EXPECTED', got '$ACTUAL'" >&2; exit 1; }
+          case "$ACTUAL" in
+            "$EXPECTED"|"$EXPECTED "*) ;;
+            *)
+              echo "Version mismatch: expected '$EXPECTED' (optionally followed by build metadata), got '$ACTUAL'" >&2
+              exit 1
+              ;;
+          esac
 
           # A command that touches SQLite must not DllNotFoundException.
           "$CDIDX_INSTALL_DIR/cdidx" . >/dev/null

--- a/changelog.d/unreleased/+release-version-verification.fixed.md
+++ b/changelog.d/unreleased/+release-version-verification.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - .github/workflows/release.yml
+  - src/CodeIndex/CodeIndex.csproj
+---
+
+## English
+
+- **Release install verification accepts the `--version` build-metadata suffix** — the release workflow's install check compared `cdidx --version` for an exact `cdidx v<tag>` match, so it failed on every release after the build-aware `--version` change (#1550) because the binary now prints a trailing ` (commit <sha>, built <date>, <clean|dirty>)` block. The check is now anchored on the `cdidx v<tag>` prefix, matching the `install.sh` validator.
+- **Tagged release builds no longer stamp `--version` as `dirty`** — the RID-targeted `dotnet publish` step rewrites `packages.lock.json` with runtime-specific entries before the build-metadata target re-runs, which made a clean tagged release report `dirty`. The dirty probe now excludes every `packages.lock.json`; genuine lock drift is still caught by the locked-mode restore in CI.
+
+## 日本語
+
+- **リリースのインストール検証が `--version` のビルドメタデータ接尾辞を受け入れるようになりました** — release workflow のインストール検証は `cdidx --version` を `cdidx v<tag>` と完全一致で比較していたため、ビルド情報付き `--version` 化 (#1550) 以降はバイナリが末尾に ` (commit <sha>, built <date>, <clean|dirty>)` を出力するようになり、すべてのリリースで失敗していました。検証を `cdidx v<tag>` 接頭辞での照合に変更し、`install.sh` のバリデータと揃えました。
+- **タグ付きリリースビルドの `--version` が `dirty` と刻まれなくなりました** — RID 指定の `dotnet publish` がビルドメタデータターゲット再実行前に `packages.lock.json` へ runtime 固有エントリを書き込むため、クリーンなタグ付きリリースまで `dirty` と報告されていました。dirty 判定からすべての `packages.lock.json` を除外しました。lock の本当のドリフトは CI の locked-mode restore が引き続き検出します。

--- a/src/CodeIndex/CodeIndex.csproj
+++ b/src/CodeIndex/CodeIndex.csproj
@@ -55,9 +55,19 @@
     `cdidx version` flag can distinguish dev builds from tagged releases
     (#1550). XML comments may not contain a double-dash, so we avoid the
     literal flag spelling here.
+    The dirty probe excludes every `packages.lock.json`: the release
+    workflow's RID-targeted `dotnet publish` step legitimately rewrites
+    the lock file with RID-specific entries before this target re-runs, so
+    a plain repo-wide probe would stamp a clean tagged release as `dirty`.
+    Genuine lock drift is still caught by the locked-mode SLN restore in CI.
     バグ報告で dev ビルドとリリースタグを区別できるよう、commit SHA / build
     date / dirty フラグをアセンブリに刻む (#1550)。XML コメント内には連続した
     ダッシュを書けないため、フラグ名そのものを記述しない。
+    dirty 判定からは `packages.lock.json` を除外する。release workflow の
+    RID 指定 `dotnet publish` は本ターゲット再実行前に lock ファイルへ
+    RID 固有エントリを正当に書き込むため、除外しないとクリーンなタグ
+    リリースまで `dirty` と刻まれてしまう。lock の本当のドリフトは CI の
+    locked-mode SLN restore が引き続き検出する。
   -->
   <Target Name="StampCdidxBuildMetadata" BeforeTargets="GetAssemblyAttributes">
     <Exec Command="git rev-parse --short=7 HEAD"
@@ -70,7 +80,7 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="CdidxGitShaRaw" />
       <Output TaskParameter="ExitCode" PropertyName="CdidxGitShaExitCode" />
     </Exec>
-    <Exec Command="git diff-index --quiet HEAD --"
+    <Exec Command="git diff-index --quiet HEAD -- &quot;:/&quot; &quot;:(top,exclude,glob)**/packages.lock.json&quot;"
           ContinueOnError="true"
           IgnoreExitCode="true"
           EchoOff="true"


### PR DESCRIPTION
## Problem

The `Release` workflow run for **v1.22.0** failed at the `create-release` job's
install-verification step:

```
Version mismatch: expected 'cdidx v1.22.0', got 'cdidx v1.22.0 (commit dffc547, built 2026-05-17, dirty)'
Error: Process completed with exit code 1.
```

Two separate defects in the release pipeline, both stemming from the
build-aware `--version` change (#1550) never being exercised end-to-end on the
release path:

1. **Exact-match verification.** `.github/workflows/release.yml` compared
   `cdidx --version` for an exact `cdidx v<tag>` match. Since #1550 the binary
   prints a trailing ` (commit <sha>, built <date>, <clean|dirty>)`
   build-metadata block, so the check would fail on **every** release after
   #1550 — even a perfectly clean build. `install.sh`'s own validator was
   updated for #1550, but this separate workflow check was missed.

2. **`dirty` stamp on a clean tagged build.** The RID-targeted
   `dotnet publish` step rewrites `packages.lock.json` with runtime-specific
   entries before the build-metadata MSBuild target re-runs, so the repo-wide
   dirty probe saw a modified tracked file and stamped the tagged release as
   `dirty`.

## Fix

- **release.yml** — anchor the verification on the `cdidx v<tag>` prefix
  (accepting an optional ` (...)` build-metadata suffix), matching the
  `install.sh` validator. A wrong version still fails.
- **CodeIndex.csproj** — exclude every `packages.lock.json` from the dirty
  probe (`git diff-index ... ":(top,exclude,glob)**/packages.lock.json"`).
  Genuine lock drift is still caught by the locked-mode SLN restore in CI;
  real source modifications still stamp `dirty`.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -c Release` — succeeds; the
  MSBuild `Exec` pathspec parses correctly.
- Verified directly with git: a `packages.lock.json`-only modification is
  excluded by the new pathspec (exit 0), while a genuine source modification
  still reports dirty (exit 1).
- No automated tests cover CI workflow YAML or the MSBuild dirty probe; the
  `--version` output format is unchanged, so existing `#1550` tests still hold.

## Note for the release

The `v1.22.0` tag/GitHub release already exist from the failed run. After this
PR merges, re-tag `v1.22.0` onto the fixed commit (or follow the
`release-changelog.md` partial-failure recovery steps) and re-run the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
