### PR TITLE
Fix large file indexing cap

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -329,7 +329,7 @@ Use the smallest change that reduces the expensive part of your run.
 | `--files <path...>` | off | Editor/save hooks or known in-place edits | Does not purge old rename/delete paths unless listed |
 | `--commits <id...>` | off | After normal commits | Requires git history but sees rename/delete paths |
 | `--changed-between <old> <new>` | off | After branch switches when both refs are known | Only as accurate as the supplied refs |
-| `--max-file-bytes <bytes>` / `CDIDX_MAX_FILE_BYTES` | `10MiB` | Legitimate large source files are skipped | Raising it can bloat the DB and slow snippet extraction |
+| `--max-file-bytes <bytes>` / `CDIDX_MAX_FILE_BYTES` | `4MiB` | Legitimate large source files are skipped | Raising it can bloat the DB and slow snippet extraction |
 | `--watch --debounce <ms>` | `500` ms | Keep an active worktree fresh during editing | Long-running process; incompatible with commit/file scoped refresh flags |
 | `--snippet-lines` / `--max-line-width` | `8` / `512` | Query payloads are too large for AI context | Smaller snippets may hide nearby context |
 | `--path`, `--exclude-path`, `--exclude-tests` | off | Queries or maps are noisy | Over-filtering can hide real matches |
@@ -1921,7 +1921,7 @@ release changelog を source of truth とします。完全な syntax line は `
 | Query result limit | `20`（`--limit`、alias `--top`） | CLI help と query runners |
 | Search snippet lines | `8`（`--snippet-lines`、最大 `20`） | CLI help と search runner |
 | Max line width | `512`（`--max-line-width`、`0` で無効） | `LineWidthFormatter.DefaultMaxLineWidth` |
-| Index max file size | `CDIDX_MAX_FILE_BYTES` 未設定時は `10MiB` | index runner help |
+| Index max file size | `CDIDX_MAX_FILE_BYTES` 未設定時は `4MiB` | index runner help |
 | Watch debounce | `500` ms（`--debounce`） | index watch runner |
 | Status stale-after hint | `24h`。`--stale-after` / `CDIDX_STALE_AFTER` / `.cdidxrc.json` で上書き | status runner |
 | Color mode | `auto`。`--color` / `CLICOLOR_FORCE` / `NO_COLOR` / `CLICOLOR=0` で上書き | `ConsoleUi` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -241,7 +241,7 @@ be audited whenever the matching help text changes.
 | Query result limit | `20` (`--limit`, alias `--top`) | CLI help and query runners |
 | Search snippet lines | `8` (`--snippet-lines`, max `20`) | CLI help and search runner |
 | Max line width | `512` (`--max-line-width`, `0` disables) | `LineWidthFormatter.DefaultMaxLineWidth` |
-| Index max file size | `10MiB` unless `CDIDX_MAX_FILE_BYTES` is set | index runner help |
+| Index max file size | `4MiB` unless `CDIDX_MAX_FILE_BYTES` is set | index runner help |
 | Watch debounce | `500` ms (`--debounce`) | index watch runner |
 | Status stale-after hint | `24h`, overridden by `--stale-after`, `CDIDX_STALE_AFTER`, or `.cdidxrc.json` | status runner |
 | Color mode | `auto`, overridden by `--color`, `CLICOLOR_FORCE`, `NO_COLOR`, or `CLICOLOR=0` | `ConsoleUi` |
@@ -851,7 +851,7 @@ cdidx report --output report.tgz --json
 | `--files <path...>` | `index` | Update only the specified files. Safe for known in-place edits or new files; old rename/delete paths are not purged unless you also list them explicitly. |
 | `--force` | `index` | Bypass the per-database index lock. Only use when you are sure no other `cdidx index` is active against the same DB; concurrent runs may corrupt the schema. |
 | `--duration-format <auto\|seconds\|hms>` | `index` | Choose human elapsed-time display for index summaries. `auto` (default) uses unit labels; `seconds` emits decimal seconds; `hms` keeps `HH:MM:SS`. JSON always keeps raw `elapsed_ms`. |
-| `--max-file-bytes <bytes>` | `index` | Override the per-file indexing limit for this run. Defaults to 10MiB, or `CDIDX_MAX_FILE_BYTES` when set. Values accept raw bytes or `K` / `M` / `G` suffixes such as `50M`. |
+| `--max-file-bytes <bytes>` | `index` | Override the per-file indexing limit for this run. Defaults to 4MiB, or `CDIDX_MAX_FILE_BYTES` when set. Values accept raw bytes or `K` / `M` / `G` suffixes such as `50M`. |
 | `--watch` | `index` | After the initial scan completes, stay running and reindex incrementally as files change (FileSystemWatcher / inotify / FSEvents). Rejects `--commits`, `--changed-between`, `--files`, and `--dry-run` because the loop already drives continuous incremental updates. |
 | `--debounce <ms>` | `index` (watch only) | Coalesce bursts of file events into a single update after `<ms>` of quiet (non-negative integer; default: 500). Invalid values emit a warning and are ignored. |
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp. Offsetless values (e.g. `2024-01-01T00:00:00`) are treated as UTC so the same flag resolves to the same instant in every timezone; append `Z` or an explicit offset (`+09:00`) to be explicit. |
@@ -2007,7 +2007,7 @@ cdidx index . --duration-format seconds
 | `--files <path...>` | off | editor/save hook や既知の in-place edit | rename/delete 旧 path は明示しない限り purge されない |
 | `--commits <id...>` | off | 通常の commit 後 | git history が必要だが rename/delete paths も扱える |
 | `--changed-between <old> <new>` | off | branch switch 後に両 ref が分かる | 渡した ref の正確さに依存 |
-| `--max-file-bytes <bytes>` / `CDIDX_MAX_FILE_BYTES` | `10MiB` | 正当な大きい source file が skip される | DB が大きくなり snippet extraction も遅くなりうる |
+| `--max-file-bytes <bytes>` / `CDIDX_MAX_FILE_BYTES` | `4MiB` | 正当な大きい source file が skip される | DB が大きくなり snippet extraction も遅くなりうる |
 | `--watch --debounce <ms>` | `500` ms | 編集中の worktree を live に保つ | long-running process。commit/file scoped refresh flags とは併用不可 |
 | `--snippet-lines` / `--max-line-width` | `8` / `512` | AI context に対して query payload が大きすぎる | 小さくしすぎると周辺文脈が見えない |
 | `--path`, `--exclude-path`, `--exclude-tests` | off | query / map が noisy | 絞り込みすぎると実 match を隠す |
@@ -2520,7 +2520,7 @@ cdidx report --output report.tgz --json
 | `--files <path...>` | `index` | 指定ファイルのみ更新。把握している in-place 編集や新規ファイル向け。rename/delete の旧パスは明示しない限り purge されない。 |
 | `--force` | `index` | 同一 DB に対する index ロックを bypass する。他の `cdidx index` が走っていないと確信できる場合のみ使う。並行実行は schema を破壊し得る。 |
 | `--duration-format <auto\|seconds\|hms>` | `index` | index summary の human 経過時間表示を選ぶ。`auto`（既定）は単位付き、`seconds` は小数秒、`hms` は `HH:MM:SS` を維持。JSON は常に raw の `elapsed_ms` を返す。 |
-| `--max-file-bytes <bytes>` | `index` | この実行で使うファイル単位の索引サイズ上限を上書きする。既定は 10MiB、または `CDIDX_MAX_FILE_BYTES` 設定値。値は raw byte 数、または `50M` のような `K` / `M` / `G` 接尾辞を受け付ける。 |
+| `--max-file-bytes <bytes>` | `index` | この実行で使うファイル単位の索引サイズ上限を上書きする。既定は 4MiB、または `CDIDX_MAX_FILE_BYTES` 設定値。値は raw byte 数、または `50M` のような `K` / `M` / `G` 接尾辞を受け付ける。 |
 | `--watch` | `index` | 初回スキャン完了後もプロセスを残し、ファイル変更を検知して差分更新を繰り返す（FileSystemWatcher / inotify / FSEvents）。連続的な差分更新を内蔵しているため `--commits` / `--changed-between` / `--files` / `--dry-run` との併用は拒否する。 |
 | `--debounce <ms>` | `index`（`--watch` 専用） | 一連のイベントを `<ms>` の静止後に 1 つの更新へ集約する（0 以上の整数。既定: 500）。不正な値は警告を出して無視する。 |
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601）。オフセットなしの値（例: `2024-01-01T00:00:00`）は UTC として解釈されるため、どのタイムゾーンから呼び出しても同じ UTC 時点になります。明示したい場合は末尾に `Z` または `+09:00` 等のオフセットを付与してください。 |

--- a/changelog.d/unreleased/1695.fixed.md
+++ b/changelog.d/unreleased/1695.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1695
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Large source files are rejected before multi-megabyte payload allocation (#1695)** — the default indexing file-size cap is now 4 MiB, so 10 MiB generated/vendor sources are skipped before the indexer accumulates a contiguous byte array; intentional large sources can still opt in with `--max-file-bytes` or `CDIDX_MAX_FILE_BYTES`.
+
+## 日本語
+
+- **大容量 source file は multi-MB payload 確保前に拒否されるようになりました (#1695)** — index の既定ファイルサイズ上限を 4 MiB にし、10 MiB の生成物 / vendor source はインデクサが連続した byte 配列を累積する前にスキップされます。意図的に大容量 source を索引したい場合は引き続き `--max-file-bytes` または `CDIDX_MAX_FILE_BYTES` で opt-in できます。

--- a/changelog.d/unreleased/1695.fixed.md
+++ b/changelog.d/unreleased/1695.fixed.md
@@ -5,6 +5,8 @@ issues:
 affected:
   - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
   - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Mcp/McpToolDefinitions.cs
+  - USER_GUIDE.md
   - tests/CodeIndex.Tests/FileIndexerTests.cs
 ---
 

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -561,7 +561,7 @@ public static class ConsoleUi
         Console.WriteLine("  --force                    Bypass the per-database index lock; only use when no other cdidx index is active");
         Console.WriteLine("  --json                     Output results as JSON (for AI/machine use)");
         Console.WriteLine("  --duration-format <format> Index elapsed time format: `auto` (default), `seconds`, or `hms`; JSON keeps raw elapsed_ms");
-        Console.WriteLine("  --max-file-bytes <bytes>  Index only files up to this size (default: 10MiB; also honors CDIDX_MAX_FILE_BYTES; accepts K/M/G suffixes)");
+        Console.WriteLine("  --max-file-bytes <bytes>  Index only files up to this size (default: 4MiB; also honors CDIDX_MAX_FILE_BYTES; accepts K/M/G suffixes)");
         Console.WriteLine("  --commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)");
         Console.WriteLine("  --changed-between <old-ref> <new-ref>");
         Console.WriteLine("                              Update only files changed between two git refs (useful after branch switches)");

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -380,8 +380,13 @@ public class FileIndexer
     }
 
     public const string MaxFileSizeEnvironmentVariable = "CDIDX_MAX_FILE_BYTES";
-    // Default maximum file size to index (10 MiB) / インデックス対象の既定最大ファイルサイズ (10 MiB)
-    public const long DefaultMaxFileSizeBytes = 10 * 1024 * 1024;
+    // Default maximum file size to index (4 MiB). Larger generated/vendor payloads
+    // can still be opted in with --max-file-bytes, but the default path should not
+    // allocate a single multi-megabyte byte[] for common source scans.
+    // インデックス対象の既定最大ファイルサイズ (4 MiB)。生成物や vendor の大容量 payload は
+    // --max-file-bytes で明示的に opt-in できるが、既定経路では一般的な source scan で
+    // multi-MB の単一 byte[] を確保しない。
+    public const long DefaultMaxFileSizeBytes = 4 * 1024 * 1024;
     // Extensionless shebang detection reads at most the first physical line within this
     // byte cap. NUL bytes or a line that reaches the cap without LF/CR are treated as
     // unsupported so binary executables and minified data are not parsed as scripts.

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -381,7 +381,7 @@ public partial class McpServer
                     {
                         ["path"] = new JsonObject { ["type"] = "string", ["description"] = "Project directory path to index" },
                         ["rebuild"] = new JsonObject { ["type"] = "boolean", ["description"] = "Delete existing index and rebuild from scratch (default: false)", ["default"] = false },
-                        ["maxFileBytes"] = new JsonObject { ["type"] = "integer", ["description"] = "Override the per-file indexing size limit for this run. Defaults to CDIDX_MAX_FILE_BYTES or 10MiB.", ["minimum"] = 1, ["maximum"] = int.MaxValue }
+                        ["maxFileBytes"] = new JsonObject { ["type"] = "integer", ["description"] = "Override the per-file indexing size limit for this run. Defaults to CDIDX_MAX_FILE_BYTES or 4MiB.", ["minimum"] = 1, ["maximum"] = int.MaxValue }
                     },
                     ["required"] = new JsonArray { "path" }
                 },

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2988,16 +2988,17 @@ public class FileIndexerTests
     [Fact]
     public void BuildRecord_ThrowsForOversizedFile()
     {
-        // Files exceeding 10 MB should throw InvalidOperationException
-        // 10MBを超えるファイルはInvalidOperationExceptionを投げる
+        // Files exceeding the default cap should throw InvalidOperationException
+        // 既定上限を超えるファイルはInvalidOperationExceptionを投げる
         var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
         try
         {
             Directory.CreateDirectory(tempDir);
             var filePath = Path.Combine(tempDir, "large.py");
-            // Create a file just over 10 MB / 10MBを少し超えるファイルを作成
-            var data = new byte[10 * 1024 * 1024 + 1];
-            File.WriteAllBytes(filePath, data);
+            // Create a sparse file just over the default cap without allocating a matching test buffer.
+            // 既定上限を少し超える sparse file を作り、同サイズのテスト用 buffer 確保を避ける。
+            using (var stream = File.Create(filePath))
+                stream.SetLength(FileIndexer.DefaultMaxFileSizeBytes + 1);
 
             var indexer = new FileIndexer(tempDir);
             Assert.Throws<InvalidOperationException>(() => indexer.BuildRecord(filePath));
@@ -3009,15 +3010,46 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void BuildRecord_DefaultRejectsTenMiBFileBeforeReadingPayload()
+    {
+        // Regression for #1695: a 10 MiB source file must be rejected from the
+        // observed stream length before the indexer accumulates one contiguous
+        // 10 MiB byte array on the LOH.
+        // #1695 の回帰: 10 MiB の source file は stream length の確認時点で拒否し、
+        // インデクサが LOH 上に連続した 10 MiB byte 配列を累積しないことを固定する。
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var filePath = Path.Combine(tempDir, "large.py");
+            using (var stream = File.Create(filePath))
+                stream.SetLength(10 * 1024 * 1024);
+
+            var indexer = new FileIndexer(tempDir);
+            var before = GC.GetAllocatedBytesForCurrentThread();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => indexer.BuildRecord(filePath));
+
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.Contains("File too large", ex.Message);
+            Assert.True(allocated < 1024 * 1024, $"Expected rejection before a 10 MiB payload allocation, saw {allocated} bytes allocated.");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void BuildRecord_AcceptsFileAtSizeLimitBoundary()
     {
         // Regression for #1529: the TOCTOU fix reads through one FileStream and caps the
-        // accumulator at MaxFileSize. A file at exactly 10 MB must still be accepted so
-        // the boundary contract documented by the oversize test stays symmetric (>10MB
-        // throws, ==10MB succeeds).
+        // accumulator at MaxFileSize. A file at exactly the default cap must still be accepted so
+        // the boundary contract documented by the oversize test stays symmetric (>cap
+        // throws, ==cap succeeds).
         // #1529 のリグレッション: TOCTOU 修正で 1 本の FileStream を通して MaxFileSize で
-        // 累積バッファを打ち切る実装にした際、ちょうど 10 MB のファイルは引き続き受け
-        // 入れる必要がある (>10MB が throw / ==10MB が成功という対称契約を維持)。
+        // 累積バッファを打ち切る実装にした際、ちょうど既定上限のファイルは引き続き受け
+        // 入れる必要がある (>上限 が throw / ==上限 が成功という対称契約を維持)。
         var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
         try
         {
@@ -3025,7 +3057,7 @@ public class FileIndexerTests
             var filePath = Path.Combine(tempDir, "boundary.py");
             // Exactly MaxFileSize bytes — ASCII so UTF-8 decode succeeds without warning.
             // ちょうど MaxFileSize バイト — ASCII なら UTF-8 デコードで警告無く成功する。
-            var data = new byte[10 * 1024 * 1024];
+            var data = new byte[(int)FileIndexer.DefaultMaxFileSizeBytes];
             for (int i = 0; i < data.Length; i++)
                 data[i] = (byte)'a';
             File.WriteAllBytes(filePath, data);


### PR DESCRIPTION
## Summary

- Lower the default index max file size from 10MiB to 4MiB so 10MiB generated/vendor sources are rejected before a contiguous payload allocation.
- Keep opt-in indexing for intentional large sources via `--max-file-bytes` / `CDIDX_MAX_FILE_BYTES`.
- Update CLI help, MCP schema text, USER_GUIDE defaults, and the bilingual changelog fragment.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests.BuildRecord"`
- `dotnet test CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: two rounds; documentation findings fixed.

## Changelog

- `changelog.d/unreleased/1695.fixed.md`

Fixes #1695
