### PR TITLE
Add JS/TS CRLF template regression coverage

### DIFF
--- a/changelog.d/unreleased/1465.fixed.md
+++ b/changelog.d/unreleased/1465.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1465
+affected:
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Pinned JS/TS CRLF template-literal column stability (#1465)** — added regression coverage that CRLF-encoded JavaScript and TypeScript template literals produce the same symbol line, column, and signature metadata as LF-encoded input.
+
+## 日本語
+
+- **JS/TS の CRLF テンプレートリテラルで列情報が安定することを固定しました (#1465)** — CRLF エンコードの JavaScript / TypeScript テンプレートリテラルでも、LF 入力と同じシンボルの行・列・シグネチャ metadata を返すことを回帰テストで保証しました。

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -22190,6 +22190,40 @@ public class SymbolExtractorTests
         Assert.Contains(tsSymbols, s => s.Kind == "class" && s.Name == "RealClass");
     }
 
+    [Theory]
+    [InlineData("javascript")]
+    [InlineData("typescript")]
+    public void Extract_JavaScriptTypeScript_CrlfTemplateLiteralKeepsColumnsAligned(string language)
+    {
+        // Regression for issue #1465: CRLF input is normalized before JS/TS lexing, so a
+        // multi-line template literal must not shift columns for later real symbols.
+        // issue #1465 の回帰: JS/TS lexing 前に CRLF 入力を正規化するため、複数行
+        // template literal が後続の本物のシンボル列をずらしてはならない。
+        const string lfContent = """
+            const src = `
+            class FakeClassInTemplate {}
+            function fakeFromTemplate() {}
+            `;
+
+            export function realFunction() {
+              return src;
+            }
+            """;
+        var crlfContent = lfContent.Replace("\n", "\r\n", StringComparison.Ordinal);
+
+        var lfSymbols = SymbolExtractor.Extract(1, language, lfContent);
+        var crlfSymbols = SymbolExtractor.Extract(1, language, crlfContent);
+
+        var lfRealFunction = Assert.Single(lfSymbols, s => s.Kind == "function" && s.Name == "realFunction");
+        var crlfRealFunction = Assert.Single(crlfSymbols, s => s.Kind == "function" && s.Name == "realFunction");
+        Assert.Equal(lfRealFunction.Line, crlfRealFunction.Line);
+        Assert.Equal(lfRealFunction.StartColumn, crlfRealFunction.StartColumn);
+        Assert.Equal(lfRealFunction.Signature, crlfRealFunction.Signature);
+
+        Assert.DoesNotContain(crlfSymbols, s => s.Name == "fakeFromTemplate");
+        Assert.DoesNotContain(crlfSymbols, s => s.Name == "FakeClassInTemplate");
+    }
+
     [Fact]
     public void Extract_CSharp_WrappedStaticConstructor_EmitsOnceAtNameLine()
     {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -22199,7 +22199,7 @@ public class SymbolExtractorTests
         // multi-line template literal must not shift columns for later real symbols.
         // issue #1465 の回帰: JS/TS lexing 前に CRLF 入力を正規化するため、複数行
         // template literal が後続の本物のシンボル列をずらしてはならない。
-        const string lfContent = """
+        const string content = """
             const src = `
             class FakeClassInTemplate {}
             function fakeFromTemplate() {}
@@ -22209,6 +22209,7 @@ public class SymbolExtractorTests
               return src;
             }
             """;
+        var lfContent = content.Replace("\r\n", "\n", StringComparison.Ordinal);
         var crlfContent = lfContent.Replace("\n", "\r\n", StringComparison.Ordinal);
 
         var lfSymbols = SymbolExtractor.Extract(1, language, lfContent);


### PR DESCRIPTION
## Summary

- Added JS/TS regression coverage proving CRLF-encoded multi-line template literals keep later symbol line, column, and signature metadata aligned with LF input.
- Confirmed template-literal phantom symbols remain suppressed for the CRLF fixture.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_JavaScriptTypeScript_CrlfTemplateLiteralKeepsColumnsAligned"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~SymbolExtractorTests.Extract_JavaScriptTypeScript_CrlfTemplateLiteralKeepsColumnsAligned"`

## Documentation and changelog

- Added changelog fragment `changelog.d/unreleased/1465.fixed.md`.
- No docs update required because the fix pins existing extractor behavior rather than changing CLI/MCP output or user-facing commands.

## Review

- Adversarial review: No blocking/actionable issues found.

## Follow-up candidates

- None.

Fixes #1465
