### PR TITLE
Fix Scala object symbol extraction

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -269,6 +269,10 @@ TypeScript decorators emit `annotation` rows for the decorator name and must not
 
 Python extraction uses `function` for ordinary functions and methods, `class` for class declarations and dynamic class factories, `property` for class attributes, `@property` descriptors, accessor decorators, `Final` constants, and walrus-assigned names, and `class_hook` for lifecycle dunder hooks such as `__init_subclass__`, `__class_getitem__`, `__set_name__`, and `__class_subclasses__`. `SubKind` refines Python property accessors as `getter` / `setter` / `deleter`, walrus assignments as `walrus`, and class hooks as `dunder`.
 
+### Scala symbol taxonomy
+
+Scala extraction uses `class` for `class` / `case class` declarations and `object` for singleton `object`, `case object`, and sealed-object declarations. When a top-level `object X` appears in the same file as a top-level `class X`, `SubKind` records `companion_object` on the object and `has_companion_object` on the class so inspect/outline consumers can show the companion relationship without treating the singleton as an instantiable class (#1823, related taxonomy tracking in #1772).
+
 ### Extending reference extraction
 
 Reference extraction is routed through `IReferenceExtractor` instances keyed by normalized language strings. Use `ReferenceExtractor.TryGetExtractor(language, out var extractor)` when a caller needs to invoke a language extractor directly; aliases such as `vue` / `svelte` normalize to `typescript`, and `razor` / `blazor` / `cshtml` normalize to `csharp`. The public `ReferenceExtractor.Extract(...)` method remains the compatibility entry point and delegates through the same registry.
@@ -1770,6 +1774,10 @@ files 1──N symbol_references
 | `attribute`, `annotation`, `type_reference`, `implicit_implementation` | raw label | 依存関係 / reference 専用の metadata、型位置エッジ、および C# async iterator の `GetAsyncEnumerator` / `MoveNextAsync` のようなコンパイラ合成の実装エッジ。既定の call-graph 行からは除外する。 |
 
 TypeScript decorator は decorator 名を `annotation` 行として出力し、decorated declaration の型位置エッジを隠してはならない。たとえば `constructor(@Inject() svc: Service)` は `Inject` を `annotation`、`Service` を `type_reference` として記録し、`@Input() profile: UserProfile` も decorator と field type の両方を記録する。
+
+### Scala symbol taxonomy
+
+Scala 抽出は `class` / `case class` 宣言を `class`、singleton の `object` / `case object` / sealed object 宣言を `object` として記録する。同じファイルに top-level の `class X` と top-level の `object X` がある場合、`SubKind` は object 側に `companion_object`、class 側に `has_companion_object` を記録し、singleton をインスタンス化可能な class と扱わずに inspect / outline consumer が companion 関係を表示できるようにする (#1823、taxonomy tracking は #1772 に関連)。
 
 ### TypeScript type-graph extraction
 

--- a/changelog.d/unreleased/1823.fixed.md
+++ b/changelog.d/unreleased/1823.fixed.md
@@ -3,7 +3,11 @@ category: fixed
 issues:
   - 1823
 affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
   - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
   - tests/CodeIndex.Tests/SymbolExtractorTests.cs
   - DEVELOPER_GUIDE.md
 ---

--- a/changelog.d/unreleased/1823.fixed.md
+++ b/changelog.d/unreleased/1823.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1823
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Scala singleton objects now use the `object` symbol kind (#1823)** — top-level `object`, `case object`, and sealed-object declarations are no longer indexed as generic classes, and same-file class/object companions are marked through `SubKind`.
+
+## 日本語
+
+- **Scala の singleton object を `object` symbol kind として記録するようになりました (#1823)** — top-level の `object`、`case object`、sealed object 宣言を generic class として index しなくなり、同一ファイルの class/object companion は `SubKind` で示します。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4358,6 +4358,7 @@ public static class QueryCommandRunner
         "method",
         "module",
         "namespace",
+        "object",
         "operator",
         "procedure",
         "property",

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1117,7 +1117,7 @@ public static partial class ReferenceExtractor
             .Where(symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null &&
                               (IsFunctionLikeSymbolKind(symbol.Kind) || symbol.Kind == "hook" || symbol.Kind == "class"
                                || symbol.Kind == "struct" || symbol.Kind == "namespace"
-                               || symbol.Kind == "property" || symbol.Kind == "class_hook"))
+                               || symbol.Kind == "object" || symbol.Kind == "property" || symbol.Kind == "class_hook"))
             .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
             .ToList();
         var containerResolver = new InnermostContainerResolver(containerCandidates);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1666,7 +1666,8 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?<visibility>private|protected)?\s*(?:override\s+)?def\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("interface", new Regex(@"^\s*(?<visibility>private|protected)?\s*(?:sealed\s+)?trait\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("enum",     new Regex(@"^\s*(?<visibility>private|protected)?\s*enum\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("class",    new Regex(@"^\s*(?<visibility>private|protected)?\s*(?:abstract\s+|sealed\s+|final\s+)?(?:case\s+)?(?:class|object)\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex(@"^\s*(?<visibility>private|protected)?\s*(?:abstract\s+|sealed\s+|final\s+)?(?:case\s+)?class\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("object",   new Regex(@"^\s*(?<visibility>private|protected)?\s*(?:sealed\s+|final\s+)?(?:case\s+)?object\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("import",   new Regex(@"^\s*type\s+(?<name>\w+)\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*import\s+(?<name>.+)", RegexOptions.Compiled), BodyStyle.None),
         ],
@@ -2083,7 +2084,7 @@ public static partial class SymbolExtractor
 
     private static readonly HashSet<string> ContainerKinds =
     [
-        "class", "struct", "interface", "namespace", "enum", "heading", "specialization", "class_hook"
+        "class", "struct", "interface", "namespace", "enum", "object", "heading", "specialization", "class_hook"
     ];
 
     /// <summary>
@@ -3930,11 +3931,35 @@ public static partial class SymbolExtractor
         MaterializeRecordPrimaryComponentSymbols(symbols, pendingRecordPrimaryComponents);
         if (lang is "javascript" or "typescript")
             ClassifyJavaScriptTypeScriptReactHooks(symbols);
+        if (lang == "scala")
+            ClassifyScalaCompanions(symbols);
         KotlinSymbolNameNormalizer.NormalizeSecondaryConstructorNames(symbols);
         if (lang == "shell")
             ExpandShellAliasSymbols(fileId, lines, symbols);
         PopulateDeclaredContainerQualifiedNames(symbols);
         return symbols;
+    }
+
+    private static void ClassifyScalaCompanions(List<SymbolRecord> symbols)
+    {
+        var topLevelClasses = symbols
+            .Where(symbol => symbol.Kind == "class"
+                && string.IsNullOrWhiteSpace(symbol.ContainerKind)
+                && !string.IsNullOrWhiteSpace(symbol.Name))
+            .GroupBy(symbol => symbol.Name, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.Ordinal);
+
+        foreach (var scalaObject in symbols.Where(symbol => symbol.Kind == "object"
+                     && string.IsNullOrWhiteSpace(symbol.ContainerKind)
+                     && !string.IsNullOrWhiteSpace(symbol.Name)))
+        {
+            if (!topLevelClasses.TryGetValue(scalaObject.Name, out var companionClasses))
+                continue;
+
+            scalaObject.SubKind ??= "companion_object";
+            foreach (var companionClass in companionClasses)
+                companionClass.SubKind ??= "has_companion_object";
+        }
     }
 
     private static void ClassifyJavaScriptTypeScriptReactHooks(List<SymbolRecord> symbols)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -30374,6 +30374,31 @@ jobs:
     }
 
     [Fact]
+    public void RunSymbols_AcceptsScalaObjectKindFilter()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_scala_object_kind");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/Main.scala", "scala", "object Main {\n  def run(): Unit = ()\n}\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json", "--lang", "scala", "--kind", "object"],
+                _jsonOptions));
+
+            var row = Assert.Single(ParseJsonLines(stdout)).RootElement;
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal("object", row.GetProperty("kind").GetString());
+            Assert.Equal("Main", row.GetProperty("name").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSymbols_PreservesCommonJsMultilineBraceBodyRanges()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_commonjs_multiline_body_ranges");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14257,6 +14257,24 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_ScalaObjectBody_AssignsObjectContainerToCalls()
+    {
+        const string content = """
+            object Main {
+              val config = loadConfig()
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "scala", content);
+        var references = ReferenceExtractor.Extract(1, "scala", content, symbols);
+
+        Assert.Contains(references, r =>
+            r.SymbolName == "loadConfig"
+            && r.ReferenceKind == "call"
+            && r.ContainerKind == "object"
+            && r.ContainerName == "Main");
+    }
+
+    [Fact]
     public void Extract_CsharpEventSubscription_DetectsAsSubscribe()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20263,7 +20263,7 @@ public class SymbolExtractorTests
             """;
         var symbols = SymbolExtractor.Extract(1, "scala", content);
 
-        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Main");
+        Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "Main");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "one" && s.StartLine == 2 && s.EndLine == 2 && s.BodyStartLine == null && s.BodyEndLine == null);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "run" && s.StartLine == 3 && s.EndLine == 5 && s.BodyStartLine == 3 && s.BodyEndLine == 5);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "three" && s.StartLine == 6 && s.EndLine == 6 && s.BodyStartLine == null && s.BodyEndLine == null);
@@ -20271,6 +20271,36 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "UserID");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Message");
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Ping");
+    }
+
+    [Fact]
+    public void Extract_Scala_DetectsCompanionAndSealedObjects()
+    {
+        var content = """
+            package example
+
+            class Config(value: String) {}
+            object Config extends App {
+              def load(): Config = Config("default")
+            }
+
+            object PackageRegistry {
+              def register(): Unit = ()
+            }
+
+            sealed trait Status
+            case object Ready extends Status
+            sealed object Closed extends Status
+            """;
+        var symbols = SymbolExtractor.Extract(1, "scala", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Config" && s.SubKind == "has_companion_object");
+        Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "Config" && s.SubKind == "companion_object");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "load" && s.ContainerKind == "object" && s.ContainerName == "Config");
+        Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "PackageRegistry");
+        Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Status");
+        Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "Ready");
+        Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "Closed");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Split Scala `object` declarations out of the generic `class` symbol kind.
- Mark same-file top-level Scala class/object companions with `SubKind`.
- Preserve `object` as a container for reference attribution and allow `--kind object` queries.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunSymbols_AcceptsScalaObjectKindFilter|FullyQualifiedName~ReferenceExtractorTests.Extract_ScalaObjectBody_AssignsObjectContainerToCalls|FullyQualifiedName~SymbolExtractorTests.Extract_Scala" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build -p:UseSharedCompilation=false`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md` with the Scala symbol taxonomy contract.
- Added `changelog.d/unreleased/1823.fixed.md`.

## Follow-up Candidates

- Follow-up issue: #2446

Fixes #1823
