### PR TITLE
Fix C# raw string quote-run closing

### DIFF
--- a/changelog.d/unreleased/1453.fixed.md
+++ b/changelog.d/unreleased/1453.fixed.md
@@ -7,6 +7,7 @@ affected:
   - src/CodeIndex/Indexer/References/Support/StructuralLineMasker.cs
   - src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
   - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
 ---
 
 ## English

--- a/changelog.d/unreleased/1453.fixed.md
+++ b/changelog.d/unreleased/1453.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1453
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - src/CodeIndex/Indexer/References/Support/StructuralLineMasker.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# raw string closing delimiter detection now requires an exact quote count (#1453)** — longer quote runs inside raw string content no longer end the string early or expose code-shaped text as phantom symbols.
+
+## 日本語
+
+- **C# raw string の終端 delimiter 判定で quote 数の完全一致を要求するようになりました (#1453)** — raw string 本文内のより長い quote run が文字列を早期終了させ、コード風テキストを疑似シンボルとして露出する問題を防ぎました。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -3175,7 +3175,7 @@ public partial class DbReader
                         var closeRun = 0;
                         while (i + closeRun < line.Length && line[i + closeRun] == '"')
                             closeRun++;
-                        if (closeRun >= runLength)
+                        if (closeRun == runLength)
                         {
                             i += closeRun;
                             break;
@@ -3237,7 +3237,7 @@ public partial class DbReader
                         var closeRun = 0;
                         while (i + closeRun < line.Length && line[i + closeRun] == '"')
                             closeRun++;
-                        if (closeRun >= rawRunLength)
+                        if (closeRun == rawRunLength)
                         {
                             i += closeRun;
                             break;

--- a/src/CodeIndex/Indexer/References/Support/StructuralLineMasker.cs
+++ b/src/CodeIndex/Indexer/References/Support/StructuralLineMasker.cs
@@ -220,11 +220,18 @@ internal static class StructuralLineMasker
                         if (stringFrame.Kind == StringKind.Raw)
                         {
                             var closeLength = CountQuoteRun(line, searchStart);
-                            if (closeLength >= stringFrame.DelimiterLength)
+                            if (closeLength == stringFrame.DelimiterLength)
                             {
                                 ReplaceWithSpaces(masked, searchStart, closeLength);
                                 searchStart += closeLength;
                                 frames.Pop();
+                                continue;
+                            }
+
+                            if (closeLength > 0)
+                            {
+                                ReplaceWithSpaces(masked, searchStart, closeLength);
+                                searchStart += closeLength;
                                 continue;
                             }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -458,9 +458,18 @@ public static partial class SymbolExtractor
                     continue;
                 }
 
-                if (ch == '"' && HasCSharpQuoteRun(line, i, state.RawDelimiterLength))
+                if (ch == '"')
                 {
                     var quoteRunLength = GetCSharpQuoteRunLength(line, i);
+                    if (quoteRunLength != state.RawDelimiterLength)
+                    {
+                        for (var j = 0; j < quoteRunLength && i + j < line.Length; j++)
+                            sanitized[i + j] = ' ';
+
+                        i += quoteRunLength;
+                        continue;
+                    }
+
                     for (var j = 0; j < quoteRunLength && i + j < line.Length; j++)
                         sanitized[i + j] = ' ';
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11,6 +11,33 @@ namespace CodeIndex.Tests;
 public class ReferenceExtractorTests
 {
     [Fact]
+    public void Extract_CsharpRawStringLongerQuoteRun_DoesNotLeakCallReferences()
+    {
+        // Regression for #1453: a raw string opened with four quotes must only
+        // close on exactly four quotes. A longer quote run inside the content
+        // stays masked so call-shaped text does not become a phantom reference.
+        // #1453 の回帰: 4 個の quote で始まった raw string は、ちょうど 4 個の
+        // quote でのみ閉じる。本文中のより長い quote run はマスクされたままになり、
+        // 呼び出し風テキストが疑似参照になってはならない。
+        const string content = """""""
+            class Service
+            {
+                void Real()
+                {
+                    var s = """"hello """""" PhantomCall() world"""";
+                    ActualCall();
+                }
+            }
+            """"""";
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "ActualCall");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "PhantomCall");
+    }
+
+    [Fact]
     public void Extract_CsharpAsyncIterator_EmitsTypeAndImplicitImplementationReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -6856,6 +6856,41 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_RawStringLongerQuoteRunDoesNotLeakPhantomSymbols()
+    {
+        // Regression for #1453 on the C# symbol scanner path: a raw string opened
+        // with four quotes must not close on a longer quote run, including from
+        // the middle of that longer run.
+        // #1453 の C# symbol scanner 経路の回帰: 4 個の quote で始まった raw
+        // string は、より長い quote run では閉じず、その途中からも閉じてはならない。
+        var content = """""""
+            namespace CsRawStringLongQuoteRun;
+
+            public class Svc
+            {
+                public string DocsExample() => """"
+                    public class HiddenBefore { }
+                    """""" public class Phantom { public void Ghost() { } }
+                    public class HiddenAfter { }
+                    """";
+
+                public int RealMethod() => 0;
+            }
+            """"""";
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "namespace" && symbol.Name == "CsRawStringLongQuoteRun");
+        Assert.Contains(symbols, symbol => symbol.Kind == "class" && symbol.Name == "Svc");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "DocsExample");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "RealMethod");
+
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "HiddenBefore");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "Phantom");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "Ghost");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "HiddenAfter");
+    }
+
+    [Fact]
     public void Extract_CSharp_PlainInterpolatedStringHoleWithNestedStringLiteral_DoesNotDropLaterHelpers()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Require exact quote-run length when closing C# raw strings across symbol/reference scanners.
- Consume longer non-closing quote runs as raw string content so the scanner cannot close from the middle of the run.
- Add reference and symbol regression tests for #1453.

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests|FullyQualifiedName~SymbolExtractorTests" (passed: 2201)
- dotnet test CodeIndex.sln (passed: 5406, skipped: 3)
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_RawStringLongerQuoteRunDoesNotLeakPhantomSymbols|FullyQualifiedName~ReferenceExtractorTests.Extract_CsharpRawStringLongerQuoteRun_DoesNotLeakCallReferences" (passed: 2, after merge)
- dotnet run --project tools/CodeIndex.Changelog -- check (passed)

## Review
- Codex adversarial review found missing direct SymbolExtractor scanner coverage.
- Added SymbolExtractor regression coverage and reran targeted validation.

## Notes
- Local cdidx index refresh/full scan hit the existing open full-scan stall tracked by #2328, so status --check remains degraded locally.

Fixes #1453