### PR TITLE
Add .NET project scoping

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -65,6 +65,12 @@ Directory scan / shared path filter (built-in skip lists + `.gitignore` / `.cdid
 
 Scoped `--files` / `--commits` refreshes reuse the same path filter as full scans. If a commit-scoped refresh includes `.gitignore` or `.cdidxignore` changes, `IndexCommandRunner` falls back to a full scan so newly ignored files are purged safely. Malformed ignore lines are reported as scan errors and skipped instead of aborting the whole run. On Windows, files and directories with Hidden or System attributes are rejected before language detection; clear those attributes before indexing project-owned sources because ignore rules cannot re-include them.
 
+### C# / .NET integration
+
+`SolutionProjectResolver` parses the plain-text `.sln` `Project(...) = "...", "...csproj"` entries and resolves C# / F# / VB project files. When exactly one `.sln` exists at the workspace root, `--project <name|path>` uses it automatically; otherwise callers can pass `--solution <path>`.
+
+Query commands that accept path filters (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `deps`, `impact`, `unused`, `hotspots`, and `validate`) expand `--project` into the matching project directory glob before hitting `DbReader`, so all existing SQL path predicates keep working. `index --project` expands to the files under the selected project directory and reuses the existing `--files` update path.
+
 ### Extractor concurrency contract
 
 `SymbolExtractor` and `ReferenceExtractor` must be safe to call concurrently for different files or repeated calls on the same file content. Shared `Regex` instances and static lookup tables are initialized once by the CLR and treated as immutable after type initialization. Per-extraction state belongs in local variables, method parameters, caller-owned collections, or language-specific state objects created for that extraction call.
@@ -1520,6 +1526,12 @@ CI で `NU1004 The packages lock file is inconsistent with the project dependenc
 ```
 
 `--files` / `--commits` の部分更新も、フルスキャンと同じパスフィルタを再利用する。commit 単位更新に `.gitignore` または `.cdidxignore` の変更が含まれる場合、`IndexCommandRunner` は newly ignored file を安全に purge するため自動でフルスキャンへフォールバックする。malformed な ignore 行は走査エラーとして報告し、その行だけをスキップして index 全体は継続する。Windows では Hidden または System 属性が付いたファイルとディレクトリを言語検出前に拒否する。プロジェクト所有のソースを索引したい場合、ignore ルールでは再包含できないため先にそれらの属性を外す。
+
+### C# / .NET integration
+
+`SolutionProjectResolver` は plain-text の `.sln` に含まれる `Project(...) = "...", "...csproj"` 行を読み、C# / F# / VB の project file を解決する。workspace root に `.sln` が 1 つだけある場合、`--project <name|path>` は自動でそれを使う。複数ある場合は caller が `--solution <path>` を渡せる。
+
+path filter を受け付ける query コマンド（`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `deps`, `impact`, `unused`, `hotspots`, `validate`）は、`--project` を対応する project directory glob に展開してから `DbReader` に渡す。これにより既存の SQL path predicate をそのまま利用できる。`index --project` は選択された project directory 配下のファイルに展開し、既存の `--files` 更新経路を再利用する。
 
 ### 抽出器の並行実行契約
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ cdidx .
 cdidx status --check --json
 cdidx search "handleRequest"
 cdidx definition UserService
+cdidx search "Handle" --project MyApp
 cdidx mcp
 ```
 
@@ -67,6 +68,9 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
   internal, and private matches; `--no-visibility-rank` keeps the legacy order.
 - Full-text, symbol, reference, caller/callee, dependency, map, inspect, and
   excerpt commands.
+- `.sln` / `.csproj`-aware `--project <name|path>` filters for indexing and
+  query commands, with `--solution <path>` when a workspace has multiple
+  solution files.
 - MCP server for AI clients such as Claude Code, Cursor, and Windsurf.
 - Local suggestion history can be listed, inspected, and exported with
   `cdidx suggestions`.
@@ -194,6 +198,7 @@ cdidx .
 cdidx status --check --json
 cdidx search "handleRequest"
 cdidx definition UserService
+cdidx search "Handle" --project MyApp
 cdidx mcp
 ```
 
@@ -214,6 +219,9 @@ cdidx mcp
   従来順が必要な場合は `--no-visibility-rank` を使えます。
 - 全文検索、シンボル、参照、caller/callee、依存関係、map、inspect、excerpt
   コマンドを提供。
+- `.sln` / `.csproj` を使った `--project <name|path>` filter により、
+  index と query コマンドを特定の .NET project 配下へ絞り込めます。
+  workspace に solution が複数ある場合は `--solution <path>` を指定します。
 - Claude Code、Cursor、Windsurf などの AI クライアント向け MCP サーバー。
 - `cdidx suggestions` でローカルの提案履歴を一覧表示、詳細表示、エクスポート可能。
 - `--files` と `--commits` による差分更新、および `--watch` による継続更新モード。

--- a/changelog.d/unreleased/1707.added.md
+++ b/changelog.d/unreleased/1707.added.md
@@ -1,0 +1,20 @@
+---
+category: added
+issues:
+  - 1707
+affected:
+  - src/CodeIndex/Cli/SolutionProjectResolver.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - README.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Added .sln/.csproj project filters (#1707)** — `cdidx index` and path-filtered query commands now accept `--project <name|path>`, with `--solution <path>` for workspaces that need an explicit solution file.
+
+## 日本語
+
+- **.sln/.csproj project filter を追加しました (#1707)** — `cdidx index` と path filter 対応の query コマンドが `--project <name|path>` を受け付け、明示的な solution file が必要な workspace では `--solution <path>` を指定できます。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -171,6 +171,8 @@ internal static class CliFlagSchema
             new() { Name = "--top", ValuePlaceholder = "<n>", Description = "Max results", Commands = Set(LimitCapableCommands) },
             new() { Name = "--lang", ValuePlaceholder = "<lang>", Description = "Filter by language", Commands = Set(LangCapableCommands) },
             new() { Name = "--path", ValuePlaceholder = "<glob>", Description = "Path filter", Commands = Set(PathFilterCommands) },
+            new() { Name = "--project", ValuePlaceholder = "<name|path>", Description = "Filter to a .sln/.csproj project", Commands = Set(PathFilterCommands.Concat(new[] { "index" }).ToArray()) },
+            new() { Name = "--solution", ValuePlaceholder = "<path>", Description = "Solution file used to resolve --project", Commands = Set(PathFilterCommands.Concat(new[] { "index" }).ToArray()) },
             new() { Name = "--exclude-path", ValuePlaceholder = "<glob>", Description = "Exclude path", Commands = Set(ExcludeFilterCommands) },
             new() { Name = "--exclude-tests", Description = "Exclude tests", Commands = Set(ExcludeFilterCommands) },
             new() { Name = "--kind", ValuePlaceholder = "<kind>", Description = "Filter by kind", Commands = Set(KindCommands) },

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -41,6 +41,17 @@ public static class IndexCommandRunner
             return CommandExitCodes.UsageError;
         }
 
+        if (options.ProjectFilterError != null)
+        {
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                options.ProjectFilterError,
+                CommandExitCodes.UsageError,
+                "Check --project / --solution and rerun the command.",
+                CommandErrorCodes.UsageError);
+        }
+
         // Snapshot cwd alongside the already-absolutized options so the finalize step can
         // detect mid-run drift (embedded host, signal handler, future plugin) and warn the
         // operator. Failure to read cwd (e.g. it was deleted out from under us) is best-effort
@@ -544,7 +555,7 @@ public static class IndexCommandRunner
     [
         "--db", "--rebuild", "--verbose", "--json", "--dry-run", "--force",
         "--watch", "--debounce", "--duration-format", "--max-file-bytes",
-        "--commits", "--files", "--help",
+        "--commits", "--changed-between", "--files", "--solution", "--project", "--help",
     ];
 
     private static readonly string[] AcceptedBackfillFoldFlags =
@@ -595,6 +606,9 @@ public static class IndexCommandRunner
         var changedBetweenRefs = new List<string>();
         var changedBetweenSpecified = false;
         var updateFiles = new List<string>();
+        var projectFilters = new List<string>();
+        string? solutionPath = null;
+        string? projectFilterError = null;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -661,6 +675,18 @@ public static class IndexCommandRunner
                     if (changedBetweenRefs.Count != 2)
                         Console.Error.WriteLine("Warning: --changed-between requires exactly two refs / --changed-between は2つのrefが必要です");
                     break;
+                case "--solution" when i + 1 < args.Length:
+                    solutionPath = args[++i];
+                    break;
+                case var option when option.StartsWith("--solution=", StringComparison.Ordinal):
+                    solutionPath = option["--solution=".Length..];
+                    break;
+                case "--project" when i + 1 < args.Length:
+                    projectFilters.Add(args[++i]);
+                    break;
+                case var option when option.StartsWith("--project=", StringComparison.Ordinal):
+                    projectFilters.Add(option["--project=".Length..]);
+                    break;
                 case "--files":
                     while (i + 1 < args.Length && !args[i + 1].StartsWith('-'))
                         updateFiles.Add(args[++i]);
@@ -685,6 +711,18 @@ public static class IndexCommandRunner
                     else
                         projectPath = args[i];
                     break;
+            }
+        }
+
+        if (projectFilters.Count > 0 && projectPath != null)
+        {
+            try
+            {
+                updateFiles.AddRange(SolutionProjectResolver.ResolveProjectFiles(projectPath, projectFilters, solutionPath));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                projectFilterError = ex.Message;
             }
         }
 
@@ -717,6 +755,9 @@ public static class IndexCommandRunner
             ChangedBetweenSpecified = changedBetweenSpecified,
             ChangedBetweenRefs = changedBetweenRefs,
             UpdateFiles = updateFiles,
+            ProjectFilters = projectFilters,
+            SolutionPath = solutionPath,
+            ProjectFilterError = projectFilterError,
             EasterEgg = easterEgg,
             DryRun = dryRun,
             Force = force,
@@ -3036,6 +3077,9 @@ public sealed class IndexCommandOptions
     public bool ChangedBetweenSpecified { get; init; }
     public List<string> ChangedBetweenRefs { get; init; } = [];
     public List<string> UpdateFiles { get; init; } = [];
+    public List<string> ProjectFilters { get; init; } = [];
+    public string? SolutionPath { get; init; }
+    public string? ProjectFilterError { get; init; }
     public string? EasterEgg { get; init; }
     public bool DryRun { get; init; }
     public bool Force { get; init; }

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -61,6 +61,8 @@ public static class QueryCommandRunner
         "--snippet-lines",
         "--snippet-focus",
         "--path",
+        "--project",
+        "--solution",
         "--exclude-path",
         "--depth",
         "--query",
@@ -3111,6 +3113,8 @@ public static class QueryCommandRunner
         int maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth;
         bool contextAfterExplicit = false;
         var pathPatterns = new List<string>();
+        var projectFilters = new List<string>();
+        string? solutionFilter = null;
         var excludePaths = new List<string>();
         bool excludeTests = false;
         DateTime? since = null;
@@ -3438,6 +3442,21 @@ public static class QueryCommandRunner
                     else
                         AddParseError(pathError!);
                     break;
+                case "--project":
+                    if (TryReadStringOptionValue(args, ref i, "--project", inlineValue, allowSeparatedDashPrefixedLiteralValue: true, out var projectName, out var projectError))
+                        projectFilters.Add(projectName!);
+                    else
+                        AddParseError(projectError!);
+                    break;
+                case "--solution":
+                    if (TryReadStringOptionValue(args, ref i, "--solution", inlineValue, allowSeparatedDashPrefixedLiteralValue: true, out var solutionValue, out var solutionError))
+                    {
+                        WarnIfDuplicateSingleValueOption("--solution", solutionValue!);
+                        solutionFilter = solutionValue;
+                    }
+                    else
+                        AddParseError(solutionError!);
+                    break;
                 case "--exclude-path":
                     if (TryReadStringOptionValue(args, ref i, "--exclude-path", inlineValue, allowSeparatedDashPrefixedLiteralValue: true, out var excludePath, out var excludePathError))
                         excludePaths.Add(excludePath!);
@@ -3598,6 +3617,19 @@ public static class QueryCommandRunner
             }
         }
 
+        if (parseErrors == null && projectFilters.Count > 0)
+        {
+            try
+            {
+                foreach (var glob in SolutionProjectResolver.ResolveProjectDirectoryGlobs(Environment.CurrentDirectory, projectFilters, solutionFilter))
+                    pathPatterns.Add(glob);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                AddParseError($"Error: {ex.Message}");
+            }
+        }
+
         return new QueryCommandOptions
         {
             DbPath = dbPath,
@@ -3621,6 +3653,8 @@ public static class QueryCommandRunner
             SnippetFocus = snippetFocus,
             MaxLineWidth = maxLineWidth,
             PathPatterns = pathPatterns,
+            ProjectFilters = projectFilters,
+            SolutionFilter = solutionFilter,
             ExcludePaths = excludePaths,
             ExcludeTests = excludeTests,
             CountOnly = countOnly,
@@ -5617,6 +5651,8 @@ public sealed class QueryCommandOptions
     public SearchSnippetFocusMode SnippetFocus { get; init; } = SearchSnippetFocusMode.Quality;
     public int MaxLineWidth { get; init; } = LineWidthFormatter.DefaultMaxLineWidth;
     public List<string> PathPatterns { get; init; } = [];
+    public List<string> ProjectFilters { get; init; } = [];
+    public string? SolutionFilter { get; init; }
     public List<string> ExcludePaths { get; init; } = [];
     public bool ExcludeTests { get; init; }
     public bool CountOnly { get; init; }

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -39,7 +39,7 @@ internal static partial class SolutionProjectResolver
             var relativeDir = Path.GetRelativePath(Path.GetFullPath(workspaceRoot), match.DirectoryPath)
                 .Replace(Path.DirectorySeparatorChar, '/')
                 .Replace(Path.AltDirectorySeparatorChar, '/');
-            globs.Add(relativeDir == "." ? "**/*" : $"{relativeDir.TrimEnd('/')}/**/*");
+            globs.Add(relativeDir == "." ? "*" : $"{relativeDir.TrimEnd('/')}/*");
         }
 
         return globs;

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -1,0 +1,148 @@
+using System.Text.RegularExpressions;
+namespace CodeIndex.Cli;
+
+internal sealed record DotNetProjectInfo(string Name, string ProjectPath, string DirectoryPath);
+
+internal static partial class SolutionProjectResolver
+{
+    public static IReadOnlyList<DotNetProjectInfo> ResolveProjects(string workspaceRoot, string? solutionPath = null)
+    {
+        var root = Path.GetFullPath(workspaceRoot);
+        var solution = ResolveSolutionPath(root, solutionPath);
+        if (solution != null)
+            return ParseSolution(solution, root);
+
+        return Directory.EnumerateFiles(root, "*.*proj", SearchOption.AllDirectories)
+            .Where(IsDotNetProjectFile)
+            .Select(path => BuildProjectInfo(path, root))
+            .OrderBy(project => project.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(project => project.ProjectPath, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public static IReadOnlyList<string> ResolveProjectDirectoryGlobs(
+        string workspaceRoot,
+        IReadOnlyList<string> requestedProjects,
+        string? solutionPath = null)
+    {
+        if (requestedProjects.Count == 0)
+            return [];
+
+        var projects = ResolveProjects(workspaceRoot, solutionPath);
+        var globs = new List<string>();
+        foreach (var requested in requestedProjects)
+        {
+            var match = MatchProject(projects, requested);
+            if (match == null)
+                throw new InvalidOperationException($"project not found in solution/workspace: {requested}");
+
+            var relativeDir = Path.GetRelativePath(Path.GetFullPath(workspaceRoot), match.DirectoryPath)
+                .Replace(Path.DirectorySeparatorChar, '/')
+                .Replace(Path.AltDirectorySeparatorChar, '/');
+            globs.Add(relativeDir == "." ? "**/*" : $"{relativeDir.TrimEnd('/')}/**/*");
+        }
+
+        return globs;
+    }
+
+    public static IReadOnlyList<string> ResolveProjectFiles(
+        string workspaceRoot,
+        IReadOnlyList<string> requestedProjects,
+        string? solutionPath = null)
+    {
+        if (requestedProjects.Count == 0)
+            return [];
+
+        var root = Path.GetFullPath(workspaceRoot);
+        var projects = ResolveProjects(root, solutionPath);
+        var files = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var requested in requestedProjects)
+        {
+            var match = MatchProject(projects, requested);
+            if (match == null)
+                throw new InvalidOperationException($"project not found in solution/workspace: {requested}");
+
+            foreach (var file in Directory.EnumerateFiles(match.DirectoryPath, "*", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(root, file)
+                    .Replace(Path.DirectorySeparatorChar, '/')
+                    .Replace(Path.AltDirectorySeparatorChar, '/');
+                files.Add(relative);
+            }
+        }
+
+        return files.ToList();
+    }
+
+    private static string? ResolveSolutionPath(string workspaceRoot, string? solutionPath)
+    {
+        if (!string.IsNullOrWhiteSpace(solutionPath))
+        {
+            var path = Path.IsPathRooted(solutionPath)
+                ? solutionPath
+                : Path.Combine(workspaceRoot, solutionPath);
+            return File.Exists(path) ? Path.GetFullPath(path) : throw new FileNotFoundException($"solution not found: {solutionPath}", path);
+        }
+
+        var solutions = Directory.EnumerateFiles(workspaceRoot, "*.sln", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return solutions.Count == 1 ? solutions[0] : null;
+    }
+
+    private static IReadOnlyList<DotNetProjectInfo> ParseSolution(string solutionPath, string workspaceRoot)
+    {
+        var solutionDir = Path.GetDirectoryName(solutionPath) ?? workspaceRoot;
+        var projects = new List<DotNetProjectInfo>();
+        foreach (var line in File.ReadLines(solutionPath))
+        {
+            var match = SolutionProjectLineRegex().Match(line);
+            if (!match.Success)
+                continue;
+
+            var projectPath = match.Groups["path"].Value.Replace('\\', Path.DirectorySeparatorChar);
+            if (!IsDotNetProjectFile(projectPath))
+                continue;
+
+            var fullPath = Path.GetFullPath(Path.Combine(solutionDir, projectPath));
+            if (File.Exists(fullPath))
+                projects.Add(BuildProjectInfo(fullPath, workspaceRoot, match.Groups["name"].Value));
+        }
+
+        return projects
+            .OrderBy(project => project.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(project => project.ProjectPath, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static DotNetProjectInfo BuildProjectInfo(string fullProjectPath, string workspaceRoot, string? solutionName = null)
+    {
+        var name = !string.IsNullOrWhiteSpace(solutionName)
+            ? solutionName
+            : Path.GetFileNameWithoutExtension(fullProjectPath);
+        var relativeProject = Path.GetRelativePath(Path.GetFullPath(workspaceRoot), fullProjectPath)
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/');
+        return new DotNetProjectInfo(name, relativeProject, Path.GetDirectoryName(fullProjectPath) ?? Path.GetFullPath(workspaceRoot));
+    }
+
+    private static DotNetProjectInfo? MatchProject(IReadOnlyList<DotNetProjectInfo> projects, string requested)
+    {
+        var trimmed = requested.Trim();
+        return projects.FirstOrDefault(project =>
+            string.Equals(project.Name, trimmed, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(project.ProjectPath, trimmed.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase)
+            || string.Equals(Path.GetFileName(project.ProjectPath), trimmed, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsDotNetProjectFile(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".fsproj", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".vbproj", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [GeneratedRegex("^Project\\([^)]*\\)\\s*=\\s*\"(?<name>[^\"]+)\",\\s*\"(?<path>[^\"]+\\.(?:csproj|fsproj|vbproj))\"", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SolutionProjectLineRegex();
+}

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -506,7 +506,6 @@ public partial class McpServer
             "validate",
             "unused_symbols",
             "symbol_hotspots",
-            "index",
         };
 
         foreach (var tool in tools.OfType<JsonObject>())

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -467,6 +467,8 @@ public partial class McpServer
                 SuggestionAnnotations())
         };
 
+        AddProjectScopeProperties(tools);
+
         // Per-deployment enablement gate (#1561). Drop any tool the operator disabled via
         // `CDIDX_MCP_TOOLS_ALLOW` / `CDIDX_MCP_TOOLS_DENY` so AI clients never see destructive
         // or out-of-scope tools advertised in the first place.
@@ -484,5 +486,49 @@ public partial class McpServer
 
         var result = new JsonObject { ["tools"] = filtered };
         return CreateSuccessResponse(id, result);
+    }
+
+    private static void AddProjectScopeProperties(JsonArray tools)
+    {
+        var scopedTools = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "search",
+            "definition",
+            "references",
+            "callers",
+            "callees",
+            "symbols",
+            "files",
+            "map",
+            "analyze_symbol",
+            "impact_analysis",
+            "deps",
+            "validate",
+            "unused_symbols",
+            "symbol_hotspots",
+            "index",
+        };
+
+        foreach (var tool in tools.OfType<JsonObject>())
+        {
+            var name = tool["name"]?.GetValue<string>();
+            if (name == null || !scopedTools.Contains(name))
+                continue;
+
+            var properties = tool["inputSchema"]?["properties"] as JsonObject;
+            if (properties == null || !properties.ContainsKey("path") || properties.ContainsKey("project"))
+                continue;
+
+            properties["project"] = new JsonObject
+            {
+                ["oneOf"] = new JsonArray { new JsonObject { ["type"] = "string" }, new JsonObject { ["type"] = "array", ["items"] = new JsonObject { ["type"] = "string" } } },
+                ["description"] = "Restrict to .sln/.csproj project name or project path. Accepts a single string or array; combines with path filters.",
+            };
+            properties["solution"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "Solution file used to resolve project filters when the workspace has multiple .sln files.",
+            };
+        }
     }
 }

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1733,7 +1733,7 @@ public partial class McpServer
             ?? (string.Equals(lang, "sql", StringComparison.Ordinal) ? "statement" : "symbol");
         if (groupBy is not ("symbol" or "file" or "statement"))
             return CreateToolErrorResponse(id, $"Unsupported symbol_hotspots groupBy '{groupBy}'. Use symbol, file, or statement.");
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
 
@@ -1834,7 +1834,7 @@ public partial class McpServer
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 50);
         var kind = args?["kind"]?.GetValue<string>()?.ToLowerInvariant();
         var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
 

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1961,8 +1961,6 @@ public partial class McpServer
         }
         if (maxFileBytes is <= 0 or > int.MaxValue)
             return CreateToolErrorResponse(id, "maxFileBytes must be a positive integer less than or equal to 2147483647");
-        var projectFilters = ReadPathList(args, "project") ?? [];
-        var solutionPath = args?["solution"]?.GetValue<string>();
         var projectPath = Path.GetFullPath(path);
 
         // Prevent path traversal — only allow indexing within current working directory
@@ -2069,16 +2067,6 @@ public partial class McpServer
         // Scan and index / スキャン・インデックス
         var scanResult = indexer.ScanFilesDetailed();
         var files = scanResult.Files;
-        if (projectFilters.Count > 0)
-        {
-            var relativeProjectFiles = SolutionProjectResolver.ResolveProjectFiles(projectPath, projectFilters, solutionPath)
-                .ToHashSet(StringComparer.Ordinal);
-            files = files
-                .Where(file => relativeProjectFiles.Contains(Path.GetRelativePath(projectPath, file)
-                    .Replace(Path.DirectorySeparatorChar, '/')
-                    .Replace(Path.AltDirectorySeparatorChar, '/')))
-                .ToList();
-        }
         var csharpWorkspace = BuildMcpCSharpStaticInterfaceWorkspaceSymbols(writer, indexer, projectPath, files);
         if (purged > 0 && hadCSharpStaticInterfaceContractsBeforePurge)
             csharpWorkspace = csharpWorkspace with { HasStaticInterfaceContracts = true };

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -274,6 +274,19 @@ public partial class McpServer
         return string.IsNullOrWhiteSpace(value) ? null : new List<string> { value };
     }
 
+    private static List<string>? ReadScopedPathList(JsonNode? args)
+    {
+        var paths = ReadPathList(args, "path") ?? [];
+        var projects = ReadPathList(args, "project") ?? [];
+        if (projects.Count == 0)
+            return paths.Count == 0 ? null : paths;
+
+        var solution = args?["solution"]?.GetValue<string>();
+        foreach (var glob in SolutionProjectResolver.ResolveProjectDirectoryGlobs(Environment.CurrentDirectory, projects, solution))
+            paths.Add(glob);
+        return paths.Count == 0 ? null : paths;
+    }
+
     /// <summary>
     /// Serialize a path filter list back into a JSON echo value.
     /// Null/empty → JSON null; single element → string; multiple → array.
@@ -351,7 +364,7 @@ public partial class McpServer
         if (TryGetValidatedMaxLineWidth(id, args, out var maxLineWidth) is JsonNode maxLineWidthError)
             return maxLineWidthError;
         var rawQuery = args?["rawQuery"]?.GetValue<bool>() ?? false;
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         var sinceStr = args?["since"]?.GetValue<string>();
@@ -438,7 +451,7 @@ public partial class McpServer
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         if (TryGetValidatedMaxLineWidth(id, args, out var maxLineWidth) is JsonNode maxLineWidthError)
             return maxLineWidthError;
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         var sinceStr = args?["since"]?.GetValue<string>();
@@ -533,7 +546,7 @@ public partial class McpServer
         var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         var includeBody = args?["includeBody"]?.GetValue<bool>() ?? false;
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         var sinceStr = args?["since"]?.GetValue<string>();
@@ -592,7 +605,7 @@ public partial class McpServer
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         if (TryGetValidatedMaxLineWidth(id, args, out var maxLineWidth) is JsonNode maxLineWidthError)
             return maxLineWidthError;
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         if (!TryResolveNameExactArgument(args, "references", out var exact, out var exactError))
@@ -657,7 +670,7 @@ public partial class McpServer
             return CreateToolErrorResponse(id, BuildNonCallGraphKindRejectionMessage("callers", kind!));
         var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         if (!TryResolveNameExactArgument(args, "callers", out var exact, out var exactError))
@@ -724,7 +737,7 @@ public partial class McpServer
             return CreateToolErrorResponse(id, BuildNonCallGraphKindRejectionMessage("callees", kind!));
         var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         if (!TryResolveNameExactArgument(args, "callees", out var exact, out var exactError))
@@ -783,7 +796,7 @@ public partial class McpServer
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
         var lang = QueryCommandRunner.NormalizeLangFilterValue(args?["lang"]?.GetValue<string>());
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         var sinceStr = args?["since"]?.GetValue<string>();
@@ -831,7 +844,7 @@ public partial class McpServer
     {
         var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 10);
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
 
@@ -869,7 +882,7 @@ public partial class McpServer
         var includeBody = args?["includeBody"]?.GetValue<bool>() ?? false;
         if (TryGetValidatedMaxLineWidth(id, args, out var maxLineWidth) is JsonNode maxLineWidthError)
             return maxLineWidthError;
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         if (!TryResolveNameExactArgument(args, "analyze_symbol", out var exact, out var exactError))
@@ -1187,7 +1200,7 @@ public partial class McpServer
         if (query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
 
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         if (pathPatterns == null || pathPatterns.Count == 0)
             return CreateToolErrorResponse(id, "Missing required parameter: path");
 
@@ -1542,7 +1555,7 @@ public partial class McpServer
     {
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 50);
         var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         var reverse = args?["reverse"]?.GetValue<bool>() ?? false;
@@ -1585,7 +1598,7 @@ public partial class McpServer
         var maxDepth = Math.Clamp(maxDepthRequested, 0, MaxImpactDepth);
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 50);
         var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
         var withPaths = args?["withPaths"]?.GetValue<bool>() ?? false;
@@ -1694,7 +1707,7 @@ public partial class McpServer
     private JsonNode ExecuteValidate(JsonNode? id, JsonNode? args)
     {
         var kind = args?["kind"]?.GetValue<string>()?.ToLowerInvariant();
-        var pathPatterns = ReadPathList(args, "path");
+        var pathPatterns = ReadScopedPathList(args);
 
         return WithDbReader(id, reader =>
         {
@@ -1948,6 +1961,8 @@ public partial class McpServer
         }
         if (maxFileBytes is <= 0 or > int.MaxValue)
             return CreateToolErrorResponse(id, "maxFileBytes must be a positive integer less than or equal to 2147483647");
+        var projectFilters = ReadPathList(args, "project") ?? [];
+        var solutionPath = args?["solution"]?.GetValue<string>();
         var projectPath = Path.GetFullPath(path);
 
         // Prevent path traversal — only allow indexing within current working directory
@@ -2054,6 +2069,16 @@ public partial class McpServer
         // Scan and index / スキャン・インデックス
         var scanResult = indexer.ScanFilesDetailed();
         var files = scanResult.Files;
+        if (projectFilters.Count > 0)
+        {
+            var relativeProjectFiles = SolutionProjectResolver.ResolveProjectFiles(projectPath, projectFilters, solutionPath)
+                .ToHashSet(StringComparer.Ordinal);
+            files = files
+                .Where(file => relativeProjectFiles.Contains(Path.GetRelativePath(projectPath, file)
+                    .Replace(Path.DirectorySeparatorChar, '/')
+                    .Replace(Path.AltDirectorySeparatorChar, '/')))
+                .ToList();
+        }
         var csharpWorkspace = BuildMcpCSharpStaticInterfaceWorkspaceSymbols(writer, indexer, projectPath, files);
         if (purged > 0 && hadCSharpStaticInterfaceContractsBeforePurge)
             csharpWorkspace = csharpWorkspace with { HasStaticInterfaceContracts = true };

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -92,6 +92,40 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void ParseArgs_ProjectFilterExpandsToProjectFiles_Issue1707()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_index_project_filter");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "Lib"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "Other"));
+            File.WriteAllText(Path.Combine(projectRoot, "Repo.sln"), """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib", "src\Lib\Lib.csproj", "{11111111-1111-1111-1111-111111111111}"
+            EndProject
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Other", "src\Other\Other.csproj", "{22222222-2222-2222-2222-222222222222}"
+            EndProject
+            """);
+            File.WriteAllText(Path.Combine(projectRoot, "src", "Lib", "Lib.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+            File.WriteAllText(Path.Combine(projectRoot, "src", "Lib", "Class1.cs"), "class Class1 {}");
+            File.WriteAllText(Path.Combine(projectRoot, "src", "Other", "Other.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+            File.WriteAllText(Path.Combine(projectRoot, "src", "Other", "Class2.cs"), "class Class2 {}");
+
+            var options = IndexCommandRunner.ParseArgs([projectRoot, "--solution", "Repo.sln", "--project", "Lib"]);
+
+            Assert.Equal(["Lib"], options.ProjectFilters);
+            Assert.Equal("Repo.sln", options.SolutionPath);
+            Assert.Contains("src/Lib/Lib.csproj", options.UpdateFiles);
+            Assert.Contains("src/Lib/Class1.cs", options.UpdateFiles);
+            Assert.DoesNotContain("src/Other/Class2.cs", options.UpdateFiles);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void HandleIndexCancelKeyPress_FirstCancelRequestsCooperativeCancellation_SecondAllowsForceExit()
     {
         using var cts = new CancellationTokenSource();

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -4358,6 +4358,7 @@ public class McpServerTests : IDisposable
             {
                 var writer = new DbWriter(db.Connection);
                 writer.MarkGraphReady();
+                writer.MarkHotspotFamilyReady("csharp", "fixture-fingerprint");
             }
 
             using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
@@ -5724,6 +5725,96 @@ public class McpServerTests : IDisposable
         }
         finally
         {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void ToolsCall_ProjectScopeFiltersHotspotsAndUnusedSymbols_Issue1707()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_mcp_project_scope");
+        var originalCurrentDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "AppA"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "AppB"));
+            File.WriteAllText(Path.Combine(projectRoot, "Repo.sln"), """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppA", "src\AppA\AppA.csproj", "{11111111-1111-1111-1111-111111111111}"
+            EndProject
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppB", "src\AppB\AppB.csproj", "{22222222-2222-2222-2222-222222222222}"
+            EndProject
+            """);
+            File.WriteAllText(Path.Combine(projectRoot, "src", "AppA", "AppA.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+            File.WriteAllText(Path.Combine(projectRoot, "src", "AppB", "AppB.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/AppA/ServiceA.cs", "csharp",
+                """
+                public class ServiceA
+                {
+                    public void UsedA() { UsedA(); }
+                    public void UnusedA() { }
+                }
+
+                public class CallerA
+                {
+                    public void Call(ServiceA service) { service.UsedA(); }
+                }
+                """);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/AppB/ServiceB.cs", "csharp",
+                """
+                public class ServiceB
+                {
+                    public void UsedB() { UsedB(); UsedB(); }
+                    public void UnusedB() { }
+                }
+
+                public class CallerB
+                {
+                    public void Call(ServiceB service)
+                    {
+                        service.UsedB();
+                        service.UsedB();
+                    }
+                }
+                """);
+            using (var db = new DbContext(dbPath))
+            {
+                var writer = new DbWriter(db.Connection);
+                writer.MarkGraphReady();
+            }
+
+            Environment.CurrentDirectory = projectRoot;
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            var hotspotsRequest = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"symbol_hotspots","arguments":{"lang":"csharp","kind":"function","project":"AppA"}}}""")!;
+            var hotspotsResponse = server.HandleMessage(hotspotsRequest)!;
+            var hotspotNames = hotspotsResponse["result"]!["structuredContent"]!["hotspots"]!
+                .AsArray()
+                .Select(symbol => symbol?["name"]?.GetValue<string>())
+                .Where(name => name != null)
+                .Cast<string>()
+                .ToHashSet(StringComparer.Ordinal);
+
+            var unusedRequest = JsonNode.Parse("""{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"unused_symbols","arguments":{"lang":"csharp","project":"AppA"}}}""")!;
+            var unusedResponse = server.HandleMessage(unusedRequest)!;
+            var unusedNames = unusedResponse["result"]!["structuredContent"]!["symbols"]!
+                .AsArray()
+                .Select(symbol => symbol?["name"]?.GetValue<string>())
+                .Where(name => name != null)
+                .Cast<string>()
+                .ToHashSet(StringComparer.Ordinal);
+
+            Assert.False(hotspotsResponse["result"]!["isError"]?.GetValue<bool>() ?? false);
+            Assert.Contains("UsedA", hotspotNames);
+            Assert.DoesNotContain("UsedB", hotspotNames);
+            Assert.False(unusedResponse["result"]!["isError"]?.GetValue<bool>() ?? false);
+            Assert.Contains("UnusedA", unusedNames);
+            Assert.DoesNotContain("UnusedB", unusedNames);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCurrentDirectory;
             TestProjectHelper.DeleteDirectory(projectRoot);
         }
     }

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -5568,7 +5568,6 @@ public class McpServerTests : IDisposable
             {
                 var writer = new DbWriter(db.Connection);
                 writer.MarkGraphReady();
-                writer.MarkHotspotFamilyReady("csharp", "fixture-fingerprint");
             }
 
             using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
@@ -5783,6 +5782,7 @@ public class McpServerTests : IDisposable
             {
                 var writer = new DbWriter(db.Connection);
                 writer.MarkGraphReady();
+                writer.MarkHotspotFamilyReady("csharp", "fixture-fingerprint");
             }
 
             Environment.CurrentDirectory = projectRoot;

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -4358,7 +4358,6 @@ public class McpServerTests : IDisposable
             {
                 var writer = new DbWriter(db.Connection);
                 writer.MarkGraphReady();
-                writer.MarkHotspotFamilyReady("csharp", "fixture-fingerprint");
             }
 
             using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
@@ -5569,6 +5568,7 @@ public class McpServerTests : IDisposable
             {
                 var writer = new DbWriter(db.Connection);
                 writer.MarkGraphReady();
+                writer.MarkHotspotFamilyReady("csharp", "fixture-fingerprint");
             }
 
             using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -84,6 +84,36 @@ public class QueryCommandRunnerTests
         Assert.Equal(0, options.MaxLineWidth);
     }
 
+    [Fact]
+    public void ParseArgs_ProjectFilterExpandsSolutionProjectToPathGlob_Issue1707()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_filter");
+        var originalCurrentDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "App"));
+            File.WriteAllText(Path.Combine(projectRoot, "CodeIndex.sln"), """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "src\App\App.csproj", "{11111111-1111-1111-1111-111111111111}"
+            EndProject
+            """);
+            File.WriteAllText(Path.Combine(projectRoot, "src", "App", "App.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+            Environment.CurrentDirectory = projectRoot;
+            var options = QueryCommandRunner.ParseArgs(["Auth", "--project", "App"], jsonDefault: false, allowNamedQuery: true);
+
+            Assert.Equal("Auth", options.Query);
+            Assert.Equal(["App"], options.ProjectFilters);
+            Assert.Equal(["src/App/**/*"], options.PathPatterns);
+            Assert.Null(options.ParseError);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCurrentDirectory;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Theory]
     [InlineData("30m", 30 * 60)]
     [InlineData("2h", 2 * 60 * 60)]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -104,7 +104,7 @@ public class QueryCommandRunnerTests
 
             Assert.Equal("Auth", options.Query);
             Assert.Equal(["App"], options.ProjectFilters);
-            Assert.Equal(["src/App/**/*"], options.PathPatterns);
+            Assert.Equal(["src/App/*"], options.PathPatterns);
             Assert.Null(options.ParseError);
         }
         finally


### PR DESCRIPTION
## Summary

- Add `.sln` / `.csproj` project resolution for C# / F# / VB projects.
- Add `--project` and `--solution` filters to CLI query commands and scoped CLI indexing.
- Mirror project scoping on read-only MCP tools while preserving MCP `index` full-scan readiness semantics.
- Document .NET project scoping in README and DEVELOPER_GUIDE.

## Validation

- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release --no-build`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- `README.md`
- `DEVELOPER_GUIDE.md`
- `changelog.d/unreleased/1707.added.md`

## Follow-up Candidates

- Existing open issue #2331 tracks the local full-scan readiness stall observed while refreshing the dogfood index.

Fixes #1707
