### PR TITLE
Centralize degradation reason codes

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -80,6 +80,27 @@ Do not add mutable static caches, shared `StringBuilder` instances, reused `Matc
 
 `status --check` keeps the DB/worktree checksum comparison in `IndexFreshnessChecker`, but the user-facing age hint threshold is resolved in `QueryCommandRunner`: CLI `--stale-after <duration>` wins over `CDIDX_STALE_AFTER`, which wins over `.cdidxrc.json`'s `stale_after`, then the 24-hour default. Supported duration suffixes are `m`, `h`, and `d`. JSON output includes `stale_after_seconds` and `index_age_seconds` only for `--check`, so clients can confirm which threshold was applied without inferring it from text.
 
+### Degradation reason codes
+
+Readiness degradation reason codes are centralized in `DegradationReasonCodes`. Add new codes there with human text, a recommended action, and an alternative action before emitting them from readers, CLI, or MCP payloads.
+
+Current stable codes and triggers:
+
+| Code | Trigger | Recovery |
+|---|---|---|
+| `missing_fold_backfill` | legacy rows do not have folded-name values | `cdidx backfill-fold` or full rebuild |
+| `stale_fold_key_version` | folded rows were stamped with an older fold-key version | `cdidx backfill-fold` or full rebuild |
+| `stale_fold_key_fingerprint` | folded rows were stamped under an older runtime fingerprint | `cdidx backfill-fold` or full rebuild |
+| `fold_rows_not_restamped` | fold metadata is current but one or more folded rows were not restamped | `cdidx backfill-fold` or full rebuild |
+| `fold_ready=false` | aggregate fold readiness bit is degraded | `cdidx backfill-fold` or full rebuild |
+| `sql_graph_contract_ready=false` | SQL graph rows do not match the current call-column / qualified-name contract | `cdidx index <projectPath>` |
+| `hotspot_family_ready=false` | one or more hotspot-family languages lack current authoritative family stamps | `cdidx index <projectPath>` |
+| `graph_table_available=false` | `symbol_references` is missing or not graph-ready | `cdidx index <projectPath>` |
+| `issues_table_available=false` | `file_issues` is missing or not issue-ready | `cdidx index <projectPath>` |
+| `csharp_symbol_name_ready=false` | C# canonical symbol-name stamps are stale | `cdidx index <projectPath>` |
+| `csharp_metadata_target_ready=false` | C# metadata-target stamps are stale | `cdidx index <projectPath>` |
+| `index_newer_than_reader=true` | the DB was written with a newer persisted contract than this reader understands | use a current `cdidx` binary or rebuild with this version |
+
 ### SQLite WAL durability policy
 
 `DbContext` opens writable indexes in WAL mode, sets `PRAGMA synchronous=NORMAL`, and pins `PRAGMA wal_autocheckpoint=1000`. Under WAL, `NORMAL` avoids per-commit fsync pressure during 500-row indexing batches while preserving database consistency after crashes; a crash can lose the last uncheckpointed transaction, but it must not corrupt committed database structure. `DbWriter` also runs `PRAGMA wal_checkpoint(PASSIVE)` after each outer transaction commit so batch boundaries give SQLite a chance to checkpoint without blocking active readers. `status --json` exposes these resolved connection values under `db_pragma_settings` (`journal_mode`, `synchronous`, `wal_autocheckpoint`) for automation and support diagnostics.

--- a/changelog.d/unreleased/1968.fixed.md
+++ b/changelog.d/unreleased/1968.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 1968
+affected:
+  - src/CodeIndex/Database/DegradationReasonCodes.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - DEVELOPER_GUIDE.md
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Centralized degraded-readiness reason codes (#1968)** — readiness degradation codes now live in a shared registry with human text and recovery actions, reducing silent mismatches between DB readers, CLI output, and MCP consumers.
+
+## 日本語
+
+- **readiness degradation reason code を一元化しました (#1968)** — degradation code を human text と復旧 action 付きの共有 registry に集約し、DB reader、CLI 出力、MCP 利用側の間で文字列不一致が静かに混入しにくくなりました。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -3156,25 +3156,19 @@ public static class IndexCommandRunner
     private static string GetFoldReadyReason(bool backfillReady, bool foldVersionMatchesCurrent, bool foldFingerprintMatchesCurrent)
     {
         if (!backfillReady)
-            return "missing_fold_backfill";
+            return DegradationReasonCodes.MissingFoldBackfill;
 
         if (!foldVersionMatchesCurrent)
-            return "stale_fold_key_version";
+            return DegradationReasonCodes.StaleFoldKeyVersion;
 
         if (!foldFingerprintMatchesCurrent)
-            return "stale_fold_key_fingerprint";
+            return DegradationReasonCodes.StaleFoldKeyFingerprint;
 
-        return "fold_rows_not_restamped";
+        return DegradationReasonCodes.FoldRowsNotRestamped;
     }
 
     private static string BuildFoldNotReadyExplanation(string? foldReadyReason)
-        => foldReadyReason switch
-        {
-            "missing_fold_backfill" => "--exact falls back to ASCII COLLATE NOCASE because legacy rows without `name_folded` remain.",
-            "stale_fold_key_version" => "--exact falls back to ASCII COLLATE NOCASE because unchanged rows still carry an older fold-key version.",
-            "stale_fold_key_fingerprint" => "--exact falls back to ASCII COLLATE NOCASE because unchanged rows still carry folded keys generated under an older runtime fingerprint.",
-            _ => "--exact falls back to ASCII COLLATE NOCASE because some folded-name rows were not restamped under the current runtime."
-        };
+        => DegradationReasonCodes.BuildFoldNotReadyExplanation(foldReadyReason);
 
     private static string BuildFoldBackfillCommand(string resolvedDbPath)
         => $"cdidx backfill-fold --db {QuoteCommandArgument(resolvedDbPath)}";
@@ -3269,19 +3263,19 @@ public static class IndexCommandRunner
 
         var degradedParts = new List<string>();
         if (!graphTableAvailable)
-            degradedParts.Add("graph_table_available=false");
+            degradedParts.Add(DegradationReasonCodes.GraphTableMissing);
         if (!issuesTableAvailable)
-            degradedParts.Add("issues_table_available=false");
+            degradedParts.Add(DegradationReasonCodes.IssuesTableMissing);
         if (!sqlGraphContractReady)
-            degradedParts.Add("sql_graph_contract_ready=false");
+            degradedParts.Add(DegradationReasonCodes.SqlGraphContractNotReady);
         if (!hotspotFamilyReady)
-            degradedParts.Add("hotspot_family_ready=false");
+            degradedParts.Add(DegradationReasonCodes.HotspotFamilyNotReady);
         if (!csharpSymbolNameReady)
-            degradedParts.Add("csharp_symbol_name_ready=false");
+            degradedParts.Add(DegradationReasonCodes.CSharpSymbolNameNotReady);
         if (!csharpMetadataTargetReady)
-            degradedParts.Add("csharp_metadata_target_ready=false");
+            degradedParts.Add(DegradationReasonCodes.CSharpMetadataTargetNotReady);
         if (!foldReady)
-            degradedParts.Add("fold_ready=false");
+            degradedParts.Add(DegradationReasonCodes.FoldReadyNotReady);
 
         return $"Index completed with degraded readiness ({string.Join(", ", degradedParts)}). Run `cdidx status --db \"{resolvedDbPath}\" --json` to inspect the current DB state.";
     }

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4815,13 +4815,13 @@ public static class QueryCommandRunner
         => !signal.ExactIndexAvailable
            && !signal.HasMissingIndex
            && !signal.HasMissingTable
-           && signal.DegradedReason?.Contains("sql_graph_contract_ready=false", StringComparison.OrdinalIgnoreCase) == true;
+           && signal.DegradedReason?.Contains(DegradationReasonCodes.SqlGraphContractNotReady, StringComparison.OrdinalIgnoreCase) == true;
 
     private static bool IsCSharpCanonicalNameSignal(ExactQuerySignal signal)
         => !signal.ExactIndexAvailable
            && !signal.HasMissingIndex
            && !signal.HasMissingTable
-           && signal.DegradedReason?.Contains("csharp_symbol_name_ready=false", StringComparison.OrdinalIgnoreCase) == true;
+           && signal.DegradedReason?.Contains(DegradationReasonCodes.CSharpSymbolNameNotReady, StringComparison.OrdinalIgnoreCase) == true;
 
     private static int WriteStatusReadinessExplanation(string fieldName)
     {
@@ -4884,10 +4884,10 @@ public static class QueryCommandRunner
             "hotspot_family_ready" => status.HotspotFamilyDegradedReason ?? fallback,
             "fold_ready" => BuildFoldNotReadyExplanation(status.FoldReadyReason),
             "index_newer_than_reader" => status.IndexNewerThanReaderReason ?? fallback,
-            "graph_table_available" => "reference / caller / callee / unused counts are degraded to 0 because the symbol_references table is missing.",
-            "issues_table_available" => "validate output is degraded to empty because the file_issues table is missing.",
-            "csharp_symbol_name_ready" => "C# exact-name for operators / conversion operators / indexers is degraded.",
-            "csharp_metadata_target_ready" => "C# deps / impact metadata-attribute edges fall back to the signature / name-suffix heuristic.",
+            "graph_table_available" => DegradationReasonCodes.GetMetadata(DegradationReasonCodes.GraphTableMissing).HumanText,
+            "issues_table_available" => DegradationReasonCodes.GetMetadata(DegradationReasonCodes.IssuesTableMissing).HumanText,
+            "csharp_symbol_name_ready" => DegradationReasonCodes.GetMetadata(DegradationReasonCodes.CSharpSymbolNameNotReady).HumanText,
+            "csharp_metadata_target_ready" => DegradationReasonCodes.GetMetadata(DegradationReasonCodes.CSharpMetadataTargetNotReady).HumanText,
             _ => fallback,
         };
 
@@ -4985,13 +4985,7 @@ public static class QueryCommandRunner
            && status.CSharpMetadataTargetReady;
 
     private static string BuildFoldNotReadyExplanation(string? foldReadyReason)
-        => foldReadyReason switch
-        {
-            "missing_fold_backfill" => "--exact falls back to ASCII COLLATE NOCASE because legacy rows without `name_folded` remain.",
-            "stale_fold_key_version" => "--exact falls back to ASCII COLLATE NOCASE because unchanged rows still carry an older fold-key version.",
-            "stale_fold_key_fingerprint" => "--exact falls back to ASCII COLLATE NOCASE because unchanged rows still carry folded keys generated under an older runtime fingerprint.",
-            _ => "--exact falls back to ASCII COLLATE NOCASE because some folded-name rows were not restamped under the current runtime."
-        };
+        => DegradationReasonCodes.BuildFoldNotReadyExplanation(foldReadyReason);
 
     private static string BuildFoldNotReadyWarning(string? foldReadyReason, string backfillCommand, string rebuildCommand)
         => $"{BuildFoldNotReadyExplanation(foldReadyReason)} Run `{backfillCommand}` to restamp folded-name columns in place, or `{rebuildCommand}` for a full rebuild.";

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -524,7 +524,7 @@ public partial class DbReader
                 Relevant: true,
                 DegradedReason: ready
                     ? null
-                    : $"cross-file hotspot family grouping for '{lang}' is degraded; run `cdidx index <projectPath>` to restamp authoritative hotspot families.");
+                    : DegradationReasonCodes.BuildHotspotFamilyLanguageDegradedReason(lang));
         }
 
         var relevantLanguages = _indexedHotspotFamilyLanguages
@@ -542,7 +542,7 @@ public partial class DbReader
         return new HotspotFamilySignal(
             Ready: false,
             Relevant: true,
-            DegradedReason: $"cross-file hotspot family grouping is degraded for: {string.Join(", ", unreadyLanguages)}; run `cdidx index <projectPath>` to restamp authoritative hotspot families.");
+            DegradedReason: DegradationReasonCodes.BuildHotspotFamilyLanguagesDegradedReason(unreadyLanguages));
     }
 
     private HashSet<string> LoadIndexes(string tableName)
@@ -573,12 +573,12 @@ public partial class DbReader
         var storedVersion = ParseFoldVersion(_conn);
         var storedFingerprint = ParseFoldFingerprint(_conn);
         if (storedVersion < 0 || string.IsNullOrWhiteSpace(storedFingerprint))
-            return "missing_fold_backfill";
+            return DegradationReasonCodes.MissingFoldBackfill;
         if (storedVersion != NameFold.Version)
-            return "stale_fold_key_version";
+            return DegradationReasonCodes.StaleFoldKeyVersion;
         if (!string.Equals(storedFingerprint, NameFold.Fingerprint(), StringComparison.Ordinal))
-            return "stale_fold_key_fingerprint";
-        return "fold_rows_not_restamped";
+            return DegradationReasonCodes.StaleFoldKeyFingerprint;
+        return DegradationReasonCodes.FoldRowsNotRestamped;
     }
 
     private HashSet<string> LoadIndexedHotspotFamilyLanguages()
@@ -824,7 +824,7 @@ public partial class DbReader
         return new SqlGraphContractSignal(
             Ready: false,
             Relevant: true,
-            DegradedReason: "sql_graph_contract_ready=false (SQL graph rows may still use a stale call-column / qualified-name contract; rerun `cdidx index <projectPath>` before trusting SQL graph/dependency results)");
+            DegradedReason: DegradationReasonCodes.BuildSqlGraphContractDegradedReason());
     }
 
     private static ExactQuerySignal CombineExactSignals(params ExactQuerySignal?[] signals)

--- a/src/CodeIndex/Database/DegradationReasonCodes.cs
+++ b/src/CodeIndex/Database/DegradationReasonCodes.cs
@@ -1,0 +1,139 @@
+namespace CodeIndex.Database;
+
+public sealed record DegradationReasonMetadata(
+    string Code,
+    string HumanText,
+    string RecommendedAction,
+    string AlternativeAction);
+
+public static class DegradationReasonCodes
+{
+    public const string MissingFoldBackfill = "missing_fold_backfill";
+    public const string StaleFoldKeyVersion = "stale_fold_key_version";
+    public const string StaleFoldKeyFingerprint = "stale_fold_key_fingerprint";
+    public const string FoldRowsNotRestamped = "fold_rows_not_restamped";
+    public const string FoldReadyNotReady = "fold_ready=false";
+    public const string SqlGraphContractNotReady = "sql_graph_contract_ready=false";
+    public const string HotspotFamilyNotReady = "hotspot_family_ready=false";
+    public const string GraphTableMissing = "graph_table_available=false";
+    public const string IssuesTableMissing = "issues_table_available=false";
+    public const string CSharpSymbolNameNotReady = "csharp_symbol_name_ready=false";
+    public const string CSharpMetadataTargetNotReady = "csharp_metadata_target_ready=false";
+    public const string IndexNewerThanReader = "index_newer_than_reader=true";
+
+    public static readonly IReadOnlyList<string> All =
+    [
+        MissingFoldBackfill,
+        StaleFoldKeyVersion,
+        StaleFoldKeyFingerprint,
+        FoldRowsNotRestamped,
+        FoldReadyNotReady,
+        SqlGraphContractNotReady,
+        HotspotFamilyNotReady,
+        GraphTableMissing,
+        IssuesTableMissing,
+        CSharpSymbolNameNotReady,
+        CSharpMetadataTargetNotReady,
+        IndexNewerThanReader,
+    ];
+
+    private static readonly IReadOnlyDictionary<string, DegradationReasonMetadata> MetadataByCode =
+        All.ToDictionary(code => code, CreateMetadata, StringComparer.Ordinal);
+
+    public static DegradationReasonMetadata GetMetadata(string code)
+        => MetadataByCode.TryGetValue(code, out var metadata)
+            ? metadata
+            : new DegradationReasonMetadata(
+                code,
+                "Index readiness is degraded for an unrecognized reason.",
+                "Run `cdidx status --json` to inspect the current DB state.",
+                "Run `cdidx index <projectPath>` to rebuild the index.");
+
+    public static string BuildFoldNotReadyExplanation(string? foldReadyReason)
+        => GetMetadata(NormalizeFoldReason(foldReadyReason)).HumanText;
+
+    public static string BuildSqlGraphContractDegradedReason()
+        => $"{SqlGraphContractNotReady} ({GetMetadata(SqlGraphContractNotReady).HumanText})";
+
+    public static string BuildHotspotFamilyLanguageDegradedReason(string language)
+        => $"cross-file hotspot family grouping for '{language}' is degraded; run `cdidx index <projectPath>` to restamp authoritative hotspot families.";
+
+    public static string BuildHotspotFamilyLanguagesDegradedReason(IEnumerable<string> languages)
+        => $"cross-file hotspot family grouping is degraded for: {string.Join(", ", languages)}; run `cdidx index <projectPath>` to restamp authoritative hotspot families.";
+
+    public static string NormalizeFoldReason(string? foldReadyReason)
+        => foldReadyReason switch
+        {
+            MissingFoldBackfill => MissingFoldBackfill,
+            StaleFoldKeyVersion => StaleFoldKeyVersion,
+            StaleFoldKeyFingerprint => StaleFoldKeyFingerprint,
+            FoldRowsNotRestamped => FoldRowsNotRestamped,
+            _ => FoldRowsNotRestamped
+        };
+
+    private static DegradationReasonMetadata CreateMetadata(string code)
+        => code switch
+        {
+            MissingFoldBackfill => new(
+                code,
+                "--exact falls back to ASCII COLLATE NOCASE because legacy rows without `name_folded` remain.",
+                "Run `cdidx backfill-fold` to restamp folded-name columns in place.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            StaleFoldKeyVersion => new(
+                code,
+                "--exact falls back to ASCII COLLATE NOCASE because unchanged rows still carry an older fold-key version.",
+                "Run `cdidx backfill-fold` to restamp folded-name columns in place.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            StaleFoldKeyFingerprint => new(
+                code,
+                "--exact falls back to ASCII COLLATE NOCASE because unchanged rows still carry folded keys generated under an older runtime fingerprint.",
+                "Run `cdidx backfill-fold` to restamp folded-name columns in place.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            FoldRowsNotRestamped => new(
+                code,
+                "--exact falls back to ASCII COLLATE NOCASE because some folded-name rows were not restamped under the current runtime.",
+                "Run `cdidx backfill-fold` to restamp folded-name columns in place.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            FoldReadyNotReady => new(
+                code,
+                "Unicode exact-name fold readiness is degraded.",
+                "Run `cdidx backfill-fold` to restamp folded-name columns in place.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            SqlGraphContractNotReady => new(
+                code,
+                "SQL graph rows may still use a stale call-column / qualified-name contract; rerun `cdidx index <projectPath>` before trusting SQL graph/dependency results.",
+                "Run `cdidx index <projectPath>` to rewrite SQL graph rows.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            HotspotFamilyNotReady => new(
+                code,
+                "Cross-file hotspot grouping may be degraded for one or more languages.",
+                "Run `cdidx index <projectPath>` to restamp authoritative hotspot families.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            GraphTableMissing => new(
+                code,
+                "Reference / caller / callee / unused counts are degraded to 0 because the symbol_references table is missing.",
+                "Run `cdidx index <projectPath>` to rebuild the graph-capable index.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            IssuesTableMissing => new(
+                code,
+                "Validate output is degraded to empty because the file_issues table is missing.",
+                "Run `cdidx index <projectPath>` to rebuild the issue table.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            CSharpSymbolNameNotReady => new(
+                code,
+                "C# exact-name for operators / conversion operators / indexers is degraded.",
+                "Run `cdidx index <projectPath>` to upgrade canonical C# symbol names.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            CSharpMetadataTargetNotReady => new(
+                code,
+                "C# metadata attribute dependency edges are using legacy heuristics.",
+                "Run `cdidx index <projectPath>` to restamp authoritative C# metadata targets.",
+                "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
+            IndexNewerThanReader => new(
+                code,
+                "This DB was written by a newer cdidx, so older readers may degrade instead of trusting newer contract stamps.",
+                "Run status with a current cdidx binary.",
+                "Rebuild the DB with the cdidx version you intend to use."),
+            _ => throw new ArgumentOutOfRangeException(nameof(code), code, "Unknown degradation reason code.")
+        };
+}

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -2255,19 +2255,19 @@ public partial class McpServer
                 // 場合は missing_fold_backfill に降格する。Issue #1535。
                 foldReadyAfter = writer.MarkFoldReady();
                 if (!foldReadyAfter)
-                    foldReadyReason = "missing_fold_backfill";
+                    foldReadyReason = DegradationReasonCodes.MissingFoldBackfill;
             }
             else if (!backfillReady)
             {
-                foldReadyReason = "missing_fold_backfill";
+                foldReadyReason = DegradationReasonCodes.MissingFoldBackfill;
             }
             else if (!foldVersionMatchesCurrent)
             {
-                foldReadyReason = "stale_fold_key_version";
+                foldReadyReason = DegradationReasonCodes.StaleFoldKeyVersion;
             }
             else if (!foldFingerprintMatchesCurrent)
             {
-                foldReadyReason = "stale_fold_key_fingerprint";
+                foldReadyReason = DegradationReasonCodes.StaleFoldKeyFingerprint;
             }
 
             writer.WriteCdidxWriterVersion(_version);

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -58,6 +58,32 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void DegradationReasonCodes_AllCodesHaveActionableMetadata()
+    {
+        foreach (var code in DegradationReasonCodes.All)
+        {
+            var metadata = DegradationReasonCodes.GetMetadata(code);
+
+            Assert.Equal(code, metadata.Code);
+            Assert.False(string.IsNullOrWhiteSpace(metadata.HumanText));
+            Assert.Contains("cdidx", metadata.RecommendedAction, StringComparison.Ordinal);
+            Assert.Contains("cdidx", metadata.AlternativeAction, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData(DegradationReasonCodes.MissingFoldBackfill, "--exact falls back")]
+    [InlineData(DegradationReasonCodes.StaleFoldKeyVersion, "older fold-key version")]
+    [InlineData(DegradationReasonCodes.StaleFoldKeyFingerprint, "older runtime fingerprint")]
+    [InlineData(DegradationReasonCodes.FoldRowsNotRestamped, "not restamped")]
+    public void DegradationReasonCodes_BuildsFoldExplanationFromCode(string code, string expectedText)
+    {
+        var explanation = DegradationReasonCodes.BuildFoldNotReadyExplanation(code);
+
+        Assert.Contains(expectedText, explanation, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CountSearchResults_NormalizesJavascriptLangSpelling()
     {
         const string query = "JavaScriptAliasToken";


### PR DESCRIPTION
## Summary

- Added a shared `DegradationReasonCodes` registry with stable codes, human text, and recovery actions.
- Replaced degraded-readiness magic strings across DB reader, CLI, and MCP indexing paths.
- Documented the current reason-code set and added a bilingual changelog fragment.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DbReaderTests`
- `dotnet test CodeIndex.sln`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~McpServerTests --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter FullyQualifiedName~McpServerTests --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md` with the degradation reason-code registry contract and current code list.
- Added `changelog.d/unreleased/1968.fixed.md`.

## Follow-up Candidates

- Local `cdidx` full-index refresh stalled during C# symbol/indexing preparation in this workspace; the commit-scoped refresh completed, but pre-existing stale/degraded index state remains locally.

Fixes #1968
