### PR TITLE
Fix deterministic search tie ordering

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -347,6 +347,8 @@ For the current use case — a local CLI tool that indexes a single project for 
 
 FTS5 works through a **virtual table** — a table that looks and behaves like a normal SQLite table but stores its data in a specialized format optimized for text search.
 
+Search result ordering must remain deterministic for identical inputs and an unchanged index. Ranking `ORDER BY` clauses should finish with stable persisted keys after user-visible relevance keys, so ties in FTS rank, file timestamp, and path never fall through to SQLite's implementation-defined row order. The chunk search `ORDER BY` ends with `f.path, c.id ASC` for this reason (#1731).
+
 ### What is an inverted index?
 
 An inverted index maps each word (token) to the list of documents (or rows) that contain it — like the index at the back of a textbook.

--- a/changelog.d/unreleased/1731.fixed.md
+++ b/changelog.d/unreleased/1731.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1731
+affected:
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Search now has a final stable tiebreaker (#1731)** — chunk search ordering now ends with the persisted chunk id, so rank/path ties no longer fall through to SQLite's implementation-defined row order.
+
+## 日本語
+
+- **検索結果に最後の安定した tie-breaker を追加しました (#1731)** — チャンク検索の並び順の末尾に永続化された chunk id を加え、rank / path が同点の結果が SQLite の実装依存の行順に落ちないようにしました。

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -546,7 +546,7 @@ public partial class DbReader
 
     private static string GetSearchOrderSql()
     {
-        return $"{PathBucketOrder}, {ExactSymbolMatchOrder}, {PrefixSymbolMatchOrder}, {SearchVisibilityOrder}, {PathTextMatchOrder}, {ChunkTextMatchOrder}, rank, f.modified DESC, f.path";
+        return $"{PathBucketOrder}, {ExactSymbolMatchOrder}, {PrefixSymbolMatchOrder}, {SearchVisibilityOrder}, {PathTextMatchOrder}, {ChunkTextMatchOrder}, rank, f.modified DESC, f.path, c.id ASC";
     }
 
     private static string SearchVisibilityOrder => @"

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -1110,6 +1110,38 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void Search_TiedChunksUseStableChunkIdOrder()
+    {
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/tied_chunks.py", Lang = "python", Size = 3000, Lines = 260,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertChunks([
+            new ChunkRecord { FileId = fileId, ChunkIndex = 0, StartLine = 1, EndLine = 20, Content = "stable_tie_marker\n" },
+            new ChunkRecord { FileId = fileId, ChunkIndex = 1, StartLine = 101, EndLine = 120, Content = "stable_tie_marker\n" },
+            new ChunkRecord { FileId = fileId, ChunkIndex = 2, StartLine = 201, EndLine = 220, Content = "stable_tie_marker\n" },
+        ]);
+
+        var first = _reader.Search("stable_tie_marker", limit: 10)
+            .Where(r => r.Path == "src/tied_chunks.py")
+            .Select(r => (r.Path, r.StartLine, r.EndLine, r.Content))
+            .ToArray();
+
+        Assert.Equal([1, 101, 201], first.Select(r => r.StartLine).ToArray());
+
+        for (var i = 0; i < 10; i++)
+        {
+            var next = _reader.Search("stable_tie_marker", limit: 10)
+                .Where(r => r.Path == "src/tied_chunks.py")
+                .Select(r => (r.Path, r.StartLine, r.EndLine, r.Content))
+                .ToArray();
+
+            Assert.Equal(first, next);
+        }
+    }
+
+    [Fact]
     public void Search_PrefersDefinitionFileOverReferenceOnlySourceFile()
     {
         var refFileId = _writer.UpsertFile(new FileRecord


### PR DESCRIPTION
## Summary

- Add a final persisted chunk-id tiebreaker to search ordering so rank/path ties stay deterministic.
- Add regression coverage for repeated tied chunk searches.
- Document the search ordering determinism contract and add a bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DbReaderTests.Search_TiedChunksUseStableChunkIdOrder`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DbReaderTests --no-restore`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Updated `DEVELOPER_GUIDE.md`.
- Added `changelog.d/unreleased/1731.fixed.md`.

## Follow-up candidates

- None.

Fixes #1731
