### PR TITLE
Fix bare repo HEAD freshness detection

### DIFF
--- a/changelog.d/unreleased/2094.fixed.md
+++ b/changelog.d/unreleased/2094.fixed.md
@@ -5,7 +5,10 @@ issues:
 affected:
   - src/CodeIndex/Cli/GitHelper.cs
   - src/CodeIndex/Cli/DbPathResolver.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
   - src/CodeIndex/Cli/WorkspaceMetadataEnricher.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
   - tests/CodeIndex.Tests/GitHelperTests.cs
   - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
 ---

--- a/changelog.d/unreleased/2094.fixed.md
+++ b/changelog.d/unreleased/2094.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 2094
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - src/CodeIndex/Cli/WorkspaceMetadataEnricher.cs
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Bare repositories and detached HEAD changes are detected more accurately (#2094)** — Git helper logic now classifies bare repositories explicitly, resolves their repository root/common directory without requiring a `.git` entry, and treats branch/detached HEAD transitions at the same commit as a workspace HEAD change.
+
+## 日本語
+
+- **bare repository と detached HEAD の変化検出をより正確にしました (#2094)** — Git helper が bare repository を明示的に分類し、`.git` エントリが無い場合でも repository root/common directory を解決します。同一 commit 上の branch/detached HEAD 遷移も workspace HEAD の変化として扱うようにしました。

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -152,6 +152,12 @@ public static class DbPathResolver
     public static string? TryReadIndexedHeadCommit(string dbPath)
         => TryReadMetaString(dbPath, CodeIndex.Database.DbContext.IndexedHeadCommitMetaKey);
 
+    public static string? TryReadIndexedHeadBranch(string dbPath)
+        => TryReadMetaString(dbPath, CodeIndex.Database.DbContext.IndexedHeadBranchMetaKey);
+
+    public static bool TryHasIndexedHeadBranchStamp(string dbPath)
+        => TryMetaKeyExists(dbPath, CodeIndex.Database.DbContext.IndexedHeadBranchMetaKey);
+
     private static string? TryReadMetaString(string dbPath, string key)
     {
         try
@@ -167,6 +173,23 @@ public static class DbPathResolver
         catch
         {
             return null;
+        }
+    }
+
+    private static bool TryMetaKeyExists(string dbPath, string key)
+    {
+        try
+        {
+            using var connection = OpenMetadataConnection(dbPath);
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT 1 FROM codeindex_meta WHERE key = @key LIMIT 1";
+            cmd.Parameters.AddWithValue("@key", key);
+            return cmd.ExecuteScalar() != null;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -155,8 +155,11 @@ public static class DbPathResolver
     public static string? TryReadIndexedHeadBranch(string dbPath)
         => TryReadMetaString(dbPath, CodeIndex.Database.DbContext.IndexedHeadBranchMetaKey);
 
-    public static bool TryHasIndexedHeadBranchStamp(string dbPath)
-        => TryMetaKeyExists(dbPath, CodeIndex.Database.DbContext.IndexedHeadBranchMetaKey);
+    public static string? TryReadIndexedHeadCommitBranch(string dbPath)
+        => TryReadMetaString(dbPath, CodeIndex.Database.DbContext.IndexedHeadCommitBranchMetaKey);
+
+    public static bool TryHasIndexedHeadCommitBranchStamp(string dbPath)
+        => TryMetaKeyExists(dbPath, CodeIndex.Database.DbContext.IndexedHeadCommitBranchMetaKey);
 
     private static string? TryReadMetaString(string dbPath, string key)
     {

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -5,6 +5,14 @@ using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
 
+public enum GitRepositoryType
+{
+    None,
+    Normal,
+    Worktree,
+    Bare,
+}
+
 /// <summary>
 /// Git integration helpers.
 /// Git連携ヘルパー。
@@ -27,7 +35,12 @@ public static class GitHelper
         if (Directory.Exists(ioDotGit)) return dotGit;
 
         // Worktree: .git is a file containing "gitdir: <path>" / worktree: .gitがファイルで "gitdir: <path>" を含む
-        if (!File.Exists(ioDotGit)) return null;
+        if (!File.Exists(ioDotGit))
+        {
+            return TryGetRepositoryType(projectRoot) == GitRepositoryType.Bare
+                ? Path.GetFullPath(projectRoot)
+                : null;
+        }
 
         var gitFileContent = File.ReadAllText(ioDotGit).Trim();
         if (!gitFileContent.StartsWith("gitdir:")) return null;
@@ -47,6 +60,25 @@ public static class GitHelper
 
         // Fallback: use worktreeGitDir itself (e.g. submodules) / フォールバック: worktreeGitDir自体を使用
         return worktreeGitDir;
+    }
+
+    /// <summary>
+    /// Try to classify the repository shape for <paramref name="projectRoot"/>.
+    /// projectRoot の git リポジトリ形状を best-effort で判定する。
+    /// </summary>
+    public static GitRepositoryType TryGetRepositoryType(string projectRoot)
+    {
+        var dotGit = Path.Combine(projectRoot, ".git");
+        var ioDotGit = LongPath.EnsureWindowsPrefix(dotGit);
+        if (Directory.Exists(ioDotGit))
+            return GitRepositoryType.Normal;
+        if (File.Exists(ioDotGit))
+            return GitRepositoryType.Worktree;
+
+        var isBare = TryRunGit(projectRoot, "rev-parse", "--is-bare-repository")?.Trim();
+        return string.Equals(isBare, "true", StringComparison.OrdinalIgnoreCase)
+            ? GitRepositoryType.Bare
+            : GitRepositoryType.None;
     }
 
     /// <summary>
@@ -333,13 +365,18 @@ public static class GitHelper
     internal static string? TryGetRepositoryRoot(string projectPath, IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides)
     {
         var cdup = TryRunGit(projectPath, gitEnvironmentOverrides, "rev-parse", "--show-cdup");
-        if (cdup == null)
-            return null;
+        if (cdup != null)
+        {
+            var value = cdup.Trim();
+            return string.IsNullOrEmpty(value)
+                ? Path.GetFullPath(projectPath)
+                : Path.GetFullPath(Path.Combine(projectPath, value));
+        }
 
-        var value = cdup.Trim();
-        return string.IsNullOrEmpty(value)
+        var isBare = TryRunGit(projectPath, gitEnvironmentOverrides, "rev-parse", "--is-bare-repository")?.Trim();
+        return string.Equals(isBare, "true", StringComparison.OrdinalIgnoreCase)
             ? Path.GetFullPath(projectPath)
-            : Path.GetFullPath(Path.Combine(projectPath, value));
+            : null;
     }
 
     private static string? TryRunGit(string projectRoot, params string[] args)

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -2937,6 +2937,7 @@ public static class IndexCommandRunner
             // full scan が「直近 full scan からブランチが動いた」をきちんと検知できる。
             // 非 git workspace で null になった場合はキーごとクリアされる。Issue #1508。
             writer.SetMeta(DbContext.IndexedHeadCommitMetaKey, currentHeadCommit);
+            writer.SetMeta(DbContext.IndexedHeadCommitBranchMetaKey, GitHelper.TryGetHeadBranch(projectRoot));
             // #1509: also stamp the always-updated "last indexed HEAD" triple (SHA + branch +
             // timestamp). Unlike #1508's IndexedHeadCommitMetaKey which only fires here on
             // full scans, this triple is also stamped at the end of incremental update runs

--- a/src/CodeIndex/Cli/WorkspaceMetadataEnricher.cs
+++ b/src/CodeIndex/Cli/WorkspaceMetadataEnricher.cs
@@ -61,17 +61,31 @@ public static class WorkspaceMetadataEnricher
         }
 
         var runtimeHead = GitHelper.TryGetHeadCommit(projectRoot);
+        var runtimeBranch = GitHelper.TryGetHeadBranch(projectRoot);
         var dirty = GitHelper.TryIsWorktreeDirty(projectRoot);
         var indexedHead = DbPathResolver.TryReadIndexedHeadCommit(dbPath);
+        var indexedBranch = DbPathResolver.TryReadIndexedHeadBranch(dbPath);
+        var hasIndexedBranchStamp = DbPathResolver.TryHasIndexedHeadBranchStamp(dbPath);
         // Detect a per-worktree branch / HEAD switch by comparing the runtime HEAD against
-        // the HEAD captured at index time. Only meaningful when both sides have a value —
-        // legacy DBs or projects indexed outside git report null and must not trigger a
-        // false-positive switch warning. Issue #1512.
+        // the HEAD captured at index time. Also compare the branch stamp when a HEAD stamp is
+        // present so branch <-> detached transitions at the same commit are still visible.
+        // Only meaningful when enough metadata exists; legacy DBs or projects indexed outside
+        // git report null and must not trigger a false-positive switch warning. Issues #1512
+        // and #2094.
         // worktree 内の branch / HEAD 切替検出。index 時点と現在で HEAD を突き合わせる。
-        // 両側が値を持つ場合のみ有意義（legacy DB や非 git は null になり誤検出を避ける）。
-        bool? headChanged = (indexedHead != null && runtimeHead != null)
+        // 同一 commit の branch/detached 遷移も branch stamp で検出する。
+        var commitChanged = indexedHead != null && runtimeHead != null
             ? !string.Equals(indexedHead, runtimeHead, StringComparison.OrdinalIgnoreCase)
             : (bool?)null;
+        var branchChanged = indexedHead != null
+            && runtimeHead != null
+            && hasIndexedBranchStamp
+            && !string.Equals(indexedBranch, runtimeBranch, StringComparison.Ordinal)
+            ? true
+            : (bool?)null;
+        bool? headChanged = commitChanged == true || branchChanged == true
+            ? true
+            : commitChanged;
 
         setter(projectRoot, runtimeHead, dirty, indexedHead, headChanged);
     }

--- a/src/CodeIndex/Cli/WorkspaceMetadataEnricher.cs
+++ b/src/CodeIndex/Cli/WorkspaceMetadataEnricher.cs
@@ -64,8 +64,8 @@ public static class WorkspaceMetadataEnricher
         var runtimeBranch = GitHelper.TryGetHeadBranch(projectRoot);
         var dirty = GitHelper.TryIsWorktreeDirty(projectRoot);
         var indexedHead = DbPathResolver.TryReadIndexedHeadCommit(dbPath);
-        var indexedBranch = DbPathResolver.TryReadIndexedHeadBranch(dbPath);
-        var hasIndexedBranchStamp = DbPathResolver.TryHasIndexedHeadBranchStamp(dbPath);
+        var indexedBranch = DbPathResolver.TryReadIndexedHeadCommitBranch(dbPath);
+        var hasIndexedBranchStamp = DbPathResolver.TryHasIndexedHeadCommitBranchStamp(dbPath);
         // Detect a per-worktree branch / HEAD switch by comparing the runtime HEAD against
         // the HEAD captured at index time. Also compare the branch stamp when a HEAD stamp is
         // present so branch <-> detached transitions at the same commit are still visible.

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -550,6 +550,7 @@ public class DbContext : IDisposable
     // full scan が改めて記録する。同じ値を `status` (no `--check`) でも参照し、
     // `worktree_head_changed` として worktree の HEAD 切替を素早く通知する。Issues #1508 / #1512。
     public const string IndexedHeadCommitMetaKey = "indexed_head_commit";
+    public const string IndexedHeadCommitBranchMetaKey = "indexed_head_commit_branch";
     // #1509: full Git HEAD commit and short branch name captured at the end of every
     // successful index run (full scan AND partial update), plus the UTC timestamp of that
     // stamp. Together they let `status` (and any future cross-session staleness check)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -2282,6 +2282,7 @@ public partial class McpServer
             // untouched and surface staleness until the next clean refresh. Issues #1508 / #1512.
             // CLI full-scan と同じく成功時のみ HEAD を記録する。partial / 失敗は旧 HEAD を残す。
             writer.SetMeta(DbContext.IndexedHeadCommitMetaKey, currentHeadCommit);
+            writer.SetMeta(DbContext.IndexedHeadCommitBranchMetaKey, GitHelper.TryGetHeadBranch(projectPath));
             // #1509: also persist the always-updated HEAD/branch/timestamp triple so
             // status / consumers can detect cross-session staleness via
             // `commits_ahead_of_indexed_head`. Same best-effort contract — git unavailability

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -124,6 +124,38 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public void ResolveGitCommonDir_BareRepository_ReturnsRepositoryDirectory()
+    {
+        var sourceRepo = CreateGitRepo();
+        File.WriteAllText(Path.Combine(sourceRepo, "tracked.txt"), "v1\n");
+        RunGit(sourceRepo, "add", "tracked.txt");
+        RunGit(sourceRepo, "commit", "-m", "initial");
+        var bareRepo = Path.Combine(_tempDir, "repo.git");
+        RunGit(_tempDir, "clone", "--bare", sourceRepo, bareRepo);
+
+        Assert.Equal(GitRepositoryType.Bare, GitHelper.TryGetRepositoryType(bareRepo));
+        Assert.Equal(Path.GetFullPath(bareRepo), Path.GetFullPath(GitHelper.ResolveGitCommonDir(bareRepo)!));
+        Assert.Equal(Path.GetFullPath(bareRepo), Path.GetFullPath(GitHelper.TryGetRepositoryRoot(bareRepo)!));
+    }
+
+    [Fact]
+    public void TryGetRepositoryType_ClassifiesNormalWorktreeBareAndNone()
+    {
+        var normalRepo = CreateGitRepo();
+        var linkedWorktree = Path.Combine(_tempDir, "linked-worktree");
+        RunGit(normalRepo, "worktree", "add", linkedWorktree);
+        var bareRepo = Path.Combine(_tempDir, "shape.git");
+        RunGit(_tempDir, "clone", "--bare", normalRepo, bareRepo);
+        var nonRepo = Path.Combine(_tempDir, "not-a-repo");
+        Directory.CreateDirectory(nonRepo);
+
+        Assert.Equal(GitRepositoryType.Normal, GitHelper.TryGetRepositoryType(normalRepo));
+        Assert.Equal(GitRepositoryType.Worktree, GitHelper.TryGetRepositoryType(linkedWorktree));
+        Assert.Equal(GitRepositoryType.Bare, GitHelper.TryGetRepositoryType(bareRepo));
+        Assert.Equal(GitRepositoryType.None, GitHelper.TryGetRepositoryType(nonRepo));
+    }
+
+    [Fact]
     public void GetChangedFilesFromCommit_ReturnsFilesForRegularCommit()
     {
         var repoDir = CreateGitRepo();

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -348,6 +348,11 @@ public class GitHubIssueReporterTests : IDisposable
             {
                 Content = MakeJsonContent("""{ "total_count": 0, "items": [] }"""),
             });
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/repos/widthdom/CodeIndex/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("[]"),
+            });
         handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
             new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
             {
@@ -362,7 +367,10 @@ public class GitHubIssueReporterTests : IDisposable
 
             Assert.Null(result.IssueUrl);
             Assert.Equal("""422: { "message": "validation failed" }""", result.Error);
-            Assert.Equal(2, handler.RequestCount);
+            Assert.Equal(3, handler.RequestCount);
+            Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+            Assert.Equal(HttpMethod.Get, handler.Requests[1].Method);
+            Assert.Equal(HttpMethod.Post, handler.Requests[2].Method);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -10853,8 +10853,46 @@ jobs:
             {
                 var writer = new DbWriter(db.Connection);
                 writer.SetMeta(DbContext.IndexedHeadCommitMetaKey, indexedHead);
-                writer.SetMeta(DbContext.IndexedHeadBranchMetaKey, indexedBranch);
+                writer.SetMeta(DbContext.IndexedHeadCommitBranchMetaKey, indexedBranch);
             }
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath, "--json"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(indexedHead, json.GetProperty("indexed_head_commit").GetString());
+            Assert.True(json.GetProperty("worktree_head_changed").GetBoolean());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunStatus_Json_ReportsDetachedHeadAfterPartialUpdateAtSameCommit()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_status_detached_head_after_partial_json");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App {}\n");
+            TestProjectHelper.RunGit(projectRoot, "add", "app.cs");
+            TestProjectHelper.RunGit(projectRoot, "commit", "-m", "initial");
+
+            Assert.Equal(CommandExitCodes.Success, IndexCommandRunner.Run([projectRoot, "--json", "--quiet"], _jsonOptions));
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var indexedHead = TestProjectHelper.RunGit(projectRoot, "rev-parse", "HEAD").Trim();
+            TestProjectHelper.RunGit(projectRoot, "checkout", "--detach", indexedHead);
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() {} }\n");
+
+            Assert.Equal(CommandExitCodes.Success, IndexCommandRunner.Run([projectRoot, "--files", "app.cs", "--json", "--quiet"], _jsonOptions));
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
                 ["--db", dbPath, "--json"],

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -10832,6 +10832,49 @@ jobs:
     }
 
     [Fact]
+    public void RunStatus_Json_ReportsWorktreeHeadChangedWhenBranchBecomesDetachedAtSameCommit()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_status_detached_head_changed_json");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App {}\n");
+            TestProjectHelper.RunGit(projectRoot, "add", "app.cs");
+            TestProjectHelper.RunGit(projectRoot, "commit", "-m", "initial");
+
+            Assert.Equal(CommandExitCodes.Success, IndexCommandRunner.Run([projectRoot, "--json", "--quiet"], _jsonOptions));
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var indexedHead = TestProjectHelper.RunGit(projectRoot, "rev-parse", "HEAD").Trim();
+            var indexedBranch = TestProjectHelper.RunGit(projectRoot, "rev-parse", "--abbrev-ref", "HEAD").Trim();
+            TestProjectHelper.RunGit(projectRoot, "checkout", "--detach", indexedHead);
+
+            using (var db = new DbContext(dbPath))
+            {
+                var writer = new DbWriter(db.Connection);
+                writer.SetMeta(DbContext.IndexedHeadCommitMetaKey, indexedHead);
+                writer.SetMeta(DbContext.IndexedHeadBranchMetaKey, indexedBranch);
+            }
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath, "--json"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(indexedHead, json.GetProperty("indexed_head_commit").GetString());
+            Assert.True(json.GetProperty("worktree_head_changed").GetBoolean());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunStatus_HumanOutput_WarnsWhenWorktreeHeadHasSwitchedSinceIndex()
     {
         // #1512: surface a `WARN` line plus an Indexed-HEAD echo and a ready-to-run reindex


### PR DESCRIPTION
## Summary

- Classify bare repositories explicitly and resolve their common git directory / repository root when `.git` is absent.
- Preserve branch/detached HEAD freshness by comparing against full-scan HEAD branch metadata, separate from the partial-update `indexed_head_branch` stamp.
- Add regression coverage for bare repos, branch-to-detached status detection, and the partial-update lifecycle edge case.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "GitHelperTests|RunStatus_Json_ReportsWorktreeHeadChangedWhenBranchBecomesDetachedAtSameCommit|RunStatus_Json_ReportsDetachedHeadAfterPartialUpdateAtSameCommit|WorkspaceMetadataEnricherTests.Enrich_StatusResult_DoesNotFlagWorktreeHeadChangedWhenPersistedHeadMatchesRuntimeHead"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet test` was also run; it currently fails only on `GitHubIssueReporterTests.TryCreateIssueDetailedAsync_CreateApiFails_ReturnsDiagnosticError` with expected request count `2` vs actual `3`, tracked by #2032.

## Documentation / Changelog

- Added `changelog.d/unreleased/2094.fixed.md`.
- No direct `CHANGELOG.md`, `AGENTS.md`, `CLAUDE.md`, or `AGENT_GUIDE.md` edits.

## Review

- Codex adversarial review first found a lifecycle mismatch between `indexed_head_commit` and `indexed_head_branch`; fixed with a full-scan-specific branch stamp.
- Second adversarial review result: `No blocking/actionable issues found.`

## Follow-up

- Existing unrelated full-suite failure tracked by #2032.

Fixes #2094
