### PR TITLE
Resolve TypeScript path alias import symbols

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -212,6 +212,8 @@ files 1──N symbol_references
 | `friend` | `friend` | C++ friend access/coupling edges kept visible in dependency-oriented graph queries. |
 | `attribute`, `annotation`, `type_reference`, `implicit_implementation` | raw label | Dependency/reference-only metadata, type-position edges, and compiler-synthesized implementation edges such as C# async iterator `GetAsyncEnumerator` / `MoveNextAsync`; excluded from default call-graph rows. |
 
+TypeScript decorators emit `annotation` rows for the decorator name and must not hide the decorated declaration's type-position edges. For example, `constructor(@Inject() svc: Service)` records `Inject` as `annotation` and `Service` as `type_reference`, and `@Input() profile: UserProfile` records both the decorator and field type.
+
 ## Why a database instead of grep?
 
 On small projects, `grep` works fine. But as a codebase grows to tens of thousands of files, `grep` becomes a bottleneck — especially when an AI agent calls it repeatedly. cdidx solves this by **reading every file once at index time** and building a search structure so that queries never need to touch the original files again.
@@ -409,7 +411,7 @@ The step size is `80 - 10 = 70` lines. A file with N lines produces `ceil((N - 8
 
 Most languages still use **compiled regex patterns**, matched one line at a time for functions, classes, and sometimes imports. JavaScript and TypeScript add a lightweight lexer/state machine on top of the regex pass for cases that line-oriented regex cannot handle reliably, such as class-body bare methods, computed and modifier-prefixed methods, scope-aware synthetic class expressions, and JS/TS-specific range resolution. Swift still uses the regex path for `func`, `class`, `struct`, `protocol`, `enum`, `indirect enum`, stored properties (including `private(set)` / `fileprivate(set)` and backtick-escaped names), and enum cases, while a small dedicated trailing-lambda pass keeps idiomatic `name { ... }` call sites visible to the graph. Kotlin also stays on the regex path. Scala has a separate block-call pass for `name { ... }` / `name { x => ... }` forms so idiomatic calls such as `foreach {}`, `Try {}`, and `synchronized {}` stay visible too. Common Lisp and Racket use a lightweight S-expression scanner that masks strings, line comments, and `#| ... |#` block comments before extracting definitions and function ranges. HTML uses a dedicated character-level state machine instead of the regex pattern loop — it walks tag openers, quoted/unquoted attribute values (including multi-line values), and masks `<script>`/`<style>`/`<textarea>`/`<title>` bodies plus `<!-- ... -->` comments so attribute-lookalike strings inside those regions do not leak phantom symbols. Named capture groups still extract identifiers for the regex-driven paths. Recent JS/TS additions also cover barrel re-export surfaces across commented, multiline, namespace, minified, TypeScript type-only-star, and `with {}` / `assert {}` import-attribute forms, while preserving the corresponding source-module `import` rows, alongside direct CommonJS named export assignments and their same-line / multiline parenthesized wrappers, multiline / constrained / async TypeScript generic-arrow RHS forms, prefix-safe function/class discrimination, and exported object-literal alias/shorthand properties.
 
-JS/TS export-surface scanning also indexes destructured named exports such as `export const { foo, renamed: localName } = source` by the emitted binding names.
+JS/TS export-surface scanning also indexes destructured named exports such as `export const { foo, renamed: localName } = source` by the emitted binding names. Module specifiers collected as `import` symbols consult the nearest `tsconfig.json` or `jsconfig.json`, follow relative `extends` chains, and apply `compilerOptions.baseUrl` / `paths` mappings before falling back to the literal specifier. Alias matches only rewrite to project-relative paths when a concrete file exists, trying TypeScript/JavaScript extensions and `index.*` candidates.
 
 Supported symbol kinds by language:
 
@@ -1661,6 +1663,8 @@ files 1──N symbol_references
 | `friend` | `friend` | C++ friend の access/coupling edge。依存関係寄りの graph query で可視化する。 |
 | `attribute`, `annotation`, `type_reference`, `implicit_implementation` | raw label | 依存関係 / reference 専用の metadata、型位置エッジ、および C# async iterator の `GetAsyncEnumerator` / `MoveNextAsync` のようなコンパイラ合成の実装エッジ。既定の call-graph 行からは除外する。 |
 
+TypeScript decorator は decorator 名を `annotation` 行として出力し、decorated declaration の型位置エッジを隠してはならない。たとえば `constructor(@Inject() svc: Service)` は `Inject` を `annotation`、`Service` を `type_reference` として記録し、`@Input() profile: UserProfile` も decorator と field type の両方を記録する。
+
 ## なぜgrepではなくデータベースなのか？
 
 小規模プロジェクトなら `grep` で十分です。しかしファイルが数万規模になると `grep` はボトルネックになります。特にAIエージェントが繰り返し検索を実行するケースで顕著です。cdidxは**すべてのファイルを一度だけ読み込んで検索用の構造を構築する**ことで、以降の検索で元のファイルを一切開かずに済むようにします。
@@ -1858,7 +1862,7 @@ LIMIT 20;
 
 大半の言語では、今も **コンパイル済み正規表現パターン**を1行ずつ適用して関数、クラス、場合によってはインポートを抽出します。一方で JavaScript / TypeScript には、行単位の正規表現だけでは安定して扱えない class body の bare method、computed / modifier 付き method、scope-aware な synthetic class expression、JS/TS 専用の range 解決を補うため、軽量な lexer / state machine を追加しています。Swift は引き続き正規表現経路ですが、`func` / `class` / `struct` / `protocol` / `enum` / `indirect enum`、`private(set)` / `fileprivate(set)` 付きの stored property、バッククォートでエスケープされた名前、そして enum case を拾うようにしており、小さな trailing-lambda 専用パスで `name { ... }` 形の慣用的な呼び出しを graph から落とさないようにしています。Kotlin も正規表現経路のままです。Scala には `name { ... }` / `name { x => ... }` 形式を拾う専用の block-call パスがあり、`foreach {}` や `Try {}`、`synchronized {}` のような慣用的な呼び出しも graph から消えないようにしています。Common Lisp と Racket は、文字列、行コメント、`#| ... |#` ブロックコメントをマスクしてから定義と関数範囲を抽出する軽量な S 式スキャナーを使います。HTML は汎用の正規表現ループを使わず、専用の文字単位 state machine でタグ構造を走査し、引用符付き/なし属性値（複数行の引用符付き値を含む）と `<script>` / `<style>` / `<textarea>` / `<title>` の raw-text 本体、`<!-- ... -->` コメントをマスクして、属性名に似た本体内文字列から phantom シンボルが漏れないようにしています。正規表現ベースの経路では引き続き名前付きキャプチャグループで識別子を取得します。
 
-JS/TS の export surface 走査は、`export const { foo, renamed: localName } = source` のような destructured named export も、実際に出力される binding 名で索引します。
+JS/TS の export surface 走査は、`export const { foo, renamed: localName } = source` のような destructured named export も、実際に出力される binding 名で索引します。`import` シンボルとして収集した module specifier は、最寄りの `tsconfig.json` / `jsconfig.json`、相対 `extends` chain、`compilerOptions.baseUrl` / `paths` mapping を使って解決し、解決できなければ literal specifier のまま残します。alias は実ファイルが存在する場合だけ project-relative path へ書き換え、TypeScript / JavaScript 拡張子と `index.*` 候補を試します。
 
 言語別対応シンボル種別:
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1193,7 +1193,7 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 - Shell, PowerShell, and Batch: command-style function calls, functions/filters, classes/enums, imports, labels, `goto` / `call` targets, and inline control-flow forms are indexed where the language supports them.
 - C# and Java: modern C# partial members remain visible to `symbols`, `definition`, and `outline`; Java sealed `permits` lists are recorded as `type_reference` graph edges.
 - JavaScript/TypeScript exports: barrel re-exports, local and string-literal export aliases, exported variables, default exports, destructured exports, and CommonJS named/default exports are indexed as exported symbols.
-- JavaScript/TypeScript imports: static imports, dynamic imports, CommonJS `require` / `require.resolve`, `import.meta.resolve`, `new URL(..., import.meta.url)`, `importScripts`, service-worker registrations, worklet loads, and worker constructors add `import` symbols when the specifier is static.
+- JavaScript/TypeScript imports: static imports, dynamic imports, CommonJS `require` / `require.resolve`, `import.meta.resolve`, `new URL(..., import.meta.url)`, `importScripts`, service-worker registrations, worklet loads, and worker constructors add `import` symbols when the specifier is static. `tsconfig.json` / `jsconfig.json` `compilerOptions.baseUrl` and `paths` aliases are resolved to indexed project paths when the target file exists.
 - Node module layouts: `.cjs` / `.mjs` are JavaScript; `.cts` / `.mts`, including `.d.cts` / `.d.mts`, are TypeScript.
 - Extensionless scripts: files with recognized shebangs are indexed for shell (`sh`, `bash`, `zsh`, `fish`, `dash`, `ksh`, `ash`), Python, Ruby, Node.js, PHP, Lua, and PowerShell.
 
@@ -2860,7 +2860,7 @@ cdidxはプロジェクトディレクトリを走査し、組み込みのスキ
 - Shell、PowerShell、Batch: command-style function call、function/filter、class/enum、import、label、`goto` / `call` target、inline control-flow を言語仕様に合わせて索引します。
 - C# と Java: C# の近年の partial member は `symbols`、`definition`、`outline` から見えます。Java の sealed `permits` list は `type_reference` graph edge として記録します。
 - JavaScript/TypeScript export: barrel re-export、local / string-literal export alias、exported variable、default export、destructured export、CommonJS named/default export を exported symbol として索引します。
-- JavaScript/TypeScript import: static import、dynamic import、CommonJS `require` / `require.resolve`、`import.meta.resolve`、`new URL(..., import.meta.url)`、`importScripts`、Service Worker registration、worklet load、worker constructor は、specifier が静的なら `import` シンボルを追加します。
+- JavaScript/TypeScript import: static import、dynamic import、CommonJS `require` / `require.resolve`、`import.meta.resolve`、`new URL(..., import.meta.url)`、`importScripts`、Service Worker registration、worklet load、worker constructor は、specifier が静的なら `import` シンボルを追加します。`tsconfig.json` / `jsconfig.json` の `compilerOptions.baseUrl` と `paths` alias は、対象ファイルが存在する場合に indexed project path へ解決します。
 - Node モジュール構成: `.cjs` / `.mjs` は JavaScript、`.cts` / `.mts`（`.d.cts` / `.d.mts` を含む）は TypeScript として扱います。
 - 拡張子なしスクリプト: 先頭行の shebang が shell (`sh`, `bash`, `zsh`, `fish`, `dash`, `ksh`, `ash`)、Python、Ruby、Node.js、PHP、Lua、PowerShell として認識できれば index 対象です。
 

--- a/changelog.d/unreleased/1886.fixed.md
+++ b/changelog.d/unreleased/1886.fixed.md
@@ -1,0 +1,23 @@
+---
+category: fixed
+issues:
+  - 1886
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - USER_GUIDE.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **TypeScript and JavaScript import symbols now resolve tsconfig path aliases (#1886)** — static module specifiers captured from imports, require calls, dynamic imports, workers, and related JS/TS module-loading forms now use `tsconfig.json` / `jsconfig.json` `baseUrl` and `paths` mappings when the target file exists.
+
+## 日本語
+
+- **TypeScript / JavaScript の import シンボルが tsconfig path alias を解決するようになりました (#1886)** — import、require、dynamic import、worker などの JS/TS module load から取得した静的 specifier は、対象ファイルが存在する場合に `tsconfig.json` / `jsconfig.json` の `baseUrl` と `paths` mapping を使うようになりました。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -144,14 +144,14 @@ public static class IndexCommandRunner
         {
             ConsoleUi.PrintBanner();
             Console.WriteLine();
-            Console.WriteLine($"  Project : {Path.GetFullPath(options.ProjectPath)}");
+            Console.WriteLine($"  Project : {Path.GetFullPath(options.ProjectPath!)}");
             Console.WriteLine($"  Output  : {resolvedDbPath}");
             Console.WriteLine($"  Mode    : {mode}");
             Console.WriteLine();
         }
 
         var ignoreCase = GitHelper.ResolveIgnoreCase(options.ProjectPath);
-        var ignoreRuleRoot = GitHelper.TryGetRepositoryRoot(options.ProjectPath) ?? Path.GetFullPath(options.ProjectPath);
+        var ignoreRuleRoot = GitHelper.TryGetRepositoryRoot(options.ProjectPath) ?? Path.GetFullPath(options.ProjectPath!);
 
         // --dry-run: scan files but do not write to database / --dry-run: ファイルスキャンのみでDBに書き込まない
         if (options.DryRun)
@@ -200,7 +200,7 @@ public static class IndexCommandRunner
                 // Git更新モード: コミットまたはref間の変更ファイル。
                 var changedFiles = new HashSet<string>(StringComparer.Ordinal);
                 var relevantIgnoreFileChanged = false;
-                var repoRoot = GitHelper.TryGetRepositoryRoot(options.ProjectPath) ?? Path.GetFullPath(options.ProjectPath);
+                var repoRoot = GitHelper.TryGetRepositoryRoot(options.ProjectPath) ?? Path.GetFullPath(options.ProjectPath!);
                 foreach (var commit in options.Commits)
                 {
                     try
@@ -393,7 +393,7 @@ public static class IndexCommandRunner
         var writer = new DbWriter(db);
         var indexer = new FileIndexer(options.ProjectPath, ignoreCase, ignoreRuleRoot, options.MaxFileSizeBytes);
         var currentHotspotFamilyMarkerFingerprints = GetHotspotFamilyMarkerFingerprints(indexer);
-        var projectRoot = Path.GetFullPath(options.ProjectPath);
+        var projectRoot = Path.GetFullPath(options.ProjectPath!);
 
         initialExitCode = isUpdateMode
             ? RunUpdateMode(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorReadiness, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd, indexCancellation.Token)
@@ -417,7 +417,7 @@ public static class IndexCommandRunner
         // partial-update batch re-acquires the lock through IndexCommandRunner.Run.
         // watch ループ突入前にロックを解放し、バッチ間に別プロセスの `cdidx index` が
         // 取得できる状態にする。各バッチ更新はサブ実行で再取得する。
-        return IndexWatchRunner.Run(options, jsonOptions, Path.GetFullPath(options.ProjectPath), Path.GetFullPath(dbPath));
+        return IndexWatchRunner.Run(options, jsonOptions, Path.GetFullPath(options.ProjectPath!), Path.GetFullPath(dbPath));
     }
 
     private static string DescribeLockHolder(IndexLockInfo? holder)
@@ -970,11 +970,15 @@ public static class IndexCommandRunner
                 targetPaths.Add(relPath);
         }
 
-        if (relevantIgnoreFileChanged || ContainsIgnoreFilePath(targetPaths))
+        var typeScriptJavaScriptConfigChanged = ContainsJavaScriptTypeScriptConfigPath(targetPaths);
+        if (relevantIgnoreFileChanged || ContainsIgnoreFilePath(targetPaths) || typeScriptJavaScriptConfigChanged)
         {
             if (!options.Json && !options.Quiet)
             {
-                Console.WriteLine("  Detected ignore-file changes; falling back to a full scan to keep the index aligned.");
+                var reason = typeScriptJavaScriptConfigChanged
+                    ? "JavaScript/TypeScript config changes"
+                    : "ignore-file changes";
+                Console.WriteLine($"  Detected {reason}; falling back to a full scan to keep the index aligned.");
                 Console.WriteLine();
             }
 
@@ -1325,7 +1329,8 @@ public static class IndexCommandRunner
                     record.Path,
                     record.Modified,
                     record.Checksum,
-                    allowReuse: (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
+                    allowReuse: record.Lang is not ("javascript" or "typescript")
+                        && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
                         && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                         && (record.Lang != "sql" || sqlGraphContractMatchesCurrent));
                 if (existingId != null)
@@ -1346,7 +1351,7 @@ public static class IndexCommandRunner
                 var fileId = writer.UpsertFile(record);
                 var chunks = ChunkSplitter.Split(fileId, content);
                 writer.InsertChunks(chunks);
-                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content, record.Path);
+                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content, absPath, Path.GetFullPath(options.ProjectPath!));
                 SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(absPath, record.Lang));
                 writer.InsertSymbols(symbols);
                 var references = ReferenceExtractor.Extract(
@@ -1699,6 +1704,20 @@ public static class IndexCommandRunner
 
     private static bool ContainsIgnoreFilePath(IEnumerable<string> paths)
         => paths.Any(FileIndexer.IsIgnoreFilePath);
+
+    private static bool ContainsJavaScriptTypeScriptConfigPath(IEnumerable<string> paths)
+        => paths.Any(IsJavaScriptTypeScriptConfigPath);
+
+    private static bool IsJavaScriptTypeScriptConfigPath(string path)
+    {
+        var fileName = Path.GetFileName(path);
+        return string.Equals(fileName, "jsconfig.json", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(fileName, "tsconfig.json", StringComparison.OrdinalIgnoreCase)
+            || (fileName.StartsWith("jsconfig.", StringComparison.OrdinalIgnoreCase)
+                && fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            || (fileName.StartsWith("tsconfig.", StringComparison.OrdinalIgnoreCase)
+                && fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+    }
 
     private static bool ContainsRelevantIgnoreFileUpdate(string projectRoot, IEnumerable<string> updateFiles)
     {
@@ -2379,7 +2398,8 @@ public static class IndexCommandRunner
                             record.Path,
                             record.Modified,
                             record.Checksum,
-                            allowReuse: (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
+                            allowReuse: record.Lang is not ("javascript" or "typescript")
+                        && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
                                 && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                                 && (record.Lang != "sql" || sqlGraphContractMatchesCurrent)
                                 && AllowReuseWithCurrentHotspotFamilyTrust(record.Lang, hotspotFamilyTrustMatchesCurrent));
@@ -2412,7 +2432,7 @@ public static class IndexCommandRunner
                     var fileId = writer.UpsertFile(record);
                     var chunks = ChunkSplitter.Split(fileId, content);
                     writer.InsertChunks(chunks);
-                    var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
+                    var symbols = SymbolExtractor.Extract(fileId, record.Lang, content, filePath, Path.GetFullPath(options.ProjectPath!));
                     SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
                     writer.InsertSymbols(symbols);
                     var references = ReferenceExtractor.Extract(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
@@ -160,6 +160,9 @@ public static partial class SymbolExtractor
 
     private static void ExtractJavaScriptTypeScriptDynamicImportSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
@@ -223,7 +226,7 @@ public static partial class SymbolExtractor
                 {
                     FileId = fileId,
                     Kind = "import",
-                    Name = moduleName,
+                    Name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, moduleName),
                     Line = moduleLineIndex + 1,
                     StartLine = moduleLineIndex + 1,
                     StartColumn = moduleStartColumn,
@@ -236,6 +239,9 @@ public static partial class SymbolExtractor
 
     private static void ExtractJavaScriptTypeScriptStaticImportModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
@@ -269,7 +275,7 @@ public static partial class SymbolExtractor
                 {
                     FileId = fileId,
                     Kind = "import",
-                    Name = moduleName,
+                    Name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, moduleName),
                     Line = moduleLineIndex + 1,
                     StartLine = moduleLineIndex + 1,
                     StartColumn = moduleStartColumn,
@@ -287,6 +293,9 @@ public static partial class SymbolExtractor
 
     private static void ExtractJavaScriptTypeScriptRequireModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
@@ -347,7 +356,7 @@ public static partial class SymbolExtractor
                 {
                     FileId = fileId,
                     Kind = "import",
-                    Name = moduleName,
+                    Name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, moduleName),
                     Line = moduleLineIndex + 1,
                     StartLine = moduleLineIndex + 1,
                     StartColumn = moduleStartColumn,
@@ -443,6 +452,9 @@ public static partial class SymbolExtractor
 
     private static void ExtractJavaScriptTypeScriptNewUrlModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
@@ -498,7 +510,7 @@ public static partial class SymbolExtractor
                 {
                     FileId = fileId,
                     Kind = "import",
-                    Name = moduleName,
+                    Name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, moduleName),
                     Line = moduleLineIndex + 1,
                     StartLine = moduleLineIndex + 1,
                     StartColumn = moduleStartColumn,
@@ -615,6 +627,9 @@ public static partial class SymbolExtractor
 
     private static void ExtractJavaScriptTypeScriptImportScriptsModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
@@ -662,7 +677,7 @@ public static partial class SymbolExtractor
                     {
                         FileId = fileId,
                         Kind = "import",
-                        Name = moduleName,
+                        Name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, moduleName),
                         Line = moduleLineIndex + 1,
                         StartLine = moduleLineIndex + 1,
                         StartColumn = moduleStartColumn,
@@ -785,6 +800,9 @@ public static partial class SymbolExtractor
 
     private static void ExtractJavaScriptTypeScriptServiceWorkerRegisterModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
@@ -792,6 +810,9 @@ public static partial class SymbolExtractor
     {
         ExtractJavaScriptTypeScriptExactModuleCallSymbols(
             fileId,
+            lang,
+            filePath,
+            projectRoot,
             rawLines,
             sanitizedLines,
             lineIndex,
@@ -799,6 +820,9 @@ public static partial class SymbolExtractor
             "navigator.serviceWorker.register");
         ExtractJavaScriptTypeScriptExactModuleCallSymbols(
             fileId,
+            lang,
+            filePath,
+            projectRoot,
             rawLines,
             sanitizedLines,
             lineIndex,
@@ -808,46 +832,58 @@ public static partial class SymbolExtractor
 
     private static void ExtractJavaScriptTypeScriptImportMetaResolveModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
         List<SymbolRecord> symbols)
     {
-        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "import.meta.resolve");
+        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "import.meta.resolve");
     }
 
     private static void ExtractJavaScriptTypeScriptWorkletAddModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
         List<SymbolRecord> symbols)
     {
-        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "audioWorklet.addModule");
-        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "paintWorklet.addModule");
-        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "layoutWorklet.addModule");
-        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "animationWorklet.addModule");
-        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "CSS.paintWorklet.addModule");
-        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "CSS.layoutWorklet.addModule");
+        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "audioWorklet.addModule");
+        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "paintWorklet.addModule");
+        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "layoutWorklet.addModule");
+        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "animationWorklet.addModule");
+        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "CSS.paintWorklet.addModule");
+        ExtractJavaScriptTypeScriptExactModuleCallSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "CSS.layoutWorklet.addModule");
     }
 
     private static void ExtractJavaScriptTypeScriptWorkerConstructorModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
         List<SymbolRecord> symbols)
     {
-        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "Worker");
-        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "SharedWorker");
-        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "window.Worker");
-        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "window.SharedWorker");
-        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "globalThis.Worker");
-        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, rawLines, sanitizedLines, lineIndex, symbols, "globalThis.SharedWorker");
+        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "Worker");
+        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "SharedWorker");
+        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "window.Worker");
+        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "window.SharedWorker");
+        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "globalThis.Worker");
+        ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(fileId, lang, filePath, projectRoot, rawLines, sanitizedLines, lineIndex, symbols, "globalThis.SharedWorker");
     }
 
     private static void ExtractJavaScriptTypeScriptNewConstructorModuleSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
@@ -905,7 +941,7 @@ public static partial class SymbolExtractor
                 {
                     FileId = fileId,
                     Kind = "import",
-                    Name = moduleName,
+                    Name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, moduleName),
                     Line = moduleLineIndex + 1,
                     StartLine = moduleLineIndex + 1,
                     StartColumn = moduleStartColumn,
@@ -918,6 +954,9 @@ public static partial class SymbolExtractor
 
     private static void ExtractJavaScriptTypeScriptExactModuleCallSymbols(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string[] rawLines,
         string[] sanitizedLines,
         int lineIndex,
@@ -968,7 +1007,7 @@ public static partial class SymbolExtractor
                 {
                     FileId = fileId,
                     Kind = "import",
-                    Name = moduleName,
+                    Name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, moduleName),
                     Line = moduleLineIndex + 1,
                     StartLine = moduleLineIndex + 1,
                     StartColumn = moduleStartColumn,
@@ -1640,6 +1679,9 @@ public static partial class SymbolExtractor
 
     private static bool TryHandleJavaScriptTypeScriptImportEqualsLine(
         long fileId,
+        string lang,
+        string? filePath,
+        string? projectRoot,
         string rawLine,
         int lineNumber,
         List<SymbolRecord> symbols)
@@ -1768,7 +1810,7 @@ public static partial class SymbolExtractor
             {
                 FileId = fileId,
                 Kind = "import",
-                Name = moduleName,
+                Name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, moduleName),
                 Line = lineNumber,
                 StartLine = lineNumber,
                 StartColumn = moduleLiteralStart,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
@@ -1,0 +1,239 @@
+using System.Text.Json;
+
+namespace CodeIndex.Indexer;
+
+public static partial class SymbolExtractor
+{
+    private sealed record TypeScriptPathAliasConfig(string ProjectDirectory, string BaseDirectory, bool HasBaseUrl, IReadOnlyList<TypeScriptPathAliasRule> Rules);
+
+    private sealed record TypeScriptPathAliasRule(string Pattern, string BaseDirectory, IReadOnlyList<string> Targets);
+
+    private static string ResolveJavaScriptTypeScriptModuleSpecifier(string lang, string? filePath, string? projectRoot, string moduleName)
+    {
+        if (lang is not ("typescript" or "javascript") || string.IsNullOrWhiteSpace(filePath))
+            return moduleName;
+
+        if (moduleName.StartsWith(".", StringComparison.Ordinal)
+            || moduleName.StartsWith("/", StringComparison.Ordinal)
+            || moduleName.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || moduleName.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            || moduleName.StartsWith("node:", StringComparison.Ordinal))
+        {
+            return moduleName;
+        }
+
+        var config = FindTypeScriptPathAliasConfig(filePath);
+        if (config == null)
+            return moduleName;
+
+        foreach (var rule in config.Rules)
+        {
+            if (!TryMatchTypeScriptPathAliasPattern(rule.Pattern, moduleName, out var wildcard))
+                continue;
+
+            foreach (var target in rule.Targets)
+            {
+                var substituted = target.Contains('*', StringComparison.Ordinal)
+                    ? target.Replace("*", wildcard, StringComparison.Ordinal)
+                    : target;
+                var candidate = Path.IsPathRooted(substituted)
+                    ? substituted
+                    : Path.Combine(rule.BaseDirectory, substituted);
+
+                if (TryResolveTypeScriptModuleFile(candidate, out var resolvedPath))
+                    return NormalizeTypeScriptResolvedModulePath(projectRoot ?? config.ProjectDirectory, resolvedPath);
+            }
+        }
+
+        if (config.HasBaseUrl
+            && TryResolveTypeScriptModuleFile(Path.Combine(config.BaseDirectory, moduleName), out var baseUrlResolvedPath))
+        {
+            return NormalizeTypeScriptResolvedModulePath(projectRoot ?? config.ProjectDirectory, baseUrlResolvedPath);
+        }
+
+        return moduleName;
+    }
+
+    private static TypeScriptPathAliasConfig? FindTypeScriptPathAliasConfig(string filePath)
+    {
+        var fullFilePath = Path.GetFullPath(filePath);
+        var directory = Directory.Exists(fullFilePath)
+            ? fullFilePath
+            : Path.GetDirectoryName(fullFilePath);
+        while (!string.IsNullOrEmpty(directory))
+        {
+            foreach (var configFileName in new[] { "tsconfig.json", "jsconfig.json" })
+            {
+                var configPath = Path.Combine(directory, configFileName);
+                if (File.Exists(configPath))
+                    return ParseTypeScriptPathAliasConfig(configPath, new HashSet<string>(StringComparer.Ordinal));
+            }
+
+            var parent = Directory.GetParent(directory)?.FullName;
+            if (string.Equals(parent, directory, StringComparison.Ordinal))
+                break;
+            directory = parent;
+        }
+
+        return null;
+    }
+
+    private static TypeScriptPathAliasConfig? ParseTypeScriptPathAliasConfig(string configPath, HashSet<string> seen)
+    {
+        configPath = Path.GetFullPath(configPath);
+        if (!seen.Add(configPath))
+            return null;
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(
+                File.ReadAllText(configPath),
+                new JsonDocumentOptions { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip });
+        }
+        catch
+        {
+            return null;
+        }
+
+        using (document)
+        {
+            var configDirectory = Path.GetDirectoryName(configPath) ?? Directory.GetCurrentDirectory();
+            var inherited = TryGetTypeScriptExtendsPath(document.RootElement, configDirectory, out var extendsPath)
+                ? ParseTypeScriptPathAliasConfig(extendsPath, seen)
+                : null;
+
+            var baseDirectory = inherited?.BaseDirectory ?? configDirectory;
+            var hasBaseUrl = inherited?.HasBaseUrl ?? false;
+            var rules = inherited?.Rules.ToList() ?? [];
+            if (document.RootElement.TryGetProperty("compilerOptions", out var compilerOptions)
+                && compilerOptions.ValueKind == JsonValueKind.Object)
+            {
+                if (compilerOptions.TryGetProperty("baseUrl", out var baseUrlElement)
+                    && baseUrlElement.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(baseUrlElement.GetString()))
+                {
+                    var baseUrl = baseUrlElement.GetString()!;
+                    baseDirectory = Path.IsPathRooted(baseUrl)
+                        ? baseUrl
+                        : Path.GetFullPath(Path.Combine(configDirectory, baseUrl));
+                    hasBaseUrl = true;
+                }
+
+                if (compilerOptions.TryGetProperty("paths", out var pathsElement)
+                    && pathsElement.ValueKind == JsonValueKind.Object)
+                {
+                    rules.Clear();
+                    foreach (var property in pathsElement.EnumerateObject())
+                    {
+                        if (property.Value.ValueKind != JsonValueKind.Array)
+                            continue;
+
+                        var targets = new List<string>();
+                        foreach (var item in property.Value.EnumerateArray())
+                        {
+                            if (item.ValueKind == JsonValueKind.String
+                                && !string.IsNullOrWhiteSpace(item.GetString()))
+                            {
+                                targets.Add(item.GetString()!);
+                            }
+                        }
+
+                        if (targets.Count > 0)
+                            rules.Add(new TypeScriptPathAliasRule(property.Name, baseDirectory, targets));
+                    }
+                }
+            }
+
+            return rules.Count == 0 && !hasBaseUrl
+                ? null
+                : new TypeScriptPathAliasConfig(configDirectory, baseDirectory, hasBaseUrl, SortTypeScriptPathAliasRules(rules));
+        }
+    }
+
+    private static IReadOnlyList<TypeScriptPathAliasRule> SortTypeScriptPathAliasRules(IReadOnlyList<TypeScriptPathAliasRule> rules) =>
+        rules
+            .OrderBy(static rule => rule.Pattern.Contains('*', StringComparison.Ordinal) ? 1 : 0)
+            .ThenByDescending(static rule => GetTypeScriptPathAliasLiteralLength(rule.Pattern))
+            .ToList();
+
+    private static int GetTypeScriptPathAliasLiteralLength(string pattern) =>
+        pattern.Count(static ch => ch != '*');
+
+    private static bool TryGetTypeScriptExtendsPath(JsonElement root, string configDirectory, out string extendsPath)
+    {
+        extendsPath = string.Empty;
+        if (!root.TryGetProperty("extends", out var extendsElement)
+            || extendsElement.ValueKind != JsonValueKind.String
+            || string.IsNullOrWhiteSpace(extendsElement.GetString()))
+        {
+            return false;
+        }
+
+        var value = extendsElement.GetString()!;
+        if (!value.StartsWith(".", StringComparison.Ordinal) && !Path.IsPathRooted(value))
+            return false;
+
+        var candidate = Path.IsPathRooted(value) ? value : Path.Combine(configDirectory, value);
+        if (!Path.HasExtension(candidate))
+            candidate += ".json";
+
+        if (!File.Exists(candidate))
+            return false;
+
+        extendsPath = candidate;
+        return true;
+    }
+
+    private static bool TryMatchTypeScriptPathAliasPattern(string pattern, string moduleName, out string wildcard)
+    {
+        wildcard = string.Empty;
+        var starIndex = pattern.IndexOf('*', StringComparison.Ordinal);
+        if (starIndex < 0)
+            return string.Equals(pattern, moduleName, StringComparison.Ordinal);
+
+        var prefix = pattern[..starIndex];
+        var suffix = pattern[(starIndex + 1)..];
+        if (!moduleName.StartsWith(prefix, StringComparison.Ordinal)
+            || !moduleName.EndsWith(suffix, StringComparison.Ordinal)
+            || moduleName.Length < prefix.Length + suffix.Length)
+        {
+            return false;
+        }
+
+        wildcard = moduleName.Substring(prefix.Length, moduleName.Length - prefix.Length - suffix.Length);
+        return true;
+    }
+
+    private static bool TryResolveTypeScriptModuleFile(string candidate, out string resolvedPath)
+    {
+        foreach (var path in EnumerateTypeScriptModuleCandidates(candidate))
+        {
+            if (File.Exists(path))
+            {
+                resolvedPath = Path.GetFullPath(path);
+                return true;
+            }
+        }
+
+        resolvedPath = string.Empty;
+        return false;
+    }
+
+    private static IEnumerable<string> EnumerateTypeScriptModuleCandidates(string candidate)
+    {
+        yield return candidate;
+
+        foreach (var extension in new[] { ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".d.ts", ".json" })
+            yield return candidate + extension;
+
+        foreach (var extension in new[] { ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".d.ts", ".json" })
+            yield return Path.Combine(candidate, "index" + extension);
+    }
+
+    private static string NormalizeTypeScriptResolvedModulePath(string projectDirectory, string resolvedPath)
+    {
+        var relativePath = Path.GetRelativePath(projectDirectory, Path.GetFullPath(resolvedPath));
+        return relativePath.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+    }
+}

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2028,7 +2028,7 @@ public static partial class SymbolExtractor
     /// <param name="content">Full file content / ファイル全体の内容</param>
     /// <param name="filePath">Relative file path when available / 利用可能なら相対ファイルパス</param>
     /// <returns>List of extracted symbols / 抽出されたシンボルのリスト</returns>
-    public static List<SymbolRecord> Extract(long fileId, string? lang, string content, string? filePath = null)
+    public static List<SymbolRecord> Extract(long fileId, string? lang, string content, string? filePath = null, string? projectRoot = null)
     {
         var originalLang = lang;
         lang = NormalizeLanguage(lang);
@@ -2232,19 +2232,19 @@ public static partial class SymbolExtractor
 
             if (lang is "javascript" or "typescript")
             {
-                ExtractJavaScriptTypeScriptDynamicImportSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
-                ExtractJavaScriptTypeScriptStaticImportModuleSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
-                ExtractJavaScriptTypeScriptRequireModuleSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
-                ExtractJavaScriptTypeScriptImportMetaResolveModuleSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
-                ExtractJavaScriptTypeScriptNewUrlModuleSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
-                ExtractJavaScriptTypeScriptImportScriptsModuleSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
-                ExtractJavaScriptTypeScriptServiceWorkerRegisterModuleSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
-                ExtractJavaScriptTypeScriptWorkletAddModuleSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
-                ExtractJavaScriptTypeScriptWorkerConstructorModuleSymbols(fileId, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptDynamicImportSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptStaticImportModuleSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptRequireModuleSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptImportMetaResolveModuleSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptNewUrlModuleSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptImportScriptsModuleSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptServiceWorkerRegisterModuleSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptWorkletAddModuleSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
+                ExtractJavaScriptTypeScriptWorkerConstructorModuleSymbols(fileId, lang, filePath, projectRoot, lines, javaScriptTypeScriptSanitizedLines!, i, symbols);
             }
 
             if (lang is "javascript" or "typescript"
-                && TryHandleJavaScriptTypeScriptImportEqualsLine(fileId, line, i + 1, symbols))
+                && TryHandleJavaScriptTypeScriptImportEqualsLine(fileId, lang, filePath, projectRoot, line, i + 1, symbols))
             {
                 continue;
             }
@@ -2661,6 +2661,8 @@ public static partial class SymbolExtractor
                         ? match.Groups["name"].Value.Trim()
                         : match.Value.Trim();
                     name = NormalizeExtractedSymbolName(lang, name, match, matchLine);
+                    if (pattern.Kind == "import" && lang is "javascript" or "typescript")
+                        name = ResolveJavaScriptTypeScriptModuleSpecifier(lang, filePath, projectRoot, name);
                     var rubyAttrNames = lang == "ruby"
                         && pattern.Kind == "property"
                         ? TryExpandRubyAttrDeclaratorList(patternMatchLine, absoluteStartColumn, match, name)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -2069,7 +2069,8 @@ public partial class McpServer
                     record.Path,
                     record.Modified,
                     record.Checksum,
-                    allowReuse: (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
+                    allowReuse: record.Lang is not ("javascript" or "typescript")
+                        && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
                         && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                         && (record.Lang != "sql" || sqlGraphContractMatchesCurrent)
                         && AllowReuseWithCurrentHotspotFamilyTrust(record.Lang, hotspotFamilyTrustMatchesCurrent));
@@ -2086,7 +2087,7 @@ public partial class McpServer
                 var fileId = writer.UpsertFile(record);
                 var chunks = ChunkSplitter.Split(fileId, content);
                 writer.InsertChunks(chunks);
-                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content, record.Path);
+                var symbols = SymbolExtractor.Extract(fileId, record.Lang, content, filePath, projectPath);
                 SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
                 writer.InsertSymbols(symbols);
                 var references = ReferenceExtractor.Extract(

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2018,6 +2018,119 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_UpdateFiles_TypeScriptConfigChangeFallsBackToFullScanForAliasSymbols()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "components"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "app", "components"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "pages"));
+            File.WriteAllText(Path.Combine(projectRoot, "tsconfig.json"), """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "@/*": ["src/*"]
+                    }
+                  }
+                }
+                """);
+            File.WriteAllText(Path.Combine(projectRoot, "src", "components", "Button.tsx"), "export const Button = 1;\n");
+            File.WriteAllText(Path.Combine(projectRoot, "app", "components", "Button.tsx"), "export const UpdatedButton = 1;\n");
+            File.WriteAllText(Path.Combine(projectRoot, "src", "pages", "Page.tsx"), "import { Button } from \"@/components/Button\";\n");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            Assert.Contains("src/components/Button.tsx", ReadImportSymbolNames(dbPath));
+
+            File.WriteAllText(Path.Combine(projectRoot, "tsconfig.json"), """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "@/*": ["app/*"]
+                    }
+                  }
+                }
+                """);
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--files", "tsconfig.json", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            var imports = ReadImportSymbolNames(dbPath);
+            Assert.Contains("app/components/Button.tsx", imports);
+            Assert.DoesNotContain("src/components/Button.tsx", imports);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_UpdateFiles_JavaScriptExtendedConfigChangeFallsBackToFullScanForAliasSymbols()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "components"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "app", "components"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "pages"));
+            File.WriteAllText(Path.Combine(projectRoot, "jsconfig.json"), """
+                {
+                  "extends": "./jsconfig.base.json"
+                }
+                """);
+            File.WriteAllText(Path.Combine(projectRoot, "jsconfig.base.json"), """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "~/*": ["src/*"]
+                    }
+                  }
+                }
+                """);
+            File.WriteAllText(Path.Combine(projectRoot, "src", "components", "Card.js"), "export const Card = 1;\n");
+            File.WriteAllText(Path.Combine(projectRoot, "app", "components", "Card.js"), "export const UpdatedCard = 1;\n");
+            File.WriteAllText(Path.Combine(projectRoot, "src", "pages", "Page.js"), "import { Card } from \"~/components/Card\";\n");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            Assert.Contains("src/components/Card.js", ReadImportSymbolNames(dbPath));
+
+            File.WriteAllText(Path.Combine(projectRoot, "jsconfig.base.json"), """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "~/*": ["app/*"]
+                    }
+                  }
+                }
+                """);
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--files", "jsconfig.base.json", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            var imports = ReadImportSymbolNames(dbPath);
+            Assert.Contains("app/components/Card.js", imports);
+            Assert.DoesNotContain("src/components/Card.js", imports);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_UpdateFiles_SkipsPathsOutsideProjectRoot()
     {
         var projectRoot = CreateTempProject();
@@ -6319,6 +6432,19 @@ public class IndexCommandRunnerTests
         return reader.ListFiles(limit: 1000)
             .Select(file => file.Path)
             .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static HashSet<string> ReadImportSymbolNames(string dbPath)
+    {
+        using var connection = OpenNonPoolingConnection(dbPath);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT name FROM symbols WHERE kind = 'import'";
+        using var reader = command.ExecuteReader();
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        while (reader.Read())
+            names.Add(reader.GetString(0));
+        return names;
     }
 
     private static string? ReadIndexedChecksum(string dbPath, string relativePath)

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -5304,6 +5304,107 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void ToolsCall_Index_ResolvesTypeScriptPathAliasesFromProjectRoot()
+    {
+        var fixtureDir = Path.Combine(Path.GetFullPath("."), $"mcp_index_ts_alias_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(fixtureDir);
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_index_ts_alias_{Guid.NewGuid():N}.db");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(fixtureDir, "src", "components"));
+            Directory.CreateDirectory(Path.Combine(fixtureDir, "src", "pages"));
+            File.WriteAllText(Path.Combine(fixtureDir, "tsconfig.json"), """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "@/*": ["src/*"]
+                    }
+                  }
+                }
+                """);
+            File.WriteAllText(Path.Combine(fixtureDir, "src", "components", "Button.tsx"), "export const Button = () => null;\n");
+            File.WriteAllText(Path.Combine(fixtureDir, "src", "pages", "Page.tsx"), "import { Button } from \"@/components/Button\";\n");
+
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+            var request = new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 1,
+                ["method"] = "tools/call",
+                ["params"] = new JsonObject
+                {
+                    ["name"] = "index",
+                    ["arguments"] = new JsonObject
+                    {
+                        ["path"] = fixtureDir,
+                        ["rebuild"] = true,
+                    }
+                }
+            };
+
+            var response = server.HandleMessage(request)!;
+
+            Assert.False(response["result"]!["isError"]?.GetValue<bool>() ?? false);
+            using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = """
+                    SELECT COUNT(*)
+                    FROM symbols
+                    WHERE kind = 'import'
+                      AND name = 'src/components/Button.tsx'
+                    """;
+                Assert.Equal(1L, (long)command.ExecuteScalar()!);
+            }
+
+            Directory.CreateDirectory(Path.Combine(fixtureDir, "app", "components"));
+            File.WriteAllText(Path.Combine(fixtureDir, "app", "components", "Button.tsx"), "export const UpdatedButton = () => null;\n");
+            File.WriteAllText(Path.Combine(fixtureDir, "tsconfig.json"), """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "@/*": ["app/*"]
+                    }
+                  }
+                }
+                """);
+
+            response = server.HandleMessage(request)!;
+
+            Assert.False(response["result"]!["isError"]?.GetValue<bool>() ?? false);
+            using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = """
+                    SELECT name, COUNT(*)
+                    FROM symbols
+                    WHERE kind = 'import'
+                      AND name IN ('src/components/Button.tsx', 'app/components/Button.tsx')
+                    GROUP BY name
+                    """;
+                using var reader = command.ExecuteReader();
+                var counts = new Dictionary<string, long>(StringComparer.Ordinal);
+                while (reader.Read())
+                    counts[reader.GetString(0)] = reader.GetInt64(1);
+
+                Assert.Equal(1L, counts["app/components/Button.tsx"]);
+                Assert.False(counts.ContainsKey("src/components/Button.tsx"));
+            }
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+            if (Directory.Exists(fixtureDir))
+                Directory.Delete(fixtureDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ToolsCall_Index_RestampsHotspotFamilyReadyWhenMarkerFingerprintChanges()
     {
         var fixtureDir = Path.Combine(Path.GetFullPath("."), $"mcp_index_marker_fingerprint_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -22225,6 +22225,41 @@ public class SymbolExtractorTests
         Assert.Contains(tsSymbols, s => s.Kind == "class" && s.Name == "RealClass");
     }
 
+    [Theory]
+    [InlineData("javascript")]
+    [InlineData("typescript")]
+    public void Extract_JavaScriptTypeScript_CrlfTemplateLiteralKeepsColumnsAligned(string language)
+    {
+        // Regression for issue #1465: CRLF input is normalized before JS/TS lexing, so a
+        // multi-line template literal must not shift columns for later real symbols.
+        // issue #1465 の回帰: JS/TS lexing 前に CRLF 入力を正規化するため、複数行
+        // template literal が後続の本物のシンボル列をずらしてはならない。
+        const string content = """
+            const src = `
+            class FakeClassInTemplate {}
+            function fakeFromTemplate() {}
+            `;
+
+            export function realFunction() {
+              return src;
+            }
+            """;
+        var lfContent = content.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var crlfContent = lfContent.Replace("\n", "\r\n", StringComparison.Ordinal);
+
+        var lfSymbols = SymbolExtractor.Extract(1, language, lfContent);
+        var crlfSymbols = SymbolExtractor.Extract(1, language, crlfContent);
+
+        var lfRealFunction = Assert.Single(lfSymbols, s => s.Kind == "function" && s.Name == "realFunction");
+        var crlfRealFunction = Assert.Single(crlfSymbols, s => s.Kind == "function" && s.Name == "realFunction");
+        Assert.Equal(lfRealFunction.Line, crlfRealFunction.Line);
+        Assert.Equal(lfRealFunction.StartColumn, crlfRealFunction.StartColumn);
+        Assert.Equal(lfRealFunction.Signature, crlfRealFunction.Signature);
+
+        Assert.DoesNotContain(crlfSymbols, s => s.Name == "fakeFromTemplate");
+        Assert.DoesNotContain(crlfSymbols, s => s.Name == "FakeClassInTemplate");
+    }
+
     [Fact]
     public void Extract_CSharp_WrappedStaticConstructor_EmitsOnceAtNameLine()
     {
@@ -24007,5 +24042,269 @@ public class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "My::Renderable");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "render");
+    }
+
+    [Fact]
+    public void Extract_TypeScript_ResolvesTsconfigPathAliasImports()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_symbols");
+        try
+        {
+            WriteFile(projectRoot, "tsconfig.json", """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "@/*": ["src/*"]
+                    }
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "src/components/Button.tsx", "export const Button = () => null;\n");
+            var sourcePath = WriteFile(projectRoot, "src/app/page.tsx", "import { Button } from \"@/components/Button\";\n");
+
+            var symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath);
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "src/components/Button.tsx");
+            Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "@/components/Button");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Extract_TypeScript_ResolvesBaseUrlOnlyImports()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_baseurl_symbols");
+        try
+        {
+            WriteFile(projectRoot, "tsconfig.json", """
+                {
+                  "compilerOptions": {
+                    "baseUrl": "src"
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "src/components/Button.tsx", "export const Button = 1;\n");
+            var sourcePath = WriteFile(projectRoot, "src/app/page.tsx", "import { Button } from \"components/Button\";\n");
+
+            var symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath);
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "src/components/Button.tsx");
+            Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "components/Button");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Extract_TypeScript_ResolvesImportEqualsRequirePathAlias()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_import_equals_alias_symbols");
+        try
+        {
+            WriteFile(projectRoot, "tsconfig.json", """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "@/*": ["src/*"]
+                    }
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "src/services/api.ts", "export = {};\n");
+            var sourcePath = WriteFile(projectRoot, "src/main.ts", "import Api = require(\"@/services/api\");\n");
+
+            var symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath);
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Api");
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "src/services/api.ts");
+            Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "@/services/api");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Extract_TypeScript_ResolvesInheritedTsconfigPathAliasImports()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_extends_symbols");
+        try
+        {
+            WriteFile(projectRoot, "tsconfig.base.json", """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "~lib/*": ["lib/*"]
+                    }
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "tsconfig.json", """
+                {
+                  "extends": "./tsconfig.base.json"
+                }
+                """);
+            WriteFile(projectRoot, "lib/math/index.ts", "export const sum = () => 0;\n");
+            var sourcePath = WriteFile(projectRoot, "src/app.ts", "import { sum } from \"~lib/math\";\n");
+
+            var symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath);
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "lib/math/index.ts");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Extract_TypeScript_ResolvesInheritedPathAliasesFromDeclaringBaseUrl()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_extends_baseurl_symbols");
+        try
+        {
+            WriteFile(projectRoot, "tsconfig.base.json", """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "~shared/*": ["shared/*"]
+                    }
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "apps/web/tsconfig.json", """
+                {
+                  "extends": "../../tsconfig.base.json",
+                  "compilerOptions": {
+                    "baseUrl": "."
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "shared/api.ts", "export const api = 1;\n");
+            WriteFile(projectRoot, "apps/web/shared/api.ts", "export const wrong = 1;\n");
+            var sourcePath = WriteFile(projectRoot, "apps/web/src/app.ts", "import { api } from \"~shared/api\";\n");
+
+            var symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath, projectRoot);
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "shared/api.ts");
+            Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "apps/web/shared/api.ts");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Extract_TypeScript_PrefersMoreSpecificTsconfigPathAliasImports()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_specificity_symbols");
+        try
+        {
+            WriteFile(projectRoot, "tsconfig.json", """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "*": ["fallback/*"],
+                      "@app/*": ["src/app/*"]
+                    }
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "fallback/@app/Button.ts", "export const Wrong = 1;\n");
+            WriteFile(projectRoot, "src/app/Button.ts", "export const Button = 1;\n");
+            var sourcePath = WriteFile(projectRoot, "src/main.ts", "import { Button } from \"@app/Button\";\n");
+
+            var symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath);
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "src/app/Button.ts");
+            Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "fallback/@app/Button.ts");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Extract_TypeScript_ResolvesNestedTsconfigAliasesRelativeToProjectRoot()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_nested_symbols");
+        try
+        {
+            WriteFile(projectRoot, "packages/app/tsconfig.json", """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "@/*": ["src/*"]
+                    }
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "packages/app/src/components/Button.tsx", "export const Button = 1;\n");
+            var sourcePath = WriteFile(projectRoot, "packages/app/src/page.tsx", "import { Button } from \"@/components/Button\";\n");
+
+            var symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath, projectRoot);
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "packages/app/src/components/Button.tsx");
+            Assert.DoesNotContain(symbols, s => s.Kind == "import" && s.Name == "src/components/Button.tsx");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Extract_JavaScript_ResolvesJsconfigPathAliasImportsAndKeepsMissesLiteral()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("jsconfig_alias_symbols");
+        try
+        {
+            WriteFile(projectRoot, "jsconfig.json", """
+                {
+                  "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                      "~components/*": ["components/*"]
+                    }
+                  }
+                }
+                """);
+            WriteFile(projectRoot, "components/Card.jsx", "export const Card = () => null;\n");
+            var sourcePath = WriteFile(projectRoot, "src/view.js", """
+                import Card from "~components/Card";
+                import Missing from "~components/Missing";
+                """);
+
+            var symbols = SymbolExtractor.Extract(1, "javascript", File.ReadAllText(sourcePath), sourcePath);
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "components/Card.jsx");
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "~components/Missing");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    private static string WriteFile(string projectRoot, string relativePath, string content)
+    {
+        var path = Path.Combine(projectRoot, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
     }
 }


### PR DESCRIPTION
## Summary

- Resolve JavaScript/TypeScript import symbols through nearest `tsconfig.json` / `jsconfig.json` `baseUrl` and `paths` mappings when the target file exists.
- Pass project-root context through CLI and MCP indexing so nested configs emit indexed project-relative paths.
- Reindex JS/TS files on full scans and fall back to full scan when incremental updates touch JS/TS config files.
- Add bilingual docs and changelog fragment.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests.Run_UpdateFiles_TypeScriptConfigChangeFallsBackToFullScanForAliasSymbols|FullyQualifiedName~IndexCommandRunnerTests.Run_UpdateFiles_JavaScriptExtendedConfigChangeFallsBackToFullScanForAliasSymbols|FullyQualifiedName~SymbolExtractorTests.Extract_TypeScript_ResolvesImportEqualsRequirePathAlias"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- `codex exec` adversarial review: `No blocking/actionable issues found.`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

## Notes

- Changelog fragment: `changelog.d/unreleased/1886.fixed.md`
- The post-commit index update completed in update mode; existing graph/hotspot/fold degraded readiness remains outside this issue.

Fixes #1886
