### PR TITLE
Bound caller graph paging

### DIFF
--- a/changelog.d/unreleased/1959.fixed.md
+++ b/changelog.d/unreleased/1959.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1959
+affected:
+  - src/CodeIndex/Database/DbReader.GraphQueries.cs
+---
+
+## English
+
+- **Bounded caller graph paging now avoids fixed 200-row intermediate pages (#1959)** — transitive impact traversal now asks SQLite only for the remaining caller result capacity plus one truncation sentinel, and boundary checks page one caller at a time instead of materializing a fixed 200-row page.
+
+## 日本語
+
+- **caller graph のページングが固定 200 行の中間ページを避けるようになりました (#1959)** — transitive impact traversal は残りの caller result 容量に truncation 検出用の 1 件を足した分だけを SQLite に要求し、boundary check も固定 200 行を materialize せず 1 caller ずつページングします。

--- a/src/CodeIndex/Database/DbReader.GraphQueries.cs
+++ b/src/CodeIndex/Database/DbReader.GraphQueries.cs
@@ -760,9 +760,13 @@ public partial class DbReader
     /// <summary>
     /// Find exact-match callers for BFS traversal. Uses per-row case sensitivity
     /// and filters to graph-supported languages only (preventing stale edges from
-    /// unsupported languages leaking into results on pre-upgrade databases).
+    /// unsupported languages leaking into results on pre-upgrade databases). The
+    /// SQL query applies the requested LIMIT/OFFSET so callers do not materialize
+    /// a larger intermediate page than they asked for.
     /// BFS 走査用の完全一致 caller 検索。行ごとの case sensitivity 判定、
     /// かつ graph 対応言語のみにフィルタ（アップグレード前 DB の古いエッジ漏れを防止）。
+    /// SQL 側で要求された LIMIT/OFFSET を適用し、呼び出し側が要求以上の中間ページを
+    /// materialize しないようにする。
     /// </summary>
     private List<CallerResult> GetCallersExact(string symbolName, int limit, int offset = 0, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false)
     {
@@ -932,7 +936,7 @@ public partial class DbReader
             // ダイヤモンド型グラフで到達可能な caller が visited 重複に隠れるのを防止。
             var needed = limit - results.Count;
             var offset = 0;
-            const int pageSize = 200;
+            var pageSize = Math.Max(1, needed + 1);
             var fetchIterations = 0;
 
             while (results.Count < limit && fetchIterations < maxFetchIterations)
@@ -1108,7 +1112,7 @@ public partial class DbReader
         IReadOnlyList<string>? excludePathPatterns,
         bool excludeTests)
     {
-        const int pageSize = 200;
+        const int pageSize = 1;
         var offset = 0;
         while (true)
         {


### PR DESCRIPTION
## Summary

- Bound transitive impact caller paging to the remaining requested result capacity plus one truncation sentinel.
- Change impact boundary checks to page one caller at a time instead of materializing fixed 200-row pages.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.GetTransitiveCallers" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog

- Added changelog fragment: `changelog.d/unreleased/1959.fixed.md`
- No README/user guide update: this narrows internal DB paging behavior without changing CLI/MCP output shape or user-visible options.

## Review

- Adversarial review of `origin/main..HEAD`: No blocking/actionable issues found.
- Attempted external `codex exec` adversarial review, but it failed before review due the Codex usage limit.

Fixes #1959
