### PR TITLE
Fix MCP required string validation

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1318,6 +1318,10 @@ Every MCP error response — both JSON-RPC `error` objects and MCP
 tool-result errors (`isError: true`) — carries a canonical
 `data` envelope so clients can branch on a stable machine-readable
 category instead of parsing the human `message` string.
+For required string tool arguments, the human message still says
+`Missing required parameter: <name>` only when the argument is absent;
+when the argument is present but empty or whitespace-only, the message
+is `Parameter "<name>" cannot be empty or whitespace-only` (#2145).
 
 - `data.category` — stable wire identifier (see table below).
 - `data.suggestion` — operator-actionable next step in English.
@@ -2504,6 +2508,7 @@ MCP は独立したシリアライズ戦略（オブジェクトを JSON など�
 #### 構造化エラーエンベロープとサーバーコード — issue #1581
 
 MCP のエラー応答は JSON-RPC の `error` オブジェクトでも、MCP ツール結果エラー（`isError: true`）でも、共通の canonical な `data` エンベロープを必ず載せる。クライアントは人間向けの `message` 文字列をパースする代わりに、安定した機械可読カテゴリで分岐できる。
+必須文字列ツール引数について、人間向け message は引数自体が無い場合だけ `Missing required parameter: <name>` となる。引数は存在するが空または空白のみの場合は `Parameter "<name>" cannot be empty or whitespace-only` を返す（#2145）。
 
 - `data.category` — 安定ワイヤ識別子（下表参照）。
 - `data.suggestion` — オペレータが取れる次のアクション（英語）。

--- a/changelog.d/unreleased/2145.fixed.md
+++ b/changelog.d/unreleased/2145.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2145
+affected:
+  - DEVELOPER_GUIDE.md
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP required string parameters now distinguish missing from blank values (#2145)** — MCP tool calls keep `Missing required parameter: <name>` for absent arguments and return `Parameter "<name>" cannot be empty or whitespace-only` when the argument is present but blank.
+
+## 日本語
+
+- **MCP の必須文字列パラメータで未指定と空白のみの値を区別するようにしました (#2145)** — MCP tool call は引数が存在しない場合は `Missing required parameter: <name>` を維持し、引数が存在して空白のみの場合は `Parameter "<name>" cannot be empty or whitespace-only` を返します。

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -287,6 +287,39 @@ public partial class McpServer
         return paths.Count == 0 ? null : paths;
     }
 
+    private static bool TryReadRequiredStringParameter(JsonNode? args, string propertyName, out string value, out string? error)
+    {
+        var node = args?[propertyName];
+        if (node is null)
+        {
+            value = string.Empty;
+            error = $"Missing required parameter: {propertyName}";
+            return false;
+        }
+
+        value = node.GetValue<string>();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            error = $"Parameter \"{propertyName}\" cannot be empty or whitespace-only";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool HasBlankPathFilter(JsonNode? args)
+    {
+        var node = args?["path"];
+        if (node is null)
+            return false;
+
+        if (node is JsonArray array)
+            return array.Count > 0 && array.All(item => string.IsNullOrWhiteSpace(item?.GetValue<string>()));
+
+        return string.IsNullOrWhiteSpace(node.GetValue<string>());
+    }
+
     /// <summary>
     /// Serialize a path filter list back into a JSON echo value.
     /// Null/empty → JSON null; single element → string; multiple → array.
@@ -352,9 +385,8 @@ public partial class McpServer
 
     private JsonNode ExecuteSearch(JsonNode? id, JsonNode? args)
     {
-        var query = args?["query"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(query))
-            return CreateToolErrorResponse(id, "Missing required parameter: query");
+        if (!TryReadRequiredStringParameter(args, "query", out var query, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
         if (query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
 
@@ -534,9 +566,8 @@ public partial class McpServer
 
     private JsonNode ExecuteDefinition(JsonNode? id, JsonNode? args)
     {
-        var query = args?["query"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(query))
-            return CreateToolErrorResponse(id, "Missing required parameter: query");
+        if (!TryReadRequiredStringParameter(args, "query", out var query, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
         if (query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
         if (IsBareVerbatimQueryToken(query))
@@ -592,9 +623,8 @@ public partial class McpServer
 
     private JsonNode ExecuteReferences(JsonNode? id, JsonNode? args)
     {
-        var query = args?["query"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(query))
-            return CreateToolErrorResponse(id, "Missing required parameter: query");
+        if (!TryReadRequiredStringParameter(args, "query", out var query, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
         if (query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
         if (IsBareVerbatimQueryToken(query))
@@ -657,9 +687,8 @@ public partial class McpServer
 
     private JsonNode ExecuteCallers(JsonNode? id, JsonNode? args)
     {
-        var query = args?["query"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(query))
-            return CreateToolErrorResponse(id, "Missing required parameter: query");
+        if (!TryReadRequiredStringParameter(args, "query", out var query, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
         if (query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
         if (IsBareVerbatimQueryToken(query))
@@ -724,9 +753,8 @@ public partial class McpServer
 
     private JsonNode ExecuteCallees(JsonNode? id, JsonNode? args)
     {
-        var query = args?["query"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(query))
-            return CreateToolErrorResponse(id, "Missing required parameter: query");
+        if (!TryReadRequiredStringParameter(args, "query", out var query, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
         if (query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
         if (IsBareVerbatimQueryToken(query))
@@ -869,9 +897,8 @@ public partial class McpServer
 
     private JsonNode ExecuteAnalyzeSymbol(JsonNode? id, JsonNode? args)
     {
-        var query = args?["query"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(query))
-            return CreateToolErrorResponse(id, "Missing required parameter: query");
+        if (!TryReadRequiredStringParameter(args, "query", out var query, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
         if (query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
         if (IsBareVerbatimQueryToken(query))
@@ -1072,9 +1099,8 @@ public partial class McpServer
 
     private JsonNode ExecuteOutline(JsonNode? id, JsonNode? args)
     {
-        var path = args?["path"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(path))
-            return CreateToolErrorResponse(id, "Missing required parameter: path");
+        if (!TryReadRequiredStringParameter(args, "path", out var path, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
 
         return WithDbReader(id, reader =>
         {
@@ -1097,9 +1123,8 @@ public partial class McpServer
 
     private JsonNode ExecuteExcerpt(JsonNode? id, JsonNode? args)
     {
-        var path = args?["path"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(path))
-            return CreateToolErrorResponse(id, "Missing required parameter: path");
+        if (!TryReadRequiredStringParameter(args, "path", out var path, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
 
         var startLine = args?["startLine"]?.GetValue<int>();
         if (startLine == null || startLine <= 0)
@@ -1194,15 +1219,16 @@ public partial class McpServer
 
     private JsonNode ExecuteFindInFile(JsonNode? id, JsonNode? args)
     {
-        var query = args?["query"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(query))
-            return CreateToolErrorResponse(id, "Missing required parameter: query");
+        if (!TryReadRequiredStringParameter(args, "query", out var query, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
         if (query.Length > MaxQueryLength)
             return CreateToolErrorResponse(id, $"Query too long (max {MaxQueryLength} characters)");
 
         var pathPatterns = ReadScopedPathList(args);
         if (pathPatterns == null || pathPatterns.Count == 0)
-            return CreateToolErrorResponse(id, "Missing required parameter: path");
+            return CreateToolErrorResponse(id, HasBlankPathFilter(args)
+                ? "Parameter \"path\" cannot be empty or whitespace-only"
+                : "Missing required parameter: path");
 
         var limit = ClampLimit(args?["limit"]?.GetValue<int>() ?? 20);
         var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
@@ -1588,9 +1614,8 @@ public partial class McpServer
 
     private JsonNode ExecuteImpactAnalysis(JsonNode? id, JsonNode? args)
     {
-        var query = args?["query"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(query))
-            return CreateToolErrorResponse(id, "Missing required parameter: query");
+        if (!TryReadRequiredStringParameter(args, "query", out var query, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
         if (IsBareVerbatimQueryToken(query))
             return CreateToolErrorResponse(id, "Add a real symbol name after the command; bare verbatim prefixes like `@` are not valid queries.");
 
@@ -1942,9 +1967,8 @@ public partial class McpServer
 
     private JsonNode ExecuteIndex(JsonNode? id, JsonNode? args)
     {
-        var path = args?["path"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(path))
-            return CreateToolErrorResponse(id, "Missing required parameter: path");
+        if (!TryReadRequiredStringParameter(args, "path", out var path, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
 
         var rebuild = args?["rebuild"]?.GetValue<bool>() ?? false;
         long? maxFileBytes = null;
@@ -2377,9 +2401,8 @@ public partial class McpServer
     private JsonNode ExecuteSuggestImprovement(JsonNode? id, JsonNode? args)
     {
         // 1. Validate required parameters / 必須パラメータのバリデーション
-        var category = args?["category"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(category))
-            return CreateToolErrorResponse(id, "Missing required parameter: category");
+        if (!TryReadRequiredStringParameter(args, "category", out var category, out var requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
 
         if (!SuggestionRecord.ValidCategories.Contains(category))
         {
@@ -2390,9 +2413,8 @@ public partial class McpServer
             return CreateToolErrorResponse(id, message, similar);
         }
 
-        var description = args?["description"]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(description))
-            return CreateToolErrorResponse(id, "Missing required parameter: description");
+        if (!TryReadRequiredStringParameter(args, "description", out var description, out requiredError))
+            return CreateToolErrorResponse(id, requiredError!);
 
         if (description.Length > MaxDescriptionLength)
             return CreateToolErrorResponse(id, $"Description too long ({description.Length} chars, max {MaxDescriptionLength})");

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -228,6 +228,75 @@ public class McpServerTests : IDisposable
         Assert.Contains("2024-11-05", McpServer.SupportedProtocolVersions);
     }
 
+    [Theory]
+    [InlineData("search")]
+    [InlineData("definition")]
+    [InlineData("references")]
+    [InlineData("callers")]
+    [InlineData("callees")]
+    [InlineData("analyze_symbol")]
+    [InlineData("impact_analysis")]
+    public void ToolCall_RequiredQuery_DistinguishesMissingFromWhitespace(string toolName)
+    {
+        var missing = CallToolAndReadErrorMessage(toolName, new JsonObject());
+        var blank = CallToolAndReadErrorMessage(toolName, new JsonObject { ["query"] = "   " });
+
+        Assert.Equal("Missing required parameter: query", missing);
+        Assert.Equal("Parameter \"query\" cannot be empty or whitespace-only", blank);
+    }
+
+    [Theory]
+    [InlineData("outline")]
+    [InlineData("excerpt")]
+    [InlineData("index")]
+    public void ToolCall_RequiredPath_DistinguishesMissingFromWhitespace(string toolName)
+    {
+        var missing = CallToolAndReadErrorMessage(toolName, new JsonObject());
+        var blank = CallToolAndReadErrorMessage(toolName, new JsonObject { ["path"] = "   " });
+
+        Assert.Equal("Missing required parameter: path", missing);
+        Assert.Equal("Parameter \"path\" cannot be empty or whitespace-only", blank);
+    }
+
+    [Fact]
+    public void ToolCall_FindInFilePath_DistinguishesMissingFromWhitespace()
+    {
+        var missing = CallToolAndReadErrorMessage("find_in_file", new JsonObject { ["query"] = "Run" });
+        var blank = CallToolAndReadErrorMessage("find_in_file", new JsonObject
+        {
+            ["query"] = "Run",
+            ["path"] = "   "
+        });
+
+        Assert.Equal("Missing required parameter: path", missing);
+        Assert.Equal("Parameter \"path\" cannot be empty or whitespace-only", blank);
+    }
+
+    [Theory]
+    [InlineData("category")]
+    [InlineData("description")]
+    public void ToolCall_SuggestImprovementRequiredStrings_DistinguishMissingFromWhitespace(string propertyName)
+    {
+        var baseArguments = new JsonObject
+        {
+            ["category"] = "unexpected_error",
+            ["description"] = "The tool should report this behavior more clearly."
+        };
+        baseArguments.Remove(propertyName);
+        var missing = CallToolAndReadErrorMessage("suggest_improvement", baseArguments);
+
+        var blankArguments = new JsonObject
+        {
+            ["category"] = "unexpected_error",
+            ["description"] = "The tool should report this behavior more clearly.",
+            [propertyName] = "   "
+        };
+        var blank = CallToolAndReadErrorMessage("suggest_improvement", blankArguments);
+
+        Assert.Equal($"Missing required parameter: {propertyName}", missing);
+        Assert.Equal($"Parameter \"{propertyName}\" cannot be empty or whitespace-only", blank);
+    }
+
     [Fact]
     public void BuildUnsupportedProtocolMessage_MentionsRequestedAndSupported()
     {
@@ -8253,6 +8322,25 @@ public class McpServerTests : IDisposable
         RaiseConsoleCancelKeyPress();
 
         Assert.False(cts.IsCancellationRequested);
+    }
+
+    private string CallToolAndReadErrorMessage(string toolName, JsonObject arguments)
+    {
+        var request = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = 1,
+            ["method"] = "tools/call",
+            ["params"] = new JsonObject
+            {
+                ["name"] = toolName,
+                ["arguments"] = arguments
+            }
+        };
+        var response = _server.HandleMessage(request)!;
+
+        Assert.True(response["result"]!["isError"]!.GetValue<bool>());
+        return response["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
     }
 
     private static void RaiseConsoleCancelKeyPress()


### PR DESCRIPTION
## Summary

- Split MCP required string validation so absent arguments keep the existing `Missing required parameter: <name>` message while blank or whitespace-only arguments return a distinct message.
- Applied the behavior consistently across required MCP string arguments for query, path, category, and description inputs.
- Documented the MCP error-message contract and added the required bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md`.
- Added `changelog.d/unreleased/2145.fixed.md`.

## Follow-up Candidates

- None.

Fixes #2145
