### PR TITLE
Fix MCP exact alias conflicts

### DIFF
--- a/changelog.d/unreleased/2140.fixed.md
+++ b/changelog.d/unreleased/2140.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2140
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP exact flag aliases now reject ambiguous combinations (#2140)** — MCP tools now fail fast when callers combine `exact`, `exactSubstring`, and `exactName`, matching the CLI guard instead of silently OR-merging conflicting exact-match intent.
+
+## 日本語
+
+- **MCP の exact flag alias が曖昧な組み合わせを拒否するようになりました (#2140)** — MCP tool は `exact`、`exactSubstring`、`exactName` の組み合わせ指定を即時エラーにし、競合する exact-match 意図を暗黙に OR 結合せず CLI guard と一致するようになりました。

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -224,30 +224,57 @@ public partial class McpServer
 
     private static bool TryResolveSearchExactArgument(JsonNode? args, out bool exact, out string? error)
     {
-        if (args?["exactName"]?.GetValue<bool>() ?? false)
+        var legacyExact = args?["exact"]?.GetValue<bool>() ?? false;
+        var exactSubstring = args?["exactSubstring"]?.GetValue<bool>() ?? false;
+        var exactName = args?["exactName"]?.GetValue<bool>() ?? false;
+
+        if (CountTrue(legacyExact, exactSubstring, exactName) > 1)
+        {
+            exact = false;
+            error = "Pass only one of 'exact', 'exactSubstring', 'exactName'.";
+            return false;
+        }
+
+        if (exactName)
         {
             exact = false;
             error = "Search does not accept 'exactName'. Use 'exactSubstring' for search, or keep 'exact' for backward compatibility.";
             return false;
         }
 
-        exact = (args?["exact"]?.GetValue<bool>() ?? false) || (args?["exactSubstring"]?.GetValue<bool>() ?? false);
+        exact = legacyExact || exactSubstring;
         error = null;
         return true;
     }
 
     private static bool TryResolveNameExactArgument(JsonNode? args, string toolName, out bool exact, out string? error)
     {
-        if (args?["exactSubstring"]?.GetValue<bool>() ?? false)
+        var legacyExact = args?["exact"]?.GetValue<bool>() ?? false;
+        var exactSubstring = args?["exactSubstring"]?.GetValue<bool>() ?? false;
+        var exactName = args?["exactName"]?.GetValue<bool>() ?? false;
+
+        if (CountTrue(legacyExact, exactSubstring, exactName) > 1)
+        {
+            exact = false;
+            error = "Pass only one of 'exact', 'exactSubstring', 'exactName'.";
+            return false;
+        }
+
+        if (exactSubstring)
         {
             exact = false;
             error = $"Tool '{toolName}' does not accept 'exactSubstring'. Use 'exactName', or keep 'exact' for backward compatibility.";
             return false;
         }
 
-        exact = (args?["exact"]?.GetValue<bool>() ?? false) || (args?["exactName"]?.GetValue<bool>() ?? false);
+        exact = legacyExact || exactName;
         error = null;
         return true;
+    }
+
+    private static int CountTrue(params bool[] values)
+    {
+        return values.Count(value => value);
     }
 
     /// <summary>

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -3542,6 +3542,31 @@ public class McpServerTests : IDisposable
     }
 
     [Theory]
+    [InlineData("search", """{"query":"Run","exact":true,"exactSubstring":true}""")]
+    [InlineData("search", """{"query":"Run","exact":true,"exactName":true}""")]
+    [InlineData("definition", """{"query":"Run","exact":true,"exactName":true}""")]
+    [InlineData("definition", """{"query":"Run","exact":true,"exactSubstring":true}""")]
+    [InlineData("references", """{"query":"Run","exact":true,"exactName":true}""")]
+    [InlineData("references", """{"query":"Run","exact":true,"exactSubstring":true}""")]
+    [InlineData("callers", """{"query":"Run","exact":true,"exactName":true}""")]
+    [InlineData("callers", """{"query":"Run","exact":true,"exactSubstring":true}""")]
+    [InlineData("callees", """{"query":"Run","exact":true,"exactName":true}""")]
+    [InlineData("callees", """{"query":"Run","exact":true,"exactSubstring":true}""")]
+    [InlineData("symbols", """{"query":"Run","exact":true,"exactName":true}""")]
+    [InlineData("symbols", """{"query":"Run","exact":true,"exactSubstring":true}""")]
+    [InlineData("analyze_symbol", """{"query":"Run","exact":true,"exactName":true}""")]
+    [InlineData("analyze_symbol", """{"query":"Run","exact":true,"exactSubstring":true}""")]
+    public void ToolsCall_ExactAliases_RejectsCombinedFlags(string toolName, string argumentsJson)
+    {
+        var request = JsonNode.Parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"" + toolName + "\",\"arguments\":" + argumentsJson + "}}")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.True(response["result"]!["isError"]!.GetValue<bool>());
+        var text = response["result"]!["content"]![0]!["text"]!.GetValue<string>();
+        Assert.Contains("Pass only one of 'exact', 'exactSubstring', 'exactName'.", text);
+    }
+
+    [Theory]
     [InlineData("""{"names":""}""", "must be an array")]
     [InlineData("""{"names":[]}""", "no usable entries")]
     [InlineData("""{"names":[""]}""", "no usable entries")]


### PR DESCRIPTION
## Summary

- Reject ambiguous MCP exact-match flag combinations before query execution.
- Preserve the existing single-flag behavior for `exact`, `exactSubstring`, and `exactName`.
- Add MCP regression coverage for search, definition, references, callers, callees, symbols, and analyze_symbol.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests"`
- `dotnet test CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: No blocking/actionable issues found.

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/2140.fixed.md`
- No docs update beyond the fragment; this is an MCP validation tightening for an already documented alias family.

Fixes #2140

## Follow-up Candidates

- None.
