### PR TITLE
Fix C# scoped parameter indexing

### DIFF
--- a/changelog.d/unreleased/1980.fixed.md
+++ b/changelog.d/unreleased/1980.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1980
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C# scoped method parameters are now indexed (#1980)** — `scoped ref` and `scoped Span<T>` method parameters are emitted as parameter-like property symbols under their function container, preserving the scoped modifier in the symbol signature.
+
+## 日本語
+
+- **C# の scoped メソッドパラメータを index するようになりました (#1980)** — `scoped ref` や `scoped Span<T>` のメソッドパラメータを function 配下の parameter 相当 property symbol として出力し、symbol signature に scoped modifier を保持します。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3389,6 +3389,17 @@ public static partial class SymbolExtractor
                         pendingRecordPrimaryComponents,
                         symbols);
 
+                    if (lang == "csharp" && pattern.Kind == "function")
+                    {
+                        CollectCSharpCallableParameterSymbols(
+                            fileId,
+                            signature,
+                            startLine,
+                            kind,
+                            name,
+                            symbols);
+                    }
+
                     // C# plain-field (kind `property`, BodyStyle.None) matches need their own
                     // advance path. The generic `sameLineEndColumn`-based advance below resolves
                     // to -1 for BodyStyle.None and would set `stopAfterFirstPatternMatch`, which
@@ -6953,6 +6964,154 @@ public static partial class SymbolExtractor
                 });
             }
         }
+    }
+
+    private static void CollectCSharpCallableParameterSymbols(
+        long fileId,
+        string signature,
+        int callableStartLine,
+        string callableKind,
+        string callableName,
+        List<SymbolRecord> symbols)
+    {
+        if (!TryGetCSharpCallableParameterList(signature, callableName, out var parameterList, out var parameterListStartLine))
+            return;
+
+        foreach (var rawParameter in SplitTopLevelRecordPrimaryComponents(parameterList, callableStartLine + parameterListStartLine))
+        {
+            if (!TryParseCSharpCallableParameter(rawParameter, out var parameter))
+                continue;
+
+            if (symbols.Any(symbol =>
+                symbol.FileId == fileId
+                && symbol.Kind == "property"
+                && symbol.Name == parameter.Name
+                && symbol.ContainerKind == callableKind
+                && symbol.ContainerName == callableName
+                && symbol.StartLine == parameter.Line))
+            {
+                continue;
+            }
+
+            symbols.Add(new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "property",
+                Name = parameter.Name,
+                Line = parameter.Line,
+                StartLine = parameter.Line,
+                EndLine = parameter.Line,
+                Signature = parameter.Signature,
+                ContainerKind = callableKind,
+                ContainerName = callableName,
+                ReturnType = parameter.Type,
+            });
+        }
+    }
+
+    private static bool TryGetCSharpCallableParameterList(
+        string signature,
+        string callableName,
+        out string parameterList,
+        out int parameterListStartLine)
+    {
+        parameterList = string.Empty;
+        parameterListStartLine = 0;
+
+        var parameterOpenIndex = FindCSharpCallableParameterListStart(signature, callableName);
+        if (parameterOpenIndex < 0)
+            return false;
+
+        var closeBracket = signature[parameterOpenIndex] == '[' ? ']' : ')';
+        var parameterCloseIndex = FindMatchingBracket(signature, parameterOpenIndex, signature[parameterOpenIndex], closeBracket);
+        if (parameterCloseIndex <= parameterOpenIndex)
+            return false;
+
+        parameterList = StripRecordComponentComments(signature[(parameterOpenIndex + 1)..parameterCloseIndex]);
+        parameterListStartLine = signature[..(parameterOpenIndex + 1)].Count(ch => ch == '\n');
+        return true;
+    }
+
+    private static int FindCSharpCallableParameterListStart(string signature, string callableName)
+    {
+        var searchIndex = 0;
+        while (searchIndex < signature.Length)
+        {
+            var nameIndex = signature.IndexOf(callableName, searchIndex, StringComparison.Ordinal);
+            if (nameIndex < 0)
+                return -1;
+
+            searchIndex = nameIndex + Math.Max(callableName.Length, 1);
+            if (!IsCSharpIdentifierBoundary(signature, nameIndex - 1)
+                || !IsCSharpIdentifierBoundary(signature, nameIndex + callableName.Length))
+            {
+                continue;
+            }
+
+            var index = nameIndex + callableName.Length;
+            while (index < signature.Length && char.IsWhiteSpace(signature[index]))
+                index++;
+
+            if (index < signature.Length && signature[index] == '<')
+            {
+                var genericCloseIndex = FindMatchingBracket(signature, index, '<', '>');
+                if (genericCloseIndex < 0)
+                    continue;
+
+                index = genericCloseIndex + 1;
+                while (index < signature.Length && char.IsWhiteSpace(signature[index]))
+                    index++;
+            }
+
+            if (index < signature.Length && signature[index] is '(' or '[')
+                return index;
+        }
+
+        return -1;
+    }
+
+    private static bool IsCSharpIdentifierBoundary(string text, int index) =>
+        index < 0
+        || index >= text.Length
+        || !(char.IsLetterOrDigit(text[index]) || text[index] is '_' or '@');
+
+    private static bool TryParseCSharpCallableParameter(RecordPrimaryComponentSlice rawParameter, out RecordPrimaryComponent parameter)
+    {
+        parameter = default;
+        if (string.IsNullOrWhiteSpace(rawParameter.Text))
+            return false;
+
+        var normalized = TrimAfterTopLevelEquals(rawParameter.Text).Trim();
+        if (normalized.Length == 0)
+            return false;
+
+        var parameterLine = rawParameter.Line;
+        var stripped = StripLeadingCSharpRecordComponentAttributes(normalized);
+        normalized = stripped.Text;
+        parameterLine += stripped.ConsumedNewlines;
+
+        var signature = normalized;
+        stripped = StripLeadingRecordComponentModifiers("csharp", normalized);
+        if (stripped.Text == normalized)
+            return false;
+
+        normalized = stripped.Text;
+        parameterLine += stripped.ConsumedNewlines;
+
+        if (normalized.Length == 0)
+            return false;
+
+        var nameMatch = Regex.Match(normalized, @"(?<name>@?[\p{L}_$][\p{L}\p{Nd}_$]*)\s*$", RegexOptions.CultureInvariant);
+        if (!nameMatch.Success)
+            return false;
+
+        var parameterName = nameMatch.Groups["name"].Value.TrimStart('@');
+        var parameterType = normalized[..nameMatch.Index].Trim();
+        if (parameterName.Length == 0 || parameterType.Length == 0)
+            return false;
+
+        parameter = new RecordPrimaryComponent(parameterName, parameterType, signature, parameterLine);
+        return true;
     }
 
     private static bool TryGetRecordPrimaryComponents(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -7076,8 +7076,11 @@ public static partial class SymbolExtractor
                     index++;
             }
 
-            if (index < signature.Length && signature[index] is '(' or '[')
+            if (index < signature.Length
+                && (signature[index] == '(' || (signature[index] == '[' && callableName == "this")))
+            {
                 return index;
+            }
         }
 
         return -1;

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -6491,6 +6491,35 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_DetectsScopedMethodParametersAsProperties()
+    {
+        var content = """
+            public class RefService
+            {
+                public void Update<T>(scoped ref T value, scoped Span<int> data)
+                {
+                }
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Contains(symbols, s =>
+            s.Kind == "property"
+            && s.Name == "value"
+            && s.ContainerKind == "function"
+            && s.ContainerName == "Update"
+            && s.ReturnType == "T"
+            && s.Signature == "scoped ref T value");
+        Assert.Contains(symbols, s =>
+            s.Kind == "property"
+            && s.Name == "data"
+            && s.ContainerKind == "function"
+            && s.ContainerName == "Update"
+            && s.ReturnType == "Span<int>"
+            && s.Signature == "scoped Span<int> data");
+    }
+
+    [Fact]
     public void Extract_CSharp_NormalizesVerbatimIdentifiers()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -6499,6 +6499,11 @@ public class SymbolExtractorTests
                 public void Update<T>(scoped ref T value, scoped Span<int> data)
                 {
                 }
+
+                public Buffer[] Buffer(scoped ref int value)
+                {
+                    return [];
+                }
             }
             """;
         var symbols = SymbolExtractor.Extract(1, "csharp", content);
@@ -6517,6 +6522,13 @@ public class SymbolExtractorTests
             && s.ContainerName == "Update"
             && s.ReturnType == "Span<int>"
             && s.Signature == "scoped Span<int> data");
+        Assert.Contains(symbols, s =>
+            s.Kind == "property"
+            && s.Name == "value"
+            && s.ContainerKind == "function"
+            && s.ContainerName == "Buffer"
+            && s.ReturnType == "int"
+            && s.Signature == "scoped ref int value");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Index C# method parameters that carry keyword modifiers such as `scoped`, `ref`, `out`, `in`, `params`, `this`, or `readonly` as parameter-like property symbols under the function container.
- Preserve the modifier-bearing parameter spelling in the symbol signature while storing the stripped parameter type for metadata.
- Add regression coverage for `scoped ref T`, `scoped Span<int>`, and a same-name array return type that previously confused callable parameter-list detection.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- Codex adversarial review: first pass found one actionable issue; fixed in `9055d7e9`
- Codex adversarial review second pass: `No blocking/actionable issues found.`

## Documentation and changelog

- Added changelog fragment: `changelog.d/unreleased/1980.fixed.md`
- No README/guide update: this is an extractor correctness fix, not a documented CLI or workflow contract change.

## Follow-up candidates

- #2318

Fixes #1980
