### PR TITLE
Fix CLI cancellation exit code

### DIFF
--- a/changelog.d/unreleased/1430.fixed.md
+++ b/changelog.d/unreleased/1430.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1430
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Top-level CLI cancellation now returns the documented cancellation exit code (#1430)** — `OperationCanceledException` no longer falls through to the generic database-error handler when a command is cancelled before completion.
+
+## 日本語
+
+- **CLI 最上位の cancellation が documented cancellation exit code を返すようになりました (#1430)** — command が完了前に cancel されたとき、`OperationCanceledException` が generic database-error handler に落ちなくなりました。

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -197,6 +197,13 @@ internal static class ProgramRunner
             EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, exitCode, ex.Code);
             return exitCode;
         }
+        catch (OperationCanceledException ex)
+        {
+            GlobalToolLog.Error($"command_complete exit_code={CommandExitCodes.CancelledBySignal} operation_cancelled type={ex.GetType().Name}: {ex.Message}");
+            Console.Error.WriteLine("Error: command cancelled before it could complete.");
+            EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, CommandExitCodes.CancelledBySignal, ex.GetType().Name);
+            return CommandExitCodes.CancelledBySignal;
+        }
         catch (Exception ex)
         {
             if (JsonOutputFailure.TryHandle(ex, out var exitCode))

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -32,6 +32,25 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void Run_OperationCanceledException_ReturnsCancelledExitCode()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            ["status"],
+            appVersion: "1.10.0",
+            beforeDispatchForTesting: () => throw new OperationCanceledException("timeout budget elapsed")));
+
+        Assert.Equal(CommandExitCodes.CancelledBySignal, exitCode);
+        Assert.Equal(string.Empty, stdout);
+
+        var trimmed = stderr.TrimEnd();
+        Assert.Equal(trimmed, stderr.Trim());
+        Assert.DoesNotContain(Environment.NewLine, trimmed);
+        Assert.DoesNotContain("OperationCanceledException", trimmed);
+        Assert.DoesNotContain("timeout budget elapsed", trimmed);
+        Assert.StartsWith("Error: command cancelled before it could complete.", trimmed);
+    }
+
+    [Fact]
     public void Run_ForcedGlobalToolLogging_WritesLifecycleAndMirrorsStderr()
     {
         var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

- Map top-level `OperationCanceledException` to the documented cancellation exit code instead of the generic database-error handler.
- Add a regression test for sanitized cancellation stderr and exit-code behavior.
- Add the bilingual changelog fragment for issue #1430.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter ProgramRunnerTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

Full `dotnet test CodeIndex.sln -p:UseSharedCompilation=false` was attempted, but the local run produced no progress for several minutes while other long-running `dotnet test CodeIndex.sln` processes were already present, so it was stopped after the targeted test and solution build succeeded.

## Documentation and Changelog

- Added `changelog.d/unreleased/1430.fixed.md`.
- No README/guide update was needed because the cancellation exit code was already documented; this change makes the top-level handler honor that existing contract.

Fixes #1430
