### PR TITLE
Remove unreachable impact depth guard

### DIFF
--- a/changelog.d/unreleased/2120.fixed.md
+++ b/changelog.d/unreleased/2120.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2120
+affected:
+  - src/CodeIndex/Database/DbReader.GraphQueries.cs
+---
+
+## English
+
+- **Removed an unreachable transitive impact depth guard (#2120)** — `GetTransitiveCallers` now relies on its enqueue-side max-depth bound without carrying a dequeue branch that cannot be reached.
+
+## 日本語
+
+- **推移的 impact の到達不能な depth ガードを削除しました (#2120)** — `GetTransitiveCallers` は enqueue 側の max-depth 制御に一本化し、到達しない dequeue 側分岐を持たないようになりました。

--- a/src/CodeIndex/Database/DbReader.GraphQueries.cs
+++ b/src/CodeIndex/Database/DbReader.GraphQueries.cs
@@ -925,8 +925,6 @@ public partial class DbReader
         while (queue.Count > 0 && results.Count < limit)
         {
             var (currentSymbol, depth) = queue.Dequeue();
-            if (depth > maxDepth)
-                break;
 
             // Fetch callers in pages, filtering out already-visited before counting toward limit.
             // This prevents diamond graphs from hiding reachable callers behind visited duplicates.


### PR DESCRIPTION
## Summary

- Removed the unreachable dequeue-side `depth > maxDepth` guard from `GetTransitiveCallers`.
- Added bilingual changelog fragment `changelog.d/unreleased/2120.fixed.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.GetTransitiveCallers"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/2120.fixed.md`.
- No README/developer documentation changes were needed because this removes dead code without changing user-facing behavior.

Fixes #2120
