### PR TITLE
Reject import kind on graph queries

### DIFF
--- a/changelog.d/unreleased/2138.fixed.md
+++ b/changelog.d/unreleased/2138.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2138
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`callers` / `callees --kind import` now rejects through the non-call-graph path (#2138)** — `import` is reported as a structural dependency edge and the CLI points users to `cdidx references <name> --kind import` instead of warning that it is only a symbol kind.
+
+## 日本語
+
+- **`callers` / `callees --kind import` が non-call-graph 用の経路で拒否されるようになりました (#2138)** — `import` を構造的な dependency edge として説明し、単なる symbol kind であるかのような警告ではなく `cdidx references <name> --kind import` へ誘導します。

--- a/changelog.d/unreleased/2138.fixed.md
+++ b/changelog.d/unreleased/2138.fixed.md
@@ -4,13 +4,15 @@ issues:
   - 2138
 affected:
   - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
   - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
 ---
 
 ## English
 
-- **`callers` / `callees --kind import` now rejects through the non-call-graph path (#2138)** — `import` is reported as a structural dependency edge and the CLI points users to `cdidx references <name> --kind import` instead of warning that it is only a symbol kind.
+- **`callers` / `callees --kind import` now rejects through the non-call-graph path (#2138)** — `import` is reported as a structural dependency edge and the CLI/MCP surfaces point users to `references <name> --kind import` instead of warning that it is only a symbol kind.
 
 ## 日本語
 
-- **`callers` / `callees --kind import` が non-call-graph 用の経路で拒否されるようになりました (#2138)** — `import` を構造的な dependency edge として説明し、単なる symbol kind であるかのような警告ではなく `cdidx references <name> --kind import` へ誘導します。
+- **`callers` / `callees --kind import` が non-call-graph 用の経路で拒否されるようになりました (#2138)** — `import` を構造的な dependency edge として説明し、CLI/MCP ともに単なる symbol kind であるかのような警告ではなく `references <name> --kind import` へ誘導します。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -5004,19 +5004,20 @@ public static class QueryCommandRunner
     // - `type_reference`: 型位置エッジは compile-time な参照であり実行時呼び出しではない。
     //   `callers Foo --kind type_reference` は宣言型や generic 制約、`is`/`as`、XML-doc `cref`
     //   などの型言及を caller edge として誤って返す。
+    // - `import`: import/include dependency edges are structural, not call-graph edges.
     // CLI 境界で弾き、正しい列挙パスである `references --kind <kind>` に誘導する。
     private static readonly HashSet<string> NonCallGraphReferenceKinds = new(StringComparer.Ordinal)
     {
-        "attribute", "annotation", "type_reference",
+        "attribute", "annotation", "type_reference", "import",
     };
 
     /// <summary>
-    /// Reject non-call-graph reference kinds (`attribute` / `annotation` / `type_reference`) on
+    /// Reject non-call-graph reference kinds (`attribute` / `annotation` / `type_reference` / `import`) on
     /// commands (`callers` / `callees`) whose data model cannot answer those queries correctly.
     /// Returns true if the kind was rejected; the caller should then return
     /// `CommandExitCodes.UsageError`.
     /// `callers` / `callees` のようにデータモデル的に metadata / 型位置参照に答えられない
-    /// コマンドで `--kind attribute` / `--kind annotation` / `--kind type_reference` を弾く。
+    /// コマンドで `--kind attribute` / `--kind annotation` / `--kind type_reference` / `--kind import` を弾く。
     /// 弾いた場合 true を返すので、呼び出し側は `CommandExitCodes.UsageError` を返すこと。
     /// </summary>
     private static bool TryRejectNonCallGraphKindForGraphCommand(string command, string? kind)
@@ -5026,6 +5027,8 @@ public static class QueryCommandRunner
 
         if (kind == "type_reference")
             Console.Error.WriteLine($"Error: '--kind type_reference' is not supported on '{command}'. Type-position references are compile-time edges (declaration types, generic constraints, `is`/`as`/`instanceof`, XML-doc `cref`), not runtime calls, so `{command} --kind type_reference` cannot return accurate call-graph rows.");
+        else if (kind == "import")
+            Console.Error.WriteLine($"Error: '--kind import' is not supported on '{command}'. Import references are structural dependency edges, not runtime calls, so `{command} --kind import` cannot return accurate call-graph rows.");
         else
             Console.Error.WriteLine($"Error: '--kind {kind}' is not supported on '{command}'. Metadata references are attributed to the enclosing body-range symbol rather than the annotated target, so `{command} --kind {kind}` cannot return accurate rows (file-level targets such as `[assembly: ...]` drop entirely).");
         Console.Error.WriteLine($"Hint: use `cdidx references <name> --kind {kind}` instead.");

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -164,22 +164,23 @@ public partial class McpServer
 
     /// <summary>
     /// Return true when the requested reference kind is NOT a call-graph kind (i.e. metadata
-    /// `attribute` / `annotation` or compile-time `type_reference`) — these are valid on the
-    /// `references` tool but must be rejected on `callers` / `callees`, whose data model
+    /// `attribute` / `annotation`, compile-time `type_reference`, or structural `import`) —
+    /// these are valid on the `references` tool but must be rejected on `callers` / `callees`, whose data model
     /// cannot answer those queries correctly. Metadata rows are attributed to the enclosing
     /// body-range symbol rather than the annotated target (so file-level targets drop
     /// entirely and method-level metadata appears under the enclosing class); `type_reference`
     /// rows are compile-time type-position edges (declaration types, generic constraints,
     /// `is`/`as`/`instanceof`, XML-doc `cref`), not runtime calls, so they misreport type
-    /// mentions as caller/callee edges.
+    /// mentions as caller/callee edges; `import` rows are structural dependency edges.
     /// `references` では有効だが `callers` / `callees` では構造的に誤答するため弾くべき kind
-    /// （metadata: `attribute` / `annotation`、型位置: `type_reference`）かを返す。metadata 行は
+    /// （metadata: `attribute` / `annotation`、型位置: `type_reference`、構造 dependency: `import`）かを返す。metadata 行は
     /// 注釈対象ではなく body-range 上の外側シンボルに帰属し、`type_reference` は実行時呼び出し
     /// ではなく compile-time な型言及（宣言型、generic 制約、`is`/`as`/`instanceof`、XML-doc
-    /// `cref` など）なので、`callers` / `callees` はいずれの kind にも正しく答えられない。
+    /// `cref` など）で、`import` は構造的な dependency edge なので、`callers` / `callees` は
+    /// いずれの kind にも正しく答えられない。
     /// </summary>
     private static bool IsNonCallGraphReferenceKind(string? kind) =>
-        kind == "attribute" || kind == "annotation" || kind == "type_reference";
+        kind == "attribute" || kind == "annotation" || kind == "type_reference" || kind == "import";
 
     /// <summary>
     /// Build the CLI / MCP error message for a non-call-graph reference kind rejected on
@@ -191,6 +192,8 @@ public partial class McpServer
     private static string BuildNonCallGraphKindRejectionMessage(string command, string kind) =>
         kind == "type_reference"
             ? $"'kind: type_reference' is not supported on '{command}'. Type-position references are compile-time edges (declaration types, generic constraints, `is`/`as`/`instanceof`, XML-doc `cref`), not runtime calls, so `{command}` cannot return accurate rows for kind 'type_reference'. Use the 'references' tool with kind 'type_reference' instead."
+            : kind == "import"
+                ? $"'kind: import' is not supported on '{command}'. Import references are structural dependency edges, not runtime calls, so `{command}` cannot return accurate rows for kind 'import'. Use the 'references' tool with kind 'import' instead."
             : $"'kind: {kind}' is not supported on '{command}'. Metadata references are attributed to the enclosing body-range symbol, so `{command}` cannot return accurate rows for kind '{kind}'. Use the 'references' tool with kind '{kind}' for metadata enumeration.";
 
     private JsonNode? TryGetValidatedMaxLineWidth(JsonNode? id, JsonNode? args, out int maxLineWidth, string propertyName = "maxLineWidth")

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -2464,9 +2464,11 @@ public class McpServerTests : IDisposable
     [InlineData("callers", "attribute")]
     [InlineData("callers", "annotation")]
     [InlineData("callers", "type_reference")]
+    [InlineData("callers", "import")]
     [InlineData("callees", "attribute")]
     [InlineData("callees", "annotation")]
     [InlineData("callees", "type_reference")]
+    [InlineData("callees", "import")]
     public void ToolsCall_CallersOrCallees_NonCallGraphKindReturnsToolError(string tool, string kind)
     {
         // issue #293 + issue #444: the MCP `callers` / `callees` tools must reject non-call-graph
@@ -2475,12 +2477,14 @@ public class McpServerTests : IDisposable
         // instead of the annotated method, and file-level targets drop entirely). `type_reference`
         // rows are compile-time type mentions (declaration types, generic constraints, `is`/`as`/
         // `instanceof`, XML-doc `cref`) and not runtime calls. AI clients should be redirected to
-        // the `references` tool for these enumerations.
+        // the `references` tool for these enumerations. `import` rows are structural dependency
+        // edges, not runtime calls, and follow the same rejection path.
         // issue #293 + issue #444 補足: MCP の `callers` / `callees` ツールは非 call-graph な kind を
         // 必ず弾く。metadata 行 (`attribute` / `annotation`) は body-range の外側シンボルに帰属する
         // ため、`callers Obsolete kind=attribute` は注釈対象のメソッドではなく外側クラスを返し、
         // file-level target は完全に脱落する。`type_reference` は宣言型・generic 制約・`is`/`as`/
         // `instanceof`・XML-doc `cref` といった compile-time な型言及であり実行時呼び出しではない。
+        // `import` 行も runtime call ではなく構造的な dependency edge なので同じ拒否経路に入る。
         // AI クライアントは列挙のために `references` ツールに誘導する。
         var requestJson = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
             + "\"params\":{\"name\":\"" + tool + "\","
@@ -2492,6 +2496,8 @@ public class McpServerTests : IDisposable
         var text = response["result"]!["content"]![0]!["text"]!.GetValue<string>();
         Assert.Contains($"'kind: {kind}' is not supported on '{tool}'", text);
         Assert.Contains("'references' tool", text);
+        if (kind == "import")
+            Assert.Contains("Import references are structural dependency edges, not runtime calls", text);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -5176,9 +5176,11 @@ jobs:
     [InlineData("callers", "attribute")]
     [InlineData("callers", "annotation")]
     [InlineData("callers", "type_reference")]
+    [InlineData("callers", "import")]
     [InlineData("callees", "attribute")]
     [InlineData("callees", "annotation")]
     [InlineData("callees", "type_reference")]
+    [InlineData("callees", "import")]
     public void RunCallersCallees_RejectNonCallGraphKind_WithUsageError(string command, string kind)
     {
         // issue #293 + issue #444: `callers` / `callees` must reject non-call-graph reference
@@ -5189,8 +5191,9 @@ jobs:
         // `container_name` is NULL. `type_reference` rows are compile-time type-position edges
         // (declaration types, generic constraints, `is`/`as`/`instanceof`, XML-doc `cref`) and
         // are not runtime calls, so `callers Foo --kind type_reference` would misreport type
-        // mentions as caller edges. The correct path for these kinds is
-        // `references <name> --kind attribute|annotation|type_reference`.
+        // mentions as caller edges. `import` rows are structural dependency edges rather than
+        // runtime calls, so callers/callees cannot answer them as graph edges. The correct path
+        // for these kinds is `references <name> --kind attribute|annotation|type_reference|import`.
         // issue #293 + issue #444 補足: `callers` / `callees` は CLI 境界で非 call-graph な
         // reference kind を必ず弾く。metadata (`attribute` / `annotation`) 行は注釈対象ではなく
         // body-range の外側シンボルに帰属するため、`callers Obsolete --kind attribute` では
@@ -5198,8 +5201,9 @@ jobs:
         // file-level target は `container_name = NULL` で完全に脱落する。`type_reference` は
         // 宣言型・generic 制約・`is`/`as`/`instanceof`・XML-doc `cref` といった compile-time な
         // 型言及であり実行時呼び出しではないので、`callers Foo --kind type_reference` は型言及を
-        // caller edge として誤って返す。正しい経路は
-        // `references <name> --kind attribute|annotation|type_reference`。
+        // caller edge として誤って返す。`import` 行は runtime call ではなく構造的な dependency
+        // edge なので callers/callees では graph edge として答えられない。正しい経路は
+        // `references <name> --kind attribute|annotation|type_reference|import`。
         var projectRoot = TestProjectHelper.CreateTempProject($"cdidx_{command}_reject_kind_{kind}");
         try
         {
@@ -5216,6 +5220,8 @@ jobs:
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
             Assert.Contains($"'--kind {kind}' is not supported on '{command}'", stderr);
             Assert.Contains($"references <name> --kind {kind}", stderr);
+            if (kind == "import")
+                Assert.Contains("Import references are structural dependency edges, not runtime calls", stderr);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Reject `callers` / `callees --kind import` through the non-call-graph kind path in the CLI.
- Apply the same `kind: "import"` rejection to MCP callers/callees tools.
- Add CLI and MCP regression coverage plus a bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunCallersCallees_RejectNonCallGraphKind_WithUsageError|FullyQualifiedName~McpServerTests.ToolsCall_CallersOrCallees_NonCallGraphKindReturnsToolError"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- `dotnet build CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review round 1 found missing MCP parity; fixed in follow-up commit.
- Adversarial review round 2: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/2138.fixed.md`.

Fixes #2138
