### PR TITLE
Fix TypeScript satisfies reference edges

### DIFF
--- a/changelog.d/unreleased/1447.fixed.md
+++ b/changelog.d/unreleased/1447.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1447
+affected:
+  - src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **TypeScript `satisfies` references no longer leak into the call graph (#1447)** — references on the right-hand side of `satisfies` are kept as `type_reference` edges and suppressed as phantom `call` edges.
+
+## 日本語
+
+- **TypeScript の `satisfies` 参照が call graph に漏れなくなりました (#1447)** — `satisfies` 右辺の参照は `type_reference` エッジとして保持し、phantom な `call` エッジとしては出さないようにしました。

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -78,6 +78,25 @@ internal static class TypeScriptReferenceExtractor
             resolveContainerForColumn);
     }
 
+    public static bool IsSatisfiesTypeOperand(string preparedLine, int tokenIndex)
+    {
+        foreach (var keywordIndex in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(preparedLine, "satisfies"))
+        {
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, keywordIndex + "satisfies".Length);
+            if (typeStart >= preparedLine.Length || tokenIndex < typeStart)
+                continue;
+
+            var typeEnd = TypedLanguageReferenceExtractor.FindKeywordFollowingTypeExpressionEnd(preparedLine, typeStart, "typescript");
+            if (typeEnd <= typeStart)
+                continue;
+
+            if (tokenIndex < typeEnd)
+                return true;
+        }
+
+        return false;
+    }
+
     private static void EmitHeritageTypeReferences(
         string preparedLine,
         List<ReferenceRecord> references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2313,16 +2313,18 @@ public static partial class ReferenceExtractor
                     return false;
                 }
 
-                  // C# positional patterns such as `case Point(var x, var y):` are type-pattern
-                  // heads, not calls. `CallRegex` still sees `Point(` and would otherwise emit a
-                  // phantom `call` edge alongside the real `type_reference`.
-                  // C# の positional pattern (`case Point(var x, var y):`) は型パターンの先頭であり、
-                  // 呼び出しではない。`CallRegex` が `Point(` を拾ってしまうため、そのままだと
-                  // 本物の `type_reference` に加えて phantom な `call` エッジが出る。
-                  var isCSharpPatternHeadCallSite = language == "csharp"
-                      && CSharpReferenceExtractor.IsPatternHeadCallSite(preparedLines, i, preparedLine, callIndex);
-                  if (isCSharpPatternHeadCallSite)
-                      return false;
+                // C# positional patterns such as `case Point(var x, var y):` are type-pattern
+                // heads, not calls. `CallRegex` still sees `Point(` and would otherwise emit a
+                // phantom `call` edge alongside the real `type_reference`.
+                // C# の positional pattern (`case Point(var x, var y):`) は型パターンの先頭であり、
+                // 呼び出しではない。`CallRegex` が `Point(` を拾ってしまうため、そのままだと
+                // 本物の `type_reference` に加えて phantom な `call` エッジが出る。
+                var isCSharpPatternHeadCallSite = language == "csharp"
+                    && CSharpReferenceExtractor.IsPatternHeadCallSite(preparedLines, i, preparedLine, callIndex);
+                if (isCSharpPatternHeadCallSite)
+                    return false;
+                if (language == "typescript" && TypeScriptReferenceExtractor.IsSatisfiesTypeOperand(preparedLine, callIndex))
+                    return false;
 
                 var callContainer = ResolveContainerForCall(callIndex);
                 if (IsConstructorCallName(language, preparedLine, callIndex))

--- a/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
@@ -531,7 +531,7 @@ internal static class TypedLanguageReferenceExtractor
     private static int FindTypeExpressionEndForLanguage(string text, int startIndex, string language, bool stopAtComma = true)
         => FindTypeExpressionEnd(text, startIndex, stopAtComma, stopAtArrow: language is not ("typescript" or "swift"));
 
-    private static int FindKeywordFollowingTypeExpressionEnd(string text, int startIndex, string language)
+    public static int FindKeywordFollowingTypeExpressionEnd(string text, int startIndex, string language)
         => FindTypeExpressionEnd(
             text,
             startIndex,

--- a/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
@@ -532,11 +532,20 @@ internal static class TypedLanguageReferenceExtractor
         => FindTypeExpressionEnd(text, startIndex, stopAtComma, stopAtArrow: language is not ("typescript" or "swift"));
 
     public static int FindKeywordFollowingTypeExpressionEnd(string text, int startIndex, string language)
-        => FindTypeExpressionEnd(
+    {
+        if (language == "typescript" && startIndex < text.Length && text[startIndex] == '{')
+        {
+            var closeBrace = ReferenceExtractor.FindMatchingChar(text, startIndex, '{', '}');
+            if (closeBrace >= 0)
+                return closeBrace + 1;
+        }
+
+        return FindTypeExpressionEnd(
             text,
             startIndex,
             stopAtArrow: language != "typescript",
             stopAtRuntimeOperator: true);
+    }
 
     private static bool IsRuntimeExpressionOperatorTerminator(string text, int index, char ch)
     {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -29251,6 +29251,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptSatisfies_CapturesTypeReferencesWithoutCalls()
+    {
+        const string content = """
+            const config = { port: 8080 } satisfies ServerConfig;
+            const wrapped = (x: number) => x satisfies Brand;
+            const chained = config satisfies ServerConfig satisfies RuntimeConfig;
+            const nested = wrap<ServerConfig satisfies RuntimeConfig>(config);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "ServerConfig" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Brand" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "RuntimeConfig" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "ServerConfig" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "Brand" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "RuntimeConfig" && r.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_TypeScriptImportExportAliases_DoNotEmitTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -29285,6 +29285,7 @@ public class ReferenceExtractorTests
             const wrapped = (x: number) => x satisfies Brand;
             const chained = config satisfies ServerConfig satisfies RuntimeConfig;
             const nested = wrap<ServerConfig satisfies RuntimeConfig>(config);
+            const parser = {} satisfies { parse(input: Request): Response };
             """;
 
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
@@ -29293,9 +29294,12 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "ServerConfig" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Brand" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RuntimeConfig" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Request" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Response" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "ServerConfig" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Brand" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "RuntimeConfig" && r.ReferenceKind == "call");
+        Assert.DoesNotContain(references, r => r.SymbolName == "parse" && r.ReferenceKind == "call");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Treat TypeScript `satisfies` right-hand operands as type-position references.
- Suppress phantom `call` edges from call-shaped members inside `satisfies` type literals.
- Add focused regression coverage for simple, chained, generic-argument, and object-type `satisfies` forms.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScript"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptSatisfies_CapturesTypeReferencesWithoutCalls"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- Codex adversarial review: `No blocking/actionable issues found.`

Notes:
- `dotnet build` / `dotnet test` emitted `NU1900` warnings because NuGet vulnerability metadata could not be fetched in the restricted network environment.
- Full `dotnet test CodeIndex.sln --no-restore` was attempted but did not complete within the local bounded wait; it was stopped after the suite showed no additional output for several minutes.
- `cdidx` full and file-scoped index refresh attempts hung locally at/near startup; this matches the existing full-scan hang symptom tracked separately and was not expanded into this PR.

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/1447.fixed.md`
- No README / guide update was needed because this is a bug fix to existing TypeScript reference extraction behavior, not a new user-facing command or option.

## Follow-up Candidates

- None.

Fixes #1447
