### PR TITLE
Fix TypeScript alias default references

### DIFF
--- a/changelog.d/unreleased/2079.fixed.md
+++ b/changelog.d/unreleased/2079.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2079
+affected:
+  - src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **TypeScript type aliases now index generic default type references (#2079)** — `type Dict<K = DefaultKey, V = DefaultValue> = Record<K, V>` now emits `type_reference` edges for the default types and alias RHS so generic alias dependencies stay visible in the graph.
+
+## 日本語
+
+- **TypeScript の type alias が generic default type 参照を index するようになりました (#2079)** — `type Dict<K = DefaultKey, V = DefaultValue> = Record<K, V>` で default type と alias RHS の `type_reference` エッジを出力し、generic alias の依存関係が graph 上で見えるようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -32,6 +32,7 @@ internal static class TypeScriptReferenceExtractor
             resolveContainerForColumn);
 
         EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitTypeAliasTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitFunctionPropertyTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitDecoratedMemberTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -101,6 +102,129 @@ internal static class TypeScriptReferenceExtractor
 
         EmitHeritageKeyword(preparedLine, "extends", references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitHeritageKeyword(preparedLine, "implements", references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitTypeAliasTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (!TryFindTypeAliasShape(preparedLine, out var nameEnd, out var assignmentIndex))
+            return;
+
+        var genericOpen = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, '<', nameEnd);
+        if (genericOpen >= 0 && genericOpen < assignmentIndex)
+        {
+            var genericClose = ReferenceExtractor.FindMatchingChar(preparedLine, genericOpen, '<', '>');
+            if (genericClose > genericOpen && genericClose < assignmentIndex)
+            {
+                EmitTypeParameterDefaultReferences(
+                    preparedLine,
+                    genericOpen + 1,
+                    genericClose,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn);
+            }
+        }
+
+        var rhsStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, assignmentIndex + 1);
+        if (rhsStart >= preparedLine.Length)
+            return;
+
+        var rhsEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(
+            preparedLine,
+            rhsStart,
+            stopAtComma: false,
+            stopAtArrow: false);
+        if (rhsEnd <= rhsStart)
+            return;
+
+        TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+            preparedLine.Substring(rhsStart, rhsEnd - rhsStart),
+            rhsStart,
+            "typescript",
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            resolveContainerForColumn(rhsStart));
+    }
+
+    private static bool TryFindTypeAliasShape(string line, out int nameEnd, out int assignmentIndex)
+    {
+        nameEnd = -1;
+        assignmentIndex = -1;
+
+        var index = 0;
+        SkipWhitespace(line, ref index);
+        TryConsumeKeyword(line, "export", ref index);
+        SkipWhitespace(line, ref index);
+        TryConsumeKeyword(line, "declare", ref index);
+        SkipWhitespace(line, ref index);
+        if (!TryConsumeKeyword(line, "type", ref index))
+            return false;
+
+        SkipWhitespace(line, ref index);
+        if (index >= line.Length || !IsTypeScriptIdentifierStart(line[index]))
+            return false;
+
+        index++;
+        while (index < line.Length && IsTypeScriptIdentifierPart(line[index]))
+            index++;
+
+        nameEnd = index;
+        assignmentIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(line, '=', nameEnd);
+        return assignmentIndex > nameEnd;
+    }
+
+    private static void EmitTypeParameterDefaultReferences(
+        string line,
+        int listStart,
+        int listEnd,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var parameterList = line.Substring(listStart, listEnd - listStart);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(parameterList))
+        {
+            var fragment = parameterList.Substring(segmentStart, segmentLength);
+            var equalsIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(fragment, '=');
+            if (equalsIndex < 0)
+                continue;
+
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, equalsIndex + 1);
+            if (typeStart >= fragment.Length)
+                continue;
+
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart, stopAtArrow: false);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteStart = listStart + segmentStart + typeStart;
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                absoluteStart,
+                "typescript",
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                resolveContainerForColumn(absoluteStart));
+        }
     }
 
     private static void EmitHeritageKeyword(
@@ -507,4 +631,7 @@ internal static class TypeScriptReferenceExtractor
 
     private static bool IsTypeScriptIdentifierPart(char ch) =>
         ch == '_' || ch == '$' || char.IsLetterOrDigit(ch);
+
+    private static bool IsTypeScriptIdentifierStart(char ch) =>
+        ch == '_' || ch == '$' || char.IsLetter(ch);
 }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -4701,6 +4701,32 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptTypeAliasGenericDefaults_EmitsDefaultAndRhsTypeReferences()
+    {
+        const string content = """
+            type DefaultKey = string;
+            type DefaultValue = unknown;
+            type Dict<K = DefaultKey, V = DefaultValue> = Record<K, V>;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "DefaultKey"
+            && reference.ReferenceKind == "type_reference"
+            && reference.Context == "type Dict<K = DefaultKey, V = DefaultValue> = Record<K, V>;");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "DefaultValue"
+            && reference.ReferenceKind == "type_reference"
+            && reference.Context == "type Dict<K = DefaultKey, V = DefaultValue> = Record<K, V>;");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Record"
+            && reference.ReferenceKind == "type_reference"
+            && reference.Context == "type Dict<K = DefaultKey, V = DefaultValue> = Record<K, V>;");
+    }
+
+    [Fact]
     public void Extract_CsharpIndentedRawStringBeforeBlockComment_DoesNotLeakXmlDocReferences()
     {
         // Regression: BuildCSharpBlockCommentLines must recognize the closing delimiter of an


### PR DESCRIPTION
## Summary

- Emit TypeScript `type_reference` edges from generic type alias default parameters.
- Emit type alias RHS references through the existing TypeScript type-expression path.
- Add regression coverage for default types and alias RHS extraction.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptTypeAliasGenericDefaults_EmitsDefaultAndRhsTypeReferences"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: `No blocking/actionable issues found.`

Note: `dotnet test CodeIndex.sln -c Release` was attempted, but it did not complete after several minutes in this shared environment with multiple concurrent solution test runs. The scoped Debug/Release reference extractor tests passed.

## Documentation and Changelog

- Added changelog fragment: `changelog.d/unreleased/2079.fixed.md`
- No README or guide update was needed; this is an indexing correctness fix without new CLI/MCP options or contract fields.

Fixes #2079
