### PR TITLE
Fix fold readiness after extractor contract changes

### DIFF
--- a/changelog.d/unreleased/2064.fixed.md
+++ b/changelog.d/unreleased/2064.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2064
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Partial reindex no longer restamps folded-name readiness after symbol extractor contract changes (#2064)** — `cdidx` now stores per-language symbol extractor contract versions with FoldReady metadata, so partial `--files` / `--commits` updates leave folded exact-match trust degraded until a full rebuild refreshes untouched legacy rows.
+
+## 日本語
+
+- **シンボル抽出器の契約変更後に partial reindex が folded-name readiness を再 stamp しないようにしました (#2064)** — `cdidx` は FoldReady metadata と合わせて言語別の symbol extractor contract version を保存するため、partial `--files` / `--commits` 更新では未更新の legacy 行が full rebuild で再生成されるまで folded exact-match trust を縮退させます。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -367,6 +367,7 @@ public static class IndexCommandRunner
         // partial update で FoldReady を restamp しない。
         var priorFoldVersion = db.GetMetaString("fold_key_version");
         var priorFoldFingerprint = db.GetMetaString("fold_key_fingerprint");
+        var priorSymbolExtractorVersionsMatchCurrent = new DbWriter(db).SymbolExtractorVersionsMatchCurrent();
         var priorCSharpSymbolNameContractVersion = db.GetMetaString(DbContext.CSharpSymbolNameContractVersionMetaKey);
         var priorMetadataTargetCsharp = db.GetMetaString(DbContext.GetMetadataTargetVersionMetaKey("csharp"));
         var priorSqlGraphContractVersion = db.GetMetaString(DbContext.SqlGraphContractVersionMetaKey);
@@ -407,8 +408,8 @@ public static class IndexCommandRunner
         var projectRoot = Path.GetFullPath(options.ProjectPath);
 
         initialExitCode = isUpdateMode
-            ? RunUpdateMode(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorReadiness, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd, indexCancellation.Token)
-            : RunFullScan(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorFoldVersion, priorFoldFingerprint, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd, indexCancellation.Token);
+            ? RunUpdateMode(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorReadiness, priorFoldVersion, priorFoldFingerprint, priorSymbolExtractorVersionsMatchCurrent, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd, indexCancellation.Token)
+            : RunFullScan(writer, indexer, projectRoot, resolvedDbPath, options, stopwatch, spinnerFrames, jsonOptions, priorFoldVersion, priorFoldFingerprint, priorSymbolExtractorVersionsMatchCurrent, priorCSharpSymbolNameContractVersion, priorMetadataTargetCsharp, priorSqlGraphContractVersion, priorHotspotFamilyVersions, priorHotspotFamilyMarkerFingerprints, currentHotspotFamilyMarkerFingerprints, priorIndexedProjectRoot, priorIndexedHeadCommit, currentHeadCommit, initialCwd, indexCancellation.Token);
             }
         }
         catch (IndexInterruptedException ex)
@@ -915,6 +916,7 @@ public static class IndexCommandRunner
         int priorReadiness,
         string? priorFoldVersion,
         string? priorFoldFingerprint,
+        bool priorSymbolExtractorVersionsMatchCurrent,
         string? priorCSharpSymbolNameContractVersion,
         string? priorMetadataTargetCsharp,
         string? priorSqlGraphContractVersion,
@@ -1030,6 +1032,7 @@ public static class IndexCommandRunner
                 jsonOptions,
                 priorFoldVersion,
                 priorFoldFingerprint,
+                priorSymbolExtractorVersionsMatchCurrent,
                 priorCSharpSymbolNameContractVersion,
                 priorMetadataTargetCsharp,
                 priorSqlGraphContractVersion,
@@ -1455,7 +1458,8 @@ public static class IndexCommandRunner
         var foldReadyAfter = !readinessDemoted
             && (priorReadiness & DbContext.FoldReadyFlag) != 0
             && priorFoldVersion == currentFoldVersion
-            && priorFoldFingerprint == currentFoldFingerprint;
+            && priorFoldFingerprint == currentFoldFingerprint
+            && priorSymbolExtractorVersionsMatchCurrent;
         string? foldReadyReasonAfter = foldReadyAfter
             ? null
             : GetFoldReadyReason(
@@ -1527,7 +1531,8 @@ public static class IndexCommandRunner
             // fold_ready=false のまま残す。
             if ((priorReadiness & DbContext.FoldReadyFlag) != 0
                 && priorFoldVersion == currentFoldVersion
-                && priorFoldFingerprint == currentFoldFingerprint)
+                && priorFoldFingerprint == currentFoldFingerprint
+                && priorSymbolExtractorVersionsMatchCurrent)
             {
                 // MarkFoldReady re-verifies inside BEGIN IMMEDIATE; a concurrent NULL-folded
                 // insert during this restamp window leaves foldReadyAfter=false. Issue #1535.
@@ -2033,6 +2038,7 @@ public static class IndexCommandRunner
         JsonSerializerOptions jsonOptions,
         string? priorFoldVersion,
         string? priorFoldFingerprint,
+        bool priorSymbolExtractorVersionsMatchCurrent,
         string? priorCSharpSymbolNameContractVersion,
         string? priorMetadataTargetCsharp,
         string? priorSqlGraphContractVersion,
@@ -2578,13 +2584,14 @@ public static class IndexCommandRunner
             // guarantee 100% backfill on a legacy DB).
             // fold は実検証が通ったときだけ stamp。legacy DB で skip された行は NULL のため、
             // 黙って stamp すると reader が fold 経路で legacy 行を見逃す。codex #86 レビュー。
-            var backfillReady = writer.AllFoldedColumnsBackfilled();
+            var backfillReady = writer.AllFoldedColumnsBackfilled(requireCurrentSymbolExtractorVersions: skipped != 0);
             var currentFoldVersion = NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture);
             var currentFoldFingerprint = NameFold.Fingerprint();
             var foldVersionMatchesCurrent = priorFoldVersion == currentFoldVersion;
             var foldFingerprintMatchesCurrent = priorFoldFingerprint == currentFoldFingerprint;
             var canRestampExistingFoldTrust = foldVersionMatchesCurrent
-                && foldFingerprintMatchesCurrent;
+                && foldFingerprintMatchesCurrent
+                && priorSymbolExtractorVersionsMatchCurrent;
             // A normal `index .` run still skips unchanged files. If the prior fold metadata
             // is stale, those skipped rows keep the old physical folded keys, so stamping the
             // NEW metadata for the whole DB would silently misadvertise trust. Only stamp when
@@ -2603,7 +2610,7 @@ public static class IndexCommandRunner
                 // Issue #1535.
                 // BEGIN IMMEDIATE 内で再検証するため、concurrent writer による NULL 差し込みで
                 // stamp は失敗し、silent な fold-trust 誤広告ではなく legacy 理由に降格する。Issue #1535。
-                foldReadyAfter = writer.MarkFoldReady();
+                foldReadyAfter = writer.MarkFoldReady(stampCurrentSymbolExtractorVersions: skipped == 0);
                 if (!foldReadyAfter)
                 {
                     backfillReady = false;

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -12,6 +12,7 @@ public class DbContext : IDisposable
 {
     public const int DefaultWalAutocheckpointPages = 1000;
     public const string DefaultSynchronousMode = "NORMAL";
+    public const string SymbolExtractorVersionMetaPrefix = "symbol_extractor_version_";
 
     private static readonly string[] RequiredCodeIndexTables =
     [
@@ -27,6 +28,9 @@ public class DbContext : IDisposable
 
     public SqliteConnection Connection => _connection;
     public bool IsReadOnly => _isReadOnly;
+
+    public static string GetSymbolExtractorVersionMetaKey(string lang)
+        => SymbolExtractorVersionMetaPrefix + lang;
 
     /// <summary>
     /// Connection-scoped schema cache. Created lazily so a `DbContext` that

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -337,6 +337,26 @@ public class DbWriter
         return cmd.ExecuteScalar() != null;
     }
 
+    public IReadOnlyList<string> GetIndexedLanguages()
+    {
+        var languages = new List<string>();
+        if (!TableExists("files"))
+            return languages;
+
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT DISTINCT f.lang
+            FROM files f
+            WHERE f.lang IS NOT NULL
+              AND f.lang <> ''
+              AND EXISTS (SELECT 1 FROM symbols s WHERE s.file_id = f.id)
+            ORDER BY f.lang";
+        using var reader = cmd.ExecuteTrackedReader();
+        while (reader.TrackedRead())
+            languages.Add(reader.GetString(0));
+        return languages;
+    }
+
     /// <summary>
     /// Clean up existing file data (FTS, chunks, symbols) before re-indexing.
     /// 再インデックス前に既存ファイルデータ（FTS、チャンク、シンボル）を削除する。
@@ -1119,13 +1139,16 @@ public class DbWriter
     /// fold_ready が嘘になるのを防ぐ。Issue #1535。
     /// </summary>
     /// <returns>True when the bit was actually stamped; false when re-verification failed.</returns>
-    public bool MarkFoldReady()
+    public bool MarkFoldReady(bool stampCurrentSymbolExtractorVersions = false)
     {
         bool ownTransaction = !IsInTransaction();
         if (ownTransaction)
             Execute("BEGIN IMMEDIATE");
         try
         {
+            if (stampCurrentSymbolExtractorVersions)
+                StampSymbolExtractorVersions();
+
             if (!AllFoldedColumnsBackfilled())
             {
                 if (ownTransaction)
@@ -1155,6 +1178,7 @@ public class DbWriter
 
             SetMeta("fold_key_version", NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture));
             SetMeta("fold_key_fingerprint", NameFold.Fingerprint());
+            StampSymbolExtractorVersions();
 
             if (ownTransaction)
             {
@@ -1170,6 +1194,16 @@ public class DbWriter
                 try { Execute("ROLLBACK"); } catch { /* best effort */ }
             }
             throw;
+        }
+    }
+
+    public void StampSymbolExtractorVersions()
+    {
+        foreach (var lang in GetIndexedLanguages())
+        {
+            SetMeta(
+                DbContext.GetSymbolExtractorVersionMetaKey(lang),
+                SymbolExtractor.GetContractVersion(lang).ToString(System.Globalization.CultureInfo.InvariantCulture));
         }
     }
 
@@ -2247,6 +2281,14 @@ public class DbWriter
         cmd.Parameters.AddWithValue("@value", (object?)value ?? DBNull.Value);
         cmd.ExecuteNonQuery();
     }
+
+    private string? GetMetaString(string key)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT value FROM codeindex_meta WHERE key = @key";
+        cmd.Parameters.AddWithValue("@key", key);
+        return cmd.ExecuteScalar() as string;
+    }
     public void ClearReadyFlags()   => Execute("PRAGMA user_version = 0");
 
     private bool TableExists(string name)
@@ -2266,8 +2308,11 @@ public class DbWriter
     /// full scan 成功時でも、incremental で skip された legacy 行が NULL のまま残っていれば
     /// fold-ready にしてはならない。stamp 前にこの実検証を通す。
     /// </summary>
-    public bool AllFoldedColumnsBackfilled()
+    public bool AllFoldedColumnsBackfilled(bool requireCurrentSymbolExtractorVersions = false)
     {
+        if (requireCurrentSymbolExtractorVersions && !SymbolExtractorVersionsMatchCurrent())
+            return false;
+
         using var cmd = _conn.CreateCommand();
         cmd.CommandText = @"
             SELECT
@@ -2277,6 +2322,19 @@ public class DbWriter
         var raw = cmd.ExecuteScalar();
         long missing = raw is long l ? l : (raw is int i ? i : 0);
         return missing == 0;
+    }
+
+    public bool SymbolExtractorVersionsMatchCurrent()
+    {
+        foreach (var lang in GetIndexedLanguages())
+        {
+            var stored = GetMetaString(DbContext.GetSymbolExtractorVersionMetaKey(lang));
+            var current = SymbolExtractor.GetContractVersion(lang).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (stored != current)
+                return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -12,6 +12,17 @@ namespace CodeIndex.Indexer;
 /// </summary>
 public static partial class SymbolExtractor
 {
+    public const int DefaultContractVersion = 1;
+
+    public static int GetContractVersion(string? lang)
+    {
+        return lang switch
+        {
+            null or "" => DefaultContractVersion,
+            _ => DefaultContractVersion,
+        };
+    }
+
     // THREAD-SAFETY: Symbol extraction is intentionally stateless per call. Shared Regex
     // instances and lookup tables are initialized once by the CLR and must be treated as
     // immutable after type initialization; per-file extraction state belongs in local

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.Versioning;
 using System.Runtime.InteropServices;
 using CodeIndex.Cli;
 using CodeIndex.Database;
+using CodeIndex.Indexer;
 using CodeIndex.Models;
 using Microsoft.Data.Sqlite;
 
@@ -5044,6 +5045,59 @@ public class IndexCommandRunnerTests
             // reader treat mixed-state rows as fully fold-ready.
             // version は "0" のままで OK。現在の NameFold.Version に昇格してはいけない。
             Assert.NotEqual(NameFold.Version.ToString(), storedVersion);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_UpdateMode_DoesNotRestampFoldReadyWhenSymbolExtractorVersionMismatches()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            RunGit(projectRoot, "init");
+            RunGit(projectRoot, "config", "user.email", "test@example.com");
+            RunGit(projectRoot, "config", "user.name", "Test");
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { }");
+            File.WriteAllText(Path.Combine(projectRoot, "untouched.cs"), "public class Untouched { }");
+            RunGit(projectRoot, "add", ".");
+            RunGit(projectRoot, "commit", "-m", "init");
+
+            var exitCode1 = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, exitCode1);
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+
+            SqliteConnection.ClearAllPools();
+            using (var conn = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = $"UPDATE codeindex_meta SET value = '0' WHERE key = '{DbContext.GetSymbolExtractorVersionMetaKey("csharp")}'";
+                cmd.ExecuteNonQuery();
+            }
+            SqliteConnection.ClearAllPools();
+
+            var targetFile = Path.Combine(projectRoot, "app.cs");
+            File.WriteAllText(targetFile, "public class App { public void Run() { } }\n");
+            File.SetLastWriteTimeUtc(targetFile, DateTime.UtcNow.AddSeconds(2));
+            var exitCode2 = IndexCommandRunner.Run([projectRoot, "--files", targetFile, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, exitCode2);
+
+            using var verify = new SqliteConnection($"Data Source={dbPath}");
+            verify.Open();
+            using var userVerCmd = verify.CreateCommand();
+            userVerCmd.CommandText = "PRAGMA user_version";
+            var userVersion = (long)userVerCmd.ExecuteScalar()!;
+            Assert.Equal(0, userVersion & DbContext.FoldReadyFlag);
+
+            using var versionCmd = verify.CreateCommand();
+            versionCmd.CommandText = $"SELECT value FROM codeindex_meta WHERE key = '{DbContext.GetSymbolExtractorVersionMetaKey("csharp")}'";
+            var storedVersion = versionCmd.ExecuteScalar() as string;
+            Assert.NotEqual(SymbolExtractor.GetContractVersion("csharp").ToString(System.Globalization.CultureInfo.InvariantCulture), storedVersion);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Track per-language symbol extractor contract versions with folded-name readiness metadata.
- Keep FoldReady degraded after partial reindex when stored extractor versions no longer match current extraction contracts.
- Add regression coverage for partial `--files` reindex with stale C# extractor metadata.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests.Run_UpdateMode_DoesNotRestampFoldReadyWhenSymbolExtractorVersionMismatches|FullyQualifiedName~IndexCommandRunnerTests.Run_UpdateMode_DoesNotRestampFoldReadyWhenFoldKeyVersionMismatches"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests"`
- `dotnet test CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`

## Documentation / Changelog

- Added changelog fragment `changelog.d/unreleased/2064.fixed.md`.
- No README or guide updates were required because this changes internal trust metadata and readiness behavior, not a public command shape.

## Review

- Adversarial review completed for `origin/main..HEAD`: No blocking/actionable issues found.
- `codex exec` review attempt failed due account usage limit, so the review was performed in this Codex session against the same workflow.

Fixes #2064
