### PR TITLE
Fix database open error categorization

### DIFF
--- a/changelog.d/unreleased/2072.fixed.md
+++ b/changelog.d/unreleased/2072.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2072
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Database open failures now keep their root-cause category (#2072)** - query commands distinguish access, I/O, SQLite corruption, and other SQLite open errors in stderr instead of collapsing them into one generic database error.
+
+## 日本語
+
+- **database open 失敗時に根本原因の分類を保持するようになりました (#2072)** - query command の stderr で access、I/O、SQLite corruption、その他の SQLite open error を区別し、汎用 database error に潰さないようにしました。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4187,6 +4187,13 @@ public static class QueryCommandRunner
         var sqlite = FindException<SqliteException>(ex);
         if (sqlite != null)
         {
+            if (sqlite.SqliteErrorCode == 14)
+            {
+                Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: database access/open denied: {sqlite.Message}");
+                Console.Error.WriteLine("Hint: check that `--db` points to a readable SQLite file, verify parent directory permissions, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.");
+                return;
+            }
+
             if (sqlite.SqliteErrorCode == 11)
             {
                 Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: SQLite reported database corruption: {sqlite.Message}");

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4151,8 +4151,7 @@ public static class QueryCommandRunner
                 }
             }
 
-            Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: database error: {ex.Message}");
-            Console.Error.WriteLine("Hint: check `--db`, or rebuild the index with `cdidx index <projectPath>` if the DB may be stale or corrupted.");
+            WriteDatabaseOpenFailure(ex, dbPath);
             Database.DbDebug.DumpToStderr(ex);
             return CommandExitCodes.DatabaseError;
         }
@@ -4163,6 +4162,69 @@ public static class QueryCommandRunner
                 Database.DbDebug.EndProfile();
             Database.DbDebug.ResetContext();
         }
+    }
+
+    private static void WriteDatabaseOpenFailure(Exception ex, string dbPath)
+    {
+        GlobalToolLog.Error($"database_open_failed db={FormatLogValue(dbPath)} exception={FormatLogValue(ex.ToString())}");
+
+        var unauthorized = FindException<UnauthorizedAccessException>(ex);
+        if (unauthorized != null)
+        {
+            Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: database access denied: {unauthorized.Message}");
+            Console.Error.WriteLine("Hint: check the permissions for `--db`, move the index to a writable location, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.");
+            return;
+        }
+
+        var io = FindException<IOException>(ex);
+        if (io != null)
+        {
+            Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: database I/O error: {io.Message}");
+            Console.Error.WriteLine("Hint: check that the `--db` path and its WAL/SHM sidecar files are readable, then refresh the index if the files were moved or removed.");
+            return;
+        }
+
+        var sqlite = FindException<SqliteException>(ex);
+        if (sqlite != null)
+        {
+            if (sqlite.SqliteErrorCode == 11)
+            {
+                Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: SQLite reported database corruption: {sqlite.Message}");
+                Console.Error.WriteLine("Hint: rebuild the index with `cdidx index <projectPath> --rebuild`, or delete the broken `.cdidx/codeindex.db*` files and run `cdidx index <projectPath>` again.");
+                return;
+            }
+
+            Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: SQLite database error ({sqlite.SqliteErrorCode}): {sqlite.Message}");
+            Console.Error.WriteLine("Hint: check `--db`, verify the index was written by a compatible cdidx version, or rebuild it with `cdidx index <projectPath> --rebuild`.");
+            return;
+        }
+
+        Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: database error: {ex.Message}");
+        Console.Error.WriteLine("Hint: check `--db`, or rebuild the index with `cdidx index <projectPath>` if the DB may be stale or corrupted.");
+    }
+
+    private static T? FindException<T>(Exception ex)
+        where T : Exception
+    {
+        for (Exception? current = ex; current != null; current = current.InnerException)
+        {
+            if (current is T typed)
+                return typed;
+        }
+
+        return null;
+    }
+
+    private static string FormatLogValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return "<empty>";
+
+        return value
+            .Replace("\\", "/", StringComparison.Ordinal)
+            .Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
     }
 
     private static void WriteProfilePayload(IReadOnlyList<QueryProfileEntry> entries, JsonSerializerOptions jsonOptions)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2343,6 +2343,12 @@ jobs:
         }
         finally
         {
+            if (OperatingSystem.IsWindows())
+            {
+                SqliteConnection.ClearAllPools();
+                System.Threading.Thread.Sleep(250);
+            }
+
             TestProjectHelper.DeleteDirectory(projectRoot);
         }
     }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2347,6 +2347,30 @@ jobs:
         }
     }
 
+    [Fact]
+    public void WithDb_SqliteCantOpenSurfacesAccessOpenCategory_Issue2072()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue2072_cantopen");
+        try
+        {
+            var missingParent = Path.Combine(projectRoot, "missing-parent");
+            var dbUri = new Uri(Path.Combine(missingParent, "codeindex.db")).AbsoluteUri + "?mode=ro";
+
+            var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbUri],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            Assert.Contains($"Error [{CommandErrorCodes.DbError}]: database access/open denied:", stderr);
+            Assert.Contains("verify parent directory permissions", stderr);
+            Assert.DoesNotContain("SQLite database error", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Theory]
     [InlineData("search-extra", "unexpected extra positional 1 argument for search")]
     [InlineData("excerpt-extra", "unexpected extra positional 1 argument for excerpt")]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2331,9 +2331,10 @@ jobs:
         {
             var dbPath = Path.Combine(projectRoot, "not-a-codeindex.db");
             File.WriteAllText(dbPath, "this is not a sqlite database");
+            var dbUri = new Uri(dbPath).AbsoluteUri + "?mode=ro&immutable=1;Pooling=False";
 
             var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
-                ["--db", dbPath],
+                ["--db", dbUri],
                 _jsonOptions));
 
             Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
@@ -2343,12 +2344,6 @@ jobs:
         }
         finally
         {
-            if (OperatingSystem.IsWindows())
-            {
-                SqliteConnection.ClearAllPools();
-                System.Threading.Thread.Sleep(250);
-            }
-
             TestProjectHelper.DeleteDirectory(projectRoot);
         }
     }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2323,6 +2323,30 @@ jobs:
         Assert.Contains("Hint: pass a path to a CodeIndex SQLite database", stderr);
     }
 
+    [Fact]
+    public void WithDb_InvalidSqliteFileSurfacesSqliteCategory_Issue2072()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue2072_invalid_sqlite");
+        try
+        {
+            var dbPath = Path.Combine(projectRoot, "not-a-codeindex.db");
+            File.WriteAllText(dbPath, "this is not a sqlite database");
+
+            var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", dbPath],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            Assert.Contains($"Error [{CommandErrorCodes.DbError}]: SQLite database error", stderr);
+            Assert.Contains("Hint: check `--db`, verify the index was written by a compatible cdidx version", stderr);
+            Assert.DoesNotContain("database error:", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Theory]
     [InlineData("search-extra", "unexpected extra positional 1 argument for search")]
     [InlineData("excerpt-extra", "unexpected extra positional 1 argument for excerpt")]


### PR DESCRIPTION
## Summary

- Categorize query-command database open failures by root cause instead of collapsing everything into a generic database error.
- Add specific stderr hints for access/open failures, I/O failures, SQLite corruption, and other SQLite errors.
- Cover invalid SQLite files and SQLite `CANTOPEN` URI failures in `QueryCommandRunnerTests`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~QueryCommandRunnerTests.WithDb_`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~QueryCommandRunnerTests`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet test CodeIndex.sln -c Release`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Added changelog fragment: `changelog.d/unreleased/2072.fixed.md`
- No README/user guide update: this changes diagnostic stderr behavior, and the user-facing release note is covered by the fragment.

Fixes #2072
