### PR TITLE
Fix ASCII spinner fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ with `--files`, `--commits`, or `--changed-between <old-ref> <new-ref>` instead
 of rebuilding; see
 [Quick Start](USER_GUIDE.md#quick-start) and
 [Incremental update reliability](USER_GUIDE.md#incremental-update-reliability).
-Terminals that request ASCII-only output with `--ascii`, `CDIDX_ASCII=1`, or a
-`LANG=C` / `POSIX` locale render progress with `#` / `-` bars instead of
-Unicode block glyphs. Very narrow Unicode-capable terminals show a
-percentage-only progress line so the display does not wrap.
+Terminals that request ASCII-only output with `--ascii`, `CDIDX_ASCII=1`,
+`NO_UNICODE`, `TERM=dumb`, accessibility env hints, or a non-UTF-8 locale render
+spinner frames as `|` / `/` / `-` / `\` and progress bars with `#` / `-` instead
+of Unicode glyphs. Very narrow Unicode-capable terminals show a percentage-only
+progress line so the display does not wrap.
 
 Use `cdidx` when a repository will be searched repeatedly from terminals,
 scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
@@ -215,10 +216,10 @@ cdidx mcp
 [クイックスタート](USER_GUIDE.md#クイックスタート) と
 [インクリメンタル更新の信頼性](USER_GUIDE.md#インクリメンタル更新の信頼性)
 を参照してください。
-`--ascii`、`CDIDX_ASCII=1`、または `LANG=C` / `POSIX` locale により ASCII-only
-出力が要求されている端末では、進捗バーは Unicode のブロック文字ではなく
-`#` / `-` で描画されます。Unicode を利用できる端末でも幅が非常に狭い場合は、
-折り返しを避けるため percentage-only の進捗行を表示します。
+`--ascii`、`CDIDX_ASCII=1`、`NO_UNICODE`、`TERM=dumb`、accessibility 系の環境変数、
+または非 UTF-8 locale により ASCII-only 出力が要求されている端末では、スピナーは
+`|` / `/` / `-` / `\`、進捗バーは `#` / `-` で描画されます。Unicode を利用できる端末でも
+幅が非常に狭い場合は、折り返しを避けるため percentage-only の進捗行を表示します。
 
 ターミナル、スクリプト、CI、AI ツールから同じリポジトリを繰り返し検索する
 場合は `cdidx` が向いています。1回限りのテキスト検索には `rg` が向いています。

--- a/changelog.d/unreleased/1767.fixed.md
+++ b/changelog.d/unreleased/1767.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1767
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - README.md
+---
+
+## English
+
+- **Progress spinners now fall back to ASCII on non-Unicode terminals (#1767)** — `cdidx` now uses `|` / `/` / `-` / `\` spinner frames when `--ascii`, `CDIDX_ASCII=1`, `NO_UNICODE`, `TERM=dumb`, accessibility environment hints, or a non-UTF-8 locale indicates Unicode glyphs may render poorly.
+
+## 日本語
+
+- **非 Unicode 端末では進捗スピナーが ASCII にフォールバックするようになりました (#1767)** — `--ascii`、`CDIDX_ASCII=1`、`NO_UNICODE`、`TERM=dumb`、accessibility 系の環境変数、または非 UTF-8 locale により Unicode glyph の表示が不安定と判断できる場合、`cdidx` は `|` / `/` / `-` / `\` のスピナーを使います。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -101,6 +101,7 @@ public static class ConsoleUi
         "⠋", "⠙", "⠹", "⠸", "⠼",
         "⠴", "⠦", "⠧", "⠇", "⠏",
     ];
+    private static readonly string[] AsciiSpinnerFrames = ["|", "/", "-", "\\"];
 
     internal static string Counted(int count, string singular, string? plural = null, string? format = null)
     {
@@ -225,8 +226,13 @@ public static class ConsoleUi
     /// Get spinner frames based on easter egg flag.
     /// イースターエッグフラグに基づくスピナーフレームを取得。
     /// </summary>
-    public static string[] GetSpinnerFrames(string? easterEgg) => easterEgg switch
+    public static string[] GetSpinnerFrames(string? easterEgg)
     {
+        if (!ShouldUseUnicodeGlyphs())
+            return AsciiSpinnerFrames;
+
+        return easterEgg switch
+        {
         "--sushi" =>
         [
             "\U0001f363 Slicing       ", "\U0001f363 Slicing.      ", "\U0001f363 Slicing..     ", "\U0001f363 Slicing...    ",
@@ -276,8 +282,9 @@ public static class ConsoleUi
             "\U0001f943 Slainte!      ",
         ],
         // Default: Braille spinner / デフォルト: ブレイルスピナー
-        _ => DefaultBrailleSpinnerFrames,
-    };
+            _ => DefaultBrailleSpinnerFrames,
+        };
+    }
 
     // --- Progress bar / プログレスバー ---
 
@@ -601,7 +608,7 @@ public static class ConsoleUi
         Console.WriteLine("  --debounce <ms>            Watch only: coalesce bursts of file events into one update after <ms> of quiet (default: 500)");
         Console.WriteLine("  --color <when>             Color output: `auto` (default), `always`, or `never`; flag wins over `CLICOLOR_FORCE` / `NO_COLOR` / `CLICOLOR` env vars, which win over TTY auto-detect");
         Console.WriteLine("  --palette <name>           ANSI palette: `basic` (8-color, default fallback), `256`, or `truecolor`; flag wins over `CDIDX_COLOR_PALETTE` env var, which wins over `COLORTERM` / `TERM` auto-detect");
-        Console.WriteLine("  --ascii                    Use ASCII progress glyphs (`#` / `-`) instead of Unicode block glyphs (also honors CDIDX_ASCII=1 and LANG=C/POSIX)");
+        Console.WriteLine("  --ascii                    Use ASCII spinner/progress glyphs instead of Unicode glyphs (also honors CDIDX_ASCII=1, NO_UNICODE, TERM=dumb, accessibility env hints, and non-UTF-8 locales)");
         Console.WriteLine("  --metrics <path>           Append one JSONL record per CLI command / MCP tool call to <path> (also honors CDIDX_METRICS=<path>)");
         Console.WriteLine("  --help, -h                 Show this help message");
         Console.WriteLine("  --version, -V              Show version information");
@@ -1510,6 +1517,13 @@ public static class ConsoleUi
         if (IsAsciiOutputRequested())
             return false;
 
+        if (IsDumbTerminal())
+            return false;
+
+        var locale = FirstNonEmptyEnvironmentVariable("LC_ALL", "LC_CTYPE", "LANG");
+        if (locale != null && !IsUnicodeLocale(locale))
+            return false;
+
         return Console.OutputEncoding.CodePage == Encoding.UTF8.CodePage
             || Console.OutputEncoding.CodePage == Encoding.Unicode.CodePage;
     }
@@ -1523,15 +1537,46 @@ public static class ConsoleUi
         if (!string.IsNullOrEmpty(ascii) && ascii != "0")
             return true;
 
+        var noUnicode = Environment.GetEnvironmentVariable("NO_UNICODE");
+        if (!string.IsNullOrEmpty(noUnicode) && noUnicode != "0")
+            return true;
+
+        var atBridgeType = Environment.GetEnvironmentVariable("AT_BRIDGE_TYPE");
+        if (!string.IsNullOrEmpty(atBridgeType))
+            return true;
+
+        var accessibilityEnabled = Environment.GetEnvironmentVariable("ACCESSIBILITY_ENABLED");
+        if (!string.IsNullOrEmpty(accessibilityEnabled) && accessibilityEnabled != "0")
+            return true;
+
         return IsPosixLocale(Environment.GetEnvironmentVariable("LC_ALL"))
             || IsPosixLocale(Environment.GetEnvironmentVariable("LC_CTYPE"))
             || IsPosixLocale(Environment.GetEnvironmentVariable("LANG"));
     }
 
+    private static bool IsDumbTerminal()
+        => string.Equals(Environment.GetEnvironmentVariable("TERM"), "dumb", StringComparison.OrdinalIgnoreCase);
+
     private static bool IsPosixLocale(string? locale)
         => locale != null
             && (locale.Equals("C", StringComparison.OrdinalIgnoreCase)
                 || locale.Equals("POSIX", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsUnicodeLocale(string locale)
+        => locale.Contains(".UTF-8", StringComparison.OrdinalIgnoreCase)
+            || locale.Contains(".UTF8", StringComparison.OrdinalIgnoreCase);
+
+    private static string? FirstNonEmptyEnvironmentVariable(params string[] names)
+    {
+        foreach (var name in names)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrEmpty(value))
+                return value;
+        }
+
+        return null;
+    }
 
     internal static void SetAsciiOutput(bool enabled) => _asciiOutputForced = enabled;
 

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -928,8 +928,10 @@ public class ConsoleUiTests
             var originalNoUnicode = Environment.GetEnvironmentVariable("NO_UNICODE");
             var originalAtBridgeType = Environment.GetEnvironmentVariable("AT_BRIDGE_TYPE");
             var originalAccessibilityEnabled = Environment.GetEnvironmentVariable("ACCESSIBILITY_ENABLED");
+            var originalOutputEncoding = Console.OutputEncoding;
             try
             {
+                Console.OutputEncoding = Encoding.UTF8;
                 Environment.SetEnvironmentVariable("CDIDX_ASCII", cdidxAscii);
                 Environment.SetEnvironmentVariable("LANG", lang);
                 Environment.SetEnvironmentVariable("LC_ALL", null);
@@ -950,6 +952,7 @@ public class ConsoleUiTests
                 Environment.SetEnvironmentVariable("NO_UNICODE", originalNoUnicode);
                 Environment.SetEnvironmentVariable("AT_BRIDGE_TYPE", originalAtBridgeType);
                 Environment.SetEnvironmentVariable("ACCESSIBILITY_ENABLED", originalAccessibilityEnabled);
+                Console.OutputEncoding = originalOutputEncoding;
             }
         }
     }

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -52,7 +52,7 @@ public class ConsoleUiTests
         Assert.Contains("--commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)", output);
         Assert.Contains("--files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed", output);
         Assert.Contains("--duration-format <format> Index elapsed time format: `auto` (default), `seconds`, or `hms`; JSON keeps raw elapsed_ms", output);
-        Assert.Contains("--ascii                    Use ASCII progress glyphs", output);
+        Assert.Contains("--ascii                    Use ASCII spinner/progress glyphs", output);
         Assert.Contains("cdidx excerpt <path> --start <line> [--end <line>] [--before <n>] [--after <n>] [--max-line-width <n>] [--focus-line <line>] [--focus-column <n>] [--focus-length <n>] [--db <path>] [--json]", output);
         Assert.Contains("--focus-column <n>         excerpt: column to keep centered when clamping (must be within the focused line)", output);
         Assert.Contains("--focus-line <line>        excerpt: line whose focused column should stay visible", output);
@@ -136,9 +136,39 @@ public class ConsoleUiTests
     [Fact]
     public void GetSpinnerFrames_Default_UsesRotatingBrailleSequence()
     {
-        var frames = ConsoleUi.GetSpinnerFrames(null);
+        WithUnicodeEnvironment(cdidxAscii: null, lang: "en_US.UTF-8", () =>
+        {
+            var frames = ConsoleUi.GetSpinnerFrames(null);
 
-        Assert.Equal(["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"], frames);
+            Assert.Equal(["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"], frames);
+        });
+    }
+
+    [Fact]
+    public void GetSpinnerFrames_CdidxAsciiEnvVar_UsesAsciiSequence()
+    {
+        WithUnicodeEnvironment(cdidxAscii: "1", lang: "en_US.UTF-8", () =>
+        {
+            Assert.Equal(["|", "/", "-", "\\"], ConsoleUi.GetSpinnerFrames(null));
+        });
+    }
+
+    [Fact]
+    public void GetSpinnerFrames_PosixLang_UsesAsciiSequence()
+    {
+        WithUnicodeEnvironment(cdidxAscii: null, lang: "C", () =>
+        {
+            Assert.Equal(["|", "/", "-", "\\"], ConsoleUi.GetSpinnerFrames(null));
+        });
+    }
+
+    [Fact]
+    public void GetSpinnerFrames_AsciiOverrideWinsOverThemedSpinner()
+    {
+        WithUnicodeEnvironment(cdidxAscii: "1", lang: "en_US.UTF-8", () =>
+        {
+            Assert.Equal(["|", "/", "-", "\\"], ConsoleUi.GetSpinnerFrames("--sushi"));
+        });
     }
 
     [Fact]
@@ -184,6 +214,42 @@ public class ConsoleUiTests
     public void ShouldUseUnicodeGlyphs_PosixLangDisablesUnicode()
     {
         WithUnicodeEnvironment(cdidxAscii: null, lang: "C", () =>
+        {
+            Assert.False(ConsoleUi.ShouldUseUnicodeGlyphs());
+        });
+    }
+
+    [Fact]
+    public void ShouldUseUnicodeGlyphs_NonUtf8LangDisablesUnicode()
+    {
+        WithUnicodeEnvironment(cdidxAscii: null, lang: "en_US", () =>
+        {
+            Assert.False(ConsoleUi.ShouldUseUnicodeGlyphs());
+        });
+    }
+
+    [Fact]
+    public void ShouldUseUnicodeGlyphs_DumbTerminalDisablesUnicode()
+    {
+        WithUnicodeEnvironment(cdidxAscii: null, lang: "en_US.UTF-8", term: "dumb", action: () =>
+        {
+            Assert.False(ConsoleUi.ShouldUseUnicodeGlyphs());
+        });
+    }
+
+    [Fact]
+    public void ShouldUseUnicodeGlyphs_NoUnicodeEnvVarDisablesUnicode()
+    {
+        WithUnicodeEnvironment(cdidxAscii: null, lang: "en_US.UTF-8", noUnicode: "1", action: () =>
+        {
+            Assert.False(ConsoleUi.ShouldUseUnicodeGlyphs());
+        });
+    }
+
+    [Fact]
+    public void ShouldUseUnicodeGlyphs_AccessibilityEnvVarDisablesUnicode()
+    {
+        WithUnicodeEnvironment(cdidxAscii: null, lang: "en_US.UTF-8", accessibilityEnabled: "1", action: () =>
         {
             Assert.False(ConsoleUi.ShouldUseUnicodeGlyphs());
         });
@@ -843,7 +909,14 @@ public class ConsoleUiTests
         }
     }
 
-    private static void WithUnicodeEnvironment(string? cdidxAscii, string? lang, Action action)
+    private static void WithUnicodeEnvironment(
+        string? cdidxAscii,
+        string? lang,
+        Action action,
+        string? term = null,
+        string? noUnicode = null,
+        string? atBridgeType = null,
+        string? accessibilityEnabled = null)
     {
         lock (TestConsoleLock.Gate)
         {
@@ -851,12 +924,20 @@ public class ConsoleUiTests
             var originalLang = Environment.GetEnvironmentVariable("LANG");
             var originalLcAll = Environment.GetEnvironmentVariable("LC_ALL");
             var originalLcCType = Environment.GetEnvironmentVariable("LC_CTYPE");
+            var originalTerm = Environment.GetEnvironmentVariable("TERM");
+            var originalNoUnicode = Environment.GetEnvironmentVariable("NO_UNICODE");
+            var originalAtBridgeType = Environment.GetEnvironmentVariable("AT_BRIDGE_TYPE");
+            var originalAccessibilityEnabled = Environment.GetEnvironmentVariable("ACCESSIBILITY_ENABLED");
             try
             {
                 Environment.SetEnvironmentVariable("CDIDX_ASCII", cdidxAscii);
                 Environment.SetEnvironmentVariable("LANG", lang);
                 Environment.SetEnvironmentVariable("LC_ALL", null);
                 Environment.SetEnvironmentVariable("LC_CTYPE", null);
+                Environment.SetEnvironmentVariable("TERM", term);
+                Environment.SetEnvironmentVariable("NO_UNICODE", noUnicode);
+                Environment.SetEnvironmentVariable("AT_BRIDGE_TYPE", atBridgeType);
+                Environment.SetEnvironmentVariable("ACCESSIBILITY_ENABLED", accessibilityEnabled);
                 action();
             }
             finally
@@ -865,6 +946,10 @@ public class ConsoleUiTests
                 Environment.SetEnvironmentVariable("LANG", originalLang);
                 Environment.SetEnvironmentVariable("LC_ALL", originalLcAll);
                 Environment.SetEnvironmentVariable("LC_CTYPE", originalLcCType);
+                Environment.SetEnvironmentVariable("TERM", originalTerm);
+                Environment.SetEnvironmentVariable("NO_UNICODE", originalNoUnicode);
+                Environment.SetEnvironmentVariable("AT_BRIDGE_TYPE", originalAtBridgeType);
+                Environment.SetEnvironmentVariable("ACCESSIBILITY_ENABLED", originalAccessibilityEnabled);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add ASCII spinner frames and route spinner selection through the existing Unicode/ASCII output policy.
- Expand Unicode fallback detection for `NO_UNICODE`, `TERM=dumb`, accessibility environment hints, and non-UTF-8 locales.
- Update README/help text and add focused ConsoleUi coverage for the fallback behavior.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ConsoleUiTests`
- `dotnet build`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll --ascii index . --dry-run`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

Full `dotnet test` was started but did not complete in a bounded local run, so it was stopped; the focused ConsoleUi test class passed.

## Documentation and Changelog

- Updated `README.md`.
- Added `changelog.d/unreleased/1767.fixed.md`.

Fixes #1767
