### PR TITLE
Sanitize top-level CLI crash stderr

### DIFF
--- a/changelog.d/unreleased/2223.fixed.md
+++ b/changelog.d/unreleased/2223.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2223
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Top-level CLI crashes no longer leak .NET stack traces to stderr (#2223)** — unhandled command failures now return a database-error exit code after writing a single sanitized stderr line while keeping full details in diagnostic logs.
+
+## 日本語
+
+- **CLI 最上位のクラッシュが stderr に .NET stack trace を漏らさなくなりました (#2223)** — 未処理の command failure は、診断ログに詳細を残しつつ単一行の sanitized stderr を出して database-error の終了コードを返すようになりました。

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -203,8 +203,7 @@ internal static class ProgramRunner
             }
 
             GlobalToolLog.Error($"unhandled_exception type={ex.GetType().FullName}: {ex}");
-            Console.Error.WriteLine("Error: command failed before it could complete. Run `cdidx report` or enable cdidx diagnostics for details.");
-            DbDebug.DumpToStderr(ex);
+            Console.Error.WriteLine("Error: command failed before it could complete. Run `cdidx report` for details.");
             EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, CommandExitCodes.DatabaseError, ex.GetType().Name);
             return CommandExitCodes.DatabaseError;
         }

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -9,7 +9,12 @@ namespace CodeIndex.Cli;
 
 internal static class ProgramRunner
 {
-    internal static int Run(string[] args, JsonSerializerOptions? jsonOptions = null, string? appVersion = null, string? configStartDirectory = null)
+    internal static int Run(
+        string[] args,
+        JsonSerializerOptions? jsonOptions = null,
+        string? appVersion = null,
+        string? configStartDirectory = null,
+        Action? beforeDispatchForTesting = null)
     {
         appVersion ??= ConsoleUi.LoadVersion();
 
@@ -114,6 +119,8 @@ internal static class ProgramRunner
 
         try
         {
+            beforeDispatchForTesting?.Invoke();
+
             if (args[0] is "mcp" or "mcp-server")
             {
                 var mcpExitCode = RunMcp(args[1..], appVersion);
@@ -196,8 +203,10 @@ internal static class ProgramRunner
             }
 
             GlobalToolLog.Error($"unhandled_exception type={ex.GetType().FullName}: {ex}");
+            Console.Error.WriteLine("Error: command failed before it could complete. Run `cdidx report` or enable cdidx diagnostics for details.");
+            DbDebug.DumpToStderr(ex);
             EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, CommandExitCodes.DatabaseError, ex.GetType().Name);
-            throw;
+            return CommandExitCodes.DatabaseError;
         }
     }
 

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -11,6 +11,27 @@ namespace CodeIndex.Tests;
 public class ProgramRunnerTests
 {
     [Fact]
+    public void Run_UnhandledException_ReturnsSanitizedSingleLineError()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            ["status"],
+            appVersion: "1.10.0",
+            beforeDispatchForTesting: () => throw new InvalidOperationException("boom")));
+
+        Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+
+        var trimmed = stderr.TrimEnd();
+        Assert.Equal(trimmed, stderr.Trim());
+        Assert.DoesNotContain(Environment.NewLine, trimmed);
+        Assert.DoesNotContain("InvalidOperationException", trimmed);
+        Assert.DoesNotContain("CodeIndex.", trimmed);
+        Assert.DoesNotContain(" at ", trimmed);
+        Assert.DoesNotContain(" in ", trimmed);
+        Assert.StartsWith("Error: command failed before it could complete.", trimmed);
+    }
+
+    [Fact]
     public void Run_ForcedGlobalToolLogging_WritesLifecycleAndMirrorsStderr()
     {
         var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

- Return a sanitized database-error exit from `ProgramRunner.Run` for otherwise unhandled top-level exceptions instead of rethrowing into the .NET host.
- Add a regression test that forces the top-level catch and asserts stderr is a single sanitized line without internal type names or stack-trace markers.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter ProgramRunnerTests`
- `dotnet build CodeIndex.sln -c Release`
- `codex exec` adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Added bilingual changelog fragment: `changelog.d/unreleased/2223.fixed.md`

## Follow-up candidates

- None.

Fixes #2223
