### PR TITLE
Fix Kotlin inline symbol sub-kinds

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -112,6 +112,7 @@ symbols (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     file_id         INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
     kind            TEXT,                    -- "function", "class", "import", "namespace", ...
+    sub_kind        TEXT,                    -- language-specific subtype such as kotlin_value_class
     name            TEXT,
     line            INTEGER,                 -- 1-based anchor line
     start_line      INTEGER,                 -- definition start line
@@ -1571,6 +1572,7 @@ symbols (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     file_id         INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
     kind            TEXT,                    -- "function"、"class"、"import"、"namespace" など
+    sub_kind        TEXT,                    -- kotlin_value_class などの言語固有の細分類
     name            TEXT,
     line            INTEGER,                 -- 1始まりのアンカー行
     start_line      INTEGER,                 -- 定義開始行

--- a/changelog.d/unreleased/1920.fixed.md
+++ b/changelog.d/unreleased/1920.fixed.md
@@ -1,0 +1,24 @@
+---
+category: fixed
+issues:
+  - 1920
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
+  - src/CodeIndex/Models/SymbolRecord.cs
+  - src/CodeIndex/Models/QueryResults.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Kotlin value classes and inline functions now expose symbol sub-kinds (#1920)** — `symbols`, `definition`, `inspect`, and MCP `analyze_symbol` JSON can distinguish Kotlin `value class` / legacy `inline class` and `inline fun` declarations, including `inline reified` functions.
+
+## 日本語
+
+- **Kotlin の value class と inline 関数がシンボル細分類を公開するようになりました (#1920)** — `symbols` / `definition` / `inspect` / MCP `analyze_symbol` の JSON で、Kotlin の `value class` / 旧 `inline class` と `inline fun`（`inline reified` を含む）を区別できるようになりました。

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -771,6 +771,7 @@ public class DbContext : IDisposable
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
                 file_id         INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
                 kind            TEXT,
+                sub_kind        TEXT,
                 name            TEXT,
                 line            INTEGER,
                 start_line      INTEGER,
@@ -828,6 +829,7 @@ public class DbContext : IDisposable
         EnsureColumn("files", "modified", "DATETIME");
         EnsureColumn("files", "indexed_at", "DATETIME");
         EnsureColumn("symbols", "start_line", "INTEGER");
+        EnsureColumn("symbols", "sub_kind", "TEXT");
         EnsureColumn("symbols", "start_column", "INTEGER");
         EnsureColumn("symbols", "end_line", "INTEGER");
         EnsureColumn("symbols", "body_start_line", "INTEGER");

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -373,7 +373,7 @@ public partial class DbReader
         using var cmd = _conn.CreateCommand();
 
         var sql = $@"
-            SELECT f.path, f.lang, s.kind, s.name, s.line,
+            SELECT f.path, f.lang, s.kind, {GetSymbolColumnSql("sub_kind")} AS sub_kind, s.name, s.line,
                    {GetSymbolColumnSql("start_line", "s.line")} AS start_line,
                    {GetSymbolColumnSql("end_line", "s.line")} AS end_line,
                    {GetSymbolColumnSql("body_start_line")} AS body_start_line,
@@ -507,17 +507,18 @@ public partial class DbReader
                 Path = reader.GetString(0),
                 Lang = GetNullableString(reader, 1),
                 Kind = reader.GetString(2),
-                Name = reader.GetString(3),
-                Line = reader.GetInt32(4),
-                StartLine = GetInt32OrFallback(reader, 5, 4),
-                EndLine = GetInt32OrFallback(reader, 6, 4),
-                BodyStartLine = GetNullableInt32(reader, 7),
-                BodyEndLine = GetNullableInt32(reader, 8),
-                Signature = GetNullableString(reader, 9),
-                ContainerKind = GetNullableString(reader, 10),
-                ContainerName = GetNullableString(reader, 11),
-                Visibility = GetNullableString(reader, 12),
-                ReturnType = GetNullableString(reader, 13),
+                SubKind = GetNullableString(reader, 3),
+                Name = reader.GetString(4),
+                Line = reader.GetInt32(5),
+                StartLine = GetInt32OrFallback(reader, 6, 5),
+                EndLine = GetInt32OrFallback(reader, 7, 5),
+                BodyStartLine = GetNullableInt32(reader, 8),
+                BodyEndLine = GetNullableInt32(reader, 9),
+                Signature = GetNullableString(reader, 10),
+                ContainerKind = GetNullableString(reader, 11),
+                ContainerName = GetNullableString(reader, 12),
+                Visibility = GetNullableString(reader, 13),
+                ReturnType = GetNullableString(reader, 14),
             });
         }
         return results;
@@ -550,6 +551,7 @@ public partial class DbReader
                 Path = symbol.Path,
                 Lang = symbol.Lang,
                 Kind = symbol.Kind,
+                SubKind = symbol.SubKind,
                 Name = symbol.Name,
                 Line = symbol.Line,
                 StartLine = symbol.StartLine,

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -532,7 +532,7 @@ public class DbWriter
             using var cmd = _conn.CreateCommand();
             cmd.CommandText = @"
                 INSERT INTO symbols (
-                    file_id, kind, name, line, start_line, start_column, end_line,
+                    file_id, kind, sub_kind, name, line, start_line, start_column, end_line,
                     body_start_line, body_end_line, signature,
                     container_kind, container_name, container_qualified_name, family_key,
                     visibility, return_type,
@@ -540,7 +540,7 @@ public class DbWriter
                     name_folded
                 )
                 VALUES (
-                    @fid, @kind, @name, @line, @startLine, @startColumn, @endLine,
+                    @fid, @kind, @subKind, @name, @line, @startLine, @startColumn, @endLine,
                     @bodyStartLine, @bodyEndLine, @signature,
                     @containerKind, @containerName, @containerQualifiedName, @familyKey,
                     @visibility, @returnType,
@@ -549,6 +549,7 @@ public class DbWriter
                 )";
             var pFid = cmd.Parameters.Add("@fid", SqliteType.Integer);
             var pKind = cmd.Parameters.Add("@kind", SqliteType.Text);
+            var pSubKind = cmd.Parameters.Add("@subKind", SqliteType.Text);
             var pName = cmd.Parameters.Add("@name", SqliteType.Text);
             var pLine = cmd.Parameters.Add("@line", SqliteType.Integer);
             var pStartLine = cmd.Parameters.Add("@startLine", SqliteType.Integer);
@@ -574,6 +575,7 @@ public class DbWriter
                 var endLine = symbol.EndLine > 0 ? symbol.EndLine : startLine;
                 pFid.Value = symbol.FileId;
                 pKind.Value = symbol.Kind;
+                pSubKind.Value = (object?)symbol.SubKind ?? DBNull.Value;
                 pName.Value = symbol.Name;
                 pLine.Value = symbol.Line;
                 pStartLine.Value = startLine;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
@@ -14,7 +14,7 @@ public static partial class SymbolExtractor
         @"\binline\s+class\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex KotlinInlineFunctionSignatureRegex = new(
-        @"\binline\s+fun\b",
+        @"\binline\b(?:(?:\s+(?:suspend|infix|operator|tailrec|external|expect|actual|abstract|override|open|final)))*\s+fun\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex KotlinReifiedTypeParameterSignatureRegex = new(
         @"<[^>\r\n]*\breified\b[^>\r\n]*>",

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
@@ -7,6 +7,43 @@ namespace CodeIndex.Indexer;
 
 public static partial class SymbolExtractor
 {
+    private static readonly Regex KotlinValueClassSignatureRegex = new(
+        @"\bvalue\s+class\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex KotlinInlineClassSignatureRegex = new(
+        @"\binline\s+class\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex KotlinInlineFunctionSignatureRegex = new(
+        @"\binline\s+fun\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex KotlinReifiedTypeParameterSignatureRegex = new(
+        @"<[^>\r\n]*\breified\b[^>\r\n]*>",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static string? ResolveLanguageSubKind(string lang, string kind, string signature, string matchLine)
+    {
+        if (lang != "kotlin")
+            return null;
+
+        var metadataSource = signature + "\n" + matchLine;
+        if (kind == "class")
+        {
+            if (KotlinValueClassSignatureRegex.IsMatch(metadataSource))
+                return "kotlin_value_class";
+            if (KotlinInlineClassSignatureRegex.IsMatch(metadataSource))
+                return "kotlin_inline_class";
+        }
+
+        if (kind == "function" && KotlinInlineFunctionSignatureRegex.IsMatch(signature))
+        {
+            return KotlinReifiedTypeParameterSignatureRegex.IsMatch(signature)
+                ? "kotlin_inline_reified_function"
+                : "kotlin_inline_function";
+        }
+
+        return null;
+    }
+
     private static bool TryFindKotlinScalaExpressionBodyEndLine(string line, int startColumn)
     {
         var parenDepth = 0;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1373,12 +1373,12 @@ public static partial class SymbolExtractor
             new("interface", new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:sealed|expect|actual)\s+)*(?:fun\s+)?interface\s+(?<name>{KotlinIdentifierPattern})", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum class / enum クラス
             new("enum",     new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:expect|actual)\s+)*enum\s+class\s+(?<name>{KotlinIdentifierPattern})", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            // Class/object with expanded modifiers: data, sealed, value, inner, annotation, expect, actual
-            // クラス/オブジェクト — 拡張修飾子対応: data, sealed, value, inner, annotation, expect, actual
-            new("class",    new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:abstract|data|sealed|open|inner|value|annotation|expect|actual)\s+)*(?:class|object)\s+(?<name>{KotlinIdentifierPattern})", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            // Class/object with expanded modifiers: data, sealed, value, inline, inner, annotation, expect, actual
+            // クラス/オブジェクト — 拡張修飾子対応: data, sealed, value, inline, inner, annotation, expect, actual
+            new("class",    new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:abstract|data|sealed|open|inner|value|inline|annotation|expect|actual)\s+)*(?:class|object)\s+(?<name>{KotlinIdentifierPattern})", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Function / 関数 (including extension, secondary constructor, override, and abstract forms)
             // 関数 — 拡張・セカンダリコンストラクタ・override・abstract 形を含む
-            new("function", new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:suspend|inline|infix|operator|tailrec|external|expect|actual|abstract|override|open|final)\s+)*fun\s+(?:{KotlinIdentifierPattern}(?:<[^>]+>)?\.)?(?<name>{KotlinIdentifierPattern})\s*[\(<](?:.*?\))?(?::\s*(?<returnType>[^ {{=]+))?", RegexOptions.Compiled), BodyStyle.Brace, "visibility", "returnType"),
+            new("function", new Regex($@"^\s*(?<visibility>public|private|protected|internal)?\s*(?:(?:suspend|inline|infix|operator|tailrec|external|expect|actual|abstract|override|open|final)\s+)*fun\s+(?:<[^>]+>\s+)?(?:{KotlinIdentifierPattern}(?:<[^>]+>)?\.)?(?<name>{KotlinIdentifierPattern})\s*[\(<](?:.*?\))?(?::\s*(?<returnType>[^ {{=]+))?", RegexOptions.Compiled), BodyStyle.Brace, "visibility", "returnType"),
             // Secondary constructor / セカンダリコンストラクタ
             new("function", new Regex(@"^\s*(?<visibility>public|private|protected|internal)?\s*constructor\s*\(", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum entry / enum エントリ
@@ -3299,6 +3299,7 @@ public static partial class SymbolExtractor
                                         BodyEndLine = bodyEndLine,
                                     Signature = signature,
                                     FamilyKey = lang == "cpp" && kind == "specialization" ? name : null,
+                                    SubKind = ResolveLanguageSubKind(lang, kind, signature, patternMatchLine),
                                     Visibility = TryGetGroup(match, pattern.VisibilityGroup),
                                     ReturnType = NormalizeMetadata(rawReturnType),
                                 },

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -35,6 +35,8 @@ public class SymbolResult
     public string Path { get; set; } = string.Empty;
     public string? Lang { get; set; }
     public string Kind { get; set; } = string.Empty;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SubKind { get; set; }
     public string Name { get; set; } = string.Empty;
     public int Line { get; set; }
     public int StartLine { get; set; }

--- a/src/CodeIndex/Models/SymbolRecord.cs
+++ b/src/CodeIndex/Models/SymbolRecord.cs
@@ -12,6 +12,9 @@ public class SymbolRecord
     /// <summary>Symbol kind: 'function', 'class', or 'import' / シンボル種別</summary>
     public string Kind { get; set; } = string.Empty;
 
+    /// <summary>Language-specific sub-kind when known / 言語固有の細分類</summary>
+    public string? SubKind { get; set; }
+
     /// <summary>Symbol name / シンボル名</summary>
     public string Name { get; set; } = string.Empty;
 

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -70,6 +70,17 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void AnalyzeSymbol_KotlinValueClassIncludesSubKind()
+    {
+        InsertIndexedFile("src/UserId.kt", "kotlin", "value class UserId(val id: Long)\n");
+
+        var analysis = _reader.AnalyzeSymbol("UserId", limit: 5, lang: "kotlin", exact: true);
+
+        var definition = Assert.Single(analysis.Definitions);
+        Assert.Equal("kotlin_value_class", definition.SubKind);
+    }
+
+    [Fact]
     public void CreateSearchReferencesCommand_RanksWithoutLoweringReferenceNames()
     {
         using var cmd = CreateSearchReferencesCommandForSql("FetchData");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15002,6 +15002,27 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Kotlin_DistinguishesValueClassesAndInlineReifiedFunctions()
+    {
+        var content = """
+            @JvmInline
+            value class UserId(val id: Long)
+            inline class LegacyId(val value: String)
+            inline fun <reified T> parse(): T = TODO()
+            inline fun render(block: () -> Unit) = block()
+            fun value(inline: String): String = inline
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "UserId" && s.SubKind == "kotlin_value_class");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "LegacyId" && s.SubKind == "kotlin_inline_class");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "parse" && s.SubKind == "kotlin_inline_reified_function");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render" && s.SubKind == "kotlin_inline_function");
+        Assert.DoesNotContain(symbols, s => s.Name == "value" && s.SubKind != null);
+    }
+
+    [Fact]
     public void Extract_Kotlin_NormalizesBacktickedSymbolNames()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -15010,6 +15010,7 @@ public class SymbolExtractorTests
             inline class LegacyId(val value: String)
             inline fun <reified T> parse(): T = TODO()
             inline fun render(block: () -> Unit) = block()
+            inline suspend fun <reified T> load(): T = TODO()
             fun value(inline: String): String = inline
             """;
 
@@ -15019,6 +15020,7 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "LegacyId" && s.SubKind == "kotlin_inline_class");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "parse" && s.SubKind == "kotlin_inline_reified_function");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render" && s.SubKind == "kotlin_inline_function");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "load" && s.SubKind == "kotlin_inline_reified_function");
         Assert.DoesNotContain(symbols, s => s.Name == "value" && s.SubKind != null);
     }
 


### PR DESCRIPTION
## Summary

- Add nullable `symbols.sub_kind` metadata and surface it through symbol/definition/analyze JSON results.
- Distinguish Kotlin `value class`, legacy `inline class`, `inline fun`, and `inline reified` declarations without changing existing `kind` values.
- Add Kotlin extractor and DB/analyze regression coverage, plus schema docs and a bilingual changelog fragment.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin_DistinguishesValueClassesAndInlineReifiedFunctions|FullyQualifiedName~DbReaderTests.AnalyzeSymbol_KotlinValueClassIncludesSubKind"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Kotlin"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet test CodeIndex.sln`
- `codex exec` adversarial review, two rounds; final result: `No blocking/actionable issues found.`

## Documentation / Changelog

- Updated `DEVELOPER_GUIDE.md` schema docs for `symbols.sub_kind`.
- Added `changelog.d/unreleased/1920.fixed.md`.

## Follow-up candidates

- Existing #2331 tracks the local `cdidx index` stall observed while trying to refresh the workspace index.

Fixes #1920
