### PR TITLE
Fix hardlinked file indexing

### DIFF
--- a/changelog.d/unreleased/1946.fixed.md
+++ b/changelog.d/unreleased/1946.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1946
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Hardlinked files are indexed once (#1946)** - Repository scans now skip second and later paths that resolve to the same hardlinked file, reporting a non-fatal warning instead of duplicating symbols and references.
+
+## 日本語
+
+- **ハードリンクされたファイルを 1 回だけ index するようになりました (#1946)** - リポジトリ走査では同じハードリンク実体を指す 2 つ目以降の path をスキップし、symbol / reference を重複登録する代わりに非 fatal warning として報告します。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -1051,6 +1051,7 @@ public static class IndexCommandRunner
         var errorList = new List<CliJsonMessage>();
         var warningList = new List<CliJsonMessage>();
         var scanErrorKeys = new HashSet<string>(StringComparer.Ordinal);
+        var visitedFileIdentities = new HashSet<FileIndexer.FileIdentity>();
         var readinessDemoted = false;
         var normalizedProjectRoot = Path.GetFullPath(projectRoot);
         var normalizedPriorIndexedProjectRoot = string.IsNullOrWhiteSpace(priorIndexedProjectRoot)
@@ -1349,6 +1350,40 @@ public static class IndexCommandRunner
                             Console.WriteLine($"  [SKIP] {relPath} (unsupported type)");
                             ResumeUpdateSpinnerAfterConsoleWrite();
                         }
+                    }
+                    continue;
+                }
+
+                if (FileIndexer.TryGetFileIdentity(absPath, out var identity) && !visitedFileIdentities.Add(identity))
+                {
+                    var message = "Skipped hardlinked file because the same file content was already indexed from another path.";
+                    warnings++;
+                    warningList.Add(new CliJsonMessage(relPath, message));
+                    if (!options.Json && !options.Quiet)
+                    {
+                        PauseUpdateSpinnerForConsoleWrite();
+                        ConsoleUi.PrintWarning($"{relPath}: {message}");
+                        ResumeUpdateSpinnerAfterConsoleWrite();
+                    }
+
+                    if (!writer.HasFileAtPath(relPath))
+                    {
+                        skipped++;
+                        continue;
+                    }
+
+                    DemoteReadinessOnce();
+                    using var deleteTxn = writer.BeginTransaction();
+                    if (writer.DeleteFileByPath(relPath))
+                    {
+                        WriteProjectRootOnce();
+                        deleteTxn.Commit();
+                        removed++;
+                        ftsMutated = true;
+                    }
+                    else
+                    {
+                        skipped++;
                     }
                     continue;
                 }

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1,7 +1,9 @@
 using System.Security.Cryptography;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using CodeIndex.Models;
+using Microsoft.Win32.SafeHandles;
 
 namespace CodeIndex.Indexer;
 
@@ -30,6 +32,8 @@ public class FileIndexer
     {
         public bool IsFatal => Severity == ScanIssueSeverity.Error;
     }
+
+    internal readonly record struct FileIdentity(ulong DeviceId, ulong Inode);
 
     public readonly record struct ScanFilesResult(
         IReadOnlyList<string> Files,
@@ -1496,11 +1500,12 @@ public class FileIndexer
         var listedDirectories = new HashSet<string>(StringComparer.Ordinal);
         var fullyScannedDirectories = new HashSet<string>(StringComparer.Ordinal);
         var attributePrunedDirectories = new HashSet<string>(StringComparer.Ordinal);
+        var visitedFileIdentities = new HashSet<FileIdentity>();
         var fullyScanned = true;
         var preloadResult = LoadAncestorIgnoreRules(errors, ref fullyScanned);
         if (preloadResult.IgnoreRulesAvailable)
         {
-            ScanDirectory(_projectRoot, files, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, preloadResult.Rules, isProjectRoot: true);
+            ScanDirectory(_projectRoot, files, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, visitedFileIdentities, preloadResult.Rules, isProjectRoot: true);
         }
         return new ScanFilesResult(
             files,
@@ -1523,6 +1528,7 @@ public class FileIndexer
         HashSet<string> listedDirectories,
         HashSet<string> fullyScannedDirectories,
         HashSet<string> attributePrunedDirectories,
+        HashSet<FileIdentity> visitedFileIdentities,
         IgnoreRuleSet activeIgnoreRules,
         bool isProjectRoot = false)
     {
@@ -1536,7 +1542,7 @@ public class FileIndexer
             return true;
         }
 
-        return EnumerateDirectory(dir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, activeIgnoreRules);
+        return EnumerateDirectory(dir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, visitedFileIdentities, activeIgnoreRules);
     }
 
     private bool EnumerateDirectory(
@@ -1549,6 +1555,7 @@ public class FileIndexer
         HashSet<string> listedDirectories,
         HashSet<string> fullyScannedDirectories,
         HashSet<string> attributePrunedDirectories,
+        HashSet<FileIdentity> visitedFileIdentities,
         IgnoreRuleSet inheritedIgnoreRules)
     {
         var fullyScanned = true;
@@ -1605,26 +1612,36 @@ public class FileIndexer
                         continue;
                     }
 
+                    var relativeFile = ToRelativePath(file);
                     // Include files with a known extension/filename or an extensionless recognized shebang
                     // 既知の拡張子・既知ファイル名、または拡張子なしで shebang を認識できるファイルを含める
                     var language = TryDetectLanguage(file);
                     if (language.Status == FileProbeStatus.ProbeFailed)
                     {
-                        var relativePath = ToRelativePath(file);
-                        errors.Add(new ScanError(relativePath, "Could not probe file for indexability/language."));
-                        probeFailedFilePaths.Add(relativePath);
+                        errors.Add(new ScanError(relativeFile, "Could not probe file for indexability/language."));
+                        probeFailedFilePaths.Add(relativeFile);
                         continue;
                     }
 
-                    if (language.Status == FileProbeStatus.Supported)
-                        results.Add(file);
-                    else
+                    if (language.Status != FileProbeStatus.Supported)
                     {
-                        var relativePath = ToRelativePath(file);
-                        nonIndexablePaths.Add(relativePath);
-                        if (HasUnknownExtension(file) && !IsInternalIndexArtifactPath(relativePath))
-                            unknownExtensionFiles.Add(relativePath);
+                        nonIndexablePaths.Add(relativeFile);
+                        if (HasUnknownExtension(file) && !IsInternalIndexArtifactPath(relativeFile))
+                            unknownExtensionFiles.Add(relativeFile);
+                        continue;
                     }
+
+                    if (TryGetFileIdentity(file, out var identity) && !visitedFileIdentities.Add(identity))
+                    {
+                        errors.Add(new ScanError(
+                            relativeFile,
+                            "Skipped hardlinked file because the same file content was already indexed from another path.",
+                            ScanIssueSeverity.Warning));
+                        nonIndexablePaths.Add(relativeFile);
+                        continue;
+                    }
+
+                    results.Add(file);
                 }
             }
 
@@ -1670,7 +1687,7 @@ public class FileIndexer
                     continue;
                 }
 
-                fullyScanned &= ScanDirectory(subDir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, activeIgnoreRules);
+                fullyScanned &= ScanDirectory(subDir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, visitedFileIdentities, activeIgnoreRules);
             }
         }
         catch (UnauthorizedAccessException)
@@ -1690,6 +1707,154 @@ public class FileIndexer
             fullyScannedDirectories.Add(ToRelativePath(dir));
 
         return fullyScanned;
+    }
+
+    internal static bool TryGetFileIdentity(string path, out FileIdentity identity)
+    {
+        identity = default;
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS() && !OperatingSystem.IsWindows())
+            return false;
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+                return TryGetWindowsFileIdentity(path, out identity);
+
+            if (OperatingSystem.IsMacOS())
+            {
+                if (StatMac(path, out var stat) != 0)
+                    return false;
+
+                identity = new FileIdentity((uint)stat.DeviceId, stat.Inode);
+                return true;
+            }
+
+            if (StatLinux(path, out var linuxStat) != 0)
+                return false;
+
+            identity = new FileIdentity(linuxStat.DeviceId, linuxStat.Inode);
+            return true;
+        }
+        catch (DllNotFoundException)
+        {
+            return false;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetWindowsFileIdentity(string path, out FileIdentity identity)
+    {
+        identity = default;
+        using var handle = CreateFile(
+            path,
+            desiredAccess: 0,
+            shareMode: FileShare.ReadWrite | FileShare.Delete,
+            securityAttributes: IntPtr.Zero,
+            creationDisposition: FileMode.Open,
+            flagsAndAttributes: FileAttributes.Normal,
+            templateFile: IntPtr.Zero);
+        if (handle.IsInvalid)
+            return false;
+
+        if (!GetFileInformationByHandle(handle, out var info))
+            return false;
+
+        var fileIndex = ((ulong)info.FileIndexHigh << 32) | info.FileIndexLow;
+        identity = new FileIdentity(info.VolumeSerialNumber, fileIndex);
+        return true;
+    }
+
+    [DllImport("libc", EntryPoint = "stat", SetLastError = true)]
+    private static extern int StatLinux(string path, out LinuxStat stat);
+
+    [DllImport("libc", EntryPoint = "stat", SetLastError = true)]
+    private static extern int StatMac(string path, out MacStat stat);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle CreateFile(
+        string fileName,
+        [MarshalAs(UnmanagedType.U4)] FileAccess desiredAccess,
+        [MarshalAs(UnmanagedType.U4)] FileShare shareMode,
+        IntPtr securityAttributes,
+        [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
+        [MarshalAs(UnmanagedType.U4)] FileAttributes flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetFileInformationByHandle(SafeFileHandle fileHandle, out WindowsFileInformation fileInformation);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WindowsFileInformation
+    {
+        public uint FileAttributes;
+        public System.Runtime.InteropServices.ComTypes.FILETIME CreationTime;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastAccessTime;
+        public System.Runtime.InteropServices.ComTypes.FILETIME LastWriteTime;
+        public uint VolumeSerialNumber;
+        public uint FileSizeHigh;
+        public uint FileSizeLow;
+        public uint NumberOfLinks;
+        public uint FileIndexHigh;
+        public uint FileIndexLow;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LinuxStat
+    {
+        public ulong DeviceId;
+        public ulong Inode;
+        public ulong LinkCount;
+        public uint Mode;
+        public uint Uid;
+        public uint Gid;
+        public int Pad0;
+        public ulong Rdev;
+        public long Size;
+        public long BlockSize;
+        public long Blocks;
+        public long AccessTimeSeconds;
+        public long AccessTimeNanoseconds;
+        public long ModificationTimeSeconds;
+        public long ModificationTimeNanoseconds;
+        public long ChangeTimeSeconds;
+        public long ChangeTimeNanoseconds;
+        public long Unused0;
+        public long Unused1;
+        public long Unused2;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MacStat
+    {
+        public int DeviceId;
+        public ushort Mode;
+        public ushort LinkCount;
+        public ulong Inode;
+        public uint Uid;
+        public uint Gid;
+        public int Rdev;
+        public MacTimespec AccessTime;
+        public MacTimespec ModificationTime;
+        public MacTimespec ChangeTime;
+        public MacTimespec BirthTime;
+        public long Size;
+        public long Blocks;
+        public int BlockSize;
+        public uint Flags;
+        public uint Generation;
+        public int Spare;
+        public long Qspare0;
+        public long Qspare1;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MacTimespec
+    {
+        public long Seconds;
+        public long Nanoseconds;
     }
 
     private static bool HasUnknownExtension(string filePath)

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -14,6 +14,40 @@ namespace CodeIndex.Tests;
 /// </summary>
 public class FileIndexerTests
 {
+    [Fact]
+    public void ScanFilesDetailed_HardlinkedFiles_SkipsDuplicatePathWithWarning()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx-hardlink-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var original = Path.Combine(tempDir, "original.cs");
+            var duplicate = Path.Combine(tempDir, "duplicate.cs");
+            File.WriteAllText(original, "class HardlinkFixture { }\n");
+            CreateHardLink(original, duplicate);
+
+            var result = new FileIndexer(tempDir).ScanFilesDetailed();
+
+            var files = result.Files.Select(Path.GetFileName).OrderBy(name => name, StringComparer.Ordinal).ToList();
+            Assert.Single(files);
+            Assert.Contains(files[0], new[] { "duplicate.cs", "original.cs" });
+            Assert.Contains(result.NonIndexablePaths, path => path is "duplicate.cs" or "original.cs");
+            var warning = Assert.Single(
+                result.Errors,
+                error => error.Severity == FileIndexer.ScanIssueSeverity.Warning
+                    && error.Message.Contains("hardlinked", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(warning.Path, new[] { "duplicate.cs", "original.cs" });
+            Assert.False(result.HadErrors);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
     [Theory]
     [InlineData("test.py", "python")]
     [InlineData("app.js", "javascript")]
@@ -3236,6 +3270,27 @@ public class FileIndexerTests
         process.WaitForExit();
         if (process.ExitCode != 0)
             throw new InvalidOperationException($"mkfifo failed: {stderr.Trim()}");
+    }
+
+    private static void CreateHardLink(string existingPath, string newPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "ln",
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add(existingPath);
+        psi.ArgumentList.Add(newPath);
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start ln / ln の起動に失敗");
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"ln failed: {stderr.Trim()}");
     }
 
     private static string RunGit(string workDir, params string[] args)

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -126,6 +126,44 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_UpdateFiles_HardlinkedTargets_SkipsDuplicatePathWithWarning()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        try
+        {
+            var original = Path.Combine(projectRoot, "original.cs");
+            var duplicate = Path.Combine(projectRoot, "duplicate.cs");
+            File.WriteAllText(original, "public class HardlinkFixture { }\n");
+            CreateHardLink(original, duplicate);
+
+            var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            File.AppendAllText(original, "public class HardlinkFixture2 { }\n");
+            File.SetLastWriteTimeUtc(original, DateTime.UtcNow.AddSeconds(2));
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--files", "original.cs", "duplicate.cs", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.Equal("update", json.GetProperty("mode").GetString());
+            var summary = json.GetProperty("summary");
+            Assert.Equal(1, summary.GetProperty("updated").GetInt32());
+            Assert.Equal(1, summary.GetProperty("warnings").GetInt32());
+            var warning = Assert.Single(json.GetProperty("warnings").EnumerateArray());
+            Assert.Contains("hardlinked", warning.GetProperty("message").GetString(), StringComparison.OrdinalIgnoreCase);
+            Assert.Single(ReadIndexedPaths(Path.Combine(projectRoot, ".cdidx", "codeindex.db")));
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void HandleIndexCancelKeyPress_FirstCancelRequestsCooperativeCancellation_SecondAllowsForceExit()
     {
         using var cts = new CancellationTokenSource();
@@ -6446,6 +6484,27 @@ public class IndexCommandRunnerTests
         process.WaitForExit();
         if (process.ExitCode != 0)
             throw new InvalidOperationException($"mkfifo failed: {stderr.Trim()}");
+    }
+
+    private static void CreateHardLink(string existingPath, string newPath)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "ln",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add(existingPath);
+        psi.ArgumentList.Add(newPath);
+
+        using var process = System.Diagnostics.Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start ln / ln の起動に失敗");
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"ln failed: {stderr.Trim()}");
     }
 
     private static void WriteOversizedAsciiFile(string path)


### PR DESCRIPTION
## Summary

- Detect file identity during full scans and skip duplicate hardlinked paths with a non-fatal warning.
- Apply the same duplicate hardlink guard to `--files` update mode and remove an already-indexed duplicate path when encountered.
- Add hardlink regression coverage for full scan and update-mode paths.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter Run_UpdateFiles_HardlinkedTargets_SkipsDuplicatePathWithWarning`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests|FullyQualifiedName~IndexCommandRunnerTests"`
- `dotnet test CodeIndex.sln -c Release`
- `dotnet build CodeIndex.sln`
- `git diff --check`

## Documentation / Changelog

- Added bilingual changelog fragment: `changelog.d/unreleased/1946.fixed.md`

## Review

- Manual adversarial review found no blocking/actionable issues.
- `codex exec review --uncommitted` was attempted but could not complete because the Codex CLI reported a usage limit.

Fixes #1946
