### PR TITLE
Cache C# active scopes per line

### DIFF
--- a/changelog.d/unreleased/2074.internal.md
+++ b/changelog.d/unreleased/2074.internal.md
@@ -1,0 +1,17 @@
+---
+category: internal
+issues:
+  - 2074
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbReader.CSharpResolution.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **C# scope resolution now reuses active scope results for repeated file/line lookups (#2074)** — `DbReader` caches resolved namespace, containing-type, and `using static` active scopes per C# file and line, reducing allocation churn during batch reference resolution.
+
+## 日本語
+
+- **C# スコープ解決が同一 file/line の active scope 結果を再利用するようになりました (#2074)** — `DbReader` は C# の namespace、包含型、`using static` の active scope をファイル・行ごとにキャッシュし、batch reference 解決時の割り当て churn を減らします。

--- a/src/CodeIndex/Database/DbReader.CSharpResolution.cs
+++ b/src/CodeIndex/Database/DbReader.CSharpResolution.cs
@@ -62,6 +62,12 @@ public partial class DbReader
 
     private HashSet<string> GetActiveCSharpTypeNamespaces(string path, int lineNumber)
     {
+        if (_activeCSharpTypeNamespacesByPathLine.TryGetValue(path, out var activeNamespacesByLine)
+            && activeNamespacesByLine.TryGetValue(lineNumber, out var cachedActiveNamespaces))
+        {
+            return cachedActiveNamespaces;
+        }
+
         if (!_csharpNamespaceScopesByPath.TryGetValue(path, out var namespaceScopes))
         {
             namespaceScopes = LoadCSharpNamespaceScopes(path);
@@ -96,11 +102,24 @@ public partial class DbReader
         foreach (var globalNamespace in GetGlobalCSharpUsingNamespaces())
             activeNamespaces.Add(globalNamespace);
 
+        if (activeNamespacesByLine == null)
+        {
+            activeNamespacesByLine = new Dictionary<int, HashSet<string>>();
+            _activeCSharpTypeNamespacesByPathLine[path] = activeNamespacesByLine;
+        }
+
+        activeNamespacesByLine[lineNumber] = activeNamespaces;
         return activeNamespaces;
     }
 
     private List<CSharpContainingTypeScope> GetActiveCSharpContainingTypeScopes(string path, int lineNumber)
     {
+        if (_activeCSharpContainingTypeScopesByPathLine.TryGetValue(path, out var activeContainingTypesByLine)
+            && activeContainingTypesByLine.TryGetValue(lineNumber, out var cachedActiveContainingTypes))
+        {
+            return cachedActiveContainingTypes;
+        }
+
         if (!_csharpContainingTypeScopesByPath.TryGetValue(path, out var containingTypeScopes))
         {
             containingTypeScopes = LoadCSharpContainingTypeScopes(path);
@@ -114,6 +133,13 @@ public partial class DbReader
                 activeContainingTypes.Add(scope);
         }
 
+        if (activeContainingTypesByLine == null)
+        {
+            activeContainingTypesByLine = new Dictionary<int, List<CSharpContainingTypeScope>>();
+            _activeCSharpContainingTypeScopesByPathLine[path] = activeContainingTypesByLine;
+        }
+
+        activeContainingTypesByLine[lineNumber] = activeContainingTypes;
         return activeContainingTypes;
     }
 
@@ -304,6 +330,12 @@ public partial class DbReader
 
     private HashSet<string> GetActiveCSharpUsingStaticTargets(string path, int lineNumber)
     {
+        if (_activeCSharpUsingStaticTargetsByPathLine.TryGetValue(path, out var activeTargetsByLine)
+            && activeTargetsByLine.TryGetValue(lineNumber, out var cachedActiveTargets))
+        {
+            return cachedActiveTargets;
+        }
+
         if (!_csharpUsingStaticScopesByPath.TryGetValue(path, out var scopes))
         {
             scopes = LoadCSharpUsingStaticScopes(path);
@@ -323,6 +355,13 @@ public partial class DbReader
         foreach (var globalTarget in GetGlobalCSharpUsingStaticTargets())
             activeTargets.Add(globalTarget);
 
+        if (activeTargetsByLine == null)
+        {
+            activeTargetsByLine = new Dictionary<int, HashSet<string>>();
+            _activeCSharpUsingStaticTargetsByPathLine[path] = activeTargetsByLine;
+        }
+
+        activeTargetsByLine[lineNumber] = activeTargets;
         return activeTargets;
     }
 

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -50,6 +50,9 @@ public partial class DbReader
     private readonly Dictionary<string, List<CSharpContainingTypeScope>> _csharpContainingTypeScopesByPath = new(StringComparer.Ordinal);
     private readonly Dictionary<string, List<CSharpUsingNamespaceScope>> _csharpUsingNamespaceScopesByPath = new(StringComparer.Ordinal);
     private readonly Dictionary<string, List<CSharpUsingAliasScope>> _csharpUsingAliasScopesByPath = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<int, HashSet<string>>> _activeCSharpTypeNamespacesByPathLine = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<int, List<CSharpContainingTypeScope>>> _activeCSharpContainingTypeScopesByPathLine = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<int, HashSet<string>>> _activeCSharpUsingStaticTargetsByPathLine = new(StringComparer.Ordinal);
     private readonly Dictionary<string, HashSet<string>> _csharpConstantPatternContainersByMemberName = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<CSharpTypeNamespaceCandidate>> _csharpTypeNamespacesByName = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<CSharpContainingTypeCandidate>> _csharpTypeContainingTypesByName = new(StringComparer.OrdinalIgnoreCase);

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -9522,6 +9522,53 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void CSharpActiveScopeResolvers_CacheRepeatedFileLineResults_Issue2074()
+    {
+        InsertIndexedFile("src/ScopeCache.cs", "csharp",
+            """
+            using System;
+            using static Probe.Color;
+
+            namespace Probe;
+
+            public enum Color
+            {
+                Red,
+                Blue
+            }
+
+            public class Demo
+            {
+                object? Match(object value)
+                {
+                    return value is Red ? value : null;
+                }
+            }
+            """);
+
+        const string path = "src/ScopeCache.cs";
+        const int lineNumber = 15;
+
+        var namespacesFirst = InvokePrivateCSharpScopeResolver("GetActiveCSharpTypeNamespaces", path, lineNumber);
+        var namespacesSecond = InvokePrivateCSharpScopeResolver("GetActiveCSharpTypeNamespaces", path, lineNumber);
+        var containingTypesFirst = InvokePrivateCSharpScopeResolver("GetActiveCSharpContainingTypeScopes", path, lineNumber);
+        var containingTypesSecond = InvokePrivateCSharpScopeResolver("GetActiveCSharpContainingTypeScopes", path, lineNumber);
+        var staticTargetsFirst = InvokePrivateCSharpScopeResolver("GetActiveCSharpUsingStaticTargets", path, lineNumber);
+        var staticTargetsSecond = InvokePrivateCSharpScopeResolver("GetActiveCSharpUsingStaticTargets", path, lineNumber);
+
+        Assert.Same(namespacesFirst, namespacesSecond);
+        Assert.Same(containingTypesFirst, containingTypesSecond);
+        Assert.Same(staticTargetsFirst, staticTargetsSecond);
+    }
+
+    private object InvokePrivateCSharpScopeResolver(string methodName, string path, int lineNumber)
+    {
+        var method = typeof(DbReader).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return method.Invoke(_reader, new object[] { path, lineNumber })!;
+    }
+
+    [Fact]
     public void SearchReferences_ExactSameLineResults_AreOrderedByColumn()
     {
         var fileId = _writer.UpsertFile(new FileRecord


### PR DESCRIPTION
## Summary

- Cache C# active namespace, containing-type, and `using static` scope results per file/line inside `DbReader`.
- Add regression coverage proving repeated file/line resolver calls reuse the same resolved collections.
- Add bilingual changelog fragment `changelog.d/unreleased/2074.internal.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.CSharpActiveScopeResolvers_CacheRepeatedFileLineResults_Issue2074"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln -c Release`
- `dotnet build CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Added `changelog.d/unreleased/2074.internal.md`.
- No user-facing docs changed; this is an internal allocation/performance improvement with unchanged CLI/MCP surface.

## Follow-up Candidates

- None.

Fixes #2074
