### PR TITLE
Add index database diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 - Read commands accept `--profile` to append SQL timing, row-count, and
   `EXPLAIN QUERY PLAN` JSON after the normal result; `--slow-query-ms <n>` logs
   profiled SQL statements that meet the threshold.
+- `cdidx diff <db1> <db2>` compares two index databases for CI or drift
+  debugging, reporting schema, file, symbol, and reference deltas with stable
+  exit codes: `0` identical, `1` drift, `2` schema mismatch, `3` unreadable DB.
 - The documented `status --json` trust contract covers `fold_ready`,
   `fold_ready_reason`, `graph_table_available`, `issues_table_available`,
   `sql_graph_contract_ready`, `sql_graph_contract_degraded_reason`,
@@ -244,6 +247,9 @@ cdidx mcp
 - read 系コマンドは `--profile` で通常結果の後に SQL の時間、行数、
   `EXPLAIN QUERY PLAN` の JSON を追加できます。`--slow-query-ms <n>` は
   閾値以上の profiled SQL をログに記録します。
+- `cdidx diff <db1> <db2>` は CI や drift 調査向けに 2 つの index DB を比較し、
+  schema、file、symbol、reference の差分を報告します。exit code は `0` identical、
+  `1` drift、`2` schema mismatch、`3` unreadable DB です。
 - 文書化された `status --json` trust contract は `fold_ready`、
   `fold_ready_reason`、`graph_table_available`、`issues_table_available`、
   `sql_graph_contract_ready`、`sql_graph_contract_degraded_reason`、

--- a/changelog.d/unreleased/1724.added.md
+++ b/changelog.d/unreleased/1724.added.md
@@ -1,0 +1,17 @@
+---
+category: added
+issues:
+  - 1724
+affected:
+  - src/CodeIndex/Cli/DiffCommandRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+---
+
+## English
+
+- **Added `cdidx diff <db1> <db2>` for index database drift checks (#1724)** — the new command compares schema versions plus file, symbol, and reference counts, lists one-sided files with a cap, supports JSON / summary-only / detailed symbol diff modes, and returns stable exit codes for identical, drift, schema mismatch, and unreadable database outcomes.
+
+## 日本語
+
+- **index DB の drift 確認向けに `cdidx diff <db1> <db2>` を追加しました (#1724)** — 新コマンドは schema version と file / symbol / reference 件数を比較し、片側だけにある file を上限付きで表示します。JSON、summary-only、詳細 symbol diff mode に対応し、identical / drift / schema mismatch / unreadable database の安定した exit code を返します。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -78,6 +78,7 @@ public static class ConsoleUi
         ("outline", "cdidx outline <path> [--db <path>] [--json]"),
         ("status", "cdidx status [--db <path>] [--json] [--check[=workspace,fold,graph,issues,hotspot,csharp,sql,newer]] [--stale-after <duration>] [--explain <field>]"),
         ("db", "cdidx db --integrity-check [--db <path>] [--json]"),
+        ("diff", "cdidx diff <db1> <db2> [--json] [--summary-only] [--detailed] [--limit <n>]"),
         ("report", "cdidx report --output <path> [--db <path>] [--json] [--log-lines <n>] [--no-log] [--include-args]"),
         ("validate", "cdidx validate [--db <path>] [--json] [--kind <kind>] [--path <glob>]"),
         ("impact", "cdidx impact <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--max-hops <n>] [--count] [--with-paths]"),
@@ -571,6 +572,7 @@ public static class ConsoleUi
         Console.WriteLine("  outline <path>             Show a file outline ordered by line, start column, kind, and name");
         Console.WriteLine("  status                     Show database statistics; add --check to verify DB/worktree match or --explain <field> for readiness help");
         Console.WriteLine("  db --integrity-check       Run SQLite `PRAGMA integrity_check` and report findings");
+        Console.WriteLine("  diff <db1> <db2>           Compare two index databases; exit 0 identical, 1 drift, 2 schema mismatch, 3 unreadable");
         Console.WriteLine("  report --output <path>     Build a redacted crash-repro tarball (.tgz) for bug reports");
         Console.WriteLine("  validate                   Report encoding issues (U+FFFD, BOM, null bytes, mixed line endings, UTF-16 BOM, likely non-UTF8)");
         Console.WriteLine("  impact <query>             Show transitive callers; type queries may return heuristic file-level dependency hints");

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -147,6 +147,45 @@ public static class DiffCommandRunner
                 connection,
                 """
                 SELECT
+                    path,
+                    lang,
+                    size,
+                    lines,
+                    checksum,
+                    modified,
+                    indexed_at
+                FROM files
+                ORDER BY
+                    path,
+                    lang,
+                    size,
+                    lines,
+                    checksum,
+                    modified,
+                    indexed_at
+                """),
+            ReadRows(
+                connection,
+                """
+                SELECT
+                    COALESCE(files.path, ''),
+                    chunks.chunk_index,
+                    chunks.start_line,
+                    chunks.end_line,
+                    chunks.content
+                FROM chunks
+                LEFT JOIN files ON files.id = chunks.file_id
+                ORDER BY
+                    COALESCE(files.path, ''),
+                    chunks.chunk_index,
+                    chunks.start_line,
+                    chunks.end_line,
+                    chunks.content
+                """),
+            ReadRows(
+                connection,
+                """
+                SELECT
                     COALESCE(files.path, ''),
                     symbols.kind,
                     symbols.sub_kind,
@@ -242,6 +281,8 @@ public static class DiffCommandRunner
             summary.SymbolCountDelta == 0 &&
             summary.ReferenceCountDelta == 0 &&
             left.Files.SetEquals(right.Files) &&
+            left.FileRows.SequenceEqual(right.FileRows, StringComparer.Ordinal) &&
+            left.ChunkRows.SequenceEqual(right.ChunkRows, StringComparer.Ordinal) &&
             left.SymbolRows.SequenceEqual(right.SymbolRows, StringComparer.Ordinal) &&
             left.ReferenceRows.SequenceEqual(right.ReferenceRows, StringComparer.Ordinal);
 
@@ -417,6 +458,8 @@ public static class DiffCommandRunner
         long SymbolCount,
         long ReferenceCount,
         HashSet<string> Files,
+        List<string> FileRows,
+        List<string> ChunkRows,
         List<string> SymbolRows,
         List<string> ReferenceRows);
 }

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -1,0 +1,308 @@
+using System.Text.Json;
+using CodeIndex.Indexer;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Cli;
+
+public static class DiffCommandRunner
+{
+    private const int DefaultDiffLimit = 20;
+    private const int DriftExitCode = 1;
+    private const int SchemaMismatchExitCode = 2;
+    private const int UnreadableExitCode = 3;
+
+    public static int Run(string[] args, JsonSerializerOptions jsonOptions)
+    {
+        var options = ParseArgs(args);
+        if (options.ShowHelp)
+        {
+            ConsoleUi.PrintUsage();
+            return CommandExitCodes.Success;
+        }
+
+        if (options.ParseError is not null)
+            return WriteCommandError(
+                options.Json || options.SummaryOnly,
+                jsonOptions,
+                options.ParseError,
+                CommandExitCodes.UsageError,
+                "Run `cdidx diff <db1> <db2> --help` to see the supported command shape.",
+                CommandErrorCodes.UsageError);
+
+        try
+        {
+            var left = ReadSnapshot(options.LeftDb!);
+            var right = ReadSnapshot(options.RightDb!);
+            var result = BuildDiff(left, right, options);
+
+            if (options.SummaryOnly)
+                WriteSummaryJson(result, jsonOptions);
+            else if (options.Json)
+                WriteJson(result, jsonOptions);
+            else
+                WriteText(result, options);
+
+            if (!result.Summary.SchemaVersionsEqual)
+                return SchemaMismatchExitCode;
+            return result.Identical ? CommandExitCodes.Success : DriftExitCode;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SqliteException or InvalidOperationException)
+        {
+            return WriteCommandError(
+                options.Json || options.SummaryOnly,
+                jsonOptions,
+                $"failed to compare databases: {ex.Message}",
+                UnreadableExitCode,
+                "Pass two readable CodeIndex SQLite database paths.",
+                CommandErrorCodes.DbError);
+        }
+    }
+
+    internal static DiffCommandOptions ParseArgs(string[] args)
+    {
+        var dbs = new List<string>(2);
+        var json = false;
+        var detailed = false;
+        var summaryOnly = false;
+        var limit = DefaultDiffLimit;
+        string? parseError = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--help" or "-h":
+                    return new DiffCommandOptions { ShowHelp = true };
+                case "--json":
+                    json = true;
+                    break;
+                case "--detailed":
+                    detailed = true;
+                    break;
+                case "--summary-only":
+                    summaryOnly = true;
+                    break;
+                case "--limit" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], out limit) || limit < 0)
+                        parseError = "--limit requires a non-negative integer";
+                    break;
+                case "--limit":
+                    parseError = "--limit requires a value";
+                    break;
+                default:
+                    if (arg.StartsWith('-'))
+                        parseError = $"diff does not support option: '{arg}'";
+                    else if (dbs.Count >= 2)
+                        parseError = $"diff accepts exactly two database paths; unexpected argument: '{arg}'";
+                    else
+                        dbs.Add(arg);
+                    break;
+            }
+
+            if (parseError is not null)
+                break;
+        }
+
+        if (parseError is null && dbs.Count != 2)
+            parseError = "diff requires exactly two database paths";
+
+        return new DiffCommandOptions
+        {
+            LeftDb = dbs.Count > 0 ? dbs[0] : null,
+            RightDb = dbs.Count > 1 ? dbs[1] : null,
+            Json = json,
+            Detailed = detailed,
+            SummaryOnly = summaryOnly,
+            Limit = limit,
+            ParseError = parseError,
+        };
+    }
+
+    private static DiffDbSnapshot ReadSnapshot(string dbPath)
+    {
+        var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
+        if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
+            throw new IOException($"database not found: {dbPath}");
+
+        var connectionString = isUri
+            ? $"Data Source={dbPath}"
+            : new SqliteConnectionStringBuilder
+            {
+                DataSource = dbPath,
+                Mode = SqliteOpenMode.ReadOnly,
+            }.ConnectionString;
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+
+        return new DiffDbSnapshot(
+            Path.GetFullPath(isUri ? dbPath : dbPath),
+            ExecuteLong(connection, "PRAGMA user_version"),
+            ExecuteLong(connection, "SELECT COUNT(*) FROM files"),
+            ExecuteLong(connection, "SELECT COUNT(*) FROM symbols"),
+            ExecuteLong(connection, "SELECT COUNT(*) FROM symbol_references"),
+            ReadStrings(connection, "SELECT path FROM files ORDER BY path"),
+            ReadStrings(connection, "SELECT COALESCE((SELECT path FROM files WHERE files.id = symbols.file_id), '') || ':' || COALESCE(line, -1) || ' ' || COALESCE(kind, '') || ' ' || COALESCE(name, '') FROM symbols ORDER BY 1"));
+    }
+
+    private static DiffJsonResult BuildDiff(DiffDbSnapshot left, DiffDbSnapshot right, DiffCommandOptions options)
+    {
+        var filesOnlyInLeft = TakeDiff(left.Files, right.Files, options.Limit);
+        var filesOnlyInRight = TakeDiff(right.Files, left.Files, options.Limit);
+        var symbolsOnlyInLeft = options.Detailed ? TakeDiff(left.SymbolKeys, right.SymbolKeys, options.Limit) : [];
+        var symbolsOnlyInRight = options.Detailed ? TakeDiff(right.SymbolKeys, left.SymbolKeys, options.Limit) : [];
+
+        var summary = new DiffSummaryJsonResult(
+            left.FileCount,
+            right.FileCount,
+            right.FileCount - left.FileCount,
+            left.SymbolCount,
+            right.SymbolCount,
+            right.SymbolCount - left.SymbolCount,
+            left.ReferenceCount,
+            right.ReferenceCount,
+            right.ReferenceCount - left.ReferenceCount,
+            left.SchemaVersion,
+            right.SchemaVersion,
+            left.SchemaVersion == right.SchemaVersion);
+
+        var identical =
+            summary.SchemaVersionsEqual &&
+            summary.FileCountDelta == 0 &&
+            summary.SymbolCountDelta == 0 &&
+            summary.ReferenceCountDelta == 0 &&
+            left.Files.SetEquals(right.Files) &&
+            (!options.Detailed || left.SymbolKeys.SetEquals(right.SymbolKeys));
+
+        return new DiffJsonResult(
+            identical ? "identical" : "different",
+            identical,
+            left.Path,
+            right.Path,
+            summary,
+            filesOnlyInLeft,
+            filesOnlyInRight,
+            options.Detailed ? symbolsOnlyInLeft : null,
+            options.Detailed ? symbolsOnlyInRight : null,
+            options.Limit,
+            options.Detailed);
+    }
+
+    private static List<string> TakeDiff(HashSet<string> source, HashSet<string> other, int limit)
+    {
+        if (limit == 0)
+            return [];
+
+        var result = new List<string>(Math.Min(source.Count, limit));
+        foreach (var item in source.Order(StringComparer.Ordinal))
+        {
+            if (other.Contains(item))
+                continue;
+            result.Add(item);
+            if (result.Count >= limit)
+                break;
+        }
+        return result;
+    }
+
+    private static long ExecuteLong(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        var value = command.ExecuteScalar();
+        return Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static HashSet<string> ReadStrings(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        var values = new HashSet<string>(StringComparer.Ordinal);
+        while (reader.Read())
+            values.Add(reader.IsDBNull(0) ? string.Empty : reader.GetString(0));
+        return values;
+    }
+
+    private static void WriteJson(DiffJsonResult result, JsonSerializerOptions jsonOptions)
+    {
+        Console.WriteLine(JsonSerializer.Serialize(
+            result,
+            CliJsonSerializerContextFactory.Create(jsonOptions).DiffJsonResult));
+    }
+
+    private static void WriteSummaryJson(DiffJsonResult result, JsonSerializerOptions jsonOptions)
+    {
+        Console.WriteLine(JsonSerializer.Serialize(
+            new DiffSummaryOnlyJsonResult(result.Status, result.Identical, result.LeftDb, result.RightDb, result.Summary),
+            CliJsonSerializerContextFactory.Create(jsonOptions).DiffSummaryOnlyJsonResult));
+    }
+
+    private static void WriteText(DiffJsonResult result, DiffCommandOptions options)
+    {
+        Console.WriteLine("Index database diff");
+        Console.WriteLine($"  left   : {result.LeftDb}");
+        Console.WriteLine($"  right  : {result.RightDb}");
+        Console.WriteLine($"  status : {result.Status}");
+        Console.WriteLine($"  schema : {result.Summary.LeftSchemaVersion} -> {result.Summary.RightSchemaVersion}");
+        Console.WriteLine($"  files  : {result.Summary.LeftFileCount} -> {result.Summary.RightFileCount} ({FormatDelta(result.Summary.FileCountDelta)})");
+        Console.WriteLine($"  symbols: {result.Summary.LeftSymbolCount} -> {result.Summary.RightSymbolCount} ({FormatDelta(result.Summary.SymbolCountDelta)})");
+        Console.WriteLine($"  refs   : {result.Summary.LeftReferenceCount} -> {result.Summary.RightReferenceCount} ({FormatDelta(result.Summary.ReferenceCountDelta)})");
+
+        WriteList("files only in left", result.FilesOnlyInLeft);
+        WriteList("files only in right", result.FilesOnlyInRight);
+        if (options.Detailed)
+        {
+            WriteList("symbols only in left", result.SymbolsOnlyInLeft ?? []);
+            WriteList("symbols only in right", result.SymbolsOnlyInRight ?? []);
+        }
+    }
+
+    private static void WriteList(string label, List<string> values)
+    {
+        if (values.Count == 0)
+            return;
+        Console.WriteLine($"  {label}:");
+        foreach (var value in values)
+            Console.WriteLine($"    - {value}");
+    }
+
+    private static string FormatDelta(long delta) => delta >= 0 ? $"+{delta}" : delta.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    private static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode, string? hint = null, string? errorCode = null)
+    {
+        if (json)
+            Console.WriteLine(JsonSerializer.Serialize(
+                new CommandErrorJsonResult("error", message, hint, errorCode),
+                CliJsonSerializerContextFactory.Create(jsonOptions).CommandErrorJsonResult));
+        else
+        {
+            Console.Error.WriteLine($"Error [{errorCode ?? CommandErrorCodes.UsageError}]: {message}");
+            if (!string.IsNullOrWhiteSpace(hint))
+                Console.Error.WriteLine($"Hint: {hint}");
+        }
+        return exitCode;
+    }
+
+    private sealed record DiffDbSnapshot(
+        string Path,
+        long SchemaVersion,
+        long FileCount,
+        long SymbolCount,
+        long ReferenceCount,
+        HashSet<string> Files,
+        HashSet<string> SymbolKeys);
+}
+
+internal sealed class DiffCommandOptions
+{
+    public string? LeftDb { get; init; }
+    public string? RightDb { get; init; }
+    public bool Json { get; init; }
+    public bool Detailed { get; init; }
+    public bool SummaryOnly { get; init; }
+    public bool ShowHelp { get; init; }
+    public int Limit { get; init; } = 20;
+    public string? ParseError { get; init; }
+}

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -214,10 +214,34 @@ public static class DiffCommandRunner
                 connection,
                 """
                 SELECT
+                    key,
+                    value
+                FROM codeindex_meta
+                WHERE
+                    key = 'hotspot_family_version'
+                    OR key = 'hotspot_family_marker_fingerprint'
+                    OR key LIKE 'hotspot_family_version_%'
+                    OR key LIKE 'hotspot_family_marker_fingerprint_%'
+                    OR key = 'csharp_symbol_name_contract_version'
+                    OR key = 'sql_graph_contract_version'
+                    OR key LIKE 'symbol_extractor_version_%'
+                    OR key LIKE 'metadata_target_version_%'
+                    OR key = 'workspace_path_case_sensitive'
+                    OR key = 'unknown_extension_file_count'
+                    OR key = 'cdidx_writer_version'
+                ORDER BY
+                    key,
+                    value
+                """),
+            ReadRows(
+                connection,
+                """
+                SELECT
                     COALESCE(files.path, ''),
                     symbols.kind,
                     symbols.sub_kind,
                     symbols.name,
+                    symbols.name_folded,
                     symbols.line,
                     symbols.start_line,
                     symbols.start_column,
@@ -239,6 +263,7 @@ public static class DiffCommandRunner
                     symbols.kind,
                     symbols.sub_kind,
                     symbols.name,
+                    symbols.name_folded,
                     symbols.line,
                     symbols.start_line,
                     symbols.start_column,
@@ -260,25 +285,29 @@ public static class DiffCommandRunner
                 SELECT
                     COALESCE(files.path, ''),
                     symbol_references.symbol_name,
+                    symbol_references.symbol_name_folded,
                     symbol_references.reference_kind,
                     symbol_references.line,
                     symbol_references.column_number,
                     symbol_references.context,
                     symbol_references.reference_line_id,
                     symbol_references.container_kind,
-                    symbol_references.container_name
+                    symbol_references.container_name,
+                    symbol_references.container_name_folded
                 FROM symbol_references
                 LEFT JOIN files ON files.id = symbol_references.file_id
                 ORDER BY
                     COALESCE(files.path, ''),
                     symbol_references.symbol_name,
+                    symbol_references.symbol_name_folded,
                     symbol_references.reference_kind,
                     symbol_references.line,
                     symbol_references.column_number,
                     symbol_references.context,
                     symbol_references.reference_line_id,
                     symbol_references.container_kind,
-                    symbol_references.container_name
+                    symbol_references.container_name,
+                    symbol_references.container_name_folded
                 """));
     }
 
@@ -313,6 +342,7 @@ public static class DiffCommandRunner
             left.ChunkRows.SequenceEqual(right.ChunkRows, StringComparer.Ordinal) &&
             left.ReferenceLineRows.SequenceEqual(right.ReferenceLineRows, StringComparer.Ordinal) &&
             left.FileIssueRows.SequenceEqual(right.FileIssueRows, StringComparer.Ordinal) &&
+            left.MetaRows.SequenceEqual(right.MetaRows, StringComparer.Ordinal) &&
             left.SymbolRows.SequenceEqual(right.SymbolRows, StringComparer.Ordinal) &&
             left.ReferenceRows.SequenceEqual(right.ReferenceRows, StringComparer.Ordinal);
 
@@ -572,6 +602,7 @@ public static class DiffCommandRunner
         List<string> ChunkRows,
         List<string> ReferenceLineRows,
         List<string> FileIssueRows,
+        List<string> MetaRows,
         List<string> SymbolRows,
         List<string> ReferenceRows);
 

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -143,16 +143,84 @@ public static class DiffCommandRunner
             ExecuteLong(connection, "SELECT COUNT(*) FROM symbols"),
             ExecuteLong(connection, "SELECT COUNT(*) FROM symbol_references"),
             ReadStrings(connection, "SELECT path FROM files ORDER BY path"),
-            ReadStrings(connection, "SELECT COALESCE((SELECT path FROM files WHERE files.id = symbols.file_id), '') || ':' || COALESCE(line, -1) || ' ' || COALESCE(kind, '') || ' ' || COALESCE(name, '') FROM symbols ORDER BY 1"),
-            ReadStrings(connection, "SELECT COALESCE((SELECT path FROM files WHERE files.id = symbol_references.file_id), '') || ':' || COALESCE(line, -1) || ':' || COALESCE(column_number, -1) || ' ' || COALESCE(reference_kind, '') || ' ' || COALESCE(symbol_name, '') || ' ' || COALESCE(context, '') FROM symbol_references ORDER BY 1"));
+            ReadRows(
+                connection,
+                """
+                SELECT
+                    COALESCE(files.path, ''),
+                    symbols.kind,
+                    symbols.sub_kind,
+                    symbols.name,
+                    symbols.line,
+                    symbols.start_line,
+                    symbols.start_column,
+                    symbols.end_line,
+                    symbols.body_start_line,
+                    symbols.body_end_line,
+                    symbols.signature,
+                    symbols.container_kind,
+                    symbols.container_name,
+                    symbols.container_qualified_name,
+                    symbols.family_key,
+                    symbols.visibility,
+                    symbols.return_type,
+                    symbols.is_metadata_target
+                FROM symbols
+                LEFT JOIN files ON files.id = symbols.file_id
+                ORDER BY
+                    COALESCE(files.path, ''),
+                    symbols.kind,
+                    symbols.sub_kind,
+                    symbols.name,
+                    symbols.line,
+                    symbols.start_line,
+                    symbols.start_column,
+                    symbols.end_line,
+                    symbols.body_start_line,
+                    symbols.body_end_line,
+                    symbols.signature,
+                    symbols.container_kind,
+                    symbols.container_name,
+                    symbols.container_qualified_name,
+                    symbols.family_key,
+                    symbols.visibility,
+                    symbols.return_type,
+                    symbols.is_metadata_target
+                """),
+            ReadRows(
+                connection,
+                """
+                SELECT
+                    COALESCE(files.path, ''),
+                    symbol_references.symbol_name,
+                    symbol_references.reference_kind,
+                    symbol_references.line,
+                    symbol_references.column_number,
+                    symbol_references.context,
+                    symbol_references.reference_line_id,
+                    symbol_references.container_kind,
+                    symbol_references.container_name
+                FROM symbol_references
+                LEFT JOIN files ON files.id = symbol_references.file_id
+                ORDER BY
+                    COALESCE(files.path, ''),
+                    symbol_references.symbol_name,
+                    symbol_references.reference_kind,
+                    symbol_references.line,
+                    symbol_references.column_number,
+                    symbol_references.context,
+                    symbol_references.reference_line_id,
+                    symbol_references.container_kind,
+                    symbol_references.container_name
+                """));
     }
 
     private static DiffJsonResult BuildDiff(DiffDbSnapshot left, DiffDbSnapshot right, DiffCommandOptions options)
     {
         var filesOnlyInLeft = TakeDiff(left.Files, right.Files, options.Limit);
         var filesOnlyInRight = TakeDiff(right.Files, left.Files, options.Limit);
-        var symbolsOnlyInLeft = options.Detailed ? TakeDiff(left.SymbolKeys, right.SymbolKeys, options.Limit) : [];
-        var symbolsOnlyInRight = options.Detailed ? TakeDiff(right.SymbolKeys, left.SymbolKeys, options.Limit) : [];
+        var symbolsOnlyInLeft = options.Detailed ? TakeDiff(left.SymbolRows, right.SymbolRows, options.Limit) : [];
+        var symbolsOnlyInRight = options.Detailed ? TakeDiff(right.SymbolRows, left.SymbolRows, options.Limit) : [];
 
         var summary = new DiffSummaryJsonResult(
             left.FileCount,
@@ -174,8 +242,8 @@ public static class DiffCommandRunner
             summary.SymbolCountDelta == 0 &&
             summary.ReferenceCountDelta == 0 &&
             left.Files.SetEquals(right.Files) &&
-            left.SymbolKeys.SetEquals(right.SymbolKeys) &&
-            left.ReferenceKeys.SetEquals(right.ReferenceKeys);
+            left.SymbolRows.SequenceEqual(right.SymbolRows, StringComparer.Ordinal) &&
+            left.ReferenceRows.SequenceEqual(right.ReferenceRows, StringComparer.Ordinal);
 
         return new DiffJsonResult(
             identical ? "identical" : "different",
@@ -208,6 +276,32 @@ public static class DiffCommandRunner
         return result;
     }
 
+    private static List<string> TakeDiff(List<string> source, List<string> other, int limit)
+    {
+        if (limit == 0)
+            return [];
+
+        var remaining = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var item in other)
+            remaining[item] = remaining.GetValueOrDefault(item) + 1;
+
+        var result = new List<string>(Math.Min(source.Count, limit));
+        foreach (var item in source)
+        {
+            if (remaining.TryGetValue(item, out var count) && count > 0)
+            {
+                remaining[item] = count - 1;
+                continue;
+            }
+
+            result.Add(item);
+            if (result.Count >= limit)
+                break;
+        }
+
+        return result;
+    }
+
     private static long ExecuteLong(SqliteConnection connection, string sql)
     {
         using var command = connection.CreateCommand();
@@ -225,6 +319,35 @@ public static class DiffCommandRunner
         while (reader.Read())
             values.Add(reader.IsDBNull(0) ? string.Empty : reader.GetString(0));
         return values;
+    }
+
+    private static List<string> ReadRows(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        var values = new List<string>();
+        while (reader.Read())
+            values.Add(EncodeRow(reader));
+        return values;
+    }
+
+    private static string EncodeRow(SqliteDataReader reader)
+    {
+        var fields = new string[reader.FieldCount];
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (reader.IsDBNull(i))
+            {
+                fields[i] = "-1:";
+                continue;
+            }
+
+            var value = Convert.ToString(reader.GetValue(i), System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+            fields[i] = value.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" + value;
+        }
+
+        return string.Join("|", fields);
     }
 
     private static void WriteJson(DiffJsonResult result, JsonSerializerOptions jsonOptions)
@@ -294,8 +417,8 @@ public static class DiffCommandRunner
         long SymbolCount,
         long ReferenceCount,
         HashSet<string> Files,
-        HashSet<string> SymbolKeys,
-        HashSet<string> ReferenceKeys);
+        List<string> SymbolRows,
+        List<string> ReferenceRows);
 }
 
 internal sealed class DiffCommandOptions

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -143,7 +143,8 @@ public static class DiffCommandRunner
             ExecuteLong(connection, "SELECT COUNT(*) FROM symbols"),
             ExecuteLong(connection, "SELECT COUNT(*) FROM symbol_references"),
             ReadStrings(connection, "SELECT path FROM files ORDER BY path"),
-            ReadStrings(connection, "SELECT COALESCE((SELECT path FROM files WHERE files.id = symbols.file_id), '') || ':' || COALESCE(line, -1) || ' ' || COALESCE(kind, '') || ' ' || COALESCE(name, '') FROM symbols ORDER BY 1"));
+            ReadStrings(connection, "SELECT COALESCE((SELECT path FROM files WHERE files.id = symbols.file_id), '') || ':' || COALESCE(line, -1) || ' ' || COALESCE(kind, '') || ' ' || COALESCE(name, '') FROM symbols ORDER BY 1"),
+            ReadStrings(connection, "SELECT COALESCE((SELECT path FROM files WHERE files.id = symbol_references.file_id), '') || ':' || COALESCE(line, -1) || ':' || COALESCE(column_number, -1) || ' ' || COALESCE(reference_kind, '') || ' ' || COALESCE(symbol_name, '') || ' ' || COALESCE(context, '') FROM symbol_references ORDER BY 1"));
     }
 
     private static DiffJsonResult BuildDiff(DiffDbSnapshot left, DiffDbSnapshot right, DiffCommandOptions options)
@@ -173,7 +174,8 @@ public static class DiffCommandRunner
             summary.SymbolCountDelta == 0 &&
             summary.ReferenceCountDelta == 0 &&
             left.Files.SetEquals(right.Files) &&
-            (!options.Detailed || left.SymbolKeys.SetEquals(right.SymbolKeys));
+            left.SymbolKeys.SetEquals(right.SymbolKeys) &&
+            left.ReferenceKeys.SetEquals(right.ReferenceKeys);
 
         return new DiffJsonResult(
             identical ? "identical" : "different",
@@ -292,7 +294,8 @@ public static class DiffCommandRunner
         long SymbolCount,
         long ReferenceCount,
         HashSet<string> Files,
-        HashSet<string> SymbolKeys);
+        HashSet<string> SymbolKeys,
+        HashSet<string> ReferenceKeys);
 }
 
 internal sealed class DiffCommandOptions

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -187,6 +187,47 @@ public static class DiffCommandRunner
                 """
                 SELECT
                     COALESCE(files.path, ''),
+                    reference_lines.line,
+                    reference_lines.context
+                FROM reference_lines
+                LEFT JOIN files ON files.id = reference_lines.file_id
+                ORDER BY
+                    COALESCE(files.path, ''),
+                    reference_lines.line,
+                    reference_lines.context
+                """),
+            ReadRows(
+                connection,
+                """
+                SELECT
+                    COALESCE(files.path, ''),
+                    file_issues.kind,
+                    file_issues.line,
+                    file_issues.message
+                FROM file_issues
+                LEFT JOIN files ON files.id = file_issues.file_id
+                ORDER BY
+                    COALESCE(files.path, ''),
+                    file_issues.kind,
+                    file_issues.line,
+                    file_issues.message
+                """),
+            ReadRows(
+                connection,
+                """
+                SELECT
+                    key,
+                    value
+                FROM codeindex_meta
+                ORDER BY
+                    key,
+                    value
+                """),
+            ReadRows(
+                connection,
+                """
+                SELECT
+                    COALESCE(files.path, ''),
                     symbols.kind,
                     symbols.sub_kind,
                     symbols.name,
@@ -283,6 +324,9 @@ public static class DiffCommandRunner
             left.Files.SetEquals(right.Files) &&
             left.FileRows.SequenceEqual(right.FileRows, StringComparer.Ordinal) &&
             left.ChunkRows.SequenceEqual(right.ChunkRows, StringComparer.Ordinal) &&
+            left.ReferenceLineRows.SequenceEqual(right.ReferenceLineRows, StringComparer.Ordinal) &&
+            left.FileIssueRows.SequenceEqual(right.FileIssueRows, StringComparer.Ordinal) &&
+            left.MetaRows.SequenceEqual(right.MetaRows, StringComparer.Ordinal) &&
             left.SymbolRows.SequenceEqual(right.SymbolRows, StringComparer.Ordinal) &&
             left.ReferenceRows.SequenceEqual(right.ReferenceRows, StringComparer.Ordinal);
 
@@ -460,6 +504,9 @@ public static class DiffCommandRunner
         HashSet<string> Files,
         List<string> FileRows,
         List<string> ChunkRows,
+        List<string> ReferenceLineRows,
+        List<string> FileIssueRows,
+        List<string> MetaRows,
         List<string> SymbolRows,
         List<string> ReferenceRows);
 }

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -31,19 +31,21 @@ public static class DiffCommandRunner
 
         try
         {
+            var leftHeader = ReadHeader(options.LeftDb!);
+            var rightHeader = ReadHeader(options.RightDb!);
+            if (leftHeader.SchemaVersion != rightHeader.SchemaVersion)
+            {
+                var schemaMismatch = BuildSchemaMismatchDiff(leftHeader, rightHeader, options);
+                WriteResult(schemaMismatch, options, jsonOptions);
+                return SchemaMismatchExitCode;
+            }
+
             var left = ReadSnapshot(options.LeftDb!);
             var right = ReadSnapshot(options.RightDb!);
             var result = BuildDiff(left, right, options);
 
-            if (options.SummaryOnly)
-                WriteSummaryJson(result, jsonOptions);
-            else if (options.Json)
-                WriteJson(result, jsonOptions);
-            else
-                WriteText(result, options);
+            WriteResult(result, options, jsonOptions);
 
-            if (!result.Summary.SchemaVersionsEqual)
-                return SchemaMismatchExitCode;
             return result.Identical ? CommandExitCodes.Success : DriftExitCode;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SqliteException or InvalidOperationException)
@@ -344,6 +346,36 @@ public static class DiffCommandRunner
             options.Detailed);
     }
 
+    private static DiffJsonResult BuildSchemaMismatchDiff(DiffDbHeader left, DiffDbHeader right, DiffCommandOptions options)
+    {
+        var summary = new DiffSummaryJsonResult(
+            left.FileCount,
+            right.FileCount,
+            right.FileCount - left.FileCount,
+            left.SymbolCount,
+            right.SymbolCount,
+            right.SymbolCount - left.SymbolCount,
+            left.ReferenceCount,
+            right.ReferenceCount,
+            right.ReferenceCount - left.ReferenceCount,
+            left.SchemaVersion,
+            right.SchemaVersion,
+            false);
+
+        return new DiffJsonResult(
+            "schema_mismatch",
+            false,
+            left.Path,
+            right.Path,
+            summary,
+            [],
+            [],
+            options.Detailed ? [] : null,
+            options.Detailed ? [] : null,
+            options.Limit,
+            options.Detailed);
+    }
+
     private static List<string> TakeDiff(HashSet<string> source, HashSet<string> other, int limit)
     {
         if (limit == 0)
@@ -393,6 +425,46 @@ public static class DiffCommandRunner
         command.CommandText = sql;
         var value = command.ExecuteScalar();
         return Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static DiffDbHeader ReadHeader(string dbPath)
+    {
+        var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
+        if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
+            throw new IOException($"database not found: {dbPath}");
+
+        var connectionString = isUri
+            ? $"Data Source={dbPath}"
+            : new SqliteConnectionStringBuilder
+            {
+                DataSource = dbPath,
+                Mode = SqliteOpenMode.ReadOnly,
+            }.ConnectionString;
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+
+        return new DiffDbHeader(
+            Path.GetFullPath(isUri ? dbPath : dbPath),
+            ExecuteLong(connection, "PRAGMA user_version"),
+            ExecuteCountIfTableExists(connection, "files"),
+            ExecuteCountIfTableExists(connection, "symbols"),
+            ExecuteCountIfTableExists(connection, "symbol_references"));
+    }
+
+    private static long ExecuteCountIfTableExists(SqliteConnection connection, string table)
+    {
+        using (var exists = connection.CreateCommand())
+        {
+            exists.CommandText = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = $table";
+            exists.Parameters.AddWithValue("$table", table);
+            if (exists.ExecuteScalar() is null)
+                return 0;
+        }
+
+        using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT COUNT(*) FROM {table}";
+        return Convert.ToInt64(command.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private static HashSet<string> ReadStrings(SqliteConnection connection, string sql)
@@ -447,6 +519,16 @@ public static class DiffCommandRunner
         Console.WriteLine(JsonSerializer.Serialize(
             new DiffSummaryOnlyJsonResult(result.Status, result.Identical, result.LeftDb, result.RightDb, result.Summary),
             CliJsonSerializerContextFactory.Create(jsonOptions).DiffSummaryOnlyJsonResult));
+    }
+
+    private static void WriteResult(DiffJsonResult result, DiffCommandOptions options, JsonSerializerOptions jsonOptions)
+    {
+        if (options.SummaryOnly)
+            WriteSummaryJson(result, jsonOptions);
+        else if (options.Json)
+            WriteJson(result, jsonOptions);
+        else
+            WriteText(result, options);
     }
 
     private static void WriteText(DiffJsonResult result, DiffCommandOptions options)
@@ -509,6 +591,13 @@ public static class DiffCommandRunner
         List<string> MetaRows,
         List<string> SymbolRows,
         List<string> ReferenceRows);
+
+    private sealed record DiffDbHeader(
+        string Path,
+        long SchemaVersion,
+        long FileCount,
+        long SymbolCount,
+        long ReferenceCount);
 }
 
 internal sealed class DiffCommandOptions

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -153,18 +153,14 @@ public static class DiffCommandRunner
                     lang,
                     size,
                     lines,
-                    checksum,
-                    modified,
-                    indexed_at
+                    checksum
                 FROM files
                 ORDER BY
                     path,
                     lang,
                     size,
                     lines,
-                    checksum,
-                    modified,
-                    indexed_at
+                    checksum
                 """),
             ReadRows(
                 connection,
@@ -213,17 +209,6 @@ public static class DiffCommandRunner
                     file_issues.kind,
                     file_issues.line,
                     file_issues.message
-                """),
-            ReadRows(
-                connection,
-                """
-                SELECT
-                    key,
-                    value
-                FROM codeindex_meta
-                ORDER BY
-                    key,
-                    value
                 """),
             ReadRows(
                 connection,
@@ -328,7 +313,6 @@ public static class DiffCommandRunner
             left.ChunkRows.SequenceEqual(right.ChunkRows, StringComparer.Ordinal) &&
             left.ReferenceLineRows.SequenceEqual(right.ReferenceLineRows, StringComparer.Ordinal) &&
             left.FileIssueRows.SequenceEqual(right.FileIssueRows, StringComparer.Ordinal) &&
-            left.MetaRows.SequenceEqual(right.MetaRows, StringComparer.Ordinal) &&
             left.SymbolRows.SequenceEqual(right.SymbolRows, StringComparer.Ordinal) &&
             left.ReferenceRows.SequenceEqual(right.ReferenceRows, StringComparer.Ordinal);
 
@@ -588,7 +572,6 @@ public static class DiffCommandRunner
         List<string> ChunkRows,
         List<string> ReferenceLineRows,
         List<string> FileIssueRows,
-        List<string> MetaRows,
         List<string> SymbolRows,
         List<string> ReferenceRows);
 

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -32,6 +32,40 @@ internal sealed record DbIntegrityCheckJsonResult(
     [property: JsonPropertyName("ok")] bool Ok,
     [property: JsonPropertyName("issues")] List<string> Issues);
 
+internal sealed record DiffSummaryJsonResult(
+    [property: JsonPropertyName("left_file_count")] long LeftFileCount,
+    [property: JsonPropertyName("right_file_count")] long RightFileCount,
+    [property: JsonPropertyName("file_count_delta")] long FileCountDelta,
+    [property: JsonPropertyName("left_symbol_count")] long LeftSymbolCount,
+    [property: JsonPropertyName("right_symbol_count")] long RightSymbolCount,
+    [property: JsonPropertyName("symbol_count_delta")] long SymbolCountDelta,
+    [property: JsonPropertyName("left_reference_count")] long LeftReferenceCount,
+    [property: JsonPropertyName("right_reference_count")] long RightReferenceCount,
+    [property: JsonPropertyName("reference_count_delta")] long ReferenceCountDelta,
+    [property: JsonPropertyName("left_schema_version")] long LeftSchemaVersion,
+    [property: JsonPropertyName("right_schema_version")] long RightSchemaVersion,
+    [property: JsonPropertyName("schema_versions_equal")] bool SchemaVersionsEqual);
+
+internal sealed record DiffJsonResult(
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("identical")] bool Identical,
+    [property: JsonPropertyName("left_db")] string LeftDb,
+    [property: JsonPropertyName("right_db")] string RightDb,
+    [property: JsonPropertyName("summary")] DiffSummaryJsonResult Summary,
+    [property: JsonPropertyName("files_only_in_left")] List<string> FilesOnlyInLeft,
+    [property: JsonPropertyName("files_only_in_right")] List<string> FilesOnlyInRight,
+    [property: JsonPropertyName("symbols_only_in_left")] List<string>? SymbolsOnlyInLeft,
+    [property: JsonPropertyName("symbols_only_in_right")] List<string>? SymbolsOnlyInRight,
+    [property: JsonPropertyName("limit")] int Limit,
+    [property: JsonPropertyName("detailed")] bool Detailed);
+
+internal sealed record DiffSummaryOnlyJsonResult(
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("identical")] bool Identical,
+    [property: JsonPropertyName("left_db")] string LeftDb,
+    [property: JsonPropertyName("right_db")] string RightDb,
+    [property: JsonPropertyName("summary")] DiffSummaryJsonResult Summary);
+
 internal sealed record ReportBundleSummary(
     [property: JsonPropertyName("output_path")] string OutputPath,
     [property: JsonPropertyName("version")] string Version,
@@ -219,6 +253,9 @@ internal sealed record VersionInfoJsonResult(
 [JsonSerializable(typeof(DefinitionResult))]
 [JsonSerializable(typeof(Dictionary<string, int>))]
 [JsonSerializable(typeof(Dictionary<string, long>))]
+[JsonSerializable(typeof(DiffJsonResult))]
+[JsonSerializable(typeof(DiffSummaryOnlyJsonResult))]
+[JsonSerializable(typeof(DiffSummaryJsonResult))]
 [JsonSerializable(typeof(ExactZeroHintResult))]
 [JsonSerializable(typeof(FileDependencyResult))]
 [JsonSerializable(typeof(FileExcerptResult))]

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -170,6 +170,7 @@ internal static class ProgramRunner
                 exitCode = commandName switch
                 {
                     "index" => IndexCommandRunner.Run(subArgs, jsonOptions),
+                    "diff" => DiffCommandRunner.Run(subArgs, jsonOptions),
                     "hooks" => HookCommandRunner.Run(subArgs, jsonOptions),
                     "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, jsonOptions),
                     "db" => DbCommandRunner.RunIntegrityCheck(subArgs, jsonOptions),

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -44,6 +44,30 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_ReturnsSuccessForSeparatelyBuiltIdenticalDatabases_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_identical_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_identical_right");
+        try
+        {
+            var leftDb = SeedDb(leftRoot, includeExtraFile: false);
+            var rightDb = SeedDb(rightRoot, includeExtraFile: false);
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--summary-only"]);
+
+            Assert.Equal(0, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("identical", document.RootElement.GetProperty("status").GetString());
+            Assert.True(document.RootElement.GetProperty("identical").GetBoolean());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_ReturnsSchemaMismatchExitCodeBeforeDriftExitCode_Issue1724()
     {
         var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_schema_left");

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -68,6 +68,30 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_ReturnsSchemaMismatchForLegacyDatabaseBeforeReadingMissingTables_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_legacy_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_legacy_right");
+        try
+        {
+            var legacyDb = CreateLegacyDbWithoutGraphTables(leftRoot);
+            var currentDb = SeedDb(rightRoot, includeExtraFile: false);
+
+            var (exitCode, output) = RunWithCapturedOut([legacyDb, currentDb, "--summary-only"]);
+
+            Assert.Equal(2, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("schema_mismatch", document.RootElement.GetProperty("status").GetString());
+            Assert.False(document.RootElement.GetProperty("summary").GetProperty("schema_versions_equal").GetBoolean());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_DetectsSameCountSymbolDriftWithoutDetailedMode_Issue1724()
     {
         var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_symbol_left");
@@ -259,6 +283,35 @@ public class DiffCommandRunnerTests
                 """);
         }
 
+        return dbPath;
+    }
+
+    private static string CreateLegacyDbWithoutGraphTables(string projectRoot)
+    {
+        var dbPath = Path.Combine(projectRoot, ".cdidx", "legacy.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+        }.ConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            PRAGMA user_version = 1;
+            CREATE TABLE files (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                path TEXT NOT NULL UNIQUE,
+                lang TEXT,
+                size INTEGER,
+                lines INTEGER,
+                checksum TEXT,
+                modified DATETIME,
+                indexed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            INSERT INTO files (path, lang, size, lines, checksum, modified)
+            VALUES ('src/Legacy.cs', 'csharp', 12, 1, 'legacy', '2026-01-01T00:00:00Z');
+            """;
+        command.ExecuteNonQuery();
         return dbPath;
     }
 

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -198,6 +198,33 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_DetectsSameCountFoldedSymbolDriftWithoutDetailedMode_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_fold_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_fold_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class Same { public void Run() { } }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class Same { public void Run() { } }");
+            UpdateFirstSymbolFoldedName(rightDb, "drifted");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--summary-only"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("different", document.RootElement.GetProperty("status").GetString());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("symbol_count_delta").GetInt64());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_DetectsSameCountChunkDriftWithoutDetailedMode_Issue1724()
     {
         var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_chunk_left");
@@ -418,6 +445,23 @@ public class DiffCommandRunnerTests
             )
             """,
             command => command.Parameters.AddWithValue("$content", content));
+    }
+
+    private static void UpdateFirstSymbolFoldedName(string dbPath, string nameFolded)
+    {
+        ExecuteNonQuery(
+            dbPath,
+            """
+            UPDATE symbols
+            SET name_folded = $nameFolded
+            WHERE id = (
+                SELECT id
+                FROM symbols
+                ORDER BY id
+                LIMIT 1
+            )
+            """,
+            command => command.Parameters.AddWithValue("$nameFolded", nameFolded));
     }
 
     private static void UpdateFirstReferenceLineContext(string dbPath, string context)

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -179,6 +179,35 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_DetectsSameCountReferenceLineDriftWithoutDetailedMode_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_refline_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_refline_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class Same { public void Run() { Foo(); } }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class Same { public void Run() { Foo(); } }");
+            UpdateFirstReferenceLineContext(rightDb, "public class Same { public void Run() { Drifted(); } }");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--summary-only"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("different", document.RootElement.GetProperty("status").GetString());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("file_count_delta").GetInt64());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("symbol_count_delta").GetInt64());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("reference_count_delta").GetInt64());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_ReturnsUnreadableExitCodeForMissingDatabase_Issue1724()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_diff_missing");
@@ -312,6 +341,23 @@ public class DiffCommandRunnerTests
             )
             """,
             command => command.Parameters.AddWithValue("$content", content));
+    }
+
+    private static void UpdateFirstReferenceLineContext(string dbPath, string context)
+    {
+        ExecuteNonQuery(
+            dbPath,
+            """
+            UPDATE reference_lines
+            SET context = $context
+            WHERE id = (
+                SELECT id
+                FROM reference_lines
+                ORDER BY id
+                LIMIT 1
+            )
+            """,
+            command => command.Parameters.AddWithValue("$context", context));
     }
 
     private static void ExecuteNonQuery(string dbPath, string sql, Action<SqliteCommand>? configure = null)

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using CodeIndex.Cli;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Tests;
+
+[Collection("SQLite pool sensitive")]
+public class DiffCommandRunnerTests
+{
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    [Fact]
+    public void Run_JsonDiffReportsSyntheticDatabaseDrift_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_right");
+        try
+        {
+            var leftDb = SeedDb(leftRoot, includeExtraFile: false);
+            var rightDb = SeedDb(rightRoot, includeExtraFile: true);
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--json", "--limit", "5"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            var root = document.RootElement;
+            Assert.Equal("different", root.GetProperty("status").GetString());
+            Assert.False(root.GetProperty("identical").GetBoolean());
+            Assert.Equal(50, root.GetProperty("summary").GetProperty("left_file_count").GetInt64());
+            Assert.Equal(51, root.GetProperty("summary").GetProperty("right_file_count").GetInt64());
+            Assert.Equal(1, root.GetProperty("summary").GetProperty("file_count_delta").GetInt64());
+            Assert.Contains(
+                root.GetProperty("files_only_in_right").EnumerateArray(),
+                item => item.GetString() == "src/Extra.cs");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_ReturnsSchemaMismatchExitCodeBeforeDriftExitCode_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_schema_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_schema_right");
+        try
+        {
+            var leftDb = SeedDb(leftRoot, includeExtraFile: false);
+            var rightDb = SeedDb(rightRoot, includeExtraFile: false);
+            SetUserVersion(rightDb, 999);
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--summary-only"]);
+
+            Assert.Equal(2, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.False(document.RootElement.GetProperty("summary").GetProperty("schema_versions_equal").GetBoolean());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_ReturnsUnreadableExitCodeForMissingDatabase_Issue1724()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_diff_missing");
+        try
+        {
+            var db = SeedDb(root, includeExtraFile: false);
+            var missing = Path.Combine(root, "missing.db");
+
+            var (exitCode, output) = RunWithCapturedOut([db, missing, "--summary-only"]);
+
+            Assert.Equal(3, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    private static string SeedDb(string projectRoot, bool includeExtraFile)
+    {
+        var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+        for (var i = 0; i < 50; i++)
+        {
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                $"src/File{i:00}.cs",
+                "csharp",
+                $$"""
+                public static class File{{i:00}}
+                {
+                    public static void Run() { }
+                }
+                """);
+        }
+
+        if (includeExtraFile)
+        {
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/Extra.cs",
+                "csharp",
+                """
+                public static class Extra
+                {
+                    public static void Run() { }
+                }
+                """);
+        }
+
+        return dbPath;
+    }
+
+    private static void SetUserVersion(string dbPath, int version)
+    {
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+        }.ConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = $"PRAGMA user_version = {version}";
+        command.ExecuteNonQuery();
+    }
+
+    private (int ExitCode, string Output) RunWithCapturedOut(string[] args)
+    {
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        lock (TestConsoleLock.Gate)
+        {
+            try
+            {
+                Console.SetOut(writer);
+                var exitCode = DiffCommandRunner.Run(args, _jsonOptions);
+                return (exitCode, writer.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -150,6 +150,35 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_DetectsSameCountChunkDriftWithoutDetailedMode_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_chunk_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_chunk_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class Same { public void Run() { } }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class Same { public void Run() { } }");
+            UpdateFirstChunkContent(rightDb, "public class Same { public void Drifted() { } }");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--summary-only"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("different", document.RootElement.GetProperty("status").GetString());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("file_count_delta").GetInt64());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("symbol_count_delta").GetInt64());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("reference_count_delta").GetInt64());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_ReturnsUnreadableExitCodeForMissingDatabase_Issue1724()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_diff_missing");
@@ -266,6 +295,23 @@ public class DiffCommandRunnerTests
                 command.Parameters.AddWithValue("$name", name);
                 command.Parameters.AddWithValue("$signature", signature);
             });
+    }
+
+    private static void UpdateFirstChunkContent(string dbPath, string content)
+    {
+        ExecuteNonQuery(
+            dbPath,
+            """
+            UPDATE chunks
+            SET content = $content
+            WHERE id = (
+                SELECT id
+                FROM chunks
+                ORDER BY id
+                LIMIT 1
+            )
+            """,
+            command => command.Parameters.AddWithValue("$content", content));
     }
 
     private static void ExecuteNonQuery(string dbPath, string sql, Action<SqliteCommand>? configure = null)

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -122,6 +122,34 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_DetectsSameCountSignatureDriftWithoutDetailedMode_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_signature_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_signature_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class Same { public string Convert(int value) => value.ToString(); }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class Same { public string Convert(int value) => value.ToString(); }");
+            InsertSyntheticMethodSymbol(leftDb, "src/Same.cs", "Convert", "public string Convert(int value)");
+            InsertSyntheticMethodSymbol(rightDb, "src/Same.cs", "Convert", "public string Convert(long value)");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--summary-only"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("different", document.RootElement.GetProperty("status").GetString());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("symbol_count_delta").GetInt64());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_ReturnsUnreadableExitCodeForMissingDatabase_Issue1724()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_diff_missing");
@@ -178,13 +206,78 @@ public class DiffCommandRunnerTests
 
     private static void SetUserVersion(string dbPath, int version)
     {
+        ExecuteNonQuery(dbPath, $"PRAGMA user_version = {version}");
+    }
+
+    private static void InsertSyntheticMethodSymbol(string dbPath, string path, string name, string signature)
+    {
+        ExecuteNonQuery(
+            dbPath,
+            """
+            INSERT INTO symbols (
+                file_id,
+                kind,
+                sub_kind,
+                name,
+                line,
+                start_line,
+                start_column,
+                end_line,
+                body_start_line,
+                body_end_line,
+                signature,
+                container_kind,
+                container_name,
+                container_qualified_name,
+                family_key,
+                visibility,
+                return_type,
+                is_metadata_target
+            )
+            VALUES (
+                (
+                SELECT id
+                FROM files
+                WHERE path = $path
+                LIMIT 1
+                ),
+                'method',
+                'method',
+                $name,
+                1,
+                1,
+                42,
+                1,
+                1,
+                1,
+                $signature,
+                'class',
+                'Same',
+                'Same',
+                'Same.Convert',
+                'public',
+                'string',
+                0
+            )
+            """,
+            command =>
+            {
+                command.Parameters.AddWithValue("$path", path);
+                command.Parameters.AddWithValue("$name", name);
+                command.Parameters.AddWithValue("$signature", signature);
+            });
+    }
+
+    private static void ExecuteNonQuery(string dbPath, string sql, Action<SqliteCommand>? configure = null)
+    {
         using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
         {
             DataSource = dbPath,
         }.ConnectionString);
         connection.Open();
         using var command = connection.CreateCommand();
-        command.CommandText = $"PRAGMA user_version = {version}";
+        command.CommandText = sql;
+        configure?.Invoke(command);
         command.ExecuteNonQuery();
     }
 

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -68,6 +68,60 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_DetectsSameCountSymbolDriftWithoutDetailedMode_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_symbol_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_symbol_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class LeftOnly { public void Run() { } }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class RightOnly { public void Run() { } }");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--summary-only"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("different", document.RootElement.GetProperty("status").GetString());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("file_count_delta").GetInt64());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("symbol_count_delta").GetInt64());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_DetectsSameCountReferenceDriftWithoutDetailedMode_Issue1724()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_ref_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_ref_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class Same { public void Run() { Foo(); } }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class Same { public void Run() { Bar(); } }");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--summary-only"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("different", document.RootElement.GetProperty("status").GetString());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("file_count_delta").GetInt64());
+            Assert.Equal(0, document.RootElement.GetProperty("summary").GetProperty("reference_count_delta").GetInt64());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_ReturnsUnreadableExitCodeForMissingDatabase_Issue1724()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_diff_missing");


### PR DESCRIPTION
## Summary

- Add `cdidx diff <db1> <db2>` with JSON, summary-only, detailed symbol diff, capped one-sided file lists, and stable exit codes.
- Compare schema versions, file/symbol/reference counts, stable indexed row projections, chunks, reference lines, file issues, folded lookup fields, and stable readiness metadata while ignoring volatile timestamps.
- Document the command and add a bilingual changelog fragment.

Fixes #1724

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DiffCommandRunnerTests` passed (11 tests).
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false` passed.
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` passed with a fresh index.
- Full `dotnet test` was attempted earlier and hit an unrelated existing concurrency failure; tracked as #2451.

## Follow-up

- #2451 tracks the unrelated full-suite concurrency test failure observed during validation.
