### PR TITLE
Fix ASCII progress fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ with `--files`, `--commits`, or `--changed-between <old-ref> <new-ref>` instead
 of rebuilding; see
 [Quick Start](USER_GUIDE.md#quick-start) and
 [Incremental update reliability](USER_GUIDE.md#incremental-update-reliability).
+Terminals that request ASCII-only output with `CDIDX_ASCII=1` or a `LANG=C` /
+`POSIX` locale render progress with `#` / `-` bars instead of Unicode block
+glyphs. Very narrow Unicode-capable terminals show a percentage-only progress
+line so the display does not wrap.
 
 Use `cdidx` when a repository will be searched repeatedly from terminals,
 scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
@@ -211,6 +215,10 @@ cdidx mcp
 [クイックスタート](USER_GUIDE.md#クイックスタート) と
 [インクリメンタル更新の信頼性](USER_GUIDE.md#インクリメンタル更新の信頼性)
 を参照してください。
+`CDIDX_ASCII=1` または `LANG=C` / `POSIX` locale により ASCII-only 出力が
+要求されている端末では、進捗バーは Unicode のブロック文字ではなく `#` / `-`
+で描画されます。Unicode を利用できる端末でも幅が非常に狭い場合は、折り返しを
+避けるため percentage-only の進捗行を表示します。
 
 ターミナル、スクリプト、CI、AI ツールから同じリポジトリを繰り返し検索する
 場合は `cdidx` が向いています。1回限りのテキスト検索には `rg` が向いています。

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ with `--files`, `--commits`, or `--changed-between <old-ref> <new-ref>` instead
 of rebuilding; see
 [Quick Start](USER_GUIDE.md#quick-start) and
 [Incremental update reliability](USER_GUIDE.md#incremental-update-reliability).
-Terminals that request ASCII-only output with `CDIDX_ASCII=1` or a `LANG=C` /
-`POSIX` locale render progress with `#` / `-` bars instead of Unicode block
-glyphs. Very narrow Unicode-capable terminals show a percentage-only progress
-line so the display does not wrap.
+Terminals that request ASCII-only output with `--ascii`, `CDIDX_ASCII=1`, or a
+`LANG=C` / `POSIX` locale render progress with `#` / `-` bars instead of
+Unicode block glyphs. Very narrow Unicode-capable terminals show a
+percentage-only progress line so the display does not wrap.
 
 Use `cdidx` when a repository will be searched repeatedly from terminals,
 scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
@@ -215,10 +215,10 @@ cdidx mcp
 [クイックスタート](USER_GUIDE.md#クイックスタート) と
 [インクリメンタル更新の信頼性](USER_GUIDE.md#インクリメンタル更新の信頼性)
 を参照してください。
-`CDIDX_ASCII=1` または `LANG=C` / `POSIX` locale により ASCII-only 出力が
-要求されている端末では、進捗バーは Unicode のブロック文字ではなく `#` / `-`
-で描画されます。Unicode を利用できる端末でも幅が非常に狭い場合は、折り返しを
-避けるため percentage-only の進捗行を表示します。
+`--ascii`、`CDIDX_ASCII=1`、または `LANG=C` / `POSIX` locale により ASCII-only
+出力が要求されている端末では、進捗バーは Unicode のブロック文字ではなく
+`#` / `-` で描画されます。Unicode を利用できる端末でも幅が非常に狭い場合は、
+折り返しを避けるため percentage-only の進捗行を表示します。
 
 ターミナル、スクリプト、CI、AI ツールから同じリポジトリを繰り返し検索する
 場合は `cdidx` が向いています。1回限りのテキスト検索には `rg` が向いています。

--- a/changelog.d/unreleased/1772.fixed.md
+++ b/changelog.d/unreleased/1772.fixed.md
@@ -4,14 +4,16 @@ issues:
   - 1772
 affected:
   - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
   - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
   - README.md
 ---
 
 ## English
 
-- **Progress bars now have an ASCII fallback (#1772)** - `CDIDX_ASCII=1` and `LANG=C` / `POSIX` locales render indexing progress with `#` / `-` bars instead of Unicode block glyphs, and very narrow Unicode terminals fall back to a percentage-only line.
+- **Progress bars now have an ASCII fallback (#1772)** - `--ascii`, `CDIDX_ASCII=1`, and `LANG=C` / `POSIX` locales render indexing progress with `#` / `-` bars instead of Unicode block glyphs, and very narrow Unicode terminals fall back to a percentage-only line.
 
 ## 日本語
 
-- **進捗バーに ASCII fallback を追加しました (#1772)** - `CDIDX_ASCII=1` や `LANG=C` / `POSIX` locale では、indexing の進捗を Unicode のブロック文字ではなく `#` / `-` のバーで表示し、非常に狭い Unicode 端末では percentage-only の行に fallback します。
+- **進捗バーに ASCII fallback を追加しました (#1772)** - `--ascii`、`CDIDX_ASCII=1`、`LANG=C` / `POSIX` locale では、indexing の進捗を Unicode のブロック文字ではなく `#` / `-` のバーで表示し、非常に狭い Unicode 端末では percentage-only の行に fallback します。

--- a/changelog.d/unreleased/1772.fixed.md
+++ b/changelog.d/unreleased/1772.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1772
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - README.md
+---
+
+## English
+
+- **Progress bars now have an ASCII fallback (#1772)** - `CDIDX_ASCII=1` and `LANG=C` / `POSIX` locales render indexing progress with `#` / `-` bars instead of Unicode block glyphs, and very narrow Unicode terminals fall back to a percentage-only line.
+
+## 日本語
+
+- **進捗バーに ASCII fallback を追加しました (#1772)** - `CDIDX_ASCII=1` や `LANG=C` / `POSIX` locale では、indexing の進捗を Unicode のブロック文字ではなく `#` / `-` のバーで表示し、非常に狭い Unicode 端末では percentage-only の行に fallback します。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -286,6 +286,7 @@ public static class ConsoleUi
     private static string[] _progressSpinnerFrames = DefaultBrailleSpinnerFrames;
     // Track last progress line length for clearing / クリア用に最後のプログレス行の長さを記録
     private static int _lastProgressLineLength;
+    private static bool _asciiOutputForced;
 
     /// <summary>
     /// Set progress bar spinner theme (reuses GetSpinnerFrames).
@@ -600,6 +601,7 @@ public static class ConsoleUi
         Console.WriteLine("  --debounce <ms>            Watch only: coalesce bursts of file events into one update after <ms> of quiet (default: 500)");
         Console.WriteLine("  --color <when>             Color output: `auto` (default), `always`, or `never`; flag wins over `CLICOLOR_FORCE` / `NO_COLOR` / `CLICOLOR` env vars, which win over TTY auto-detect");
         Console.WriteLine("  --palette <name>           ANSI palette: `basic` (8-color, default fallback), `256`, or `truecolor`; flag wins over `CDIDX_COLOR_PALETTE` env var, which wins over `COLORTERM` / `TERM` auto-detect");
+        Console.WriteLine("  --ascii                    Use ASCII progress glyphs (`#` / `-`) instead of Unicode block glyphs (also honors CDIDX_ASCII=1 and LANG=C/POSIX)");
         Console.WriteLine("  --metrics <path>           Append one JSONL record per CLI command / MCP tool call to <path> (also honors CDIDX_METRICS=<path>)");
         Console.WriteLine("  --help, -h                 Show this help message");
         Console.WriteLine("  --version, -V              Show version information");
@@ -1514,6 +1516,9 @@ public static class ConsoleUi
 
     private static bool IsAsciiOutputRequested()
     {
+        if (_asciiOutputForced)
+            return true;
+
         var ascii = Environment.GetEnvironmentVariable("CDIDX_ASCII");
         if (!string.IsNullOrEmpty(ascii) && ascii != "0")
             return true;
@@ -1527,6 +1532,10 @@ public static class ConsoleUi
         => locale != null
             && (locale.Equals("C", StringComparison.OrdinalIgnoreCase)
                 || locale.Equals("POSIX", StringComparison.OrdinalIgnoreCase));
+
+    internal static void SetAsciiOutput(bool enabled) => _asciiOutputForced = enabled;
+
+    internal static bool IsAsciiOutputForced() => _asciiOutputForced;
 
     /// <summary>
     /// Get console window width safely (some environments throw IOException).

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -312,15 +312,11 @@ public static class ConsoleUi
         if (current % 50 != 0 && current != total)
             return;
 
-        const int barWidth = 32;
-        var pct = (double)current / total;
-        int filled = (int)Math.Round(pct * barWidth);
-        if (filled > barWidth) filled = barWidth;
-
-        // Show spinner while in progress, checkmark on completion / 処理中はスピナー、完了時はチェックマーク
-        var spinner = current == total ? " " : _progressSpinnerFrames[(current / 50) % _progressSpinnerFrames.Length];
-        var bar = new string('\u2588', filled) + new string('\u2591', barWidth - filled);
-        var line = $"{spinner} {bar} {pct * 100,5:F1}%  [{current:N0}/{total:N0}]";
+        var line = FormatProgressLine(
+            current,
+            total,
+            redirected ? 80 : GetWindowWidth(),
+            ShouldUseUnicodeGlyphs());
 
         if (!redirected)
         {
@@ -338,6 +334,36 @@ public static class ConsoleUi
             // Fallback for redirected output / リダイレクト時はフォールバック
             output.WriteLine(line.TrimStart());
         }
+    }
+
+    internal static string FormatProgressLine(int current, int total, int windowWidth, bool useUnicodeGlyphs)
+    {
+        const int barWidth = 32;
+        var pct = (double)current / total;
+        var percentAndCounts = $"{pct * 100,5:F1}%  [{current:N0}/{total:N0}]";
+
+        if (useUnicodeGlyphs && windowWidth < 40)
+            return percentAndCounts;
+
+        int filled = (int)Math.Round(pct * barWidth);
+        if (filled > barWidth) filled = barWidth;
+        if (filled < 0) filled = 0;
+
+        var spinner = ResolveProgressSpinner(current, total, useUnicodeGlyphs);
+        var bar = useUnicodeGlyphs
+            ? new string('\u2588', filled) + new string('\u2591', barWidth - filled)
+            : $"[{new string('#', filled)}{new string('-', barWidth - filled)}]";
+        return $"{spinner} {bar} {percentAndCounts}";
+    }
+
+    private static string ResolveProgressSpinner(int current, int total, bool useUnicodeGlyphs)
+    {
+        if (current == total)
+            return " ";
+
+        return useUnicodeGlyphs
+            ? _progressSpinnerFrames[(current / 50) % _progressSpinnerFrames.Length]
+            : "-";
     }
 
     /// <summary>
@@ -1476,6 +1502,31 @@ public static class ConsoleUi
         var cliColor = Environment.GetEnvironmentVariable("CLICOLOR");
         return cliColor == "0";
     }
+
+    internal static bool ShouldUseUnicodeGlyphs()
+    {
+        if (IsAsciiOutputRequested())
+            return false;
+
+        return Console.OutputEncoding.CodePage == Encoding.UTF8.CodePage
+            || Console.OutputEncoding.CodePage == Encoding.Unicode.CodePage;
+    }
+
+    private static bool IsAsciiOutputRequested()
+    {
+        var ascii = Environment.GetEnvironmentVariable("CDIDX_ASCII");
+        if (!string.IsNullOrEmpty(ascii) && ascii != "0")
+            return true;
+
+        return IsPosixLocale(Environment.GetEnvironmentVariable("LC_ALL"))
+            || IsPosixLocale(Environment.GetEnvironmentVariable("LC_CTYPE"))
+            || IsPosixLocale(Environment.GetEnvironmentVariable("LANG"));
+    }
+
+    private static bool IsPosixLocale(string? locale)
+        => locale != null
+            && (locale.Equals("C", StringComparison.OrdinalIgnoreCase)
+                || locale.Equals("POSIX", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Get console window width safely (some environments throw IOException).

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -53,6 +53,8 @@ internal static class ProgramRunner
             return CommandExitCodes.InvalidArgument;
         }
 
+        TryConsumeAsciiFlag(ref args);
+
         if (!TryConsumeMetricsFlag(ref args, out var metricsPath, out var metricsError))
         {
             Console.Error.WriteLine(metricsError);
@@ -290,6 +292,40 @@ internal static class ProgramRunner
             ConsoleUi.SetColorMode(requested.Value);
         args = kept.ToArray();
         return true;
+    }
+
+    internal static void TryConsumeAsciiFlag(ref string[] args)
+    {
+        ConsoleUi.SetAsciiOutput(false);
+        if (args.Length == 0)
+            return;
+
+        var kept = new List<string>(args.Length);
+        var passthrough = false;
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (passthrough)
+            {
+                kept.Add(arg);
+                continue;
+            }
+            if (arg == "--")
+            {
+                passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+            if (arg == "--ascii")
+            {
+                ConsoleUi.SetAsciiOutput(true);
+                continue;
+            }
+
+            kept.Add(arg);
+        }
+
+        args = kept.ToArray();
     }
 
     // Strip `--palette <name>` / `--palette=<name>` from `args` before

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -52,6 +52,7 @@ public class ConsoleUiTests
         Assert.Contains("--commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)", output);
         Assert.Contains("--files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed", output);
         Assert.Contains("--duration-format <format> Index elapsed time format: `auto` (default), `seconds`, or `hms`; JSON keeps raw elapsed_ms", output);
+        Assert.Contains("--ascii                    Use ASCII progress glyphs", output);
         Assert.Contains("cdidx excerpt <path> --start <line> [--end <line>] [--before <n>] [--after <n>] [--max-line-width <n>] [--focus-line <line>] [--focus-column <n>] [--focus-length <n>] [--db <path>] [--json]", output);
         Assert.Contains("--focus-column <n>         excerpt: column to keep centered when clamping (must be within the focused line)", output);
         Assert.Contains("--focus-line <line>        excerpt: line whose focused column should stay visible", output);

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -140,6 +140,54 @@ public class ConsoleUiTests
         Assert.Equal(["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"], frames);
     }
 
+    [Fact]
+    public void FormatProgressLine_UnicodeEnabled_UsesBlockGlyphBar()
+    {
+        var line = ConsoleUi.FormatProgressLine(25, 100, windowWidth: 80, useUnicodeGlyphs: true);
+
+        Assert.Contains('█', line);
+        Assert.Contains('░', line);
+        Assert.DoesNotContain('#', line);
+        Assert.Contains("25.0%  [25/100]", line);
+    }
+
+    [Fact]
+    public void FormatProgressLine_AsciiFallback_UsesAsciiBarAndSpinner()
+    {
+        var line = ConsoleUi.FormatProgressLine(25, 100, windowWidth: 80, useUnicodeGlyphs: false);
+
+        Assert.StartsWith("- [########", line);
+        Assert.Contains("------------------------]", line);
+        Assert.DoesNotContain('█', line);
+        Assert.DoesNotContain('░', line);
+    }
+
+    [Fact]
+    public void FormatProgressLine_NarrowUnicodeTerminal_UsesPercentageOnly()
+    {
+        var line = ConsoleUi.FormatProgressLine(2, 4, windowWidth: 39, useUnicodeGlyphs: true);
+
+        Assert.Equal(" 50.0%  [2/4]", line);
+    }
+
+    [Fact]
+    public void ShouldUseUnicodeGlyphs_CdidxAsciiEnvVarDisablesUnicode()
+    {
+        WithUnicodeEnvironment(cdidxAscii: "1", lang: "en_US.UTF-8", () =>
+        {
+            Assert.False(ConsoleUi.ShouldUseUnicodeGlyphs());
+        });
+    }
+
+    [Fact]
+    public void ShouldUseUnicodeGlyphs_PosixLangDisablesUnicode()
+    {
+        WithUnicodeEnvironment(cdidxAscii: null, lang: "C", () =>
+        {
+            Assert.False(ConsoleUi.ShouldUseUnicodeGlyphs());
+        });
+    }
+
     [Theory]
     [InlineData(0L, "0 bytes")]
     [InlineData(1023L, "1,023 bytes")]
@@ -790,6 +838,32 @@ public class ConsoleUiTests
                 Environment.SetEnvironmentVariable("TERM", originalTerm);
                 Environment.SetEnvironmentVariable("CDIDX_COLOR_PALETTE", originalPaletteEnv);
                 ConsoleUi.SetColorPalette(originalPalette);
+            }
+        }
+    }
+
+    private static void WithUnicodeEnvironment(string? cdidxAscii, string? lang, Action action)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalAscii = Environment.GetEnvironmentVariable("CDIDX_ASCII");
+            var originalLang = Environment.GetEnvironmentVariable("LANG");
+            var originalLcAll = Environment.GetEnvironmentVariable("LC_ALL");
+            var originalLcCType = Environment.GetEnvironmentVariable("LC_CTYPE");
+            try
+            {
+                Environment.SetEnvironmentVariable("CDIDX_ASCII", cdidxAscii);
+                Environment.SetEnvironmentVariable("LANG", lang);
+                Environment.SetEnvironmentVariable("LC_ALL", null);
+                Environment.SetEnvironmentVariable("LC_CTYPE", null);
+                action();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("CDIDX_ASCII", originalAscii);
+                Environment.SetEnvironmentVariable("LANG", originalLang);
+                Environment.SetEnvironmentVariable("LC_ALL", originalLcAll);
+                Environment.SetEnvironmentVariable("LC_CTYPE", originalLcCType);
             }
         }
     }

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -308,6 +308,27 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void TryConsumeAsciiFlag_StripsFlagBeforeDoubleDashAndForcesAscii()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var original = ConsoleUi.IsAsciiOutputForced();
+            try
+            {
+                var args = new[] { "index", "--ascii", "--", "--ascii" };
+                ProgramRunner.TryConsumeAsciiFlag(ref args);
+
+                Assert.True(ConsoleUi.IsAsciiOutputForced());
+                Assert.Equal(new[] { "index", "--", "--ascii" }, args);
+            }
+            finally
+            {
+                ConsoleUi.SetAsciiOutput(original);
+            }
+        }
+    }
+
+    [Fact]
     public void Run_InvalidColorValue_ReturnsInvalidArgument()
     {
         var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(


### PR DESCRIPTION
## Summary

- Add ASCII progress rendering for `--ascii`, `CDIDX_ASCII=1`, and `LANG=C` / `POSIX` terminals.
- Fall back to percentage-only progress on very narrow Unicode-capable terminals.
- Document the terminal capability behavior and add a bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests"`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests|FullyQualifiedName~ProgramRunnerTests"`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog

- Updated `README.md`.
- Added `changelog.d/unreleased/1772.fixed.md`.

## Review

- Manual adversarial review of `origin/main..HEAD`: No blocking/actionable issues found.
- Attempted `codex exec` adversarial review, but it was blocked by the current Codex usage limit.

## Follow-up candidates

- None.

Fixes #1772
