### PR TITLE
Fix fold key verification for skipped rows

### DIFF
--- a/changelog.d/unreleased/2066.fixed.md
+++ b/changelog.d/unreleased/2066.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2066
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Fold readiness now validates skipped rows' stored folded keys (#2066)** — partial and unchanged indexing no longer re-advertise Unicode exact-match trust when existing folded values were generated under a stale runtime fingerprint.
+
+## 日本語
+
+- **Fold readiness が skip 行に保存済みの folded key も検証するようになりました (#2066)** — partial / unchanged indexing で、古い runtime fingerprint 由来の folded 値が残っている場合に Unicode exact-match trust を再広告しなくなりました。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -2917,7 +2917,9 @@ public static class IndexCommandRunner
             // guarantee 100% backfill on a legacy DB).
             // fold は実検証が通ったときだけ stamp。legacy DB で skip された行は NULL のため、
             // 黙って stamp すると reader が fold 経路で legacy 行を見逃す。codex #86 レビュー。
-            var backfillReady = writer.AllFoldedColumnsBackfilled(requireCurrentSymbolExtractorVersions: skipped != 0);
+            var backfillReady = writer.AllFoldedColumnsBackfilled(
+                requireCurrentSymbolExtractorVersions: skipped != 0);
+            var foldedKeysCurrent = skipped == 0 || writer.AllFoldedColumnValuesMatchCurrentFold();
             var currentFoldVersion = NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture);
             var currentFoldFingerprint = NameFold.Fingerprint();
             var foldVersionMatchesCurrent = priorFoldVersion == currentFoldVersion;
@@ -2935,7 +2937,7 @@ public static class IndexCommandRunner
             // skipped 行は旧 key のまま残る。全件再生成済み（skipped==0）か、事前 metadata が
             // current と一致しているときだけ FoldReady を stamp する。途中中断で
             // user_version だけ落ちた current DB もここで回復させる。
-            if (backfillReady && (skipped == 0 || canRestampExistingFoldTrust))
+            if (backfillReady && foldedKeysCurrent && (skipped == 0 || canRestampExistingFoldTrust))
             {
                 // MarkFoldReady re-verifies inside BEGIN IMMEDIATE; if a concurrent writer slipped
                 // in a NULL-folded row between the upfront check and this stamp, the stamp is

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1294,7 +1294,7 @@ public class DbWriter
             if (stampCurrentSymbolExtractorVersions)
                 StampSymbolExtractorVersions();
 
-            if (!AllFoldedColumnsBackfilled())
+            if (!AllFoldedColumnsBackfilled(requireCurrentFoldKeys: true))
             {
                 if (ownTransaction)
                 {
@@ -2453,7 +2453,9 @@ public class DbWriter
     /// full scan 成功時でも、incremental で skip された legacy 行が NULL のまま残っていれば
     /// fold-ready にしてはならない。stamp 前にこの実検証を通す。
     /// </summary>
-    public bool AllFoldedColumnsBackfilled(bool requireCurrentSymbolExtractorVersions = false)
+    public bool AllFoldedColumnsBackfilled(
+        bool requireCurrentSymbolExtractorVersions = false,
+        bool requireCurrentFoldKeys = false)
     {
         if (requireCurrentSymbolExtractorVersions && !SymbolExtractorVersionsMatchCurrent())
             return false;
@@ -2466,7 +2468,55 @@ public class DbWriter
               + (SELECT COUNT(*) FROM symbol_references WHERE container_name IS NOT NULL AND container_name_folded IS NULL)";
         var raw = cmd.ExecuteScalar();
         long missing = raw is long l ? l : (raw is int i ? i : 0);
-        return missing == 0;
+        if (missing != 0)
+            return false;
+
+        return !requireCurrentFoldKeys || AllFoldedColumnValuesMatchCurrentFold();
+    }
+
+    public bool AllFoldedColumnValuesMatchCurrentFold()
+    {
+        using (var cmd = _conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT name, name_folded FROM symbols WHERE name IS NOT NULL";
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
+            {
+                var expected = NameFold.Fold(reader.GetString(0));
+                var actual = reader.IsDBNull(1) ? null : reader.GetString(1);
+                if (!string.Equals(actual, expected, StringComparison.Ordinal))
+                    return false;
+            }
+        }
+
+        using (var cmd = _conn.CreateCommand())
+        {
+            cmd.CommandText = @"
+                SELECT symbol_name, symbol_name_folded, container_name, container_name_folded
+                FROM symbol_references
+                WHERE symbol_name IS NOT NULL OR container_name IS NOT NULL";
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
+            {
+                if (!reader.IsDBNull(0))
+                {
+                    var expected = NameFold.Fold(reader.GetString(0));
+                    var actual = reader.IsDBNull(1) ? null : reader.GetString(1);
+                    if (!string.Equals(actual, expected, StringComparison.Ordinal))
+                        return false;
+                }
+
+                if (!reader.IsDBNull(2))
+                {
+                    var expected = NameFold.Fold(reader.GetString(2));
+                    var actual = reader.IsDBNull(3) ? null : reader.GetString(3);
+                    if (!string.Equals(actual, expected, StringComparison.Ordinal))
+                        return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     public bool SymbolExtractorVersionsMatchCurrent()

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -2238,12 +2238,13 @@ public partial class McpServer
             // would silently miss legacy rows on the folded-equality path. Codex #86 review.
             // MCP も incremental で skip される legacy 行が残るため、実検証を通してから stamp。
             var backfillReady = writer.AllFoldedColumnsBackfilled();
+            var foldedKeysCurrent = skipped == 0 || writer.AllFoldedColumnValuesMatchCurrentFold();
             var currentFoldVersion = NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture);
             var currentFoldFingerprint = NameFold.Fingerprint();
             var foldVersionMatchesCurrent = priorFoldVersion == currentFoldVersion;
             var foldFingerprintMatchesCurrent = priorFoldFingerprint == currentFoldFingerprint;
             var canRestampExistingFoldTrust = foldVersionMatchesCurrent && foldFingerprintMatchesCurrent;
-            if (backfillReady && (skipped == 0 || canRestampExistingFoldTrust))
+            if (backfillReady && foldedKeysCurrent && (skipped == 0 || canRestampExistingFoldTrust))
             {
                 // MarkFoldReady re-verifies inside BEGIN IMMEDIATE; a concurrent NULL-folded
                 // insert during this restamp window leaves foldReadyAfter=false and degrades

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -6002,6 +6002,62 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_FullScan_DoesNotRestampFoldReadyWhenSkippedRowsCarryStaleFoldKeys()
+    {
+        // Issue #2066: current fold metadata alone is not enough to trust skipped rows.
+        // If a legacy/corrupt row carries a non-NULL folded key that no longer matches
+        // NameFold.Fold(name), an unchanged full scan must keep FoldReady demoted.
+        // Issue #2066: metadata が current でも、skip 行の実 folded key が現在の
+        // NameFold.Fold(name) と違うなら FoldReady を回復してはいけない。
+        var projectRoot = CreateTempProject();
+        try
+        {
+            RunGit(projectRoot, "init");
+            RunGit(projectRoot, "config", "user.email", "test@example.com");
+            RunGit(projectRoot, "config", "user.name", "Test");
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class Straße { }");
+            RunGit(projectRoot, "add", ".");
+            RunGit(projectRoot, "commit", "-m", "init");
+
+            var exitCode1 = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, exitCode1);
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+
+            SqliteConnection.ClearAllPools();
+            using (var conn = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = """
+                    PRAGMA user_version = 0;
+                    UPDATE symbols SET name_folded = 'straße' WHERE name = 'Straße';
+                    """;
+                cmd.ExecuteNonQuery();
+            }
+            SqliteConnection.ClearAllPools();
+
+            var exitCode2 = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, exitCode2);
+
+            using var verify = new SqliteConnection($"Data Source={dbPath}");
+            verify.Open();
+            using var userVerCmd = verify.CreateCommand();
+            userVerCmd.CommandText = "PRAGMA user_version";
+            var userVersion = (long)userVerCmd.ExecuteScalar()!;
+            Assert.Equal(0, userVersion & DbContext.FoldReadyFlag);
+
+            using var foldedCmd = verify.CreateCommand();
+            foldedCmd.CommandText = "SELECT name_folded FROM symbols WHERE name = 'Straße'";
+            Assert.Equal("straße", foldedCmd.ExecuteScalar() as string);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_FullScan_RestampsFoldReadyWhenUserVersionWasClearedButFoldMetadataStillMatches()
     {
         // #97 codex review: if a previous refresh cleared user_version before restamping


### PR DESCRIPTION
## Summary

- Validate existing non-NULL folded columns against the current `NameFold.Fold()` output before restamping fold readiness.
- Apply the same guard to CLI full scans, MCP indexing, and the transactional `MarkFoldReady` restamp path.
- Add a regression test for skipped rows carrying stale folded keys.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~IndexCommandRunnerTests.Run_FullScan_DoesNotRestampFoldReadyWhenSkippedRowsCarryStaleFoldKeys`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests.Run_FullScan_DoesNotRestampFoldReadyWhenSkippedRowsCarryStaleFoldKeys|FullyQualifiedName~McpServerTests.ToolsCall_Index_DoesNotRestampFoldReadyWhenFoldKeyVersionMismatches"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests"`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: `No blocking/actionable issues found.`

Full-suite `dotnet test` was also run twice; both runs exposed the unrelated flaky `HttpMcpTransportTests.HttpTransport_RequestLogger_RecordsMethodStatusDurationAndAuthOutcome` failure tracked in #2419. The same test passed when run alone.

## Changelog

- Added `changelog.d/unreleased/2066.fixed.md`.

## Follow-up

- See #2419 for the unrelated full-suite HTTP request logger test flake found during validation.

Fixes #2066
