### PR TITLE
Fix TypeScript conditional generic refs

### DIFF
--- a/changelog.d/unreleased/1985.fixed.md
+++ b/changelog.d/unreleased/1985.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1985
+affected:
+  - src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **TypeScript conditional generic constraints now emit branch type references (#1985)** — generic constraints such as `<T extends Array<infer U> ? Promise<U[]> : Nested<Fallback>>` now index references from the condition, true branch, and false branch.
+
+## 日本語
+
+- **TypeScript の conditional generic constraint が分岐内の型参照を出力するようになりました (#1985)** — `<T extends Array<infer U> ? Promise<U[]> : Nested<Fallback>>` のような generic constraint で、条件・true 分岐・false 分岐の型参照を index するようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -31,6 +31,7 @@ internal static class TypeScriptReferenceExtractor
             lineNumber,
             resolveContainerForColumn);
 
+        EmitGenericConstraintTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitFunctionPropertyTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -76,6 +77,62 @@ internal static class TypeScriptReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+    }
+
+    private static void EmitGenericConstraintTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        for (var index = 0; index < preparedLine.Length; index++)
+        {
+            if (preparedLine[index] != '<')
+                continue;
+
+            var closeIndex = ReferenceExtractor.FindMatchingChar(preparedLine, index, '<', '>');
+            if (closeIndex <= index)
+                continue;
+
+            var clauseStart = index + 1;
+            var clause = preparedLine.Substring(clauseStart, closeIndex - clauseStart);
+            foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(clause))
+            {
+                var fragment = clause.Substring(segmentStart, segmentLength);
+                foreach (var extendsIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(fragment, "extends"))
+                {
+                    var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, extendsIndex + "extends".Length);
+                    if (typeStart >= fragment.Length)
+                        continue;
+
+                    var typeEnd = FindGenericConstraintExpressionEnd(fragment, typeStart);
+                    if (typeEnd <= typeStart)
+                        continue;
+
+                    var absoluteStart = clauseStart + segmentStart + typeStart;
+                    ReferenceExtractor.AddTypeScriptTypeExpressionSegments(
+                        references,
+                        seen,
+                        fileId,
+                        fragment.Substring(typeStart, typeEnd - typeStart),
+                        absoluteStart,
+                        context,
+                        lineNumber,
+                        resolveContainerForColumn(absoluteStart));
+                }
+            }
+
+            index = closeIndex;
+        }
+    }
+
+    private static int FindGenericConstraintExpressionEnd(string fragment, int typeStart)
+    {
+        var equalsIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(fragment, '=', typeStart);
+        return equalsIndex >= 0 ? equalsIndex : fragment.Length;
     }
 
     private static void EmitHeritageTypeReferences(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1149,7 +1149,7 @@ public static partial class ReferenceExtractor
             ignoredSegments: ignoredSegments);
     }
 
-    private static void AddTypeScriptTypeExpressionSegments(
+    internal static void AddTypeScriptTypeExpressionSegments(
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -627,7 +627,7 @@ public static partial class ReferenceExtractor
         ["typescript"] = new HashSet<string>(StringComparer.Ordinal)
         {
             "any", "bigint", "boolean", "false", "never", "null", "number", "object", "string",
-            "symbol", "true", "undefined", "unknown", "void",
+            "infer", "keyof", "readonly", "symbol", "true", "undefined", "unique", "unknown", "void",
         },
         ["kotlin"] = new HashSet<string>(StringComparer.Ordinal)
         {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -11,6 +11,43 @@ namespace CodeIndex.Tests;
 public class ReferenceExtractorTests
 {
     [Fact]
+    public void Extract_TypeScriptGenericConditionalConstraint_EmitsBranchTypeReferences()
+    {
+        const string content = """
+            export function unwrap<T extends Array<infer U> ? Promise<U[]> : Nested<Fallback>>(value: T): T {
+                return value;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Array"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "unwrap");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "U"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "unwrap");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Promise"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "unwrap");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Nested"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "unwrap");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Fallback"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "unwrap");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "infer"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_CsharpAsyncIterator_EmitsTypeAndImplicitImplementationReferences()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Emit TypeScript type references from generic `extends` constraints that contain conditional types.
- Reuse the existing TypeScript type-expression walker for the conditional condition, true branch, and false branch.
- Suppress TypeScript type operators such as `infer`, `keyof`, `readonly`, and `unique` from `type_reference` rows.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptGenericConditionalConstraint_EmitsBranchTypeReferences" --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: `No blocking/actionable issues found.`

Full `dotnet test CodeIndex.sln` was attempted, but the run produced no final summary after several minutes and was stopped.

## Documentation and Changelog

- Added `changelog.d/unreleased/1985.fixed.md`.
- No AGENTS.md, CLAUDE.md, or AGENT_GUIDE.md changes.

Fixes #1985
