### PR TITLE
Fix TypeScript decorator type references

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -211,6 +211,8 @@ files 1──N symbol_references
 | `friend` | `friend` | C++ friend access/coupling edges kept visible in dependency-oriented graph queries. |
 | `attribute`, `annotation`, `type_reference`, `implicit_implementation` | raw label | Dependency/reference-only metadata, type-position edges, and compiler-synthesized implementation edges such as C# async iterator `GetAsyncEnumerator` / `MoveNextAsync`; excluded from default call-graph rows. |
 
+TypeScript decorators emit `annotation` rows for the decorator name and must not hide the decorated declaration's type-position edges. For example, `constructor(@Inject() svc: Service)` records `Inject` as `annotation` and `Service` as `type_reference`, and `@Input() profile: UserProfile` records both the decorator and field type.
+
 ## Why a database instead of grep?
 
 On small projects, `grep` works fine. But as a codebase grows to tens of thousands of files, `grep` becomes a bottleneck — especially when an AI agent calls it repeatedly. cdidx solves this by **reading every file once at index time** and building a search structure so that queries never need to touch the original files again.
@@ -1659,6 +1661,8 @@ files 1──N symbol_references
 | `subscribe`, `unsubscribe` | `event` | call-graph query で可視化するイベント配線エッジ。 |
 | `friend` | `friend` | C++ friend の access/coupling edge。依存関係寄りの graph query で可視化する。 |
 | `attribute`, `annotation`, `type_reference`, `implicit_implementation` | raw label | 依存関係 / reference 専用の metadata、型位置エッジ、および C# async iterator の `GetAsyncEnumerator` / `MoveNextAsync` のようなコンパイラ合成の実装エッジ。既定の call-graph 行からは除外する。 |
+
+TypeScript decorator は decorator 名を `annotation` 行として出力し、decorated declaration の型位置エッジを隠してはならない。たとえば `constructor(@Inject() svc: Service)` は `Inject` を `annotation`、`Service` を `type_reference` として記録し、`@Input() profile: UserProfile` も decorator と field type の両方を記録する。
 
 ## なぜgrepではなくデータベースなのか？
 

--- a/changelog.d/unreleased/1903.fixed.md
+++ b/changelog.d/unreleased/1903.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1903
+affected:
+  - src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **TypeScript decorated declarations keep their type references (#1903)** — Angular, NestJS, and TypeORM-style decorators now emit decorator metadata without hiding parameter, return, or field type-reference edges.
+
+## 日本語
+
+- **TypeScript の decorated declaration で型参照が維持されるようになりました (#1903)** — Angular / NestJS / TypeORM 形式の decorator は decorator metadata を出力しつつ、parameter / return / field の type-reference edge を隠さなくなりました。

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -34,6 +34,7 @@ internal static class TypeScriptReferenceExtractor
         EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitFunctionPropertyTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitDecoratedMemberTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         TypedLanguageReferenceExtractor.EmitColonVariableTypeReferences(
             preparedLine,
             DeclarationKeywords,
@@ -142,7 +143,10 @@ internal static class TypeScriptReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
     {
-        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(');
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(
+            preparedLine,
+            '(',
+            SkipLeadingDecorators(preparedLine));
         if (openParen <= 0)
             return;
 
@@ -167,6 +171,51 @@ internal static class TypeScriptReferenceExtractor
             return;
 
         var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, returnColon + 1);
+        if (typeStart >= preparedLine.Length)
+            return;
+
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart, stopAtArrow: false);
+        if (typeEnd <= typeStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(typeStart, typeEnd - typeStart),
+            typeStart,
+            "typescript",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(typeStart));
+    }
+
+    private static void EmitDecoratedMemberTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var memberStart = SkipLeadingDecorators(preparedLine);
+        if (memberStart <= 0 || memberStart >= preparedLine.Length)
+            return;
+
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':', memberStart);
+        if (colonIndex < 0)
+            return;
+
+        var openParen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '(', memberStart);
+        if (openParen >= 0 && openParen < colonIndex)
+            return;
+
+        var equalsIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '=', memberStart);
+        if (equalsIndex >= 0 && equalsIndex < colonIndex)
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
         if (typeStart >= preparedLine.Length)
             return;
 
@@ -332,6 +381,40 @@ internal static class TypeScriptReferenceExtractor
         }
 
         return false;
+    }
+
+    private static int SkipLeadingDecorators(string line)
+    {
+        var index = 0;
+        while (index < line.Length)
+        {
+            while (index < line.Length && char.IsWhiteSpace(line[index]))
+                index++;
+
+            if (index >= line.Length || line[index] != '@')
+                return index;
+
+            index++;
+            while (index < line.Length && (IsTypeScriptIdentifierPart(line[index]) || line[index] == '.'))
+                index++;
+
+            while (index < line.Length && char.IsWhiteSpace(line[index]))
+                index++;
+
+            if (index < line.Length && line[index] == '(')
+            {
+                var closeParen = ReferenceExtractor.FindMatchingChar(line, index, '(', ')');
+                if (closeParen < 0)
+                    return index;
+
+                index = closeParen + 1;
+            }
+
+            while (index < line.Length && char.IsWhiteSpace(line[index]))
+                index++;
+        }
+
+        return index;
     }
 
     private static bool IsImportExportOpeningBrace(IReadOnlyList<string> preparedLines, int openLineIndex, int openColumn)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -29207,6 +29207,38 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptDecoratedMembers_CaptureDecoratorAndTypeReferences()
+    {
+        const string content = """
+            class Controller {
+                @Get("/users") find(@Optional() @Inject(USER_REPOSITORY) repo: UserRepository, @Param("id") id: UserId): Promise<UserDto> {
+                    return repo.find(id);
+                }
+
+                @Input() profile: UserProfile;
+                @Column({ type: "json" }) settings!: SettingsDocument;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Get" && r.ReferenceKind == "annotation");
+        Assert.Contains(references, r => r.SymbolName == "Optional" && r.ReferenceKind == "annotation");
+        Assert.Contains(references, r => r.SymbolName == "Inject" && r.ReferenceKind == "annotation");
+        Assert.Contains(references, r => r.SymbolName == "Param" && r.ReferenceKind == "annotation");
+        Assert.Contains(references, r => r.SymbolName == "Input" && r.ReferenceKind == "annotation");
+        Assert.Contains(references, r => r.SymbolName == "Column" && r.ReferenceKind == "annotation");
+
+        Assert.Contains(references, r => r.SymbolName == "UserRepository" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "UserId" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Promise" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "UserDto" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "UserProfile" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "SettingsDocument" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptImportExportAliases_DoNotEmitTypeReferences()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Preserve TypeScript type-reference extraction when decorators precede methods, parameters, and fields.
- Add regression coverage for Angular/NestJS/TypeORM-style decorated TypeScript members.
- Document the TypeScript decorator reference contract and add a changelog fragment.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptDecoratedMembers_CaptureDecoratorAndTypeReferences|FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptTypedDeclarations_CaptureStructuralTypeReferences"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet test CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs tests/CodeIndex.Tests/ReferenceExtractorTests.cs DEVELOPER_GUIDE.md changelog.d/unreleased/1903.fixed.md --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md`.
- Added `changelog.d/unreleased/1903.fixed.md`.

## Review

- Codex adversarial review found one blocking process issue: the changelog fragment was untracked.
- Fixed by staging the fragment before commit.

Fixes #1903
