### PR TITLE
Fix C# implicit partial method symbols

### DIFF
--- a/changelog.d/unreleased/1981.fixed.md
+++ b/changelog.d/unreleased/1981.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1981
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C# partial methods with omitted return types now index as `void` (#1981)** — `symbols` / `definition` no longer drop old-style `partial M();` declarations when their return type is implied.
+
+## 日本語
+
+- **戻り値型を省略した C# partial method を `void` としてインデックスするようになりました (#1981)** — 古い形式の `partial M();` 宣言で戻り値型が暗黙の場合でも、`symbols` / `definition` から欠落しなくなりました。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -1091,6 +1091,23 @@ public static partial class SymbolExtractor
             && pattern.BodyStyle == BodyStyle.None
             && pattern.ReturnTypeGroup != null;
 
+    private static string? NormalizeCSharpImplicitPartialMethodReturnType(
+        string? lang,
+        SymbolPattern pattern,
+        Match match,
+        string? returnType)
+    {
+        if (lang == "csharp"
+            && pattern.Kind == "function"
+            && pattern.ReturnTypeGroup != null
+            && returnType == "partial")
+        {
+            return "void";
+        }
+
+        return returnType;
+    }
+
     private static bool HasInvalidCSharpReturnTypeSuffix(string? returnType)
     {
         if (string.IsNullOrWhiteSpace(returnType))

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -1108,6 +1108,22 @@ public static partial class SymbolExtractor
         return returnType;
     }
 
+    private static void NormalizeCSharpImplicitPartialConstructorReturnTypes(List<SymbolRecord> symbols)
+    {
+        foreach (var symbol in symbols)
+        {
+            var signature = symbol.Signature?.TrimStart();
+            if (symbol.Kind == "function"
+                && symbol.ReturnType == "void"
+                && string.Equals(symbol.Name, symbol.ContainerName, StringComparison.Ordinal)
+                && signature != null
+                && CSharpPartialFunctionDeclarationSignatureRegex.IsMatch(signature))
+            {
+                symbol.ReturnType = null;
+            }
+        }
+    }
+
     private static bool HasInvalidCSharpReturnTypeSuffix(string? returnType)
     {
         if (string.IsNullOrWhiteSpace(returnType))

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1122,6 +1122,13 @@ public static partial class SymbolExtractor
             // CSharpTupleSuffixPattern を CSharpTypePattern と共有することで、ctor 否定先読みと上流の
             // property / method / plain-field 行が tuple サフィックス戻り値の受理形について常に一致する。Closes #349.
             new("function",  new Regex($@"^\s*(?:(?:unsafe|extern)\s+)*(?<visibility>{CSharpVisibilityPattern})\s+(?:(?:unsafe|extern|partial)\s+)*(?<name>{CSharpIdentifierPattern})\s*\((?!.*\){CSharpTupleSuffixPattern}\s*{CSharpIdentifierPattern}\s*(?:[{{(;]|=>|=(?![=>])))", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // Partial method declaration with an omitted return type. Older partial-method
+            // syntax can omit the accessibility modifier and still mean `void`; keep this
+            // after the constructor row so `public partial Widget();` remains a constructor.
+            // 戻り値型を省略した partial method 宣言。旧来の partial method 構文では
+            // accessibility を省略し、戻り値型は `void` とみなされる。`public partial Widget();`
+            // は constructor のまま扱うため、この行は constructor 行の後ろに置く。
+            new("function",  new Regex($@"^\s*(?:(?:static|sealed|readonly|unsafe|extern|virtual|override|abstract|async|new|file|ref(?:\s+readonly)?)\s+)*(?<returnType>partial)\s+(?<name>{CSharpIdentifierPattern})\s*{CSharpMethodTypeParameterListPattern}\(", RegexOptions.Compiled), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
             // Static constructor / 静的コンストラクタ
             // Keep this ahead of the property rows so same-line compact bodies such as
             // `class C { static C() { } public int P { get; set; } }` emit the static ctor
@@ -2587,7 +2594,11 @@ public static partial class SymbolExtractor
                         lineOffset = FindNextSameLineBraceStatementStart(matchLine, absoluteStartColumn + Math.Max(1, match.Length), lang);
                         continue;
                     }
-                    var rawReturnType = TryGetGroup(match, pattern.ReturnTypeGroup);
+                    var rawReturnType = NormalizeCSharpImplicitPartialMethodReturnType(
+                        lang,
+                        pattern,
+                        match,
+                        TryGetGroup(match, pattern.ReturnTypeGroup));
                       if (lang == "csharp"
                           && pattern.ReturnTypeGroup != null
                           && HasInvalidCSharpReturnTypeSuffix(rawReturnType))

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3791,6 +3791,8 @@ public static partial class SymbolExtractor
         if (lang == "php")
             ExtractPhpDocblockImportTypeSymbols(fileId, lines, symbols);
         AssignContainers(symbols, lines, csharpLineStartStates);
+        if (lang == "csharp")
+            NormalizeCSharpImplicitPartialConstructorReturnTypes(symbols);
         if (lang == "go")
             AssignGoMethodReceiverContainers(symbols);
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10597,12 +10597,13 @@ public class SymbolExtractorTests
     public void Extract_CSharp_DetectsPartialMethods()
     {
         // C# 9 extended partial methods / C# 9 拡張 partial メソッド
-        var content = "public partial class App\n{\n    partial void OnInit();\n    public partial string GetName();\n}";
+        var content = "public partial class App\n{\n    partial void OnInit();\n    partial OnImplicit();\n    public partial string GetName();\n}";
         var symbols = SymbolExtractor.Extract(1, "csharp", content);
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "App");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "OnInit");
-        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "GetName");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "OnInit" && s.ReturnType == "void");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "OnImplicit" && s.ReturnType == "void");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "GetName" && s.ReturnType == "string");
     }
 
     [Fact]
@@ -10623,7 +10624,8 @@ public class SymbolExtractorTests
             s.Kind == "function"
             && s.Name == "Widget"
             && s.Line == 3
-            && s.Visibility == "public");
+            && s.Visibility == "public"
+            && s.ReturnType == null);
         Assert.Contains(symbols, s =>
             s.Kind == "function"
             && s.Name == "Widget"

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -10613,6 +10613,7 @@ public class SymbolExtractorTests
             public partial class Widget
             {
                 public partial Widget();
+                partial Widget();
                 public partial Widget() { }
                 unsafe public partial Widget(int* ptr) { }
             }
@@ -10630,13 +10631,18 @@ public class SymbolExtractorTests
             s.Kind == "function"
             && s.Name == "Widget"
             && s.Line == 4
+            && s.ReturnType == null);
+        Assert.Contains(symbols, s =>
+            s.Kind == "function"
+            && s.Name == "Widget"
+            && s.Line == 5
             && s.Visibility == "public"
             && s.BodyStartLine is not null
             && s.BodyEndLine is not null);
         Assert.Contains(symbols, s =>
             s.Kind == "function"
             && s.Name == "Widget"
-            && s.Line == 5
+            && s.Line == 6
             && s.Visibility == "public");
     }
 


### PR DESCRIPTION
## Summary

- Index old-style C# `partial M();` declarations as functions with inferred `void` return type.
- Preserve partial constructor handling when the constructor omits visibility, so `partial Widget();` remains constructor-like with no return type.
- Add regression coverage for explicit `void`, inferred `void`, typed partial methods, and partial constructors.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_DetectsPartialMethods|FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_DetectsPartialConstructors"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet build CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/1981.fixed.md`
- No README / guide updates required; this is extractor behavior for existing symbol output.

## Review

- Codex adversarial review found one blocking overlap with omitted-visibility partial constructors.
- Follow-up fix added and second adversarial review reported: `No blocking/actionable issues found.`

Fixes #1981
