### PR TITLE
Fix Razor event handler references

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -132,7 +132,7 @@ symbol_references (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     file_id         INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
     symbol_name     TEXT,                    -- referenced symbol name
-    reference_kind  TEXT,                    -- "call", "instantiate", "subscribe", "friend", "attribute", "annotation", "decorator", "type_reference", "implicit_implementation"
+    reference_kind  TEXT,                    -- "call", "instantiate", "subscribe", "razor_event_binding", "friend", "attribute", "annotation", "decorator", "type_reference", "implicit_implementation"
     line            INTEGER,                 -- 1-based line number
     column_number   INTEGER,                 -- 1-based column number
     context         TEXT,                    -- trimmed source line
@@ -207,7 +207,7 @@ files 1──N symbol_references
 | Raw kind | Logical graph kind | Notes |
 |---|---|---|
 | `call`, `instantiate` | `invoke` | Executable invocation edges. |
-| `razor_event_binding` | raw label | Razor `@on...="Handler"` event bindings from markup to C# handler names. |
+| `razor_event_binding` | `event` | Razor `@on...="Handler"` event bindings from markup to C# handler names. |
 | `subscribe`, `unsubscribe` | `event` | Event wiring edges kept visible in call-graph queries. |
 | `friend` | `friend` | C++ friend access/coupling edges kept visible in dependency-oriented graph queries. |
 | `attribute`, `annotation`, `type_reference`, `implicit_implementation` | raw label | Dependency/reference-only metadata, type-position edges, and compiler-synthesized implementation edges such as C# async iterator `GetAsyncEnumerator` / `MoveNextAsync`; excluded from default call-graph rows. |
@@ -1589,7 +1589,7 @@ symbol_references (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     file_id         INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
     symbol_name     TEXT,                    -- 参照先シンボル名
-    reference_kind  TEXT,                    -- "call", "instantiate", "subscribe", "attribute", "annotation", "decorator", "type_reference", "implicit_implementation"
+    reference_kind  TEXT,                    -- "call", "instantiate", "subscribe", "razor_event_binding", "attribute", "annotation", "decorator", "type_reference", "implicit_implementation"
     line            INTEGER,                 -- 1始まりの行番号
     column_number   INTEGER,                 -- 1始まりの列番号
     context         TEXT,                    -- trim済みソース行

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -207,6 +207,7 @@ files 1──N symbol_references
 | Raw kind | Logical graph kind | Notes |
 |---|---|---|
 | `call`, `instantiate` | `invoke` | Executable invocation edges. |
+| `razor_event_binding` | raw label | Razor `@on...="Handler"` event bindings from markup to C# handler names. |
 | `subscribe`, `unsubscribe` | `event` | Event wiring edges kept visible in call-graph queries. |
 | `friend` | `friend` | C++ friend access/coupling edges kept visible in dependency-oriented graph queries. |
 | `attribute`, `annotation`, `type_reference`, `implicit_implementation` | raw label | Dependency/reference-only metadata, type-position edges, and compiler-synthesized implementation edges such as C# async iterator `GetAsyncEnumerator` / `MoveNextAsync`; excluded from default call-graph rows. |

--- a/changelog.d/unreleased/2030.fixed.md
+++ b/changelog.d/unreleased/2030.fixed.md
@@ -6,7 +6,10 @@ affected:
   - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
   - src/CodeIndex/Indexer/References/Languages/RazorReferenceExtractor.cs
   - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
   - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
   - DEVELOPER_GUIDE.md
 ---
 

--- a/changelog.d/unreleased/2030.fixed.md
+++ b/changelog.d/unreleased/2030.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 2030
+affected:
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - src/CodeIndex/Indexer/References/Languages/RazorReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Razor event handlers now get explicit binding references (#2030)** — `@on...="Handler"` markup emits `razor_event_binding` references, records inherited interface handler bindings when `@implements` is present, and indexes `@attribute` directive types.
+
+## 日本語
+
+- **Razor イベントハンドラが明示的な binding 参照として記録されるようになりました (#2030)** — `@on...="Handler"` マークアップは `razor_event_binding` 参照を出力し、`@implements` がある場合は継承 interface 側の handler binding も記録し、`@attribute` directive の型も index します。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4876,7 +4876,7 @@ public static class QueryCommandRunner
     // compile-time な `type_reference` エッジを含む。C++ の `friend` 宣言も extractor が出す
     // dependency edge として受け付け、graph query にも参加させる。
     private static readonly string[] AllValidReferenceKinds =
-        ["annotation", "attribute", "call", "friend", "import", "instantiate", "subscribe", "type_reference", "unsubscribe"];
+        ["annotation", "attribute", "call", "friend", "import", "instantiate", "razor_event_binding", "subscribe", "type_reference", "unsubscribe"];
     // Reference kinds that `callers` / `callees` can legitimately return. Metadata kinds
     // (`attribute` / `annotation`) and type-position edges (`type_reference`) are structurally
     // not call-graph edges, so those queries are rejected at the CLI / MCP boundary. C++ `friend`
@@ -4885,7 +4885,7 @@ public static class QueryCommandRunner
     // や型位置エッジ (`type_reference`) は構造的に call-graph エッジではないため、CLI / MCP 境界で弾く。
     // C++ の `friend` は graph に出す coupling edge。
     private static readonly string[] CallGraphOnlyReferenceKinds =
-        ["call", "friend", "instantiate", "subscribe", "unsubscribe"];
+        ["call", "friend", "instantiate", "razor_event_binding", "subscribe", "unsubscribe"];
 
     private static void WriteKindHint(string? kind, DbReader reader)
     {

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -123,7 +123,7 @@ public partial class DbReader
             ELSE 0
         END";
     private const string InvokeReferenceKindsSql = "('call', 'instantiate')";
-    private const string EventReferenceKindsSql = "('subscribe', 'unsubscribe')";
+    private const string EventReferenceKindsSql = "('subscribe', 'unsubscribe', 'razor_event_binding')";
     // Reference kinds that participate in the call-graph (callers/callees/hotspots). Metadata
     // kinds such as `attribute` / `annotation` are excluded so they do not inflate the graph
     // with non-call edges (issue #293); C++ `friend` declarations are retained because they are
@@ -131,7 +131,7 @@ public partial class DbReader
     // call-graph (callers/callees/hotspots) に参加する reference kind。`attribute` / `annotation`
     // のようなメタデータ kind は非呼び出しエッジなのでここから除外する (issue #293)。C++ の
     // `friend` 宣言は access/coupling edge として依存関係 graph query に含める (issue #1943)。
-    internal const string CallGraphReferenceKindsSql = "('call', 'instantiate', 'subscribe', 'unsubscribe', 'friend')";
+    internal const string CallGraphReferenceKindsSql = "('call', 'instantiate', 'subscribe', 'unsubscribe', 'razor_event_binding', 'friend')";
     private const string SyntheticTopLevelCallerName = "<top-level>";
     private const string SyntheticTopLevelCallerKind = "function";
 

--- a/src/CodeIndex/Indexer/References/Languages/RazorReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RazorReferenceExtractor.cs
@@ -15,7 +15,9 @@ internal static class RazorReferenceExtractor
         string context,
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn,
-        IReadOnlySet<string>? definitionNames)
+        IReadOnlySet<string>? definitionNames,
+        IReadOnlySet<string>? fileDefinitionNames,
+        IReadOnlyList<string>? implementedTypeNames)
     {
         LanguageReferenceExtractionSupport.EmitRazorReferences(
             originalLine,
@@ -25,6 +27,8 @@ internal static class RazorReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn,
-            definitionNames);
+            definitionNames,
+            fileDefinitionNames,
+            implementedTypeNames);
     }
 }

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -939,6 +939,9 @@ public static partial class ReferenceExtractor
         var razorReferenceLines = isRazorFile
             ? RazorReferenceExtractor.MaskCommentLines(lines)
             : null;
+        var razorImplementedTypeNames = isRazorFile
+            ? LanguageReferenceExtractionSupport.ExtractRazorImplementedTypeNames(lines)
+            : null;
         // Group JS/TS tagged template call sites by line for O(1) lookup in the per-line loop.
         // Tagged templates like `gql\`...\`` / `styled.div\`...\`` / `sql\`...${x}...\`` have no
         // trailing `(`, so CallRegex cannot see them. The structural masker already identifies
@@ -998,6 +1001,9 @@ public static partial class ReferenceExtractor
 
                     return names;
                 });
+        var fileDefinitionNames = isRazorFile
+            ? new HashSet<string>(symbols.Select(symbol => symbol.Name), StringComparer.Ordinal)
+            : null;
         var sqlDefinitionLeafSpansByLine = language == "sql"
             ? SqlReferenceExtractor.BuildDefinitionLeafSpansByLine(lines, symbols)
             : null;
@@ -2792,7 +2798,9 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     ResolveContainerForCall,
-                    definitionNames);
+                    definitionNames,
+                    fileDefinitionNames,
+                    razorImplementedTypeNames);
             }
 
             if (language == "python")

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -541,7 +541,7 @@ internal static class LanguageReferenceExtractionSupport
         @"^\s*@inject\s+(?<type>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s+[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex RazorEventHandlerRegex = new(
-        @"@on[A-Za-z_]\w*\s*=\s*""(?<name>[A-Za-z_]\w*)""",
+        @"@on[A-Za-z_]\w*\s*=\s*""@?(?<name>[A-Za-z_]\w*)""",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static void EmitTypePositionReferences(

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -534,6 +534,9 @@ internal static class LanguageReferenceExtractionSupport
     private static readonly Regex RazorDirectiveTypeRegex = new(
         @"^\s*@(?:inherits|implements|model)\s+(?<type>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex RazorAttributeTypeRegex = new(
+        @"^\s*@attribute\s+\[\s*(?<type>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex RazorInjectRegex = new(
         @"^\s*@inject\s+(?<type>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s+[A-Za-z_]\w*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -643,7 +646,9 @@ internal static class LanguageReferenceExtractionSupport
         string context,
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn,
-        IReadOnlySet<string>? definitionNames)
+        IReadOnlySet<string>? definitionNames,
+        IReadOnlySet<string>? fileDefinitionNames,
+        IReadOnlyList<string>? implementedTypeNames)
     {
         foreach (Match match in RazorComponentTagRegex.Matches(originalLine))
         {
@@ -667,7 +672,9 @@ internal static class LanguageReferenceExtractionSupport
                 resolveContainerForColumn(nameIndex));
         }
 
-        foreach (var match in EnumerateMatches(RazorDirectiveTypeRegex, originalLine).Concat(EnumerateMatches(RazorInjectRegex, originalLine)))
+        foreach (var match in EnumerateMatches(RazorDirectiveTypeRegex, originalLine)
+                     .Concat(EnumerateMatches(RazorAttributeTypeRegex, originalLine))
+                     .Concat(EnumerateMatches(RazorInjectRegex, originalLine)))
         {
             var group = match.Groups["type"];
             ReferenceExtractor.AddTypeExpressionSegments(
@@ -685,20 +692,61 @@ internal static class LanguageReferenceExtractionSupport
         foreach (Match match in RazorEventHandlerRegex.Matches(originalLine))
         {
             var name = match.Groups["name"].Value;
-            if (definitionNames?.Contains(name) == true)
-                continue;
+            var nameIndex = match.Groups["name"].Index;
+            var container = resolveContainerForColumn(nameIndex);
+            var kind = "razor_event_binding";
 
             ReferenceExtractor.AddReference(
                 references,
                 seen,
                 fileId,
                 name,
-                match.Groups["name"].Index,
-                "call",
+                nameIndex,
+                kind,
                 context,
                 lineNumber,
-                resolveContainerForColumn(match.Groups["name"].Index));
+                container);
+
+            if (fileDefinitionNames?.Contains(name) == true || implementedTypeNames is not { Count: > 0 })
+                continue;
+
+            foreach (var implementedTypeName in implementedTypeNames)
+            {
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    nameIndex,
+                    "implicit_implementation",
+                    context,
+                    lineNumber,
+                    new SymbolRecord
+                    {
+                        Kind = "interface",
+                        Name = LastQualifiedSegment(implementedTypeName),
+                        Line = lineNumber,
+                        StartLine = lineNumber,
+                        EndLine = lineNumber
+                    });
+            }
         }
+    }
+
+    public static IReadOnlyList<string> ExtractRazorImplementedTypeNames(IReadOnlyList<string> originalLines)
+    {
+        List<string>? result = null;
+        foreach (var line in originalLines)
+        {
+            var match = RazorDirectiveTypeRegex.Match(line);
+            if (!match.Success || !line.TrimStart().StartsWith("@implements", StringComparison.Ordinal))
+                continue;
+
+            result ??= new List<string>();
+            result.Add(match.Groups["type"].Value);
+        }
+
+        return result ?? (IReadOnlyList<string>)Array.Empty<string>();
     }
 
     public static bool[] BuildGoImportBlockLineMap(IReadOnlyList<string> originalLines)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -12140,6 +12140,55 @@ jobs:
     }
 
     [Fact]
+    public void RunCallers_JsonKeepsRazorEventBindingsVisibleByDefault()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_callers_razor_event_binding");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "Pages"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "Pages", "User.razor"),
+                """
+                <button @onclick="HandleClick">Save</button>
+
+                @code {
+                    void HandleClick() { }
+                }
+                """);
+
+            var (indexExitCode, _, _) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--json", "--quiet"],
+                _jsonOptions));
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunCallers(
+                ["HandleClick", "--db", dbPath, "--json", "--lang", "csharp", "--exact"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal("HandleClick", json.GetProperty("callee_name").GetString());
+            Assert.Equal("event", json.GetProperty("reference_kind").GetString());
+
+            var (referencesExitCode, referencesStdout, referencesStderr) = CaptureConsole(() => QueryCommandRunner.RunReferences(
+                ["HandleClick", "--db", dbPath, "--kind", "razor_event_binding", "--lang", "csharp", "--exact"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, referencesExitCode);
+            Assert.DoesNotContain("not a known reference kind", referencesStderr);
+            Assert.Contains("razor_event_binding", referencesStdout);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunCallers_SurfacesMixedReferenceKindsWhenContainerMixesCallAndSubscribe()
     {
         // #501: a single container that reaches the same callee via both `call` and

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -12150,6 +12150,7 @@ jobs:
                 Path.Combine(projectRoot, "Pages", "User.razor"),
                 """
                 <button @onclick="HandleClick">Save</button>
+                <button @onclick="@HandleClick">Save explicit</button>
 
                 @code {
                     void HandleClick() { }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12156,11 +12156,14 @@ public class ReferenceExtractorTests
     {
         const string content = """
             @inherits App.Pages.BasePage
+            @implements App.Pages.IUserActions
+            @attribute [Authorize]
             @inject Services.UserService UserService
 
             <UserCard User="CurrentUser" />
             <Shared.DetailPanel />
             <button @onclick="HandleClick">Save</button>
+            <button @onclick="InheritedClick">Inherited</button>
             <input @ref="inputRef" @key="person" @bind="Value" />
             @* <AdminPanel /> *@
             <!-- <AuditPanel /> -->
@@ -12191,10 +12194,23 @@ public class ReferenceExtractorTests
             .IndexOf("DetailPanel", StringComparison.Ordinal) + 1;
 
         Assert.Contains(references, r => r.SymbolName == "BasePage" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "IUserActions" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Authorize" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "UserService" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "UserCard" && r.ReferenceKind == "call");
         Assert.Contains(references, r => r.SymbolName == "DetailPanel" && r.ReferenceKind == "call" && r.Column == qualifiedComponentColumn);
-        Assert.Contains(references, r => r.SymbolName == "HandleClick" && r.ReferenceKind == "call");
+        Assert.Contains(references, r => r.SymbolName == "HandleClick" && r.ReferenceKind == "razor_event_binding");
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "HandleClick"
+            && r.ReferenceKind == "implicit_implementation");
+        Assert.Contains(references, r =>
+            r.SymbolName == "InheritedClick"
+            && r.ReferenceKind == "razor_event_binding");
+        Assert.Contains(references, r =>
+            r.SymbolName == "InheritedClick"
+            && r.ReferenceKind == "implicit_implementation"
+            && r.ContainerKind == "interface"
+            && r.ContainerName == "IUserActions");
         Assert.Contains(references, r => r.SymbolName == "Save" && r.ReferenceKind == "call");
         Assert.Contains(aliasReferences, r => r.SymbolName == "UserCard" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "AdminPanel" && r.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -12333,6 +12333,7 @@ public class ReferenceExtractorTests
             <UserCard User="CurrentUser" />
             <Shared.DetailPanel />
             <button @onclick="HandleClick">Save</button>
+            <button @onclick="@HandleClick">Save explicit</button>
             <button @onclick="InheritedClick">Inherited</button>
             <input @ref="inputRef" @key="person" @bind="Value" />
             @* <AdminPanel /> *@


### PR DESCRIPTION
## Summary
- emit Razor @on event handlers as explicit razor_event_binding references
- keep Razor event bindings visible in callers/callees as event edges and accepted by references --kind
- add @implements inherited handler linkage and @attribute type references

## Documentation and changelog
- Updated DEVELOPER_GUIDE.md reference-kind taxonomy.
- Added changelog fragment: changelog.d/unreleased/2030.fixed.md

Fixes #2030

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_RazorBlazor_CapturesComponentsDirectivesInjectionAndEventHandlers"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunCallers_JsonKeepsRazorEventBindingsVisibleByDefault"
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet test

## Follow-up candidates
- None.