### PR TITLE
Fix Kotlin infix call reference extraction

### DIFF
--- a/changelog.d/unreleased/1661.fixed.md
+++ b/changelog.d/unreleased/1661.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1661
+affected:
+  - src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Kotlin infix calls are now indexed as call references (#1661)** — Kotlin expressions such as `1 to "one"`, bitwise infix operations, ranges, and same-file `infix fun` calls now emit `call` references for the infix function name.
+
+## 日本語
+
+- **Kotlin の infix 呼び出しを call reference として索引化するようになりました (#1661)** — `1 to "one"`、ビット演算の infix、range、同一ファイル内の `infix fun` 呼び出しで、infix 関数名の `call` reference を出力します。

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -19,9 +19,19 @@ internal static class KotlinReferenceExtractor
     private static readonly Regex BacktickConstructorCallRegex = new(
         @"(?<![\w$])(?<name>`[^`\r\n]+`)(?:\s*<[^()\r\n]+>)?\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex InfixFunctionDeclarationRegex = new(
+        @"(?<![\w$])infix\s+fun\s+(?:<[^()\r\n]+>\s*)?(?:(?:[_\p{L}][\w$]*|`[^`\r\n]+`)\s*\.\s*)?(?<name>[_\p{L}][\w$]*)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex InfixCallRegex = new(
+        @"(?<![\w$])(?<left>(?:[_\p{L}][\w$]*|\d+))\s+(?<name>[_\p{L}][\w$]*)\s+(?<right>\S+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly string[] DeclarationKeywords = ["val", "var"];
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
+    private static readonly HashSet<string> BuiltInInfixFunctionNames = new(StringComparer.Ordinal)
+    {
+        "and", "downTo", "or", "shl", "shr", "to", "until", "ushr", "xor",
+    };
 
     public static HashSet<string> BuildConstructorTypeNames(string language, IReadOnlyList<SymbolRecord> symbols)
     {
@@ -53,6 +63,25 @@ internal static class KotlinReferenceExtractor
 
     public static bool IsConstructorCallName(string name, IReadOnlySet<string> constructorTypeNames)
         => constructorTypeNames.Contains(name);
+
+    public static HashSet<string> BuildInfixFunctionNames(string language, IReadOnlyList<SymbolRecord> symbols)
+    {
+        var names = new HashSet<string>(BuiltInInfixFunctionNames, StringComparer.Ordinal);
+        if (language != "kotlin")
+            return names;
+
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Kind != "function" || string.IsNullOrWhiteSpace(symbol.Signature))
+                continue;
+
+            var match = InfixFunctionDeclarationRegex.Match(symbol.Signature);
+            if (match.Success)
+                names.Add(match.Groups["name"].Value);
+        }
+
+        return names;
+    }
 
     private static bool IsConstructableClassSymbol(SymbolRecord symbol)
     {
@@ -104,6 +133,55 @@ internal static class KotlinReferenceExtractor
         string preparedLine,
         Action<string, int> addCallLikeReference)
         => TrailingLambdaReferenceExtractor.EmitReferences(preparedLine, addCallLikeReference);
+
+    public static void EmitInfixCallReferences(
+        string preparedLine,
+        string originalLine,
+        IReadOnlySet<string> infixFunctionNames,
+        Action<string, int> addCallLikeReference)
+    {
+        foreach (Match match in InfixCallRegex.Matches(originalLine))
+        {
+            var nameGroup = match.Groups["name"];
+            var name = nameGroup.Value;
+            if (!infixFunctionNames.Contains(name))
+                continue;
+            if (!IsUnmaskedSpan(preparedLine, nameGroup.Index, nameGroup.Length))
+                continue;
+            if (IsLikelyDeclarationOrImport(preparedLine, match.Index))
+                continue;
+
+            addCallLikeReference(name, nameGroup.Index);
+        }
+    }
+
+    private static bool IsUnmaskedSpan(string preparedLine, int start, int length)
+    {
+        if (start < 0 || length <= 0 || start + length > preparedLine.Length)
+            return false;
+
+        for (var i = 0; i < length; i++)
+        {
+            if (char.IsWhiteSpace(preparedLine[start + i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsLikelyDeclarationOrImport(string preparedLine, int expressionIndex)
+    {
+        var prefix = preparedLine[..Math.Max(0, expressionIndex)].TrimStart();
+        return prefix.StartsWith("import ", StringComparison.Ordinal)
+               || prefix.StartsWith("package ", StringComparison.Ordinal)
+               || prefix.StartsWith("class ", StringComparison.Ordinal)
+               || prefix.StartsWith("interface ", StringComparison.Ordinal)
+               || prefix.StartsWith("object ", StringComparison.Ordinal)
+               || prefix.StartsWith("fun ", StringComparison.Ordinal)
+               || prefix.StartsWith("infix fun ", StringComparison.Ordinal)
+               || (prefix.StartsWith("val ", StringComparison.Ordinal) && !prefix.Contains('='))
+               || (prefix.StartsWith("var ", StringComparison.Ordinal) && !prefix.Contains('='));
+    }
 
     public static void EmitMethodReferenceReferences(
         string preparedLine,

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -20,7 +20,7 @@ internal static class KotlinReferenceExtractor
         @"(?<![\w$])(?<name>`[^`\r\n]+`)(?:\s*<[^()\r\n]+>)?\s*\(",
         RegexOptions.Compiled);
     private static readonly Regex InfixFunctionDeclarationRegex = new(
-        @"(?<![\w$])infix\s+fun\s+(?:<[^()\r\n]+>\s*)?(?:(?:[_\p{L}][\w$]*|`[^`\r\n]+`)\s*\.\s*)?(?<name>[_\p{L}][\w$]*)\b",
+        @"(?<![\w$])infix\s+fun\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex InfixCallRegex = new(
         @"(?<![\w$])(?<left>(?:[_\p{L}][\w$]*|\d+))\s+(?<name>[_\p{L}][\w$]*)\s+(?<right>\S+)",
@@ -72,12 +72,11 @@ internal static class KotlinReferenceExtractor
 
         foreach (var symbol in symbols)
         {
-            if (symbol.Kind != "function" || string.IsNullOrWhiteSpace(symbol.Signature))
+            if (symbol.Kind != "function" || string.IsNullOrWhiteSpace(symbol.Name) || string.IsNullOrWhiteSpace(symbol.Signature))
                 continue;
 
-            var match = InfixFunctionDeclarationRegex.Match(symbol.Signature);
-            if (match.Success)
-                names.Add(match.Groups["name"].Value);
+            if (InfixFunctionDeclarationRegex.IsMatch(symbol.Signature))
+                names.Add(symbol.Name);
         }
 
         return names;

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -22,8 +22,8 @@ internal static class KotlinReferenceExtractor
     private static readonly Regex InfixFunctionDeclarationRegex = new(
         @"(?<![\w$])infix\s+fun\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex InfixCallRegex = new(
-        @"(?<![\w$])(?<left>(?:[_\p{L}][\w$]*|\d+))\s+(?<name>[_\p{L}][\w$]*)\s+(?<right>\S+)",
+    private static readonly Regex IdentifierRegex = new(
+        @"(?<![\w$])(?<name>[_\p{L}][\w$]*)(?![\w$])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly string[] DeclarationKeywords = ["val", "var"];
@@ -139,7 +139,7 @@ internal static class KotlinReferenceExtractor
         IReadOnlySet<string> infixFunctionNames,
         Action<string, int> addCallLikeReference)
     {
-        foreach (Match match in InfixCallRegex.Matches(originalLine))
+        foreach (Match match in IdentifierRegex.Matches(originalLine))
         {
             var nameGroup = match.Groups["name"];
             var name = nameGroup.Value;
@@ -149,6 +149,11 @@ internal static class KotlinReferenceExtractor
                 continue;
             if (IsLikelyDeclarationOrImport(preparedLine, match.Index))
                 continue;
+            if (!HasLikelyInfixOperandBefore(originalLine, nameGroup.Index)
+                || !HasLikelyInfixOperandAfter(originalLine, nameGroup.Index + nameGroup.Length))
+            {
+                continue;
+            }
 
             addCallLikeReference(name, nameGroup.Index);
         }
@@ -180,6 +185,35 @@ internal static class KotlinReferenceExtractor
                || prefix.StartsWith("infix fun ", StringComparison.Ordinal)
                || (prefix.StartsWith("val ", StringComparison.Ordinal) && !prefix.Contains('='))
                || (prefix.StartsWith("var ", StringComparison.Ordinal) && !prefix.Contains('='));
+    }
+
+    private static bool HasLikelyInfixOperandBefore(string preparedLine, int nameIndex)
+    {
+        var cursor = nameIndex - 1;
+        while (cursor >= 0 && char.IsWhiteSpace(preparedLine[cursor]))
+            cursor--;
+        if (cursor < 0 || preparedLine[cursor] is '=' or ',' or '(' or '[' or '{' or ':' or ';')
+            return false;
+
+        if (ReferenceExtractor.IsJavaIdentifierPart(preparedLine[cursor]))
+        {
+            var end = cursor + 1;
+            while (cursor >= 0 && ReferenceExtractor.IsJavaIdentifierPart(preparedLine[cursor]))
+                cursor--;
+            var previousWord = preparedLine.Substring(cursor + 1, end - cursor - 1);
+            if (previousWord is "return" or "throw" or "if" or "while" or "when" or "for" or "val" or "var" or "fun" or "class")
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasLikelyInfixOperandAfter(string preparedLine, int afterNameIndex)
+    {
+        var cursor = afterNameIndex;
+        while (cursor < preparedLine.Length && char.IsWhiteSpace(preparedLine[cursor]))
+            cursor++;
+        return cursor < preparedLine.Length && preparedLine[cursor] is not (',' or ')' or ']' or '}' or ':' or ';');
     }
 
     public static void EmitMethodReferenceReferences(

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -22,6 +22,9 @@ internal static class KotlinReferenceExtractor
     private static readonly Regex InfixFunctionDeclarationRegex = new(
         @"(?<![\w$])infix\s+fun\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex InfixFunctionNameRegex = new(
+        @"(?<![\w$])infix\s+fun\s+(?:<[^()\r\n]+>\s*)?(?:(?:[_\p{L}][\w$]*|`[^`\r\n]+`)(?:\s*<[^>\r\n]+>)?\s*\.\s*)*(?<name>[_\p{L}][\w$]*)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex IdentifierRegex = new(
         @"(?<![\w$])(?<name>[_\p{L}][\w$]*)(?![\w$])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -76,10 +79,28 @@ internal static class KotlinReferenceExtractor
                 continue;
 
             if (InfixFunctionDeclarationRegex.IsMatch(symbol.Signature))
+            {
                 names.Add(symbol.Name);
+                var dotIndex = symbol.Name.LastIndexOf('.');
+                if (dotIndex >= 0 && dotIndex + 1 < symbol.Name.Length)
+                    names.Add(symbol.Name[(dotIndex + 1)..]);
+            }
         }
 
         return names;
+    }
+
+    public static void AddDeclaredInfixFunctionNames(string language, IEnumerable<string> lines, HashSet<string> names)
+    {
+        if (language != "kotlin")
+            return;
+
+        foreach (var line in lines)
+        {
+            var match = InfixFunctionNameRegex.Match(line);
+            if (match.Success)
+                names.Add(match.Groups["name"].Value);
+        }
     }
 
     private static bool IsConstructableClassSymbol(SymbolRecord symbol)
@@ -159,6 +180,12 @@ internal static class KotlinReferenceExtractor
         }
     }
 
+    public static bool IsInfixFunctionDeclarationSite(string preparedLine, int nameIndex)
+    {
+        var prefix = preparedLine[..Math.Max(0, nameIndex)];
+        return InfixFunctionDeclarationRegex.IsMatch(prefix);
+    }
+
     private static bool IsUnmaskedSpan(string preparedLine, int start, int length)
     {
         if (start < 0 || length <= 0 || start + length > preparedLine.Length)
@@ -176,6 +203,9 @@ internal static class KotlinReferenceExtractor
     private static bool IsLikelyDeclarationOrImport(string preparedLine, int expressionIndex)
     {
         var prefix = preparedLine[..Math.Max(0, expressionIndex)].TrimStart();
+        if (InfixFunctionDeclarationRegex.IsMatch(prefix))
+            return true;
+
         return prefix.StartsWith("import ", StringComparison.Ordinal)
                || prefix.StartsWith("package ", StringComparison.Ordinal)
                || prefix.StartsWith("class ", StringComparison.Ordinal)

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -33,7 +33,7 @@ internal static class KotlinReferenceExtractor
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
     private static readonly HashSet<string> BuiltInInfixFunctionNames = new(StringComparer.Ordinal)
     {
-        "and", "downTo", "or", "shl", "shr", "to", "until", "ushr", "xor",
+        "and", "downTo", "or", "shl", "shr", "step", "to", "until", "ushr", "xor",
     };
 
     public static HashSet<string> BuildConstructorTypeNames(string language, IReadOnlyList<SymbolRecord> symbols)

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1071,6 +1071,7 @@ public static partial class ReferenceExtractor
         var csharpKnownTypeNames = BuildCSharpKnownTypeNames(language, symbols);
         var kotlinConstructorTypeNames = KotlinReferenceExtractor.BuildConstructorTypeNames(language, symbols);
         var kotlinInfixFunctionNames = KotlinReferenceExtractor.BuildInfixFunctionNames(language, symbols);
+        KotlinReferenceExtractor.AddDeclaredInfixFunctionNames(language, lines, kotlinInfixFunctionNames);
         var callableDefinitionNames = BuildCallableDefinitionNames(language, symbols);
         var dockerfileStageNames = DockerfileReferenceExtractor.BuildStageNames(language, symbols);
         var dockerfileVariableNames = DockerfileReferenceExtractor.BuildVariableNames(language, symbols);
@@ -2299,6 +2300,8 @@ public static partial class ReferenceExtractor
                 if (language == "rust" && RustReferenceExtractor.IsFunctionDeclarationCallSite(preparedLine, callIndex))
                     return false;
                 if (language == "rust" && RustReferenceExtractor.IsDeriveAttributeCallSite(preparedLine, normalizedName, callIndex))
+                    return false;
+                if (language == "kotlin" && KotlinReferenceExtractor.IsInfixFunctionDeclarationSite(preparedLine, callIndex))
                     return false;
 
                 // Suppress the same-line Java ctor declarator's self-call. CallRegex matches

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1070,6 +1070,7 @@ public static partial class ReferenceExtractor
         var csharpQualifiedTypePatternLookup = BuildCSharpQualifiedTypePatternLookup(language, symbols);
         var csharpKnownTypeNames = BuildCSharpKnownTypeNames(language, symbols);
         var kotlinConstructorTypeNames = KotlinReferenceExtractor.BuildConstructorTypeNames(language, symbols);
+        var kotlinInfixFunctionNames = KotlinReferenceExtractor.BuildInfixFunctionNames(language, symbols);
         var callableDefinitionNames = BuildCallableDefinitionNames(language, symbols);
         var dockerfileStageNames = DockerfileReferenceExtractor.BuildStageNames(language, symbols);
         var dockerfileVariableNames = DockerfileReferenceExtractor.BuildVariableNames(language, symbols);
@@ -2514,7 +2515,14 @@ public static partial class ReferenceExtractor
                 if (language == "swift")
                     SwiftReferenceExtractor.EmitTrailingClosureReferences(preparedLine, AddCallLikeReference);
                 else if (language == "kotlin")
+                {
+                    KotlinReferenceExtractor.EmitInfixCallReferences(
+                        preparedLine,
+                        originalLine,
+                        kotlinInfixFunctionNames,
+                        AddCallLikeReference);
                     KotlinReferenceExtractor.EmitTrailingLambdaReferences(preparedLine, AddCallLikeReference);
+                }
 
                 if (language == "fsharp")
                 {

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2486,6 +2486,44 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinInfixCalls_TrackBuiltInAndUserDefinedFunctions()
+    {
+        const string content = """
+            class Bag {
+                infix fun add(item: String): Bag = this
+                infix fun merge(other: Bag): Bag = this
+
+                fun build(other: Bag, value: Int) {
+                    val pair = 1 to "one"
+                    val shifted = value shl 4
+                    val masked = value and 15
+                    val ranged = 1 until 10
+                    val countdown = 10 downTo 1
+                    val combined = value or 2
+                    val toggled = value xor 3
+                    val shrunk = value shr 1
+                    this add "item"
+                    this merge other
+                    val words = "plain text to ignore"
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
+
+        foreach (var name in new[] { "to", "shl", "and", "until", "downTo", "or", "xor", "shr", "add", "merge" })
+        {
+            Assert.Contains(references, r => r.SymbolName == name && r.ReferenceKind == "call");
+        }
+
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "to"
+            && r.ReferenceKind == "call"
+            && r.Context.Contains("plain text", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_DockerfileFromStageReferences_IndexNamedStagesAndIgnoreBaseImages()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2506,6 +2506,7 @@ public class ReferenceExtractorTests
                     val masked = value and 15
                     val ranged = 1 until 10
                     val countdown = 10 downTo 1
+                    val evens = 0..10 step 2
                     val combined = value or 2
                     val toggled = value xor 3
                     val shrunk = value shr 1
@@ -2521,7 +2522,7 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "kotlin", content);
         var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
 
-        foreach (var name in new[] { "to", "shl", "and", "until", "downTo", "or", "xor", "shr", "add", "merge", "combine", "link" })
+        foreach (var name in new[] { "to", "shl", "and", "until", "downTo", "step", "or", "xor", "shr", "add", "merge", "combine", "link" })
         {
             Assert.True(
                 references.Any(r => r.SymbolName == name && r.ReferenceKind == "call"),

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2499,6 +2499,8 @@ public class ReferenceExtractorTests
                     val xs = listOf("a")
                     val box = demo.Box()
                     val pair = 1 to "one"
+                    val named = "name" to value
+                    val summed = (1 + 2) to "sum"
                     val shifted = value shl 4
                     val masked = value and 15
                     val ranged = 1 until 10
@@ -2523,6 +2525,7 @@ public class ReferenceExtractorTests
             Assert.Contains(references, r => r.SymbolName == name && r.ReferenceKind == "call");
         }
 
+        Assert.True(references.Count(r => r.SymbolName == "to" && r.ReferenceKind == "call") >= 3);
         Assert.DoesNotContain(references, r =>
             r.SymbolName == "to"
             && r.ReferenceKind == "call"

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2494,6 +2494,7 @@ public class ReferenceExtractorTests
                 infix fun merge(other: Bag): Bag = this
                 infix fun List<String>.combine(other: List<String>): List<String> = this
                 infix fun demo.Box.link(other: demo.Box): demo.Box = this
+                private infix fun demo.Box.hidden(other: demo.Box): demo.Box = this
 
                 fun build(other: Bag, value: Int) {
                     val xs = listOf("a")
@@ -2522,7 +2523,9 @@ public class ReferenceExtractorTests
 
         foreach (var name in new[] { "to", "shl", "and", "until", "downTo", "or", "xor", "shr", "add", "merge", "combine", "link" })
         {
-            Assert.Contains(references, r => r.SymbolName == name && r.ReferenceKind == "call");
+            Assert.True(
+                references.Any(r => r.SymbolName == name && r.ReferenceKind == "call"),
+                $"Expected Kotlin infix call reference for {name}.");
         }
 
         Assert.True(references.Count(r => r.SymbolName == "to" && r.ReferenceKind == "call") >= 3);
@@ -2530,6 +2533,10 @@ public class ReferenceExtractorTests
             r.SymbolName == "to"
             && r.ReferenceKind == "call"
             && r.Context.Contains("plain text", StringComparison.Ordinal));
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "hidden"
+            && r.ReferenceKind == "call"
+            && r.Context.Contains("private infix fun", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2492,8 +2492,12 @@ public class ReferenceExtractorTests
             class Bag {
                 infix fun add(item: String): Bag = this
                 infix fun merge(other: Bag): Bag = this
+                infix fun List<String>.combine(other: List<String>): List<String> = this
+                infix fun demo.Box.link(other: demo.Box): demo.Box = this
 
                 fun build(other: Bag, value: Int) {
+                    val xs = listOf("a")
+                    val box = demo.Box()
                     val pair = 1 to "one"
                     val shifted = value shl 4
                     val masked = value and 15
@@ -2504,6 +2508,8 @@ public class ReferenceExtractorTests
                     val shrunk = value shr 1
                     this add "item"
                     this merge other
+                    xs combine xs
+                    box link box
                     val words = "plain text to ignore"
                 }
             }
@@ -2512,7 +2518,7 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "kotlin", content);
         var references = ReferenceExtractor.Extract(1, "kotlin", content, symbols);
 
-        foreach (var name in new[] { "to", "shl", "and", "until", "downTo", "or", "xor", "shr", "add", "merge" })
+        foreach (var name in new[] { "to", "shl", "and", "until", "downTo", "or", "xor", "shr", "add", "merge", "combine", "link" })
         {
             Assert.Contains(references, r => r.SymbolName == name && r.ReferenceKind == "call");
         }


### PR DESCRIPTION
## Summary
- Add Kotlin infix call reference extraction for built-in operators/range helpers and same-file infix functions.
- Suppress infix function declarations so they do not appear as call sites.
- Add regression coverage for built-in, literal/parenthesized receiver, extension receiver, and declaration-suppression cases.
- Add a bilingual changelog fragment.

Fixes #1661

Related existing issue observed during local index refresh: #2331

## Validation
- dotnet build CodeIndex.sln
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"
- dotnet test CodeIndex.sln
- dotnet run --project tools/CodeIndex.Changelog -- check
- Codex adversarial review: No blocking/actionable issues found.