### PR TITLE
Fix long-path file probes

### DIFF
--- a/changelog.d/unreleased/2189.fixed.md
+++ b/changelog.d/unreleased/2189.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 2189
+affected:
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+---
+
+## English
+
+- **Long Windows paths now work across non-walker DB, lock, config, and metadata probes (#2189)** — DB existence checks, lock metadata reads, suggestion/config/report files, Git metadata probes, MCP readiness checks, and exclude-file reads now route filesystem API paths through `LongPath.EnsureWindowsPrefix(...)` where appropriate, so deep Windows workspaces no longer silently report missing files after the indexer itself can see them.
+
+## 日本語
+
+- **walker 以外の DB / lock / config / metadata 確認でも Windows の長いパスを扱えるようになりました (#2189)** — DB 存在確認、lock metadata 読み取り、suggestion / config / report ファイル、Git metadata probe、MCP readiness 確認、exclude-file 読み取りで必要な filesystem API パスを `LongPath.EnsureWindowsPrefix(...)` 経由にし、indexer が見つけられる深い Windows workspace で後続処理がファイルを missing と誤判定しないようにしました。

--- a/src/CodeIndex/Cli/CdidxConfigFile.cs
+++ b/src/CodeIndex/Cli/CdidxConfigFile.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
 
@@ -224,7 +225,7 @@ internal static class CdidxConfigFile
         while (current is not null)
         {
             var candidate = Path.Combine(current.FullName, FileName);
-            if (File.Exists(candidate))
+            if (File.Exists(LongPath.EnsureWindowsPrefix(candidate)))
                 return candidate;
             current = current.Parent;
         }

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -433,14 +433,15 @@ public static class ConsoleUi
     {
         var exeDir = AppContext.BaseDirectory;
         var path = Path.Combine(exeDir, "version.json");
-        if (!File.Exists(path))
+        if (!File.Exists(LongPath.EnsureWindowsPrefix(path)))
         {
             // Fallback: look relative to current directory / カレントディレクトリからの相対パスでフォールバック
             path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "version.json");
         }
-        if (File.Exists(path))
+        var ioPath = LongPath.EnsureWindowsPrefix(path);
+        if (File.Exists(ioPath))
         {
-            var json = File.ReadAllText(path);
+            var json = File.ReadAllText(ioPath);
             using var doc = System.Text.Json.JsonDocument.Parse(json);
             if (doc.RootElement.TryGetProperty("version", out var ver))
                 return ver.GetString() ?? "0.0.0";

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Cli;
@@ -38,7 +39,7 @@ public static class DbCommandRunner
 
         var dbPath = options.DbPath;
         var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
-        if (!isUri && !File.Exists(dbPath))
+        if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
             return WriteCommandError(
                 options.Json,
                 jsonOptions,

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -21,14 +21,15 @@ public static class GitHelper
     public static string? ResolveGitCommonDir(string projectRoot)
     {
         var dotGit = Path.Combine(projectRoot, ".git");
+        var ioDotGit = LongPath.EnsureWindowsPrefix(dotGit);
 
         // Normal repository: .git is a directory / 通常リポジトリ: .gitがディレクトリ
-        if (Directory.Exists(dotGit)) return dotGit;
+        if (Directory.Exists(ioDotGit)) return dotGit;
 
         // Worktree: .git is a file containing "gitdir: <path>" / worktree: .gitがファイルで "gitdir: <path>" を含む
-        if (!File.Exists(dotGit)) return null;
+        if (!File.Exists(ioDotGit)) return null;
 
-        var gitFileContent = File.ReadAllText(dotGit).Trim();
+        var gitFileContent = File.ReadAllText(ioDotGit).Trim();
         if (!gitFileContent.StartsWith("gitdir:")) return null;
 
         var worktreeGitDir = gitFileContent["gitdir:".Length..].Trim();
@@ -37,9 +38,10 @@ public static class GitHelper
 
         // Read commondir to find the shared .git directory / commondirを読んで共有.gitディレクトリを見つける
         var commonDirFile = Path.Combine(worktreeGitDir, "commondir");
-        if (File.Exists(commonDirFile))
+        var ioCommonDirFile = LongPath.EnsureWindowsPrefix(commonDirFile);
+        if (File.Exists(ioCommonDirFile))
         {
-            var commonDirRelative = File.ReadAllText(commonDirFile).Trim();
+            var commonDirRelative = File.ReadAllText(ioCommonDirFile).Trim();
             return Path.GetFullPath(Path.Combine(worktreeGitDir, commonDirRelative));
         }
 
@@ -420,16 +422,17 @@ public static class GitHelper
                 return ignoreCase;
 
             var probePath = Path.Combine(normalizedRoot, $".cdidx_case_probe_{Guid.NewGuid():N}");
-            File.WriteAllText(probePath, string.Empty);
+            var ioProbePath = LongPath.EnsureWindowsPrefix(probePath);
+            File.WriteAllText(ioProbePath, string.Empty);
             try
             {
                 if (TryCreateCaseVariant(probePath, out var variant))
-                    return File.Exists(variant);
+                    return File.Exists(LongPath.EnsureWindowsPrefix(variant));
             }
             finally
             {
-                if (File.Exists(probePath))
-                    File.Delete(probePath);
+                if (File.Exists(ioProbePath))
+                    File.Delete(ioProbePath);
             }
         }
         catch

--- a/src/CodeIndex/Cli/HookCommandRunner.cs
+++ b/src/CodeIndex/Cli/HookCommandRunner.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
 
@@ -76,48 +77,55 @@ public static class HookCommandRunner
 
     private static int Install(HookCommandOptions options, JsonSerializerOptions jsonOptions, string projectPath, string hooksDir, string hookPath, string chainedHookPath)
     {
-        Directory.CreateDirectory(hooksDir);
+        Directory.CreateDirectory(LongPath.EnsureWindowsPrefix(hooksDir));
 
-        if (File.Exists(hookPath))
+        var ioHookPath = LongPath.EnsureWindowsPrefix(hookPath);
+        var ioChainedHookPath = LongPath.EnsureWindowsPrefix(chainedHookPath);
+        if (File.Exists(ioHookPath))
         {
-            var existing = File.ReadAllText(hookPath);
+            var existing = File.ReadAllText(ioHookPath);
             if (!IsManagedHook(existing))
             {
-                if (File.Exists(chainedHookPath) && !options.Force)
+                if (File.Exists(ioChainedHookPath) && !options.Force)
                     return WriteResult(options.Json, jsonOptions, "error", $"chained hook already exists: {chainedHookPath}", projectPath, hookPath, chainedHookPath, CommandExitCodes.UsageError);
-                if (File.Exists(chainedHookPath))
-                    File.Delete(chainedHookPath);
-                File.Move(hookPath, chainedHookPath);
+                if (File.Exists(ioChainedHookPath))
+                    File.Delete(ioChainedHookPath);
+                File.Move(ioHookPath, ioChainedHookPath);
             }
         }
 
-        File.WriteAllText(hookPath, BuildHookScript(chainedHookPath));
-        MakeExecutable(hookPath);
+        File.WriteAllText(ioHookPath, BuildHookScript(chainedHookPath));
+        MakeExecutable(ioHookPath);
 
-        return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, File.Exists(chainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
+        return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, File.Exists(ioChainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
     }
 
     private static int Uninstall(HookCommandOptions options, JsonSerializerOptions jsonOptions, string projectPath, string hookPath, string chainedHookPath)
     {
-        if (!File.Exists(hookPath))
-            return WriteResult(options.Json, jsonOptions, "absent", "cdidx pre-commit hook is not installed", projectPath, hookPath, File.Exists(chainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
+        var ioHookPath = LongPath.EnsureWindowsPrefix(hookPath);
+        var ioChainedHookPath = LongPath.EnsureWindowsPrefix(chainedHookPath);
+        if (!File.Exists(ioHookPath))
+            return WriteResult(options.Json, jsonOptions, "absent", "cdidx pre-commit hook is not installed", projectPath, hookPath, File.Exists(ioChainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
 
-        var existing = File.ReadAllText(hookPath);
+        var existing = File.ReadAllText(ioHookPath);
         if (!IsManagedHook(existing) && !options.Force)
             return WriteResult(options.Json, jsonOptions, "error", "pre-commit hook is not managed by cdidx; pass --force to remove it", projectPath, hookPath, null, CommandExitCodes.UsageError);
 
-        File.Delete(hookPath);
-        if (File.Exists(chainedHookPath))
-            File.Move(chainedHookPath, hookPath);
+        File.Delete(ioHookPath);
+        if (File.Exists(ioChainedHookPath))
+            File.Move(ioChainedHookPath, ioHookPath);
 
         return WriteResult(options.Json, jsonOptions, "uninstalled", "cdidx pre-commit hook uninstalled", projectPath, hookPath, null, CommandExitCodes.Success);
     }
 
     private static int Status(HookCommandOptions options, JsonSerializerOptions jsonOptions, string projectPath, string hookPath, string chainedHookPath)
     {
-        var installed = File.Exists(hookPath) && IsManagedHook(File.ReadAllText(hookPath));
-        var status = installed ? "installed" : File.Exists(hookPath) ? "custom" : "absent";
-        return WriteResult(options.Json, jsonOptions, status, $"cdidx pre-commit hook is {status}", projectPath, hookPath, File.Exists(chainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
+        var ioHookPath = LongPath.EnsureWindowsPrefix(hookPath);
+        var ioChainedHookPath = LongPath.EnsureWindowsPrefix(chainedHookPath);
+        var hookExists = File.Exists(ioHookPath);
+        var installed = hookExists && IsManagedHook(File.ReadAllText(ioHookPath));
+        var status = installed ? "installed" : hookExists ? "custom" : "absent";
+        return WriteResult(options.Json, jsonOptions, status, $"cdidx pre-commit hook is {status}", projectPath, hookPath, File.Exists(ioChainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
     }
 
     private static int UnknownCommand(HookCommandOptions options, JsonSerializerOptions jsonOptions, string projectPath)

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -3120,15 +3120,21 @@ public static class IndexCommandRunner
                 patterns = [$"{dbDirRelative.TrimEnd('/')}/"];
             }
 
-            var existingContent = File.Exists(excludeFile) ? File.ReadAllText(excludeFile) : "";
+            var ioExcludeFile = LongPath.EnsureWindowsPrefix(excludeFile);
+            var existingContent = File.Exists(ioExcludeFile) ? File.ReadAllText(ioExcludeFile) : "";
             var existingLines = existingContent.Split('\n').Select(l => l.TrimEnd('\r')).ToHashSet();
 
             var missing = patterns.Where(p => !existingLines.Contains(p)).ToList();
             if (missing.Count == 0) return;
 
-            Directory.CreateDirectory(Path.GetDirectoryName(excludeFile)!);
+            Directory.CreateDirectory(LongPath.EnsureWindowsPrefix(Path.GetDirectoryName(excludeFile)!));
 
-            using var sw = File.AppendText(excludeFile);
+            using var stream = new FileStream(
+                ioExcludeFile,
+                FileMode.Append,
+                FileAccess.Write,
+                FileShare.Read);
+            using var sw = new StreamWriter(stream);
             if (existingContent.Length > 0 && !existingContent.EndsWith('\n'))
                 sw.WriteLine();
             sw.WriteLine("# cdidx (CodeIndex) — auto-generated");

--- a/src/CodeIndex/Cli/IndexLock.cs
+++ b/src/CodeIndex/Cli/IndexLock.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
 
@@ -120,7 +121,8 @@ internal sealed class IndexLock : IDisposable
         var infoPath = GetInfoPath(lockPath);
         try
         {
-            if (!File.Exists(infoPath))
+            var ioInfoPath = LongPath.EnsureWindowsPrefix(infoPath);
+            if (!File.Exists(ioInfoPath))
                 return null;
             // FileShare.ReadWrite mirrors what a concurrent holder might be doing
             // (the holder may overwrite the .info on stale recovery), so a
@@ -128,7 +130,7 @@ internal sealed class IndexLock : IDisposable
             // 保持者が .info を上書きしている可能性があるため FileShare.ReadWrite で
             // 開き、共有モード不一致で読みを失敗させない。
             using var stream = new FileStream(
-                infoPath,
+                ioInfoPath,
                 FileMode.Open,
                 FileAccess.Read,
                 FileShare.ReadWrite);

--- a/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+++ b/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using CodeIndex.Database;
+using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
 
@@ -147,7 +148,7 @@ internal static class JsonEnvelopeWrapper
         try
         {
             var resolvedPath = dbPath;
-            if (!dbPathExplicit && !File.Exists(resolvedPath))
+            if (!dbPathExplicit && !File.Exists(LongPath.EnsureWindowsPrefix(resolvedPath)))
                 return null;
             return DbPathResolver.TryReadIndexedHeadCommit(DbPathResolver.NormalizeDbPath(resolvedPath));
         }

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -3909,7 +3909,7 @@ public static class QueryCommandRunner
         // are meaningless to the filesystem API but are understood by SQLite.
         // URI 形式の --db を受け入れるため、file: で始まる値は File.Exists チェックをスキップ。
         var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
-        if (!isUri && !File.Exists(dbPath))
+        if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
         {
             Console.Error.WriteLine($"Error [{CommandErrorCodes.DbNotFound}]: database not found at {Path.GetFullPath(dbPath)}");
             Console.Error.WriteLine("Hint: create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command.");

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Cli;
@@ -185,7 +186,7 @@ public static class ReportCommandRunner
 
     internal static (string Text, List<ReportSchemaTable> Tables, string? DbPath, bool DbIncluded) BuildSchemaSummary(string dbPath)
     {
-        if (!File.Exists(dbPath))
+        if (!File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
         {
             var missingText = $"no SQLite index found at: {dbPath}\nRun `cdidx index <projectPath>` first if you want schema details attached.\n";
             return (missingText, new List<ReportSchemaTable>(), dbPath, false);

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using CodeIndex.Indexer;
 using CodeIndex.Models;
 
 namespace CodeIndex.Cli;
@@ -270,10 +271,11 @@ public class SuggestionStore
     /// </summary>
     private List<SuggestionRecord> ReadUnlocked()
     {
-        if (!File.Exists(_filePath))
+        var ioPath = LongPath.EnsureWindowsPrefix(_filePath);
+        if (!File.Exists(ioPath))
             return new List<SuggestionRecord>();
 
-        var json = File.ReadAllText(_filePath);
+        var json = File.ReadAllText(ioPath);
         if (string.IsNullOrWhiteSpace(json))
             return new List<SuggestionRecord>();
 
@@ -320,10 +322,11 @@ public class SuggestionStore
         int skip = 0,
         int? take = null)
     {
-        if (!File.Exists(_filePath))
+        var ioPath = LongPath.EnsureWindowsPrefix(_filePath);
+        if (!File.Exists(ioPath))
             return new List<SuggestionRecord>();
 
-        var snapshot = File.ReadAllBytes(_filePath);
+        var snapshot = File.ReadAllBytes(ioPath);
         if (snapshot.Length == 0)
             return new List<SuggestionRecord>();
 
@@ -531,8 +534,8 @@ public class SuggestionStore
         try
         {
             var backupPath = _filePath + ".bak";
-            if (File.Exists(_filePath))
-                File.Move(_filePath, backupPath, overwrite: true);
+            if (File.Exists(LongPath.EnsureWindowsPrefix(_filePath)))
+                File.Move(LongPath.EnsureWindowsPrefix(_filePath), LongPath.EnsureWindowsPrefix(backupPath), overwrite: true);
         }
         catch
         {

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -91,7 +91,7 @@ public class DbContext : IDisposable
             var normalized = TryGetLocalPath(dbPath);
             if (normalized != null)
             {
-                if (!File.Exists(normalized))
+                if (!File.Exists(LongPath.EnsureWindowsPrefix(normalized)))
                 {
                     message = $"database not found: {dbPath}";
                     isNotFound = true;
@@ -101,7 +101,7 @@ public class DbContext : IDisposable
                 openTarget = normalized;
             }
         }
-        else if (!File.Exists(dbPath))
+        else if (!File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
         {
             message = $"database not found: {dbPath}";
             isNotFound = true;

--- a/src/CodeIndex/Mcp/AuditLogSink.cs
+++ b/src/CodeIndex/Mcp/AuditLogSink.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using CodeIndex.Indexer;
 
 namespace CodeIndex.Mcp;
 
@@ -141,19 +142,23 @@ internal sealed class AuditLogSink : IDisposable
             {
                 var current = SlotPath(slot);
                 var next = SlotPath(slot + 1);
-                if (!File.Exists(current))
+                var ioCurrent = LongPath.EnsureWindowsPrefix(current);
+                var ioNext = LongPath.EnsureWindowsPrefix(next);
+                if (!File.Exists(ioCurrent))
                     continue;
-                if (File.Exists(next))
-                    SafeDelete(next);
-                File.Move(current, next);
+                if (File.Exists(ioNext))
+                    SafeDelete(ioNext);
+                File.Move(ioCurrent, ioNext);
             }
 
-            if (File.Exists(_path))
+            var ioPath = LongPath.EnsureWindowsPrefix(_path);
+            if (File.Exists(ioPath))
             {
                 var first = SlotPath(1);
-                if (File.Exists(first))
-                    SafeDelete(first);
-                File.Move(_path, first);
+                var ioFirst = LongPath.EnsureWindowsPrefix(first);
+                if (File.Exists(ioFirst))
+                    SafeDelete(ioFirst);
+                File.Move(ioPath, ioFirst);
             }
             _bytesWritten = 0;
         }

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -1367,7 +1367,7 @@ public partial class McpServer : IDisposable
         // shaped values because they may carry query params meaningless to the filesystem.
         // CLI と同じく file: URI を受け付け、サンドボックス用の escape hatch に到達できるようにする。
         var isUri = _dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
-        if (!isUri && !File.Exists(_dbPath))
+        if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(_dbPath)))
         {
             // Drop any stale cached context so the next tool call can re-open after the user
             // creates the DB (e.g. via an external `cdidx index`). Without this, a missed

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1894,7 +1894,7 @@ public partial class McpServer
             ["version"] = _version,
             ["timestamp"] = DateTime.UtcNow.ToString("O"),
             ["db_path"] = _dbPath,
-            ["db_exists"] = File.Exists(_dbPath),
+            ["db_exists"] = File.Exists(LongPath.EnsureWindowsPrefix(_dbPath)),
         };
         return CreateToolResult(id, $"cdidx v{_version} is ready.", payload);
     }


### PR DESCRIPTION
## Summary

- Route non-walker DB, MCP, lock, suggestion, Git metadata, hook, report, config, and exclude-file filesystem probes through `LongPath.EnsureWindowsPrefix(...)`.
- Keep URI-shaped DB paths on the existing URI path and preserve user-facing display paths while using prefixed paths for filesystem APIs.
- Add the unreleased bilingual changelog fragment for issue #2189.

## Validation

- `dotnet build`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release`
- `dotnet test --filter LongPathTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `codex exec` adversarial review, with blocking findings addressed in the final commit

## Documentation / Changelog

- Added `changelog.d/unreleased/2189.fixed.md`.
- No README or guide changes were required because this extends the existing long-path behavior to additional internal filesystem probes without changing CLI syntax or documented contracts.

Fixes #2189

## Follow-up candidates

- None.
