### PR TITLE
Reject ambiguous --commits refs

### DIFF
--- a/changelog.d/unreleased/2093.fixed.md
+++ b/changelog.d/unreleased/2093.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2093
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **`--commits` now rejects git ranges and tag refs before indexing (#2093)** - commit-scoped updates validate each argument as a single commit-ish and return a usage error instead of silently treating revision-set syntax or tag refs as commit inputs.
+
+## 日本語
+
+- **`--commits` が index 前に git range と tag ref を拒否するようになりました (#2093)** - commit 指定の更新では各引数を単一 commit-ish として検証し、revision-set 構文や tag ref を commit 入力として黙って扱わず usage error を返します。

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -55,12 +55,7 @@ public static class GitHelper
     /// </summary>
     public static List<string> GetChangedFilesFromCommit(string projectRoot, string commitId)
     {
-        // Validate commit ID to prevent argument injection (only hex + common ref chars allowed)
-        // Reject values starting with "-" to prevent git option injection even without "--" separator
-        // コミットIDをバリデーションし引数インジェクションを防止（16進数+一般的な参照文字のみ許可）
-        // "-"で始まる値も拒否し、"--"セパレータなしでもgitオプション注入を防止
-        if (commitId.StartsWith('-') || !Regex.IsMatch(commitId, @"^[a-zA-Z0-9_./^~\-]+$"))
-            throw new ArgumentException($"Invalid commit ID: {commitId}");
+        ValidateSingleCommitRef(projectRoot, commitId);
 
         var psi = new ProcessStartInfo
         {
@@ -88,6 +83,36 @@ public static class GitHelper
         return output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
             .Select(FileIndexer.NormalizePathSeparators)
             .ToList();
+    }
+
+    private static void ValidateSingleCommitRef(string projectRoot, string commitId)
+    {
+        // Reject range/pathspec syntax before invoking git so --commits remains a list
+        // of single commit-ish values, not revision-set expressions.
+        if (string.IsNullOrWhiteSpace(commitId)
+            || commitId.StartsWith('-')
+            || commitId.Contains("..", StringComparison.Ordinal)
+            || commitId.Contains("^{", StringComparison.Ordinal)
+            || commitId.Contains(':')
+            || !Regex.IsMatch(commitId, @"^[a-zA-Z0-9_./^~\-]+$"))
+        {
+            throw new ArgumentException(
+                $"Invalid commit ID '{commitId}'. Provide a single commit-ish; ranges and tag refs are not accepted. Use `git rev-parse --verify <ref>^{{commit}}` to validate it.");
+        }
+
+        var symbolicName = TryRunGit(projectRoot, "rev-parse", "--symbolic-full-name", commitId)?.Trim();
+        if (symbolicName != null && symbolicName.StartsWith("refs/tags/", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Invalid commit ID '{commitId}'. Tag refs are not accepted for --commits; pass the peeled commit SHA from `git rev-parse --verify {commitId}^{{commit}}`.");
+        }
+
+        var resolved = TryRunGit(projectRoot, "rev-parse", "--verify", $"{commitId}^{{commit}}")?.Trim();
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            throw new ArgumentException(
+                $"Invalid commit ID '{commitId}'. Git could not resolve it to a single commit. Use `git rev-parse --verify <ref>^{{commit}}` to validate it.");
+        }
     }
 
     /// <summary>

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -213,9 +213,9 @@ public static class IndexCommandRunner
                 var changedFiles = new HashSet<string>(StringComparer.Ordinal);
                 var relevantIgnoreFileChanged = false;
                 var repoRoot = GitHelper.TryGetRepositoryRoot(options.ProjectPath) ?? Path.GetFullPath(options.ProjectPath!);
-                foreach (var commit in options.Commits)
+                try
                 {
-                    try
+                    foreach (var commit in options.Commits)
                     {
                         var changed = GitHelper.GetChangedFilesFromCommit(options.ProjectPath, commit);
                         var normalized = NormalizeCommitFileTargets(options.ProjectPath, repoRoot, changed, out var commitTouchedRelevantIgnoreFile);
@@ -223,7 +223,16 @@ public static class IndexCommandRunner
                         foreach (var path in normalized)
                             changedFiles.Add(path);
                     }
-                    catch { /* ignore git errors in dry-run */ }
+                }
+                catch (Exception ex)
+                {
+                    return WriteCommandError(
+                        options.Json,
+                        jsonOptions,
+                        $"failed to resolve changed files from git commits: {ex.Message}",
+                        CommandExitCodes.UsageError,
+                        "Check the commit IDs and rerun `cdidx index <projectPath> --commits <id> [id ...]`.",
+                        CommandErrorCodes.UsageError);
                 }
                 if (options.ChangedBetweenRefs.Count == 2)
                 {

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -161,6 +161,40 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public void GetChangedFilesFromCommit_RejectsRevisionRanges()
+    {
+        var repoDir = CreateGitRepo();
+
+        File.WriteAllText(Path.Combine(repoDir, "first.txt"), "hello\n");
+        RunGit(repoDir, "add", "first.txt");
+        RunGit(repoDir, "commit", "-m", "initial");
+        File.WriteAllText(Path.Combine(repoDir, "second.txt"), "hello\n");
+        RunGit(repoDir, "add", "second.txt");
+        RunGit(repoDir, "commit", "-m", "second");
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => GitHelper.GetChangedFilesFromCommit(repoDir, "HEAD~1..HEAD"));
+
+        Assert.Contains("ranges and tag refs are not accepted", ex.Message);
+    }
+
+    [Fact]
+    public void GetChangedFilesFromCommit_RejectsTagRefs()
+    {
+        var repoDir = CreateGitRepo();
+
+        File.WriteAllText(Path.Combine(repoDir, "first.txt"), "hello\n");
+        RunGit(repoDir, "add", "first.txt");
+        RunGit(repoDir, "commit", "-m", "initial");
+        RunGit(repoDir, "tag", "v1.0");
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => GitHelper.GetChangedFilesFromCommit(repoDir, "v1.0"));
+
+        Assert.Contains("Tag refs are not accepted", ex.Message);
+    }
+
+    [Fact]
     public void GetChangedFilesFromCommit_ReturnsFilesForMergeCommit()
     {
         var repoDir = CreateGitRepo();

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -362,7 +362,10 @@ public class GitHubIssueReporterTests : IDisposable
 
             Assert.Null(result.IssueUrl);
             Assert.Equal("""422: { "message": "validation failed" }""", result.Error);
-            Assert.Equal(2, handler.RequestCount);
+            Assert.Equal(3, handler.RequestCount);
+            Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+            Assert.Equal(HttpMethod.Get, handler.Requests[1].Method);
+            Assert.Equal(HttpMethod.Post, handler.Requests[2].Method);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -4825,6 +4825,32 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_DryRunWithInvalidCommitRange_ReturnsUsageError()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            RunGit(projectRoot, "init");
+            File.WriteAllText(Path.Combine(projectRoot, "tracked.cs"), "class Sample {}\n");
+            RunGit(projectRoot, "add", "tracked.cs");
+            RunGit(projectRoot, "commit", "-m", "initial");
+            File.WriteAllText(Path.Combine(projectRoot, "other.cs"), "class Other {}\n");
+            RunGit(projectRoot, "add", "other.cs");
+            RunGit(projectRoot, "commit", "-m", "other");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--dry-run", "--commits", "HEAD~1..HEAD", "--json"]);
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Contains("ranges and tag refs are not accepted", json.GetProperty("message").GetString());
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_DryRun_IgnoresUnixFifoWithoutHanging()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
## Summary
- Validate `--commits` inputs as single commit-ish values before running `git diff-tree`.
- Reject git revision ranges, `^{...}` dereferences, pathspec-style refs, and tag refs with a usage error and validation hint.
- Make dry-run commit resolution fail closed instead of swallowing git commit errors.
- Align `GitHubIssueReporterTests` with the current search + label-list idempotency fallback request flow that was failing CI.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~GitHelperTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~IndexCommandRunnerTests.Run_DryRunWithInvalidCommitRange_ReturnsUsageError`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~GitHelperTests|FullyQualifiedName~IndexCommandRunnerTests.Run_DryRunWithInvalidCommitRange_ReturnsUsageError"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~GitHubIssueReporterTests.TryCreateIssueDetailedAsync_CreateApiFails_ReturnsDiagnosticError`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter GitHubIssueReporterTests --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog
- Added `changelog.d/unreleased/2093.fixed.md`.
- No README or developer guide update was needed; this tightens invalid `--commits` input handling without changing documented command syntax.
- No changelog fragment was added for #2396 because it is a test-only CI expectation fix.

## Review
- Adversarial review for #2093: No blocking/actionable issues found.
- Adversarial review for #2396 CI fix: No blocking/actionable issues found.

## Follow-up Candidates
- None.

Fixes #2093
Fixes #2396