### PR TITLE
Fix find zero-result path hint

### DIFF
--- a/changelog.d/unreleased/1406.fixed.md
+++ b/changelog.d/unreleased/1406.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1406
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbReader.FilesStatus.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`find` now distinguishes path misses from content misses (#1406)** — when `--path` matches files but the query has no in-file hits, the CLI now says the path matched and suggests broadening the query instead of incorrectly telling users to broaden `--path`.
+
+## 日本語
+
+- **`find` が path の不一致と本文検索の不一致を区別するようになりました (#1406)** — `--path` がファイルに一致しているものの query が本文内で一致しない場合、CLI は path が一致したことを示し、誤って `--path` を広げるよう促すのではなく query を広げるよう案内します。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -1362,6 +1362,7 @@ public static class QueryCommandRunner
             var results = reader.FindInFiles(options.Query, options.Limit, options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, options.ContextBefore, options.ContextAfter, options.Exact, options.MaxLineWidth);
             if (results.Count == 0)
             {
+                var candidateFileCount = reader.CountFindCandidateFiles(options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests);
                 if (options.Json)
                 {
                     var payload = BuildJsonZeroResultPayload(reader, jsonOptions, resultsKey: "results", queryOptions: options, extraFields: payload =>
@@ -1372,14 +1373,22 @@ public static class QueryCommandRunner
                         payload["before"] = options.ContextBefore;
                         payload["after"] = options.ContextAfter;
                         payload["exact"] = options.Exact;
-                        payload["file_count"] = 0;
+                        payload["file_count"] = candidateFileCount;
                     });
                     Console.WriteLine(payload.ToJsonString(jsonOptions));
                 }
                 else
                 {
                     Console.Error.WriteLine(BuildZeroResultLine("No matches found", options));
-                    WriteZeroResultHints(options, reader, filterHint: "try broadening --path or adding another --path value; --path is required for find.");
+                    if (candidateFileCount > 0)
+                    {
+                        var fileText = ConsoleUi.Counted(candidateFileCount, "file");
+                        WriteZeroResultHints(options, reader, filterHint: $"--path matched {fileText}, but the query did not match their contents. Try a broader query or check the query syntax.");
+                    }
+                    else
+                    {
+                        WriteZeroResultHints(options, reader, filterHint: "try broadening --path or adding another --path value; --path is required for find.");
+                    }
                 }
                 return CommandExitCodes.NotFound;
             }

--- a/src/CodeIndex/Database/DbReader.FilesStatus.cs
+++ b/src/CodeIndex/Database/DbReader.FilesStatus.cs
@@ -1,5 +1,6 @@
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -99,6 +100,24 @@ public partial class DbReader
         }
 
         return results;
+    }
+
+    public int CountFindCandidateFiles(string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false)
+    {
+        if (pathPatterns == null || pathPatterns.Count == 0)
+            return 0;
+
+        using var fileCmd = _conn.CreateCommand();
+        var sql = "SELECT COUNT(*) FROM files f WHERE 1=1";
+        if (lang != null)
+            sql += " AND f.lang = @lang";
+        AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
+        fileCmd.CommandText = sql;
+        if (lang != null)
+            fileCmd.Parameters.AddWithValue("@lang", lang);
+        AddPathFilterParameters(fileCmd, pathPatterns, excludePathPatterns);
+
+        return Convert.ToInt32(fileCmd.ExecuteScalar(), CultureInfo.InvariantCulture);
     }
 
     public QueryCountResult CountFindInFiles(string query, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool exact = false)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -27828,7 +27828,7 @@ jobs:
     }
 
     [Fact]
-    public void RunFind_ZeroResultHintDoesNotSuggestRemovingRequiredPath()
+    public void RunFind_ZeroResultHintDistinguishesPathMatchesFromQueryMiss_Issue1406()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_zero_hint");
         try
@@ -27847,8 +27847,38 @@ jobs:
 
             Assert.Equal(CommandExitCodes.NotFound, exitCode);
             Assert.Contains("No matches found.", stderr);
-            Assert.Contains("broadening --path or adding another --path value", normalizedStderr);
+            Assert.Contains("--path matched 1 file, but the query did not match their contents", stderr);
+            Assert.Contains("try a broader query or check the query syntax", normalizedStderr);
+            Assert.DoesNotContain("broadening --path or adding another --path value", normalizedStderr);
             Assert.DoesNotContain("try removing --lang, --path", normalizedStderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunFind_ZeroResultHintStillSuggestsBroadeningUnmatchedPath_Issue1406()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_zero_path_hint");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "README.md",
+                "markdown",
+                "hello world\n");
+
+            var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["hello", "--db", dbPath, "--path", "src/**/*.cs"],
+                _jsonOptions));
+            var normalizedStderr = stderr.ToLowerInvariant();
+
+            Assert.Equal(CommandExitCodes.NotFound, exitCode);
+            Assert.Contains("broadening --path or adding another --path value", normalizedStderr);
+            Assert.DoesNotContain("query did not match", normalizedStderr);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Distinguish `find` zero-result cases where `--path` matched files from cases where the path matched no files.
- Report the matched candidate file count for `find --json` zero-result output.
- Add focused tests for both the content-miss and path-miss hint paths.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "RunFind_ZeroResultHint"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll find "new Regex" --path "src/CodeIndex/Indexer/References/**"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll find "new Regex" --path "does-not-exist/**"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Added changelog fragment: `changelog.d/unreleased/1406.fixed.md`
- No README or guide updates were needed because the change corrects a misleading zero-result hint without adding new user workflow.

## Follow-up Candidates

- None.

Fixes #1406
