### PR TITLE
Fix hotspot family degradation reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
   `path_case_sensitive`, `db_pragma_settings`, `stale_after_seconds`,
   `index_age_seconds`, `degraded_reason`, `recommended_action`, and `alternative_action`; keep this
   list synchronized with `DEVELOPER_GUIDE.md` and `AGENT_GUIDE.md`.
+  `hotspot_family_degraded_reason` distinguishes legacy DBs without hotspot-family
+  support (`hotspot_family_support_not_indexed`), stale metadata
+  (`hotspot_family_metadata_stale`), and indexes written while marker fingerprints
+  were unavailable (`hotspot_family_disabled_at_index_time`); hotspot-family
+  readiness is tracked by per-language `hotspot_family_version_<lang>` metadata
+  introduced with hotspot-family contract version 2.
 - Local-first storage in `.cdidx/codeindex.db`.
 - 78 detected languages, with symbol and graph support where available.
 - MCP `tools/list` descriptions include a `Language support:` clause sourced
@@ -248,6 +254,12 @@ cdidx mcp
   `path_case_sensitive`、`db_pragma_settings`、`stale_after_seconds`、
   `index_age_seconds`、`degraded_reason`、`recommended_action`、`alternative_action` を対象にします。
   この一覧は `DEVELOPER_GUIDE.md` と `AGENT_GUIDE.md` に同期してください。
+  `hotspot_family_degraded_reason` は、hotspot-family 未対応の legacy DB
+  (`hotspot_family_support_not_indexed`)、古い metadata
+  (`hotspot_family_metadata_stale`)、marker fingerprint が利用できない状態で書かれた index
+  (`hotspot_family_disabled_at_index_time`) を区別します。hotspot-family readiness は
+  hotspot-family contract version 2 で導入された言語別
+  `hotspot_family_version_<lang>` metadata で追跡されます。
 - `.cdidx/codeindex.db` に保存するローカルファースト設計。
 - 78 言語を検出し、対応言語ではシンボルとグラフも利用可能。
 - MCP の `tools/list` 説明には、`cdidx languages` と同じ言語レジストリから

--- a/changelog.d/unreleased/1971.fixed.md
+++ b/changelog.d/unreleased/1971.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 1971
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Models/QueryResults.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - README.md
+---
+
+## English
+
+- **Hotspot-family degradation now reports actionable reasons (#1971)** — `hotspot_family_degraded_reason` distinguishes legacy DBs without hotspot-family metadata, stale metadata, and indexes written without marker fingerprints so users know whether to rebuild or restamp the index.
+
+## 日本語
+
+- **hotspot-family の縮退理由を具体的に表示するようになりました (#1971)** — `hotspot_family_degraded_reason` が hotspot-family metadata の無い legacy DB、古い metadata、marker fingerprint 無しで書かれた index を区別し、rebuild / restamp のどちらが必要か判断できるようにします。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -524,7 +524,7 @@ public partial class DbReader
                 Relevant: true,
                 DegradedReason: ready
                     ? null
-                    : $"cross-file hotspot family grouping for '{lang}' is degraded; run `cdidx index <projectPath>` to restamp authoritative hotspot families.");
+                    : FormatHotspotFamilyDegradedReason([lang]));
         }
 
         var relevantLanguages = _indexedHotspotFamilyLanguages
@@ -542,7 +542,51 @@ public partial class DbReader
         return new HotspotFamilySignal(
             Ready: false,
             Relevant: true,
-            DegradedReason: $"cross-file hotspot family grouping is degraded for: {string.Join(", ", unreadyLanguages)}; run `cdidx index <projectPath>` to restamp authoritative hotspot families.");
+            DegradedReason: FormatHotspotFamilyDegradedReason(unreadyLanguages));
+    }
+
+    private string FormatHotspotFamilyDegradedReason(IReadOnlyList<string> languages)
+    {
+        var grouped = languages
+            .Select(language => (Language: language, Reason: ResolveHotspotFamilyDegradedReason(language)))
+            .GroupBy(item => item.Reason, item => item.Language, StringComparer.Ordinal)
+            .OrderBy(group => group.Key, StringComparer.Ordinal)
+            .Select(group => $"{group.Key}={string.Join(",", group.OrderBy(value => value, StringComparer.Ordinal))}");
+
+        return $"cross-file hotspot family grouping is degraded ({string.Join("; ", grouped)}); {GetHotspotFamilyRecoveryAction(languages)}";
+    }
+
+    private string ResolveHotspotFamilyDegradedReason(string lang)
+    {
+        if (!_symbolColumns.Contains("family_key") || !_symbolColumns.Contains("container_qualified_name"))
+            return "hotspot_family_support_not_indexed";
+
+        var raw = TryGetMetaString(_conn, DbContext.GetHotspotFamilyVersionMetaKey(lang));
+        var fingerprint = TryGetMetaString(_conn, DbContext.GetHotspotFamilyMarkerFingerprintMetaKey(lang));
+        if (string.IsNullOrWhiteSpace(raw))
+            return "hotspot_family_support_not_indexed";
+
+        if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var version)
+            || version != DbContext.HotspotFamilyVersion)
+        {
+            return "hotspot_family_metadata_stale";
+        }
+
+        return string.IsNullOrWhiteSpace(fingerprint)
+            ? "hotspot_family_disabled_at_index_time"
+            : "hotspot_family_metadata_stale";
+    }
+
+    private string GetHotspotFamilyRecoveryAction(IReadOnlyList<string> languages)
+    {
+        var reasons = languages
+            .Select(ResolveHotspotFamilyDegradedReason)
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (reasons.SetEquals(["hotspot_family_metadata_stale"]))
+            return "run `cdidx index <projectPath> --files <changedFiles>` or `cdidx index <projectPath>` to restamp authoritative hotspot families.";
+
+        return "run `cdidx index <projectPath>` to rebuild and stamp authoritative hotspot families.";
     }
 
     private HashSet<string> LoadIndexes(string tableName)

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -479,11 +479,13 @@ public class StatusResult
     /// <summary>
     /// True when authoritative cross-file hotspot-family grouping metadata is current for every
     /// marker-capable language currently indexed in this DB. False means `hotspots` can still
-    /// run, but duplicate-name families may be conservatively degraded until `cdidx index .`
-    /// restamps the hotspot-family metadata.
+    /// run, but duplicate-name families may be conservatively degraded. The degraded reason
+    /// distinguishes legacy DBs that predate hotspot-family support, stale metadata, and
+    /// indexes written while marker fingerprints were unavailable.
     /// 現在 index 済みの marker-capable 言語すべてで authoritative な hotspot-family metadata
     /// が最新なら true。false の間も `hotspots` は動くが、duplicate-name family は保守的
-    /// fallback に縮退しうるため、`cdidx index .` で metadata を restamp する必要がある。
+    /// fallback に縮退しうる。reason は legacy DB、古い metadata、marker fingerprint 未利用
+    /// index を区別する。
     /// </summary>
     [JsonPropertyName("hotspot_family_ready")]
     public bool HotspotFamilyReady { get; set; } = true;

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -3499,7 +3499,7 @@ public class DbReaderTests : IDisposable
 
         Assert.True(signal.Relevant);
         Assert.False(signal.Ready);
-        Assert.Contains("csharp", signal.DegradedReason);
+        Assert.Contains("hotspot_family_support_not_indexed=csharp", signal.DegradedReason);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -5797,7 +5797,7 @@ public class IndexCommandRunnerTests
             var (updateExitCode, updateJson) = RunAndCaptureJson([projectRoot, "--files", "src/Caller.cs", "--json"]);
             Assert.Equal(CommandExitCodes.Success, updateExitCode);
             Assert.False(updateJson.GetProperty("hotspot_family_ready").GetBoolean());
-            Assert.Contains("csharp", updateJson.GetProperty("hotspot_family_degraded_reason").GetString());
+            Assert.Contains("hotspot_family_support_not_indexed=csharp", updateJson.GetProperty("hotspot_family_degraded_reason").GetString());
 
             File.WriteAllText(callerPath, "public class Caller { public void Call(Api api) { api.Run(); api.Run(1); api.Run(); api.Run(1); } }");
             File.SetLastWriteTimeUtc(callerPath, DateTime.UtcNow.AddSeconds(4));

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -4487,8 +4487,8 @@ public class McpServerTests : IDisposable
             var structured = response["result"]!["structuredContent"]!;
             Assert.False(structured["hotspot_family_ready"]!.GetValue<bool>());
             Assert.False(structured["hotspotFamilyReady"]!.GetValue<bool>());
-            Assert.Contains("csharp", structured["hotspot_family_degraded_reason"]!.GetValue<string>());
-            Assert.Contains("csharp", structured["hotspotFamilyDegradedReason"]!.GetValue<string>());
+            Assert.Contains("hotspot_family_support_not_indexed=csharp", structured["hotspot_family_degraded_reason"]!.GetValue<string>());
+            Assert.Contains("hotspot_family_support_not_indexed=csharp", structured["hotspotFamilyDegradedReason"]!.GetValue<string>());
         }
         finally
         {
@@ -5800,7 +5800,7 @@ public class McpServerTests : IDisposable
             Assert.True(structured["degraded"]!.GetValue<bool>());
             Assert.False(structured["hotspot_family_ready"]!.GetValue<bool>());
             Assert.False(structured["hotspotFamilyReady"]!.GetValue<bool>());
-            Assert.Contains("csharp", structured["hotspot_family_degraded_reason"]!.GetValue<string>());
+            Assert.Contains("hotspot_family_support_not_indexed=csharp", structured["hotspot_family_degraded_reason"]!.GetValue<string>());
             Assert.Contains("degraded", response["result"]!["content"]![0]!["text"]!.GetValue<string>());
         }
         finally
@@ -5891,7 +5891,7 @@ public class McpServerTests : IDisposable
             Assert.False(structured["hotspot_family_ready"]!.GetValue<bool>());
             Assert.False(structured["hotspotFamilyReady"]!.GetValue<bool>());
             Assert.True(structured["degraded"]!.GetValue<bool>());
-            Assert.Contains("csharp", structured["hotspot_family_degraded_reason"]!.GetValue<string>());
+            Assert.Contains("hotspot_family_disabled_at_index_time=csharp", structured["hotspot_family_degraded_reason"]!.GetValue<string>());
         }
         finally
         {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -10774,7 +10774,7 @@ jobs:
             Assert.Equal(0, json.GetProperty("count").GetInt32());
             Assert.False(json.GetProperty("hotspot_family_ready").GetBoolean());
             Assert.True(json.GetProperty("degraded").GetBoolean());
-            Assert.Contains("csharp", json.GetProperty("hotspot_family_degraded_reason").GetString());
+            Assert.Contains("hotspot_family_support_not_indexed=csharp", json.GetProperty("hotspot_family_degraded_reason").GetString());
             Assert.True(json.GetProperty("graph_table_available").GetBoolean());
         }
         finally
@@ -10819,7 +10819,7 @@ jobs:
             Assert.Equal(string.Empty, stderr);
             Assert.False(json.GetProperty("hotspot_family_ready").GetBoolean());
             Assert.True(json.GetProperty("degraded").GetBoolean());
-            Assert.Contains("csharp", json.GetProperty("hotspot_family_degraded_reason").GetString());
+            Assert.Contains("hotspot_family_support_not_indexed=csharp", json.GetProperty("hotspot_family_degraded_reason").GetString());
         }
         finally
         {
@@ -11917,7 +11917,40 @@ jobs:
             Assert.Equal(0, json.GetProperty("count").GetInt32());
             Assert.False(json.GetProperty("hotspot_family_ready").GetBoolean());
             Assert.True(json.GetProperty("degraded").GetBoolean());
-            Assert.Contains("csharp", json.GetProperty("hotspot_family_degraded_reason").GetString());
+            Assert.Contains("hotspot_family_disabled_at_index_time=csharp", json.GetProperty("hotspot_family_degraded_reason").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunHotspots_ZeroJson_ReportsStaleHotspotFamilyMetadata()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_hotspots_family_stale_zero_json");
+        try
+        {
+            var dbPath = CreateHotspotFamilyFixtureDb(projectRoot, markHotspotFamilyReady: true);
+            using (var db = new DbContext(dbPath))
+            {
+                var writer = new DbWriter(db.Connection);
+                writer.SetMeta(DbContext.GetHotspotFamilyVersionMetaKey("csharp"), "1");
+            }
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunHotspots(
+                ["--db", dbPath, "--json", "--lang", "csharp", "--kind", "function"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.NotFound, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(0, json.GetProperty("count").GetInt32());
+            Assert.False(json.GetProperty("hotspot_family_ready").GetBoolean());
+            Assert.True(json.GetProperty("degraded").GetBoolean());
+            Assert.Contains("hotspot_family_metadata_stale=csharp", json.GetProperty("hotspot_family_degraded_reason").GetString());
         }
         finally
         {

--- a/tests/CodeIndex.Tests/golden/status.json
+++ b/tests/CodeIndex.Tests/golden/status.json
@@ -70,7 +70,7 @@
   "graph_table_available": false,
   "issues_table_available": false,
   "hotspot_family_ready": false,
-  "hotspot_family_degraded_reason": "cross-file hotspot family grouping is degraded for: csharp; run \u0060cdidx index \u003CprojectPath\u003E\u0060 to restamp authoritative hotspot families.",
+  "hotspot_family_degraded_reason": "cross-file hotspot family grouping is degraded (hotspot_family_support_not_indexed=csharp); run \u0060cdidx index \u003CprojectPath\u003E\u0060 to rebuild and stamp authoritative hotspot families.",
   "csharp_symbol_name_ready": false,
   "csharp_metadata_target_ready": false,
   "sql_graph_contract_ready": true,


### PR DESCRIPTION
## Summary

- Distinguish hotspot-family readiness degradation causes with explicit reason codes for legacy DBs, stale metadata, and missing marker fingerprints.
- Surface the updated reason text through status/hotspots JSON and MCP structured output, with focused tests and snapshot coverage.
- Document the hotspot-family reason taxonomy and add the bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests|FullyQualifiedName~QueryCommandRunnerTests.RunHotspots|FullyQualifiedName~McpServerTests|FullyQualifiedName~IndexCommandRunnerTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~JsonOutputSnapshotTests"`
- `UPDATE_SNAPSHOTS=1 dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~JsonOutputSnapshotTests.RunStatus_JsonOutput_MatchesGolden"`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `git diff --check`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation And Changelog

- Updated `README.md` and `StatusResult` XML docs.
- Added `changelog.d/unreleased/1971.fixed.md`.

## Follow-Up Candidates

- None.

Fixes #1971
