### PR TITLE
Add JS default export arrow regression coverage

### DIFF
--- a/changelog.d/unreleased/1439.fixed.md
+++ b/changelog.d/unreleased/1439.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1439
+affected:
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **JS/TS default-export async arrow call attribution is now covered (#1439)** — regression coverage now verifies calls inside `export default async (...) => { ... }` attach to the synthetic `default` function container.
+
+## 日本語
+
+- **JS/TS の default export async arrow の呼び出し帰属をテストで固定しました (#1439)** — `export default async (...) => { ... }` 内の呼び出しが合成 `default` 関数コンテナへ紐付くことを回帰テストで確認するようになりました。

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -10,6 +10,33 @@ namespace CodeIndex.Tests;
 /// </summary>
 public class ReferenceExtractorTests
 {
+    [Theory]
+    [InlineData("javascript")]
+    [InlineData("typescript")]
+    public void Extract_JsTsDefaultExportAsyncArrow_AttachesCallsToDefaultFunction(string language)
+    {
+        const string content = """
+            import { db } from "./db";
+            export default async (req, res) => {
+                return db.users.findById(req.id);
+            };
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, language, content);
+        var references = ReferenceExtractor.Extract(1, language, content, symbols);
+
+        Assert.Contains(symbols, symbol =>
+            symbol.Kind == "function"
+            && symbol.Name == "default"
+            && symbol.BodyStartLine == 2
+            && symbol.BodyEndLine == 4);
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "findById"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerKind == "function"
+            && reference.ContainerName == "default");
+    }
+
     [Fact]
     public void Extract_CsharpAsyncIterator_EmitsTypeAndImplicitImplementationReferences()
     {


### PR DESCRIPTION
## Summary

- Adds JS and TS regression coverage for `export default async (...) => { ... }`.
- Verifies calls inside the default-exported async arrow attach to the synthetic `default` function container.
- Adds the required bilingual changelog fragment.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_JsTsDefaultExportAsyncArrow_AttachesCallsToDefaultFunction"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files tests/CodeIndex.Tests/ReferenceExtractorTests.cs changelog.d/unreleased/1439.fixed.md --json`

`dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` still reports existing stale/readiness issues unrelated to this PR.

## Documentation and Changelog

- Added `changelog.d/unreleased/1439.fixed.md`.
- No docs changes were needed because this PR only locks existing JS/TS reference attribution behavior with regression coverage.

## Follow-up Candidates

- #2328

Fixes #1439
