### PR TITLE
Fix COLUMNS terminal width handling

### DIFF
--- a/changelog.d/unreleased/1770.fixed.md
+++ b/changelog.d/unreleased/1770.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1770
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+---
+
+## English
+
+- **Console width now honors `COLUMNS` (#1770)** - `cdidx` uses a positive `COLUMNS` value before falling back to `Console.WindowWidth` or 80 columns, so piped and scripted output can request wider terminal formatting.
+
+## 日本語
+
+- **コンソール幅が `COLUMNS` を反映するようになりました (#1770)** - `cdidx` は正の `COLUMNS` 値を `Console.WindowWidth` や 80 列 fallback より優先するため、pipe や script 経由の出力でも広い端末幅を指定できます。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -1541,8 +1541,11 @@ public static class ConsoleUi
     /// Get console window width safely (some environments throw IOException).
     /// コンソール幅を安全に取得する（一部環境ではIOExceptionが発生する）。
     /// </summary>
-    private static int GetWindowWidth()
+    internal static int GetWindowWidth()
     {
+        if (TryGetColumnsEnvironmentWidth(out var columnsWidth))
+            return columnsWidth;
+
         try
         {
             var w = Console.WindowWidth;
@@ -1552,5 +1555,15 @@ public static class ConsoleUi
         {
             return 80;
         }
+    }
+
+    private static bool TryGetColumnsEnvironmentWidth(out int width)
+    {
+        var columns = Environment.GetEnvironmentVariable("COLUMNS");
+        if (int.TryParse(columns, NumberStyles.Integer, CultureInfo.InvariantCulture, out width) && width > 0)
+            return true;
+
+        width = 0;
+        return false;
     }
 }

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -172,6 +172,28 @@ public class ConsoleUiTests
     }
 
     [Fact]
+    public void GetWindowWidth_ColumnsEnvVarSet_UsesColumnsValue()
+    {
+        WithColumnsEnvironment("200", () =>
+        {
+            Assert.Equal(200, ConsoleUi.GetWindowWidth());
+        });
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("wide")]
+    public void GetWindowWidth_InvalidColumnsEnvVar_FallsBackToConsoleOrDefault(string? columns)
+    {
+        WithColumnsEnvironment(columns, () =>
+        {
+            Assert.True(ConsoleUi.GetWindowWidth() > 0);
+        });
+    }
+
+    [Fact]
     public void ShouldUseUnicodeGlyphs_CdidxAsciiEnvVarDisablesUnicode()
     {
         WithUnicodeEnvironment(cdidxAscii: "1", lang: "en_US.UTF-8", () =>
@@ -865,6 +887,23 @@ public class ConsoleUiTests
                 Environment.SetEnvironmentVariable("LANG", originalLang);
                 Environment.SetEnvironmentVariable("LC_ALL", originalLcAll);
                 Environment.SetEnvironmentVariable("LC_CTYPE", originalLcCType);
+            }
+        }
+    }
+
+    private static void WithColumnsEnvironment(string? columns, Action action)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalColumns = Environment.GetEnvironmentVariable("COLUMNS");
+            try
+            {
+                Environment.SetEnvironmentVariable("COLUMNS", columns);
+                action();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("COLUMNS", originalColumns);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Honor a positive COLUMNS environment variable before falling back to Console.WindowWidth or 80 columns.
- Add ConsoleUi regression coverage for valid and invalid COLUMNS values.
- Add a bilingual changelog fragment for #1770.

Fixes #1770

## Validation
- dotnet build
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ConsoleUiTests
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ChangelogToolTests
- dotnet test
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json

## Documentation / Changelog
- Added changelog fragment: changelog.d/unreleased/1770.fixed.md
- No documentation changes required; this restores the documented terminal width fallback behavior without adding a new CLI contract.

## Review
- Adversarial review: No blocking/actionable issues found.

## Follow-up candidates
- None.