### PR TITLE
Fix impact event subscription anchors

### DIFF
--- a/changelog.d/unreleased/2132.fixed.md
+++ b/changelog.d/unreleased/2132.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2132
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbReader.GraphQueries.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Impact file hints now anchor on C# event subscriptions (#2132)** — `impact` treats `subscribe` / `unsubscribe` reference rows as strong file-level evidence, so event subscription sites are not dropped when no structured type evidence or metadata bypass applies.
+
+## 日本語
+
+- **impact の file hint が C# event subscription を anchor として扱うようになりました (#2132)** — `impact` は `subscribe` / `unsubscribe` 参照行を強い file-level evidence として扱うため、structured type evidence や metadata bypass が無い event subscription site も落とさなくなりました。

--- a/src/CodeIndex/Database/DbReader.GraphQueries.cs
+++ b/src/CodeIndex/Database/DbReader.GraphQueries.cs
@@ -1750,7 +1750,7 @@ public partial class DbReader
             // 過剰に metadata 経由で広げないようにする。
             if (!evidenceCache.TryGetValue(candidate.SourceFileId, out var hasEvidence))
             {
-                hasEvidence = SourceFileHasInvokeReferenceTo(candidate.SourceFileId, definition.Name)
+                hasEvidence = SourceFileHasAnchorReferenceTo(candidate.SourceFileId, definition.Name)
                               || SourceFileHasStructuredTypeEvidence(candidate.SourceFileId, definition.Name);
                 evidenceCache[candidate.SourceFileId] = hasEvidence;
             }
@@ -1923,21 +1923,22 @@ public partial class DbReader
         return false;
     }
 
-    // A `call` or `instantiate` reference to `typeName` inside the source file is a stronger
-    // anchor than structured type evidence (signature / return-type tokens). When such a
-    // reference exists, the source/target relationship is pinned by the call graph itself,
-    // so `GetFileDependencyHintsToResolvedType` does not need to widen via the looser
-    // metadata bypass. Symbol-name match is intentionally exact (no suffix-strip alias)
-    // because callable references already carry the authoritative name — applying the C#
-    // `[Foo]` → `FooAttribute` alias here would let an unrelated `Foo()` method call
-    // anchor `impact FooAttribute` and over-report blast radius (issue #1881).
-    // `typeName` への `call` / `instantiate` 参照は signature / return 型のトークンより強い
-    // anchor で、call graph 自体が source/target の関係を確定するため metadata bypass を
+    // A `call`, `instantiate`, `subscribe`, or `unsubscribe` reference to `typeName` inside
+    // the source file is a stronger anchor than structured type evidence (signature /
+    // return-type tokens). When such a reference exists, the source/target relationship
+    // is pinned by the call graph itself, so `GetFileDependencyHintsToResolvedType` does
+    // not need to widen via the looser metadata bypass. Symbol-name match is
+    // intentionally exact (no suffix-strip alias) because callable references already
+    // carry the authoritative name — applying the C# `[Foo]` → `FooAttribute` alias here
+    // would let an unrelated `Foo()` method call anchor `impact FooAttribute` and
+    // over-report blast radius (issue #1881).
+    // `typeName` への `call` / `instantiate` / `subscribe` / `unsubscribe` 参照は signature /
+    // return 型のトークンより強い anchor で、call graph 自体が source/target の関係を確定するため metadata bypass を
     // 経由した widening は不要になる。比較は厳密一致のみで行う：callable な参照は
     // 既に authoritative な名前を保持しているため、C# の `[Foo]` → `FooAttribute` のような
     // suffix alias を適用すると、無関係な `Foo()` 呼び出しが `impact FooAttribute` を
     // 不当に anchor してしまい blast radius を過大報告する (issue #1881)。
-    private bool SourceFileHasInvokeReferenceTo(long fileId, string typeName)
+    private bool SourceFileHasAnchorReferenceTo(long fileId, string typeName)
     {
         if (!_hasReferencesTable || string.IsNullOrWhiteSpace(typeName))
             return false;
@@ -1947,7 +1948,7 @@ public partial class DbReader
             FROM symbol_references r
             WHERE r.file_id = @fileId
               AND r.symbol_name = @typeName
-              AND r.reference_kind IN {InvokeReferenceKindsSql}
+              AND r.reference_kind IN {ImpactAnchorReferenceKindsSql}
             LIMIT 1";
         cmd.Parameters.AddWithValue("@fileId", fileId);
         cmd.Parameters.AddWithValue("@typeName", typeName);

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -124,6 +124,7 @@ public partial class DbReader
         END";
     private const string InvokeReferenceKindsSql = "('call', 'instantiate')";
     private const string EventReferenceKindsSql = "('subscribe', 'unsubscribe')";
+    private const string ImpactAnchorReferenceKindsSql = "('call', 'instantiate', 'subscribe', 'unsubscribe')";
     // Reference kinds that participate in the call-graph (callers/callees/hotspots). Metadata
     // kinds such as `attribute` / `annotation` are excluded so they do not inflate the graph
     // with non-call edges (issue #293); C++ `friend` declarations are retained because they are

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -8612,6 +8612,48 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void SourceFileHasAnchorReference_SubscribeAnchorsFileImpactWithoutStructuredTypeEvidence()
+    {
+        // issue #2132: C# event subscriptions are compile-time dependencies just like
+        // calls/instantiations. The file-level impact evidence guard must treat the
+        // `subscribe` row itself as an anchor, even when no method signature or
+        // return-type token mentions the event name and no metadata bypass applies.
+        // issue #2132: C# の event subscription は call / instantiate と同じく
+        // compile-time dependency なので、method signature / return 型に event 名が
+        // 出ず metadata bypass も使えない場合でも、`subscribe` 行そのものを
+        // file-level impact の anchor として扱う。
+        var svcFileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/Svc.cs",
+            Lang = "csharp",
+            Size = 64,
+            Lines = 6,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertReferences(new[]
+        {
+            new ReferenceRecord
+            {
+                FileId = svcFileId,
+                SymbolName = "Changed",
+                ReferenceKind = "subscribe",
+                Line = 4,
+                Column = 16,
+                Context = "source.Changed += OnChanged;",
+                ContainerKind = null,
+                ContainerName = null,
+            },
+        });
+
+        var method = typeof(DbReader).GetMethod("SourceFileHasAnchorReferenceTo", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var anchored = (bool)method.Invoke(_reader, new object[] { svcFileId, "Changed" })!;
+
+        Assert.True(anchored);
+    }
+
+    [Fact]
     public void AnalyzeImpact_CSharpVerbatimQueryKeepsOriginalInputOnMiss()
     {
         // issue #960: verbatim C# queries should normalize for lookup when a match


### PR DESCRIPTION
## Summary

- Treat `subscribe` / `unsubscribe` reference rows as impact file-hint anchors.
- Add a regression test for C# event subscription anchor detection without structured type evidence.
- Add the unreleased changelog fragment for #2132.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.SourceFileHasAnchorReference_SubscribeAnchorsFileImpactWithoutStructuredTypeEvidence|FullyQualifiedName~DbReaderTests.GetFileDependencyHints_InvokeReferenceAnchorsFileImpactWithoutStructuredTypeEvidence"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/2132.fixed.md`.
- No README or guide updates were needed because this is a precision fix to existing `impact` behavior, not a new command or option contract.

## Follow-up Candidates

- None.

Fixes #2132
