### PR TITLE
Fix C# hotspot false method candidates

### DIFF
--- a/changelog.d/unreleased/1405.fixed.md
+++ b/changelog.d/unreleased/1405.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1405
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **C# hotspots no longer promote bodyless call-site method names (#1405)** — `hotspots` and grouped hotspot results now skip C# function candidates without a body span, preventing BCL/library calls such as `GetInt32` from being reported as project definitions.
+
+## 日本語
+
+- **C# の `hotspots` が body を持たない呼び出し地点のメソッド名を昇格しないようになりました (#1405)** — `hotspots` と grouped hotspot は body span のない C# function 候補を除外し、`GetInt32` などの BCL / ライブラリ呼び出しをプロジェクト定義として報告しないようになりました。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -1642,13 +1642,14 @@ public partial class DbReader
         var csharpFunctionDefinitionGateSql = _symbolColumns.Contains("body_start_line")
             && _symbolColumns.Contains("body_end_line")
             && _symbolColumns.Contains("signature")
+            && _symbolColumns.Contains("container_kind")
             ? @"
                   AND NOT (
                       f.lang = 'csharp'
                       AND s.kind = 'function'
                       AND (
                           (s.body_start_line IS NULL AND s.body_end_line IS NULL)
-                          OR COALESCE(s.signature, '') NOT LIKE '% ' || s.name || '(%'
+                          OR (s.container_kind = 'function' AND COALESCE(s.signature, '') LIKE '%.' || s.name || '(%')
                       )
                   )"
             : string.Empty;
@@ -2014,13 +2015,14 @@ public partial class DbReader
         var csharpFunctionDefinitionGateSql = _symbolColumns.Contains("body_start_line")
             && _symbolColumns.Contains("body_end_line")
             && _symbolColumns.Contains("signature")
+            && _symbolColumns.Contains("container_kind")
             ? @"
                   AND NOT (
                       f.lang = 'csharp'
                       AND s.kind = 'function'
                       AND (
                           (s.body_start_line IS NULL AND s.body_end_line IS NULL)
-                          OR COALESCE(s.signature, '') NOT LIKE '% ' || s.name || '(%'
+                          OR (s.container_kind = 'function' AND COALESCE(s.signature, '') LIKE '%.' || s.name || '(%')
                       )
                   )"
             : string.Empty;

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -1647,6 +1647,7 @@ public partial class DbReader
                   AND NOT (
                       f.lang = 'csharp'
                       AND s.kind = 'function'
+                      AND s.container_kind = 'function'
                       AND (
                           (s.body_start_line IS NULL AND s.body_end_line IS NULL)
                           OR (s.container_kind = 'function' AND COALESCE(s.signature, '') LIKE '%.' || s.name || '(%')
@@ -2020,6 +2021,7 @@ public partial class DbReader
                   AND NOT (
                       f.lang = 'csharp'
                       AND s.kind = 'function'
+                      AND s.container_kind = 'function'
                       AND (
                           (s.body_start_line IS NULL AND s.body_end_line IS NULL)
                           OR (s.container_kind = 'function' AND COALESCE(s.signature, '') LIKE '%.' || s.name || '(%')

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -1639,6 +1639,19 @@ public partial class DbReader
                         THEN 'container|' || CAST(s.file_id AS TEXT) || '|' || COALESCE(s.kind, '') || '|' || {containerQualifiedNameSql}
                     ELSE NULL
                 END";
+        var csharpFunctionDefinitionGateSql = _symbolColumns.Contains("body_start_line")
+            && _symbolColumns.Contains("body_end_line")
+            && _symbolColumns.Contains("signature")
+            ? @"
+                  AND NOT (
+                      f.lang = 'csharp'
+                      AND s.kind = 'function'
+                      AND (
+                          (s.body_start_line IS NULL AND s.body_end_line IS NULL)
+                          OR COALESCE(s.signature, '') NOT LIKE '% ' || s.name || '(%'
+                      )
+                  )"
+            : string.Empty;
         // Ambiguity is computed from the unscoped language/kind candidate set so `--path`
         // cannot hide an out-of-scope duplicate and accidentally promote a same-name symbol
         // back to codebase-wide counting. Cross-file grouping is allowed only when the
@@ -1666,16 +1679,7 @@ public partial class DbReader
                        COALESCE({familyTargetKeySql}, {containerTargetKeySql}) AS count_safe_key
                 FROM symbols s
                 JOIN files f ON s.file_id = f.id
-                WHERE s.kind NOT IN ('import', 'namespace')
-                  AND NOT (
-                      f.lang = 'csharp'
-                      AND s.kind = 'function'
-                      AND (
-                          ({GetSymbolColumnSql("body_start_line")} IS NULL AND {GetSymbolColumnSql("body_end_line")} IS NULL)
-                          OR {GetSymbolColumnSql("signature", "''")} NOT LIKE '% ' || s.name || '(%'
-                          OR {GetSymbolColumnSql("signature", "''")} LIKE '% override %'
-                      )
-                  )";
+                WHERE s.kind NOT IN ('import', 'namespace')" + csharpFunctionDefinitionGateSql;
 
         // Restrict to graph-supported languages only / グラフ対応言語のみに制限
         var graphLangs = ReferenceExtractor.GetSupportedLanguages();
@@ -2007,6 +2011,19 @@ public partial class DbReader
                         THEN 'container|' || CAST(s.file_id AS TEXT) || '|' || COALESCE(s.kind, '') || '|' || {containerQualifiedNameSql}
                     ELSE NULL
                 END";
+        var csharpFunctionDefinitionGateSql = _symbolColumns.Contains("body_start_line")
+            && _symbolColumns.Contains("body_end_line")
+            && _symbolColumns.Contains("signature")
+            ? @"
+                  AND NOT (
+                      f.lang = 'csharp'
+                      AND s.kind = 'function'
+                      AND (
+                          (s.body_start_line IS NULL AND s.body_end_line IS NULL)
+                          OR COALESCE(s.signature, '') NOT LIKE '% ' || s.name || '(%'
+                      )
+                  )"
+            : string.Empty;
         var graphLangs = ReferenceExtractor.GetSupportedLanguages().ToList();
         var sql = $@"
             WITH all_candidate_symbols AS (
@@ -2023,16 +2040,7 @@ public partial class DbReader
                        COALESCE({familyTargetKeySql}, {containerTargetKeySql}) AS count_safe_key
                 FROM symbols s
                 JOIN files f ON s.file_id = f.id
-                WHERE s.kind NOT IN ('import', 'namespace')
-                  AND NOT (
-                      f.lang = 'csharp'
-                      AND s.kind = 'function'
-                      AND (
-                          ({GetSymbolColumnSql("body_start_line")} IS NULL AND {GetSymbolColumnSql("body_end_line")} IS NULL)
-                          OR {GetSymbolColumnSql("signature", "''")} NOT LIKE '% ' || s.name || '(%'
-                          OR {GetSymbolColumnSql("signature", "''")} LIKE '% override %'
-                      )
-                  )";
+                WHERE s.kind NOT IN ('import', 'namespace')" + csharpFunctionDefinitionGateSql;
 
         if (lang != null)
             sql += SymbolLanguageFileIdFilter;

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -1666,7 +1666,16 @@ public partial class DbReader
                        COALESCE({familyTargetKeySql}, {containerTargetKeySql}) AS count_safe_key
                 FROM symbols s
                 JOIN files f ON s.file_id = f.id
-                WHERE s.kind NOT IN ('import', 'namespace')";
+                WHERE s.kind NOT IN ('import', 'namespace')
+                  AND NOT (
+                      f.lang = 'csharp'
+                      AND s.kind = 'function'
+                      AND (
+                          ({GetSymbolColumnSql("body_start_line")} IS NULL AND {GetSymbolColumnSql("body_end_line")} IS NULL)
+                          OR {GetSymbolColumnSql("signature", "''")} NOT LIKE '% ' || s.name || '(%'
+                          OR {GetSymbolColumnSql("signature", "''")} LIKE '% override %'
+                      )
+                  )";
 
         // Restrict to graph-supported languages only / グラフ対応言語のみに制限
         var graphLangs = ReferenceExtractor.GetSupportedLanguages();
@@ -2014,7 +2023,16 @@ public partial class DbReader
                        COALESCE({familyTargetKeySql}, {containerTargetKeySql}) AS count_safe_key
                 FROM symbols s
                 JOIN files f ON s.file_id = f.id
-                WHERE s.kind NOT IN ('import', 'namespace')";
+                WHERE s.kind NOT IN ('import', 'namespace')
+                  AND NOT (
+                      f.lang = 'csharp'
+                      AND s.kind = 'function'
+                      AND (
+                          ({GetSymbolColumnSql("body_start_line")} IS NULL AND {GetSymbolColumnSql("body_end_line")} IS NULL)
+                          OR {GetSymbolColumnSql("signature", "''")} NOT LIKE '% ' || s.name || '(%'
+                          OR {GetSymbolColumnSql("signature", "''")} LIKE '% override %'
+                      )
+                  )";
 
         if (lang != null)
             sql += SymbolLanguageFileIdFilter;

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -2793,16 +2793,6 @@ public class DbReaderTests : IDisposable
                     reader.Load(dataReader);
                 }
             }
-
-            public sealed class TeeWriter : System.IO.TextWriter
-            {
-                public override System.Text.Encoding Encoding => System.Text.Encoding.UTF8;
-
-                public override void WriteLine(string? value)
-                {
-                    System.Console.WriteLine(value);
-                }
-            }
             """);
 
         var results = _reader.GetSymbolHotspots(
@@ -2815,7 +2805,6 @@ public class DbReaderTests : IDisposable
 
         Assert.DoesNotContain(results, result => result.Symbol.Name == "GetInt32");
         Assert.DoesNotContain(results, result => result.Symbol.Name == "Max");
-        Assert.DoesNotContain(results, result => result.Symbol.Name == "WriteLine");
         var load = Assert.Single(results.Where(result => result.Symbol.Name == "Load"));
         Assert.Equal(2, load.ReferenceCount);
 
@@ -2829,7 +2818,6 @@ public class DbReaderTests : IDisposable
 
         Assert.DoesNotContain(groupedResults, result => result.Symbol.Name == "GetInt32");
         Assert.DoesNotContain(groupedResults, result => result.Symbol.Name == "Max");
-        Assert.DoesNotContain(groupedResults, result => result.Symbol.Name == "WriteLine");
         var groupedLoad = Assert.Single(groupedResults.Where(result => result.Symbol.Name == "Load"));
         Assert.Equal(2, groupedLoad.ReferenceCount);
     }

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -2775,6 +2775,11 @@ public class DbReaderTests : IDisposable
             """
             public class Reader
             {
+                public T Identity<T>(T value)
+                {
+                    return value;
+                }
+
                 public void Load(Microsoft.Data.Sqlite.SqliteDataReader reader)
                 {
                     var first = reader.GetInt32(0);
@@ -2782,6 +2787,7 @@ public class DbReaderTests : IDisposable
                     var max = Math.Max(
                         first,
                         second);
+                    _ = Identity(max);
                 }
             }
 
@@ -2807,6 +2813,8 @@ public class DbReaderTests : IDisposable
         Assert.DoesNotContain(results, result => result.Symbol.Name == "Max");
         var load = Assert.Single(results.Where(result => result.Symbol.Name == "Load"));
         Assert.Equal(2, load.ReferenceCount);
+        var identity = Assert.Single(results.Where(result => result.Symbol.Name == "Identity"));
+        Assert.Equal(1, identity.ReferenceCount);
 
         var groupedResults = _reader.GetGroupedSymbolHotspots(
             limit: 10,
@@ -2820,6 +2828,8 @@ public class DbReaderTests : IDisposable
         Assert.DoesNotContain(groupedResults, result => result.Symbol.Name == "Max");
         var groupedLoad = Assert.Single(groupedResults.Where(result => result.Symbol.Name == "Load"));
         Assert.Equal(2, groupedLoad.ReferenceCount);
+        var groupedIdentity = Assert.Single(groupedResults.Where(result => result.Symbol.Name == "Identity"));
+        Assert.Equal(1, groupedIdentity.ReferenceCount);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -377,6 +377,9 @@ public class DbReaderTests : IDisposable
                 Line = 1,
                 StartLine = 1,
                 EndLine = 3,
+                BodyStartLine = 2,
+                BodyEndLine = 3,
+                Signature = "public void RealCallTarget()",
             },
             new SymbolRecord
             {
@@ -386,6 +389,9 @@ public class DbReaderTests : IDisposable
                 Line = 5,
                 StartLine = 5,
                 EndLine = 7,
+                BodyStartLine = 6,
+                BodyEndLine = 7,
+                Signature = "public void SubscribeOnlyTarget()",
             },
         ]);
 
@@ -2760,6 +2766,72 @@ public class DbReaderTests : IDisposable
         Assert.Equal("src/api.cs", run.Symbol.Path);
         Assert.Equal("Api", run.Symbol.ContainerName);
         Assert.Equal(2, run.ReferenceCount);
+    }
+
+    [Fact]
+    public void GetSymbolHotspots_CSharpSkipsBodylessCallSiteFunctionCandidates()
+    {
+        InsertIndexedFile("src/reader.cs", "csharp",
+            """
+            public class Reader
+            {
+                public void Load(Microsoft.Data.Sqlite.SqliteDataReader reader)
+                {
+                    var first = reader.GetInt32(0);
+                    var second = reader.GetInt32(1);
+                    var max = Math.Max(
+                        first,
+                        second);
+                }
+            }
+
+            public class App
+            {
+                public void Run(Reader reader, Microsoft.Data.Sqlite.SqliteDataReader dataReader)
+                {
+                    reader.Load(dataReader);
+                    reader.Load(dataReader);
+                }
+            }
+
+            public sealed class TeeWriter : System.IO.TextWriter
+            {
+                public override System.Text.Encoding Encoding => System.Text.Encoding.UTF8;
+
+                public override void WriteLine(string? value)
+                {
+                    System.Console.WriteLine(value);
+                }
+            }
+            """);
+
+        var results = _reader.GetSymbolHotspots(
+            limit: 10,
+            kind: "function",
+            lang: "csharp",
+            pathPatterns: ["src/reader.cs"],
+            excludePathPatterns: null,
+            excludeTests: false);
+
+        Assert.DoesNotContain(results, result => result.Symbol.Name == "GetInt32");
+        Assert.DoesNotContain(results, result => result.Symbol.Name == "Max");
+        Assert.DoesNotContain(results, result => result.Symbol.Name == "WriteLine");
+        var load = Assert.Single(results.Where(result => result.Symbol.Name == "Load"));
+        Assert.Equal(2, load.ReferenceCount);
+
+        var groupedResults = _reader.GetGroupedSymbolHotspots(
+            limit: 10,
+            kind: "function",
+            lang: "csharp",
+            pathPatterns: ["src/reader.cs"],
+            excludePathPatterns: null,
+            excludeTests: false);
+
+        Assert.DoesNotContain(groupedResults, result => result.Symbol.Name == "GetInt32");
+        Assert.DoesNotContain(groupedResults, result => result.Symbol.Name == "Max");
+        Assert.DoesNotContain(groupedResults, result => result.Symbol.Name == "WriteLine");
+        var groupedLoad = Assert.Single(groupedResults.Where(result => result.Symbol.Name == "Load"));
+        Assert.Equal(2, groupedLoad.ReferenceCount);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -2799,6 +2799,19 @@ public class DbReaderTests : IDisposable
                     reader.Load(dataReader);
                 }
             }
+
+            public interface IService
+            {
+                void Execute();
+            }
+
+            public class ServiceConsumer
+            {
+                public void Run(IService service)
+                {
+                    service.Execute();
+                }
+            }
             """);
 
         var results = _reader.GetSymbolHotspots(
@@ -2815,6 +2828,8 @@ public class DbReaderTests : IDisposable
         Assert.Equal(2, load.ReferenceCount);
         var identity = Assert.Single(results.Where(result => result.Symbol.Name == "Identity"));
         Assert.Equal(1, identity.ReferenceCount);
+        var execute = Assert.Single(results.Where(result => result.Symbol.Name == "Execute"));
+        Assert.Equal(1, execute.ReferenceCount);
 
         var groupedResults = _reader.GetGroupedSymbolHotspots(
             limit: 10,
@@ -2830,6 +2845,8 @@ public class DbReaderTests : IDisposable
         Assert.Equal(2, groupedLoad.ReferenceCount);
         var groupedIdentity = Assert.Single(groupedResults.Where(result => result.Symbol.Name == "Identity"));
         Assert.Equal(1, groupedIdentity.ReferenceCount);
+        var groupedExecute = Assert.Single(groupedResults.Where(result => result.Symbol.Name == "Execute"));
+        Assert.Equal(1, groupedExecute.ReferenceCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Gate C# function hotspot candidates so function-scoped call-site artifacts are not promoted as project definitions.
- Cover bodyless BCL-style calls, dotted multiline calls, generic methods, and bodyless interface API definitions in hotspot tests.
- Add a bilingual changelog fragment for #1405.

Fixes #1405

## Validation
- dotnet build
- dotnet test --filter FullyQualifiedName~CodeIndex.Tests.DbReaderTests
- dotnet run --project tools/CodeIndex.Changelog -- check
- Codex adversarial review: No blocking/actionable issues found.

## Changelog
- changelog.d/unreleased/1405.fixed.md

## Notes
- Local cdidx index rebuild is blocked by open issue #2331; full rebuild stalled at 0/310 and was stopped.