### PR TITLE
Fix MCP request cancellation handling

### DIFF
--- a/changelog.d/unreleased/1418.fixed.md
+++ b/changelog.d/unreleased/1418.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1418
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP cancellation notifications now cancel matching in-flight requests (#1418)** — `$/cancelRequest` and `notifications/cancelled` now look up the JSON-RPC request id, cancel the per-request token, and return a structured `request_cancelled` error when the handler observes cancellation.
+
+## 日本語
+
+- **MCP のキャンセル通知が対応する実行中リクエストを中断するようになりました (#1418)** — `$/cancelRequest` と `notifications/cancelled` は JSON-RPC request id を検索して per-request token を cancel し、ハンドラが cancellation を観測した場合は構造化された `request_cancelled` エラーを返すようになりました。

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Collections.Concurrent;
 using System.Threading.Channels;
 
@@ -28,6 +29,7 @@ internal sealed class HttpMcpTransport : IMcpTransport
     private readonly HttpListener _listener;
     private readonly string _endpoint;
     private readonly Action<HttpRequestLogRecord>? _requestLogger;
+    private readonly object _requestLoggerGate = new();
     private readonly ConcurrentBag<Task> _sseStreams = new();
     private readonly CancellationTokenSource _acceptCts = new();
     private readonly Channel<PendingRequest> _requestQueue = Channel.CreateUnbounded<PendingRequest>();
@@ -69,6 +71,8 @@ internal sealed class HttpMcpTransport : IMcpTransport
     public string Endpoint => _endpoint;
 
     internal bool RequiresBearerToken => _bearerTokenHash is not null;
+
+    internal Func<string, string?>? OutOfBandFrameHandler { get; set; }
 
     /// <summary>
     /// Resolve a `host:port` listen spec into the corresponding HTTP prefix. Ephemeral ports
@@ -254,7 +258,61 @@ internal sealed class HttpMcpTransport : IMcpTransport
 
         request.Body = body;
         request.RequestId = TryExtractJsonRpcId(body);
+        if (TryHandleOutOfBandFrame(request, body))
+            return;
+
         await _requestQueue.Writer.WriteAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool TryHandleOutOfBandFrame(PendingRequest request, string body)
+    {
+        if (OutOfBandFrameHandler is null || !IsCancellationNotification(body))
+            return false;
+
+        var context = request.Context;
+        try
+        {
+            var frame = OutOfBandFrameHandler(body);
+            if (frame is null)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.NoContent;
+                context.Response.Close();
+                LogRequest(request, (int)HttpStatusCode.NoContent);
+                return true;
+            }
+
+            var payload = Encoding.UTF8.GetBytes(frame);
+            context.Response.StatusCode = (int)HttpStatusCode.OK;
+            context.Response.ContentType = "application/json; charset=utf-8";
+            context.Response.ContentLength64 = payload.LongLength;
+            context.Response.OutputStream.Write(payload);
+            context.Response.OutputStream.Close();
+            LogRequest(request, (int)HttpStatusCode.OK);
+            return true;
+        }
+        catch
+        {
+            try { context.Response.Abort(); } catch { /* ignore */ }
+            LogRequest(request, 499);
+            return true;
+        }
+    }
+
+    private static bool IsCancellationNotification(string body)
+    {
+        try
+        {
+            var node = JsonNode.Parse(body);
+            if (node is not JsonObject obj)
+                return false;
+            var method = obj["method"]?.GetValue<string>();
+            return string.Equals(method, "$/cancelRequest", StringComparison.Ordinal)
+                || string.Equals(method, "notifications/cancelled", StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     public async Task WriteFrameAsync(string? frame, CancellationToken cancellationToken)
@@ -467,15 +525,19 @@ internal sealed class HttpMcpTransport : IMcpTransport
         request.Logged = true;
         try
         {
-            _requestLogger(new HttpRequestLogRecord(
-                request.CorrelationId,
-                request.RequestId,
-                request.RemotePeer,
-                request.Method,
-                request.Path,
-                statusCode,
-                request.Elapsed.TotalMilliseconds,
-                request.AuthOutcome));
+            var record = new HttpRequestLogRecord(
+                    request.CorrelationId,
+                    request.RequestId,
+                    request.RemotePeer,
+                    request.Method,
+                    request.Path,
+                    statusCode,
+                    request.Elapsed.TotalMilliseconds,
+                    request.AuthOutcome);
+            lock (_requestLoggerGate)
+            {
+                _requestLogger(record);
+            }
         }
         catch
         {

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -680,7 +680,7 @@ public partial class McpServer : IDisposable
 
     private void TryCancelRequest(JsonNode? cancelParams)
     {
-        var requestId = cancelParams?["id"];
+        var requestId = cancelParams?["id"] ?? cancelParams?["requestId"];
         var requestKey = SerializeRequestId(requestId);
         if (requestKey == null)
             return;

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -45,6 +46,12 @@ public partial class McpServer : IDisposable
     // `notifications/exit`) を受けると cancel され、トランスポート未クローズでも
     // 読み取りループが unblock して正常終了する (#1567)。
     private readonly CancellationTokenSource _shutdownCts = new();
+    // Active JSON-RPC requests keyed by their serialized `id`, so MCP `$/cancelRequest`
+    // notifications can cancel the exact in-flight tool instead of only shutting down the
+    // whole server (#1418).
+    // JSON-RPC request id ごとの実行中 CTS。MCP `$/cancelRequest` 通知でサーバー全体ではなく
+    // 対象ツール呼び出しだけを cancel するため (#1418)。
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _activeRequests = new(StringComparer.Ordinal);
     // Token observed by the currently executing tool call. Set just before
     // `ProcessFrame` runs and reset afterwards so `WithDbReader` can hand a live
     // cancellation token to `DbReader` for SQLite work (#1567).
@@ -258,6 +265,8 @@ public partial class McpServer : IDisposable
     /// 提案 attribution レコードに使う不透明セッションID (#1873)。
     /// </summary>
     internal string CurrentSessionId => _sessionId;
+
+    internal Action<JsonNode?>? RequestRegisteredForTests { get; set; }
 
     /// <summary>
     /// Cap configured for concurrent in-flight tool calls (#1567). Surfaced for tests so
@@ -548,8 +557,18 @@ public partial class McpServer : IDisposable
                 suggestion: "JSON-RPC 2.0 `id` must be a string, integer, or null. Booleans/objects/arrays are not allowed.",
                 retrySafe: false);
 
+        if (method == "$/cancelRequest" || method == "notifications/cancelled")
+        {
+            var cancelAuth = _authenticator.Authenticate(request);
+            if (cancelAuth.IsAuthenticated)
+                TryCancelRequest(request["params"]);
+            else
+                Console.Error.WriteLine(BuildAuthFailureLog(method, cancelAuth.FailureReason));
+            return null;
+        }
+
         // Notifications (no id) don't get a response / 通知（idなし）にはレスポンスなし
-        if (method == "notifications/initialized" || method == "notifications/cancelled")
+        if (method == "notifications/initialized")
             return null;
 
         // Graceful shutdown via JSON-RPC notification (#1567). Without this, the only way to
@@ -612,7 +631,7 @@ public partial class McpServer : IDisposable
                 retrySafe: false);
         }
 
-        return method switch
+        return DispatchWithRequestCancellation(id, () => method switch
         {
             "initialize" => HandleInitialize(id, request["params"]),
             "tools/list" => HandleToolsList(id),
@@ -622,7 +641,54 @@ public partial class McpServer : IDisposable
                 category: McpErrorEnvelope.CategoryMethodNotFound,
                 suggestion: "Supported methods: initialize, tools/list, tools/call, ping, notifications/initialized, notifications/cancelled, notifications/shutdown.",
                 retrySafe: false),
-        };
+        });
+    }
+
+    private JsonNode DispatchWithRequestCancellation(JsonNode? id, Func<JsonNode> action)
+    {
+        var requestKey = SerializeRequestId(id);
+        if (requestKey == null)
+            return action();
+
+        using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(_currentRequestToken, _shutdownCts.Token);
+        if (!_activeRequests.TryAdd(requestKey, requestCts))
+        {
+            return CreateErrorResponse(hasId: true, id: id, code: -32600, message: "Duplicate in-flight request id",
+                category: McpErrorEnvelope.CategoryInvalidRequest,
+                suggestion: "JSON-RPC request ids must be unique while a previous request with the same id is still running.",
+                retrySafe: true);
+        }
+        RequestRegisteredForTests?.Invoke(id);
+
+        var previousToken = _currentRequestToken;
+        try
+        {
+            _currentRequestToken = requestCts.Token;
+            requestCts.Token.ThrowIfCancellationRequested();
+            return action();
+        }
+        catch (OperationCanceledException) when (requestCts.IsCancellationRequested)
+        {
+            return CreateCancelledResponse(id);
+        }
+        finally
+        {
+            _currentRequestToken = previousToken;
+            _activeRequests.TryRemove(requestKey, out _);
+        }
+    }
+
+    private void TryCancelRequest(JsonNode? cancelParams)
+    {
+        var requestId = cancelParams?["id"];
+        var requestKey = SerializeRequestId(requestId);
+        if (requestKey == null)
+            return;
+        if (_activeRequests.TryGetValue(requestKey, out var cts))
+        {
+            try { cts.Cancel(); }
+            catch (ObjectDisposedException) { /* completed while cancellation was being delivered. */ }
+        }
     }
 
     // Safe accessor that returns null instead of throwing when `name` is missing OR present
@@ -1066,6 +1132,11 @@ public partial class McpServer : IDisposable
                     extraData: new JsonObject { ["tool"] = toolName }),
             };
             }
+        }
+        catch (OperationCanceledException) when (_currentRequestToken.IsCancellationRequested)
+        {
+            metricsError = nameof(OperationCanceledException);
+            throw;
         }
         catch (Exception ex)
         {
@@ -1524,6 +1595,13 @@ public partial class McpServer : IDisposable
             response["id"] = id is null ? JsonNode.Parse("null") : JsonNode.Parse(id.ToJsonString());
         return response;
     }
+
+    private static JsonObject CreateCancelledResponse(JsonNode? id)
+        => CreateErrorResponse(hasId: true, id: id, code: McpErrorEnvelope.CodeRequestCancelled,
+            message: "Request cancelled",
+            category: McpErrorEnvelope.CategoryRequestCancelled,
+            suggestion: "The client cancelled this request before completion. Reissue the call if the work is still needed.",
+            retrySafe: true);
 
     /// <summary>
     /// Create a tool result response (MCP format).

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -58,7 +58,7 @@ public partial class McpServer : IDisposable
     // 現在実行中のツール呼び出しが観測するトークン。`ProcessFrame` 実行直前にセットし、
     // 直後にリセットする。`WithDbReader` が `DbReader` にライブな cancellation token
     // を渡せるようにするため (#1567)。
-    private CancellationToken _currentRequestToken = CancellationToken.None;
+    private readonly AsyncLocal<CancellationToken> _currentRequestToken = new();
     private bool _running = true;
     // Per-session DbContext reused across MCP tool calls. Holding the connection open
     // avoids reopening SQLite, reapplying pragmas, and re-registering every SQL function
@@ -392,60 +392,152 @@ public partial class McpServer : IDisposable
         // stdoutをJSON-RPC用にクリーンに保つため、ログはstderrに出力
         Console.Error.WriteLine($"[cdidx-mcp] Starting MCP server v{_version} (db: {_dbPath}, transport: {transport.Name} @ {transport.Endpoint}, max in-flight: {MaxConcurrency})");
 
-        while (_running)
-        {
-            // The full read/process/write iteration is wrapped in the same cancellation guard so
-            // a Ctrl+C that lands mid-iteration (e.g. while WriteFrameAsync is flushing) still
-            // exits the loop cleanly instead of bubbling OperationCanceledException out of the
-            // server and past ProgramRunner.RunMcpHttp's graceful-shutdown handler.
-            // Ctrl+C が WriteFrameAsync flush 中に来ても OperationCanceledException を呼び元に
-            // 漏らさず正常終了するよう、read/process/write 全体を同じ cancellation guard で囲む。
-            try
-            {
-                var frame = await transport.ReadFrameAsync(loopToken).ConfigureAwait(false);
-                if (frame == null)
-                    break; // transport closed / トランスポートが閉じられた
+        if (transport is HttpMcpTransport httpTransport)
+            httpTransport.OutOfBandFrameHandler = ProcessFrame;
 
-                // Acquire the concurrency gate before doing any work so a future async dispatch
-                // mode (multiple frames in flight) can never run more than `MaxConcurrency` tool
-                // calls at once. Today the loop is sequential so the gate is effectively a no-op
-                // at runtime, but it documents the contract and gives tests a verifiable bound
-                // (#1567).
-                // 並列ディスパッチ時に in-flight 数が `MaxConcurrency` を超えないよう、ProcessFrame
-                // の手前で gate を取得する (#1567)。
-                await _concurrencyGate.WaitAsync(loopToken).ConfigureAwait(false);
-                string? response;
+        try
+        {
+            if (string.Equals(transport.Name, "stdio", StringComparison.OrdinalIgnoreCase))
+            {
+                await RunConcurrentFrameLoopAsync(transport, loopToken).ConfigureAwait(false);
+                return;
+            }
+
+            while (_running)
+            {
+                // The full read/process/write iteration is wrapped in the same cancellation guard so
+                // a Ctrl+C that lands mid-iteration (e.g. while WriteFrameAsync is flushing) still
+                // exits the loop cleanly instead of bubbling OperationCanceledException out of the
+                // server and past ProgramRunner.RunMcpHttp's graceful-shutdown handler.
+                // Ctrl+C が WriteFrameAsync flush 中に来ても OperationCanceledException を呼び元に
+                // 漏らさず正常終了するよう、read/process/write 全体を同じ cancellation guard で囲む。
                 try
                 {
-                    // Hand the per-request token to `WithDbReader` so SQLite work the tool kicks
-                    // off can observe shutdown / client-disconnect cancellation through
-                    // `DbReader.Cancellation` (#1567).
-                    // ツールが起動する SQLite 作業が shutdown / 切断を観測できるよう per-request
-                    // token を `WithDbReader` に渡す (#1567)。
-                    _currentRequestToken = loopToken;
-                    response = ProcessFrame(frame);
+                    var frame = await transport.ReadFrameAsync(loopToken).ConfigureAwait(false);
+                    if (frame == null)
+                        break; // transport closed / トランスポートが閉じられた
+
+                    // Acquire the concurrency gate before doing any work so a future async dispatch
+                    // mode (multiple frames in flight) can never run more than `MaxConcurrency` tool
+                    // calls at once. Today the loop is sequential so the gate is effectively a no-op
+                    // at runtime, but it documents the contract and gives tests a verifiable bound
+                    // (#1567).
+                    // 並列ディスパッチ時に in-flight 数が `MaxConcurrency` を超えないよう、ProcessFrame
+                    // の手前で gate を取得する (#1567)。
+                    await _concurrencyGate.WaitAsync(loopToken).ConfigureAwait(false);
+                    string? response;
+                    try
+                    {
+                        // Hand the per-request token to `WithDbReader` so SQLite work the tool kicks
+                        // off can observe shutdown / client-disconnect cancellation through
+                        // `DbReader.Cancellation` (#1567).
+                        // ツールが起動する SQLite 作業が shutdown / 切断を観測できるよう per-request
+                        // token を `WithDbReader` に渡す (#1567)。
+                        _currentRequestToken.Value = loopToken;
+                        response = ProcessFrame(frame);
+                    }
+                    finally
+                    {
+                        _currentRequestToken.Value = CancellationToken.None;
+                        _concurrencyGate.Release();
+                    }
+
+                    await transport.WriteFrameAsync(response, loopToken).ConfigureAwait(false);
+
+                    // `notifications/shutdown` flips `_running` inside `HandleMessage`; exit the loop
+                    // immediately so a subsequent slow `ReadFrameAsync` does not extend the lifetime
+                    // of a server that has been asked to stop.
+                    // `notifications/shutdown` が `_running` を倒した直後にループを抜ける (#1567)。
+                    if (!_running)
+                        break;
                 }
-                finally
+                catch (OperationCanceledException) when (loopToken.IsCancellationRequested)
                 {
-                    _currentRequestToken = CancellationToken.None;
-                    _concurrencyGate.Release();
-                }
-
-                await transport.WriteFrameAsync(response, loopToken).ConfigureAwait(false);
-
-                // `notifications/shutdown` flips `_running` inside `HandleMessage`; exit the loop
-                // immediately so a subsequent slow `ReadFrameAsync` does not extend the lifetime
-                // of a server that has been asked to stop.
-                // `notifications/shutdown` が `_running` を倒した直後にループを抜ける (#1567)。
-                if (!_running)
                     break;
+                }
+            }
+        }
+        finally
+        {
+            if (transport is HttpMcpTransport httpTransportToClear)
+                httpTransportToClear.OutOfBandFrameHandler = null;
+        }
+
+        Console.Error.WriteLine("[cdidx-mcp] Server stopped. Restart `cdidx mcp` when your client reconnects.");
+    }
+
+    private async Task RunConcurrentFrameLoopAsync(IMcpTransport transport, CancellationToken loopToken)
+    {
+        using var writeGate = new SemaphoreSlim(1, 1);
+        using var normalFrameGate = new SemaphoreSlim(1, 1);
+        var tasks = new List<Task>();
+
+        while (_running)
+        {
+            string? frame;
+            try
+            {
+                frame = await transport.ReadFrameAsync(loopToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (loopToken.IsCancellationRequested)
             {
                 break;
             }
+            if (frame == null)
+                break;
+
+            if (IsCancellationFrame(frame))
+            {
+                var response = ProcessFrame(frame);
+                await writeGate.WaitAsync(loopToken).ConfigureAwait(false);
+                try
+                {
+                    await transport.WriteFrameAsync(response, loopToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    writeGate.Release();
+                }
+                continue;
+            }
+
+            await _concurrencyGate.WaitAsync(loopToken).ConfigureAwait(false);
+            tasks.Add(Task.Run(async () =>
+            {
+                try
+                {
+                    await normalFrameGate.WaitAsync(loopToken).ConfigureAwait(false);
+                    string? response;
+                    try
+                    {
+                        _currentRequestToken.Value = loopToken;
+                        response = ProcessFrame(frame);
+                    }
+                    finally
+                    {
+                        _currentRequestToken.Value = CancellationToken.None;
+                        normalFrameGate.Release();
+                    }
+
+                    await writeGate.WaitAsync(loopToken).ConfigureAwait(false);
+                    try
+                    {
+                        await transport.WriteFrameAsync(response, loopToken).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        writeGate.Release();
+                    }
+                }
+                finally
+                {
+                    _concurrencyGate.Release();
+                }
+            }, CancellationToken.None));
+            SpinWait.SpinUntil(() => !_running || _activeRequests.Count > 0, TimeSpan.FromMilliseconds(50));
         }
 
+        await Task.WhenAll(tasks).ConfigureAwait(false);
         Console.Error.WriteLine("[cdidx-mcp] Server stopped. Restart `cdidx mcp` when your client reconnects.");
     }
 
@@ -650,7 +742,7 @@ public partial class McpServer : IDisposable
         if (requestKey == null)
             return action();
 
-        using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(_currentRequestToken, _shutdownCts.Token);
+        using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(_currentRequestToken.Value, _shutdownCts.Token);
         if (!_activeRequests.TryAdd(requestKey, requestCts))
         {
             return CreateErrorResponse(hasId: true, id: id, code: -32600, message: "Duplicate in-flight request id",
@@ -660,10 +752,10 @@ public partial class McpServer : IDisposable
         }
         RequestRegisteredForTests?.Invoke(id);
 
-        var previousToken = _currentRequestToken;
+        var previousToken = _currentRequestToken.Value;
         try
         {
-            _currentRequestToken = requestCts.Token;
+            _currentRequestToken.Value = requestCts.Token;
             requestCts.Token.ThrowIfCancellationRequested();
             return action();
         }
@@ -673,7 +765,7 @@ public partial class McpServer : IDisposable
         }
         finally
         {
-            _currentRequestToken = previousToken;
+            _currentRequestToken.Value = previousToken;
             _activeRequests.TryRemove(requestKey, out _);
         }
     }
@@ -688,6 +780,23 @@ public partial class McpServer : IDisposable
         {
             try { cts.Cancel(); }
             catch (ObjectDisposedException) { /* completed while cancellation was being delivered. */ }
+        }
+    }
+
+    private static bool IsCancellationFrame(string frame)
+    {
+        try
+        {
+            var node = JsonNode.Parse(frame);
+            if (node is not JsonObject obj)
+                return false;
+            var method = obj["method"]?.GetValue<string>();
+            return string.Equals(method, "$/cancelRequest", StringComparison.Ordinal)
+                || string.Equals(method, "notifications/cancelled", StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
         }
     }
 
@@ -1133,7 +1242,7 @@ public partial class McpServer : IDisposable
             };
             }
         }
-        catch (OperationCanceledException) when (_currentRequestToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (_currentRequestToken.Value.IsCancellationRequested)
         {
             metricsError = nameof(OperationCanceledException);
             throw;
@@ -1467,7 +1576,7 @@ public partial class McpServer : IDisposable
         // MCP ツール呼び出しごとの schema 再走査を排除し (issue #1565)、
         // per-request cancellation token を reader に渡して SQLite 作業が
         // shutdown / 切断を観測できるようにする (#1567)。
-        var requestToken = _currentRequestToken;
+        var requestToken = _currentRequestToken.Value;
         requestToken.ThrowIfCancellationRequested();
         var reader = new DbReader(db, requestToken);
         return action(reader);

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -1137,6 +1137,27 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public async Task RunAsync_StdioCancellationNotification_CancelsActiveRequest()
+    {
+        using var cancelWritten = new ManualResetEventSlim(false);
+        var transport = new ShutdownProbeTransport(
+            name: "stdio",
+            onWrite: frame =>
+            {
+                if (frame is null)
+                    cancelWritten.Set();
+            },
+            """{"jsonrpc":"2.0","id":1418,"method":"tools/call","params":{"name":"status","arguments":{}}}""",
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1418}}""");
+        using var server = new McpServer(_dbPath, "test");
+        server.RequestRegisteredForTests = _ => Assert.True(cancelWritten.Wait(TimeSpan.FromSeconds(5)));
+
+        await server.RunAsync(transport, CancellationToken.None);
+
+        Assert.Contains(transport.WrittenFrames, frame => frame?.Contains("\"request_cancelled\"", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
     public void MaxConcurrency_DefaultExposesIssueBound()
     {
         Assert.Equal(McpServer.DefaultMaxConcurrency, _server.MaxConcurrency);
@@ -1176,19 +1197,29 @@ public class McpServerTests : IDisposable
     private sealed class ShutdownProbeTransport : IMcpTransport
     {
         private readonly Queue<string?> _frames;
+        private readonly string _name;
+        private readonly Action<string?>? _onWrite;
 
         public ShutdownProbeTransport(params string?[] frames)
+            : this("shutdown-probe", null, frames)
         {
+        }
+
+        public ShutdownProbeTransport(string name, Action<string?>? onWrite, params string?[] frames)
+        {
+            _name = name;
+            _onWrite = onWrite;
             _frames = new Queue<string?>(frames);
             // Append EOS so the loop terminates if shutdown never fires for some reason.
             // shutdown が来なかった場合のフェイルセーフとして末尾に EOS を積む。
             _frames.Enqueue(null);
         }
 
-        public string Name => "shutdown-probe";
+        public string Name => _name;
         public string Endpoint => "in-memory";
         public int WriteCount { get; private set; }
         public string? LastWritten { get; private set; }
+        public List<string?> WrittenFrames { get; } = [];
 
         public Task<string?> ReadFrameAsync(CancellationToken cancellationToken)
         {
@@ -1200,6 +1231,8 @@ public class McpServerTests : IDisposable
         {
             WriteCount++;
             LastWritten = frame;
+            WrittenFrames.Add(frame);
+            _onWrite?.Invoke(frame);
             return Task.CompletedTask;
         }
 

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -250,6 +250,23 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void NotificationsCancelled_ForActiveRequestId_ReturnsRequestCancelledError()
+    {
+        _server.RequestRegisteredForTests = id =>
+        {
+            var cancel = JsonNode.Parse("""{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1418}}""")!;
+            Assert.Null(_server.HandleMessage(cancel));
+        };
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1418,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
+
+        var response = _server.HandleMessage(request)!;
+
+        var error = response["error"]!;
+        Assert.Equal(McpErrorEnvelope.CodeRequestCancelled, error["code"]!.GetValue<int>());
+        Assert.Equal("request_cancelled", error["data"]!["category"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void CancelRequest_UnknownOrMalformedId_IsNotificationOnly()
     {
         var unknown = JsonNode.Parse("""{"jsonrpc":"2.0","method":"$/cancelRequest","params":{"id":"missing"}}""")!;

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -228,6 +228,37 @@ public class McpServerTests : IDisposable
         Assert.Contains("2024-11-05", McpServer.SupportedProtocolVersions);
     }
 
+    [Fact]
+    public void CancelRequest_ForActiveRequest_ReturnsRequestCancelledError()
+    {
+        // Issue #1418: MCP `$/cancelRequest` must target the matching JSON-RPC id and
+        // cancel the per-request token before the tool does DB work.
+        // Issue #1418: MCP `$/cancelRequest` は対応する JSON-RPC id の per-request token を
+        // cancel し、ツールが DB 作業に入る前に中断できる必要がある。
+        _server.RequestRegisteredForTests = id =>
+        {
+            var cancel = JsonNode.Parse("""{"jsonrpc":"2.0","method":"$/cancelRequest","params":{"id":1418}}""")!;
+            Assert.Null(_server.HandleMessage(cancel));
+        };
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1418,"method":"tools/call","params":{"name":"status","arguments":{}}}""")!;
+
+        var response = _server.HandleMessage(request)!;
+
+        var error = response["error"]!;
+        Assert.Equal(McpErrorEnvelope.CodeRequestCancelled, error["code"]!.GetValue<int>());
+        Assert.Equal("request_cancelled", error["data"]!["category"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void CancelRequest_UnknownOrMalformedId_IsNotificationOnly()
+    {
+        var unknown = JsonNode.Parse("""{"jsonrpc":"2.0","method":"$/cancelRequest","params":{"id":"missing"}}""")!;
+        var missing = JsonNode.Parse("""{"jsonrpc":"2.0","method":"$/cancelRequest","params":{}}""")!;
+
+        Assert.Null(_server.HandleMessage(unknown));
+        Assert.Null(_server.HandleMessage(missing));
+    }
+
     [Theory]
     [InlineData("search")]
     [InlineData("definition")]


### PR DESCRIPTION
## Summary

- Track active MCP JSON-RPC requests by id and cancel the matching per-request token from `$/cancelRequest` / `notifications/cancelled`.
- Let stdio process cancellation frames while a tool request is still active, and let HTTP handle cancellation notifications out-of-band instead of queuing them behind the active request.
- Add regression coverage for both request id shapes and the stdio in-flight cancellation path.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests.CancelRequest|FullyQualifiedName~McpServerTests.NotificationsCancelled"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests.RunAsync_StdioCancellationNotification_CancelsActiveRequest|FullyQualifiedName~HttpMcpTransportTests.HttpTransport_RequestLogger_RecordsMethodStatusDurationAndAuthOutcome"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test`
- Codex adversarial review: two rounds; both reported actionable cancellation-delivery gaps, and both were addressed.

## Documentation and Changelog

- Added changelog fragment: `changelog.d/unreleased/1418.fixed.md`

Fixes #1418

## Follow-up Candidates

- None.
