### PR TITLE
Fix C# generic attribute type references

### DIFF
--- a/changelog.d/unreleased/1455.fixed.md
+++ b/changelog.d/unreleased/1455.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1455
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# generic attribute type arguments are now indexed (#1455)** — C# 11 no-argument generic attributes such as `[Serializable<MyType>]` now emit `type_reference` rows for their type arguments.
+
+## 日本語
+
+- **C# generic attribute の型引数を index するようになりました (#1455)** — `[Serializable<MyType>]` のような C# 11 の引数なし generic attribute で、型引数の `type_reference` 行を出力するようになりました。

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2740,6 +2740,27 @@ public static partial class ReferenceExtractor
                     if (definitionNames != null && definitionNames.Contains(name))
                         continue;
                     AddReference(references, seen, fileId, name, nameIndex, "attribute", context, lineNumber, container);
+                    var genericStart = nameIndex + rawName.Length;
+                    while (genericStart < preparedLine.Length && char.IsWhiteSpace(preparedLine[genericStart]))
+                        genericStart++;
+                    if (genericStart < preparedLine.Length && preparedLine[genericStart] == '<')
+                    {
+                        var genericEnd = genericStart;
+                        if (TrySkipBalancedGenericArgs(preparedLine, ref genericEnd, out _)
+                            && genericEnd > genericStart + 2)
+                        {
+                            AddTypeExpressionSegments(
+                                references,
+                                seen,
+                                fileId,
+                                preparedLine.Substring(genericStart + 1, genericEnd - genericStart - 2),
+                                genericStart + 1,
+                                context,
+                                lineNumber,
+                                container,
+                                "csharp");
+                        }
+                    }
                     if (CSharpReferenceExtractor.TryGetCallerInfoAttributeTypeName(rawName, preparedLine, nameIndex) is { } callerInfoAttributeTypeName)
                     {
                         AddReference(

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -26180,6 +26180,43 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpGenericNoArgAttribute_RecordsTypeArgumentReferences()
+    {
+        // Regression (issue #1455): C# 11 generic attributes must still emit references for
+        // custom type arguments inside the attribute's `<...>` list.
+        // リグレッション (issue #1455): C# 11 の generic attribute では、属性の `<...>` 内に
+        // 現れるユーザー定義型引数も参照として記録すること。
+        const string content = """
+            public class Payload
+            {
+            }
+
+            public class Converter
+            {
+            }
+
+            [Serializable<Payload>]
+            [MyAttr<Dictionary<string, Converter>>]
+            public class Data
+            {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        var serializable = Assert.Single(references.Where(r => r.SymbolName == "Serializable"));
+        Assert.Equal("attribute", serializable.ReferenceKind);
+        var myAttr = Assert.Single(references.Where(r => r.SymbolName == "MyAttr"));
+        Assert.Equal("attribute", myAttr.ReferenceKind);
+        Assert.Contains(references, r => r.SymbolName == "Payload" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Dictionary" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Converter" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "string" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_CsharpNestedGenericNoArgAttribute_ClassifiedAsAttribute()
     {
         // Regression (issue #293 round-16 follow-up): nested generic no-arg C#


### PR DESCRIPTION
## Summary
- Index C# no-argument generic attribute type arguments as type_reference rows.
- Add regression coverage for [Serializable<Payload>] and nested generic attribute arguments.
- Add bilingual changelog fragment for #1455.

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~CsharpGenericNoArgAttribute|FullyQualifiedName~CsharpNestedGenericNoArgAttribute|FullyQualifiedName~CsharpMultiLineAttributeArgumentEnum"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json
- Codex adversarial review: No blocking/actionable issues found.

## Documentation and changelog
- Added changelog.d/unreleased/1455.fixed.md
- No docs update required; this fixes reference extraction behavior without changing commands, flags, or documented workflow.

## Follow-up candidates
- None.

Fixes #1455