### PR TITLE
Fix CLI exit code taxonomy

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -871,11 +871,14 @@ If a query itself begins with `-`, pass it as `--query <query>` or `-- <query>`.
 | Code | Meaning |
 |---|---|
 | `0` | Success |
-| `1` | Usage error (invalid arguments) |
+| `1` | Usage error (missing command, missing required positional input, or command-shape error) |
 | `2` | Not found (no search results, missing directory) |
-| `3` | Database error |
+| `3` | Permanent database error |
 | `4` | Feature unavailable on this build (for example CLI `--json` on a manually trimmed custom build) |
 | `5` | Stale index (`status --check` found DB/workspace differences) |
+| `6` | Transient database error (SQLite `BUSY` / `LOCKED`, retry with backoff) |
+| `7` | Invalid argument value (for example invalid `--kind`, `--color`, or `--metrics`) |
+| `8` | Cancelled by signal / Ctrl-C (`SIGINT` / `SIGTERM`-style cancellation path) |
 
 ### Error codes
 
@@ -894,6 +897,7 @@ For scripts and AI agents that need to classify failures without substring-match
 | `E009_FEATURE_UNAVAILABLE` | Requested feature is unavailable in this build (e.g. `--json` on a manually trimmed custom build) |
 | `E010_USAGE_ERROR` | Argument parse error, conflicting flags, or unknown subcommand |
 | `E011_DIRECTORY_NOT_FOUND` | Project / target directory passed to `cdidx index` does not exist |
+| `E012_INTERRUPTED` | The user interrupted the command with Ctrl-C / signal cancellation |
 
 ### Debugging reader errors
 

--- a/changelog.d/unreleased/2096.fixed.md
+++ b/changelog.d/unreleased/2096.fixed.md
@@ -1,0 +1,23 @@
+---
+category: fixed
+issues:
+  - 2096
+affected:
+  - src/CodeIndex/Cli/CommandExitCodes.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - USER_GUIDE.md
+  - tests/CodeIndex.Tests/CommandErrorCodesTests.cs
+  - tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
+  - tests/CodeIndex.Tests/MetricsSinkTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **CLI exit codes now distinguish retryable DB locks, invalid arguments, and cancellation (#2096)** — scripts can branch on transient SQLite `BUSY` / `LOCKED` failures (`6`), invalid option values (`7`), and Ctrl-C cancellation (`8`) instead of treating them all as generic usage or database errors.
+
+## 日本語
+
+- **CLI exit code がリトライ可能な DB lock、invalid argument、cancel を区別するようになりました (#2096)** — script は transient な SQLite `BUSY` / `LOCKED` 失敗 (`6`)、不正な option 値 (`7`)、Ctrl-C cancel (`8`) を generic な usage/database error と分けて判定できます。

--- a/src/CodeIndex/Cli/CommandExitCodes.cs
+++ b/src/CodeIndex/Cli/CommandExitCodes.cs
@@ -12,5 +12,9 @@ public static class CommandExitCodes
     public const int DatabaseError = 3;
     public const int FeatureUnavailable = 4;
     public const int StaleIndex = 5;
-    public const int Interrupted = 130;
+    public const int TransientDatabaseError = 6;
+    public const int InvalidArgument = 7;
+    public const int CancelledBySignal = 8;
+    public const int Interrupted = CancelledBySignal;
+    public const int LegacyInterrupted = 130;
 }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -2212,19 +2212,24 @@ public static class IndexCommandRunner
         }
     }
 
-    private static int WriteDatabaseFilesystemError(bool json, JsonSerializerOptions jsonOptions, string dbPath, Exception ex) =>
-        WriteCommandError(
+    private static int WriteDatabaseFilesystemError(bool json, JsonSerializerOptions jsonOptions, string dbPath, Exception ex)
+    {
+        var transient = ex is SqliteException { SqliteErrorCode: 5 or 6 };
+        return WriteCommandError(
             json,
             jsonOptions,
             $"database write failed for {dbPath}: {CollapseLineBreaks(ex.Message)}",
-            CommandExitCodes.DatabaseError,
-            "Check that the database file and parent directory exist and are writable, then retry `cdidx index`.",
-            CommandErrorCodes.DbNotWritable);
+            transient ? CommandExitCodes.TransientDatabaseError : CommandExitCodes.DatabaseError,
+            transient
+                ? "Another process may be holding the database. Wait for it to finish, or retry with backoff."
+                : "Check that the database file and parent directory exist and are writable, then retry `cdidx index`.",
+            transient ? CommandErrorCodes.DbLocked : CommandErrorCodes.DbNotWritable);
+    }
 
     private static bool IsDatabaseFilesystemError(Exception ex) =>
         ex is UnauthorizedAccessException
         || ex is IOException
-        || ex is SqliteException { SqliteErrorCode: 8 or 10 or 14 };
+        || ex is SqliteException { SqliteErrorCode: 5 or 6 or 8 or 10 or 14 };
 
     private static int RunFullScan(
         DbWriter writer,

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -41,24 +41,24 @@ internal static class ProgramRunner
         {
             Console.Error.WriteLine(colorError);
             Console.Error.WriteLine("Hint: use one of `auto`, `always`, `never`.");
-            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.UsageError} color_flag_invalid=true");
-            return CommandExitCodes.UsageError;
+            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.InvalidArgument} color_flag_invalid=true");
+            return CommandExitCodes.InvalidArgument;
         }
 
         if (!TryConsumePaletteFlag(ref args, out var paletteError))
         {
             Console.Error.WriteLine(paletteError);
             Console.Error.WriteLine("Hint: use one of `basic`, `256`, `truecolor`.");
-            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.UsageError} palette_flag_invalid=true");
-            return CommandExitCodes.UsageError;
+            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.InvalidArgument} palette_flag_invalid=true");
+            return CommandExitCodes.InvalidArgument;
         }
 
         if (!TryConsumeMetricsFlag(ref args, out var metricsPath, out var metricsError))
         {
             Console.Error.WriteLine(metricsError);
             Console.Error.WriteLine("Hint: pass `--metrics <path>` (e.g. `--metrics out.jsonl`).");
-            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.UsageError} metrics_flag_invalid=true");
-            return CommandExitCodes.UsageError;
+            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.InvalidArgument} metrics_flag_invalid=true");
+            return CommandExitCodes.InvalidArgument;
         }
 
         using var metricsSession = MetricsSink.TryStart(metricsPath);
@@ -216,7 +216,7 @@ internal static class ProgramRunner
     internal static int MapCodeIndexExceptionExitCode(string code) => code switch
     {
         CommandErrorCodes.DbNotFound => CommandExitCodes.NotFound,
-        CommandErrorCodes.DbLocked => CommandExitCodes.DatabaseError,
+        CommandErrorCodes.DbLocked => CommandExitCodes.TransientDatabaseError,
         CommandErrorCodes.DbNotWritable => CommandExitCodes.DatabaseError,
         CommandErrorCodes.DbIntegrityFailed => CommandExitCodes.DatabaseError,
         CommandErrorCodes.SchemaTooNew => CommandExitCodes.DatabaseError,
@@ -224,7 +224,8 @@ internal static class ProgramRunner
         CommandErrorCodes.DbError => CommandExitCodes.DatabaseError,
         CommandErrorCodes.DirectoryNotFound => CommandExitCodes.NotFound,
         CommandErrorCodes.FeatureUnavailable => CommandExitCodes.FeatureUnavailable,
-        CommandErrorCodes.UsageError => CommandExitCodes.UsageError,
+        CommandErrorCodes.UsageError => CommandExitCodes.InvalidArgument,
+        CommandErrorCodes.Interrupted => CommandExitCodes.CancelledBySignal,
         _ => CommandExitCodes.DatabaseError,
     };
 

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -421,6 +421,8 @@ public static class QueryCommandRunner
         var options = ParseArgs(cmdArgs, jsonDefault: false, allowNamedQuery: true);
         if (TryWriteUnsupportedOptionError("references", cmdArgs, CliFlagSchema.GetAcceptedFlagNamesForCommand("references"), options.Query))
             return CommandExitCodes.UsageError;
+        if (TryWriteInvalidKindFilterError(options, "references", AllValidReferenceKinds, AllValidKinds))
+            return CommandExitCodes.InvalidArgument;
         if (TryWriteParseError(options, "references"))
             return CommandExitCodes.UsageError;
         if (!TryResolveNameExactMode(options, "references", out var exact, out var exactError))
@@ -547,6 +549,8 @@ public static class QueryCommandRunner
             return CommandExitCodes.UsageError;
         if (TryRejectNonCallGraphKindForGraphCommand("callers", options.Kind))
             return CommandExitCodes.UsageError;
+        if (TryWriteInvalidKindFilterError(options, "callers", CallGraphOnlyReferenceKinds, AllValidReferenceKinds, AllValidKinds))
+            return CommandExitCodes.InvalidArgument;
         if (!TryResolveNameExactMode(options, "callers", out var exact, out var exactError))
         {
             Console.Error.WriteLine(exactError);
@@ -671,6 +675,8 @@ public static class QueryCommandRunner
             return CommandExitCodes.UsageError;
         if (TryRejectNonCallGraphKindForGraphCommand("callees", options.Kind))
             return CommandExitCodes.UsageError;
+        if (TryWriteInvalidKindFilterError(options, "callees", CallGraphOnlyReferenceKinds, AllValidReferenceKinds, AllValidKinds))
+            return CommandExitCodes.InvalidArgument;
         if (!TryResolveNameExactMode(options, "callees", out var exact, out var exactError))
         {
             Console.Error.WriteLine(exactError);
@@ -813,6 +819,8 @@ public static class QueryCommandRunner
         var options = ParseArgs(cmdArgs, jsonDefault: false, allowNamedQuery: true);
         if (TryWriteUnsupportedOptionError("symbols", cmdArgs, CliFlagSchema.GetAcceptedFlagNamesForCommand("symbols"), options.Query))
             return CommandExitCodes.UsageError;
+        if (TryWriteInvalidKindFilterError(options, "symbols", KnownSymbolKindFilters))
+            return CommandExitCodes.InvalidArgument;
         if (TryWriteParseError(options, "symbols"))
             return CommandExitCodes.UsageError;
         if (TryWriteBlankQueryError(options, "symbols"))
@@ -4048,6 +4056,58 @@ public static class QueryCommandRunner
         Console.Error.WriteLine("Hint: fix the invalid or missing option value, then rerun with the command shape below.");
         Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
         return true;
+    }
+
+    private static readonly HashSet<string> KnownSymbolKindFilters = new(StringComparer.Ordinal)
+    {
+        "accessor",
+        "associatedtype",
+        "class",
+        "class_hook",
+        "constant",
+        "constructor",
+        "delegate",
+        "enum",
+        "event",
+        "field",
+        "function",
+        "heading",
+        "hook",
+        "impl",
+        "import",
+        "interface",
+        "label",
+        "method",
+        "module",
+        "namespace",
+        "operator",
+        "procedure",
+        "property",
+        "record",
+        "reference",
+        "specialization",
+        "struct",
+        "test.method",
+        "trait",
+        "type",
+        "typealias",
+        "union",
+        "variable",
+    };
+
+    private static bool TryWriteInvalidKindFilterError(QueryCommandOptions options, string commandName, IReadOnlyCollection<string> acceptedKinds, params IReadOnlyCollection<string>[] alternateAcceptedKinds)
+    {
+        if (options.Kind != null
+            && !acceptedKinds.Contains(options.Kind)
+            && !alternateAcceptedKinds.Any(kinds => kinds.Contains(options.Kind)))
+        {
+            Console.Error.WriteLine($"Error: invalid --kind value `{options.Kind}`.");
+            Console.Error.WriteLine($"Hint: use one of: {string.Join(", ", acceptedKinds)}.");
+            Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
+            return true;
+        }
+
+        return false;
     }
 
     private static bool TryWriteUnsupportedOptionError(string commandName, string[] cmdArgs, IEnumerable<string> supportedOptions, string? queryLiteral = null)

--- a/tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
+++ b/tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
@@ -221,14 +221,15 @@ public class CodeIndexExceptionTests
     [Theory]
     [InlineData(CommandErrorCodes.DbNotFound, CommandExitCodes.NotFound)]
     [InlineData(CommandErrorCodes.DirectoryNotFound, CommandExitCodes.NotFound)]
-    [InlineData(CommandErrorCodes.DbLocked, CommandExitCodes.DatabaseError)]
+    [InlineData(CommandErrorCodes.DbLocked, CommandExitCodes.TransientDatabaseError)]
     [InlineData(CommandErrorCodes.DbNotWritable, CommandExitCodes.DatabaseError)]
     [InlineData(CommandErrorCodes.DbIntegrityFailed, CommandExitCodes.DatabaseError)]
     [InlineData(CommandErrorCodes.SchemaTooNew, CommandExitCodes.DatabaseError)]
     [InlineData(CommandErrorCodes.TempStoreExhausted, CommandExitCodes.DatabaseError)]
     [InlineData(CommandErrorCodes.DbError, CommandExitCodes.DatabaseError)]
     [InlineData(CommandErrorCodes.FeatureUnavailable, CommandExitCodes.FeatureUnavailable)]
-    [InlineData(CommandErrorCodes.UsageError, CommandExitCodes.UsageError)]
+    [InlineData(CommandErrorCodes.UsageError, CommandExitCodes.InvalidArgument)]
+    [InlineData(CommandErrorCodes.Interrupted, CommandExitCodes.CancelledBySignal)]
     [InlineData("E999_UNKNOWN", CommandExitCodes.DatabaseError)]
     public void MapCodeIndexExceptionExitCode_MapsKnownCodesToTaxonomy(string code, int expectedExitCode)
     {

--- a/tests/CodeIndex.Tests/CommandErrorCodesTests.cs
+++ b/tests/CodeIndex.Tests/CommandErrorCodesTests.cs
@@ -106,6 +106,47 @@ public class CommandErrorCodesTests
         Assert.Contains("[E001_DB_NOT_FOUND]", stderr);
     }
 
+    [Fact]
+    public void Symbols_InvalidKind_ReturnsInvalidArgumentExitCode()
+    {
+        var (exitCode, _, stderr) = CaptureStreams(() => QueryCommandRunner.RunSymbols(["--kind", "invalid_kind"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+        Assert.Contains("invalid --kind", stderr);
+    }
+
+    [Theory]
+    [InlineData("hook")]
+    [InlineData("import")]
+    [InlineData("property")]
+    public void Symbols_KnownExtractorKinds_DoNotReturnInvalidArgument(string kind)
+    {
+        var (exitCode, _, stderr) = CaptureStreams(() => QueryCommandRunner.RunSymbols(["--kind", kind], _jsonOptions));
+
+        Assert.NotEqual(CommandExitCodes.InvalidArgument, exitCode);
+        Assert.DoesNotContain("invalid --kind", stderr);
+    }
+
+    [Theory]
+    [InlineData("references")]
+    [InlineData("callers")]
+    [InlineData("callees")]
+    public void KindFilteredCommands_InvalidKind_ReturnInvalidArgumentExitCode(string command)
+    {
+        var args = new[] { "Foo", "--kind", "invalid_kind" };
+
+        var (exitCode, _, stderr) = CaptureStreams(() => command switch
+        {
+            "references" => QueryCommandRunner.RunReferences(args, _jsonOptions),
+            "callers" => QueryCommandRunner.RunCallers(args, _jsonOptions),
+            "callees" => QueryCommandRunner.RunCallees(args, _jsonOptions),
+            _ => throw new ArgumentOutOfRangeException(nameof(command), command, null),
+        });
+
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+        Assert.Contains("invalid --kind", stderr);
+    }
+
     private (int ExitCode, string StdOut, string StdErr) RunDbIntegrityCheckCapturingStreams(string[] args)
     {
         lock (TestConsoleLock.Gate)
@@ -182,6 +223,29 @@ public class CommandErrorCodesTests
                 Console.SetOut(outWriter);
                 Console.SetError(errWriter);
                 var exitCode = QueryCommandRunner.RunSearch(args, _jsonOptions);
+                return (exitCode, outWriter.ToString(), errWriter.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    private static (int ExitCode, string StdOut, string StdErr) CaptureStreams(Func<int> run)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            using var outWriter = new StringWriter();
+            using var errWriter = new StringWriter();
+            try
+            {
+                Console.SetOut(outWriter);
+                Console.SetError(errWriter);
+                var exitCode = run();
                 return (exitCode, outWriter.ToString(), errWriter.ToString());
             }
             finally

--- a/tests/CodeIndex.Tests/MetricsSinkTests.cs
+++ b/tests/CodeIndex.Tests/MetricsSinkTests.cs
@@ -156,13 +156,13 @@ public class MetricsSinkTests
     }
 
     [Fact]
-    public void Run_InvalidMetricsFlag_ReportsUsageError()
+    public void Run_InvalidMetricsFlag_ReportsInvalidArgument()
     {
         var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(
             ["--metrics"],
             appVersion: "1.10.0"));
 
-        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
         Assert.Contains("--metrics requires a path value", stderr);
     }
 

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -308,13 +308,13 @@ public class ProgramRunnerTests
     }
 
     [Fact]
-    public void Run_InvalidColorValue_ReturnsUsageError()
+    public void Run_InvalidColorValue_ReturnsInvalidArgument()
     {
         var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(
             ["--color=sparkly", "status"],
             appVersion: "1.10.0"));
 
-        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
         Assert.Contains("invalid --color value `sparkly`", stderr);
         Assert.Contains("Hint:", stderr);
     }
@@ -425,13 +425,13 @@ public class ProgramRunnerTests
     }
 
     [Fact]
-    public void Run_InvalidPaletteValue_ReturnsUsageError()
+    public void Run_InvalidPaletteValue_ReturnsInvalidArgument()
     {
         var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(
             ["--palette=fancy", "status"],
             appVersion: "1.10.0"));
 
-        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
         Assert.Contains("invalid --palette value `fancy`", stderr);
         Assert.Contains("Hint:", stderr);
     }


### PR DESCRIPTION
## Summary

- Split CLI exit codes for transient SQLite locks, invalid argument values, and signal cancellation.
- Return invalid-argument exit code for invalid global option values and unknown `--kind` filters on symbol/reference graph commands.
- Document the updated exit-code taxonomy and add the changelog fragment.

## Validation

- `dotnet restore src/CodeIndex/CodeIndex.csproj --locked-mode`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~CommandErrorCodesTests|FullyQualifiedName~ProgramRunnerTests|FullyQualifiedName~MetricsSinkTests|FullyQualifiedName~CodeIndexExceptionTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~CommandErrorCodesTests|FullyQualifiedName~RunSymbols_SwiftKindFiltersSeparateTypealiasAndAssociatedtype|FullyQualifiedName~RunCallersCallees_RejectNonCallGraphKind_WithUsageError|FullyQualifiedName~GraphCommands_SymbolKindArgumentWarnsAboutReferenceKindSemantics|FullyQualifiedName~RunSymbols_VBOperatorDeclarationsUseDistinctExactNames|FullyQualifiedName~RunValidate_KindTypo_SuggestsClosestKind_Issue1582"`
- `dotnet test --no-restore`
- `codex exec review --uncommitted --dangerously-bypass-approvals-and-sandbox`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Updated `USER_GUIDE.md`.
- Added `changelog.d/unreleased/2096.fixed.md`.

## Follow-up Candidates

- None.

Fixes #2096
