### PR TITLE
Fix TypeScript mapped type references

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -214,6 +214,10 @@ files 1──N symbol_references
 
 TypeScript decorators emit `annotation` rows for the decorator name and must not hide the decorated declaration's type-position edges. For example, `constructor(@Inject() svc: Service)` records `Inject` as `annotation` and `Service` as `type_reference`, and `@Input() profile: UserProfile` records both the decorator and field type.
 
+### TypeScript type-graph extraction
+
+TypeScript extraction emits `type_reference` edges from type-only constructs as dependency metadata, not executable call-graph edges. Type aliases, mapped types, indexed access types, conditional types, template literal type holes, and `infer` clauses are scanned for referenced identifiers while TypeScript type operators such as `keyof`, `in`, `as`, `extends`, and `infer` are suppressed as keywords. For example, ``type Getters<T> = { [K in keyof T as `get${Capitalize<K>}`]: () => T[K] }`` records references to `T`, `K`, and `Capitalize`; `type Unwrap<T> = T extends Promise<infer U> ? U : never` records `T`, `Promise`, and `U`.
+
 ## Why a database instead of grep?
 
 On small projects, `grep` works fine. But as a codebase grows to tens of thousands of files, `grep` becomes a bottleneck — especially when an AI agent calls it repeatedly. cdidx solves this by **reading every file once at index time** and building a search structure so that queries never need to touch the original files again.
@@ -1664,6 +1668,10 @@ files 1──N symbol_references
 | `attribute`, `annotation`, `type_reference`, `implicit_implementation` | raw label | 依存関係 / reference 専用の metadata、型位置エッジ、および C# async iterator の `GetAsyncEnumerator` / `MoveNextAsync` のようなコンパイラ合成の実装エッジ。既定の call-graph 行からは除外する。 |
 
 TypeScript decorator は decorator 名を `annotation` 行として出力し、decorated declaration の型位置エッジを隠してはならない。たとえば `constructor(@Inject() svc: Service)` は `Inject` を `annotation`、`Service` を `type_reference` として記録し、`@Input() profile: UserProfile` も decorator と field type の両方を記録する。
+
+### TypeScript type-graph extraction
+
+TypeScript 抽出は、type-only 構文から `type_reference` edge を dependency metadata として出力し、実行される call-graph edge とは扱わない。type alias、mapped type、indexed access type、conditional type、template literal type の hole、`infer` 句では参照先 identifier を走査し、`keyof`、`in`、`as`、`extends`、`infer` のような TypeScript type operator は keyword として抑止する。たとえば ``type Getters<T> = { [K in keyof T as `get${Capitalize<K>}`]: () => T[K] }`` は `T`、`K`、`Capitalize` への参照を記録し、`type Unwrap<T> = T extends Promise<infer U> ? U : never` は `T`、`Promise`、`U` を記録する。
 
 ## なぜgrepではなくデータベースなのか？
 

--- a/changelog.d/unreleased/1888.fixed.md
+++ b/changelog.d/unreleased/1888.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1888
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Fixed TypeScript mapped-type reference extraction (#1888)** — mapped type clauses such as `keyof T`, `T[K]`, template literal type holes, and conditional `infer` clauses now emit type-parameter references instead of leaving utility-type chains opaque.
+
+## 日本語
+
+- **TypeScript mapped type の参照抽出を修正しました (#1888)** — `keyof T`、`T[K]`、template literal type の hole、conditional type の `infer` 句が type parameter への参照を出すようになり、utility type chain が不透明にならないようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -9,7 +9,9 @@ internal static class TypeScriptReferenceExtractor
     private static readonly HashSet<string> MappedTypeClauseIgnoredSegments = new(StringComparer.Ordinal)
     {
         "as",
+        "extends",
         "in",
+        "infer",
         "keyof",
         "readonly",
     };

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -6,6 +6,13 @@ internal static class TypeScriptReferenceExtractor
 {
     private static readonly string[] DeclarationKeywords = ["const", "let", "var"];
     private static readonly string[] TypeOperatorKeywords = ["as", "satisfies", "instanceof"];
+    private static readonly HashSet<string> MappedTypeClauseIgnoredSegments = new(StringComparer.Ordinal)
+    {
+        "as",
+        "in",
+        "keyof",
+        "readonly",
+    };
 
     public static void EmitTypePositionReferences(
         IReadOnlyList<string> preparedLines,
@@ -31,6 +38,7 @@ internal static class TypeScriptReferenceExtractor
             lineNumber,
             resolveContainerForColumn);
 
+        EmitMappedTypeMemberReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitHeritageTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitTypeAliasTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitCallableSignatureTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -78,6 +86,68 @@ internal static class TypeScriptReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+    }
+
+    private static void EmitMappedTypeMemberReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        var bracketStart = preparedLine.IndexOf('[');
+        if (bracketStart < 0)
+            return;
+
+        var bracketEnd = ReferenceExtractor.FindMatchingChar(preparedLine, bracketStart, '[', ']');
+        if (bracketEnd <= bracketStart)
+            return;
+
+        var clause = preparedLine.Substring(bracketStart + 1, bracketEnd - bracketStart - 1);
+        if (!clause.Contains("keyof", StringComparison.Ordinal)
+            && !clause.Contains(" in ", StringComparison.Ordinal)
+            && !clause.Contains(" as ", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var clauseStart = bracketStart + 1;
+        ReferenceExtractor.AddTypeExpressionSegments(
+            references,
+            seen,
+            fileId,
+            clause,
+            clauseStart,
+            context,
+            lineNumber,
+            resolveContainerForColumn(clauseStart),
+            "typescript",
+            MappedTypeClauseIgnoredSegments);
+
+        var colonIndex = TypedLanguageReferenceExtractor.FindTopLevelChar(preparedLine, ':', bracketEnd + 1);
+        if (colonIndex < 0)
+            return;
+
+        var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, colonIndex + 1);
+        if (typeStart >= preparedLine.Length)
+            return;
+
+        var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart, stopAtArrow: false);
+        if (typeEnd <= typeStart)
+            return;
+
+        ReferenceExtractor.AddTypeExpressionSegments(
+            references,
+            seen,
+            fileId,
+            preparedLine.Substring(typeStart, typeEnd - typeStart),
+            typeStart,
+            context,
+            lineNumber,
+            resolveContainerForColumn(typeStart),
+            "typescript");
     }
 
     private static void EmitHeritageTypeReferences(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -6,6 +6,16 @@ namespace CodeIndex.Indexer;
 
 public static partial class ReferenceExtractor
 {
+    private static readonly HashSet<string> TypeScriptTypeExpressionIgnoredSegments = new(StringComparer.Ordinal)
+    {
+        "as",
+        "extends",
+        "in",
+        "infer",
+        "keyof",
+        "readonly",
+    };
+
     internal static bool HasTrailingCSharpTypePatternIntro(string text, Regex introRegex)
     {
         foreach (Match match in introRegex.Matches(text))
@@ -1211,6 +1221,12 @@ public static partial class ReferenceExtractor
                 i++;
 
             var segment = expression.Substring(segmentStart, i - segmentStart);
+            if (TypeScriptTypeExpressionIgnoredSegments.Contains(segment))
+            {
+                i--;
+                continue;
+            }
+
             AddTypeReferenceSegment(references, seen, fileId, segment, expressionStartInLine + segmentStart, context, lineNumber, container, "typescript");
             i--;
         }
@@ -2034,6 +2050,8 @@ public static partial class ReferenceExtractor
         SymbolRecord? container,
         IReadOnlySet<string>? ignoredSegments = null)
     {
+        ignoredSegments ??= TypeScriptTypeExpressionIgnoredSegments;
+
         int i = 0;
         while (i < expression.Length)
         {
@@ -2072,6 +2090,12 @@ public static partial class ReferenceExtractor
                 i++;
 
             var segment = expression.Substring(segmentStart, i - segmentStart);
+            if (TypeScriptTypeExpressionIgnoredSegments.Contains(segment)
+                || ignoredSegments != null && ignoredSegments.Contains(segment))
+            {
+                continue;
+            }
+
             AddTypeReferenceSegment(
                 references,
                 seen,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -176,7 +176,7 @@ public static partial class ReferenceExtractor
         },
         ["typescript"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "import", "super", "yield",
+            "as", "extends", "import", "in", "infer", "keyof", "readonly", "super", "yield",
         },
         // Python contextual keywords / Python の文脈キーワード
         ["python"] = new HashSet<string>(StringComparer.Ordinal)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -176,7 +176,7 @@ public static partial class ReferenceExtractor
         },
         ["typescript"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "as", "extends", "import", "in", "infer", "keyof", "readonly", "super", "yield",
+            "import", "super", "yield",
         },
         // Python contextual keywords / Python の文脈キーワード
         ["python"] = new HashSet<string>(StringComparer.Ordinal)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -30311,6 +30311,36 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptMappedAndConditionalTypes_EmitTypeParameterReferences()
+    {
+        const string content = """
+            type Getters<T> = {
+              [K in keyof T as `get${Capitalize<K>}`]: () => T[K];
+            };
+            type AwaitedValue<T> = T extends Promise<infer U> ? U : never;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "T" && r.ReferenceKind == "type_reference" && r.Line == 2);
+        Assert.Contains(references, r =>
+            r.SymbolName == "K" && r.ReferenceKind == "type_reference" && r.Line == 2);
+        Assert.Contains(references, r =>
+            r.SymbolName == "Capitalize" && r.ReferenceKind == "type_reference" && r.Line == 2);
+        Assert.Contains(references, r =>
+            r.SymbolName == "T" && r.ReferenceKind == "type_reference" && r.Line == 4);
+        Assert.Contains(references, r =>
+            r.SymbolName == "Promise" && r.ReferenceKind == "type_reference" && r.Line == 4);
+        Assert.Contains(references, r =>
+            r.SymbolName == "U" && r.ReferenceKind == "type_reference" && r.Line == 4);
+        Assert.DoesNotContain(references, r =>
+            (r.SymbolName is "keyof" or "in" or "as" or "infer" or "never")
+            && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeExpressions_IgnoreTemplateRawTextAndStringKeys()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -30318,6 +30318,9 @@ public class ReferenceExtractorTests
               [K in keyof T as `get${Capitalize<K>}`]: () => T[K];
             };
             type AwaitedValue<T> = T extends Promise<infer U> ? U : never;
+            function useApi(api: Api) {
+              api.in();
+            }
             """;
 
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
@@ -30335,9 +30338,14 @@ public class ReferenceExtractorTests
             r.SymbolName == "Promise" && r.ReferenceKind == "type_reference" && r.Line == 4);
         Assert.Contains(references, r =>
             r.SymbolName == "U" && r.ReferenceKind == "type_reference" && r.Line == 4);
-        Assert.DoesNotContain(references, r =>
-            (r.SymbolName is "keyof" or "in" or "as" or "infer" or "never")
-            && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r =>
+            r.SymbolName == "in" && r.ReferenceKind == "call" && r.Line == 6);
+        var forbiddenTypeOperators = references
+            .Where(r =>
+                (r.SymbolName is "keyof" or "in" or "as" or "extends" or "infer" or "never")
+                && r.ReferenceKind == "type_reference")
+            .Select(r => $"{r.SymbolName}@{r.Line}:{r.Column}");
+        Assert.Empty(forbiddenTypeOperators);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Emit TypeScript `type_reference` rows from mapped-type clauses such as `keyof T`, remapped template literal keys, and indexed access uses like `T[K]`.
- Suppress TypeScript type-operator keywords only in type-reference extraction, preserving valid call references such as `api.in()`.
- Document the TypeScript type-graph model in `DEVELOPER_GUIDE.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_TypeScriptMappedAndConditionalTypes_EmitTypeParameterReferences"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release`
- Adversarial review round 1 found a call-suppression regression risk; fixed in commit `68493171`.
- Adversarial review round 2: `No blocking/actionable issues found.`

## Documentation / Changelog

- Updated `DEVELOPER_GUIDE.md` in English and Japanese.
- Added changelog fragment `changelog.d/unreleased/1888.fixed.md`.

Fixes #1888
