### PR TITLE
Cache folded names during batch writes

### DIFF
--- a/changelog.d/unreleased/2075.fixed.md
+++ b/changelog.d/unreleased/2075.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2075
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+---
+
+## English
+
+- **Cached folded-name computation during batch writes (#2075)** — symbol and reference inserts now reuse per-batch `NameFold.Fold` results for repeated names, reducing redundant Unicode normalization work without changing persisted values.
+
+## 日本語
+
+- **バッチ書き込み中の folded-name 計算をキャッシュしました (#2075)** — symbol / reference の挿入時に、同じ名前に対する `NameFold.Fold` 結果をバッチ内で再利用し、永続化される値を変えずに重複した Unicode 正規化処理を削減します。

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -543,6 +543,7 @@ public class DbWriter
         for (int i = 0; i < symbols.Count; i += BatchSize)
         {
             int end = Math.Min(i + BatchSize, symbols.Count);
+            var foldedNameCache = new Dictionary<string, string?>(StringComparer.Ordinal);
             // Only create a batch transaction when not already inside an outer transaction
             // 外部トランザクション内でない場合のみバッチトランザクションを作成
             using var transaction = !IsInTransaction() ? BeginTransaction() : null;
@@ -613,7 +614,7 @@ public class DbWriter
                 pIsMetadataTarget.Value = symbol.IsMetadataTarget.HasValue
                     ? (symbol.IsMetadataTarget.Value ? 1 : 0)
                     : (object)DBNull.Value;
-                pNameFolded.Value = (object?)NameFold.Fold(symbol.Name) ?? DBNull.Value;
+                pNameFolded.Value = FoldedNameDbValue(symbol.Name, foldedNameCache);
                 cmd.ExecuteNonQuery();
             }
 
@@ -720,6 +721,7 @@ public class DbWriter
         for (int i = 0; i < references.Count; i += BatchSize)
         {
             int end = Math.Min(i + BatchSize, references.Count);
+            var foldedNameCache = new Dictionary<string, string?>(StringComparer.Ordinal);
             // Always open a chunk-scoped transaction or SAVEPOINT so reference_lines and
             // symbol_references share one rollback boundary; without it a mid-chunk failure
             // under an outer transaction would orphan committed reference_lines (#1518).
@@ -784,8 +786,8 @@ public class DbWriter
                 pReferenceLineId.Value = referenceLineId;
                 pContainerKind.Value = (object?)reference.ContainerKind ?? DBNull.Value;
                 pContainerName.Value = (object?)reference.ContainerName ?? DBNull.Value;
-                pSymbolNameFolded.Value = (object?)NameFold.Fold(reference.SymbolName) ?? DBNull.Value;
-                pContainerNameFolded.Value = (object?)NameFold.Fold(reference.ContainerName) ?? DBNull.Value;
+                pSymbolNameFolded.Value = FoldedNameDbValue(reference.SymbolName, foldedNameCache);
+                pContainerNameFolded.Value = FoldedNameDbValue(reference.ContainerName, foldedNameCache);
                 cmd.ExecuteNonQuery();
             }
 
@@ -2434,6 +2436,20 @@ public class DbWriter
         }
 
         return rows.Count;
+    }
+
+    private static object FoldedNameDbValue(string? name, Dictionary<string, string?> cache)
+    {
+        if (name == null)
+            return DBNull.Value;
+
+        if (!cache.TryGetValue(name, out var folded))
+        {
+            folded = NameFold.Fold(name);
+            cache[name] = folded;
+        }
+
+        return (object?)folded ?? DBNull.Value;
     }
 
     private void SetReadyBit(int flag)


### PR DESCRIPTION
## Summary
- Cache `NameFold.Fold` results per insert batch for symbol names and reference/container names.
- Preserve existing persisted folded-name values and `DBNull` handling.
- Add bilingual changelog fragment `changelog.d/unreleased/2075.fixed.md`.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DatabaseTests"`
- `dotnet build`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: No blocking/actionable issues found.

## Documentation / Changelog
- Added `changelog.d/unreleased/2075.fixed.md`.
- No README or guide changes needed; behavior/output contract is unchanged.

## Follow-up candidates
- None.

Fixes #2075
