### PR TITLE
Fix bare catch handling in CLI and database paths

### DIFF
--- a/changelog.d/unreleased/1411.fixed.md
+++ b/changelog.d/unreleased/1411.fixed.md
@@ -1,0 +1,23 @@
+---
+category: fixed
+issues:
+  - 1411
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - src/CodeIndex/Cli/GlobalToolLog.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - src/CodeIndex/Cli/IndexLock.cs
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Database/PreparedCommandCache.cs
+---
+
+## English
+
+- **Bare catch blocks no longer swallow fatal or cancellation exceptions (#1411)** — best-effort CLI and database cleanup/probe paths now catch only the expected exception types, or explicitly rethrow after cleanup, so cancellation, out-of-memory failures, and programming errors surface correctly.
+
+## 日本語
+
+- **裸の catch ブロックが致命的例外やキャンセル例外を握りつぶさないようになりました (#1411)** — CLI と database のベストエフォートな cleanup/probe 経路は想定される例外型だけを捕捉するか、cleanup 後に明示的に再送出するため、キャンセル、メモリ不足、プログラミングエラーが正しく表面化します。

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -173,7 +173,7 @@ public static class DbPathResolver
             var raw = cmd.ExecuteScalar();
             return raw is string value && !string.IsNullOrWhiteSpace(value) ? value : null;
         }
-        catch
+        catch (SqliteException)
         {
             return null;
         }
@@ -190,7 +190,7 @@ public static class DbPathResolver
             cmd.Parameters.AddWithValue("@key", key);
             return cmd.ExecuteScalar() != null;
         }
-        catch
+        catch (SqliteException)
         {
             return false;
         }
@@ -320,7 +320,7 @@ public static class DbPathResolver
 
             return samples;
         }
-        catch
+        catch (SqliteException)
         {
             // Fall back to persisted metadata / 永続化 metadata 側へフォールバック
             return [];
@@ -349,7 +349,7 @@ public static class DbPathResolver
                 if (string.Equals(checksum, sample.Checksum, StringComparison.OrdinalIgnoreCase))
                     checksumMatches++;
             }
-            catch
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 // Ignore unreadable samples and keep comparing the rest.
                 // 読み込めないサンプルは無視して残りを比較する。

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -38,7 +38,7 @@ internal static class GlobalToolLog
             session.Write("INFO", $"args={FormatArgs(args)}");
             return session;
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             CurrentSession.Value = null;
             return null;
@@ -190,7 +190,7 @@ internal static class GlobalToolLog
                     _writer.WriteLine($"{DateTimeOffset.UtcNow:O} [{level}] {message}");
                     _writer.Flush();
                 }
-                catch
+                catch (Exception ex) when (ex is IOException or ObjectDisposedException)
                 {
                     // Best-effort only / ベストエフォートのみ
                 }

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -127,7 +127,7 @@ internal static class GlobalToolLog
             foreach (var file in oldLogs)
                 file.Delete();
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // Best-effort only / ベストエフォートのみ
         }

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -210,7 +210,7 @@ internal static class GlobalToolLog
                     if (_originalError != null)
                         Console.SetError(_originalError);
                 }
-                catch
+                catch (Exception ex) when (ex is IOException or ObjectDisposedException)
                 {
                     // Best-effort only / ベストエフォートのみ
                 }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -3391,7 +3391,7 @@ public static class IndexCommandRunner
 
                 pendingSymbols.AddRange(SymbolExtractor.Extract(0, record.Lang, content, record.Path));
             }
-            catch
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
             {
                 // The real indexing pass reports file failures; this pre-pass only supplies
                 // workspace symbols for cross-file static interface member matching.

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -898,7 +898,7 @@ public static class IndexCommandRunner
         {
             return Environment.CurrentDirectory;
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return null;
         }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -877,7 +877,7 @@ public static class IndexCommandRunner
         {
             return Path.GetFullPath(value);
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
         {
             return value;
         }

--- a/src/CodeIndex/Cli/IndexLock.cs
+++ b/src/CodeIndex/Cli/IndexLock.cs
@@ -102,7 +102,7 @@ internal sealed class IndexLock : IDisposable
                 ProjectPath: Path.GetFullPath(projectPath));
             File.WriteAllText(infoPath, SerializeInfo(info), Encoding.UTF8);
         }
-        catch
+        catch (Exception)
         {
             stream.Dispose();
             throw;
@@ -140,7 +140,7 @@ internal sealed class IndexLock : IDisposable
                 return null;
             return ParseInfo(text);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
             return null;
         }
@@ -156,7 +156,7 @@ internal sealed class IndexLock : IDisposable
         {
             File.Delete(_infoPath);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // Best-effort. / ベストエフォート。
         }
@@ -165,7 +165,7 @@ internal sealed class IndexLock : IDisposable
         {
             _stream.Dispose();
         }
-        catch
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
         {
             // Best-effort. / ベストエフォート。
         }
@@ -174,7 +174,7 @@ internal sealed class IndexLock : IDisposable
         {
             File.Delete(_lockPath);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // Best-effort cleanup; a leftover empty lockfile does not block future
             // acquires because the next Acquire opens it with OpenOrCreate.

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -147,7 +147,7 @@ internal static class IndexWatchRunner
         {
             if (watcher != null)
             {
-                try { watcher.EnableRaisingEvents = false; } catch { }
+                try { watcher.EnableRaisingEvents = false; } catch (Exception ex) when (ex is IOException or InvalidOperationException or ObjectDisposedException) { }
                 watcher.Dispose();
             }
         }
@@ -278,7 +278,7 @@ internal static class IndexWatchRunner
                 }
             }
         }
-        catch (Exception)
+        catch (JsonException)
         {
             detail = string.Empty;
         }

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -84,7 +84,7 @@ internal static class IndexWatchRunner
                     if (filter.ShouldSkip)
                         return;
                 }
-                catch (Exception)
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException or ArgumentException or NotSupportedException)
                 {
                     // Filter failures must not silently drop the event; defer to the sub-update
                     // pass to log a per-file warning if the path is genuinely broken.

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -172,7 +172,7 @@ public class SuggestionStore
 
                     SaveUnlocked(existing);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException and not OutOfMemoryException)
                 {
                     // Best-effort — GitHub submission failure does not fail the local operation.
                     // ベストエフォート — GitHub 送信失敗はローカル操作を失敗させない。
@@ -454,9 +454,9 @@ public class SuggestionStore
             File.WriteAllText(tempPath, json);
             File.Move(tempPath, _filePath, overwrite: true);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            try { File.Delete(tempPath); } catch { /* best-effort cleanup / ベストエフォートのクリーンアップ */ }
+            try { File.Delete(tempPath); } catch (Exception deleteEx) when (deleteEx is IOException or UnauthorizedAccessException) { /* best-effort cleanup / ベストエフォートのクリーンアップ */ }
             throw;
         }
     }
@@ -562,7 +562,7 @@ public class SuggestionStore
             if (File.Exists(LongPath.EnsureWindowsPrefix(_filePath)))
                 File.Move(LongPath.EnsureWindowsPrefix(_filePath), LongPath.EnsureWindowsPrefix(backupPath), overwrite: true);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // Best-effort — if we can't rename, continue with empty list.
             // ベストエフォート — リネームできなければ空リストで続行。

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -316,7 +316,7 @@ public class DbContext : IDisposable
             var uri = new Uri(trimmed);
             return uri.IsFile ? uri.LocalPath : null;
         }
-        catch
+        catch (UriFormatException)
         {
             return null;
         }

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -263,7 +263,7 @@ public class DbContext : IDisposable
                 if (attempt < maxOpenAttempts)
                     sleep?.Invoke(50 * attempt);
             }
-            catch
+            catch (Exception)
             {
                 connection.Dispose();
                 throw;

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1355,11 +1355,11 @@ public class DbWriter
             }
             return true;
         }
-        catch
+        catch (Exception)
         {
             if (ownTransaction)
             {
-                try { Execute("ROLLBACK"); } catch { /* best effort */ }
+                try { Execute("ROLLBACK"); } catch (SqliteException) { /* best effort */ }
             }
             throw;
         }

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -2729,11 +2729,11 @@ public class DbWriter
                 ownTransaction = false;
             }
         }
-        catch
+        catch (Exception)
         {
             if (ownTransaction)
             {
-                try { Execute("ROLLBACK"); } catch { /* best effort */ }
+                try { Execute("ROLLBACK"); } catch (SqliteException) { /* best effort */ }
             }
             throw;
         }

--- a/src/CodeIndex/Database/PreparedCommandCache.cs
+++ b/src/CodeIndex/Database/PreparedCommandCache.cs
@@ -71,7 +71,7 @@ internal sealed class PreparedCommandCache : IDisposable
             configureSchema(cmd);
             cmd.Prepare();
         }
-        catch
+        catch (Exception)
         {
             cmd.Dispose();
             throw;


### PR DESCRIPTION
## Summary

- Narrowed best-effort `catch` blocks in CLI and database paths so they no longer swallow cancellation, fatal exceptions, or unexpected programming errors.
- Kept cleanup/probe behavior best-effort only for expected I/O, SQLite, URI/path, and disposal failures.
- Added bilingual changelog fragment `changelog.d/unreleased/1411.fixed.md`.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SuggestionStoreTests|FullyQualifiedName~DbPathResolverTests|FullyQualifiedName~IndexLock"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review round 1 found remaining swallowed broad catches; fixed in follow-up commit.
- Adversarial review round 2 found two additional broad catches; fixed in follow-up commit. Review loop stopped at the documented two-round limit.

## Documentation and changelog

- Changelog fragment: `changelog.d/unreleased/1411.fixed.md`
- No README or guide update required; CLI/API surface is unchanged.

Fixes #1411
