### PR TITLE
Fix unsupported installer RID guidance

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -978,13 +978,14 @@ curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh 
 What `install.sh` does, in order (see `install.sh`):
 
 1. **Detect platform.** `uname -s` / `uname -m` are normalized to the
-   `<os>-<arch>` RID the release workflow publishes (`linux-x64`,
-   `linux-arm64`, `osx-arm64`, `win-x64`; see
-   [Platform Support](docs/platform-support.md)). Alpine / musl is
-   rejected up front with an actionable error because the self-contained
-   binary links against glibc. `osx-x64` is rejected because the release
-   matrix does not ship that RID, with NuGet global-tool and source-build
-   alternatives in the error text.
+   `<os>-<arch>` RID and validates it against the release workflow's
+   published asset list (`linux-x64`, `linux-arm64`, `osx-arm64`,
+   `win-x64`, `win-arm64`; see [Platform Support](docs/platform-support.md))
+   before any release-asset download. Alpine / musl is rejected up front
+   with an actionable error because the self-contained binary links against
+   glibc. Unsupported RIDs such as `osx-x64` fail with the detected RID,
+   supported list, NuGet global-tool and source-build alternatives, and the
+   issue link for requesting official platform support.
 2. **Detect existing install first.** If `INSTALL_DIR/cdidx` already
    exists, the installer caches its parsed `--version` output before any
    network work so later version-selection and repair decisions can
@@ -2382,7 +2383,7 @@ curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh 
 
 `install.sh` が順に行うこと（`install.sh` 参照）:
 
-1. **プラットフォーム検出。** `uname -s` / `uname -m` をリリースワークフローが publish する `<os>-<arch>` RID（`linux-x64`、`linux-arm64`、`osx-arm64`、`win-x64`。詳細は [プラットフォームサポート](docs/platform-support.md#プラットフォームサポート)）に正規化。自己完結型バイナリは glibc にリンクされているため、Alpine / musl は先頭で明示的に拒否する。リリース行列が `osx-x64` を出していないため、こちらも拒否し、エラー文で NuGet global tool と source build の代替手段を案内する。
+1. **プラットフォーム検出。** `uname -s` / `uname -m` を `<os>-<arch>` RID に正規化し、release asset の download 前にリリースワークフローが publish する一覧（`linux-x64`、`linux-arm64`、`osx-arm64`、`win-x64`、`win-arm64`。詳細は [プラットフォームサポート](docs/platform-support.md#プラットフォームサポート)）と照合する。自己完結型バイナリは glibc にリンクされているため、Alpine / musl は先頭で明示的に拒否する。`osx-x64` などの未対応 RID は、検出 RID、対応一覧、NuGet global tool / source build の代替手段、公式 platform support をリクエストする issue link を含むエラーで拒否する。
 2. **既存インストールを先に検出。** `INSTALL_DIR/cdidx` が既にある場合は、ネットワークへ行く前に `--version` を解釈して保持する。これにより、後続のバージョン選択や repair 判定で「健全な一致」なのか「古い/不完全な install」なのかを区別できる。
 3. **バージョン解決。** 明示引数がある場合は `v` プレフィックス付き・無しの両方を受け付ける（`v1.8.0` / `1.8.0`）。引数なしでも GitHub API（`/repos/Widthdom/CodeIndex/releases/latest`）を叩いて latest tag を解決し、`jq` があれば `tag_name` 取得に使い、無ければ portability のため従来どおり `grep` + `sed` にフォールバックする。そのうえで健全な既存 install がその latest tag と一致している場合だけ download を skip する。壊れた `v0.0.0` install や必須隣接資産欠落 install は再インストール対象として扱う。HTTP 失敗も `403` rate limit / `404` / `5xx` / 実際の curl network error を分けて案内する。
 4. **明示バージョン指定時は再インストールまたは切り替えに進む。** 引数なし再実行も latest release を対象にするが、明示ターゲット版では、同版でも必ず再インストールへ進み、別版なら切り替えへ進む。壊れた `v0.0.0` install や、同版でも必須資産が欠けている install も置き換え対象として扱う — これは意図した挙動。

--- a/changelog.d/unreleased/1601.fixed.md
+++ b/changelog.d/unreleased/1601.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1601
+affected:
+  - install.sh
+  - docs/platform-support.md
+  - DEVELOPER_GUIDE.md
+  - tests/CodeIndex.Tests/InstallScriptTests.cs
+---
+
+## English
+
+- **Unsupported installer RIDs now fail before artifact download (#1601)** — `install.sh` validates the detected RID against the published release asset list and reports the detected RID, supported RIDs, install/build alternatives, and the platform-support issue link instead of falling through to a release-asset 404.
+
+## 日本語
+
+- **installer の未対応 RID を artifact download 前に拒否するようになりました (#1601)** — `install.sh` は検出した RID を公開済み release asset 一覧と照合し、release asset の 404 まで進む代わりに、検出 RID、対応 RID、install/build の代替手段、platform support リクエスト用 issue link を表示します。

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -17,8 +17,10 @@ GitHub releases publish and checksum these first-class runtime identifiers:
 | `win-arm64` | `CodeIndex-win-arm64.zip` | Windows on ARM64. |
 
 The one-line `install.sh` installer supports the Unix tarball path for Linux and
-macOS. Windows users should install from the release ZIP, use the NuGet global
-tool, or build from source.
+macOS. It validates the detected RID against the official release asset list
+before downloading, so unsupported RIDs fail with platform guidance instead of a
+release-asset 404. Windows users should install from the release ZIP, use the
+NuGet global tool, or build from source.
 
 ## Not Published As Release Assets
 
@@ -66,8 +68,9 @@ checksum 対象にしています。
 | `win-arm64` | `CodeIndex-win-arm64.zip` | Windows on ARM64 向けです。 |
 
 ワンライナーの `install.sh` は Linux と macOS の Unix tarball 経路を対象に
-しています。Windows では release ZIP、NuGet global tool、または source build
-を使ってください。
+しています。download 前に検出 RID を公式 release asset 一覧と照合するため、
+未対応 RID は release asset の 404 ではなく platform guidance として失敗します。
+Windows では release ZIP、NuGet global tool、または source build を使ってください。
 
 ## 公式アセットとして未公開のもの
 

--- a/install.sh
+++ b/install.sh
@@ -102,6 +102,29 @@ published_release_rids() {
     printf '%s' "linux-x64, linux-arm64, osx-arm64, win-x64, win-arm64"
 }
 
+platform_support_request_url() {
+    printf 'https://github.com/%s/issues/new?title=Request%%20official%%20release%%20asset%%20for%%20RID' "$REPO"
+}
+
+is_published_release_rid() {
+    case "$1" in
+        linux-x64|linux-arm64|osx-arm64|win-x64|win-arm64)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+validate_published_release_rid() {
+    if is_published_release_rid "$RID"; then
+        return 0
+    fi
+
+    error "Unsupported release asset RID: ${RID}. Official release assets are published for $(published_release_rids). Install via 'dotnet tool install -g cdidx' with the .NET SDK, build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r ${RID} --self-contained true', or request official platform support at $(platform_support_request_url). See https://github.com/${REPO}/blob/main/docs/platform-support.md."
+}
+
 cleanup() {
     if [ -n "$TMPDIR_CLEANUP" ]; then
         rm -rf "$TMPDIR_CLEANUP"
@@ -620,15 +643,17 @@ detect_platform() {
     case "$arch" in
         x86_64|amd64)   ARCH_NAME="x64"   ;;
         aarch64|arm64)  ARCH_NAME="arm64"  ;;
-        *)              error "Unsupported architecture: $arch. Official release assets are published for $(published_release_rids). Other RIDs such as linux-x86, osx-x64, and win-x86 are not currently shipped. Install via 'dotnet tool install -g cdidx' with the .NET SDK, or build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r <rid> --self-contained true'. See https://github.com/${REPO}/blob/main/docs/platform-support.md." ;;
+        *)              error "Unsupported architecture: $arch. Official release assets are published for $(published_release_rids). Other RIDs such as linux-x86, osx-x64, and win-x86 are not currently shipped. Install via 'dotnet tool install -g cdidx' with the .NET SDK, build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r <rid> --self-contained true', or request official platform support at $(platform_support_request_url). See https://github.com/${REPO}/blob/main/docs/platform-support.md." ;;
     esac
 
     RID="${OS_NAME}-${ARCH_NAME}"
 
     # osx-x64 is not published / osx-x64 はリリースしていない
     if [ "$RID" = "osx-x64" ]; then
-        error "macOS x86_64 (Intel) binaries are not published as CodeIndex-osx-x64.tar.gz. Install via 'dotnet tool install -g cdidx' with the .NET SDK, or build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true'. See https://github.com/${REPO}/blob/main/docs/platform-support.md."
+        error "macOS x86_64 (Intel) binaries are not published as CodeIndex-osx-x64.tar.gz. Official release assets are published for $(published_release_rids). Install via 'dotnet tool install -g cdidx' with the .NET SDK, build from source with 'dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r osx-x64 --self-contained true', or request official platform support at $(platform_support_request_url). See https://github.com/${REPO}/blob/main/docs/platform-support.md."
     fi
+
+    validate_published_release_rid
 
     # Reject musl-based Linux (e.g. Alpine) — published binaries require glibc
     # musl系Linux（Alpine等）を拒否 — リリースバイナリはglibcが必要

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -1846,6 +1846,29 @@ public sealed class InstallScriptTests : IDisposable
         Assert.Contains("linux-x86, osx-x64, and win-x86 are not currently shipped", stderr);
         Assert.Contains("dotnet tool install -g cdidx", stderr);
         Assert.Contains("dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r <rid> --self-contained true", stderr);
+        Assert.Contains("issues/new?title=Request%20official%20release%20asset%20for%20RID", stderr);
+        Assert.Contains("docs/platform-support.md", stderr);
+    }
+
+    [Fact]
+    public void ValidatePublishedReleaseRid_UnsupportedResolvedRid_FailsBeforeDownloadWithActionableGuidance()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (exitCode, _, stderr) = RunInstallerSnippet(
+            """
+            RID="linux-arm"
+            validate_published_release_rid
+            """,
+            enforceStrictMode: false);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unsupported release asset RID: linux-arm", stderr);
+        Assert.Contains("linux-x64, linux-arm64, osx-arm64, win-x64, win-arm64", stderr);
+        Assert.Contains("dotnet tool install -g cdidx", stderr);
+        Assert.Contains("dotnet publish src/CodeIndex/CodeIndex.csproj -c Release -r linux-arm --self-contained true", stderr);
+        Assert.Contains("issues/new?title=Request%20official%20release%20asset%20for%20RID", stderr);
         Assert.Contains("docs/platform-support.md", stderr);
     }
 


### PR DESCRIPTION
## Summary

- Validate the installer-detected RID against the published release asset list before any release download.
- Expand unsupported RID guidance with the detected RID, supported list, install/build alternatives, and platform-support issue link.
- Document the behavior and add the bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter InstallScriptTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `docs/platform-support.md`.
- Updated `DEVELOPER_GUIDE.md`.
- Added `changelog.d/unreleased/1601.fixed.md`.

## Follow-up Candidates

- None.

Fixes #1601
