### PR TITLE
Fix C# primary constructor parameter symbols

### DIFF
--- a/changelog.d/unreleased/1454.fixed.md
+++ b/changelog.d/unreleased/1454.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1454
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C# class and struct primary constructor parameters are now indexed as contained properties (#1454)** — `class C(string name)` and `struct S(int value)` now surface their primary constructor parameters as symbols on the containing type, matching the captured-member references used inside the type body.
+
+## 日本語
+
+- **C# の class / struct primary constructor 引数を contained property として index するようになりました (#1454)** — `class C(string name)` や `struct S(int value)` の primary constructor 引数が包含型上の symbol として出るようになり、型本体内で使われる captured member 参照とつながります。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -7162,9 +7162,11 @@ public static partial class SymbolExtractor
         if (!recordMatch.Success)
             return false;
 
-        var parameterOpenIndex = FindRecordPrimaryComponentListStart(
-            declaration,
-            recordMatch.Index + recordMatch.Length + javaLeadingAnnotationOffset);
+        var parameterOpenIndex = lang == "csharp"
+            ? FindCSharpPrimaryConstructorParameterListStart(declaration, recordMatch.Index + recordMatch.Length)
+            : FindRecordPrimaryComponentListStart(
+                declaration,
+                recordMatch.Index + recordMatch.Length + javaLeadingAnnotationOffset);
         if (parameterOpenIndex < 0)
             return false;
 
@@ -7284,8 +7286,8 @@ public static partial class SymbolExtractor
         if (lang == "csharp")
         {
             return kind == "struct"
-                ? new Regex(@"^\s*(?:(?:public|private|protected\s+internal|private\s+protected|protected|internal)\s+)?(?:(?:static|partial|readonly|file|new|ref|unsafe)\s+)*record\s+struct\s+" + Regex.Escape(recordName) + @"\b", RegexOptions.CultureInvariant)
-                : new Regex(@"^\s*(?:(?:public|private|protected\s+internal|private\s+protected|protected|internal)\s+)?(?:(?:static|partial|abstract|sealed|readonly|file|new|unsafe)\s+)*record(?:\s+class)?\s+" + Regex.Escape(recordName) + @"\b", RegexOptions.CultureInvariant);
+                ? new Regex(@"^\s*(?:(?:public|private|protected\s+internal|private\s+protected|protected|internal)\s+)?(?:(?:static|partial|readonly|file|new|ref|unsafe)\s+)*(?:record\s+)?struct\s+" + Regex.Escape(recordName) + @"\b", RegexOptions.CultureInvariant)
+                : new Regex(@"^\s*(?:(?:public|private|protected\s+internal|private\s+protected|protected|internal)\s+)?(?:(?:static|partial|abstract|sealed|readonly|file|new|unsafe)\s+)*(?:record(?:\s+class)?\s+|class\s+)" + Regex.Escape(recordName) + @"\b", RegexOptions.CultureInvariant);
         }
 
         if (lang == "kotlin")
@@ -7296,6 +7298,45 @@ public static partial class SymbolExtractor
         }
 
         return new Regex(@"^\s*(?:public|private|protected)?\s*(?:(?:static|final|abstract|sealed|non-sealed|strictfp)\s+)*record\s+" + Regex.Escape(recordName) + @"\b", RegexOptions.CultureInvariant);
+    }
+
+    private static int FindCSharpPrimaryConstructorParameterListStart(string declaration, int startIndex)
+    {
+        var index = Math.Max(0, startIndex);
+        if (!SkipCSharpGenericTypeParameterList(declaration, ref index))
+            return -1;
+
+        while (index < declaration.Length && char.IsWhiteSpace(declaration[index]))
+            index++;
+
+        return index < declaration.Length && declaration[index] == '('
+            ? index
+            : -1;
+    }
+
+    private static bool SkipCSharpGenericTypeParameterList(string declaration, ref int index)
+    {
+        if (index >= declaration.Length || declaration[index] != '<')
+            return true;
+
+        var depth = 0;
+        for (; index < declaration.Length; index++)
+        {
+            var ch = declaration[index];
+            if (ch == '<')
+                depth++;
+            else if (ch == '>')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    index++;
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static int FindRecordPrimaryComponentListStart(string declaration, int startIndex)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -8023,6 +8023,65 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_ClassPrimaryConstructorParameters_AreIndexedAsContainedProperties()
+    {
+        var content = """
+            namespace App;
+
+            public class Worker(string name, int id)
+            {
+                public string Describe() => $"{name}#{id}";
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var name = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "name" && s.ContainerName == "Worker"));
+        Assert.Equal("class", name.ContainerKind);
+        Assert.Equal("string", name.ReturnType);
+        Assert.Equal("string name", name.Signature);
+
+        var id = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "id" && s.ContainerName == "Worker"));
+        Assert.Equal("int", id.ReturnType);
+        Assert.Equal("int id", id.Signature);
+    }
+
+    [Fact]
+    public void Extract_CSharp_StructPrimaryConstructorParameters_AreIndexedAsContainedProperties()
+    {
+        var content = """
+            namespace App;
+
+            internal readonly struct Range(int start, int length)
+            {
+                public int End => start + length;
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var start = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "start" && s.ContainerName == "Range"));
+        Assert.Equal("struct", start.ContainerKind);
+        Assert.Equal("int", start.ReturnType);
+
+        var length = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "length" && s.ContainerName == "Range"));
+        Assert.Equal("struct", length.ContainerKind);
+        Assert.Equal("int", length.ReturnType);
+    }
+
+    [Fact]
+    public void Extract_CSharp_GenericConstraintNewCall_IsNotPrimaryConstructorParameter()
+    {
+        var content = """
+            public class Factory<T> where T : new()
+            {
+                public T Create() => new T();
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.ContainerName == "Factory" && s.Name == "new");
+    }
+
+    [Fact]
     public void Extract_CSharp_WrappedHeaderWithInterpolationHoleContainingNestedVerbatim_PreservesInnerLiteral()
     {
         // An interpolation hole in an outer `$"..."` must be classified as Code so the


### PR DESCRIPTION
## Summary
- Index C# class and struct primary constructor parameters as contained property symbols.
- Keep record positional-member extraction on the shared path while avoiding generic constraint new() false positives.
- Add a bilingual changelog fragment for #1454.

Fixes #1454

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"
- dotnet test
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet build
- Codex adversarial review: No blocking/actionable issues found.

## Documentation / Changelog
- Added changelog fragment: changelog.d/unreleased/1454.fixed.md
- AGENTS.md, CLAUDE.md, and AGENT_GUIDE.md were not modified.

## Follow-up Candidates
- None.