### PR TITLE
Reduce string allocation overhead

### DIFF
--- a/changelog.d/unreleased/1962.fixed.md
+++ b/changelog.d/unreleased/1962.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1962
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Reduced indexing allocations for large source files (#1962)** — File content line endings are now normalized in a single pass, and JavaScript/TypeScript extraction seeds hot `StringBuilder` instances with input-size estimates.
+
+## 日本語
+
+- **大きなソースファイルの索引時割り当てを削減しました (#1962)** — ファイル内容の改行正規化を 1 パス化し、JavaScript / TypeScript 抽出のホットパス `StringBuilder` に入力サイズ由来の初期容量を設定しました。

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -2119,8 +2119,8 @@ public class FileIndexer
                 warning = $"{relativePath}: contains invalid UTF-8 bytes (replaced with U+FFFD)";
             }
         }
-        // Normalize line endings to LF / 改行をLFに正規化
-        content = content.Replace("\r\n", "\n").Replace("\r", "\n");
+        // Normalize line endings to LF in one pass / 改行を1パスでLFに正規化
+        content = NormalizeLineEndings(content);
         // Strip every line-leading UTF-8 BOM (U+FEFF): the leading BOM at offset 0
         // and any BOM that immediately follows a `\n` (e.g. from accidental file
         // concatenation or tool insertion). Leading BOM alone would make `^\s*`-
@@ -2172,6 +2172,31 @@ public class FileIndexer
         };
 
         return (record, content, bytes, warning);
+    }
+
+    internal static string NormalizeLineEndings(string content)
+    {
+        var firstCarriageReturn = content.IndexOf('\r');
+        if (firstCarriageReturn < 0)
+            return content;
+
+        var builder = new StringBuilder(content.Length);
+        builder.Append(content, 0, firstCarriageReturn);
+
+        for (var index = firstCarriageReturn; index < content.Length; index++)
+        {
+            if (content[index] != '\r')
+            {
+                builder.Append(content[index]);
+                continue;
+            }
+
+            builder.Append('\n');
+            if (index + 1 < content.Length && content[index + 1] == '\n')
+                index++;
+        }
+
+        return builder.ToString();
     }
 
     private string BuildFileTooLargeMessage(long actualBytes, bool grewDuringRead)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
@@ -1571,7 +1571,7 @@ public static partial class SymbolExtractor
             return line[start..endExclusive].Trim();
         }
 
-        var builder = new StringBuilder();
+        var builder = new StringBuilder(EstimateJavaScriptTypeScriptLineSliceLength(rawLines, startLineIndex, endLineIndex));
         for (var lineIndex = startLineIndex; lineIndex <= endLineIndex; lineIndex++)
         {
             if (lineIndex > startLineIndex)
@@ -1662,7 +1662,7 @@ public static partial class SymbolExtractor
         if (startLineIndex == endLineIndex)
             return rawLines[startLineIndex].Trim();
 
-        var builder = new StringBuilder();
+        var builder = new StringBuilder(EstimateJavaScriptTypeScriptLineSliceLength(rawLines, startLineIndex, endLineIndex));
         for (var lineIndex = startLineIndex; lineIndex <= endLineIndex; lineIndex++)
         {
             if (lineIndex > startLineIndex)
@@ -1675,6 +1675,35 @@ public static partial class SymbolExtractor
         }
 
         return builder.ToString().Trim();
+    }
+
+    private static int EstimateJavaScriptTypeScriptLineSliceLength(string[] lines, int startLineIndex, int endLineIndex)
+    {
+        if (lines.Length == 0)
+            return 0;
+
+        startLineIndex = Math.Clamp(startLineIndex, 0, lines.Length - 1);
+        endLineIndex = Math.Clamp(endLineIndex, startLineIndex, lines.Length - 1);
+
+        var capacity = 0;
+        for (var lineIndex = startLineIndex; lineIndex <= endLineIndex; lineIndex++)
+            capacity += lines[lineIndex].Length + (lineIndex > startLineIndex ? 1 : 0);
+
+        return capacity;
+    }
+
+    private static int EstimateJavaScriptTypeScriptStatementCapacity(string[] lines, int startLineIndex)
+    {
+        if (lines.Length == 0)
+            return 0;
+
+        startLineIndex = Math.Clamp(startLineIndex, 0, lines.Length - 1);
+        var endExclusive = Math.Min(lines.Length, startLineIndex + 16);
+        var capacity = 0;
+        for (var lineIndex = startLineIndex; lineIndex < endExclusive; lineIndex++)
+            capacity += lines[lineIndex].Length + (lineIndex > startLineIndex ? 1 : 0);
+
+        return capacity;
     }
 
     private static bool TryHandleJavaScriptTypeScriptImportEqualsLine(
@@ -2277,8 +2306,9 @@ public static partial class SymbolExtractor
 
         startColumnText = startColumn + startLineSlice.IndexOf("export", StringComparison.Ordinal);
 
-        var clauseBuilder = new System.Text.StringBuilder();
-        var signatureBuilder = new System.Text.StringBuilder();
+        var builderCapacity = EstimateJavaScriptTypeScriptStatementCapacity(sanitizedLines, startLineIndex);
+        var clauseBuilder = new System.Text.StringBuilder(builderCapacity);
+        var signatureBuilder = new System.Text.StringBuilder(builderCapacity);
 
         for (int lineIndex = startLineIndex; lineIndex < sanitizedLines.Length; lineIndex++)
         {
@@ -2393,8 +2423,9 @@ public static partial class SymbolExtractor
 
         startColumnText = startColumn + startLineSlice.IndexOf("export", StringComparison.Ordinal);
 
-        var clauseBuilder = new System.Text.StringBuilder();
-        var signatureBuilder = new System.Text.StringBuilder();
+        var builderCapacity = EstimateJavaScriptTypeScriptStatementCapacity(sanitizedLines, startLineIndex);
+        var clauseBuilder = new System.Text.StringBuilder(builderCapacity);
+        var signatureBuilder = new System.Text.StringBuilder(builderCapacity);
 
         for (int lineIndex = startLineIndex; lineIndex < sanitizedLines.Length; lineIndex++)
         {
@@ -5144,7 +5175,7 @@ public static partial class SymbolExtractor
 
     private static string CollectJavaScriptTypeScriptAssignedRhsHeader(string[] sanitizedLines, int startLineIndex, int startColumn)
     {
-        var builder = new System.Text.StringBuilder();
+        var builder = new System.Text.StringBuilder(EstimateJavaScriptTypeScriptStatementCapacity(sanitizedLines, startLineIndex));
         var parenDepth = 0;
         var bracketDepth = 0;
         var braceDepth = 0;
@@ -5309,8 +5340,9 @@ public static partial class SymbolExtractor
         rhsEndColumn = -1;
         signature = string.Empty;
 
-        var rhsBuilder = new System.Text.StringBuilder();
-        var signatureBuilder = new System.Text.StringBuilder();
+        var builderCapacity = EstimateJavaScriptTypeScriptStatementCapacity(sanitizedLines, assignmentLineIndex);
+        var rhsBuilder = new System.Text.StringBuilder(builderCapacity);
+        var signatureBuilder = new System.Text.StringBuilder(builderCapacity);
         var pendingWrapperParenClose = false;
 
         for (int lineIndex = assignmentLineIndex; lineIndex < sanitizedLines.Length; lineIndex++)
@@ -6155,7 +6187,7 @@ public static partial class SymbolExtractor
         if (exportedName[^1] != quote)
             return exportedName;
 
-        var builder = new StringBuilder();
+        var builder = new StringBuilder(Math.Max(0, exportedName.Length - 2));
         for (var index = 1; index < exportedName.Length - 1; index++)
         {
             var ch = exportedName[index];

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2524,6 +2524,16 @@ public class FileIndexerTests
         }
     }
 
+    [Theory]
+    [InlineData("line1\r\nline2\r\n", "line1\nline2\n")]
+    [InlineData("line1\rline2\r", "line1\nline2\n")]
+    [InlineData("crlf\r\ncr\rlf\n", "crlf\ncr\nlf\n")]
+    [InlineData("line1\nline2\n", "line1\nline2\n")]
+    public void NormalizeLineEndings_CollapsesCrVariantsToLf(string input, string expected)
+    {
+        Assert.Equal(expected, FileIndexer.NormalizeLineEndings(input));
+    }
+
     [Fact]
     public void BuildRecord_LeadingBomStrippedFromContent()
     {


### PR DESCRIPTION
## Summary

- Normalize file content line endings in one pass instead of chaining full-string replacements.
- Seed JavaScript/TypeScript extractor `StringBuilder` hot paths with input-size estimates to reduce growth reallocations.
- Add a bilingual changelog fragment for issue #1962.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"` (failed: existing performance budget test `Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget` took 28.64s > 20s under local load; 1017/1018 passed)
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` (reported stale/degraded existing local index; attempted refresh earlier did not complete in practical time)
- Codex adversarial review: No blocking/actionable issues found.

## Documentation / Changelog

- Added `changelog.d/unreleased/1962.fixed.md`.
- No README/guide behavior contract changed.

Fixes #1962
