### PR TITLE
Fix C# split generic constraint signatures

### DIFF
--- a/changelog.d/unreleased/1984.fixed.md
+++ b/changelog.d/unreleased/1984.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1984
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C# type signatures now preserve split nested generic constraints (#1984)** — multiline `where` clauses such as `where T : IEnumerable<U>` now keep the generic constraint type arguments in stored symbol signatures.
+
+## 日本語
+
+- **C# 型シグネチャが分割されたネスト generic 制約を保持するようになりました (#1984)** — `where T : IEnumerable<U>` のような複数行の `where` 句で、保存される symbol signature に generic 制約の型引数が残るようになりました。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -2737,18 +2737,39 @@ public static partial class SymbolExtractor
 
     private static int FindCSharpWhereConstraintToken(string signature)
     {
-        for (int i = 0; i < signature.Length; i++)
+        var lexState = new CSharpLexState();
+        var lineStart = 0;
+
+        while (lineStart <= signature.Length)
         {
-            if (!signature.AsSpan(i).StartsWith("where".AsSpan(), StringComparison.Ordinal))
-                continue;
+            var lineEnd = signature.IndexOf('\n', lineStart);
+            if (lineEnd < 0)
+                lineEnd = signature.Length;
 
-            var before = i == 0 ? '\0' : signature[i - 1];
-            var afterIndex = i + "where".Length;
-            var after = afterIndex < signature.Length ? signature[afterIndex] : '\0';
-            if (!IsCSharpWhereTokenBoundary(before) || !IsCSharpWhereTokenBoundary(after))
-                continue;
+            var line = signature[lineStart..lineEnd];
+            var lexedLine = LexCSharpLine(line, lexState);
+            lexState = lexedLine.EndState;
+            var sanitizedLine = lexedLine.SanitizedLine;
 
-            return i;
+            for (int i = 0; i < sanitizedLine.Length; i++)
+            {
+                if (!sanitizedLine.AsSpan(i).StartsWith("where".AsSpan(), StringComparison.Ordinal))
+                    continue;
+
+                var absoluteIndex = lineStart + i;
+                var before = absoluteIndex == 0 ? '\0' : signature[absoluteIndex - 1];
+                var afterIndex = absoluteIndex + "where".Length;
+                var after = afterIndex < signature.Length ? signature[afterIndex] : '\0';
+                if (!IsCSharpWhereTokenBoundary(before) || !IsCSharpWhereTokenBoundary(after))
+                    continue;
+
+                return absoluteIndex;
+            }
+
+            if (lineEnd == signature.Length)
+                break;
+
+            lineStart = lineEnd + 1;
         }
 
         return -1;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -2762,6 +2762,8 @@ public static partial class SymbolExtractor
                 var after = afterIndex < signature.Length ? signature[afterIndex] : '\0';
                 if (!IsCSharpWhereTokenBoundary(before) || !IsCSharpWhereTokenBoundary(after))
                     continue;
+                if (!LooksLikeCSharpConstraintClause(signature, absoluteIndex))
+                    continue;
 
                 return absoluteIndex;
             }
@@ -2777,6 +2779,37 @@ public static partial class SymbolExtractor
 
     private static bool IsCSharpWhereTokenBoundary(char ch)
         => ch == '\0' || !(char.IsLetterOrDigit(ch) || ch == '_' || ch == '@');
+
+    private static bool LooksLikeCSharpConstraintClause(string signature, int whereIndex)
+    {
+        var i = whereIndex + "where".Length;
+        while (i < signature.Length && char.IsWhiteSpace(signature[i]))
+            i++;
+
+        if (i >= signature.Length)
+            return false;
+
+        if (signature[i] == '@')
+            i++;
+
+        if (i >= signature.Length || !IsCSharpConstraintIdentifierStart(signature[i]))
+            return false;
+
+        i++;
+        while (i < signature.Length && IsCSharpConstraintIdentifierPart(signature[i]))
+            i++;
+
+        while (i < signature.Length && char.IsWhiteSpace(signature[i]))
+            i++;
+
+        return i < signature.Length && signature[i] == ':';
+    }
+
+    private static bool IsCSharpConstraintIdentifierStart(char ch)
+        => char.IsLetter(ch) || ch == '_';
+
+    private static bool IsCSharpConstraintIdentifierPart(char ch)
+        => char.IsLetterOrDigit(ch) || ch == '_';
 
     private enum CSharpHeaderFrameKind
     {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -2720,8 +2720,42 @@ public static partial class SymbolExtractor
                 rawSlice.Append(line, from, to - from);
         }
 
-        return SanitizeCSharpTypeHeaderSlice(rawSlice.ToString()).Trim();
+        var sanitized = SanitizeCSharpTypeHeaderSlice(rawSlice.ToString()).Trim();
+        return NormalizeCSharpConstraintGenericWhitespace(sanitized);
     }
+
+    private static string NormalizeCSharpConstraintGenericWhitespace(string signature)
+    {
+        var whereIndex = FindCSharpWhereConstraintToken(signature);
+        if (whereIndex < 0)
+            return signature;
+
+        var prefix = signature[..whereIndex];
+        var constraints = CollapseCSharpGenericTypeWhitespace(signature[whereIndex..]);
+        return prefix + constraints;
+    }
+
+    private static int FindCSharpWhereConstraintToken(string signature)
+    {
+        for (int i = 0; i < signature.Length; i++)
+        {
+            if (!signature.AsSpan(i).StartsWith("where".AsSpan(), StringComparison.Ordinal))
+                continue;
+
+            var before = i == 0 ? '\0' : signature[i - 1];
+            var afterIndex = i + "where".Length;
+            var after = afterIndex < signature.Length ? signature[afterIndex] : '\0';
+            if (!IsCSharpWhereTokenBoundary(before) || !IsCSharpWhereTokenBoundary(after))
+                continue;
+
+            return i;
+        }
+
+        return -1;
+    }
+
+    private static bool IsCSharpWhereTokenBoundary(char ch)
+        => ch == '\0' || !(char.IsLetterOrDigit(ch) || ch == '_' || ch == '@');
 
     private enum CSharpHeaderFrameKind
     {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -7485,6 +7485,28 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_WrappedTypeHeaderWithSplitGenericConstraints_PreservesNestedConstraintTypes()
+    {
+        var content = """
+            namespace Demo;
+
+            public sealed class Foo<T, U>
+                where T : IEnumerable<
+                    U>,
+                    IComparable<
+                    string>
+            {
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var foo = Assert.Single(symbols.Where(s => s.Kind == "class" && s.Name == "Foo"));
+        Assert.Equal(
+            "public sealed class Foo<T, U> where T : IEnumerable<U>, IComparable<string>",
+            foo.Signature);
+    }
+
+    [Fact]
     public void Extract_CSharp_WrappedEnumHeader_IncludesUnderlyingTypeInSignature()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -7507,6 +7507,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_WrappedPrimaryCtorHeaderWithWhereInStringDefault_PreservesLiteralWhitespace()
+    {
+        var content = """
+            namespace Demo;
+
+            public sealed class Foo(
+                string label = "where X< T >")
+                : BaseFoo
+            {
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var foo = Assert.Single(symbols.Where(s => s.Kind == "class" && s.Name == "Foo"));
+        Assert.Equal(
+            "public sealed class Foo( string label = \"where X< T >\") : BaseFoo",
+            foo.Signature);
+    }
+
+    [Fact]
     public void Extract_CSharp_WrappedEnumHeader_IncludesUnderlyingTypeInSignature()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -7527,6 +7527,26 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_WrappedPrimaryCtorHeaderWithWhereParameterName_PreservesLiteralWhitespace()
+    {
+        var content = """
+            namespace Demo;
+
+            public sealed class Foo(
+                string where = "X< T >")
+                : BaseFoo
+            {
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var foo = Assert.Single(symbols.Where(s => s.Kind == "class" && s.Name == "Foo"));
+        Assert.Equal(
+            "public sealed class Foo( string where = \"X< T >\") : BaseFoo",
+            foo.Signature);
+    }
+
+    [Fact]
     public void Extract_CSharp_WrappedEnumHeader_IncludesUnderlyingTypeInSignature()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Preserve nested generic type arguments in multiline C# `where` constraint signatures.
- Keep literal whitespace intact when `where` appears in string defaults or as a contextual identifier parameter name.
- Add regression coverage and a bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_WrappedTypeHeaderWithSplitGenericConstraints_PreservesNestedConstraintTypes|FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_WrappedPrimaryCtorHeaderWithWhereInStringDefault_PreservesLiteralWhitespace|FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_WrappedPrimaryCtorHeaderWithWhereParameterName_PreservesLiteralWhitespace"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_Wrapped"`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/1984.fixed.md`.
- No README or guide update was needed; this is a C# symbol extraction correctness fix without a new user-facing command or workflow.

## Follow-up Candidates

- None.

Fixes #1984
