### PR TITLE
Align human summary labels

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -530,6 +530,7 @@ Done.
   SQL graph: ready
   Hotspots : ready
   C# names : ready
+  C# meta  : ready
   Fold     : ready
   Elapsed  : 2.4s
 ```
@@ -2265,19 +2266,20 @@ interactive terminal では spinner と progress bar が動き続けます。待
 
 Done.
 
-  Files   : 42
-  Chunks  : 318
-  Symbols : 156
-  Refs    : 1,024
-  Updated : 14
-  Skipped : 28 (unchanged)
-  Graph   : ready
-  Issues  : ready
+  Files    : 42
+  Chunks   : 318
+  Symbols  : 156
+  Refs     : 1,024
+  Updated  : 14
+  Skipped  : 28 (unchanged)
+  Graph    : ready
+  Issues   : ready
   SQL graph: ready
-  Hotspots: ready
-  C# names: ready
-  Fold    : ready
-  Elapsed : 2.4s
+  Hotspots : ready
+  C# names : ready
+  C# meta  : ready
+  Fold     : ready
+  Elapsed  : 2.4s
 ```
 
 対話ターミナルで長時間インデックスするときも、`Indexing...` は次の 50 ファイル更新まで固定文字列に落ちず、スピナーとして動き続けます。警告はその場で表示されますが、各警告の直後にスピナーが再開するため、処理が止まったようには見えません。stdout をリダイレクトしている場合（例: `cdidx . > out.txt`）は、stdout には `Indexing...` を 1 回だけ出し、警告は stderr に分離したまま、stdout には行単位の進捗だけを出します。

--- a/changelog.d/unreleased/+align-status-labels.fixed.md
+++ b/changelog.d/unreleased/+align-status-labels.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Aligned human status and index summary labels** — `cdidx index` and `cdidx status` now pad label/value rows from a shared formatter so labels such as `SQL graph` no longer shift the colon out of column.
+
+## 日本語
+
+- **human status / index summary のラベル位置を揃えました** — `cdidx index` と `cdidx status` は共通 formatter で label/value 行を padding するようになり、`SQL graph` などの長いラベルでもコロン位置がずれなくなりました。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -56,6 +56,8 @@ public enum DurationOutputFormat
 /// </summary>
 public static class ConsoleUi
 {
+    public const int SummaryLabelWidth = 9;
+
     private static readonly (string Command, string Usage)[] CommandUsageLines =
     [
         ("index", "cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--quiet] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--watch [--debounce <ms>]]"),
@@ -91,6 +93,9 @@ public static class ConsoleUi
         ("mcp", "cdidx mcp [--db <path>]"),
         ("license", "cdidx license"),
     ];
+
+    public static string FormatSummaryLine(string label, object? value, int labelWidth = SummaryLabelWidth, string indent = "")
+        => $"{indent}{label.PadRight(labelWidth)}: {value}";
 
     private const int SpinnerFrameDelayMs = 100;
     private const int SpinnerStopDelayMs = 20;

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -1841,23 +1841,23 @@ public static class IndexCommandRunner
             Console.WriteLine();
             Console.WriteLine("Done.");
             Console.WriteLine();
-            Console.WriteLine($"  Files    : {totalFiles:N0} (total in DB)");
-            Console.WriteLine($"  Chunks   : {totalChunks:N0}");
-            Console.WriteLine($"  Symbols  : {totalSymbols:N0}");
-            Console.WriteLine($"  Refs     : {totalReferences:N0}");
-            Console.WriteLine($"  Updated  : {updated:N0}");
-            if (removed > 0) Console.WriteLine($"  Removed  : {removed:N0}");
-            if (skipped > 0) Console.WriteLine($"  Skipped  : {skipped:N0}");
-            if (warnings > 0) Console.WriteLine($"  Warnings : {warnings:N0}");
-            if (errors > 0) Console.WriteLine($"  Errors   : {errors:N0}");
-            Console.WriteLine($"  Graph    : {(graphTableAvailableAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Issues   : {(issuesTableAvailableAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  SQL graph: {(sqlGraphContractReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Hotspots : {(hotspotFamilyReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  C# names : {(csharpSymbolNameReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  C# meta  : {(csharpMetadataTargetReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Fold     : {(foldReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Elapsed  : {ConsoleUi.FormatDuration(stopwatch.Elapsed, options.DurationFormat)}");
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Files", $"{totalFiles:N0} (total in DB)", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Chunks", $"{totalChunks:N0}", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Symbols", $"{totalSymbols:N0}", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Refs", $"{totalReferences:N0}", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Updated", $"{updated:N0}", indent: "  "));
+            if (removed > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Removed", $"{removed:N0}", indent: "  "));
+            if (skipped > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Skipped", $"{skipped:N0}", indent: "  "));
+            if (warnings > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Warnings", $"{warnings:N0}", indent: "  "));
+            if (errors > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Errors", $"{errors:N0}", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Graph", graphTableAvailableAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Issues", issuesTableAvailableAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("SQL graph", sqlGraphContractReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Hotspots", hotspotFamilyReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("C# names", csharpSymbolNameReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("C# meta", csharpMetadataTargetReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Fold", foldReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Elapsed", ConsoleUi.FormatDuration(stopwatch.Elapsed, options.DurationFormat), indent: "  "));
             Console.WriteLine();
             if (errors > 0)
                 ConsoleUi.PrintWarning($"Some files failed to update. Fix the reported files or permissions, then rerun `cdidx index \"{projectRoot}\"` to restore a fully ready index.");
@@ -3088,11 +3088,11 @@ public static class IndexCommandRunner
             Console.WriteLine();
             Console.WriteLine("Done.");
             Console.WriteLine();
-            Console.WriteLine($"  Files    : {totalFiles:N0}");
-            Console.WriteLine($"  Chunks   : {totalChunks:N0}");
-            Console.WriteLine($"  Symbols  : {totalSymbols:N0}");
-            Console.WriteLine($"  Refs     : {totalReferences:N0}");
-            if (skipped > 0) Console.WriteLine($"  Skipped  : {skipped:N0} (unchanged)");
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Files", $"{totalFiles:N0}", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Chunks", $"{totalChunks:N0}", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Symbols", $"{totalSymbols:N0}", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Refs", $"{totalReferences:N0}", indent: "  "));
+            if (skipped > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Skipped", $"{skipped:N0} (unchanged)", indent: "  "));
             if (options.Verbose && scanResult.UnknownExtensionFiles.Count > 0)
             {
                 Console.WriteLine($"  Unknown extension files: {scanResult.UnknownExtensionFiles.Count:N0}");
@@ -3101,16 +3101,16 @@ public static class IndexCommandRunner
                 if (scanResult.UnknownExtensionFiles.Count > 5)
                     Console.WriteLine($"    ... {scanResult.UnknownExtensionFiles.Count - 5:N0} more");
             }
-            if (warnings > 0) Console.WriteLine($"  Warnings : {warnings:N0}");
-            if (errors > 0) Console.WriteLine($"  Errors   : {errors:N0}");
-            Console.WriteLine($"  Graph    : {(graphTableAvailableAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Issues   : {(issuesTableAvailableAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  SQL graph: {(sqlGraphContractReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Hotspots : {(hotspotFamilyReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  C# names : {(csharpSymbolNameReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  C# meta  : {(csharpMetadataTargetReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Fold     : {(foldReadyAfter ? "ready" : "degraded")}");
-            Console.WriteLine($"  Elapsed  : {ConsoleUi.FormatDuration(stopwatch.Elapsed, options.DurationFormat)}");
+            if (warnings > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Warnings", $"{warnings:N0}", indent: "  "));
+            if (errors > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Errors", $"{errors:N0}", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Graph", graphTableAvailableAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Issues", issuesTableAvailableAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("SQL graph", sqlGraphContractReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Hotspots", hotspotFamilyReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("C# names", csharpSymbolNameReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("C# meta", csharpMetadataTargetReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Fold", foldReadyAfter ? "ready" : "degraded", indent: "  "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("Elapsed", ConsoleUi.FormatDuration(stopwatch.Elapsed, options.DurationFormat), indent: "  "));
             Console.WriteLine();
             if (errors > 0)
                 ConsoleUi.PrintWarning($"Some files failed to index. Fix the reported files or permissions, then rerun `cdidx index \"{projectRoot}\"` to restore a fully ready index.");

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -2038,19 +2038,19 @@ public static class QueryCommandRunner
                     Console.WriteLine(status.Summary);
                 Console.WriteLine();
                 if (status.Version != null)
-                    Console.WriteLine($"Version  : cdidx v{status.Version}");
-                Console.WriteLine($"Files    : {status.Files:N0}");
-                Console.WriteLine($"Chunks   : {status.Chunks:N0}");
-                Console.WriteLine($"Symbols  : {status.Symbols:N0}");
-                Console.WriteLine($"Refs     : {status.References:N0}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Version", $"cdidx v{status.Version}"));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Files", $"{status.Files:N0}"));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Chunks", $"{status.Chunks:N0}"));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Symbols", $"{status.Symbols:N0}"));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Refs", $"{status.References:N0}"));
                 if (status.IndexedAt != null)
-                    Console.WriteLine($"Indexed  : {status.IndexedAt:O}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Indexed", $"{status.IndexedAt:O}"));
                 if (status.LatestModified != null)
-                    Console.WriteLine($"Source   : {status.LatestModified:O}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Source", $"{status.LatestModified:O}"));
                 if (status.GitHead != null)
-                    Console.WriteLine($"Git HEAD : {status.GitHead}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Git HEAD", status.GitHead));
                 if (status.GitIsDirty != null)
-                    Console.WriteLine($"Git Dirty: {status.GitIsDirty}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Git Dirty", status.GitIsDirty));
                 // #1509 surface: SHA / branch / timestamp / drift come from the per-success
                 // stamp (indexed_head_sha / _branch / _timestamp) and reflect last-touched HEAD
                 // regardless of update mode. #1508/#1512's IndexedHeadCommit (full-scan only)
@@ -2060,16 +2060,16 @@ public static class QueryCommandRunner
                     var branchSuffix = string.IsNullOrWhiteSpace(status.IndexedHeadBranch)
                         ? string.Empty
                         : $" (branch {status.IndexedHeadBranch})";
-                    Console.WriteLine($"Idx HEAD : {status.IndexedHeadSha}{branchSuffix}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Idx HEAD", $"{status.IndexedHeadSha}{branchSuffix}"));
                 }
                 else if (status.IndexedHeadCommit != null && !string.Equals(status.IndexedHeadCommit, status.GitHead, StringComparison.OrdinalIgnoreCase))
                 {
-                    Console.WriteLine($"Idx HEAD : {status.IndexedHeadCommit}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Idx HEAD", status.IndexedHeadCommit));
                 }
                 if (status.IndexedHeadTimestamp != null)
-                    Console.WriteLine($"Idx Stamp: {status.IndexedHeadTimestamp:O}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Idx Stamp", $"{status.IndexedHeadTimestamp:O}"));
                 if (status.CommitsAheadOfIndexedHead is { } ahead && ahead > 0)
-                    Console.WriteLine($"Idx Drift: workspace is {ConsoleUi.Counted(ahead, "commit")} ahead of indexed HEAD — rerun `cdidx index .` to refresh.");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Idx Drift", $"workspace is {ConsoleUi.Counted(ahead, "commit")} ahead of indexed HEAD — rerun `cdidx index .` to refresh."));
                 if (status.WorkspaceCheck != null)
                 {
                     WriteStatusAge(status, staleAfter.Value);
@@ -2088,15 +2088,15 @@ public static class QueryCommandRunner
                         Console.WriteLine($"  {kind,-12} {count,6}");
                 }
                 if (status.GraphSupportedLanguages is { Count: > 0 })
-                    Console.WriteLine($"Graph   : {status.GraphSupportedLanguages.Count} languages ({string.Join(", ", status.GraphSupportedLanguages)})");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Graph", $"{status.GraphSupportedLanguages.Count} languages ({string.Join(", ", status.GraphSupportedLanguages)})"));
                 // #1546: surface the persisted filesystem case-sensitivity so operators can
                 // diagnose phantom path collapses on case-sensitive APFS / WSL / ReFS volumes.
                 // #1546: case-sensitivity を診断用に明示する。
                 if (status.PathCaseSensitive != null)
-                    Console.WriteLine($"FS Case : {(status.PathCaseSensitive == true ? "case-sensitive" : "case-insensitive")}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("FS Case", status.PathCaseSensitive == true ? "case-sensitive" : "case-insensitive"));
                 WriteStatusReadinessSummary(status, options);
                 if (status.WorktreeHeadChanged == true)
-                    Console.WriteLine($"WARN    : worktree HEAD changed since the index was built ({ShortSha(status.IndexedHeadCommit)} -> {ShortSha(status.GitHead)}). Run `{BuildReindexRepairCommand(status.ProjectRoot, options.DbPath, options.DbPathExplicit)}` to refresh the index for the current branch.");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", $"worktree HEAD changed since the index was built ({ShortSha(status.IndexedHeadCommit)} -> {ShortSha(status.GitHead)}). Run `{BuildReindexRepairCommand(status.ProjectRoot, options.DbPath, options.DbPathExplicit)}` to refresh the index for the current branch."));
                 if (status.IndexNewerThanReader)
                 {
                     var reason = status.IndexNewerThanReaderReason ?? "DB was written by a newer cdidx than this binary.";
@@ -2105,46 +2105,46 @@ public static class QueryCommandRunner
                         : status.Version is { Length: > 0 } readerVersion
                             ? $" (reader: cdidx v{readerVersion})"
                             : "";
-                    Console.WriteLine($"WARN    : {reason}{writerLabel}");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", $"{reason}{writerLabel}"));
                 }
                 if (!status.GraphTableAvailable)
-                    Console.WriteLine("WARN    : symbol_references table missing — reference / caller / callee / unused counts are degraded to 0.");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", "symbol_references table missing — reference / caller / callee / unused counts are degraded to 0."));
                 if (!status.IssuesTableAvailable)
-                    Console.WriteLine("WARN    : file_issues table missing — validate output is degraded to empty.");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", "file_issues table missing — validate output is degraded to empty."));
                 if (!status.SqlGraphContractReady)
-                    Console.WriteLine($"WARN    : SQL graph/dependency results may be stale. Run `{BuildSqlGraphContractRepairCommand(status.ProjectRoot, options.DbPath, options.DbPathExplicit)}` before trusting SQL references/callers/deps/unused/hotspots.");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", $"SQL graph/dependency results may be stale. Run `{BuildSqlGraphContractRepairCommand(status.ProjectRoot, options.DbPath, options.DbPathExplicit)}` before trusting SQL references/callers/deps/unused/hotspots."));
                 if (!status.HotspotFamilyReady && status.HotspotFamilyDegradedReason != null)
                 {
-                    Console.WriteLine($"WARN    : {status.HotspotFamilyDegradedReason}");
-                    Console.WriteLine("Hint    : rerun `cdidx index <projectPath>` to restore authoritative cross-file hotspot families.");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", status.HotspotFamilyDegradedReason));
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Hint", "rerun `cdidx index <projectPath>` to restore authoritative cross-file hotspot families."));
                 }
                 if (!status.CSharpSymbolNameReady)
-                    Console.WriteLine($"WARN    : C# exact-name for operators / conversion operators / indexers is degraded. Run `{BuildCSharpCanonicalNameRepairCommand(status.ProjectRoot, options.DbPath, options.DbPathExplicit)}` to upgrade canonical symbol names in place.");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", $"C# exact-name for operators / conversion operators / indexers is degraded. Run `{BuildCSharpCanonicalNameRepairCommand(status.ProjectRoot, options.DbPath, options.DbPathExplicit)}` to upgrade canonical symbol names in place."));
                 // #435: tell the user when deps / impact metadata-attribute edges fall back
                 // to the legacy signature / name-suffix heuristic (impostor classes may be
                 // silently promoted or demoted until the authoritative resolver is re-run).
                 // #435: deps / impact の metadata-attribute edge が legacy heuristic に
                 // 縮退しているときは明示する。
                 if (!status.CSharpMetadataTargetReady)
-                    Console.WriteLine("WARN    : C# deps / impact metadata-attribute edges fall back to the signature / name-suffix heuristic. Run `cdidx index .` to re-stamp authoritative is_metadata_target values.");
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", "C# deps / impact metadata-attribute edges fall back to the signature / name-suffix heuristic. Run `cdidx index .` to re-stamp authoritative is_metadata_target values."));
                 // #86: tell the user when `--exact` is running on the ASCII NOCASE fallback.
                 // #86: --exact が ASCII NOCASE fallback で動いているときは明示する。
                 if (!status.FoldReady)
                 {
                     if (IsFoldOnlyReadinessDegraded(status) && status.DegradedReason != null && status.RecommendedAction != null && status.AlternativeAction != null)
                     {
-                        Console.WriteLine($"WARN    : {status.DegradedReason}");
-                        Console.WriteLine($"Hint    : run `{status.RecommendedAction}` to restamp folded-name columns in place.");
-                        Console.WriteLine($"Hint    : or run `{status.AlternativeAction}` for a full rebuild.");
+                        Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", status.DegradedReason));
+                        Console.WriteLine(ConsoleUi.FormatSummaryLine("Hint", $"run `{status.RecommendedAction}` to restamp folded-name columns in place."));
+                        Console.WriteLine(ConsoleUi.FormatSummaryLine("Hint", $"or run `{status.AlternativeAction}` for a full rebuild."));
                     }
                     else
                     {
-                        Console.WriteLine($"WARN    : {BuildFoldNotReadyWarning(status.FoldReadyReason, BuildFoldBackfillCommand(options.DbPath, options.DbPathExplicit), BuildFoldRebuildRepairCommand(status.ProjectRoot, options.DbPath, options.DbPathExplicit))}");
+                        Console.WriteLine(ConsoleUi.FormatSummaryLine("WARN", BuildFoldNotReadyWarning(status.FoldReadyReason, BuildFoldBackfillCommand(options.DbPath, options.DbPathExplicit), BuildFoldRebuildRepairCommand(status.ProjectRoot, options.DbPath, options.DbPathExplicit))));
                     }
                 }
                 var totalLangs = FileIndexer.GetLanguageExtensions().Values.Distinct().Count();
                 var symbolLangs = SymbolExtractor.GetSupportedLanguages().Count;
-                Console.WriteLine($"Support : {totalLangs} detected, {symbolLangs} with symbols, {status.GraphSupportedLanguages?.Count ?? 0} with graph");
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Support", $"{totalLangs} detected, {symbolLangs} with symbols, {status.GraphSupportedLanguages?.Count ?? 0} with graph"));
             }
 
             if (!options.CheckWorkspace)

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -4340,6 +4340,10 @@ public class IndexCommandRunnerTests
             Assert.Contains("Issues   : degraded", output);
             Assert.Contains("SQL graph: ready", output);
             Assert.Contains("Fold     : degraded", output);
+            var readinessLines = output.Split('\n')
+                .Where(line => line.Contains(": ready", StringComparison.Ordinal) || line.Contains(": degraded", StringComparison.Ordinal))
+                .ToList();
+            Assert.All(readinessLines, line => Assert.Equal(readinessLines[0].IndexOf(':', StringComparison.Ordinal), line.IndexOf(':', StringComparison.Ordinal)));
         }
         finally
         {
@@ -4741,7 +4745,7 @@ public class IndexCommandRunnerTests
             }
 
             Assert.Equal(CommandExitCodes.Success, humanExitCode);
-            Assert.Contains("WARN    : C# exact-name for operators / conversion operators / indexers is degraded.", output);
+            Assert.Contains("WARN     : C# exact-name for operators / conversion operators / indexers is degraded.", output);
             Assert.Contains("--db", output);
             Assert.Contains(Path.GetFullPath(projectRoot), output);
             Assert.Contains(Path.GetFullPath(dbPath), output);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -11185,7 +11185,7 @@ jobs:
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
-            Assert.Contains("WARN    : worktree HEAD changed since the index was built", stdout);
+            Assert.Contains("WARN     : worktree HEAD changed since the index was built", stdout);
             Assert.Contains(staleHead[..12], stdout);
             Assert.Contains("cdidx index", stdout);
         }
@@ -11221,8 +11221,8 @@ jobs:
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
             Assert.Contains("older fold-key version", stdout);
-            Assert.Contains("Hint    : run `cdidx backfill-fold --db", stdout);
-            Assert.Contains("Hint    : or run `cdidx index", stdout);
+            Assert.Contains("Hint     : run `cdidx backfill-fold --db", stdout);
+            Assert.Contains("Hint     : or run `cdidx index", stdout);
             Assert.Contains("--rebuild", stdout);
         }
         finally


### PR DESCRIPTION
## Summary

- Add a shared human summary formatter so `cdidx index` and `cdidx status` align label/value colons at the same column.
- Update index completion output examples in `USER_GUIDE.md`, including the Japanese example shown in the screenshot.
- Add regression coverage for readiness summary colon alignment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests|FullyQualifiedName~QueryCommandRunnerTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and Changelog

- Updated `USER_GUIDE.md`.
- Added `changelog.d/unreleased/+align-status-labels.fixed.md`.

## Follow-up

- None.
