### PR TITLE
Fix C# contract prepass stalls

### DIFF
--- a/changelog.d/unreleased/2380.fixed.md
+++ b/changelog.d/unreleased/2380.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2380
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **C# incremental index refresh no longer stalls on static-interface helper code (#2380)** — the static interface contract pre-pass now only invokes symbol extraction for files that contain a plausible contract member inside an interface body, avoiding false positives from helper method names and string literals such as `CSharpStaticInterface...`.
+
+## 日本語
+
+- **C# の差分 index refresh が static interface helper code で停滞しないようになりました (#2380)** — static interface contract の pre-pass は、interface 本体内に contract member らしい宣言があるファイルだけで symbol extraction を実行するようになり、`CSharpStaticInterface...` のような helper method 名や文字列リテラル由来の false positive を避けます。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -3371,11 +3371,284 @@ public static class IndexCommandRunner
             symbols.Any(IsCSharpStaticInterfaceContractSymbol) || hadPendingContracts);
     }
 
-    private static bool MayContainCSharpStaticInterfaceContract(string content)
-        => ContainsCSharpWord(content, "interface")
-           && ContainsCSharpWord(content, "static")
-           && (ContainsCSharpWord(content, "abstract")
-               || ContainsCSharpWord(content, "virtual"));
+    internal static bool MayContainCSharpStaticInterfaceContract(string content)
+    {
+        var masked = MaskCSharpCommentsAndStrings(content);
+        var index = 0;
+        while ((index = IndexOfCSharpWord(masked, "interface", index)) >= 0)
+        {
+            var bodyStart = masked.IndexOf('{', index + "interface".Length);
+            if (bodyStart < 0)
+                return false;
+
+            if (CSharpInterfaceBodyMayContainStaticContract(masked, bodyStart))
+                return true;
+
+            index = bodyStart + 1;
+        }
+
+        return false;
+    }
+
+    private static bool CSharpInterfaceBodyMayContainStaticContract(string masked, int bodyStart)
+    {
+        var depth = 1;
+        var memberStart = bodyStart + 1;
+        for (var index = bodyStart + 1; index < masked.Length; index++)
+        {
+            var ch = masked[index];
+            if (ch == '{')
+            {
+                if (depth == 1 && CSharpMemberHeaderHasStaticContract(masked, memberStart, index))
+                    return true;
+
+                depth++;
+            }
+            else if (ch == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return false;
+
+                if (depth == 1)
+                    memberStart = index + 1;
+            }
+            else if (ch == ';' && depth == 1)
+            {
+                if (CSharpMemberHeaderHasStaticContract(masked, memberStart, index))
+                    return true;
+
+                memberStart = index + 1;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool CSharpMemberHeaderHasStaticContract(string masked, int start, int endExclusive)
+    {
+        if (start < 0 || endExclusive <= start || endExclusive > masked.Length)
+            return false;
+
+        var header = masked[start..endExclusive];
+        return ContainsCSharpWord(header, "static")
+               && (ContainsCSharpWord(header, "abstract")
+                   || ContainsCSharpWord(header, "virtual"));
+    }
+
+    private static int IndexOfCSharpWord(string text, string word, int startIndex)
+    {
+        var index = Math.Max(0, startIndex);
+        while (index < text.Length)
+        {
+            index = text.IndexOf(word, index, StringComparison.Ordinal);
+            if (index < 0)
+                return -1;
+
+            var before = index == 0 ? '\0' : text[index - 1];
+            var afterIndex = index + word.Length;
+            var after = afterIndex >= text.Length ? '\0' : text[afterIndex];
+            if (!IsCSharpIdentifierPart(before) && !IsCSharpIdentifierPart(after))
+                return index;
+
+            index += word.Length;
+        }
+
+        return -1;
+    }
+
+    private static string MaskCSharpCommentsAndStrings(string content)
+    {
+        var chars = content.ToCharArray();
+        var inLineComment = false;
+        var inBlockComment = false;
+        var inString = false;
+        var inChar = false;
+        var inVerbatimString = false;
+        var inRawString = false;
+        var rawQuoteCount = 0;
+
+        for (var index = 0; index < chars.Length; index++)
+        {
+            var ch = chars[index];
+            var next = index + 1 < chars.Length ? chars[index + 1] : '\0';
+
+            if (inLineComment)
+            {
+                if (ch is '\r' or '\n')
+                {
+                    inLineComment = false;
+                }
+                else
+                {
+                    chars[index] = ' ';
+                }
+
+                continue;
+            }
+
+            if (inBlockComment)
+            {
+                if (ch == '*' && next == '/')
+                {
+                    chars[index] = ' ';
+                    chars[index + 1] = ' ';
+                    index++;
+                    inBlockComment = false;
+                }
+                else if (ch is not ('\r' or '\n'))
+                {
+                    chars[index] = ' ';
+                }
+
+                continue;
+            }
+
+            if (inRawString)
+            {
+                if (ch == '"' && HasConsecutiveQuotes(chars, index, rawQuoteCount))
+                {
+                    for (var quote = 0; quote < rawQuoteCount && index + quote < chars.Length; quote++)
+                        chars[index + quote] = ' ';
+                    index += rawQuoteCount - 1;
+                    inRawString = false;
+                }
+                else if (ch is not ('\r' or '\n'))
+                {
+                    chars[index] = ' ';
+                }
+
+                continue;
+            }
+
+            if (inVerbatimString)
+            {
+                if (ch == '"' && next == '"')
+                {
+                    chars[index] = ' ';
+                    chars[index + 1] = ' ';
+                    index++;
+                }
+                else if (ch == '"')
+                {
+                    chars[index] = ' ';
+                    inVerbatimString = false;
+                }
+                else if (ch is not ('\r' or '\n'))
+                {
+                    chars[index] = ' ';
+                }
+
+                continue;
+            }
+
+            if (inString)
+            {
+                if (ch == '\\' && next != '\0')
+                {
+                    chars[index] = ' ';
+                    chars[index + 1] = ' ';
+                    index++;
+                }
+                else if (ch == '"')
+                {
+                    chars[index] = ' ';
+                    inString = false;
+                }
+                else if (ch is not ('\r' or '\n'))
+                {
+                    chars[index] = ' ';
+                }
+
+                continue;
+            }
+
+            if (inChar)
+            {
+                if (ch == '\\' && next != '\0')
+                {
+                    chars[index] = ' ';
+                    chars[index + 1] = ' ';
+                    index++;
+                }
+                else if (ch == '\'')
+                {
+                    chars[index] = ' ';
+                    inChar = false;
+                }
+                else if (ch is not ('\r' or '\n'))
+                {
+                    chars[index] = ' ';
+                }
+
+                continue;
+            }
+
+            if (ch == '/' && next == '/')
+            {
+                chars[index] = ' ';
+                chars[index + 1] = ' ';
+                index++;
+                inLineComment = true;
+            }
+            else if (ch == '/' && next == '*')
+            {
+                chars[index] = ' ';
+                chars[index + 1] = ' ';
+                index++;
+                inBlockComment = true;
+            }
+            else if (ch == '@' && next == '"')
+            {
+                chars[index] = ' ';
+                chars[index + 1] = ' ';
+                index++;
+                inVerbatimString = true;
+            }
+            else if (ch == '"' && HasConsecutiveQuotes(chars, index, 3))
+            {
+                rawQuoteCount = CountConsecutiveQuotes(chars, index);
+                for (var quote = 0; quote < rawQuoteCount && index + quote < chars.Length; quote++)
+                    chars[index + quote] = ' ';
+                index += rawQuoteCount - 1;
+                inRawString = true;
+            }
+            else if (ch == '"')
+            {
+                chars[index] = ' ';
+                inString = true;
+            }
+            else if (ch == '\'')
+            {
+                chars[index] = ' ';
+                inChar = true;
+            }
+        }
+
+        return new string(chars);
+    }
+
+    private static bool HasConsecutiveQuotes(char[] chars, int index, int count)
+    {
+        if (index + count > chars.Length)
+            return false;
+
+        for (var offset = 0; offset < count; offset++)
+        {
+            if (chars[index + offset] != '"')
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int CountConsecutiveQuotes(char[] chars, int index)
+    {
+        var count = 0;
+        while (index + count < chars.Length && chars[index + count] == '"')
+            count++;
+        return count;
+    }
 
     private static bool IsCSharpStaticInterfaceContractSymbol(SymbolRecord symbol)
         => symbol.Kind is "function" or "property"

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -191,6 +191,38 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void MayContainCSharpStaticInterfaceContract_RealContract_ReturnsTrue()
+    {
+        const string content = """
+        public interface IFixture<T>
+        {
+            static abstract T Create();
+            static virtual int Count => 0;
+        }
+        """;
+
+        Assert.True(IndexCommandRunner.MayContainCSharpStaticInterfaceContract(content));
+    }
+
+    [Fact]
+    public void MayContainCSharpStaticInterfaceContract_HelperNamesAndStrings_ReturnsFalse()
+    {
+        var content = File.ReadAllText(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "src",
+            "CodeIndex",
+            "Database",
+            "DbWriter.cs"));
+
+        Assert.False(IndexCommandRunner.MayContainCSharpStaticInterfaceContract(content));
+    }
+
+    [Fact]
     public void HandleIndexCancelKeyPress_FirstCancelRequestsCooperativeCancellation_SecondAllowsForceExit()
     {
         using var cts = new CancellationTokenSource();


### PR DESCRIPTION
## Summary

- Narrowed the C# static interface contract pre-pass so it only runs symbol extraction for files with plausible `static abstract` / `static virtual` members inside an interface body.
- Added regression coverage for a real contract and for helper-name/string-literal false positives like `DbWriter.cs`.
- Added the bilingual changelog fragment `changelog.d/unreleased/2380.fixed.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests.MayContainCSharpStaticInterfaceContract"`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits 834473fe4b88c5c6a9bf9e3175dd283d3a57015c --json`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test` (one unrelated/flaky `HttpMcpTransportTests.HttpTransport_RequestLogger_RecordsMethodStatusDurationAndAuthOutcome` failure; the same test passed when rerun directly)
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~HttpMcpTransportTests.HttpTransport_RequestLogger_RecordsMethodStatusDurationAndAuthOutcome"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --rebuild --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Changelog fragment: `changelog.d/unreleased/2380.fixed.md`
- No guide/documentation changes were required because this fixes internal index refresh behavior without changing CLI flags or output contracts.

Fixes #2380
