### PR TITLE
Wait for sha256sums.txt to propagate in release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,29 +357,49 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
-          ASSET_NAME: CodeIndex-linux-x64.tar.gz
+          # install.sh downloads BOTH the linux-x64 tarball and sha256sums.txt,
+          # and the CDN can propagate each release asset independently. Polling
+          # only the tarball let the verify step run while sha256sums.txt was
+          # still 404 on the download CDN, which is exactly how the v1.22.1
+          # release failed ("Failed to download sha256sums.txt ... HTTP 404").
+          # Poll every asset the verify step fetches so a slow-propagating
+          # asset is waited out instead of failing the release.
+          # install.sh は linux-x64 tarball と sha256sums.txt の両方を
+          # ダウンロードし、CDN は各 release asset を独立に伝播させる。
+          # tarball だけをポーリングしていたため、sha256sums.txt がまだ
+          # download CDN 上で 404 のまま verify step が走り、v1.22.1 の
+          # リリースが "Failed to download sha256sums.txt ... HTTP 404" で
+          # 失敗した。verify step が取得する全 asset をポーリングし、伝播の
+          # 遅い asset があってもリリースを失敗させず待ち切る。
+          ASSET_NAMES: CodeIndex-linux-x64.tar.gz sha256sums.txt
         run: |
           set -euo pipefail
           # gh release create returns once the GitHub API records the assets,
           # but the public download URL (download/<tag>/<asset>) is served via
-          # a CDN that can lag a few seconds. Poll the actual download URL
-          # before running install.sh so the verify step doesn't 404 on a
-          # transient propagation gap.
+          # a CDN that can lag a few seconds. Poll each download URL before
+          # running install.sh so the verify step doesn't 404 on a transient
+          # propagation gap.
           # gh release create は API 反映直後に戻るが、download URL は CDN
           # 経由で配信されるため数秒のラグが起きうる。install.sh が 404 で
-          # 落ちないよう、download URL 自体が取得可能になるまでポーリングする。
-          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG_NAME}/${ASSET_NAME}"
-          for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            code="$(curl -fsSL -o /dev/null -w '%{http_code}' -I "$url" || true)"
-            if [ "$code" = "200" ]; then
-              echo "Asset reachable after $attempt attempt(s)."
-              exit 0
+          # 落ちないよう、各 download URL が取得可能になるまでポーリングする。
+          for asset in $ASSET_NAMES; do
+            url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG_NAME}/${asset}"
+            reachable=
+            for attempt in 1 2 3 4 5 6 7 8 9 10; do
+              code="$(curl -fsSL -o /dev/null -w '%{http_code}' -I "$url" || true)"
+              if [ "$code" = "200" ]; then
+                echo "Asset ${asset} reachable after $attempt attempt(s)."
+                reachable=1
+                break
+              fi
+              echo "Attempt $attempt: ${asset} HTTP $code, retrying in 5s..."
+              sleep 5
+            done
+            if [ -z "$reachable" ]; then
+              echo "Asset $url did not become reachable in time." >&2
+              exit 1
             fi
-            echo "Attempt $attempt: HTTP $code, retrying in 5s..."
-            sleep 5
           done
-          echo "Asset $url did not become reachable in time." >&2
-          exit 1
 
       - name: Verify install.sh against the published release
         env:

--- a/changelog.d/unreleased/+release-asset-propagation-wait.fixed.md
+++ b/changelog.d/unreleased/+release-asset-propagation-wait.fixed.md
@@ -1,0 +1,13 @@
+---
+category: fixed
+affected:
+  - .github/workflows/release.yml
+---
+
+## English
+
+- **Release workflow now waits for `sha256sums.txt` to propagate before verifying the install** — the install-verification step polled only the platform tarball, so a release could fail when the CDN had not yet served `sha256sums.txt` (the v1.22.1 release failed with `Failed to download sha256sums.txt ... HTTP 404`). The wait step now polls every asset `install.sh` downloads, so an asset that propagates slowly is waited out instead of failing the release.
+
+## 日本語
+
+- **リリースワークフローがインストール検証前に `sha256sums.txt` の伝播を待つようになりました** — インストール検証ステップはプラットフォーム tarball のみをポーリングしていたため、CDN がまだ `sha256sums.txt` を配信していない場合にリリースが失敗していました（v1.22.1 のリリースが `Failed to download sha256sums.txt ... HTTP 404` で失敗）。待機ステップは `install.sh` がダウンロードする全 asset をポーリングするようになり、伝播の遅い asset があってもリリースを失敗させず待ち切ります。


### PR DESCRIPTION
## Problem

The `Release` workflow run for **v1.22.1** failed at the `create-release` job's
install-verification step:

```
==> Downloading CodeIndex-linux-x64.tar.gz...
==> Downloading checksums...
ERROR: Failed to download sha256sums.txt from GitHub release host at
https://github.com/Widthdom/CodeIndex/releases/download/v1.22.1/sha256sums.txt
(HTTP 404).
Error: Process completed with exit code 1.
```

The tarball downloaded fine, but `sha256sums.txt` 404'd. The `Wait for release
assets to be downloadable` step polls the GitHub download CDN before running
`install.sh` precisely to absorb the few-second propagation lag — but it polled
**only** `CodeIndex-linux-x64.tar.gz`. `install.sh` downloads *both* the
platform tarball *and* `sha256sums.txt`, and the CDN propagates each release
asset independently. The verify step ran as soon as the tarball was reachable,
while `sha256sums.txt` was still 404 on the CDN.

## Fix

`.github/workflows/release.yml` — make the wait step poll **every** asset
`install.sh` fetches (the linux-x64 tarball and `sha256sums.txt`) instead of
just the tarball. A slow-propagating asset is now waited out (10 × 5s per
asset) instead of failing the release. A genuinely missing asset still fails
the step.

## Validation

- This is a CI-workflow-only change; there is no automated test coverage for
  release workflow YAML, consistent with prior release-workflow fixes (#2314).
- `dotnet run --project tools/CodeIndex.Changelog -- check` — passes (the new
  bilingual fragment validates).
- Reviewed the polling loop: each asset gets its own retry budget, `reachable`
  is reset per asset, and an unreachable asset exits non-zero with the URL.

## Note for the release

The `v1.22.1` tag and GitHub release already exist from the failed run, and the
assets (including `sha256sums.txt`) are published. After this PR merges, simply
re-run the failed `Release` workflow (or the `create-release` job) — the assets
are long since propagated, so verification will pass. Future releases get the
robust multi-asset wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
