### PR TITLE
Cover Kotlin and Scala triple-quoted string masking

### DIFF
--- a/changelog.d/unreleased/1446.fixed.md
+++ b/changelog.d/unreleased/1446.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1446
+affected:
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin and Scala triple-quoted string masking is now covered for #1446** — regression coverage confirms call-shaped sample code inside raw string bodies does not create phantom references.
+
+## 日本語
+
+- **Kotlin / Scala の三重引用符文字列マスクを #1446 として固定しました** — raw 文字列本文内の呼び出し形サンプルコードが疑似参照にならないことを回帰テストで確認するようにしました。

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -28118,9 +28118,9 @@ public class ReferenceExtractorTests
     [Fact]
     public void Extract_KotlinTripleQuotedString_DoesNotLeakPhantomCallReferences()
     {
-        // Regression for issue #385: call-looking identifiers inside a Kotlin
+        // Regression for issues #385 and #1446: call-looking identifiers inside a Kotlin
         // multi-line raw string (""".. .""") must not be captured as references.
-        // issue #385 回帰: Kotlin の複数行 raw 文字列（"""..."""）の内側にある
+        // issue #385 / #1446 回帰: Kotlin の複数行 raw 文字列（"""..."""）の内側にある
         // 呼び出しらしい識別子は参照として抽出してはならない。
         const string content = """"
             package demo
@@ -28282,10 +28282,10 @@ public class ReferenceExtractorTests
     [Fact]
     public void Extract_ScalaTripleQuotedString_DoesNotLeakPhantomCallReferences()
     {
-        // Regression for issue #385: call-looking identifiers inside a Scala
+        // Regression for issues #385 and #1446: call-looking identifiers inside a Scala
         // multi-line raw string (""".. .""", including interpolator-prefixed forms
         // such as `s"""..."""` / `raw"""..."""`) must not be captured as references.
-        // issue #385 回帰: Scala の複数行 raw 文字列（"""...""" および `s"""..."""` /
+        // issue #385 / #1446 回帰: Scala の複数行 raw 文字列（"""...""" および `s"""..."""` /
         // `raw"""..."""` などの interpolator 形式）の内側にある呼び出しらしい識別子は
         // 参照として抽出してはならない。
         const string content = """"


### PR DESCRIPTION
## Summary

- Marked the existing Kotlin and Scala triple-quoted string reference regression tests as covering #1446.
- Added a bilingual changelog fragment for the #1446 fix.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_KotlinTripleQuotedString_DoesNotLeakPhantomCallReferences|FullyQualifiedName~ReferenceExtractorTests.Extract_ScalaTripleQuotedString_DoesNotLeakPhantomCallReferences"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Added `changelog.d/unreleased/1446.fixed.md`.
- No README or developer-guide update was needed because this confirms existing reference-extraction behavior and does not change CLI/MCP surface area.

## Follow-up candidates

- `cdidx . --json` full refresh stalled at `indexed 0/314 file(s)` locally; this appears covered by open #2331.

Fixes #1446
