### PR TITLE
Document sandboxed build validation

### DIFF
--- a/.codex/workflows/precommit.md
+++ b/.codex/workflows/precommit.md
@@ -27,4 +27,14 @@ dotnet build CodeIndex.sln -c Release
 dotnet test CodeIndex.sln -c Release
 ```
 
+In sandboxed environments where the shared Roslyn compilation server cannot
+start or connect reliably, add `-p:UseSharedCompilation=false` to build and
+test commands. This avoids the 5-minute shared compilation socket timeout while
+preserving the same project and configuration coverage:
+
+```bash
+dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false
+dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false
+```
+
 If a command cannot run in the current environment, report the reason and the exact command the user should run.

--- a/changelog.d/unreleased/2133.docs.md
+++ b/changelog.d/unreleased/2133.docs.md
@@ -1,0 +1,15 @@
+---
+category: docs
+issues:
+  - 2133
+affected:
+  - .codex/workflows/precommit.md
+---
+
+## English
+
+- **Documented sandboxed build validation without shared compilation (#2133)** — the precommit workflow now tells agents to add `-p:UseSharedCompilation=false` to build and test commands when sandboxed environments cannot use the shared Roslyn compilation server reliably.
+
+## 日本語
+
+- **sandbox 環境で shared compilation を使わない build 検証手順を文書化しました (#2133)** — sandbox 環境で共有 Roslyn compilation server を安定して利用できない場合に、precommit workflow が build / test コマンドへ `-p:UseSharedCompilation=false` を追加するよう案内します。


### PR DESCRIPTION
## Summary

- Document `-p:UseSharedCompilation=false` as the sandboxed build/test workaround in the precommit workflow.
- Add the issue-based bilingual changelog fragment for the workflow documentation change.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter ChangelogToolTests -p:UseSharedCompilation=false`
- `git diff --cached --check`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Updated `.codex/workflows/precommit.md`.
- Added `changelog.d/unreleased/2133.docs.md`.

## Notes

- Full local `cdidx` re-index attempts were interrupted by the local execution environment with exit code 143 before completion; the targeted docs/changelog validation passed.

Fixes #2133
