### PR TITLE
Fix C# same-file private unused filtering

### DIFF
--- a/changelog.d/unreleased/1403.fixed.md
+++ b/changelog.d/unreleased/1403.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 1403
+affected:
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **`unused` now suppresses C# private same-file false positives (#1403)** — private and file-private C# candidates are checked against same-file indexed text before reporting, so symbols used only within their defining file are no longer listed as likely unused.
+
+## 日本語
+
+- **`unused` が C# private の同一ファイル利用を false positive として出さないようになりました (#1403)** — C# の private / file-private 候補は報告前に同一ファイルの indexed text と照合され、定義ファイル内だけで使われているシンボルを likely unused として列挙しなくなりました。

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -410,6 +410,9 @@ public class DbContext : IDisposable
             "sql_normalize_csharp_verbatim_name",
             (string? text) => string.IsNullOrWhiteSpace(text) ? null : CSharpVerbatimNameNormalizer.Normalize(text));
         connection.CreateFunction(
+            "csharp_identifier_occurrence_count",
+            (string? text, string? identifier) => CountCSharpIdentifierOccurrences(text, identifier));
+        connection.CreateFunction(
             "sql_normalize_exact_source_name",
             (string? text, string? lang) => string.IsNullOrWhiteSpace(text) ? null : ExactSourceSearchNormalizer.Normalize(text, lang));
         connection.CreateFunction(
@@ -476,6 +479,315 @@ public class DbContext : IDisposable
             "sql_allow_leaf_fallback_at",
             (string? symbolName, string? context, string? containerName, long? columnNumber) =>
                 SqlNameResolver.AllowLeafFallbackAtColumn(symbolName, context, containerName, ToNullableInt(columnNumber)) ? 1 : 0);
+    }
+
+    private static int CountCSharpIdentifierOccurrences(string? text, string? identifier)
+    {
+        if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(identifier))
+            return 0;
+
+        text = MaskCSharpCommentsAndStrings(text);
+        var count = 0;
+        var searchIndex = 0;
+        while (searchIndex < text.Length)
+        {
+            var index = text.IndexOf(identifier, searchIndex, StringComparison.Ordinal);
+            if (index < 0)
+                break;
+
+            var beforeIndex = index - 1;
+            var afterIndex = index + identifier.Length;
+            var hasIdentifierBefore = beforeIndex >= 0 && IsCSharpIdentifierPart(text[beforeIndex]);
+            var hasIdentifierAfter = afterIndex < text.Length && IsCSharpIdentifierPart(text[afterIndex]);
+            if (!hasIdentifierBefore && !hasIdentifierAfter)
+                count++;
+
+            searchIndex = index + identifier.Length;
+        }
+
+        return count;
+    }
+
+    private static bool IsCSharpIdentifierPart(char ch)
+    {
+        return ch == '_' || char.IsLetterOrDigit(ch);
+    }
+
+    private static string MaskCSharpCommentsAndStrings(string text)
+    {
+        var chars = text.ToCharArray();
+        var inBlockComment = false;
+        var inLineComment = false;
+        var inString = false;
+        var inChar = false;
+        var inVerbatimString = false;
+
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var ch = chars[i];
+            var next = i + 1 < chars.Length ? chars[i + 1] : '\0';
+
+            if (inLineComment)
+            {
+                if (ch is '\r' or '\n')
+                    inLineComment = false;
+                else
+                    chars[i] = ' ';
+                continue;
+            }
+
+            if (inBlockComment)
+            {
+                if (ch == '*' && next == '/')
+                {
+                    chars[i] = ' ';
+                    chars[i + 1] = ' ';
+                    i++;
+                    inBlockComment = false;
+                }
+                else if (ch is not ('\r' or '\n'))
+                {
+                    chars[i] = ' ';
+                }
+                continue;
+            }
+
+            if (inString)
+            {
+                if (ch == '\\' && !inVerbatimString && next != '\0')
+                {
+                    chars[i] = ' ';
+                    if (next is not ('\r' or '\n'))
+                        chars[i + 1] = ' ';
+                    i++;
+                    continue;
+                }
+
+                if (inVerbatimString && ch == '"' && next == '"')
+                {
+                    chars[i] = ' ';
+                    chars[i + 1] = ' ';
+                    i++;
+                    continue;
+                }
+
+                if (ch == '"')
+                    inString = false;
+
+                chars[i] = ch is '\r' or '\n' ? ch : ' ';
+                continue;
+            }
+
+            if (inChar)
+            {
+                if (ch == '\\' && next != '\0')
+                {
+                    chars[i] = ' ';
+                    if (next is not ('\r' or '\n'))
+                        chars[i + 1] = ' ';
+                    i++;
+                    continue;
+                }
+
+                if (ch == '\'')
+                    inChar = false;
+
+                chars[i] = ch is '\r' or '\n' ? ch : ' ';
+                continue;
+            }
+
+            if (ch == '/' && next == '/')
+            {
+                chars[i] = ' ';
+                chars[i + 1] = ' ';
+                i++;
+                inLineComment = true;
+                continue;
+            }
+
+            if (ch == '/' && next == '*')
+            {
+                chars[i] = ' ';
+                chars[i + 1] = ' ';
+                i++;
+                inBlockComment = true;
+                continue;
+            }
+
+            if (TryMaskCSharpRawString(chars, ref i))
+                continue;
+
+            if (TryMaskCSharpInterpolatedString(chars, ref i))
+                continue;
+
+            if (ch == '@' && next == '"')
+            {
+                chars[i] = ' ';
+                chars[i + 1] = ' ';
+                i++;
+                inString = true;
+                inVerbatimString = true;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                chars[i] = ' ';
+                inString = true;
+                inVerbatimString = false;
+                continue;
+            }
+
+            if (ch == '\'')
+            {
+                chars[i] = ' ';
+                inChar = true;
+            }
+        }
+
+        return new string(chars);
+    }
+
+    private static bool TryMaskCSharpRawString(char[] chars, ref int index)
+    {
+        var start = index;
+        var cursor = start;
+        while (cursor < chars.Length && chars[cursor] == '$')
+            cursor++;
+
+        if (cursor + 2 >= chars.Length
+            || chars[cursor] != '"'
+            || chars[cursor + 1] != '"'
+            || chars[cursor + 2] != '"')
+        {
+            return false;
+        }
+
+        var quoteCount = 0;
+        while (cursor + quoteCount < chars.Length && chars[cursor + quoteCount] == '"')
+            quoteCount++;
+        if (quoteCount < 3)
+            return false;
+
+        var interpolationDollarCount = cursor - start;
+        MaskRangePreservingNewLines(chars, start, cursor + quoteCount);
+        var search = cursor + quoteCount;
+        var interpolationBraceDepth = 0;
+        while (search < chars.Length)
+        {
+            if (interpolationBraceDepth == 0 && HasQuoteRun(chars, search, quoteCount))
+            {
+                MaskRangePreservingNewLines(chars, search, search + quoteCount);
+                index = search + quoteCount - 1;
+                return true;
+            }
+
+            if (interpolationDollarCount > 0 && chars[search] == '{')
+            {
+                interpolationBraceDepth++;
+            }
+            else if (interpolationBraceDepth > 0 && chars[search] == '}')
+            {
+                interpolationBraceDepth--;
+            }
+            else if (interpolationBraceDepth == 0 && chars[search] is not ('\r' or '\n'))
+            {
+                chars[search] = ' ';
+            }
+            search++;
+        }
+
+        index = chars.Length - 1;
+        return true;
+    }
+
+    private static bool TryMaskCSharpInterpolatedString(char[] chars, ref int index)
+    {
+        var start = index;
+        if (chars[start] != '$')
+            return false;
+
+        var cursor = start + 1;
+        var verbatim = false;
+        if (cursor < chars.Length && chars[cursor] == '@')
+        {
+            verbatim = true;
+            cursor++;
+        }
+
+        if (cursor >= chars.Length || chars[cursor] != '"')
+            return false;
+
+        MaskRangePreservingNewLines(chars, start, cursor + 1);
+        var braceDepth = 0;
+        for (var i = cursor + 1; i < chars.Length; i++)
+        {
+            var ch = chars[i];
+            var next = i + 1 < chars.Length ? chars[i + 1] : '\0';
+
+            if (braceDepth == 0 && ch == '"' && !(verbatim && next == '"'))
+            {
+                chars[i] = ' ';
+                index = i;
+                return true;
+            }
+
+            if (verbatim && braceDepth == 0 && ch == '"' && next == '"')
+            {
+                chars[i] = ' ';
+                chars[i + 1] = ' ';
+                i++;
+                continue;
+            }
+
+            if (!verbatim && braceDepth == 0 && ch == '\\' && next != '\0')
+            {
+                chars[i] = ' ';
+                if (next is not ('\r' or '\n'))
+                    chars[i + 1] = ' ';
+                i++;
+                continue;
+            }
+
+            if (ch == '{')
+            {
+                braceDepth++;
+                continue;
+            }
+
+            if (braceDepth > 0 && ch == '}')
+            {
+                braceDepth--;
+                continue;
+            }
+
+            if (braceDepth == 0 && ch is not ('\r' or '\n'))
+                chars[i] = ' ';
+        }
+
+        index = chars.Length - 1;
+        return true;
+    }
+
+    private static bool HasQuoteRun(char[] chars, int start, int quoteCount)
+    {
+        if (start + quoteCount > chars.Length)
+            return false;
+        for (var i = 0; i < quoteCount; i++)
+        {
+            if (chars[start + i] != '"')
+                return false;
+        }
+        return true;
+    }
+
+    private static void MaskRangePreservingNewLines(char[] chars, int start, int end)
+    {
+        for (var i = start; i < end && i < chars.Length; i++)
+        {
+            if (chars[i] is not ('\r' or '\n'))
+                chars[i] = ' ';
+        }
     }
 
     private static void RegisterConnectionFunctionsWithRetry(

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -71,6 +71,27 @@ public partial class DbReader
     private const int UnusedPublicCandidateBudget = 2048;
     private const string SymbolLanguageFileIdFilter = " AND s.file_id IN (SELECT id FROM files WHERE lang = @lang)";
 
+    private static string BuildSameFilePrivateUseExclusionSql(string symbolAlias, string fileAlias, string visibilitySql, string startLineSql, string endLineSql)
+    {
+        return $@"
+              AND NOT (
+                  {fileAlias}.lang = 'csharp'
+                  AND {visibilitySql} IN ('private', 'fileprivate')
+                  AND {symbolAlias}.name <> ''
+                  AND EXISTS (
+                      SELECT 1
+                      FROM chunks same_file_chunk
+                      WHERE same_file_chunk.file_id = {symbolAlias}.file_id
+                        AND csharp_identifier_occurrence_count(same_file_chunk.content, {symbolAlias}.name) > 0
+                        AND (
+                            same_file_chunk.end_line < {startLineSql}
+                            OR same_file_chunk.start_line > {endLineSql}
+                            OR csharp_identifier_occurrence_count(same_file_chunk.content, {symbolAlias}.name) > 1
+                        )
+                  )
+              )";
+    }
+
     private static string GetHotspotReferenceWeightSql(string referenceKindSql) => $@"
         CASE {referenceKindSql}
             WHEN 'call' THEN 1.0
@@ -2474,6 +2495,15 @@ public partial class DbReader
                                 ))
                          ))
                   )";
+        if (_hasChunksTable && HasTable("chunks"))
+        {
+            sql += BuildSameFilePrivateUseExclusionSql(
+                "s",
+                "f",
+                visibilitySql,
+                GetSymbolColumnSql("start_line", "s.line"),
+                GetSymbolColumnSql("end_line", "s.line"));
+        }
         sql += $"\n              AND {BuildAmbiguousCSharpEnumMemberExclusionSql("s", "f", pathPatterns, excludePathPatterns, excludeTests)}";
 
         if (lang != null)
@@ -2619,6 +2649,15 @@ public partial class DbReader
                                 ))
                      ))
               )";
+        if (_hasChunksTable && HasTable("chunks"))
+        {
+            sql += BuildSameFilePrivateUseExclusionSql(
+                "s",
+                "f",
+                $"lower({GetSymbolColumnSql("visibility", "''")})",
+                GetSymbolColumnSql("start_line", "s.line"),
+                GetSymbolColumnSql("end_line", "s.line"));
+        }
         sql += $"\n              AND {BuildAmbiguousCSharpEnumMemberExclusionSql("s", "f", pathPatterns, excludePathPatterns, excludeTests)}";
 
         if (lang != null)
@@ -3545,7 +3584,7 @@ public partial class DbReader
             return (
                 UnusedBucketLikelyPrivate,
                 "medium",
-                "private/file-local symbol with no indexed references; same-file uses may still be missed");
+                "private/file-local symbol with no indexed references after same-file text validation");
         }
 
         return (

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -12667,7 +12667,7 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
-    public void GetUnusedSymbols_PrivateHelperWithSameFileUse_IsNotLabeledHighConfidence()
+    public void GetUnusedSymbols_PrivateHelperWithSameFileUse_IsNotReported()
     {
         var fileId = _writer.UpsertFile(new FileRecord
         {
@@ -12684,14 +12684,22 @@ public class DbReaderTests : IDisposable
                 FileId = fileId,
                 ChunkIndex = 0,
                 StartLine = 1,
-                EndLine = 8,
-                Content = """
+                EndLine = 13,
+                Content = """""
                 public class LocalUseFixture
                 {
                     public void Run() { Hidden(); }
+                    public void RunInterpolated() { _ = $"{HiddenInterpolated()}"; }
+                    public void RunRawInterpolated() { _ = $"""{RawInterpolated()}"""; }
                     private void Hidden() { }
+                    private void HiddenInterpolated() { }
+                    private void RawInterpolated() { }
+                    // CommentOnly is not a real use.
+                    private void CommentOnly() { }
+                    private void StringOnly() { _ = "StringOnly"; }
+                    private void RawStringOnly() { _ = """RawStringOnly"""; }
                 }
-                """,
+                """"",
             }
         ]);
         _writer.InsertSymbols(
@@ -12713,6 +12721,71 @@ public class DbReaderTests : IDisposable
             {
                 FileId = fileId,
                 Kind = "function",
+                Name = "HiddenInterpolated",
+                Line = 6,
+                StartLine = 6,
+                EndLine = 6,
+                Signature = "private void HiddenInterpolated() { }",
+                Visibility = "private",
+                ContainerKind = "class",
+                ContainerName = "LocalUseFixture",
+            },
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = "RawInterpolated",
+                Line = 7,
+                StartLine = 7,
+                EndLine = 7,
+                Signature = "private void RawInterpolated() { }",
+                Visibility = "private",
+                ContainerKind = "class",
+                ContainerName = "LocalUseFixture",
+            },
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = "CommentOnly",
+                Line = 9,
+                StartLine = 9,
+                EndLine = 9,
+                Signature = "private void CommentOnly() { }",
+                Visibility = "private",
+                ContainerKind = "class",
+                ContainerName = "LocalUseFixture",
+            },
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = "StringOnly",
+                Line = 10,
+                StartLine = 10,
+                EndLine = 10,
+                Signature = "private void StringOnly() { _ = \"StringOnly\"; }",
+                Visibility = "private",
+                ContainerKind = "class",
+                ContainerName = "LocalUseFixture",
+            },
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = "RawStringOnly",
+                Line = 11,
+                StartLine = 11,
+                EndLine = 11,
+                Signature = "private void RawStringOnly() { _ = \"\"\"RawStringOnly\"\"\"; }",
+                Visibility = "private",
+                ContainerKind = "class",
+                ContainerName = "LocalUseFixture",
+            },
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
                 Name = "Hidden",
                 Line = 4,
                 StartLine = 4,
@@ -12727,10 +12800,12 @@ public class DbReaderTests : IDisposable
         var unused = _reader.GetUnusedSymbols(limit: 10, kind: null, lang: "csharp",
             pathPatterns: ["local_use_fixture.cs"], excludePathPatterns: null, excludeTests: false);
 
-        var hidden = Assert.Single(unused, symbol => symbol.Name == "Hidden");
-        Assert.Equal("likely_unused_private", hidden.UnusedBucket);
-        Assert.Equal("medium", hidden.UnusedConfidence);
-        Assert.Contains("same-file uses may still be missed", hidden.UnusedReason);
+        Assert.DoesNotContain(unused, symbol => symbol.Name == "Hidden");
+        Assert.DoesNotContain(unused, symbol => symbol.Name == "HiddenInterpolated");
+        Assert.DoesNotContain(unused, symbol => symbol.Name == "RawInterpolated");
+        Assert.Contains(unused, symbol => symbol.Name == "CommentOnly");
+        Assert.Contains(unused, symbol => symbol.Name == "StringOnly");
+        Assert.Contains(unused, symbol => symbol.Name == "RawStringOnly");
     }
 
     [Fact]
@@ -15125,8 +15200,9 @@ public class DbReaderTests : IDisposable
                 Content = """
                 public class LocalUseFixture
                 {
-                    public void Run() { Hidden(); }
-                    private void Hidden() { }
+                    public void Run() { HiddenUsed(); }
+                    private void HiddenUsed() { }
+                    private void HiddenUnused() { }
                     internal void InternalOnly() { }
                 }
                 """,
@@ -15162,11 +15238,24 @@ public class DbReaderTests : IDisposable
             {
                 FileId = fileId,
                 Kind = "function",
-                Name = "Hidden",
+                Name = "HiddenUsed",
                 Line = 4,
                 StartLine = 4,
                 EndLine = 4,
-                Signature = "private void Hidden() { }",
+                Signature = "private void HiddenUsed() { }",
+                Visibility = "private",
+                ContainerKind = "class",
+                ContainerName = "LocalUseFixture",
+            },
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = "HiddenUnused",
+                Line = 5,
+                StartLine = 5,
+                EndLine = 5,
+                Signature = "private void HiddenUnused() { }",
                 Visibility = "private",
                 ContainerKind = "class",
                 ContainerName = "LocalUseFixture",
@@ -15176,9 +15265,9 @@ public class DbReaderTests : IDisposable
                 FileId = fileId,
                 Kind = "function",
                 Name = "InternalOnly",
-                Line = 5,
-                StartLine = 5,
-                EndLine = 5,
+                Line = 6,
+                StartLine = 6,
+                EndLine = 6,
                 Signature = "internal void InternalOnly() { }",
                 Visibility = "internal",
                 ContainerKind = "class",
@@ -15188,9 +15277,13 @@ public class DbReaderTests : IDisposable
 
         var unused = _reader.GetUnusedSymbols(limit: 3, kind: null, lang: "csharp",
             pathPatterns: ["diversified_unused_fixture.cs"], excludePathPatterns: null, excludeTests: false);
+        var count = _reader.CountUnusedSymbols(kind: null, lang: "csharp",
+            pathPatterns: ["diversified_unused_fixture.cs"], excludePathPatterns: null, excludeTests: false);
 
-        Assert.Equal(["Hidden", "InternalOnly", "LocalUseFixture"], unused.Select(symbol => symbol.Name).ToArray());
+        Assert.DoesNotContain(unused, symbol => symbol.Name == "HiddenUsed");
+        Assert.Equal(["HiddenUnused", "InternalOnly", "LocalUseFixture"], unused.Select(symbol => symbol.Name).ToArray());
         Assert.Equal(["likely_unused_private", "maybe_unused_nonpublic", "public_or_exported_no_refs"], unused.Select(symbol => symbol.UnusedBucket).ToArray());
+        Assert.Equal(4, count.Count);
     }
 
     [Fact]
@@ -15296,8 +15389,8 @@ public class DbReaderTests : IDisposable
         var unused = _reader.GetUnusedSymbols(limit: 4, kind: null, lang: "csharp",
             pathPatterns: ["reflection_diversified_unused_fixture.cs"], excludePathPatterns: null, excludeTests: false);
 
-        Assert.Equal(["Hidden", "InternalOnly", "UserDto", "FullName"], unused.Select(symbol => symbol.Name).ToArray());
-        Assert.Equal(["likely_unused_private", "maybe_unused_nonpublic", "public_or_exported_no_refs", "reflection_or_config_suspect"], unused.Select(symbol => symbol.UnusedBucket).ToArray());
+        Assert.Equal(["InternalOnly", "UserDto", "FullName", "Run"], unused.Select(symbol => symbol.Name).ToArray());
+        Assert.Equal(["maybe_unused_nonpublic", "public_or_exported_no_refs", "reflection_or_config_suspect", "public_or_exported_no_refs"], unused.Select(symbol => symbol.UnusedBucket).ToArray());
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using CodeIndex.Cli;
 using CodeIndex.Database;
 using CodeIndex.Mcp;
@@ -77,7 +78,15 @@ public class HttpMcpTransportTests : IDisposable
     public async Task HttpTransport_RequestLogger_RecordsMethodStatusDurationAndAuthOutcome()
     {
         var records = new List<HttpMcpTransport.HttpRequestLogRecord>();
-        await using var harness = await McpHttpHarness.StartAsync(_dbPath, bearerToken: "token", requestLogger: records.Add);
+        using var recordsReady = new CountdownEvent(3);
+        await using var harness = await McpHttpHarness.StartAsync(_dbPath, bearerToken: "token", requestLogger: record =>
+        {
+            lock (records)
+            {
+                records.Add(record);
+            }
+            recordsReady.Signal();
+        });
 
         using var client = new HttpClient();
         using (var missingAuth = new HttpRequestMessage(HttpMethod.Post, harness.Endpoint)
@@ -104,23 +113,30 @@ public class HttpMcpTransportTests : IDisposable
             Assert.Equal(HttpStatusCode.OK, okResponse.StatusCode);
         }
 
-        Assert.Equal(3, records.Count);
-        Assert.Equal("missing", records[0].AuthOutcome);
-        Assert.Equal((int)HttpStatusCode.Unauthorized, records[0].StatusCode);
-        Assert.Equal("POST", records[0].Method);
-        Assert.Equal("/", records[0].Path);
-        Assert.Null(records[0].RequestId);
-        Assert.True(records[0].DurationMs >= 0);
-        Assert.False(string.IsNullOrWhiteSpace(records[0].CorrelationId));
-        Assert.False(string.IsNullOrWhiteSpace(records[0].RemotePeer));
+        Assert.True(recordsReady.Wait(TimeSpan.FromSeconds(5)));
+        HttpMcpTransport.HttpRequestLogRecord[] snapshot;
+        lock (records)
+        {
+            snapshot = records.ToArray();
+        }
 
-        Assert.Equal("missing", records[1].AuthOutcome);
-        Assert.Equal("GET", records[1].Method);
-        Assert.Equal((int)HttpStatusCode.Unauthorized, records[1].StatusCode);
+        Assert.Equal(3, snapshot.Length);
+        Assert.Equal("missing", snapshot[0].AuthOutcome);
+        Assert.Equal((int)HttpStatusCode.Unauthorized, snapshot[0].StatusCode);
+        Assert.Equal("POST", snapshot[0].Method);
+        Assert.Equal("/", snapshot[0].Path);
+        Assert.Null(snapshot[0].RequestId);
+        Assert.True(snapshot[0].DurationMs >= 0);
+        Assert.False(string.IsNullOrWhiteSpace(snapshot[0].CorrelationId));
+        Assert.False(string.IsNullOrWhiteSpace(snapshot[0].RemotePeer));
 
-        Assert.Equal("ok", records[2].AuthOutcome);
-        Assert.Equal("7", records[2].RequestId);
-        Assert.Equal((int)HttpStatusCode.OK, records[2].StatusCode);
+        Assert.Equal("missing", snapshot[1].AuthOutcome);
+        Assert.Equal("GET", snapshot[1].Method);
+        Assert.Equal((int)HttpStatusCode.Unauthorized, snapshot[1].StatusCode);
+
+        Assert.Equal("ok", snapshot[2].AuthOutcome);
+        Assert.Equal("7", snapshot[2].RequestId);
+        Assert.Equal((int)HttpStatusCode.OK, snapshot[2].StatusCode);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -7209,8 +7209,8 @@ public class McpServerTests : IDisposable
 
         Assert.False(response["result"]!["isError"]?.GetValue<bool>() ?? false);
         var symbols = response["result"]!["structuredContent"]!["symbols"]!.AsArray();
-        Assert.Equal(["Hidden", "InternalOnly", "UserDto", "FullName"], symbols.Select(symbol => symbol!["name"]!.GetValue<string>()).ToArray());
-        Assert.Equal("reflection_or_config_suspect", symbols[3]!["unusedBucket"]!.GetValue<string>());
+        Assert.Equal(["InternalOnly", "UserDto", "FullName", "Run"], symbols.Select(symbol => symbol!["name"]!.GetValue<string>()).ToArray());
+        Assert.Equal("reflection_or_config_suspect", symbols[2]!["unusedBucket"]!.GetValue<string>());
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -6205,10 +6205,10 @@ jobs:
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
-            Assert.Equal(["Hidden", "InternalOnly", "UserDto", "FullName"], symbols.EnumerateArray().Select(symbol => symbol.GetProperty("name").GetString()).ToArray());
-            Assert.Equal(1, json.GetProperty("returned_bucket_counts").GetProperty("likely_unused_private").GetInt32());
+            Assert.Equal(["InternalOnly", "UserDto", "FullName", "Run"], symbols.EnumerateArray().Select(symbol => symbol.GetProperty("name").GetString()).ToArray());
+            Assert.False(json.GetProperty("returned_bucket_counts").TryGetProperty("likely_unused_private", out _));
             Assert.Equal(1, json.GetProperty("returned_bucket_counts").GetProperty("maybe_unused_nonpublic").GetInt32());
-            Assert.Equal(1, json.GetProperty("returned_bucket_counts").GetProperty("public_or_exported_no_refs").GetInt32());
+            Assert.Equal(2, json.GetProperty("returned_bucket_counts").GetProperty("public_or_exported_no_refs").GetInt32());
             Assert.Equal(1, json.GetProperty("returned_bucket_counts").GetProperty("reflection_or_config_suspect").GetInt32());
         }
         finally


### PR DESCRIPTION
## Summary

- Suppress C# private/file-private unused candidates when the defining file contains a real same-file identifier use outside comments and strings.
- Keep count/list behavior aligned for CLI and MCP unused-symbol output.
- Add regression coverage for direct calls, interpolated calls, comments, normal strings, and raw strings.
- Stabilize the HTTP MCP request logger assertion that failed on macOS CI by waiting for asynchronous log delivery before asserting.

Fixes #1403

## Changelog

- Added fragment: changelog.d/unreleased/1403.fixed.md

## Validation

- dotnet build
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests|FullyQualifiedName~QueryCommandRunnerTests.RunUnused_WithJsonDiversifiesReflectionSuspectBeforeLimit|FullyQualifiedName~McpServerTests.ToolsCall_UnusedSymbols_DiversifiesReflectionSuspectBeforeLimit"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~HttpMcpTransportTests.HttpTransport_RequestLogger_RecordsMethodStatusDurationAndAuthOutcome"
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll unused --lang csharp --exclude-tests --path src/CodeIndex/Cli/GitHubIssueReporter.cs --json --limit 100
- Codex adversarial review (3 rounds; blocking/actionable findings addressed)

## Follow-up candidates

- #2437