### PR TITLE
Fix JSON search stream terminator

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -575,7 +575,7 @@ For the AI agent search-rule template, see [AI Integration](USER_GUIDE.md#ai-int
 
 ### Output format
 
-Query commands (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `excerpt`, `map`, `inspect`, `suggestions`) default to **human-readable output**. Use `--json` for JSON lines output (one JSON object per line), designed for easy parsing by AI agents.
+Query commands (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `excerpt`, `map`, `inspect`, `suggestions`) default to **human-readable output**. Use `--json` for JSON lines output (one JSON object per line), designed for easy parsing by AI agents. `search --json` appends a final `{"done":true,"count":N,"interrupted":false}` sentinel after result rows, including zero-result responses, so stream consumers can distinguish a clean end from a truncated/interrupted stream.
 
 Adding `--json-envelope` to a query command (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `excerpt`, `map`, `inspect`, `outline`, `status`, `validate`, `languages`, `impact`, `deps`, `unused`, `hotspots`) wraps the per-line `--json` stream into a single `{"metadata": {...}, "results": [...]}` document. `metadata` carries `api_version`, `command`, `cdidx_version`, `elapsed_ms`, `db_path`, `result_count`, `exit_code`, and (when applicable) `query_normalized` and `indexed_at_head_sha`. The flag implies `--json`, so callers do not need to pass both. The default output remains the legacy NDJSON / array form for one release; the envelope will become the default in the next major release, at which point the flat form will be opt-in via `--json-flat`.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -841,7 +841,7 @@ cdidx report --output report.tgz --json
 | Option | Applies to | Description |
 |---|---|---|
 | `--db <path>` | All commands except `languages`; for `mcp`, only `--db` is supported | Database file path. `index` defaults to `<projectPath>/.cdidx/codeindex.db`; query commands default to `.cdidx/codeindex.db` in the current directory. Query commands without `--db` keep trusting that default `.cdidx/codeindex.db` sibling path, so moving or renaming the current repo does not leave stale workspace metadata behind. For explicit query DBs, workspace metadata such as `project_root`, `git_head`, and `git_is_dirty` comes from the persisted `indexed_project_root` stored in that DB when available. Legacy explicit DBs created before that metadata existed may return those fields as `null` / absent until you rerun `cdidx index <projectPath> --db <path>` or a scoped update that actually commits at least one file delete/update against the intended project, even if the explicit path itself looks like `.../.cdidx/codeindex.db`. |
-| `--json` | All commands except `mcp` | JSON output (for AI/machine use) |
+| `--json` | All commands except `mcp` | JSON output (for AI/machine use). `search --json` writes newline-delimited result objects followed by a final `{"done":true,"count":N,"interrupted":false}` sentinel, including zero-result output, so stream consumers can detect clean completion. |
 | `--status <all\|submitted\|unsubmitted>` | `suggestions` | Filter local suggestion history by GitHub submission state. |
 | `--language <lang>` / `--lang <lang>` | `suggestions` | Filter local suggestion history by recorded target language. |
 | `--category <category>` | `suggestions` | Filter local suggestion history by suggestion category. |

--- a/changelog.d/unreleased/1659.fixed.md
+++ b/changelog.d/unreleased/1659.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 1659
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+  - tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
+  - DEVELOPER_GUIDE.md
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`search --json` now ends clean streams with a done sentinel (#1659)** — result streams now append `{"done":true,"count":N,"interrupted":false}`, including zero-result output, so consumers can distinguish clean completion from truncated output.
+
+## 日本語
+
+- **`search --json` が正常終了時に done sentinel を出力するようになりました (#1659)** — 結果ストリームの末尾に `{"done":true,"count":N,"interrupted":false}` を追加し、ゼロ件出力でも正常終了と途中で切れた出力を判別できるようになりました。

--- a/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+++ b/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
@@ -183,11 +183,25 @@ internal static class JsonEnvelopeWrapper
 
             if (node is null)
                 continue;
+            if (IsJsonStreamDoneSentinel(node))
+                continue;
 
             array.Add(node);
         }
 
         return array;
+    }
+
+    private static bool IsJsonStreamDoneSentinel(JsonNode node)
+    {
+        if (node is not JsonObject obj)
+            return false;
+        return obj.TryGetPropertyValue("done", out var doneNode)
+            && doneNode is JsonValue doneValue
+            && doneValue.TryGetValue<bool>(out var done)
+            && done
+            && obj.TryGetPropertyValue("interrupted", out _)
+            && obj.TryGetPropertyValue("count", out _);
     }
 
     // Mirrors the value-taking options in QueryCommandRunner.ParseArgs so we can locate the

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -59,6 +59,11 @@ internal sealed record QueryPathErrorJsonResult(
     [property: JsonPropertyName("path")] string Path,
     [property: JsonPropertyName("error")] string Error);
 
+internal sealed record JsonStreamDoneResult(
+    [property: JsonPropertyName("done")] bool Done,
+    [property: JsonPropertyName("count")] int Count,
+    [property: JsonPropertyName("interrupted")] bool Interrupted);
+
 internal sealed record LanguageEntryJsonResult(
     [property: JsonPropertyName("lang")] string Lang,
     [property: JsonPropertyName("extensions")] List<string> Extensions,
@@ -239,6 +244,7 @@ internal sealed record VersionInfoJsonResult(
 [JsonSerializable(typeof(IndexUpdateSummaryJsonResult))]
 [JsonSerializable(typeof(IndexWatchEventJsonResult))]
 [JsonSerializable(typeof(HookCommandJsonResult))]
+[JsonSerializable(typeof(JsonStreamDoneResult))]
 [JsonSerializable(typeof(LanguageEntryJsonResult))]
 [JsonSerializable(typeof(LanguagesJsonResult))]
 [JsonSerializable(typeof(List<CalleeResult>))]

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -366,7 +366,10 @@ public static class QueryCommandRunner
             if (results.Count == 0)
             {
                 if (options.Json)
+                {
                     Console.WriteLine(BuildJsonZeroResultPayload(reader, jsonOptions, resultsKey: "results", query: options.Query, queryOptions: options).ToJsonString(jsonOptions));
+                    WriteJsonStreamDone(0, jsonOptions);
+                }
                 else if (!options.Json)
                 {
                     Console.Error.WriteLine(BuildZeroResultLine("No results found", options));
@@ -382,6 +385,7 @@ public static class QueryCommandRunner
                     Console.WriteLine(JsonSerializer.Serialize(
                         SearchSnippetFormatter.ToCompactResult(r, options.Query, options.SnippetLines, exact, options.MaxLineWidth, r.Lang, options.SnippetFocus),
                         CliJsonSerializerContextFactory.Create(jsonOptions).CompactSearchResult));
+                WriteJsonStreamDone(results.Count, jsonOptions);
             }
             else
             {
@@ -399,6 +403,11 @@ public static class QueryCommandRunner
             return CommandExitCodes.Success;
         });
     }
+
+    private static void WriteJsonStreamDone(int count, JsonSerializerOptions jsonOptions)
+        => Console.WriteLine(JsonSerializer.Serialize(
+            new JsonStreamDoneResult(Done: true, Count: count, Interrupted: false),
+            CliJsonSerializerContextFactory.Create(jsonOptions).JsonStreamDoneResult));
 
     public static int RunDefinition(string[] cmdArgs, JsonSerializerOptions jsonOptions)
     {

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -343,6 +343,7 @@ public static class QueryCommandRunner
         if (TryWriteUnexpectedExtraPositionals("search", options))
             return CommandExitCodes.UsageError;
 
+        int? jsonDoneCount = null;
         return WithDb(options, jsonOptions, reader =>
         {
             if (options.CountOnly)
@@ -368,7 +369,7 @@ public static class QueryCommandRunner
                 if (options.Json)
                 {
                     Console.WriteLine(BuildJsonZeroResultPayload(reader, jsonOptions, resultsKey: "results", query: options.Query, queryOptions: options).ToJsonString(jsonOptions));
-                    WriteJsonStreamDone(0, jsonOptions);
+                    jsonDoneCount = 0;
                 }
                 else if (!options.Json)
                 {
@@ -385,7 +386,7 @@ public static class QueryCommandRunner
                     Console.WriteLine(JsonSerializer.Serialize(
                         SearchSnippetFormatter.ToCompactResult(r, options.Query, options.SnippetLines, exact, options.MaxLineWidth, r.Lang, options.SnippetFocus),
                         CliJsonSerializerContextFactory.Create(jsonOptions).CompactSearchResult));
-                WriteJsonStreamDone(results.Count, jsonOptions);
+                jsonDoneCount = results.Count;
             }
             else
             {
@@ -401,6 +402,10 @@ public static class QueryCommandRunner
                 Console.Error.WriteLine($"({results.Count} results in {fileCount} files)");
             }
             return CommandExitCodes.Success;
+        }, exitCode =>
+        {
+            if (options.Json && jsonDoneCount.HasValue)
+                WriteJsonStreamDone(jsonDoneCount.Value, jsonOptions);
         });
     }
 
@@ -4150,7 +4155,7 @@ public static class QueryCommandRunner
     // preview 系オプションの検証はコマンド別 allowlist に寄せたため、この shim は常に null を返す。
     private static string? ValidatePreviewOptions(string commandName, string[] args, bool allowMaxLineWidth, bool allowFocusOptions) => null;
 
-    private static int WithDb(QueryCommandOptions options, JsonSerializerOptions jsonOptions, Func<DbReader, int> action)
+    private static int WithDb(QueryCommandOptions options, JsonSerializerOptions jsonOptions, Func<DbReader, int> action, Action<int>? afterProfile = null)
     {
         var dbPath = options.DbPath;
         if (s_batchReader == null)
@@ -4199,6 +4204,7 @@ public static class QueryCommandRunner
             var profileEntries = profiling ? Database.DbDebug.EndProfile() : [];
             if (options.Profile)
                 WriteProfilePayload(profileEntries, jsonOptions);
+            afterProfile?.Invoke(exitCode);
             return exitCode;
         }
         catch (FtsQuerySyntaxException ex)

--- a/tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
+++ b/tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
@@ -163,12 +163,52 @@ public class JsonEnvelopeWrapperTests
                 "1.0.0"));
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
-            // Legacy default: each result on its own line, no envelope wrapper.
-            // 既存 default: 1 結果 1 行、envelope は付かない。
+            // Legacy default: results remain newline-delimited JSON, followed by a done sentinel.
+            // 既存 default: 結果は newline-delimited JSON のまま、最後に done sentinel が付く。
             Assert.DoesNotContain("\"metadata\"", stdout);
             Assert.DoesNotContain("\"results\"", stdout);
-            using var document = JsonDocument.Parse(stdout.Trim());
-            Assert.Equal("src/App.cs", document.RootElement.GetProperty("path").GetString());
+            var lines = stdout.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(2, lines.Length);
+            using var resultDocument = JsonDocument.Parse(lines[0]);
+            Assert.Equal("src/App.cs", resultDocument.RootElement.GetProperty("path").GetString());
+            using var doneDocument = JsonDocument.Parse(lines[1]);
+            Assert.True(doneDocument.RootElement.GetProperty("done").GetBoolean());
+            Assert.Equal(1, doneDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.False(doneDocument.RootElement.GetProperty("interrupted").GetBoolean());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Search_WithoutEnvelope_ZeroResultsEmitsDoneSentinel()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("envelope_legacy_zero_done");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/App.cs",
+                "csharp",
+                "class App {}\n");
+
+            var (exitCode, stdout, _) = CaptureConsole(() => ProgramRunner.Run(
+                ["search", "DoesNotExist_xyz_123", "--db", dbPath, "--json"],
+                _jsonOptions,
+                "1.0.0"));
+
+            Assert.Equal(CommandExitCodes.NotFound, exitCode);
+            var lines = stdout.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(2, lines.Length);
+            using var zeroDocument = JsonDocument.Parse(lines[0]);
+            Assert.Equal(0, zeroDocument.RootElement.GetProperty("count").GetInt32());
+            using var doneDocument = JsonDocument.Parse(lines[1]);
+            Assert.True(doneDocument.RootElement.GetProperty("done").GetBoolean());
+            Assert.Equal(0, doneDocument.RootElement.GetProperty("count").GetInt32());
+            Assert.False(doneDocument.RootElement.GetProperty("interrupted").GetBoolean());
         }
         finally
         {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -210,6 +210,7 @@ public class QueryCommandRunnerTests
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
                 ["Authenticate", "--db", dbPath, "--json", "--profile", "--slow-query-ms", "0"],
                 _jsonOptions));
+            var rawLines = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var lines = stdout
                 .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Where(line =>
@@ -221,6 +222,10 @@ public class QueryCommandRunnerTests
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
+            using (var doneDocument = JsonDocument.Parse(rawLines[^1]))
+            {
+                Assert.True(IsJsonStreamDoneSentinel(doneDocument.RootElement));
+            }
             Assert.Equal(2, lines.Length);
 
             using var resultDocument = JsonDocument.Parse(lines[0]);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -210,7 +210,14 @@ public class QueryCommandRunnerTests
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
                 ["Authenticate", "--db", dbPath, "--json", "--profile", "--slow-query-ms", "0"],
                 _jsonOptions));
-            var lines = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var lines = stdout
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(line =>
+                {
+                    using var document = JsonDocument.Parse(line);
+                    return !IsJsonStreamDoneSentinel(document.RootElement);
+                })
+                .ToArray();
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
@@ -267,13 +274,13 @@ public class QueryCommandRunnerTests
             var (exitCode, stdout, stderr) = CaptureConsoleWithInput(
                 input,
                 () => QueryCommandRunner.RunBatch(["--db", dbPath], _jsonOptions));
-            var lines = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var lines = ParseJsonLines(stdout);
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
-            Assert.Equal(2, lines.Length);
-            using var searchDocument = JsonDocument.Parse(lines[0]);
-            using var symbolDocument = JsonDocument.Parse(lines[1]);
+            Assert.Equal(2, lines.Count);
+            using var searchDocument = lines[0];
+            using var symbolDocument = lines[1];
             Assert.Equal("src/auth.cs", searchDocument.RootElement.GetProperty("path").GetString());
             Assert.Equal("AuthFixture", symbolDocument.RootElement.GetProperty("name").GetString());
         }
@@ -30862,7 +30869,11 @@ jobs:
     {
         var jsonLine = stdout
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Last();
+            .Last(line =>
+            {
+                using var document = JsonDocument.Parse(line);
+                return !IsJsonStreamDoneSentinel(document.RootElement);
+            });
         return JsonDocument.Parse(jsonLine);
     }
 
@@ -30994,8 +31005,16 @@ jobs:
         return stdout
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(line => JsonDocument.Parse(line))
+            .Where(document => !IsJsonStreamDoneSentinel(document.RootElement))
             .ToList();
     }
+
+    private static bool IsJsonStreamDoneSentinel(JsonElement element)
+        => element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty("done", out var done)
+            && done.ValueKind is JsonValueKind.True
+            && element.TryGetProperty("interrupted", out _)
+            && element.TryGetProperty("count", out _);
 
     private static (string ProjectRoot, string DbPath) CreateUnusedFixtureDb()
     {

--- a/tests/CodeIndex.Tests/golden/search.json
+++ b/tests/CodeIndex.Tests/golden/search.json
@@ -34,3 +34,8 @@
   },
   "score": "\u003CSCORE\u003E"
 }
+{
+  "done": true,
+  "count": 1,
+  "interrupted": false
+}


### PR DESCRIPTION
## Summary

- Add a final `{"done":true,"count":N,"interrupted":false}` sentinel to `search --json` result streams, including zero-result output.
- Keep `--json-envelope` output as a single envelope by filtering the sentinel out of wrapped results.
- Ensure `search --json --profile` emits profile JSON before the final sentinel.

## Validation

- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md` and `USER_GUIDE.md`.
- Added changelog fragment `changelog.d/unreleased/1659.fixed.md`.

## Follow-up Candidates

- None.

Fixes #1659
