### PR TITLE
Fix C# snippet raw span reconstruction

### DIFF
--- a/changelog.d/unreleased/1774.fixed.md
+++ b/changelog.d/unreleased/1774.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1774
+affected:
+  - src/CodeIndex/Cli/SearchSnippetFormatter.cs
+  - tests/CodeIndex.Tests/SearchSnippetFormatterTests.cs
+---
+
+## English
+
+- **C# normalized snippets no longer clamp to a fabricated raw span (#1774)** — search snippets now explicitly validate raw index map endpoints before focusing a clamped C# normalized match, falling back to unfocused clamping when the normalized span cannot be reconstructed.
+
+## 日本語
+
+- **C# 正規化スニペットが作り物の raw span にクランプされないようになりました (#1774)** — 検索スニペットは C# 正規化一致をクランプの焦点にする前に raw index map の両端を明示的に検証し、正規化 span を復元できない場合は焦点なしのクランプへフォールバックします。

--- a/src/CodeIndex/Cli/SearchSnippetFormatter.cs
+++ b/src/CodeIndex/Cli/SearchSnippetFormatter.cs
@@ -203,11 +203,32 @@ public static class SearchSnippetFormatter
         if (matchColumn <= 0)
             return LineWidthFormatter.ClampLine(originalLine, maxLineWidth);
 
-        var normalizedStart = matchColumn - 1;
-        var normalizedEnd = Math.Min(rawIndexMap.Length - 1, normalizedStart + Math.Max(1, matchLength) - 1);
-        var rawFocusColumn = rawIndexMap[normalizedStart] + 1;
-        var rawFocusLength = rawIndexMap[normalizedEnd] - rawIndexMap[normalizedStart] + 1;
+        if (!TryReconstructRawSpan(rawIndexMap, normalizedStart: matchColumn - 1, matchLength, out var rawFocusColumn, out var rawFocusLength))
+            return LineWidthFormatter.ClampLine(originalLine, maxLineWidth);
+
         return LineWidthFormatter.ClampLine(originalLine, maxLineWidth, rawFocusColumn, rawFocusLength);
+    }
+
+    internal static bool TryReconstructRawSpan(int[] rawIndexMap, int normalizedStart, int matchLength, out int rawFocusColumn, out int rawFocusLength)
+    {
+        rawFocusColumn = 0;
+        rawFocusLength = 0;
+
+        if (normalizedStart < 0 || matchLength <= 0)
+            return false;
+
+        var normalizedEnd = normalizedStart + matchLength - 1;
+        if (normalizedEnd < normalizedStart || normalizedEnd >= rawIndexMap.Length)
+            return false;
+
+        var rawStart = rawIndexMap[normalizedStart];
+        var rawEnd = rawIndexMap[normalizedEnd];
+        if (rawStart < 0 || rawEnd < rawStart)
+            return false;
+
+        rawFocusColumn = rawStart + 1;
+        rawFocusLength = rawEnd - rawStart + 1;
+        return true;
     }
 
     private static (int Column, int Length) FindBestMatchColumn(string line, string normalizedQuery, string[] tokens, bool caseSensitive, SearchSnippetFocusMode focusMode)

--- a/tests/CodeIndex.Tests/SearchSnippetFormatterTests.cs
+++ b/tests/CodeIndex.Tests/SearchSnippetFormatterTests.cs
@@ -99,6 +99,29 @@ public class SearchSnippetFormatterTests
     }
 
     [Fact]
+    public void TryReconstructRawSpan_ReturnsFalse_WhenNormalizedSpanCannotAnchorEnd()
+    {
+        var mapped = SearchSnippetFormatter.TryReconstructRawSpan([0, 1, 2], normalizedStart: 1, matchLength: 4, out var rawColumn, out var rawLength);
+
+        Assert.False(mapped);
+        Assert.Equal(0, rawColumn);
+        Assert.Equal(0, rawLength);
+    }
+
+    [Fact]
+    public void TryReconstructRawSpan_MapsVerbatimBoundaryToRawColumns()
+    {
+        var normalized = CSharpVerbatimNameNormalizer.Normalize("using @Foo.@Bar;", out var rawIndexMap);
+
+        var matchStart = normalized.IndexOf("Foo.Bar", StringComparison.Ordinal);
+        var mapped = SearchSnippetFormatter.TryReconstructRawSpan(rawIndexMap, matchStart, "Foo.Bar".Length, out var rawColumn, out var rawLength);
+
+        Assert.True(mapped);
+        Assert.Equal(8, rawColumn);
+        Assert.Equal(8, rawLength);
+    }
+
+    [Fact]
     public void Format_TruncatedAfterOnly_WhenMatchIsNearStart()
     {
         // Match on line 1 with maxLines=2 out of 6 — truncated after only


### PR DESCRIPTION
## Summary

- Validate normalized-to-raw snippet span reconstruction before focusing a clamped C# normalized match.
- Fall back to unfocused clamping when the raw index map cannot anchor both endpoints, avoiding fabricated highlight focus spans.
- Add regression coverage for invalid normalized spans and verbatim identifier raw-column mapping.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SearchSnippetFormatterTests"`
- `dotnet test CodeIndex.sln -c Release`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/1774.fixed.md`.
- No README or guide updates were needed because this is a bug fix to existing snippet clamping behavior and does not add CLI/MCP fields or flags.

Fixes #1774
