### PR TITLE
Fix JS TS optional chain references

### DIFF
--- a/changelog.d/unreleased/1989.fixed.md
+++ b/changelog.d/unreleased/1989.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1989
+affected:
+  - src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **JS/TS references now keep optional member chains and discriminant guards (#1989)** — optional chains such as `foo?.bar?.baz` now emit full member-chain references, and string-literal guards such as `foo.type === 'bar'` emit discriminator property and type-tag references.
+
+## 日本語
+
+- **JS/TS 参照が optional member chain と discriminant guard を保持するようになりました (#1989)** — `foo?.bar?.baz` のような optional chain で完全な member-chain 参照を出し、`foo.type === 'bar'` のような文字列リテラル guard で discriminator property と type-tag 参照を出すようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
@@ -74,18 +74,20 @@ internal static class JavaScriptReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForCall)
     {
+        var contextMatches = DiscriminantStringGuardRegex.Matches(contextLine);
+        var matchOrdinal = 0;
         foreach (Match match in DiscriminantStringGuardRegex.Matches(preparedLine))
         {
             var objectName = match.Groups["object"].Value;
             var propertyName = match.Groups["property"].Value;
             var propertyIndex = match.Groups["property"].Index;
             var literalGroup = match.Groups["literal"];
-            var contextMatch = DiscriminantStringGuardRegex.Match(contextLine);
-            var rawLiteral = contextMatch.Success
-                ? contextMatch.Groups["literal"].Value
+            var rawLiteral = matchOrdinal < contextMatches.Count
+                ? contextMatches[matchOrdinal].Groups["literal"].Value
                 : literalGroup.Index >= 0 && literalGroup.Index + literalGroup.Length <= contextLine.Length
                 ? contextLine.Substring(literalGroup.Index, literalGroup.Length)
                 : literalGroup.Value;
+            matchOrdinal++;
             var literalValue = UnescapeSimpleStringLiteral(rawLiteral);
             var chain = $"{objectName}.{propertyName}";
             var container = resolveContainerForCall(match.Groups["object"].Index);

--- a/src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
@@ -65,8 +65,8 @@ internal static class JavaScriptReferenceExtractor
     }
 
     public static void EmitDiscriminantStringGuardReferences(
-        string preparedLine,
-        string contextLine,
+        string detectionLine,
+        string sourceLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -74,20 +74,15 @@ internal static class JavaScriptReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForCall)
     {
-        var contextMatches = DiscriminantStringGuardRegex.Matches(contextLine);
-        var matchOrdinal = 0;
-        foreach (Match match in DiscriminantStringGuardRegex.Matches(preparedLine))
+        foreach (Match match in DiscriminantStringGuardRegex.Matches(detectionLine))
         {
             var objectName = match.Groups["object"].Value;
             var propertyName = match.Groups["property"].Value;
             var propertyIndex = match.Groups["property"].Index;
             var literalGroup = match.Groups["literal"];
-            var rawLiteral = matchOrdinal < contextMatches.Count
-                ? contextMatches[matchOrdinal].Groups["literal"].Value
-                : literalGroup.Index >= 0 && literalGroup.Index + literalGroup.Length <= contextLine.Length
-                ? contextLine.Substring(literalGroup.Index, literalGroup.Length)
+            var rawLiteral = literalGroup.Index >= 0 && literalGroup.Index + literalGroup.Length <= sourceLine.Length
+                ? sourceLine.Substring(literalGroup.Index, literalGroup.Length)
                 : literalGroup.Value;
-            matchOrdinal++;
             var literalValue = UnescapeSimpleStringLiteral(rawLiteral);
             var chain = $"{objectName}.{propertyName}";
             var container = resolveContainerForCall(match.Groups["object"].Index);

--- a/src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
@@ -5,6 +5,7 @@ namespace CodeIndex.Indexer;
 
 internal static class JavaScriptReferenceExtractor
 {
+    private const string JavaScriptIdentifierPattern = @"[_\p{L}\$][\w$]*";
     // JavaScript / TypeScript allow zero-argument constructor calls without parentheses:
     // `new Foo;`, `new Date;`, `new Demo.Provider;`, `new Box<number>;`.
     // Keep this language-gated at the call site so Java / C# / other `new` forms still require
@@ -14,6 +15,113 @@ internal static class JavaScriptReferenceExtractor
     private static readonly Regex ParenlessConstructorRegex = new(
         $@"\bnew\s+(?:{ReferenceExtractor.CSharpIdentifierPattern}\s*\.\s*)*(?<name>{ReferenceExtractor.CSharpIdentifierPattern})(?:\s*<[^>\n]+>)?",
         RegexOptions.Compiled);
+    private static readonly Regex DiscriminantStringGuardRegex = new(
+        $@"(?<![\w$])(?<object>{JavaScriptIdentifierPattern})\s*(?:\.|\?\.)\s*(?<property>{JavaScriptIdentifierPattern})\s*(?:===|==|!==|!=)\s*(?<quote>[""'])(?<literal>(?:\\.|(?!\k<quote>).)*)\k<quote>",
+        RegexOptions.Compiled);
+
+    public static void EmitOptionalMemberChainReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        var index = 0;
+        while (index < preparedLine.Length)
+        {
+            if (!TryReadIdentifier(preparedLine, index, out var root, out var rootStart, out var rootEnd))
+            {
+                index++;
+                continue;
+            }
+
+            index = rootEnd;
+            var chain = root;
+            var emittedAny = false;
+            var probe = rootEnd;
+            while (TryReadMemberContinuation(preparedLine, probe, out var member, out _, out var memberEnd))
+            {
+                chain = $"{chain}.{member}";
+                probe = memberEnd;
+                emittedAny = true;
+
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    chain,
+                    rootStart,
+                    "reference",
+                    context,
+                    lineNumber,
+                    resolveContainerForCall(rootStart));
+            }
+
+            if (emittedAny)
+                index = Math.Max(index, probe);
+        }
+    }
+
+    public static void EmitDiscriminantStringGuardReferences(
+        string preparedLine,
+        string contextLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForCall)
+    {
+        foreach (Match match in DiscriminantStringGuardRegex.Matches(preparedLine))
+        {
+            var objectName = match.Groups["object"].Value;
+            var propertyName = match.Groups["property"].Value;
+            var propertyIndex = match.Groups["property"].Index;
+            var literalGroup = match.Groups["literal"];
+            var contextMatch = DiscriminantStringGuardRegex.Match(contextLine);
+            var rawLiteral = contextMatch.Success
+                ? contextMatch.Groups["literal"].Value
+                : literalGroup.Index >= 0 && literalGroup.Index + literalGroup.Length <= contextLine.Length
+                ? contextLine.Substring(literalGroup.Index, literalGroup.Length)
+                : literalGroup.Value;
+            var literalValue = UnescapeSimpleStringLiteral(rawLiteral);
+            var chain = $"{objectName}.{propertyName}";
+            var container = resolveContainerForCall(match.Groups["object"].Index);
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                chain,
+                match.Groups["object"].Index,
+                "reference",
+                context,
+                lineNumber,
+                container);
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                propertyName,
+                propertyIndex,
+                "reference",
+                context,
+                lineNumber,
+                container);
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                $"{chain}={literalValue}",
+                match.Groups["literal"].Index,
+                "type_tag",
+                context,
+                lineNumber,
+                container);
+        }
+    }
 
     public static void EmitParenlessConstructorReferences(
         string preparedLine,
@@ -84,4 +192,80 @@ internal static class JavaScriptReferenceExtractor
 
         return false;
     }
+
+    private static bool TryReadMemberContinuation(
+        string line,
+        int start,
+        out string member,
+        out int memberStart,
+        out int memberEnd)
+    {
+        member = string.Empty;
+        memberStart = -1;
+        memberEnd = start;
+
+        var probe = SkipWhitespace(line, start);
+        if (probe >= line.Length)
+            return false;
+
+        if (line[probe] == '.')
+        {
+            probe++;
+        }
+        else if (line[probe] == '?' && probe + 1 < line.Length && line[probe + 1] == '.')
+        {
+            probe += 2;
+        }
+        else
+        {
+            return false;
+        }
+
+        probe = SkipWhitespace(line, probe);
+        if (probe >= line.Length || line[probe] == '(' || line[probe] == '[')
+            return false;
+
+        if (!TryReadIdentifier(line, probe, out member, out memberStart, out memberEnd))
+            return false;
+
+        return true;
+    }
+
+    private static bool TryReadIdentifier(string line, int start, out string identifier, out int identifierStart, out int identifierEnd)
+    {
+        identifier = string.Empty;
+        identifierStart = start;
+        identifierEnd = start;
+
+        if (start > 0 && IsIdentifierPart(line[start - 1]))
+            return false;
+        if (start >= line.Length || !IsIdentifierStart(line[start]))
+            return false;
+
+        var end = start + 1;
+        while (end < line.Length && IsIdentifierPart(line[end]))
+            end++;
+
+        identifier = line[start..end];
+        identifierEnd = end;
+        return true;
+    }
+
+    private static int SkipWhitespace(string line, int start)
+    {
+        while (start < line.Length && char.IsWhiteSpace(line[start]))
+            start++;
+        return start;
+    }
+
+    private static bool IsIdentifierStart(char c) =>
+        c == '_' || c == '$' || char.IsLetter(c);
+
+    private static bool IsIdentifierPart(char c) =>
+        IsIdentifierStart(c) || char.IsDigit(c);
+
+    private static string UnescapeSimpleStringLiteral(string value) =>
+        value.Replace("\\\"", "\"", StringComparison.Ordinal)
+            .Replace("\\'", "'", StringComparison.Ordinal)
+            .Replace("\\\\", "\\", StringComparison.Ordinal);
 }

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2282,8 +2282,8 @@ public static partial class ReferenceExtractor
                     ResolveContainerForCall);
 
                 JavaScriptReferenceExtractor.EmitDiscriminantStringGuardReferences(
-                    preparedLine,
-                    context,
+                    referenceStructuralLines[i],
+                    originalLine,
                     references,
                     seen,
                     fileId,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -2266,6 +2266,25 @@ public static partial class ReferenceExtractor
 
             if (language is "javascript" or "typescript")
             {
+                JavaScriptReferenceExtractor.EmitOptionalMemberChainReferences(
+                    preparedLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
+
+                JavaScriptReferenceExtractor.EmitDiscriminantStringGuardReferences(
+                    preparedLine,
+                    context,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
+
                 JavaScriptReferenceExtractor.EmitParenlessConstructorReferences(
                     preparedLine,
                     preparedLines,

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -30372,6 +30372,69 @@ public class ReferenceExtractorTests
             && r.ContainerName == "render");
     }
 
+    [Fact]
+    public void Extract_TypeScriptOptionalChains_EmitsFullMemberChains()
+    {
+        const string content = """
+            export function render(viewModel: ViewModel) {
+                viewModel?.profile?.avatar?.url ?? fallbackUrl;
+                viewModel?.profile?.load?.();
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "viewModel.profile"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "render");
+        Assert.Contains(references, r =>
+            r.SymbolName == "viewModel.profile.avatar"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "render");
+        Assert.Contains(references, r =>
+            r.SymbolName == "viewModel.profile.avatar.url"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "render");
+        Assert.Contains(references, r =>
+            r.SymbolName == "viewModel.profile.load"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "render");
+    }
+
+    [Fact]
+    public void Extract_TypeScriptDiscriminantStringGuard_EmitsPropertyAndTypeTag()
+    {
+        const string content = """
+            type Shape =
+                | { type: 'circle'; radius: number }
+                | { type: 'square'; side: number };
+
+            export function area(shape: Shape) {
+                if (shape.type === 'circle') {
+                    return shape.radius;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "shape.type"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "area");
+        Assert.Contains(references, r =>
+            r.SymbolName == "type"
+            && r.ReferenceKind == "reference"
+            && r.ContainerName == "area");
+        Assert.Contains(references, r =>
+            r.SymbolName == "shape.type=circle"
+            && r.ReferenceKind == "type_tag"
+            && r.ContainerName == "area");
+    }
+
     private static SymbolRecord Container(string name, string kind, int startLine, int endLine) =>
         new()
         {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -30415,6 +30415,9 @@ public class ReferenceExtractorTests
                 if (shape.type === 'circle') {
                     return shape.radius;
                 }
+                if (shape.type === 'circle' || shape.type === 'square') {
+                    return 0;
+                }
             }
             """;
 
@@ -30431,6 +30434,10 @@ public class ReferenceExtractorTests
             && r.ContainerName == "area");
         Assert.Contains(references, r =>
             r.SymbolName == "shape.type=circle"
+            && r.ReferenceKind == "type_tag"
+            && r.ContainerName == "area");
+        Assert.Contains(references, r =>
+            r.SymbolName == "shape.type=square"
             && r.ReferenceKind == "type_tag"
             && r.ContainerName == "area");
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -30518,7 +30518,7 @@ public class ReferenceExtractorTests
                 if (shape.type === 'circle') {
                     return shape.radius;
                 }
-                if (shape.type === 'circle' || shape.type === 'square') {
+                /* x.kind === 'fake' */ if (shape.type === 'circle' || shape.type === 'square') {
                     return 0;
                 }
             }
@@ -30543,6 +30543,9 @@ public class ReferenceExtractorTests
             r.SymbolName == "shape.type=square"
             && r.ReferenceKind == "type_tag"
             && r.ContainerName == "area");
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "shape.type=fake"
+            && r.ReferenceKind == "type_tag");
     }
 
     private static SymbolRecord Container(string name, string kind, int startLine, int endLine) =>


### PR DESCRIPTION
## Summary

- Emit full JS/TS member-chain references for optional chains such as `foo?.bar?.baz`.
- Emit discriminator property references and `type_tag` references for string-literal guards such as `foo.type === 'bar'`.
- Add regression coverage for optional-chain method calls, nullish-coalescing chains, multiple same-line guards, and guard-shaped comments.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet test CodeIndex.sln -c Release --no-build`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Documentation and Changelog

- Added `changelog.d/unreleased/1989.fixed.md`.
- No AGENT.md, CLAUDE.md, or AGENT_GUIDE.md changes.

## Follow-up Candidates

- #2331

Fixes #1989
