### PR TITLE
Fix TSX generic component references

### DIFF
--- a/changelog.d/unreleased/2081.fixed.md
+++ b/changelog.d/unreleased/2081.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2081
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **TSX generic component invocations now index type arguments (#2081)** — component tags such as `<List<Item> />`, `<Provider<State, Action> />`, and `<Foo<{ a: number }> {...rest} />` now emit component call edges and `type_reference` rows for their explicit JSX type arguments.
+
+## 日本語
+
+- **TSX の generic component 呼び出しで型引数を index するようになりました (#2081)** — `<List<Item> />`、`<Provider<State, Action> />`、`<Foo<{ a: number }> {...rest} />` のような component tag で、component call edge と明示 JSX 型引数の `type_reference` 行を出力するようになりました。

--- a/changelog.d/unreleased/2081.fixed.md
+++ b/changelog.d/unreleased/2081.fixed.md
@@ -4,6 +4,7 @@ issues:
   - 2081
 affected:
   - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
   - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
 ---
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -2072,6 +2072,9 @@ public static partial class ReferenceExtractor
                 i++;
 
             var segment = expression.Substring(segmentStart, i - segmentStart);
+            if (IsTypeScriptTypeLabelSegment(expression, i))
+                continue;
+
             AddTypeReferenceSegment(
                 references,
                 seen,
@@ -2084,6 +2087,17 @@ public static partial class ReferenceExtractor
                 "typescript",
                 ignoredSegments: ignoredSegments);
         }
+    }
+
+    private static bool IsTypeScriptTypeLabelSegment(string expression, int segmentEnd)
+    {
+        var next = segmentEnd;
+        while (next < expression.Length && char.IsWhiteSpace(expression[next]))
+            next++;
+
+        return next < expression.Length
+            && expression[next] == ':'
+            && (next + 1 >= expression.Length || expression[next + 1] != ':');
     }
 
     private static int ScanTypeScriptTemplateLiteralForTypeExpression(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1652,6 +1652,7 @@ public static partial class ReferenceExtractor
                     var nameIndex = match.Groups["name"].Index;
                     var jsxContainer = ResolveContainerForCall(nameIndex);
                     var firstDotIndex = fullName.IndexOf('.');
+                    var tagEndIndex = nameIndex + fullName.Length;
 
                     AddReference(
                         references,
@@ -1677,6 +1678,29 @@ public static partial class ReferenceExtractor
                             context,
                             lineNumber,
                             jsxContainer);
+                    }
+
+                    if (language == "typescript")
+                    {
+                        var genericStart = SkipWhitespace(preparedLine, tagEndIndex);
+                        if (genericStart < preparedLine.Length && preparedLine[genericStart] == '<')
+                        {
+                            var genericEnd = genericStart;
+                            if (TrySkipBalancedGenericArgs(preparedLine, ref genericEnd, out _)
+                                && genericEnd > genericStart + 2)
+                            {
+                                AddTypeExpressionSegments(
+                                    references,
+                                    seen,
+                                    fileId,
+                                    preparedLine.Substring(genericStart + 1, genericEnd - genericStart - 2),
+                                    genericStart + 1,
+                                    context,
+                                    lineNumber,
+                                    jsxContainer,
+                                    "typescript");
+                            }
+                        }
                     }
                 }
             }

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1686,7 +1686,7 @@ public static partial class ReferenceExtractor
                         if (genericStart < preparedLine.Length && preparedLine[genericStart] == '<')
                         {
                             var genericEnd = genericStart;
-                            if (TrySkipBalancedGenericArgs(preparedLine, ref genericEnd, out _)
+                            if (TrySkipTypeScriptJsxTypeArguments(preparedLine, ref genericEnd)
                                 && genericEnd > genericStart + 2)
                             {
                                 AddTypeExpressionSegments(
@@ -3310,6 +3310,56 @@ public static partial class ReferenceExtractor
         var extension = Path.GetExtension(path);
         return string.Equals(extension, ".jsx", StringComparison.OrdinalIgnoreCase)
             || string.Equals(extension, ".tsx", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TrySkipTypeScriptJsxTypeArguments(string preparedLine, ref int scan)
+    {
+        if (scan >= preparedLine.Length || preparedLine[scan] != '<')
+            return false;
+
+        var depth = 0;
+        while (scan < preparedLine.Length)
+        {
+            var ch = preparedLine[scan++];
+            if (ch == '\'' || ch == '"')
+            {
+                while (scan < preparedLine.Length)
+                {
+                    var quoted = preparedLine[scan++];
+                    if (quoted == '\\')
+                    {
+                        scan = Math.Min(scan + 1, preparedLine.Length);
+                        continue;
+                    }
+
+                    if (quoted == ch)
+                        break;
+                }
+
+                continue;
+            }
+
+            if (ch == '=' && scan < preparedLine.Length && preparedLine[scan] == '>')
+            {
+                scan++;
+                continue;
+            }
+
+            if (ch == '<')
+            {
+                depth++;
+            }
+            else if (ch == '>')
+            {
+                depth--;
+                if (depth == 0)
+                    return true;
+                if (depth < 0)
+                    return false;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsRazorFilePath(string? path)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1646,8 +1646,12 @@ public static partial class ReferenceExtractor
 
             if (isJsxFile && (language is "javascript" or "typescript"))
             {
+                var jsxTypeArgumentSkipUntil = -1;
                 foreach (Match match in JsxElementOpenRegex.Matches(preparedLine))
                 {
+                    if (match.Index < jsxTypeArgumentSkipUntil)
+                        continue;
+
                     var fullName = match.Groups["name"].Value;
                     var nameIndex = match.Groups["name"].Index;
                     var jsxContainer = ResolveContainerForCall(nameIndex);
@@ -1689,6 +1693,7 @@ public static partial class ReferenceExtractor
                             if (TrySkipTypeScriptJsxTypeArguments(preparedLine, ref genericEnd)
                                 && genericEnd > genericStart + 2)
                             {
+                                jsxTypeArgumentSkipUntil = Math.Max(jsxTypeArgumentSkipUntil, genericEnd);
                                 AddTypeExpressionSegments(
                                     references,
                                     seen,

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -51,6 +51,7 @@ public class ReferenceExtractorTests
                         <List<Item> items={items} />
                         <Provider<State, Action> value={ctx} />
                         <Foo<{ a: number }> {...rest} />
+                        <Mapper<(item: Item) => Result> />
                     </>
                 );
             }
@@ -72,6 +73,10 @@ public class ReferenceExtractorTests
             && reference.ReferenceKind == "call"
             && reference.ContainerName == "Screen");
         Assert.Contains(references, reference =>
+            reference.SymbolName == "Mapper"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "Screen");
+        Assert.Contains(references, reference =>
             reference.SymbolName == "Item"
             && reference.ReferenceKind == "type_reference"
             && reference.ContainerName == "Screen");
@@ -84,9 +89,12 @@ public class ReferenceExtractorTests
             && reference.ReferenceKind == "type_reference"
             && reference.ContainerName == "Screen");
         Assert.Contains(references, reference =>
-            reference.SymbolName == "a"
+            reference.SymbolName == "Result"
             && reference.ReferenceKind == "type_reference"
             && reference.ContainerName == "Screen");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName is "a" or "item"
+            && reference.ReferenceKind == "type_reference");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -38,6 +38,58 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TsxGenericComponentInvocations_EmitsComponentCallsAndTypeArguments()
+    {
+        const string content = """
+            type Item = { id: string };
+            type State = { count: number };
+            type Action = { type: string };
+
+            export function Screen({ items, ctx, rest }: Props) {
+                return (
+                    <>
+                        <List<Item> items={items} />
+                        <Provider<State, Action> value={ctx} />
+                        <Foo<{ a: number }> {...rest} />
+                    </>
+                );
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols, path: "Screen.tsx");
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "List"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "Screen");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Provider"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "Screen");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Foo"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "Screen");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Item"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Screen");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "State"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Screen");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Action"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Screen");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "a"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Screen");
+    }
+
+    [Fact]
     public void Extract_CsharpRawStringLongerQuoteRun_DoesNotLeakCallReferences()
     {
         // Regression for #1453: a raw string opened with four quotes must only

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -95,6 +95,9 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, reference =>
             reference.SymbolName is "a" or "item"
             && reference.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName is "Item" or "State" or "Action" or "Result"
+            && reference.ReferenceKind == "call");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Index explicit TSX JSX component type arguments as `type_reference` rows.
- Preserve component `call` rows for generic JSX tags while suppressing false `call` rows from type arguments.
- Skip TypeScript type labels/property keys and function parameter names when extracting type-expression references.

## Validation

- `dotnet test CodeIndex.sln -c Release --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TsxGenericComponentInvocations_EmitsComponentCallsAndTypeArguments"`
- `dotnet test CodeIndex.sln -c Release --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`

## Documentation and changelog

- Added changelog fragment: `changelog.d/unreleased/2081.fixed.md`
- No README or guide updates were needed; this is a reference extraction bug fix with no CLI contract change.

## Review

- Ran Codex adversarial review twice.
- Round 1 found TS function-type arrow truncation and object-property-key false positives; both were fixed.
- Round 2 found type arguments being emitted as false JSX component calls; fixed and revalidated.

Fixes #2081
