### PR TITLE
Parallelize full-scan extraction

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -54,12 +54,9 @@ The lock files for projects with zero direct `PackageReference` entries (e.g. `t
 ### Indexing pipeline
 
 ```
-Directory scan / shared path filter (built-in skip lists + `.gitignore` / `.cdidxignore` + reparse/Windows Hidden/System attribute pruning) → Language detection → File read (UTF-8)
-  → UPSERT file record
-  → Split into chunks (80 lines, 10-line overlap)
-  → Extract symbols via regex
-  → Extract lightweight references via regex
-  → Batch insert chunks + symbols + references (500 per transaction)
+Directory scan / shared path filter (built-in skip lists + `.gitignore` / `.cdidxignore` + reparse/Windows Hidden/System attribute pruning)
+  → Parallel extraction workers (`--parallelism`, `CDIDX_INDEX_PARALLELISM`; default CPU count capped at 16) read UTF-8, split chunks, extract symbols/references, and validate content
+  → Single SQLite writer checks unchanged-file reuse, UPSERTs file records, and inserts chunks + symbols + references + issues in per-file transactions
   → Populate FTS5 index
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 - MCP server for AI clients such as Claude Code, Cursor, and Windsurf.
 - Local suggestion history can be listed, inspected, and exported with
   `cdidx suggestions`.
-- Incremental refreshes with `--files` and `--commits`, plus continuous `--watch` mode.
+- Parallel full-scan extraction with configurable `--parallelism`, incremental refreshes
+  with `--files` and `--commits`, plus continuous `--watch` mode.
 - Exact DB/worktree freshness checks with `status --check`, including an
   overridable age threshold via `--stale-after` / `CDIDX_STALE_AFTER`.
 - Human `status` output translates readiness flags and `status --explain <field>`

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -330,6 +330,7 @@ Use the smallest change that reduces the expensive part of your run.
 | `--commits <id...>` | off | After normal commits | Requires git history but sees rename/delete paths |
 | `--changed-between <old> <new>` | off | After branch switches when both refs are known | Only as accurate as the supplied refs |
 | `--max-file-bytes <bytes>` / `CDIDX_MAX_FILE_BYTES` | `4MiB` | Legitimate large source files are skipped | Raising it can bloat the DB and slow snippet extraction |
+| `--parallelism <n>` / `CDIDX_INDEX_PARALLELISM` | CPU count, capped at `16` | Full-scan extraction is CPU-bound | Higher values can increase memory and IO pressure |
 | `--watch --debounce <ms>` | `500` ms | Keep an active worktree fresh during editing | Long-running process; incompatible with commit/file scoped refresh flags |
 | `--snippet-lines` / `--max-line-width` | `8` / `512` | Query payloads are too large for AI context | Smaller snippets may hide nearby context |
 | `--path`, `--exclude-path`, `--exclude-tests` | off | Queries or maps are noisy | Over-filtering can hide real matches |
@@ -852,6 +853,7 @@ cdidx report --output report.tgz --json
 | `--force` | `index` | Bypass the per-database index lock. Only use when you are sure no other `cdidx index` is active against the same DB; concurrent runs may corrupt the schema. |
 | `--duration-format <auto\|seconds\|hms>` | `index` | Choose human elapsed-time display for index summaries. `auto` (default) uses unit labels; `seconds` emits decimal seconds; `hms` keeps `HH:MM:SS`. JSON always keeps raw `elapsed_ms`. |
 | `--max-file-bytes <bytes>` | `index` | Override the per-file indexing limit for this run. Defaults to 4MiB, or `CDIDX_MAX_FILE_BYTES` when set. Values accept raw bytes or `K` / `M` / `G` suffixes such as `50M`. |
+| `--parallelism <n>` | `index` | Set full-scan extraction worker count. Defaults to CPU count capped at 16, or `CDIDX_INDEX_PARALLELISM` when set. SQLite writes stay single-consumer. |
 | `--watch` | `index` | After the initial scan completes, stay running and reindex incrementally as files change (FileSystemWatcher / inotify / FSEvents). Rejects `--commits`, `--changed-between`, `--files`, and `--dry-run` because the loop already drives continuous incremental updates. |
 | `--debounce <ms>` | `index` (watch only) | Coalesce bursts of file events into a single update after `<ms>` of quiet (non-negative integer; default: 500). Invalid values emit a warning and are ignored. |
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp. Offsetless values (e.g. `2024-01-01T00:00:00`) are treated as UTC so the same flag resolves to the same instant in every timezone; append `Z` or an explicit offset (`+09:00`) to be explicit. |
@@ -2009,6 +2011,7 @@ cdidx index . --duration-format seconds
 | `--commits <id...>` | off | 通常の commit 後 | git history が必要だが rename/delete paths も扱える |
 | `--changed-between <old> <new>` | off | branch switch 後に両 ref が分かる | 渡した ref の正確さに依存 |
 | `--max-file-bytes <bytes>` / `CDIDX_MAX_FILE_BYTES` | `4MiB` | 正当な大きい source file が skip される | DB が大きくなり snippet extraction も遅くなりうる |
+| `--parallelism <n>` / `CDIDX_INDEX_PARALLELISM` | CPU 数、最大 `16` | フルスキャンの抽出が CPU-bound | 大きくするとメモリと IO の圧力が増えうる |
 | `--watch --debounce <ms>` | `500` ms | 編集中の worktree を live に保つ | long-running process。commit/file scoped refresh flags とは併用不可 |
 | `--snippet-lines` / `--max-line-width` | `8` / `512` | AI context に対して query payload が大きすぎる | 小さくしすぎると周辺文脈が見えない |
 | `--path`, `--exclude-path`, `--exclude-tests` | off | query / map が noisy | 絞り込みすぎると実 match を隠す |
@@ -2522,6 +2525,7 @@ cdidx report --output report.tgz --json
 | `--force` | `index` | 同一 DB に対する index ロックを bypass する。他の `cdidx index` が走っていないと確信できる場合のみ使う。並行実行は schema を破壊し得る。 |
 | `--duration-format <auto\|seconds\|hms>` | `index` | index summary の human 経過時間表示を選ぶ。`auto`（既定）は単位付き、`seconds` は小数秒、`hms` は `HH:MM:SS` を維持。JSON は常に raw の `elapsed_ms` を返す。 |
 | `--max-file-bytes <bytes>` | `index` | この実行で使うファイル単位の索引サイズ上限を上書きする。既定は 4MiB、または `CDIDX_MAX_FILE_BYTES` 設定値。値は raw byte 数、または `50M` のような `K` / `M` / `G` 接尾辞を受け付ける。 |
+| `--parallelism <n>` | `index` | フルスキャンの抽出 worker 数を指定する。既定は CPU 数を最大 16 に丸めた値、または `CDIDX_INDEX_PARALLELISM` 設定値。SQLite 書き込みは単一 consumer のまま。 |
 | `--watch` | `index` | 初回スキャン完了後もプロセスを残し、ファイル変更を検知して差分更新を繰り返す（FileSystemWatcher / inotify / FSEvents）。連続的な差分更新を内蔵しているため `--commits` / `--changed-between` / `--files` / `--dry-run` との併用は拒否する。 |
 | `--debounce <ms>` | `index`（`--watch` 専用） | 一連のイベントを `<ms>` の静止後に 1 つの更新へ集約する（0 以上の整数。既定: 500）。不正な値は警告を出して無視する。 |
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601）。オフセットなしの値（例: `2024-01-01T00:00:00`）は UTC として解釈されるため、どのタイムゾーンから呼び出しても同じ UTC 時点になります。明示したい場合は末尾に `Z` または `+09:00` 等のオフセットを付与してください。 |

--- a/changelog.d/unreleased/1842.changed.md
+++ b/changelog.d/unreleased/1842.changed.md
@@ -1,0 +1,21 @@
+---
+category: changed
+issues:
+  - 1842
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - README.md
+  - USER_GUIDE.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Full-scan indexing now parallelizes extraction (#1842)** — `cdidx index` runs file reads, chunking, symbol extraction, reference extraction, and content validation through bounded worker tasks while keeping SQLite writes single-consumer; use `--parallelism <n>` or `CDIDX_INDEX_PARALLELISM` to tune the worker count.
+
+## 日本語
+
+- **フルスキャン index の抽出処理を並列化しました (#1842)** — `cdidx index` はファイル読み込み、chunk 分割、symbol 抽出、reference 抽出、content 検証を bounded worker task で実行し、SQLite 書き込みは単一 consumer のまま維持します。worker 数は `--parallelism <n>` または `CDIDX_INDEX_PARALLELISM` で調整できます。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -216,6 +216,7 @@ internal static class CliFlagSchema
             new() { Name = "--force", Description = "Bypass the per-database index lock", Commands = Set("index") },
             new() { Name = "--duration-format", ValuePlaceholder = "<auto|seconds|hms>", Description = "Index elapsed time display format", Commands = Set("index") },
             new() { Name = "--max-file-bytes", ValuePlaceholder = "<bytes>", Description = "Override the per-file indexing size limit", Commands = Set("index") },
+            new() { Name = "--parallelism", ValuePlaceholder = "<n>", Description = "Full-scan extraction worker count (default: CPU count capped at 16; also honors CDIDX_INDEX_PARALLELISM)", Commands = Set("index") },
             new() { Name = "--commits", ValuePlaceholder = "<id>", Description = "Update files changed in given git commits", Commands = Set("index") },
             new() { Name = "--changed-between", ValuePlaceholder = "<old-ref> <new-ref>", Description = "Update files changed between two git refs", Commands = Set("index") },
             new() { Name = "--files", ValuePlaceholder = "<path>", Description = "Update only the specified files", Commands = Set("index") },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -562,6 +562,7 @@ public static class ConsoleUi
         Console.WriteLine("  --json                     Output results as JSON (for AI/machine use)");
         Console.WriteLine("  --duration-format <format> Index elapsed time format: `auto` (default), `seconds`, or `hms`; JSON keeps raw elapsed_ms");
         Console.WriteLine("  --max-file-bytes <bytes>  Index only files up to this size (default: 4MiB; also honors CDIDX_MAX_FILE_BYTES; accepts K/M/G suffixes)");
+        Console.WriteLine("  --parallelism <n>         Full-scan extraction workers (default: CPU count capped at 16; also honors CDIDX_INDEX_PARALLELISM)");
         Console.WriteLine("  --commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)");
         Console.WriteLine("  --changed-between <old-ref> <new-ref>");
         Console.WriteLine("                              Update only files changed between two git refs (useful after branch switches)");

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Collections.Concurrent;
 using System.Text.Json;
 using CodeIndex.Database;
 using CodeIndex.Indexer;
@@ -555,6 +556,7 @@ public static class IndexCommandRunner
     [
         "--db", "--rebuild", "--verbose", "--json", "--dry-run", "--force",
         "--watch", "--debounce", "--duration-format", "--max-file-bytes",
+        "--parallelism",
         "--commits", "--changed-between", "--files", "--solution", "--project", "--help",
     ];
 
@@ -599,6 +601,7 @@ public static class IndexCommandRunner
         int? watchDebounceMs = null;
         var durationFormat = DurationOutputFormat.Auto;
         long? maxFileSizeBytes = ReadMaxFileSizeBytesFromEnvironment();
+        var parallelism = ReadIndexParallelismFromEnvironment();
         string? easterEgg = null;
         int spinnerFlagCount = 0;
         bool randomSpinner = false;
@@ -661,6 +664,12 @@ public static class IndexCommandRunner
                     break;
                 case var option when option.StartsWith("--max-file-bytes=", StringComparison.Ordinal):
                     maxFileSizeBytes = ParseMaxFileBytes(option["--max-file-bytes=".Length..], maxFileSizeBytes);
+                    break;
+                case "--parallelism" when i + 1 < args.Length:
+                    parallelism = ParseIndexParallelism(args[++i], parallelism, "--parallelism");
+                    break;
+                case var option when option.StartsWith("--parallelism=", StringComparison.Ordinal):
+                    parallelism = ParseIndexParallelism(option["--parallelism=".Length..], parallelism, "--parallelism");
                     break;
                 case "--commits":
                     while (i + 1 < args.Length && !args[i + 1].StartsWith('-'))
@@ -765,7 +774,32 @@ public static class IndexCommandRunner
             WatchDebounceMs = watchDebounceMs,
             DurationFormat = durationFormat,
             MaxFileSizeBytes = maxFileSizeBytes,
+            Parallelism = parallelism,
         };
+    }
+
+    internal const string IndexParallelismEnvironmentVariable = "CDIDX_INDEX_PARALLELISM";
+
+    internal static int DefaultIndexParallelism()
+        => Math.Clamp(Environment.ProcessorCount, 1, 16);
+
+    private static int ReadIndexParallelismFromEnvironment()
+    {
+        var fallback = DefaultIndexParallelism();
+        var value = Environment.GetEnvironmentVariable(IndexParallelismEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return ParseIndexParallelism(value, fallback, IndexParallelismEnvironmentVariable);
+    }
+
+    private static int ParseIndexParallelism(string value, int fallback, string source)
+    {
+        if (int.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed) && parsed > 0)
+            return parsed;
+
+        Console.Error.WriteLine($"Warning: invalid {source} value '{value}' (ignored; use a positive integer) / 不正な {source} 値 '{value}'（無視。正の整数を指定）");
+        return fallback;
     }
 
     private static long? ReadMaxFileSizeBytesFromEnvironment()
@@ -2272,6 +2306,8 @@ public static class IndexCommandRunner
         string? currentJsonIndexFile = null;
         CancellationTokenSource? jsonHeartbeatCts = null;
         Task? jsonHeartbeatTask = null;
+        var extractionParallelism = Math.Max(1, options.Parallelism);
+        var parallelizeExtraction = options.Rebuild || writer.GetCounts().files == 0;
 
         void StartIndexSpinnerIfNeeded()
         {
@@ -2397,19 +2433,83 @@ public static class IndexCommandRunner
                 ConsoleUi.PrintProgress(0, files.Count);
             }
 
-            foreach (var filePath in files)
+            using var extractionResults = new BlockingCollection<FullScanFileWorkItem>(Math.Max(1, extractionParallelism * 4));
+            var nextFileIndex = -1;
+            var workers = Enumerable.Range(0, extractionParallelism)
+                .Select(_ => Task.Factory.StartNew(() =>
+                {
+                    while (true)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var fileIndex = Interlocked.Increment(ref nextFileIndex);
+                        if (fileIndex >= files.Count)
+                            break;
+
+                        var filePath = files[fileIndex];
+                        try
+                        {
+                            var (record, content, rawBytes, warning) = indexer.BuildRecordWithRawBytes(filePath);
+                            IReadOnlyList<ChunkRecord>? chunks = null;
+                            IReadOnlyList<SymbolRecord>? symbols = null;
+                            IReadOnlyList<ReferenceRecord>? references = null;
+                            IReadOnlyList<FileIssue>? issues = null;
+                            if (parallelizeExtraction)
+                            {
+                                chunks = ChunkSplitter.Split(0, content);
+                                symbols = SymbolExtractor.Extract(0, record.Lang, content);
+                                SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
+                                references = ReferenceExtractor.Extract(
+                                    0,
+                                    record.Lang,
+                                    content,
+                                    symbols,
+                                    record.Path,
+                                    record.Lang == "csharp" ? csharpWorkspace.Symbols : null);
+                                issues = FileIndexer.ValidateContent(record.Path, rawBytes, content);
+                            }
+                            extractionResults.Add(
+                                FullScanFileWorkItem.Success(filePath, record, content, rawBytes, warning, chunks, symbols, references, issues),
+                                cancellationToken);
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            extractionResults.Add(FullScanFileWorkItem.Failure(filePath, ex), cancellationToken);
+                        }
+                    }
+                }, cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default))
+                .ToArray();
+
+            _ = Task.WhenAll(workers).ContinueWith(
+                task =>
+                {
+                    extractionResults.CompleteAdding();
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            while (!extractionResults.IsCompleted)
             {
                 ThrowIfFullScanCancelled(processed, files.Count);
-                currentJsonIndexFile = FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectRoot, filePath));
+                if (!extractionResults.TryTake(out var item, millisecondsTimeout: 100))
+                    continue;
+
+                currentJsonIndexFile = FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectRoot, item.FilePath));
                 EnsureIndexingActivityVisible();
                 try
                 {
-                    var (record, content, rawBytes, warning) = indexer.BuildRecordWithRawBytes(filePath);
+                    if (item.Exception != null)
+                        throw item.Exception;
 
-                    if (warning != null && !options.Json && !options.Quiet)
+                    var record = item.Record!;
+                    if (item.Warning != null && !options.Json && !options.Quiet)
                     {
                         PauseIndexSpinnerForConsoleWrite();
-                        ConsoleUi.PrintWarning(warning);
+                        ConsoleUi.PrintWarning(item.Warning);
                         ResumeIndexSpinnerAfterConsoleWrite();
                     }
 
@@ -2451,21 +2551,27 @@ public static class IndexCommandRunner
 
                     using var txn = writer.BeginTransaction();
                     var fileId = writer.UpsertFile(record);
-                    var chunks = ChunkSplitter.Split(fileId, content);
+                    var chunks = item.Chunks == null
+                        ? ChunkSplitter.Split(fileId, item.Content!)
+                        : ReassignChunkFileIds(item.Chunks, fileId);
                     writer.InsertChunks(chunks);
-                    var symbols = SymbolExtractor.Extract(fileId, record.Lang, content);
-                    SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
+                    var symbols = item.Symbols == null
+                        ? SymbolExtractor.Extract(fileId, record.Lang, item.Content!)
+                        : ReassignSymbolFileIds(item.Symbols, fileId);
+                    if (item.Symbols == null)
+                        SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(item.FilePath, record.Lang));
                     writer.InsertSymbols(symbols);
-                    var references = ReferenceExtractor.Extract(
-                        fileId,
-                        record.Lang,
-                        content,
-                        symbols,
-                        record.Path,
-                        record.Lang == "csharp" ? csharpWorkspace.Symbols : null);
+                    var references = item.References == null
+                        ? ReferenceExtractor.Extract(
+                            fileId,
+                            record.Lang,
+                            item.Content!,
+                            symbols,
+                            record.Path,
+                            record.Lang == "csharp" ? csharpWorkspace.Symbols : null)
+                        : ReassignReferenceFileIds(item.References, fileId);
                     writer.InsertReferences(references);
-                    // Validate content for encoding issues / エンコーディング問題を検証
-                    var issues = FileIndexer.ValidateContent(record.Path, rawBytes, content);
+                    var issues = item.Issues ?? FileIndexer.ValidateContent(record.Path, item.RawBytes!, item.Content!);
                     writer.InsertIssues(fileId, issues);
                     WriteProjectRootOnce();
                     txn.Commit();
@@ -2481,12 +2587,12 @@ public static class IndexCommandRunner
                 catch (Exception ex)
                 {
                     errors++;
-                    errorList.Add(new CliJsonMessage(filePath, ex.Message));
+                    errorList.Add(new CliJsonMessage(item.FilePath, ex.Message));
                     if (!options.Json)
                     {
                         PauseIndexSpinnerForConsoleWrite();
                         ConsoleUi.ClearProgressLine();
-                        Console.Error.WriteLine(FormatPerFileErrorLine("ERR ", filePath, ex));
+                        Console.Error.WriteLine(FormatPerFileErrorLine("ERR ", item.FilePath, ex));
                         ResumeIndexSpinnerAfterConsoleWrite();
                     }
                 }
@@ -2502,6 +2608,7 @@ public static class IndexCommandRunner
                     ResumeIndexSpinnerAfterConsoleWrite();
                 }
             }
+            Task.WaitAll(workers, cancellationToken);
         }
         finally
         {
@@ -2802,6 +2909,27 @@ public static class IndexCommandRunner
     private static string BuildFoldRebuildCommand(string projectRoot, string resolvedDbPath)
         => $"cdidx index {QuoteCommandArgument(projectRoot)} --db {QuoteCommandArgument(resolvedDbPath)} --rebuild";
 
+    private static IReadOnlyList<ChunkRecord> ReassignChunkFileIds(IReadOnlyList<ChunkRecord> chunks, long fileId)
+    {
+        foreach (var chunk in chunks)
+            chunk.FileId = fileId;
+        return chunks;
+    }
+
+    private static IReadOnlyList<SymbolRecord> ReassignSymbolFileIds(IReadOnlyList<SymbolRecord> symbols, long fileId)
+    {
+        foreach (var symbol in symbols)
+            symbol.FileId = fileId;
+        return symbols;
+    }
+
+    private static IReadOnlyList<ReferenceRecord> ReassignReferenceFileIds(IReadOnlyList<ReferenceRecord> references, long fileId)
+    {
+        foreach (var reference in references)
+            reference.FileId = fileId;
+        return references;
+    }
+
     private static FoldOnlyRemediation? BuildFoldOnlyReadinessRemediation(
         bool graphTableAvailable,
         bool issuesTableAvailable,
@@ -3028,6 +3156,36 @@ public static class IndexCommandRunner
         IReadOnlyList<SymbolRecord> Symbols,
         bool HasStaticInterfaceContracts);
 
+    private sealed record FullScanFileWorkItem(
+        string FilePath,
+        FileRecord? Record,
+        string? Content,
+        byte[]? RawBytes,
+        string? Warning,
+        IReadOnlyList<ChunkRecord>? Chunks,
+        IReadOnlyList<SymbolRecord>? Symbols,
+        IReadOnlyList<ReferenceRecord>? References,
+        IReadOnlyList<FileIssue>? Issues,
+        Exception? Exception)
+    {
+        public static FullScanFileWorkItem Success(
+            string filePath,
+            FileRecord record,
+            string content,
+            byte[] rawBytes,
+            string? warning,
+            IReadOnlyList<ChunkRecord>? chunks,
+            IReadOnlyList<SymbolRecord>? symbols,
+            IReadOnlyList<ReferenceRecord>? references,
+            IReadOnlyList<FileIssue>? issues)
+        {
+            return new FullScanFileWorkItem(filePath, record, content, rawBytes, warning, chunks, symbols, references, issues, null);
+        }
+
+        public static FullScanFileWorkItem Failure(string filePath, Exception exception)
+            => new(filePath, null, null, null, null, null, null, null, null, exception);
+    }
+
     private sealed record FoldOnlyRemediation(
         string DegradedReason,
         string RecommendedAction,
@@ -3087,6 +3245,7 @@ public sealed class IndexCommandOptions
     public int? WatchDebounceMs { get; init; }
     public DurationOutputFormat DurationFormat { get; init; } = DurationOutputFormat.Auto;
     public long? MaxFileSizeBytes { get; init; }
+    public int Parallelism { get; init; } = IndexCommandRunner.DefaultIndexParallelism();
 }
 
 public sealed class BackfillFoldCommandOptions

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -256,6 +256,40 @@ public class IndexCommandRunnerTests
         }
     }
 
+    [Fact]
+    public void ParseArgs_ParallelismFlag_ParsesPositiveValue()
+    {
+        var options = IndexCommandRunner.ParseArgs([".", "--parallelism", "3"]);
+
+        Assert.Equal(3, options.Parallelism);
+    }
+
+    [Fact]
+    public void ParseArgs_ParallelismInlineFlag_ParsesPositiveValue()
+    {
+        var options = IndexCommandRunner.ParseArgs([".", "--parallelism=4"]);
+
+        Assert.Equal(4, options.Parallelism);
+    }
+
+    [Fact]
+    public void ParseArgs_IndexParallelismEnvironment_ProvidesDefault()
+    {
+        var original = Environment.GetEnvironmentVariable(IndexCommandRunner.IndexParallelismEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(IndexCommandRunner.IndexParallelismEnvironmentVariable, "2");
+
+            var options = IndexCommandRunner.ParseArgs(["."]);
+
+            Assert.Equal(2, options.Parallelism);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(IndexCommandRunner.IndexParallelismEnvironmentVariable, original);
+        }
+    }
+
     [Theory]
     [InlineData("--duration-format", "auto", DurationOutputFormat.Auto)]
     [InlineData("--duration-format", "seconds", DurationOutputFormat.Seconds)]


### PR DESCRIPTION
## Summary
- Parallelize fresh/rebuild full-scan extraction with bounded workers while preserving a single SQLite writer.
- Add --parallelism and CDIDX_INDEX_PARALLELISM for tuning worker count.
- Update CLI help, docs, tests, and changelog fragment.

Fixes #1842

## Documentation and changelog
- Updated README.md, USER_GUIDE.md, and DEVELOPER_GUIDE.md.
- Added changelog fragment: changelog.d/unreleased/1842.changed.md.

## Validation
- dotnet build CodeIndex.sln
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~IndexCommandRunnerTests.ParseArgs_Parallelism
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~CliFlagSchemaTests
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index tools/CodeIndex.TestTelemetry --db /private/tmp/cdidx-issue1842-merge-smoke.db --parallelism 2 --json --force
- dotnet run --project tools/CodeIndex.Changelog -- check

## Review
- Internal adversarial review: No blocking/actionable issues found.
- codex exec adversarial review attempt was blocked by usage limit before producing review output.

## Follow-up candidates
- None.

## Notes
- A broad IndexCommandRunnerTests filter was stopped after running too long in this shared machine; narrower parser and schema tests passed.
- Post-commit local index refresh with --commits HEAD was stopped because it appeared to be waiting on the shared index lock.