### PR TITLE
Reuse prepared commands in DbReader C# lookups

### DIFF
--- a/changelog.d/unreleased/2208.fixed.md
+++ b/changelog.d/unreleased/2208.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2208
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbReader.CSharpResolution.cs
+  - tests/CodeIndex.Tests/PreparedCommandCacheTests.cs
+---
+
+## English
+
+- **DbReader now reuses prepared commands for C# reference-resolution lookups (#2208)** — reader instances created from a shared `DbContext` now lease cached prepared commands for repeated C# symbol/reference resolution queries instead of recreating the same SQLite commands in tight loops.
+
+## 日本語
+
+- **DbReader が C# 参照解決 lookup で prepared command を再利用するようになりました (#2208)** — 共有 `DbContext` から作成された reader は、タイトなループ内で同じ SQLite command を毎回作り直さず、C# の symbol/reference 解決クエリで cached prepared command を借用します。

--- a/src/CodeIndex/Database/DbReader.CSharpResolution.cs
+++ b/src/CodeIndex/Database/DbReader.CSharpResolution.cs
@@ -175,38 +175,45 @@ public partial class DbReader
 
         var lastDot = qualifiedName.LastIndexOf('.');
         var shortName = lastDot >= 0 ? qualifiedName[(lastDot + 1)..] : qualifiedName;
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT f.path, s.kind, s.name, s.container_name, s.container_qualified_name, s.visibility, s.signature, s.body_start_line, s.body_end_line, s.start_line, s.end_line
             FROM symbols s
             JOIN files f ON s.file_id = f.id
             WHERE f.lang = 'csharp'
               AND s.name = @symbolName COLLATE NOCASE
               AND s.kind IN ('class', 'struct', 'interface')";
-        cmd.Parameters.AddWithValue("@symbolName", shortName);
+        var cmd = RentCommand(sql, static c => c.Parameters.Add("@symbolName", SqliteType.Text));
+        SetParameter(cmd, "@symbolName", shortName);
 
         CSharpContainingTypeScope? resolved = null;
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        try
         {
-            var scope = CreateCSharpContainingTypeScope(
-                reader.GetString(0),
-                GetNullableString(reader, 1),
-                GetNullableString(reader, 2),
-                GetNullableString(reader, 3),
-                GetNullableString(reader, 4),
-                GetNullableString(reader, 5),
-                GetNullableString(reader, 6),
-                reader.IsDBNull(7) ? null : reader.GetInt32(7),
-                reader.IsDBNull(8) ? null : reader.GetInt32(8),
-                reader.IsDBNull(9) ? null : reader.GetInt32(9),
-                reader.IsDBNull(10) ? null : reader.GetInt32(10));
-            if (scope == null)
-                continue;
-            if (!string.Equals(scope.QualifiedName, qualifiedName, StringComparison.Ordinal))
-                continue;
-            resolved = scope;
-            break;
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
+            {
+                var scope = CreateCSharpContainingTypeScope(
+                    reader.GetString(0),
+                    GetNullableString(reader, 1),
+                    GetNullableString(reader, 2),
+                    GetNullableString(reader, 3),
+                    GetNullableString(reader, 4),
+                    GetNullableString(reader, 5),
+                    GetNullableString(reader, 6),
+                    reader.IsDBNull(7) ? null : reader.GetInt32(7),
+                    reader.IsDBNull(8) ? null : reader.GetInt32(8),
+                    reader.IsDBNull(9) ? null : reader.GetInt32(9),
+                    reader.IsDBNull(10) ? null : reader.GetInt32(10));
+                if (scope == null)
+                    continue;
+                if (!string.Equals(scope.QualifiedName, qualifiedName, StringComparison.Ordinal))
+                    continue;
+                resolved = scope;
+                break;
+            }
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         _csharpContainingTypeScopeByQualifiedName[qualifiedName] = resolved;
@@ -407,8 +414,7 @@ public partial class DbReader
 
     private List<CSharpUsingNamespaceScope> LoadCSharpUsingNamespaceScopes(string path)
     {
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT s.kind, s.line, s.body_start_line, s.body_end_line, s.end_line, s.signature, f.lines
             FROM symbols s
             JOIN files f ON s.file_id = f.id
@@ -416,36 +422,44 @@ public partial class DbReader
               AND f.lang = 'csharp'
               AND (s.kind = 'import' OR s.kind = 'namespace')
             ORDER BY s.line";
-        cmd.Parameters.AddWithValue("@path", path);
+        var cmd = RentCommand(sql, static c => c.Parameters.Add("@path", SqliteType.Text));
+        SetParameter(cmd, "@path", path);
 
         var namespaceScopes = new List<(int StartLine, int EndLine)>();
         var imports = new List<(int Line, string Signature)>();
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        try
         {
-            var kind = reader.GetString(0);
-            var line = reader.GetInt32(1);
-            if (kind == "namespace")
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
             {
-                var startLine = reader.IsDBNull(2) ? line : reader.GetInt32(2);
-                var endLine = reader.IsDBNull(3)
-                    ? (reader.IsDBNull(4) ? line : reader.GetInt32(4))
-                    : reader.GetInt32(3);
-                var signature = GetNullableString(reader, 5);
-                if (!string.IsNullOrWhiteSpace(signature)
-                    && signature.TrimEnd().EndsWith(';')
-                    && !reader.IsDBNull(6))
+                var kind = reader.GetString(0);
+                var line = reader.GetInt32(1);
+                if (kind == "namespace")
                 {
-                    endLine = Math.Max(endLine, reader.GetInt32(6));
+                    var startLine = reader.IsDBNull(2) ? line : reader.GetInt32(2);
+                    var endLine = reader.IsDBNull(3)
+                        ? (reader.IsDBNull(4) ? line : reader.GetInt32(4))
+                        : reader.GetInt32(3);
+                    var signature = GetNullableString(reader, 5);
+                    if (!string.IsNullOrWhiteSpace(signature)
+                        && signature.TrimEnd().EndsWith(';')
+                        && !reader.IsDBNull(6))
+                    {
+                        endLine = Math.Max(endLine, reader.GetInt32(6));
+                    }
+
+                    if (startLine > 0 && endLine >= startLine)
+                        namespaceScopes.Add((startLine, endLine));
+                    continue;
                 }
 
-                if (startLine > 0 && endLine >= startLine)
-                    namespaceScopes.Add((startLine, endLine));
-                continue;
+                if (!reader.IsDBNull(5))
+                    imports.Add((line, reader.GetString(5)));
             }
-
-            if (!reader.IsDBNull(5))
-                imports.Add((line, reader.GetString(5)));
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         var scopes = new List<CSharpUsingNamespaceScope>();
@@ -814,8 +828,7 @@ public partial class DbReader
 
     private List<CSharpUsingStaticScope> LoadCSharpUsingStaticScopes(string path)
     {
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT s.kind, s.line, s.body_start_line, s.body_end_line, s.end_line, s.signature, f.lines
             FROM symbols s
             JOIN files f ON s.file_id = f.id
@@ -823,36 +836,44 @@ public partial class DbReader
               AND f.lang = 'csharp'
               AND (s.kind = 'import' OR s.kind = 'namespace')
             ORDER BY s.line";
-        cmd.Parameters.AddWithValue("@path", path);
+        var cmd = RentCommand(sql, static c => c.Parameters.Add("@path", SqliteType.Text));
+        SetParameter(cmd, "@path", path);
 
         var namespaceScopes = new List<(int StartLine, int EndLine)>();
         var imports = new List<(int Line, string Signature)>();
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        try
         {
-            var kind = reader.GetString(0);
-            var line = reader.GetInt32(1);
-            if (kind == "namespace")
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
             {
-                var startLine = reader.IsDBNull(2) ? line : reader.GetInt32(2);
-                var endLine = reader.IsDBNull(3)
-                    ? (reader.IsDBNull(4) ? line : reader.GetInt32(4))
-                    : reader.GetInt32(3);
-                var signature = GetNullableString(reader, 5);
-                if (!string.IsNullOrWhiteSpace(signature)
-                    && signature.TrimEnd().EndsWith(';')
-                    && !reader.IsDBNull(6))
+                var kind = reader.GetString(0);
+                var line = reader.GetInt32(1);
+                if (kind == "namespace")
                 {
-                    endLine = Math.Max(endLine, reader.GetInt32(6));
+                    var startLine = reader.IsDBNull(2) ? line : reader.GetInt32(2);
+                    var endLine = reader.IsDBNull(3)
+                        ? (reader.IsDBNull(4) ? line : reader.GetInt32(4))
+                        : reader.GetInt32(3);
+                    var signature = GetNullableString(reader, 5);
+                    if (!string.IsNullOrWhiteSpace(signature)
+                        && signature.TrimEnd().EndsWith(';')
+                        && !reader.IsDBNull(6))
+                    {
+                        endLine = Math.Max(endLine, reader.GetInt32(6));
+                    }
+
+                    if (startLine > 0 && endLine >= startLine)
+                        namespaceScopes.Add((startLine, endLine));
+                    continue;
                 }
 
-                if (startLine > 0 && endLine >= startLine)
-                    namespaceScopes.Add((startLine, endLine));
-                continue;
+                if (!reader.IsDBNull(5))
+                    imports.Add((line, reader.GetString(5)));
             }
-
-            if (!reader.IsDBNull(5))
-                imports.Add((line, reader.GetString(5)));
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         var scopes = new List<CSharpUsingStaticScope>();
@@ -973,8 +994,7 @@ public partial class DbReader
         if (_csharpGlobalUsingStaticTargets != null)
             return _csharpGlobalUsingStaticTargets;
 
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT s.signature
             FROM symbols s
             JOIN files f ON s.file_id = f.id
@@ -982,16 +1002,24 @@ public partial class DbReader
               AND s.kind = 'import'";
 
         var targets = new HashSet<string>(StringComparer.Ordinal);
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        var cmd = RentCommand(sql, static _ => { });
+        try
         {
-            if (reader.IsDBNull(0))
-                continue;
-            if (TryParseCSharpUsingStaticImport(reader.GetString(0), out var target, out var isGlobal)
-                && isGlobal)
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
             {
-                targets.Add(target!);
+                if (reader.IsDBNull(0))
+                    continue;
+                if (TryParseCSharpUsingStaticImport(reader.GetString(0), out var target, out var isGlobal)
+                    && isGlobal)
+                {
+                    targets.Add(target!);
+                }
             }
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         _csharpGlobalUsingStaticTargets = targets;
@@ -1003,8 +1031,7 @@ public partial class DbReader
         if (_csharpGlobalUsingAliasesByName != null)
             return _csharpGlobalUsingAliasesByName;
 
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT s.signature
             FROM symbols s
             JOIN files f ON s.file_id = f.id
@@ -1012,22 +1039,30 @@ public partial class DbReader
               AND s.kind = 'import'";
 
         var aliases = new Dictionary<string, CSharpUsingAliasScope>(StringComparer.Ordinal);
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        var cmd = RentCommand(sql, static _ => { });
+        try
         {
-            if (reader.IsDBNull(0))
-                continue;
-            if (TryParseCSharpUsingAliasImport(reader.GetString(0), out var aliasName, out var targetQualifiedName, out var isGlobal)
-                && isGlobal)
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
             {
-                aliases[aliasName!] = new CSharpUsingAliasScope(
-                    aliasName!,
-                    targetQualifiedName!,
-                    0,
-                    1,
-                    int.MaxValue,
-                    IsKnownCSharpTypeQualifiedName(targetQualifiedName!));
+                if (reader.IsDBNull(0))
+                    continue;
+                if (TryParseCSharpUsingAliasImport(reader.GetString(0), out var aliasName, out var targetQualifiedName, out var isGlobal)
+                    && isGlobal)
+                {
+                    aliases[aliasName!] = new CSharpUsingAliasScope(
+                        aliasName!,
+                        targetQualifiedName!,
+                        0,
+                        1,
+                        int.MaxValue,
+                        IsKnownCSharpTypeQualifiedName(targetQualifiedName!));
+                }
             }
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         _csharpGlobalUsingAliasesByName = aliases;
@@ -1039,8 +1074,7 @@ public partial class DbReader
         if (_csharpGlobalUsingNamespaces != null)
             return _csharpGlobalUsingNamespaces;
 
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT s.signature
             FROM symbols s
             JOIN files f ON s.file_id = f.id
@@ -1048,16 +1082,24 @@ public partial class DbReader
               AND s.kind = 'import'";
 
         var namespaces = new HashSet<string>(StringComparer.Ordinal);
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        var cmd = RentCommand(sql, static _ => { });
+        try
         {
-            if (reader.IsDBNull(0))
-                continue;
-            if (TryParseCSharpUsingNamespaceImport(reader.GetString(0), out var target, out var isGlobal)
-                && isGlobal)
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
             {
-                namespaces.Add(target!);
+                if (reader.IsDBNull(0))
+                    continue;
+                if (TryParseCSharpUsingNamespaceImport(reader.GetString(0), out var target, out var isGlobal)
+                    && isGlobal)
+                {
+                    namespaces.Add(target!);
+                }
             }
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         _csharpGlobalUsingNamespaces = namespaces;
@@ -1570,38 +1612,45 @@ public partial class DbReader
         if (_csharpTypeNamespacesByName.TryGetValue(symbolName, out var cached))
             return cached;
 
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT DISTINCT s.container_kind, s.container_name, s.container_qualified_name, f.path, s.visibility, s.signature
             FROM symbols s
             JOIN files f ON s.file_id = f.id
             WHERE f.lang = 'csharp'
               AND s.name = @symbolName COLLATE NOCASE
               AND s.kind IN ('class', 'struct', 'interface', 'enum', 'delegate')";
-        cmd.Parameters.AddWithValue("@symbolName", symbolName);
+        var cmd = RentCommand(sql, static c => c.Parameters.Add("@symbolName", SqliteType.Text));
+        SetParameter(cmd, "@symbolName", symbolName);
 
         var namespaces = new List<CSharpTypeNamespaceCandidate>();
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        try
         {
-            var containerKind = GetNullableString(reader, 0);
-            var path = reader.GetString(3);
-            var visibility = GetNullableString(reader, 4);
-            var signature = GetNullableString(reader, 5);
-            var isFileLocal = string.Equals(visibility, "file", StringComparison.OrdinalIgnoreCase)
-                || (!string.IsNullOrWhiteSpace(signature) && signature.Contains("file ", StringComparison.Ordinal));
-            if (string.Equals(containerKind, "namespace", StringComparison.Ordinal))
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
             {
-                var qualifiedNamespace = GetNullableString(reader, 2);
-                var fallbackNamespace = GetNullableString(reader, 1);
-                var namespaceName = NormalizeDbCSharpQualifiedName(qualifiedNamespace ?? fallbackNamespace ?? string.Empty)
-                    ?? string.Empty;
-                namespaces.Add(new CSharpTypeNamespaceCandidate(namespaceName, path, isFileLocal));
-                continue;
-            }
+                var containerKind = GetNullableString(reader, 0);
+                var path = reader.GetString(3);
+                var visibility = GetNullableString(reader, 4);
+                var signature = GetNullableString(reader, 5);
+                var isFileLocal = string.Equals(visibility, "file", StringComparison.OrdinalIgnoreCase)
+                    || (!string.IsNullOrWhiteSpace(signature) && signature.Contains("file ", StringComparison.Ordinal));
+                if (string.Equals(containerKind, "namespace", StringComparison.Ordinal))
+                {
+                    var qualifiedNamespace = GetNullableString(reader, 2);
+                    var fallbackNamespace = GetNullableString(reader, 1);
+                    var namespaceName = NormalizeDbCSharpQualifiedName(qualifiedNamespace ?? fallbackNamespace ?? string.Empty)
+                        ?? string.Empty;
+                    namespaces.Add(new CSharpTypeNamespaceCandidate(namespaceName, path, isFileLocal));
+                    continue;
+                }
 
-            if (containerKind == null)
-                namespaces.Add(new CSharpTypeNamespaceCandidate(string.Empty, path, isFileLocal));
+                if (containerKind == null)
+                    namespaces.Add(new CSharpTypeNamespaceCandidate(string.Empty, path, isFileLocal));
+            }
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         _csharpTypeNamespacesByName[symbolName] = namespaces;
@@ -1613,33 +1662,40 @@ public partial class DbReader
         if (_csharpTypeContainingTypesByName.TryGetValue(symbolName, out var cached))
             return cached;
 
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT DISTINCT s.container_kind, s.container_name, s.container_qualified_name, s.visibility, s.signature
             FROM symbols s
             JOIN files f ON s.file_id = f.id
             WHERE f.lang = 'csharp'
               AND s.name = @symbolName COLLATE NOCASE
               AND s.kind IN ('class', 'struct', 'interface', 'enum', 'delegate')";
-        cmd.Parameters.AddWithValue("@symbolName", symbolName);
+        var cmd = RentCommand(sql, static c => c.Parameters.Add("@symbolName", SqliteType.Text));
+        SetParameter(cmd, "@symbolName", symbolName);
 
         var containingTypes = new List<CSharpContainingTypeCandidate>();
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        try
         {
-            var containerKind = GetNullableString(reader, 0);
-            if (containerKind is not ("class" or "struct" or "interface"))
-                continue;
-
-            var containerQualifiedName = GetNullableString(reader, 2);
-            var containerName = GetNullableString(reader, 1);
-            var qualifiedContainer = NormalizeDbCSharpQualifiedName(containerQualifiedName ?? containerName ?? string.Empty);
-            if (!string.IsNullOrWhiteSpace(qualifiedContainer))
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
             {
-                containingTypes.Add(new CSharpContainingTypeCandidate(
-                    qualifiedContainer,
-                    IsNestedCSharpTypeAccessibleFromDerivedType(GetNullableString(reader, 3), GetNullableString(reader, 4))));
+                var containerKind = GetNullableString(reader, 0);
+                if (containerKind is not ("class" or "struct" or "interface"))
+                    continue;
+
+                var containerQualifiedName = GetNullableString(reader, 2);
+                var containerName = GetNullableString(reader, 1);
+                var qualifiedContainer = NormalizeDbCSharpQualifiedName(containerQualifiedName ?? containerName ?? string.Empty);
+                if (!string.IsNullOrWhiteSpace(qualifiedContainer))
+                {
+                    containingTypes.Add(new CSharpContainingTypeCandidate(
+                        qualifiedContainer,
+                        IsNestedCSharpTypeAccessibleFromDerivedType(GetNullableString(reader, 3), GetNullableString(reader, 4))));
+                }
             }
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         _csharpTypeContainingTypesByName[symbolName] = containingTypes;
@@ -1651,33 +1707,40 @@ public partial class DbReader
         if (_csharpConstantPatternContainersByMemberName.TryGetValue(symbolName, out var cached))
             return cached;
 
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = @"
+        var sql = @"
             SELECT s.kind, s.container_kind, s.container_name, s.container_qualified_name, s.signature
             FROM symbols s
             JOIN files f ON s.file_id = f.id
             WHERE f.lang = 'csharp'
               AND s.name = @symbolName COLLATE NOCASE
               AND s.container_name IS NOT NULL";
-        cmd.Parameters.AddWithValue("@symbolName", symbolName);
+        var cmd = RentCommand(sql, static c => c.Parameters.Add("@symbolName", SqliteType.Text));
+        SetParameter(cmd, "@symbolName", symbolName);
 
         var containers = new HashSet<string>(StringComparer.Ordinal);
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
+        try
         {
-            var kind = reader.GetString(0);
-            var containerKind = GetNullableString(reader, 1);
-            var containerName = GetNullableString(reader, 2);
-            if (string.IsNullOrWhiteSpace(containerName))
-                continue;
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
+            {
+                var kind = reader.GetString(0);
+                var containerKind = GetNullableString(reader, 1);
+                var containerName = GetNullableString(reader, 2);
+                if (string.IsNullOrWhiteSpace(containerName))
+                    continue;
 
-            var isConstantPatternMember = (kind == "enum" && containerKind == "enum")
-                || (containerKind is "class" or "struct" && !reader.IsDBNull(4) && IsCSharpConstSignature(reader.GetString(4)));
-            if (!isConstantPatternMember)
-                continue;
+                var isConstantPatternMember = (kind == "enum" && containerKind == "enum")
+                    || (containerKind is "class" or "struct" && !reader.IsDBNull(4) && IsCSharpConstSignature(reader.GetString(4)));
+                if (!isConstantPatternMember)
+                    continue;
 
-            var qualifiedContainer = GetNullableString(reader, 3);
-            containers.Add(string.IsNullOrWhiteSpace(qualifiedContainer) ? containerName! : qualifiedContainer!);
+                var qualifiedContainer = GetNullableString(reader, 3);
+                containers.Add(string.IsNullOrWhiteSpace(qualifiedContainer) ? containerName! : qualifiedContainer!);
+            }
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
         }
 
         _csharpConstantPatternContainersByMemberName[symbolName] = containers;

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -36,6 +36,7 @@ public partial class DbReader
     private static readonly Regex CSharpUsingNamespaceImportRegex = new(@"^\s*(?:global\s+)?using\s+(?!static\b)(?<target>[^;=]+)", RegexOptions.Compiled);
     private static readonly IReadOnlyDictionary<string, string> QueryLanguageAliases = BuildQueryLanguageAliases();
     private readonly SqliteConnection _conn;
+    private readonly PreparedCommandCache? _commandCache;
     private readonly bool _isReadOnly;
     private readonly DbSchemaCache? _schemaCache;
     private readonly CancellationToken _cancellation;
@@ -320,7 +321,8 @@ public partial class DbReader
         : this(context?.Connection ?? throw new ArgumentNullException(nameof(context)),
                context.IsReadOnly,
                context.SchemaCache,
-               CancellationToken.None)
+               CancellationToken.None,
+               context.PreparedCommands)
     {
     }
 
@@ -334,7 +336,8 @@ public partial class DbReader
         : this(context?.Connection ?? throw new ArgumentNullException(nameof(context)),
                context.IsReadOnly,
                context.SchemaCache,
-               cancellation)
+               cancellation,
+               context.PreparedCommands)
     {
     }
 
@@ -356,8 +359,14 @@ public partial class DbReader
     }
 
     public DbReader(SqliteConnection connection, bool isReadOnly, DbSchemaCache? schemaCache, CancellationToken cancellation)
+        : this(connection, isReadOnly, schemaCache, cancellation, commandCache: null)
+    {
+    }
+
+    private DbReader(SqliteConnection connection, bool isReadOnly, DbSchemaCache? schemaCache, CancellationToken cancellation, PreparedCommandCache? commandCache)
     {
         _conn = connection;
+        _commandCache = commandCache;
         // SQL user functions are registered once per connection by `DbContext` when the
         // connection is opened. Re-registering on every `DbReader` construction wasted CPU
         // on hot MCP/CLI paths that build a short-lived reader per request (#1564).
@@ -444,6 +453,28 @@ public partial class DbReader
     /// プライベートフィールドに触れずに済むようにする。
     /// </summary>
     public void ThrowIfCancellationRequested() => _cancellation.ThrowIfCancellationRequested();
+
+    private SqliteCommand RentCommand(string sql, Action<SqliteCommand> configureSchema)
+    {
+        if (_commandCache != null)
+            return _commandCache.GetOrAdd(sql, configureSchema);
+
+        var cmd = _conn.CreateCommand();
+        cmd.CommandText = sql;
+        configureSchema(cmd);
+        return cmd;
+    }
+
+    private void ReleaseCommand(SqliteCommand cmd)
+    {
+        if (_commandCache == null)
+            cmd.Dispose();
+    }
+
+    private static void SetParameter(SqliteCommand cmd, string name, object? value)
+    {
+        cmd.Parameters[name].Value = value ?? DBNull.Value;
+    }
 
     private static (bool Newer, string? Reason) DetectNewerThanReaderContracts(SqliteConnection conn, int userVersion)
     {

--- a/tests/CodeIndex.Tests/PreparedCommandCacheTests.cs
+++ b/tests/CodeIndex.Tests/PreparedCommandCacheTests.cs
@@ -348,6 +348,70 @@ public class PreparedCommandCacheTests : IDisposable
         Assert.Equal(touched, reader.GetDateTime(0));
     }
 
+    [Fact]
+    public void DbReader_WithCache_ReusesCSharpResolutionCommandsAcrossReaders()
+    {
+        var writer = new DbWriter(_db);
+        var fileId = writer.UpsertFile(new FileRecord
+        {
+            Path = "src/pattern.cs",
+            Lang = "csharp",
+            Size = 80,
+            Lines = 4,
+            Checksum = "reader-cache",
+            Modified = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        writer.InsertSymbols(new[]
+        {
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "enum",
+                Name = "Color",
+                Line = 1,
+                StartLine = 1,
+                EndLine = 1,
+                Signature = "enum Color { Red }",
+            },
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "enum",
+                Name = "Red",
+                Line = 1,
+                StartLine = 1,
+                EndLine = 1,
+                Signature = "Red",
+                ContainerKind = "enum",
+                ContainerName = "Color",
+                ContainerQualifiedName = "Color",
+            },
+        });
+        writer.InsertReferences(new[]
+        {
+            new ReferenceRecord
+            {
+                FileId = fileId,
+                SymbolName = "Red",
+                ReferenceKind = "type_reference",
+                Line = 4,
+                Column = 18,
+                Context = "case Red: break;",
+            },
+        });
+
+        var firstReader = new DbReader(_db);
+        firstReader.SearchReferences("Red", lang: "csharp", referenceKind: "type_reference", exact: true);
+        var countAfterFirstReader = _db.PreparedCommands.Count;
+
+        Assert.True(countAfterFirstReader > 0);
+
+        var secondReader = new DbReader(_db);
+        secondReader.SearchReferences("Red", lang: "csharp", referenceKind: "type_reference", exact: true);
+
+        Assert.Equal(countAfterFirstReader, _db.PreparedCommands.Count);
+    }
+
     public void Dispose()
     {
         _db.Dispose();


### PR DESCRIPTION
## Summary

- Wire `DbReader(DbContext)` through the shared `PreparedCommandCache`.
- Reuse prepared commands for repeated C# reference-resolution lookup queries.
- Add reader-side cache reuse coverage and a bilingual changelog fragment.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~PreparedCommandCacheTests"`
- `dotnet test CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/2208.fixed.md`.
- No README or guide changes were needed; behavior is an internal performance fix with no CLI/MCP contract change.

Fixes #2208
