### PR TITLE
Add extractor regression coverage

### DIFF
--- a/changelog.d/unreleased/1815.internal.md
+++ b/changelog.d/unreleased/1815.internal.md
@@ -1,0 +1,16 @@
+---
+category: internal
+issues:
+  - 1815
+affected:
+  - tests/CodeIndex.Tests/ReferenceExtractorProductionCoverageTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Added regression coverage for production reference and Swift symbol extractors (#1815)** — Swift, Objective-C, Gradle, Terraform, PowerShell, and Batch reference extraction now have focused tests, and Swift symbol extraction has representative declaration coverage.
+
+## 日本語
+
+- **本番 reference extractor と Swift symbol extractor の回帰テストを追加しました (#1815)** — Swift、Objective-C、Gradle、Terraform、PowerShell、Batch の reference 抽出に focused test を追加し、Swift の symbol 抽出にも代表的な宣言種別のテストを追加しました。

--- a/tests/CodeIndex.Tests/ReferenceExtractorProductionCoverageTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorProductionCoverageTests.cs
@@ -1,0 +1,479 @@
+using CodeIndex.Indexer;
+using CodeIndex.Models;
+
+namespace CodeIndex.Tests;
+
+public class SwiftReferenceExtractorTests
+{
+    [Fact]
+    public void Extract_Swift_BasicCall_IsReferenced()
+    {
+        var references = Extract("""
+            func login() {
+                authenticate()
+            }
+            """);
+
+        AssertCall(references, "authenticate");
+    }
+
+    [Fact]
+    public void Extract_Swift_QualifiedCall_UsesInvokedMemberName()
+    {
+        var references = Extract("""
+            func run() {
+                ServiceFactory.shared.makeClient()
+            }
+            """);
+
+        AssertCall(references, "makeClient");
+    }
+
+    [Fact]
+    public void Extract_Swift_MethodCallOnChain_IsReferenced()
+    {
+        var references = Extract("""
+            func run(items: [Item]) {
+                items.publisher().compactMap(transform).sink(receiveValue: save)
+            }
+            """);
+
+        AssertCall(references, "publisher");
+        AssertCall(references, "compactMap");
+        AssertCall(references, "sink");
+    }
+
+    [Fact]
+    public void Extract_Swift_TypePositions_AreTypeReferences()
+    {
+        var references = Extract("""
+            func handle(value: Payload) -> ResultWrapper {
+                let model: UserModel = load()
+                if model is PremiumUser {
+                    publish(model)
+                }
+                return ResultWrapper()
+            }
+            """);
+
+        AssertTypeReference(references, "Payload");
+        AssertTypeReference(references, "ResultWrapper");
+        AssertTypeReference(references, "UserModel");
+        AssertTypeReference(references, "PremiumUser");
+    }
+
+    [Fact]
+    public void Extract_Swift_CommentsAndDeclarations_DoNotEmitCalls()
+    {
+        var references = Extract("""
+            func declaredOnly() {}
+            // ignoredCall()
+            let value = "fakeCall()"
+            """);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "declaredOnly" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "ignoredCall");
+        Assert.DoesNotContain(references, r => r.SymbolName == "fakeCall");
+    }
+
+    private static IReadOnlyList<ReferenceRecord> Extract(string content)
+    {
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        return ReferenceExtractor.Extract(1, "swift", content, symbols);
+    }
+
+    private static void AssertCall(IReadOnlyCollection<ReferenceRecord> references, string symbolName)
+        => Assert.Contains(references, r => r.SymbolName == symbolName && r.ReferenceKind == "call");
+
+    private static void AssertTypeReference(IReadOnlyCollection<ReferenceRecord> references, string symbolName)
+        => Assert.Contains(references, r => r.SymbolName == symbolName && r.ReferenceKind == "type_reference");
+}
+
+public class ObjectiveCReferenceExtractorTests
+{
+    [Fact]
+    public void Extract_ObjectiveC_CFunctionCall_IsReferenced()
+    {
+        var references = Extract("""
+            void Run(void) {
+                CFRelease(token);
+            }
+            """);
+
+        AssertCall(references, "CFRelease");
+    }
+
+    [Fact]
+    public void Extract_ObjectiveC_ClassMessage_IsReferenced()
+    {
+        var references = Extract("""
+            void Run(void) {
+                id client = [HTTPClient sharedClient];
+            }
+            """);
+
+        AssertCall(references, "sharedClient");
+    }
+
+    [Fact]
+    public void Extract_ObjectiveC_ChainedMessage_IsReferenced()
+    {
+        var references = Extract("""
+            void Run(void) {
+                id client = [HTTPClient sharedClient];
+                id request = [client requestBuilder];
+                [request send];
+            }
+            """);
+
+        AssertCall(references, "sharedClient");
+        AssertCall(references, "requestBuilder");
+        AssertCall(references, "send");
+    }
+
+    [Fact]
+    public void Extract_ObjectiveC_TypePositions_AreTypeReferences()
+    {
+        var references = Extract("""
+            @interface Controller : BaseController <ControllerDelegate>
+            @property (nonatomic, strong) UserModel *model;
+            - (Result *)handle:(Payload *)payload;
+            @end
+            """);
+
+        AssertTypeReference(references, "BaseController");
+        AssertTypeReference(references, "ControllerDelegate");
+        AssertTypeReference(references, "UserModel");
+    }
+
+    [Fact]
+    public void Extract_ObjectiveC_CommentsAndDeclarations_DoNotEmitCalls()
+    {
+        var references = Extract("""
+            @interface Service
+            - (void)declaredOnly;
+            @end
+            // [Service ignoredCall];
+            NSString *text = @"fakeCall()";
+            """);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "declaredOnly" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "ignoredCall");
+        Assert.DoesNotContain(references, r => r.SymbolName == "fakeCall");
+    }
+
+    private static IReadOnlyList<ReferenceRecord> Extract(string content)
+    {
+        var symbols = SymbolExtractor.Extract(1, "objc", content);
+        return ReferenceExtractor.Extract(1, "objc", content, symbols);
+    }
+
+    private static void AssertCall(IReadOnlyCollection<ReferenceRecord> references, string symbolName)
+        => Assert.Contains(references, r => r.SymbolName == symbolName && r.ReferenceKind == "call");
+
+    private static void AssertTypeReference(IReadOnlyCollection<ReferenceRecord> references, string symbolName)
+        => Assert.Contains(references, r => r.SymbolName == symbolName && r.ReferenceKind == "type_reference");
+}
+
+public class GradleReferenceExtractorTests
+{
+    [Fact]
+    public void Extract_Gradle_BlockDslCall_IsReferenced()
+    {
+        var references = Extract("""
+            plugins {
+                id 'java'
+            }
+            """);
+
+        AssertCall(references, "plugins");
+    }
+
+    [Fact]
+    public void Extract_Gradle_CommandDslCall_IsReferenced()
+    {
+        var references = Extract("""
+            apply plugin: 'java'
+            """);
+
+        AssertCall(references, "apply");
+    }
+
+    [Fact]
+    public void Extract_Gradle_TaskWithTypeArgument_IsReferenced()
+    {
+        var references = Extract("""
+            task buildJar(type: Jar) {
+                dependsOn compileJava
+            }
+            """);
+
+        AssertCall(references, "task");
+    }
+
+    [Fact]
+    public void Extract_Gradle_MethodCallOnChain_IsReferenced()
+    {
+        var references = Extract("""
+            dependencies {
+                implementation project(':core')
+                configurations.runtimeClasspath.get().files()
+            }
+            """);
+
+        AssertCall(references, "dependencies");
+        AssertCall(references, "implementation");
+        AssertCall(references, "project");
+        AssertCall(references, "get");
+        AssertCall(references, "files");
+    }
+
+    [Fact]
+    public void Extract_Gradle_AssignmentsAndComments_DoNotEmitCalls()
+    {
+        var references = Extract("""
+            version = '1.0'
+            group = 'demo'
+            // ignoredCall()
+            """);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "version" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "group" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "ignoredCall");
+    }
+
+    private static IReadOnlyList<ReferenceRecord> Extract(string content)
+    {
+        var symbols = SymbolExtractor.Extract(1, "gradle", content);
+        return ReferenceExtractor.Extract(1, "gradle", content, symbols);
+    }
+
+    private static void AssertCall(IReadOnlyCollection<ReferenceRecord> references, string symbolName)
+        => Assert.Contains(references, r => r.SymbolName == symbolName && r.ReferenceKind == "call");
+}
+
+public class TerraformReferenceExtractorTests
+{
+    [Fact]
+    public void Extract_Terraform_VariableReference_IsReferenced()
+    {
+        var references = Extract("""
+            variable "region" {}
+            output "region" {
+              value = var.region
+            }
+            """);
+
+        AssertReference(references, "region");
+    }
+
+    [Fact]
+    public void Extract_Terraform_ModuleReference_IsReferenced()
+    {
+        var references = Extract("""
+            module "network" {
+              source = "./network"
+            }
+            output "subnet" {
+              value = module.network.subnet_id
+            }
+            """);
+
+        AssertReference(references, "network");
+    }
+
+    [Fact]
+    public void Extract_Terraform_ResourceReference_IsReferenced()
+    {
+        var references = Extract("""
+            resource "aws_instance" "web" {}
+            output "id" {
+              value = aws_instance.web.id
+            }
+            """);
+
+        AssertReference(references, "web");
+    }
+
+    [Fact]
+    public void Extract_Terraform_DataReference_IsReferenced()
+    {
+        var references = Extract("""
+            data "aws_ami" "ubuntu" {}
+            output "ami" {
+              value = data.aws_ami.ubuntu.id
+            }
+            """);
+
+        AssertReference(references, "ubuntu");
+    }
+
+    [Fact]
+    public void Extract_Terraform_DefinitionsAndComments_DoNotEmitReferences()
+    {
+        var references = Extract("""
+            variable "region" {}
+            resource "aws_s3_bucket" "logs" {}
+            # var.ignored
+            output "literal" {
+              value = "module.fake"
+            }
+            """);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "region" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "logs" && r.ReferenceKind == "reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "ignored");
+        Assert.DoesNotContain(references, r => r.SymbolName == "fake");
+    }
+
+    private static IReadOnlyList<ReferenceRecord> Extract(string content)
+    {
+        var symbols = SymbolExtractor.Extract(1, "terraform", content);
+        return ReferenceExtractor.Extract(1, "terraform", content, symbols);
+    }
+
+    private static void AssertReference(IReadOnlyCollection<ReferenceRecord> references, string symbolName)
+        => Assert.Contains(references, r => r.SymbolName == symbolName && r.ReferenceKind == "reference");
+}
+
+public class PowerShellReferenceExtractorTests
+{
+    [Fact]
+    public void Extract_PowerShell_StatementStartCall_IsReferenced()
+    {
+        var references = Extract("""
+            Write-Host "hello"
+            """);
+
+        AssertCall(references, "Write-Host");
+    }
+
+    [Fact]
+    public void Extract_PowerShell_PipelineCall_IsReferenced()
+    {
+        var references = Extract("""
+            $items | ForEach-Object { Process-One $_ }
+            """);
+
+        AssertCall(references, "ForEach-Object");
+        AssertCall(references, "Process-One");
+    }
+
+    [Fact]
+    public void Extract_PowerShell_AssignmentCall_IsReferenced()
+    {
+        var references = Extract("""
+            $result = Invoke-RestMethod -Uri $Uri
+            """);
+
+        AssertCall(references, "Invoke-RestMethod");
+    }
+
+    [Fact]
+    public void Extract_PowerShell_ChainedPipelineCalls_AreReferenced()
+    {
+        var references = Extract("""
+            $items | Where-Object { $_.Enabled } | Select-Object Name
+            """);
+
+        AssertCall(references, "Where-Object");
+        AssertCall(references, "Select-Object");
+    }
+
+    [Fact]
+    public void Extract_PowerShell_OperatorsAndComments_DoNotEmitCalls()
+    {
+        var references = Extract("""
+            # Write-Host "ignored"
+            if ($count -lt 10) { return }
+            $name = "Fake-Call"
+            """);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "Write-Host");
+        Assert.DoesNotContain(references, r => r.SymbolName == "lt");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Fake-Call");
+    }
+
+    private static IReadOnlyList<ReferenceRecord> Extract(string content)
+    {
+        var symbols = SymbolExtractor.Extract(1, "powershell", content);
+        return ReferenceExtractor.Extract(1, "powershell", content, symbols);
+    }
+
+    private static void AssertCall(IReadOnlyCollection<ReferenceRecord> references, string symbolName)
+        => Assert.Contains(references, r => r.SymbolName == symbolName && r.ReferenceKind == "call");
+}
+
+public class BatchReferenceExtractorTests
+{
+    [Fact]
+    public void Extract_Batch_GotoTarget_IsReferenced()
+    {
+        var references = Extract("""
+            goto :Build
+            :Build
+            """);
+
+        AssertCall(references, "Build");
+    }
+
+    [Fact]
+    public void Extract_Batch_CallTarget_IsReferenced()
+    {
+        var references = Extract("""
+            call :RunTests
+            :RunTests
+            """);
+
+        AssertCall(references, "RunTests");
+    }
+
+    [Fact]
+    public void Extract_Batch_InlineCommandTargets_AreReferenced()
+    {
+        var references = Extract("""
+            goto :Build & call :Package
+            :Build
+            :Package
+            """);
+
+        AssertCall(references, "Build");
+        AssertCall(references, "Package");
+    }
+
+    [Fact]
+    public void Extract_Batch_ConditionalJumpTarget_IsReferenced()
+    {
+        var references = Extract("""
+            if errorlevel 1 goto :Retry
+            :Retry
+            """);
+
+        AssertCall(references, "Retry");
+    }
+
+    [Fact]
+    public void Extract_Batch_CommentsEscapesAndEof_DoNotEmitCalls()
+    {
+        var references = Extract("""
+            rem goto :Ignored
+            :: call :Commented
+            echo ^& goto :Escaped
+            goto :EOF
+            """);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "Ignored");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Commented");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Escaped");
+        Assert.DoesNotContain(references, r => r.SymbolName == "EOF");
+    }
+
+    private static IReadOnlyList<ReferenceRecord> Extract(string content)
+    {
+        var symbols = SymbolExtractor.Extract(1, "batch", content);
+        return ReferenceExtractor.Extract(1, "batch", content, symbols);
+    }
+
+    private static void AssertCall(IReadOnlyCollection<ReferenceRecord> references, string symbolName)
+        => Assert.Contains(references, r => r.SymbolName == symbolName && r.ReferenceKind == "call");
+}

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -112,6 +112,69 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Swift_DetectsRepresentativeDeclarationKinds()
+    {
+        const string content = """
+            import Foundation
+
+            public protocol StoreProtocol {
+                associatedtype Element
+            }
+
+            @MainActor
+            public final class UserStore {
+                public var currentUser: User?
+
+                public init() {}
+
+                public func loadUser() -> User {
+                    fetchUser()
+                }
+
+                deinit {}
+
+                subscript(index: Int) -> User {
+                    currentUser!
+                }
+            }
+
+            struct User {}
+
+            enum Status {
+                case active, disabled = "disabled"
+            }
+
+            typealias UserIdentifier = String
+            macro stringify<T>(_ value: T) = #externalMacro(module: "Macros", type: "StringifyMacro")
+            precedencegroup PipelinePrecedence {}
+            infix operator |>: PipelinePrecedence
+            extension Array where Element == User {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Foundation");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "StoreProtocol");
+        Assert.Contains(symbols, s => s.Kind == "associatedtype" && s.Name == "Element");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "UserStore");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "currentUser" && s.ContainerName == "UserStore");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "init" && s.ContainerName == "UserStore");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "loadUser" && s.ContainerName == "UserStore");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "deinit" && s.ContainerName == "UserStore");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "subscript" && s.ContainerName == "UserStore");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "User");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Status");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "active" && s.ContainerName == "Status");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "disabled" && s.ContainerName == "Status");
+        Assert.Contains(symbols, s => s.Kind == "typealias" && s.Name == "UserIdentifier");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "stringify");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "PipelinePrecedence");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "|>");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name.StartsWith("Array", StringComparison.Ordinal));
+        Assert.DoesNotContain(symbols, s => s.Name == "fetchUser" && s.Kind == "function");
+    }
+
+    [Fact]
     public void Extract_Python_DetectsGenericFunctionsAndTypeAliases()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Add focused reference extraction tests for Swift, Objective-C, Gradle, Terraform, PowerShell, and Batch.
- Add representative Swift symbol extraction coverage for functions, types, properties, imports, operators, macros, and aliases.
- Add changelog fragment `changelog.d/unreleased/1815.internal.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SwiftReferenceExtractorTests|FullyQualifiedName~ObjectiveCReferenceExtractorTests|FullyQualifiedName~GradleReferenceExtractorTests|FullyQualifiedName~TerraformReferenceExtractorTests|FullyQualifiedName~PowerShellReferenceExtractorTests|FullyQualifiedName~BatchReferenceExtractorTests|FullyQualifiedName~Extract_Swift_DetectsRepresentativeDeclarationKinds"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --rebuild --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: No blocking/actionable issues found.

## Documentation and changelog

- No user-facing documentation change was needed; this PR only adds test coverage.
- Changelog fragment: `changelog.d/unreleased/1815.internal.md`

## Follow-up candidates

- None.

Fixes #1815