### PR TITLE
Clarify numeric option bounds errors

### DIFF
--- a/changelog.d/unreleased/2071.fixed.md
+++ b/changelog.d/unreleased/2071.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2071
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Numeric CLI parse errors now include bounds context (#2071)** — invalid values for bounded integer flags such as `--limit`, `--snippet-lines`, and `--max-line-width` now report the accepted range instead of only saying that a positive or non-negative integer is required.
+
+## 日本語
+
+- **数値 CLI オプションの parse error に範囲情報を含めるようにしました (#2071)** — `--limit`、`--snippet-lines`、`--max-line-width` など上限付き整数フラグの不正値は、正の整数または非負整数が必要というだけでなく、受け入れ可能な範囲も表示するようになりました。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -1438,23 +1438,23 @@ public static class QueryCommandRunner
                     i++;
                 }
                 if ((arg == "--limit" || arg == "--top") && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var limit) || limit <= 0))
-                    return $"Error: {arg} requires a positive integer, got '{value}'";
+                    return BuildPositiveIntegerError("--limit", value, arg);
                 if ((arg == "--limit" || arg == "--top")
                     && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var limitCeil)
                     && NumericFlagUpperBounds.TryGetValue("--limit", out var limitMax)
                     && limitCeil > limitMax)
-                    return $"Error: --limit must be less than or equal to {limitMax}, got '{value}'.";
+                    return BuildPositiveIntegerUpperBoundError("--limit", value, limitMax);
                 if (arg == "--max-line-width" && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var widthValue) || widthValue < 0))
-                    return $"Error: {arg} requires a non-negative integer, got '{value}'";
+                    return BuildNonNegativeIntegerError(arg, value);
                 if (arg == "--max-line-width" && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var widthCeil) && widthCeil > LineWidthFormatter.MaxAllowedLineWidth)
-                    return $"Error: --max-line-width must be less than or equal to {LineWidthFormatter.MaxAllowedLineWidth} (got '{value}').";
+                    return BuildNonNegativeIntegerUpperBoundError("--max-line-width", value, LineWidthFormatter.MaxAllowedLineWidth);
                 if ((arg == "--before" || arg == "--after") && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var context) || context < 0))
-                    return $"Error: {arg} requires a non-negative integer, got '{value}'";
+                    return BuildNonNegativeIntegerError(arg, value);
                 if ((arg == "--before" || arg == "--after")
                     && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var contextCeil)
                     && NumericFlagUpperBounds.TryGetValue(arg, out var contextMax)
                     && contextCeil > contextMax)
-                    return $"Error: {arg} must be less than or equal to {contextMax}, got '{value}'.";
+                    return BuildNonNegativeIntegerUpperBoundError(arg, value, contextMax);
                 if (arg == "--query")
                 {
                     queryCount++;
@@ -5607,13 +5607,13 @@ public static class QueryCommandRunner
         if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out value) || value <= 0)
         {
             value = 0;
-            error = $"Error: {optionName} requires a positive integer, got '{rawValue}'. Hint: retry with `{optionName} 1` or another positive integer.";
+            error = BuildPositiveIntegerError(optionName, rawValue);
             return false;
         }
 
         if (NumericFlagUpperBounds.TryGetValue(optionName, out var maxAllowed) && value > maxAllowed)
         {
-            error = $"Error: {optionName} must be less than or equal to {maxAllowed}, got '{rawValue}'. Hint: retry with `{optionName} {maxAllowed}` or a smaller positive integer.";
+            error = BuildPositiveIntegerUpperBoundError(optionName, rawValue, maxAllowed);
             value = 0;
             return false;
         }
@@ -5627,19 +5627,44 @@ public static class QueryCommandRunner
         if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out value) || value < 0)
         {
             value = 0;
-            error = $"Error: {optionName} requires a non-negative integer, got '{rawValue}'. Hint: retry with `{optionName} 0` or another non-negative integer.";
+            error = BuildNonNegativeIntegerError(optionName, rawValue);
             return false;
         }
 
         if (NumericFlagUpperBounds.TryGetValue(optionName, out var maxAllowed) && value > maxAllowed)
         {
-            error = $"Error: {optionName} must be less than or equal to {maxAllowed}, got '{rawValue}'. Hint: retry with `{optionName} {maxAllowed}` or a smaller non-negative integer.";
+            error = BuildNonNegativeIntegerUpperBoundError(optionName, rawValue, maxAllowed);
             value = 0;
             return false;
         }
 
         error = null;
         return true;
+    }
+
+    private static string BuildPositiveIntegerError(string optionName, string rawValue, string? displayOptionName = null)
+    {
+        displayOptionName ??= optionName;
+        if (NumericFlagUpperBounds.TryGetValue(optionName, out var maxAllowed))
+            return $"Error: {displayOptionName} requires an integer between 1 and {maxAllowed}, got '{rawValue}'. Hint: retry with `{displayOptionName} 1` or another value up to {maxAllowed}.";
+        return $"Error: {displayOptionName} requires a positive integer, got '{rawValue}'. Hint: retry with `{displayOptionName} 1` or another positive integer.";
+    }
+
+    private static string BuildPositiveIntegerUpperBoundError(string optionName, string rawValue, int maxAllowed)
+    {
+        return $"Error: {optionName} must be less than or equal to {maxAllowed}, got '{rawValue}'. Hint: retry with `{optionName} {maxAllowed}` or a smaller positive integer.";
+    }
+
+    private static string BuildNonNegativeIntegerError(string optionName, string rawValue)
+    {
+        if (NumericFlagUpperBounds.TryGetValue(optionName, out var maxAllowed))
+            return $"Error: {optionName} requires an integer between 0 and {maxAllowed}, got '{rawValue}'. Hint: retry with `{optionName} 0` or another value up to {maxAllowed}.";
+        return $"Error: {optionName} requires a non-negative integer, got '{rawValue}'. Hint: retry with `{optionName} 0` or another non-negative integer.";
+    }
+
+    private static string BuildNonNegativeIntegerUpperBoundError(string optionName, string rawValue, int maxAllowed)
+    {
+        return $"Error: {optionName} must be less than or equal to {maxAllowed}, got '{rawValue}'. Hint: retry with `{optionName} {maxAllowed}` or a smaller non-negative integer.";
     }
 
     private static bool TryReadRawOptionValue(string[] args, ref int index, string optionName, string? inlineValue, out string? value, out string? error)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerInvariantCultureTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerInvariantCultureTests.cs
@@ -57,7 +57,7 @@ public class QueryCommandRunnerInvariantCultureTests
             allowNamedQuery: true);
 
         Assert.NotNull(options.ParseError);
-        Assert.Contains("--limit requires a positive integer", options.ParseError);
+        Assert.Contains("--limit requires an integer between 1 and 10000", options.ParseError);
         Assert.Contains("got '-5'", options.ParseError);
     }
 
@@ -72,7 +72,7 @@ public class QueryCommandRunnerInvariantCultureTests
             allowNamedQuery: true);
 
         Assert.NotNull(options.ParseError);
-        Assert.Contains("--before requires a non-negative integer", options.ParseError);
+        Assert.Contains("--before requires an integer between 0 and 1000", options.ParseError);
         Assert.Contains("got '-1'", options.ParseError);
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2013,15 +2013,32 @@ jobs:
         Assert.Equal(0, options.ContextAfter);
         Assert.Equal(SearchSnippetFormatter.DefaultSnippetLines, options.SnippetLines);
         Assert.NotNull(options.ParseError);
-        Assert.Contains("Error: --limit requires a positive integer", options.ParseError);
-        Assert.Contains("Hint: retry with `--limit 1` or another positive integer.", options.ParseError);
-        Assert.Contains("Error: --start requires a positive integer", options.ParseError);
-        Assert.Contains("Error: --end requires a positive integer", options.ParseError);
-        Assert.Contains("Error: --before requires a non-negative integer", options.ParseError);
-        Assert.Contains("Hint: retry with `--before 0` or another non-negative integer.", options.ParseError);
-        Assert.Contains("Error: --after requires a non-negative integer", options.ParseError);
-        Assert.Contains("Error: --snippet-lines requires a positive integer", options.ParseError);
+        Assert.Contains("Error: --limit requires an integer between 1 and 10000", options.ParseError);
+        Assert.Contains("Hint: retry with `--limit 1` or another value up to 10000.", options.ParseError);
+        Assert.Contains("Error: --start requires an integer between 1 and 10000000", options.ParseError);
+        Assert.Contains("Error: --end requires an integer between 1 and 10000000", options.ParseError);
+        Assert.Contains("Error: --before requires an integer between 0 and 1000", options.ParseError);
+        Assert.Contains("Hint: retry with `--before 0` or another value up to 1000.", options.ParseError);
+        Assert.Contains("Error: --after requires an integer between 0 and 1000", options.ParseError);
+        Assert.Contains("Error: --snippet-lines requires an integer between 1 and 20", options.ParseError);
         Assert.Equal(string.Empty, stderr);
+    }
+
+    [Theory]
+    [InlineData("--limit", "not-a-number", "between 1 and 10000")]
+    [InlineData("--snippet-lines", "0", "between 1 and 20")]
+    [InlineData("--max-line-width", "-1", "between 0 and 4096")]
+    public void ParseArgs_InvalidNumericOptionsIncludeBoundsContext_Issue2071(string flag, string value, string expectedRange)
+    {
+        var options = QueryCommandRunner.ParseArgs(
+            ["needle", flag, value],
+            jsonDefault: false,
+            allowNamedQuery: true);
+
+        Assert.NotNull(options.ParseError);
+        Assert.Contains(flag, options.ParseError!);
+        Assert.Contains(expectedRange, options.ParseError!);
+        Assert.Contains($"got '{value}'", options.ParseError!);
     }
 
     // Regression lock for #1503: numeric CLI flags must reject values above the documented
@@ -2868,14 +2885,14 @@ jobs:
     }
 
     [Theory]
-    [InlineData("search-limit", "search", "--limit requires a positive integer")]
-    [InlineData("search-top", "search", "--limit requires a positive integer")]
-    [InlineData("search-snippet-lines", "search", "--snippet-lines requires a positive integer")]
-    [InlineData("impact-depth", "impact", "--depth requires a non-negative integer")]
-    [InlineData("excerpt-start", "excerpt", "--start requires a positive integer")]
-    [InlineData("excerpt-end", "excerpt", "--end requires a positive integer")]
-    [InlineData("excerpt-before", "excerpt", "--before requires a non-negative integer")]
-    [InlineData("excerpt-after", "excerpt", "--after requires a non-negative integer")]
+    [InlineData("search-limit", "search", "--limit requires an integer between 1 and 10000")]
+    [InlineData("search-top", "search", "--limit requires an integer between 1 and 10000")]
+    [InlineData("search-snippet-lines", "search", "--snippet-lines requires an integer between 1 and 20")]
+    [InlineData("impact-depth", "impact", "--depth requires an integer between 0 and 64")]
+    [InlineData("excerpt-start", "excerpt", "--start requires an integer between 1 and 10000000")]
+    [InlineData("excerpt-end", "excerpt", "--end requires an integer between 1 and 10000000")]
+    [InlineData("excerpt-before", "excerpt", "--before requires an integer between 0 and 1000")]
+    [InlineData("excerpt-after", "excerpt", "--after requires an integer between 0 and 1000")]
     public void QueryEntrypoints_InvalidNumericOptionsReturnUsageError(string scenario, string command, string expectedErrorFragment)
     {
         var (exitCode, _, stderr) = CaptureConsole(() => RunCommandWithInvalidNumeric(scenario));
@@ -2902,22 +2919,22 @@ jobs:
     // 実在の index 済み DB と実在ファイルを用意することで、ParseArgs が「不正値を既定値に差し替えて続行」へ
     // 退行した場合に本当に stdout へ結果が漏れる経路を作り、stdout 空のアサーションが偶然通ってしまう逃げ道を塞ぐ。
     [Theory]
-    [InlineData("symbols", "0", "--limit", "--limit requires a positive integer")]
-    [InlineData("symbols", "-5", "--limit", "--limit requires a positive integer")]
-    [InlineData("symbols", "0", "--top", "--limit requires a positive integer")]
-    [InlineData("symbols", "-5", "--top", "--limit requires a positive integer")]
-    [InlineData("search", "0", "--limit", "--limit requires a positive integer")]
-    [InlineData("search", "-5", "--limit", "--limit requires a positive integer")]
-    [InlineData("search", "0", "--top", "--limit requires a positive integer")]
-    [InlineData("search", "-5", "--top", "--limit requires a positive integer")]
-    [InlineData("search", "0", "--snippet-lines", "--snippet-lines requires a positive integer")]
-    [InlineData("impact", "-1", "--max-hops", "--max-hops requires a non-negative integer")]
-    [InlineData("impact", "-1", "--depth", "--depth requires a non-negative integer")]
-    [InlineData("excerpt", "0", "--start", "--start requires a positive integer")]
-    [InlineData("excerpt", "-5", "--start", "--start requires a positive integer")]
-    [InlineData("excerpt", "0", "--end", "--end requires a positive integer")]
-    [InlineData("excerpt", "-1", "--before", "--before requires a non-negative integer")]
-    [InlineData("excerpt", "-1", "--after", "--after requires a non-negative integer")]
+    [InlineData("symbols", "0", "--limit", "--limit requires an integer between 1 and 10000")]
+    [InlineData("symbols", "-5", "--limit", "--limit requires an integer between 1 and 10000")]
+    [InlineData("symbols", "0", "--top", "--limit requires an integer between 1 and 10000")]
+    [InlineData("symbols", "-5", "--top", "--limit requires an integer between 1 and 10000")]
+    [InlineData("search", "0", "--limit", "--limit requires an integer between 1 and 10000")]
+    [InlineData("search", "-5", "--limit", "--limit requires an integer between 1 and 10000")]
+    [InlineData("search", "0", "--top", "--limit requires an integer between 1 and 10000")]
+    [InlineData("search", "-5", "--top", "--limit requires an integer between 1 and 10000")]
+    [InlineData("search", "0", "--snippet-lines", "--snippet-lines requires an integer between 1 and 20")]
+    [InlineData("impact", "-1", "--max-hops", "--max-hops requires an integer between 0 and 64")]
+    [InlineData("impact", "-1", "--depth", "--depth requires an integer between 0 and 64")]
+    [InlineData("excerpt", "0", "--start", "--start requires an integer between 1 and 10000000")]
+    [InlineData("excerpt", "-5", "--start", "--start requires an integer between 1 and 10000000")]
+    [InlineData("excerpt", "0", "--end", "--end requires an integer between 1 and 10000000")]
+    [InlineData("excerpt", "-1", "--before", "--before requires an integer between 0 and 1000")]
+    [InlineData("excerpt", "-1", "--after", "--after requires an integer between 0 and 1000")]
     public void QueryEntrypoints_OutOfRangeNumericOptionsFailClosed_Issue161(string command, string value, string option, string expectedErrorFragment)
     {
         var projectRoot = TestProjectHelper.CreateTempProject(
@@ -3237,7 +3254,7 @@ jobs:
                 _jsonOptions));
 
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
-            Assert.Contains("--focus-column requires a positive integer", stderr);
+            Assert.Contains("--focus-column requires an integer between 1 and 100000", stderr);
         }
         finally
         {
@@ -3260,7 +3277,7 @@ jobs:
                 _jsonOptions));
 
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
-            Assert.Contains("--max-line-width requires a non-negative integer", stderr);
+            Assert.Contains("--max-line-width requires an integer between 0 and 4096", stderr);
         }
         finally
         {
@@ -27500,7 +27517,7 @@ jobs:
             _jsonOptions));
 
         Assert.Equal(CommandExitCodes.UsageError, exitCode);
-        Assert.Contains("--before requires a non-negative integer", stderr);
+        Assert.Contains("--before requires an integer between 0 and 1000", stderr);
     }
 
     [Fact]
@@ -27511,7 +27528,7 @@ jobs:
             _jsonOptions));
 
         Assert.Equal(CommandExitCodes.UsageError, exitCode);
-        Assert.Contains("--limit requires a positive integer", stderr);
+        Assert.Contains("--limit requires an integer between 1 and 10000", stderr);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- Add shared numeric parse error builders that include accepted ranges for bounded CLI integer flags.
- Apply the range-aware errors to normal query parsing and `find` argument pre-validation.
- Update CLI parse-error tests and invariant-culture tests for the new message contract.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerInvariantCultureTests" -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln --no-restore -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Added changelog fragment `changelog.d/unreleased/2071.fixed.md`.
- No README or guide update was needed because this only changes CLI validation error text.

## Review

- Adversarial review: `No blocking/actionable issues found.`

Fixes #2071
