### PR TITLE
Fix stale checksum rename rows

### DIFF
--- a/changelog.d/unreleased/2065.fixed.md
+++ b/changelog.d/unreleased/2065.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2065
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+---
+
+## English
+
+- **Partial indexing now purges stale rename rows with matching checksums (#2065)** — unchanged-skip and reindex paths now remove deleted old paths that share the current file checksum, preventing duplicate chunks or symbols after rename-and-restore workflows.
+
+## 日本語
+
+- **partial index が checksum 一致の古い rename 行を削除するようになりました (#2065)** — unchanged skip と reindex の経路で、現在のファイルと同じ checksum を持つ削除済み旧 path を削除し、rename 後に戻す操作で chunk / symbol が重複して残る問題を防ぎます。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -1581,6 +1581,7 @@ public static class IndexCommandRunner
                         && (record.Lang != "sql" || sqlGraphContractMatchesCurrent));
                 if (existingId != null)
                 {
+                    writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                     skipped++;
                     if (options.Verbose && !options.Json && !options.Quiet)
                     {
@@ -1593,6 +1594,7 @@ public static class IndexCommandRunner
 
                 DemoteReadinessOnce();
                 using var txn = writer.BeginTransaction();
+                writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                 WriteProjectRootOnce();
                 var fileId = writer.UpsertFile(record);
                 var chunks = ChunkSplitter.Split(fileId, content);
@@ -2758,6 +2760,7 @@ public static class IndexCommandRunner
                     }
                     if (existingId != null)
                     {
+                        writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                         skipped++;
                         processed++;
                         if (FileIndexer.SupportsHotspotFamilyMarkerLanguage(record.Lang) && record.Lang != null)
@@ -2781,6 +2784,7 @@ public static class IndexCommandRunner
                     }
 
                     using var txn = writer.BeginTransaction();
+                    writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                     var fileId = writer.UpsertFile(record);
                     var chunks = item.Chunks == null
                         ? ChunkSplitter.Split(fileId, item.Content!)

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -381,6 +381,60 @@ public class DbWriter
     }
 
     /// <summary>
+    /// Purge stale DB rows for deleted/renamed files that still share the current file's checksum.
+    /// 現在のファイルと同じ checksum を持つ削除/rename 済みの古いDB行を削除する。
+    /// </summary>
+    public int PurgeStaleFilesSharingChecksum(string projectRoot, string retainedRelativePath, string? checksum)
+    {
+        if (string.IsNullOrEmpty(checksum))
+            return 0;
+
+        var staleIds = new List<long>();
+        var cmd = RentCommand(
+            "SELECT id, path FROM files WHERE checksum = @checksum AND path <> @path",
+            static c =>
+            {
+                c.Parameters.Add("@checksum", SqliteType.Text);
+                c.Parameters.Add("@path", SqliteType.Text);
+            });
+        try
+        {
+            cmd.Parameters["@checksum"].Value = checksum;
+            cmd.Parameters["@path"].Value = retainedRelativePath;
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
+            {
+                var id = reader.GetInt64(0);
+                var relativePath = reader.GetString(1);
+                var absolutePath = Path.Combine(projectRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+                if (!File.Exists(LongPath.EnsureWindowsPrefix(absolutePath)))
+                    staleIds.Add(id);
+            }
+        }
+        finally
+        {
+            ReleaseCommand(cmd);
+        }
+
+        if (staleIds.Count == 0)
+            return 0;
+
+        using var txn = !IsInTransaction() ? BeginTransaction() : null;
+        using var deleteCmd = _conn.CreateCommand();
+        deleteCmd.CommandText = "DELETE FROM files WHERE id = @id";
+        var pId = deleteCmd.Parameters.Add("@id", SqliteType.Integer);
+        deleteCmd.Prepare();
+        foreach (var id in staleIds)
+        {
+            pId.Value = id;
+            deleteCmd.ExecuteNonQuery();
+        }
+        txn?.Commit();
+
+        return staleIds.Count;
+    }
+
+    /// <summary>
     /// Check whether a file row already exists for the given relative path.
     /// 指定した相対パスの file 行が既に存在するか確認する。
     /// </summary>

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -235,6 +235,55 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void PurgeStaleFilesSharingChecksum_RemovesDeletedRenameRowsOnly()
+    {
+        var projectRoot = Path.Combine(Path.GetTempPath(), $"cdidx_checksum_purge_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllText(Path.Combine(projectRoot, "src/current.py"), "print('same')\n");
+            File.WriteAllText(Path.Combine(projectRoot, "src/duplicate.py"), "print('same')\n");
+
+            var modified = new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc);
+            var currentId = _writer.UpsertFile(new FileRecord
+            {
+                Path = "src/current.py", Lang = "python", Size = 14, Lines = 1,
+                Checksum = "same_checksum", Modified = modified,
+            });
+            var staleId = _writer.UpsertFile(new FileRecord
+            {
+                Path = "src/renamed-away.py", Lang = "python", Size = 14, Lines = 1,
+                Checksum = "same_checksum", Modified = modified,
+            });
+            var duplicateId = _writer.UpsertFile(new FileRecord
+            {
+                Path = "src/duplicate.py", Lang = "python", Size = 14, Lines = 1,
+                Checksum = "same_checksum", Modified = modified,
+            });
+            _writer.InsertChunks([
+                new() { FileId = currentId, ChunkIndex = 0, StartLine = 1, EndLine = 1, Content = "current" },
+                new() { FileId = staleId, ChunkIndex = 0, StartLine = 1, EndLine = 1, Content = "stale" },
+                new() { FileId = duplicateId, ChunkIndex = 0, StartLine = 1, EndLine = 1, Content = "duplicate" },
+            ]);
+
+            var purged = _writer.PurgeStaleFilesSharingChecksum(projectRoot, "src/current.py", "same_checksum");
+
+            Assert.Equal(1, purged);
+            Assert.True(_writer.HasFileAtPath("src/current.py"));
+            Assert.False(_writer.HasFileAtPath("src/renamed-away.py"));
+            Assert.True(_writer.HasFileAtPath("src/duplicate.py"));
+            using var cmd = _db.Connection.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM chunks";
+            Assert.Equal(2L, (long)cmd.ExecuteScalar()!);
+        }
+        finally
+        {
+            if (Directory.Exists(projectRoot))
+                TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void InsertChunks_InsertsAndPopulatesFts()
     {
         var fileId = _writer.UpsertFile(new FileRecord


### PR DESCRIPTION
## Summary

- Purge deleted stale DB rows that share the current file checksum during unchanged-skip and reindex paths.
- Keep existing duplicate files with the same checksum when they still exist on disk.
- Add regression coverage for the rename/delete checksum cleanup path.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DatabaseTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/2065.fixed.md`

## Follow-up Candidates

- None.

Fixes #2065
