### PR TITLE
Fix C# indexing stalls on StructuralLineMasker

### DIFF
--- a/changelog.d/unreleased/2300.fixed.md
+++ b/changelog.d/unreleased/2300.fixed.md
@@ -1,0 +1,24 @@
+---
+category: fixed
+issues:
+  - 2300
+  - 2303
+  - 2318
+  - 2328
+  - 2331
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **C# indexing no longer stalls on namespace, class declaration, and line-comment text (#2300, #2303, #2318, #2328, #2331)** — the C# symbol scanner now stops class declaration collection at terminators, skips member-header merging for namespace/import/comment lines, and the C# attribute scanner ignores `//` comment tails before doing cross-line attribute lookahead. Full-scan liveness output also reports files processed by the C# workspace pre-pass.
+
+## 日本語
+
+- **C# indexing が namespace、class 宣言、行コメントの文字列で停滞しなくなりました (#2300, #2303, #2318, #2328, #2331)** — C# symbol scanner は class 宣言収集を終端で止め、namespace/import/comment 行で member-header merge をスキップし、C# 属性 scanner は cross-line 属性 lookahead の前に `//` コメント末尾を無視するようになりました。full-scan の liveness output でも C# workspace pre-pass の処理ファイルを表示します。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -2386,7 +2386,12 @@ public static class IndexCommandRunner
         EnsureIndexingActivityVisible();
         ReportJsonIndexProgressIfNeeded();
         StartJsonHeartbeatIfNeeded();
-        var csharpWorkspace = BuildCSharpStaticInterfaceWorkspaceSymbols(writer, indexer, projectRoot, files);
+        var csharpWorkspace = BuildCSharpStaticInterfaceWorkspaceSymbols(
+            writer,
+            indexer,
+            projectRoot,
+            files,
+            file => currentJsonIndexFile = file);
 
         try
         {
@@ -2949,7 +2954,8 @@ public static class IndexCommandRunner
         DbWriter writer,
         FileIndexer indexer,
         string projectRoot,
-        IEnumerable<string> filePaths)
+        IEnumerable<string> filePaths,
+        Action<string?>? reportCurrentFile = null)
     {
         var pendingSymbols = new List<SymbolRecord>();
         var pendingPaths = new HashSet<string>(StringComparer.Ordinal);
@@ -2971,6 +2977,7 @@ public static class IndexCommandRunner
 
             try
             {
+                reportCurrentFile?.Invoke(relativePath);
                 var (record, content, _, _) = indexer.BuildRecordWithRawBytes(absolutePath);
                 if (record.Lang != "csharp")
                     continue;
@@ -2981,6 +2988,10 @@ public static class IndexCommandRunner
             {
                 // The real indexing pass reports file failures; this pre-pass only supplies
                 // workspace symbols for cross-file static interface member matching.
+            }
+            finally
+            {
+                reportCurrentFile?.Invoke(null);
             }
         }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -3814,6 +3814,9 @@ public static partial class ReferenceExtractor
             for (var ci = 0; ci < line.Length; ci++)
             {
                 var c = line[ci];
+                if (c == '/' && ci + 1 < line.Length && line[ci + 1] == '/')
+                    break;
+
                 if (char.IsWhiteSpace(c))
                     continue;
 
@@ -3998,6 +4001,9 @@ public static partial class ReferenceExtractor
             while (ci < line.Length)
             {
                 var c = line[ci];
+                if (c == '/' && ci + 1 < line.Length && line[ci + 1] == '/' && parenDepth == 0)
+                    break;
+
                 if (c == '(')
                 {
                     parenDepth++;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -1772,6 +1772,9 @@ public static partial class SymbolExtractor
     private static CSharpPropertyMatchCandidate BuildCSharpPropertyMatchLine(string[] lines, string[] csharpMatchLines, int startLineIndex)
     {
         var matchLine = csharpMatchLines[startLineIndex];
+        if (IsCSharpNonMemberHeaderLine(matchLine))
+            return new CSharpPropertyMatchCandidate(matchLine, startLineIndex, startLineIndex);
+
         var isPropertyHeaderPrefix = CSharpPropertyHeaderPrefixRegex.IsMatch(matchLine);
         var isMethodHeaderPrefix = CSharpMethodHeaderPrefixRegex.IsMatch(matchLine);
         if (string.IsNullOrWhiteSpace(matchLine)
@@ -1895,6 +1898,16 @@ public static partial class SymbolExtractor
         }
 
         return new CSharpPropertyMatchCandidate(matchLine, startLineIndex, startLineIndex);
+    }
+
+    private static bool IsCSharpNonMemberHeaderLine(string line)
+    {
+        var trimmed = line.TrimStart();
+        return trimmed.StartsWith("namespace ", StringComparison.Ordinal)
+            || trimmed.StartsWith("using ", StringComparison.Ordinal)
+            || trimmed.StartsWith("global using ", StringComparison.Ordinal)
+            || trimmed.StartsWith("extern alias ", StringComparison.Ordinal)
+            || trimmed.StartsWith("//", StringComparison.Ordinal);
     }
 
     private static CSharpPropertyMatchCandidate ContinueConfirmedCSharpPropertyMatch(
@@ -2634,21 +2647,21 @@ public static partial class SymbolExtractor
         out int lastLineIndex,
         out int? lastLineExclusiveEndColumn)
     {
-        var lexState = new CSharpLexState();
         var parenDepth = 0;
         var bracketDepth = 0;
 
         var limit = Math.Min(lines.Length, startLineIndex + CSharpTypeHeaderLookaheadLineLimit);
         for (int i = startLineIndex; i < limit; i++)
         {
-            var lexedLine = LexCSharpLine(lines[i], lexState);
-            lexState = lexedLine.EndState;
-            var sanitizedLine = lexedLine.SanitizedLine;
+            var sanitizedLine = lines[i];
             var fromColumn = i == startLineIndex ? startColumn : 0;
 
             for (int column = fromColumn; column < sanitizedLine.Length; column++)
             {
                 var ch = sanitizedLine[column];
+                if (ch == '/' && column + 1 < sanitizedLine.Length && sanitizedLine[column + 1] == '/')
+                    break;
+
                 switch (ch)
                 {
                     case '(':

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2167,6 +2167,9 @@ public static partial class SymbolExtractor
                 continue;
 
             var line = lines[i];
+            if (lang == "csharp" && line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+                continue;
+
             if (lang == "go"
                 && TryHandleGoBlockLine(fileId, line, i, symbols, ref goImportBlock))
             {
@@ -7232,7 +7235,11 @@ public static partial class SymbolExtractor
             {
                 parameterOpenIndex = FindRecordPrimaryComponentListStart(declaration, 0);
                 if (parameterOpenIndex < 0)
+                {
+                    if (FindRecordDeclarationTerminatorIndex(declaration, 0) >= 0)
+                        return declaration;
                     continue;
+                }
             }
 
             if (parameterCloseIndex < 0)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -168,6 +168,27 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CsharpLineCommentAttributeCandidate_DoesNotScanToEndOfFile()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("class Service");
+        builder.AppendLine("{");
+        builder.AppendLine("    void Run()");
+        builder.AppendLine("    {");
+        for (var i = 0; i < 1000; i++)
+            builder.AppendLine($"        Call{i}(); // argument, [not an attribute candidate");
+        builder.AppendLine("        ActualCall();");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+
+        var content = builder.ToString();
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        Assert.Contains(references, reference => reference.SymbolName == "ActualCall");
+    }
+
+    [Fact]
     public void Extract_TypeScriptGenericConditionalConstraint_EmitsBranchTypeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -12,6 +12,25 @@ namespace CodeIndex.Tests;
 /// </summary>
 public class SymbolExtractorTests
 {
+    [Fact]
+    public void Extract_CsharpFileScopedNamespace_DoesNotEnterMemberHeaderMerge()
+    {
+        const string content = """
+            namespace CodeIndex.Indexer;
+
+            internal static class StructuralLineMasker
+            {
+                internal static string[] MaskLines(string? lang, string[] originalLines)
+                    => originalLines;
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "namespace" && symbol.Name == "CodeIndex.Indexer");
+        Assert.Contains(symbols, symbol => symbol.Kind == "class" && symbol.Name == "StructuralLineMasker");
+    }
+
     [Theory]
     [InlineData("javascript")]
     [InlineData("typescript")]


### PR DESCRIPTION
## Summary

- Fix C# symbol extraction paths that could scan excessive text around file-scoped namespaces, non-primary-constructor class declarations, and line comments.
- Stop C# attribute lookahead at `//` comment tails so comment text cannot drive cross-line scans.
- Show the file being processed during the C# workspace pre-pass when JSON full-scan liveness output is active.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~SymbolExtractorTests|FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CsharpFileScopedNamespace_DoesNotEnterMemberHeaderMerge|FullyQualifiedName~ReferenceExtractorTests.Extract_CsharpLineCommentAttributeCandidate_DoesNotScanToEndOfFile"`
- `dotnet test CodeIndex.sln -c Release`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Indexer/References/Support/StructuralLineMasker.cs --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: No blocking/actionable issues found.

## Changelog

- `changelog.d/unreleased/2300.fixed.md`

## Follow-up

- None.

Fixes #2300
Fixes #2303
Fixes #2318
Fixes #2328
Fixes #2331
