### PR TITLE
Standardize CLI error message format

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -62,6 +62,18 @@ Directory scan / shared path filter (built-in skip lists + `.gitignore` / `.cdid
 
 Scoped `--files` / `--commits` refreshes reuse the same path filter as full scans. If a commit-scoped refresh includes `.gitignore` or `.cdidxignore` changes, `IndexCommandRunner` falls back to a full scan so newly ignored files are purged safely. Malformed ignore lines are reported as scan errors and skipped instead of aborting the whole run. On Windows, files and directories with Hidden or System attributes are rejected before language detection; clear those attributes before indexing project-owned sources because ignore rules cannot re-include them.
 
+### CLI recoverable error format
+
+Recoverable command errors in human output use the canonical line shape below. Include only non-null lines, but every error must include a recovery hint:
+
+```text
+Error: <message>
+Hint: <actionable recovery path>
+Usage: <command shape>
+```
+
+When an error code is available, the first line is `Error [<code>]: <message>`. Use `CommandErrorWriter` for new CLI parse, validation, and filesystem preflight errors so `ProgramRunner`, `IndexCommandRunner`, and query runners keep the same format. JSON error payloads continue to use `CommandErrorJsonResult`.
+
 ### C# / .NET integration
 
 `SolutionProjectResolver` parses the plain-text `.sln` `Project(...) = "...", "...csproj"` entries and resolves C# / F# / VB project files. When exactly one `.sln` exists at the workspace root, `--project <name|path>` uses it automatically; otherwise callers can pass `--solution <path>`.

--- a/changelog.d/unreleased/1955.fixed.md
+++ b/changelog.d/unreleased/1955.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 1955
+affected:
+  - src/CodeIndex/Cli/CommandErrorWriter.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **CLI recoverable errors now use one human-readable shape (#1955)** — parse, validation, and path preflight failures now share the `Error` / `Hint` / optional `Usage` format so users get a consistent recovery path.
+
+## 日本語
+
+- **CLI の回復可能なエラーが人間向けの共通形式になりました (#1955)** — parse / validation / path preflight の失敗が `Error` / `Hint` / 必要に応じた `Usage` 形式を共有し、ユーザーが一貫した復旧手順を確認できるようになりました。

--- a/src/CodeIndex/Cli/CommandErrorWriter.cs
+++ b/src/CodeIndex/Cli/CommandErrorWriter.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+
+namespace CodeIndex.Cli;
+
+internal static class CommandErrorWriter
+{
+    internal const string DefaultHint = "Run '<cmd> --help' for usage information.";
+
+    internal static void Write(string message, string? hint = null, string? usage = null, string? errorCode = null)
+    {
+        var prefix = errorCode is null ? "Error" : $"Error [{errorCode}]";
+        Console.Error.WriteLine($"{prefix}: {message}");
+        Console.Error.WriteLine($"Hint: {hint ?? DefaultHint}");
+        if (usage != null)
+            Console.Error.WriteLine($"Usage: {usage}");
+    }
+
+    internal static int Write(
+        string message,
+        int exitCode,
+        string? hint = null,
+        string? usage = null,
+        string? errorCode = null)
+    {
+        Write(message, hint, usage, errorCode);
+        return exitCode;
+    }
+
+    internal static int WriteJsonOrHuman(
+        bool json,
+        JsonSerializerOptions jsonOptions,
+        string message,
+        int exitCode,
+        string? hint = null,
+        string? usage = null,
+        string? errorCode = null)
+    {
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(
+                new CommandErrorJsonResult("error", message, hint, errorCode),
+                CliJsonSerializerContextFactory.Create(jsonOptions).CommandErrorJsonResult));
+            return exitCode;
+        }
+
+        Write(message, exitCode, hint, usage, errorCode);
+        return exitCode;
+    }
+}

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -65,19 +65,13 @@ public static class IndexCommandRunner
 
         if (!Directory.Exists(options.ProjectPath))
         {
-            if (options.Json)
-                Console.WriteLine(JsonSerializer.Serialize(new CommandErrorJsonResult(
-                    "error",
-                    $"directory not found: {options.ProjectPath}",
-                    "Check the project path and rerun `cdidx index <projectPath>` with an existing directory.",
-                    CommandErrorCodes.DirectoryNotFound),
-                    jsonContext.CommandErrorJsonResult));
-            else
-            {
-                Console.Error.WriteLine($"Error [{CommandErrorCodes.DirectoryNotFound}]: directory not found: {options.ProjectPath}");
-                Console.Error.WriteLine("Hint: check the project path and rerun `cdidx index <projectPath>` with an existing directory.");
-            }
-            return CommandExitCodes.NotFound;
+            return CommandErrorWriter.WriteJsonOrHuman(
+                options.Json,
+                jsonOptions,
+                $"directory not found: {options.ProjectPath}",
+                CommandExitCodes.NotFound,
+                "check the project path and rerun `cdidx index <projectPath>` with an existing directory.",
+                errorCode: CommandErrorCodes.DirectoryNotFound);
         }
 
         if (options.Watch)
@@ -2208,20 +2202,7 @@ public static class IndexCommandRunner
     }
 
     private static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode, string? hint = null, string? errorCode = null)
-    {
-        if (json)
-            Console.WriteLine(JsonSerializer.Serialize(
-                new CommandErrorJsonResult("error", message, hint, errorCode),
-                CliJsonSerializerContextFactory.Create(jsonOptions).CommandErrorJsonResult));
-        else
-        {
-            var prefix = errorCode is null ? "Error" : $"Error [{errorCode}]";
-            Console.Error.WriteLine($"{prefix}: {message}");
-            if (hint != null)
-                Console.Error.WriteLine($"Hint: {hint}");
-        }
-        return exitCode;
-    }
+        => CommandErrorWriter.WriteJsonOrHuman(json, jsonOptions, message, exitCode, hint, errorCode: errorCode);
 
     private static int WriteInterruptedResult(bool json, JsonSerializerOptions jsonOptions, int filesProcessed, int? filesTotal)
     {

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -27,9 +27,10 @@ internal static class ProgramRunner
         var configResult = CdidxConfigFile.LoadAndApply(configStartDirectory ?? Environment.CurrentDirectory);
         if (configResult.Failed)
         {
-            Console.Error.WriteLine(configResult.Error);
-            Console.Error.WriteLine($"Hint: fix or remove `{CdidxConfigFile.FileName}`, or set `{CdidxConfigFile.DisableEnvVar}=1` to bypass it.");
-            return CommandExitCodes.UsageError;
+            return CommandErrorWriter.Write(
+                StripErrorPrefix(configResult.Error ?? "configuration file validation failed."),
+                CommandExitCodes.UsageError,
+                $"fix or remove `{CdidxConfigFile.FileName}`, or set `{CdidxConfigFile.DisableEnvVar}=1` to bypass it.");
         }
 
         using var globalToolLog = GlobalToolLog.TryStart(args, appVersion);
@@ -39,24 +40,21 @@ internal static class ProgramRunner
 
         if (!TryConsumeColorFlag(ref args, out var colorError))
         {
-            Console.Error.WriteLine(colorError);
-            Console.Error.WriteLine("Hint: use one of `auto`, `always`, `never`.");
+            CommandErrorWriter.Write(StripErrorPrefix(colorError), "use one of `auto`, `always`, `never`.");
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.InvalidArgument} color_flag_invalid=true");
             return CommandExitCodes.InvalidArgument;
         }
 
         if (!TryConsumePaletteFlag(ref args, out var paletteError))
         {
-            Console.Error.WriteLine(paletteError);
-            Console.Error.WriteLine("Hint: use one of `basic`, `256`, `truecolor`.");
+            CommandErrorWriter.Write(StripErrorPrefix(paletteError), "use one of `basic`, `256`, `truecolor`.");
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.InvalidArgument} palette_flag_invalid=true");
             return CommandExitCodes.InvalidArgument;
         }
 
         if (!TryConsumeMetricsFlag(ref args, out var metricsPath, out var metricsError))
         {
-            Console.Error.WriteLine(metricsError);
-            Console.Error.WriteLine("Hint: pass `--metrics <path>` (e.g. `--metrics out.jsonl`).");
+            CommandErrorWriter.Write(StripErrorPrefix(metricsError), "pass `--metrics <path>` (e.g. `--metrics out.jsonl`).");
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.InvalidArgument} metrics_flag_invalid=true");
             return CommandExitCodes.InvalidArgument;
         }
@@ -970,34 +968,40 @@ internal static class ProgramRunner
     private static int RunCompletions(string[] cmdArgs)
     {
         if (cmdArgs.Length == 0)
-        {
-            Console.Error.WriteLine("Error: --completions requires a shell value.");
-            Console.Error.WriteLine("Hint: rerun with one of `bash`, `zsh`, or `fish`.");
-            Console.Error.WriteLine("Usage: cdidx --completions <shell>");
-            return CommandExitCodes.UsageError;
-        }
+            return CommandErrorWriter.Write(
+                "--completions requires a shell value.",
+                CommandExitCodes.UsageError,
+                "rerun with one of `bash`, `zsh`, or `fish`.",
+                "cdidx --completions <shell>");
 
         if (cmdArgs[0].StartsWith("-", StringComparison.Ordinal))
-        {
-            Console.Error.WriteLine($"Error: --completions requires a shell value, got option-like token '{cmdArgs[0]}'.");
-            Console.Error.WriteLine("Hint: rerun with one of `bash`, `zsh`, or `fish`.");
-            Console.Error.WriteLine("Usage: cdidx --completions <shell>");
-            return CommandExitCodes.UsageError;
-        }
+            return CommandErrorWriter.Write(
+                $"--completions requires a shell value, got option-like token '{cmdArgs[0]}'.",
+                CommandExitCodes.UsageError,
+                "rerun with one of `bash`, `zsh`, or `fish`.",
+                "cdidx --completions <shell>");
 
         if (cmdArgs.Length > 1)
-        {
-            Console.Error.WriteLine($"Error: --completions accepts exactly one shell value, got extra {ConsoleUi.Counted(cmdArgs.Length - 1, "argument")}: {string.Join(", ", cmdArgs.Skip(1).Select(arg => $"`{arg}`"))}.");
-            Console.Error.WriteLine("Hint: rerun with exactly one shell name: `bash`, `zsh`, or `fish`.");
-            Console.Error.WriteLine("Usage: cdidx --completions <shell>");
-            return CommandExitCodes.UsageError;
-        }
+            return CommandErrorWriter.Write(
+                $"--completions accepts exactly one shell value, got extra {ConsoleUi.Counted(cmdArgs.Length - 1, "argument")}: {string.Join(", ", cmdArgs.Skip(1).Select(arg => $"`{arg}`"))}.",
+                CommandExitCodes.UsageError,
+                "rerun with exactly one shell name: `bash`, `zsh`, or `fish`.",
+                "cdidx --completions <shell>");
 
         if (ConsoleUi.PrintCompletions(cmdArgs[0]))
             return CommandExitCodes.Success;
 
-        Console.Error.WriteLine("Usage: cdidx --completions <shell>");
-        return CommandExitCodes.UsageError;
+        return CommandErrorWriter.Write(
+            $"unsupported completion shell `{cmdArgs[0]}`.",
+            CommandExitCodes.UsageError,
+            "rerun with one of `bash`, `zsh`, or `fish`.",
+            "cdidx --completions <shell>");
+    }
+
+    private static string StripErrorPrefix(string message)
+    {
+        const string prefix = "Error: ";
+        return message.StartsWith(prefix, StringComparison.Ordinal) ? message[prefix.Length..] : message;
     }
 
     private static int ShowError(string[] args, string message)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4290,11 +4290,14 @@ public static class QueryCommandRunner
         if (options.ParseError == null && dbPathError == null)
             return false;
 
+        var primaryError = options.ParseError ?? dbPathError!;
         CommandErrorWriter.Write(
-            StripErrorPrefix(options.ParseError ?? dbPathError!),
-            "fix the invalid or missing option value, then rerun with the command shape below.",
+            StripErrorPrefix(primaryError),
+            primaryError == dbPathError && options.ParseError == null
+                ? "create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command."
+                : "fix the invalid or missing option value, then rerun with the command shape below.",
             GetUsageLineOrThrow(commandName),
-            ExtractErrorCode(options.ParseError ?? dbPathError!));
+            ExtractErrorCode(primaryError));
         if (options.ParseError != null && dbPathError != null)
             CommandErrorWriter.Write(
                 StripErrorPrefix(dbPathError),
@@ -4315,7 +4318,7 @@ public static class QueryCommandRunner
         if (File.Exists(LongPath.EnsureWindowsPrefix(options.DbPath)))
             return null;
 
-        return $"Error [{CommandErrorCodes.DbNotFound}]: --db '{options.DbPath}' does not point to an existing database file. Hint: create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command.";
+        return $"Error [{CommandErrorCodes.DbNotFound}]: --db '{options.DbPath}' does not point to an existing database file.";
     }
 
     private static readonly HashSet<string> KnownSymbolKindFilters = new(StringComparer.Ordinal)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4290,12 +4290,17 @@ public static class QueryCommandRunner
         if (options.ParseError == null && dbPathError == null)
             return false;
 
-        if (options.ParseError != null)
-            Console.Error.WriteLine(options.ParseError);
-        if (dbPathError != null)
-            Console.Error.WriteLine(dbPathError);
-        Console.Error.WriteLine("Hint: fix the invalid or missing option value, then rerun with the command shape below.");
-        Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
+        CommandErrorWriter.Write(
+            StripErrorPrefix(options.ParseError ?? dbPathError!),
+            "fix the invalid or missing option value, then rerun with the command shape below.",
+            GetUsageLineOrThrow(commandName),
+            ExtractErrorCode(options.ParseError ?? dbPathError!));
+        if (options.ParseError != null && dbPathError != null)
+            CommandErrorWriter.Write(
+                StripErrorPrefix(dbPathError),
+                "create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command.",
+                GetUsageLineOrThrow(commandName),
+                ExtractErrorCode(dbPathError));
         return true;
     }
 
@@ -4356,9 +4361,10 @@ public static class QueryCommandRunner
             && !acceptedKinds.Contains(options.Kind)
             && !alternateAcceptedKinds.Any(kinds => kinds.Contains(options.Kind)))
         {
-            Console.Error.WriteLine($"Error: invalid --kind value `{options.Kind}`.");
-            Console.Error.WriteLine($"Hint: use one of: {string.Join(", ", acceptedKinds)}.");
-            Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
+            CommandErrorWriter.Write(
+                $"invalid --kind value `{options.Kind}`.",
+                $"use one of: {string.Join(", ", acceptedKinds)}.",
+                GetUsageLineOrThrow(commandName));
             return true;
         }
 
@@ -4408,24 +4414,25 @@ public static class QueryCommandRunner
 
             if (normalizedArg == "--group-by-name")
             {
-                Console.Error.WriteLine("Error: --group-by-name is only supported by 'hotspots'.");
-                Console.Error.WriteLine("Hint: remove `--group-by-name` here, or rerun with `cdidx hotspots --group-by-name ...`.");
-                Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
+                CommandErrorWriter.Write(
+                    "--group-by-name is only supported by 'hotspots'.",
+                    "remove `--group-by-name` here, or rerun with `cdidx hotspots --group-by-name ...`.",
+                    GetUsageLineOrThrow(commandName));
                 return true;
             }
 
             if (normalizedArg == "--group-by")
             {
-                Console.Error.WriteLine("Error: --group-by is only supported by 'hotspots'.");
-                Console.Error.WriteLine("Hint: remove `--group-by` here, or rerun with `cdidx hotspots --group-by <symbol|file|statement> ...`.");
-                Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
+                CommandErrorWriter.Write(
+                    "--group-by is only supported by 'hotspots'.",
+                    "remove `--group-by` here, or rerun with `cdidx hotspots --group-by <symbol|file|statement> ...`.",
+                    GetUsageLineOrThrow(commandName));
                 return true;
             }
 
             if (normalizedArg == arg && ValueTakingOptions.Contains(normalizedArg) && i + 1 < cmdArgs.Length)
                 i++;
 
-            Console.Error.WriteLine($"Error: {arg} is not supported for {commandName}.");
             // Suggest the closest accepted flag for this command when the user mistypes
             // a flag name (e.g. `--paht` → `--path`). Built on the same suggester used for
             // subcommand typos so the recovery experience is consistent (#1582).
@@ -4444,10 +4451,13 @@ public static class QueryCommandRunner
             if (eq > 0)
                 nameForSuggestion = nameForSuggestion[..eq];
             var suggestion = ConsoleUi.FindClosestMatch(nameForSuggestion, supported.Where(o => o != "--"));
-            if (suggestion != null)
-                Console.Error.WriteLine($"Did you mean: {suggestion}?");
-            Console.Error.WriteLine($"Hint: remove `{arg}` and rerun, or use only the options shown in `{commandName} --help`.");
-            Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
+            var hint = suggestion == null
+                ? $"remove `{arg}` and rerun, or use only the options shown in `{commandName} --help`."
+                : $"Did you mean: {suggestion}? Remove `{arg}` and rerun, or use `{suggestion}` if that is what you meant.";
+            CommandErrorWriter.Write(
+                $"{arg} is not supported for {commandName}.",
+                hint,
+                GetUsageLineOrThrow(commandName));
             return true;
         }
 
@@ -4459,9 +4469,10 @@ public static class QueryCommandRunner
         if (options.ExtraNames.Count == 0)
             return false;
 
-        Console.Error.WriteLine($"Error: unexpected extra positional {ConsoleUi.Counted(options.ExtraNames.Count, "argument")} for {commandName}: {string.Join(", ", options.ExtraNames.Select(name => $"`{name}`"))}.");
-        Console.Error.WriteLine("Hint: quote multi-word queries as a single argument, or remove the extra positional values.");
-        Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
+        CommandErrorWriter.Write(
+            $"unexpected extra positional {ConsoleUi.Counted(options.ExtraNames.Count, "argument")} for {commandName}: {string.Join(", ", options.ExtraNames.Select(name => $"`{name}`"))}.",
+            "quote multi-word queries as a single argument, or remove the extra positional values.",
+            GetUsageLineOrThrow(commandName));
         return true;
     }
 
@@ -4474,9 +4485,10 @@ public static class QueryCommandRunner
         if (unexpected.Count == 0)
             return false;
 
-        Console.Error.WriteLine($"Error: {commandName} does not accept positional arguments: {string.Join(", ", unexpected)}.");
-        Console.Error.WriteLine("Hint: remove the extra positional arguments and use the documented flags only.");
-        Console.Error.WriteLine($"Usage: {GetUsageLineOrThrow(commandName)}");
+        CommandErrorWriter.Write(
+            $"{commandName} does not accept positional arguments: {string.Join(", ", unexpected)}.",
+            "remove the extra positional arguments and use the documented flags only.",
+            GetUsageLineOrThrow(commandName));
         return true;
     }
 
@@ -4519,11 +4531,7 @@ public static class QueryCommandRunner
     }
 
     private static void WriteUsageError(string message, string usage, string hint)
-    {
-        Console.Error.WriteLine($"Error: {message}");
-        Console.Error.WriteLine($"Hint: {hint}");
-        Console.Error.WriteLine($"Usage: {usage}");
-    }
+        => CommandErrorWriter.Write(message, hint, usage);
 
     // Reject queries that were supplied but resolve to empty / whitespace-only text so the user gets
     // a distinct error instead of the generic "<cmd> requires a query argument" message that fires
@@ -4545,9 +4553,29 @@ public static class QueryCommandRunner
     }
 
     private static void WriteValidationError(string message, string hint)
+        => CommandErrorWriter.Write(message, hint);
+
+    private static string StripErrorPrefix(string message)
     {
-        Console.Error.WriteLine($"Error: {message}");
-        Console.Error.WriteLine($"Hint: {hint}");
+        const string prefix = "Error: ";
+        if (message.StartsWith(prefix, StringComparison.Ordinal))
+            return message[prefix.Length..];
+
+        var codedPrefixEnd = message.IndexOf("]: ", StringComparison.Ordinal);
+        if (message.StartsWith("Error [", StringComparison.Ordinal) && codedPrefixEnd >= 0)
+            return message[(codedPrefixEnd + 3)..];
+
+        return message;
+    }
+
+    private static string? ExtractErrorCode(string message)
+    {
+        const string prefix = "Error [";
+        if (!message.StartsWith(prefix, StringComparison.Ordinal))
+            return null;
+
+        var end = message.IndexOf("]: ", StringComparison.Ordinal);
+        return end > prefix.Length ? message[prefix.Length..end] : null;
     }
 
     private static void WriteRepoMapSection(string title, IEnumerable<string> rows)

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -319,6 +319,26 @@ public class ProgramRunnerTests
         Assert.Contains("Hint:", stderr);
     }
 
+    [Fact]
+    public void CliRecoverableErrors_UseCanonicalHumanFormat_Issue1955()
+    {
+        var missingProject = Path.Combine(Path.GetTempPath(), $"cdidx_missing_{Guid.NewGuid():N}");
+
+        var cases = new[]
+        {
+            CaptureConsole(() => ProgramRunner.Run(["--completions"], appVersion: "1.10.0")),
+            CaptureConsole(() => IndexCommandRunner.Run([missingProject], new JsonSerializerOptions(JsonSerializerDefaults.Web))),
+            CaptureConsole(() => QueryCommandRunner.RunSearch(["Symbol", "--since", "not-a-date"], new JsonSerializerOptions(JsonSerializerDefaults.Web))),
+        };
+
+        Assert.All(cases, result =>
+        {
+            Assert.NotEqual(CommandExitCodes.Success, result.ExitCode);
+            Assert.Equal(string.Empty, result.Stdout);
+            AssertCanonicalCommandError(result.Stderr);
+        });
+    }
+
     [Theory]
     [InlineData(new[] { "--palette=truecolor", "status" }, ColorPalette.Truecolor, new[] { "status" })]
     [InlineData(new[] { "status", "--palette", "256" }, ColorPalette.Color256, new[] { "status" })]
@@ -603,6 +623,17 @@ public class ProgramRunnerTests
                 Console.SetError(originalErr);
             }
         }
+    }
+
+    private static void AssertCanonicalCommandError(string stderr)
+    {
+        var lines = stderr.TrimEnd().Split(Environment.NewLine);
+        Assert.InRange(lines.Length, 2, 3);
+        Assert.StartsWith("Error", lines[0]);
+        Assert.Contains(": ", lines[0]);
+        Assert.StartsWith("Hint: ", lines[1]);
+        if (lines.Length == 3)
+            Assert.StartsWith("Usage: ", lines[2]);
     }
 
     private sealed class ThrowingResolver : IJsonTypeInfoResolver

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -350,6 +350,7 @@ public class ProgramRunnerTests
             CaptureConsole(() => ProgramRunner.Run(["--completions"], appVersion: "1.10.0")),
             CaptureConsole(() => IndexCommandRunner.Run([missingProject], new JsonSerializerOptions(JsonSerializerDefaults.Web))),
             CaptureConsole(() => QueryCommandRunner.RunSearch(["Symbol", "--since", "not-a-date"], new JsonSerializerOptions(JsonSerializerDefaults.Web))),
+            CaptureConsole(() => QueryCommandRunner.RunSearch(["Symbol", "--db", Path.Combine(missingProject, "missing.db")], new JsonSerializerOptions(JsonSerializerDefaults.Web))),
         };
 
         Assert.All(cases, result =>

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2205,7 +2205,7 @@ jobs:
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
             Assert.Contains("Error [E001_DB_NOT_FOUND]: --db", stderr);
             Assert.Contains("does not point to an existing database file", stderr);
-            Assert.Contains("Hint: fix the invalid or missing option value", stderr);
+            Assert.Contains("Hint: create or refresh the index with `cdidx index <projectPath>`", stderr);
             Assert.Contains($"Usage: {ConsoleUi.GetUsageLine("search")}", stderr);
         }
         finally
@@ -30123,7 +30123,7 @@ jobs:
         // Verify full (absolute) path is shown, not just the basename / フルパス表示を検証
         Assert.Contains(Path.GetFullPath(missingDbPath), stderr);
         Assert.Contains("does not point to an existing database file", stderr);
-        Assert.Contains("Hint: fix the invalid or missing option value", stderr);
+        Assert.Contains("Hint: create or refresh the index with `cdidx index <projectPath>`", stderr);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add a shared CLI command error writer for canonical human output.
- Route ProgramRunner, IndexCommandRunner, and QueryCommandRunner recoverable errors through the shared Error/Hint/Usage shape.
- Document the contract and add a bilingual changelog fragment.

## Documentation / Changelog
- Documented the CLI recoverable error format in DEVELOPER_GUIDE.md.
- Added changelog fragment: changelog.d/unreleased/1955.fixed.md.

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProgramRunnerTests.CliRecoverableErrors_UseCanonicalHumanFormat_Issue1955|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_UnsupportedFlagTypo_SuggestsClosestFlag|FullyQualifiedName~ChangelogToolTests" -p:UseSharedCompilation=false
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.QueryEntrypoints_InvalidSinceReturnUsageError|FullyQualifiedName~QueryCommandRunnerTests.QueryEntrypoints_MissingOrSwallowedOptionValuesReturnUsageError|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_ExplicitMissingDbReturnsUsageErrorBeforeOpeningReader_Issue2073|FullyQualifiedName~QueryCommandRunnerTests.RunStatus_MissingDatabaseReturnsGuidance|FullyQualifiedName~ProgramRunnerTests.CliRecoverableErrors_UseCanonicalHumanFormat_Issue1955" -p:UseSharedCompilation=false
- dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json

## Review
- Codex adversarial review: No blocking/actionable issues found.

## Follow-up Candidates
- None.

Fixes #1955