### PR TITLE
Fix symbols blank positional query handling

### DIFF
--- a/changelog.d/unreleased/2144.fixed.md
+++ b/changelog.d/unreleased/2144.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2144
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`cdidx symbols` now rejects whitespace-only positional queries (#2144)** — `symbols "   "` now fails fast with `Error: symbols query cannot be empty or whitespace-only`, matching the distinct blank-query diagnostics used by the other query commands.
+
+## 日本語
+
+- **`cdidx symbols` が空白のみの positional query を拒否するようになりました (#2144)** — `symbols "   "` は他の query 系コマンドと同じく、`Error: symbols query cannot be empty or whitespace-only` の明確な blank-query 診断で早期に失敗するようになりました。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -815,6 +815,8 @@ public static class QueryCommandRunner
             return CommandExitCodes.UsageError;
         if (TryWriteParseError(options, "symbols"))
             return CommandExitCodes.UsageError;
+        if (TryWriteBlankQueryError(options, "symbols"))
+            return CommandExitCodes.UsageError;
         if (!TryResolveNameExactMode(options, "symbols", out var exact, out var exactError))
         {
             Console.Error.WriteLine(exactError);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -27849,6 +27849,20 @@ jobs:
         Assert.Contains($"Usage: {ConsoleUi.GetUsageLine("inspect")}", stderr);
     }
 
+    [Fact]
+    public void RunSymbols_BlankPositionalQueryReturnsDistinctUsageError()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+            ["   "],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("Error: symbols query cannot be empty or whitespace-only", stderr);
+        Assert.DoesNotContain("symbol name list is empty after normalization", stderr);
+        Assert.Contains("empty or whitespace-only arguments", stderr);
+        Assert.Contains($"Usage: {ConsoleUi.GetUsageLine("symbols")}", stderr);
+    }
+
     [Theory]
     [InlineData("search")]
     [InlineData("definition")]


### PR DESCRIPTION
## Summary

- Reject whitespace-only positional queries for `cdidx symbols` with the shared blank-query usage error.
- Add focused regression coverage for `symbols "   "`.
- Add the bilingual changelog fragment for issue #2144.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "RunSymbols_BlankPositionalQueryReturnsDistinctUsageError|QueryCommands_WhitespaceQueryReturnUsageErrorWithDistinctMessage|RunInspect_BlankQueryReturnsDistinctUsageError"`
- `dotnet test CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll symbols "   "`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `codex exec` adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Added `changelog.d/unreleased/2144.fixed.md`.
- No README or guide changes were needed because this aligns `symbols` with the already documented blank-query behavior.

## Follow-up Candidates

- None.

Fixes #2144
