### PR TITLE
Strip line-leading zero-width spaces

### DIFF
--- a/changelog.d/unreleased/2117.fixed.md
+++ b/changelog.d/unreleased/2117.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 2117
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Indexer/Scanning/ChunkSplitter.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Line-leading zero-width spaces are stripped during indexing (#2117)** — the line-leading invisible cleanup now removes `U+200B` alongside `U+FEFF`, while preserving mid-line occurrences and the no-allocation fast path for files that do not need cleanup.
+
+## 日本語
+
+- **インデックス時に行頭の zero-width space も剥がすようになりました (#2117)** — 行頭不可視文字の cleanup は `U+FEFF` に加えて `U+200B` も削除し、行中の出現と cleanup 不要ファイルの no-allocation 高速パスは維持します。

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -945,9 +945,9 @@ public static partial class ReferenceExtractor
         var isRazorFile = IsRazorFilePath(path) || requestedLanguage is "razor" or "blazor" or "cshtml";
 
         // Null / empty fast path — keep the direct-call null-safe contract that
-        // FileIndexer.StripLineLeadingBom's IsNullOrEmpty check used to provide
+        // FileIndexer.StripLineLeadingInvisibles' IsNullOrEmpty check used to provide
         // before the CRLF normalization step was added in front of it. Closes #183.
-        // null / 空入力は早期 return。CRLF 正規化を StripLineLeadingBom の前に
+        // null / 空入力は早期 return。CRLF 正規化を StripLineLeadingInvisibles の前に
         // 入れたことで helper 側の IsNullOrEmpty による null 許容が効かなくなる
         // ため、direct call の null セーフ契約をここで復元する。Closes #183.
         if (string.IsNullOrEmpty(content))

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -911,7 +911,7 @@ public static partial class ReferenceExtractor
                 return [];
             if (content.Contains('\r'))
                 content = content.Replace("\r\n", "\n").Replace("\r", "\n");
-            content = FileIndexer.StripLineLeadingBom(content);
+            content = FileIndexer.StripLineLeadingInvisibles(content);
 
             return pluginExtractor.Extract(
                     fileId,
@@ -968,21 +968,20 @@ public static partial class ReferenceExtractor
 
         // Normalize CRLF / CR to LF first so direct callers that bypass FileIndexer
         // still present a `\n`-only content stream, and then strip line-leading
-        // UTF-8 BOM (U+FEFF) defensively so `^\s*`-anchored patterns match on
-        // line 1 and on any mid-file line that begins with a BOM (e.g. from file
-        // concatenation or tool insertion). StripLineLeadingBom assumes `\n` is
-        // the sole line separator, so the CRLF pass must come first. Non-line-
-        // leading U+FEFF is preserved so content with intentional ZWNBSP inside
-        // a string literal stays verbatim. Closes #183.
-        // まず CRLF / CR を LF に正規化する。StripLineLeadingBom は `\n` を唯一の
+        // UTF-8 BOM (U+FEFF) and zero-width space (U+200B) defensively so
+        // `^\s*`-anchored patterns match on line 1 and on any mid-file line that
+        // begins with such a marker (e.g. from file concatenation or tool insertion).
+        // StripLineLeadingInvisibles assumes `\n` is the sole line separator, so the
+        // CRLF pass must come first. Non-line-leading markers are preserved. Closes #183/#2117.
+        // まず CRLF / CR を LF に正規化する。StripLineLeadingInvisibles は `\n` を唯一の
         // 行区切りとして行頭判定するので、FileIndexer を経由しない direct call
-        // でも CRLF 正規化を済ませてから呼ばないと mid-file の行頭 BOM を剥がし
-        // 損なう。続いて行頭 U+FEFF のみ剥がし、1 行目と mid-file の行頭 BOM 両方
-        // で `^\s*` 固定パターンを成立させる。行頭以外の U+FEFF (文字列リテラル中
-        // の意図的な ZWNBSP 等) はそのまま保持する。Closes #183.
+        // でも CRLF 正規化を済ませてから呼ばないと mid-file の行頭 marker を剥がし
+        // 損なう。続いて行頭 U+FEFF/U+200B のみ剥がし、1 行目と mid-file の行頭
+        // marker 両方で `^\s*` 固定パターンを成立させる。行頭以外の marker は
+        // そのまま保持する。Closes #183/#2117.
         if (content.Contains('\r'))
             content = content.Replace("\r\n", "\n").Replace("\r", "\n");
-        content = FileIndexer.StripLineLeadingBom(content);
+        content = FileIndexer.StripLineLeadingInvisibles(content);
 
         var maskedContent = string.Equals(language, "java", StringComparison.OrdinalIgnoreCase)
             ? MaskJavaTextBlocks(content)

--- a/src/CodeIndex/Indexer/Scanning/ChunkSplitter.cs
+++ b/src/CodeIndex/Indexer/Scanning/ChunkSplitter.cs
@@ -70,17 +70,16 @@ public static class ChunkSplitter
         // 防御的CRLF正規化 — BuildRecordで正規化済みだが、直接呼び出し時の安全策。
         if (content.Contains('\r'))
             content = content.Replace("\r\n", "\n").Replace("\r", "\n");
-        // Defensive line-leading UTF-8 BOM strip — BuildRecord already strips the
-        // leading BOM and any BOM that follows `\n`, but this method is public and
-        // may be called directly. Mid-line U+FEFF (e.g. inside a string literal)
-        // is preserved. Closes #183.
-        // 防御的な行頭 UTF-8 BOM 剥離 — BuildRecord で先頭 BOM と `\n` 直後の BOM を
-        // 既に剥がしているが、本メソッドはpublicで直接呼ばれうる。行頭以外の
-        // U+FEFF (文字列リテラル内等) はそのまま残す。Closes #183.
-        content = FileIndexer.StripLineLeadingBom(content);
-        // Re-check for empty after BOM/CRLF strip so BOM-only input yields no chunks,
+        // Defensive line-leading invisible strip — BuildRecord already strips the
+        // leading BOM/ZWSP markers and any that follow `\n`, but this method is public
+        // and may be called directly. Mid-line markers are preserved. Closes #183/#2117.
+        // 防御的な行頭不可視文字剥離 — BuildRecord で先頭 BOM/ZWSP と `\n` 直後の marker を
+        // 既に剥がしているが、本メソッドはpublicで直接呼ばれうる。行頭以外はそのまま残す。
+        // Closes #183/#2117.
+        content = FileIndexer.StripLineLeadingInvisibles(content);
+        // Re-check for empty after invisible/CRLF strip so marker-only input yields no chunks,
         // matching the no-chunks contract for empty files.
-        // BOM/CRLF剥離後に再度空判定し、BOMのみの入力が空ファイルと同じく0チャンクになるようにする。
+        // 不可視文字/CRLF剥離後に再度空判定し、markerのみの入力が空ファイルと同じく0チャンクになるようにする。
         if (content.Length == 0)
             return [];
         // Skip oversize-line files (e.g. 1 MB minified `.min.js`, base64 blobs):

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -2319,7 +2319,7 @@ public class FileIndexer
         // CRLF / CR のみを LF に潰すため、BOM の追加 / 削除はインクリメンタル
         // 再索引で引き続き検知される。Closes #183。OS をまたいだ CRLF / LF の
         // 同一性は ComputeChecksum 自体で担保する。#1544 参照。
-        content = StripLineLeadingBom(content);
+        content = StripLineLeadingInvisibles(content);
         // Accurate line count: ignore trailing newline, and treat content that became
         // empty after CRLF / BOM stripping as zero lines (not `"".Split('\n') == [""]`'s
         // off-by-one of 1) so `files.lines` stays consistent with the 0-chunk contract
@@ -2392,37 +2392,36 @@ public class FileIndexer
     }
 
     /// <summary>
-    /// Strip every line-leading UTF-8 BOM (U+FEFF). Assumes CRLF has already been
-    /// normalized to LF so `\n` is the sole line separator. Preserves non-line-
-    /// leading U+FEFF verbatim (intentional ZWNBSP inside string literals etc.).
-    /// 行頭の UTF-8 BOM (U+FEFF) のみ剥がす。呼び出し前に CRLF が LF へ
-    /// 正規化済みであることを前提とする。行頭以外の U+FEFF (文字列リテラル等で
-    /// 意図的に使われる ZWNBSP) はそのまま保持する。
+    /// Strip every line-leading UTF-8 BOM (U+FEFF) and zero-width space (U+200B).
+    /// Assumes CRLF has already been normalized to LF so `\n` is the sole line
+    /// separator. Preserves non-line-leading invisibles verbatim.
+    /// 行頭の UTF-8 BOM (U+FEFF) と zero-width space (U+200B) のみ剥がす。
+    /// 呼び出し前に CRLF が LF へ正規化済みであることを前提とする。
+    /// 行頭以外の不可視文字はそのまま保持する。
     /// </summary>
-    internal static string StripLineLeadingBom(string content)
+    internal static string StripLineLeadingInvisibles(string content)
     {
         if (string.IsNullOrEmpty(content))
             return content;
-        // Fast path: BOM-free files (the dominant case) skip the line-tracking
+        // Fast path: invisible-free files (the dominant case) skip the line-tracking
         // scan and return the input unchanged so no StringBuilder is allocated.
-        // 高速パス: BOM が一切無いファイル (支配的ケース) は行頭追跡走査を回避し、
-        // 入力をそのまま返して StringBuilder を確保しない。
-        if (!content.Contains('\uFEFF'))
+        // 高速パス: 対象の不可視文字が一切無いファイル (支配的ケース) は行頭追跡走査を
+        // 回避し、入力をそのまま返して StringBuilder を確保しない。
+        if (!content.Contains('\uFEFF') && !content.Contains('\u200B'))
             return content;
 
-        // U+FEFF is present somewhere. Locate the first *line-leading* BOM in a
-        // single pass; if every occurrence is mid-line (intentional ZWNBSP
-        // inside string literals etc.), return the input unchanged so the
-        // no-strip path also avoids any allocation.
-        // U+FEFF が含まれている。最初の「行頭」 BOM を 1 パスで探し、行頭以外
-        // のみ (文字列リテラル内の意図的な ZWNBSP 等) であれば入力をそのまま
-        // 返し、「剥がし不要」のケースでも割り当てを発生させない。
+        // A target invisible is present somewhere. Locate the first line-leading
+        // occurrence in a single pass; if every occurrence is mid-line, return
+        // the input unchanged so the no-strip path also avoids any allocation.
+        // 対象の不可視文字が含まれている。最初の「行頭」出現を 1 パスで探し、行頭
+        // 以外のみであれば入力をそのまま返し、「剥がし不要」のケースでも割り当てを
+        // 発生させない。
         int firstStripIndex = -1;
         bool atLineStart = true;
         for (int i = 0; i < content.Length; i++)
         {
             char c = content[i];
-            if (c == '\uFEFF' && atLineStart)
+            if (IsLineLeadingInvisible(c) && atLineStart)
             {
                 firstStripIndex = i;
                 break;
@@ -2432,29 +2431,31 @@ public class FileIndexer
         if (firstStripIndex < 0)
             return content;
 
-        // Allocate only after at least one line-leading BOM is confirmed. The
-        // capacity accounts for stripping at least the BOM at firstStripIndex.
-        // 少なくとも 1 つの行頭 BOM が確定した時点で初めて確保する。容量は
-        // firstStripIndex の BOM を必ず剥がす分を差し引いた値にしておく。
+        // Allocate only after at least one line-leading invisible is confirmed.
+        // The capacity accounts for stripping at least the char at firstStripIndex.
+        // 少なくとも 1 つの行頭不可視文字が確定した時点で初めて確保する。容量は
+        // firstStripIndex の文字を必ず剥がす分を差し引いた値にしておく。
         var sb = new StringBuilder(content.Length - 1);
         if (firstStripIndex > 0)
             sb.Append(content, 0, firstStripIndex);
-        // The char at firstStripIndex is itself a line-leading BOM; resume
+        // The char at firstStripIndex is itself a line-leading invisible; resume
         // after it with atLineStart = true so consecutive BOMs at the same
-        // logical position (e.g. multiple BOMs right after `\n`) are stripped.
-        // firstStripIndex の文字自体が行頭 BOM。直後から再開し atLineStart を
-        // true に戻すことで `\n` 直後に連続する BOM も同じ論理位置として剥がす。
+        // logical position (e.g. multiple markers right after `\n`) are stripped.
+        // firstStripIndex の文字自体が行頭不可視文字。直後から再開し atLineStart を
+        // true に戻すことで `\n` 直後に連続する marker も同じ論理位置として剥がす。
         atLineStart = true;
         for (int i = firstStripIndex + 1; i < content.Length; i++)
         {
             char c = content[i];
-            if (c == '\uFEFF' && atLineStart)
+            if (IsLineLeadingInvisible(c) && atLineStart)
                 continue;
             sb.Append(c);
             atLineStart = c == '\n';
         }
         return sb.ToString();
     }
+
+    private static bool IsLineLeadingInvisible(char c) => c is '\uFEFF' or '\u200B';
 
     /// <summary>
     /// Validate file content for encoding issues.

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2099,9 +2099,9 @@ public static partial class SymbolExtractor
             return [];
 
         // Null / empty fast path — keep the direct-call null-safe contract that
-        // FileIndexer.StripLineLeadingBom's IsNullOrEmpty check used to provide
+        // FileIndexer.StripLineLeadingInvisibles' IsNullOrEmpty check used to provide
         // before the CRLF normalization step was added in front of it. Closes #183.
-        // null / 空入力は早期 return。CRLF 正規化を StripLineLeadingBom の前に
+        // null / 空入力は早期 return。CRLF 正規化を StripLineLeadingInvisibles の前に
         // 入れたことで helper 側の IsNullOrEmpty による null 許容が効かなくなる
         // ため、direct call の null セーフ契約をここで復元する。Closes #183.
         if (string.IsNullOrEmpty(content))
@@ -2122,7 +2122,7 @@ public static partial class SymbolExtractor
 
         if (content.Contains('\r'))
             content = content.Replace("\r\n", "\n").Replace("\r", "\n");
-        content = FileIndexer.StripLineLeadingBom(content);
+        content = FileIndexer.StripLineLeadingInvisibles(content);
 
         if (pluginLanguage != null
             && !PatternCache.ContainsKey(pluginLanguage)

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2961,70 +2961,68 @@ public class FileIndexerTests
     }
 
     [Fact]
-    public void StripLineLeadingBom_BomFreeContent_ReturnsSameInstance()
+    public void StripLineLeadingInvisibles_InvisibleFreeContent_ReturnsSameInstance()
     {
-        // BOM-free content (the dominant case) must hit the fast path and
+        // Invisible-free content (the dominant case) must hit the fast path and
         // return the same string instance, asserting no StringBuilder is
-        // allocated. Closes #1495.
-        // BOM が無いファイル (支配的ケース) は高速パスで同じ string インスタンスを
-        // 返し、StringBuilder を割り当てないことを保証する。Closes #1495.
+        // allocated. Closes #1495/#2117.
+        // 対象の不可視文字が無いファイル (支配的ケース) は高速パスで同じ string インスタンスを
+        // 返し、StringBuilder を割り当てないことを保証する。Closes #1495/#2117.
         var input = "using System;\nnamespace Plain;\nclass C { }\n";
-        var output = FileIndexer.StripLineLeadingBom(input);
+        var output = FileIndexer.StripLineLeadingInvisibles(input);
         Assert.Same(input, output);
     }
 
     [Fact]
-    public void StripLineLeadingBom_MidLineBomOnly_ReturnsSameInstance()
+    public void StripLineLeadingInvisibles_MidLineInvisiblesOnly_ReturnsSameInstance()
     {
-        // Content that carries U+FEFF only mid-line (intentional ZWNBSP in a
-        // string literal, identifier, or comment — never line-leading) must
-        // also hit the no-allocation path and return the same instance, so
-        // the no-op case never pays the StringBuilder cost. Closes #1495.
-        // 行頭以外にのみ U+FEFF を含むファイル (文字列リテラル内の意図的な ZWNBSP 等)
-        // も割り当て無しのパスを通り、同じインスタンスを返すことを保証する。Closes #1495.
-        var input = "var s = \"A\uFEFFB\";\nvar t = \"\uFEFF\";\n";
-        var output = FileIndexer.StripLineLeadingBom(input);
+        // Content that carries U+FEFF/U+200B only mid-line must also hit the
+        // no-allocation path and return the same instance, so the no-op case
+        // never pays the StringBuilder cost. Closes #1495/#2117.
+        // 行頭以外にのみ U+FEFF/U+200B を含むファイルも割り当て無しのパスを通り、
+        // 同じインスタンスを返すことを保証する。Closes #1495/#2117.
+        var input = "var s = \"A\uFEFFB\";\nvar t = \"A\u200BB\";\n";
+        var output = FileIndexer.StripLineLeadingInvisibles(input);
         Assert.Same(input, output);
-        // Mid-line U+FEFF stays verbatim so the source-of-truth payload is
+        // Mid-line invisibles stay verbatim so the source-of-truth payload is
         // not silently corrupted for code that embeds ZWNBSP intentionally.
-        // 行頭以外の U+FEFF はそのまま保持し、意図的に ZWNBSP を埋め込んだ
+        // 行頭以外の不可視文字はそのまま保持し、意図的に ZWNBSP を埋め込んだ
         // コードの payload を破壊しないことを併せて確認する。
         Assert.Contains('\uFEFF', output);
+        Assert.Contains('\u200B', output);
     }
 
     [Fact]
-    public void StripLineLeadingBom_EmptyContent_ReturnsSameInstance()
+    public void StripLineLeadingInvisibles_EmptyContent_ReturnsSameInstance()
     {
         // Empty input must short-circuit before any scan or allocation.
         // 空入力は走査・割り当ての前に短絡することを保証する。
-        Assert.Same(string.Empty, FileIndexer.StripLineLeadingBom(string.Empty));
+        Assert.Same(string.Empty, FileIndexer.StripLineLeadingInvisibles(string.Empty));
     }
 
     [Fact]
-    public void StripLineLeadingBom_LineLeadingBoms_StrippedWhileMidLineBomPreserved()
+    public void StripLineLeadingInvisibles_LineLeadingInvisibles_StrippedWhileMidLineInvisiblesPreserved()
     {
-        // File-leading and post-newline BOMs are stripped, while mid-line
-        // U+FEFF inside a literal is preserved verbatim. This pins the
-        // narrowed #183 contract through the new deferred-allocation path.
-        // 先頭 BOM および `\n` 直後の BOM は剥がし、行内の U+FEFF は
-        // そのまま保持することを確認する。#183 で狭められた契約を新パスで再固定。
-        var input = "\uFEFFline1\n\uFEFFline2 has \"A\uFEFFB\"\nline3\n";
-        var output = FileIndexer.StripLineLeadingBom(input);
+        // File-leading and post-newline U+FEFF/U+200B markers are stripped, while
+        // mid-line markers inside a literal are preserved verbatim.
+        // 先頭および `\n` 直後の U+FEFF/U+200B は剥がし、行内の marker は
+        // そのまま保持することを確認する。
+        var input = "\uFEFFline1\n\u200Bline2 has \"A\uFEFFB\"\n\uFEFF\u200Bline3 has \"A\u200BB\"\n";
+        var output = FileIndexer.StripLineLeadingInvisibles(input);
 
-        Assert.Equal("line1\nline2 has \"A\uFEFFB\"\nline3\n", output);
+        Assert.Equal("line1\nline2 has \"A\uFEFFB\"\nline3 has \"A\u200BB\"\n", output);
     }
 
     [Fact]
-    public void StripLineLeadingBom_ConsecutiveLineLeadingBoms_AllStripped()
+    public void StripLineLeadingInvisibles_ConsecutiveLineLeadingInvisibles_AllStripped()
     {
-        // Multiple BOMs sharing the same logical line-start (e.g. a doubled
-        // BOM at offset 0 from accidental tool concatenation) must all be
-        // stripped, matching the original foreach loop's invariant that
-        // skipping a BOM does not reset `atLineStart`.
-        // 同じ論理行頭に重なる連続 BOM (オフセット 0 の二重 BOM 等) は全て
-        // 剥がす。元実装の「BOM スキップで atLineStart を更新しない」契約を保つ。
-        var input = "\uFEFF\uFEFFhello\n\uFEFF\uFEFFworld\n";
-        var output = FileIndexer.StripLineLeadingBom(input);
+        // Multiple invisible markers sharing the same logical line-start must all
+        // be stripped, preserving the invariant that skipping a marker does not
+        // reset `atLineStart`.
+        // 同じ論理行頭に重なる連続 marker は全て剥がす。「marker スキップで
+        // atLineStart を更新しない」契約を保つ。
+        var input = "\uFEFF\u200Bhello\n\u200B\uFEFFworld\n";
+        var output = FileIndexer.StripLineLeadingInvisibles(input);
 
         Assert.Equal("hello\nworld\n", output);
     }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -28608,8 +28608,8 @@ public class ReferenceExtractorTests
     public void Extract_Csharp_CrlfLeadingBom_ExtractsReferencesOnFirstLine()
     {
         // Direct-call input with CRLF line endings AND a leading BOM: the CRLF → LF
-        // normalization must run before StripLineLeadingBom so call sites on mid-file
-        // BOM lines are still captured. Closes #183.
+        // normalization must run before StripLineLeadingInvisibles so call sites on
+        // mid-file BOM lines are still captured. Closes #183.
         // CRLF 改行 + 先頭 BOM の direct call: CRLF → LF 正規化を helper より先に通す
         // ことで、mid-file 行頭 BOM 直後の呼び出しも参照として拾える。Closes #183.
         const string content = "\uFEFFnamespace BomRefCrlf;\r\npublic class C\r\n{\r\n    public void Run()\r\n    {\r\n\uFEFF        Helper();\r\n    }\r\n    public void Helper() { }\r\n}\r\n";

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -28588,9 +28588,9 @@ public class ReferenceExtractorTests
     public void Extract_NullContent_ReturnsEmpty()
     {
         // Direct callers that pass `null` must not throw. The #183 CRLF-normalization
-        // step added ahead of StripLineLeadingBom would otherwise dereference `null`
+        // step added ahead of StripLineLeadingInvisibles would otherwise dereference `null`
         // before the helper's IsNullOrEmpty guard could run. Closes #183.
-        // direct call で `null` を渡してもスローしない。#183 で StripLineLeadingBom
+        // direct call で `null` を渡してもスローしない。#183 で StripLineLeadingInvisibles
         // の前段に CRLF 正規化を入れたため、helper 側 IsNullOrEmpty まで届かず
         // `null` を逆参照してしまう回帰を防ぐ。Closes #183.
         Assert.Empty(ReferenceExtractor.Extract(1, "csharp", null!, Array.Empty<CodeIndex.Models.SymbolRecord>()));

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -23562,10 +23562,10 @@ public class SymbolExtractorTests
     public void Extract_Csharp_CrlfLeadingBom_IndexesFirstLineImport()
     {
         // Direct-call input with CRLF line endings AND a leading BOM: the CRLF → LF
-        // normalization must run before StripLineLeadingBom so the line-leading BOM
-        // logic still recognizes mid-file BOMs (helper treats `\n` as the sole line
+        // normalization must run before StripLineLeadingInvisibles so the line-leading
+        // cleanup still recognizes mid-file BOMs (helper treats `\n` as the sole line
         // separator). Closes #183.
-        // CRLF 改行 + 先頭 BOM の direct call: StripLineLeadingBom は `\n` を唯一の
+        // CRLF 改行 + 先頭 BOM の direct call: StripLineLeadingInvisibles は `\n` を唯一の
         // 行区切りとして扱うので、CRLF → LF 正規化を helper より先に通さないと
         // mid-file 行頭 BOM を剥がし損ねる。Closes #183.
         const string content = "\uFEFFusing System;\r\n\r\n\uFEFFnamespace CrlfBom;\r\n";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -23542,9 +23542,9 @@ public class SymbolExtractorTests
     public void Extract_NullContent_ReturnsEmpty()
     {
         // Direct callers that pass `null` must not throw. The #183 CRLF-normalization
-        // step added ahead of StripLineLeadingBom would otherwise dereference `null`
+        // step added ahead of StripLineLeadingInvisibles would otherwise dereference `null`
         // before the helper's IsNullOrEmpty guard could run. Closes #183.
-        // direct call で `null` を渡してもスローしない。#183 で StripLineLeadingBom
+        // direct call で `null` を渡してもスローしない。#183 で StripLineLeadingInvisibles
         // の前段に CRLF 正規化を入れたため、helper 側 IsNullOrEmpty まで届かず
         // `null` を逆参照してしまう回帰を防ぐ。Closes #183.
         Assert.Empty(SymbolExtractor.Extract(1, "csharp", null!));


### PR DESCRIPTION
## Summary

- Extend line-leading cleanup from `U+FEFF` only to `U+FEFF` plus `U+200B`.
- Preserve mid-line `U+FEFF` / `U+200B` and the no-allocation fast path for files that do not need cleanup.
- Apply the same helper through indexing, chunk splitting, symbol extraction, reference extraction, and plugin extraction paths.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests"`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Csharp_CrlfLeadingBom_IndexesFirstLineImport|FullyQualifiedName~ReferenceExtractorTests.Extract_Csharp_CrlfLeadingBom_ExtractsReferencesOnFirstLine"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_NullContent_ReturnsEmpty"`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/2117.fixed.md`.

## Follow-up Candidates

- None.

Fixes #2117
