### PR TITLE
Implement MCP resources and prompts

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1276,6 +1276,12 @@ Piping `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` into
   `serverInfo.name`, `serverInfo.version` (read via
   `ConsoleUi.LoadVersion()` — the same `version.json` source), and the
   long `instructions` string that guides AI clients on tool selection.
+- The advertised capability surface includes `tools`, `resources`, and
+  `prompts`. `resources/list` pages indexed files as `cdidx://file/<path>`
+  URIs and `resources/read` reconstructs file text from indexed chunks.
+  `prompts/list` exposes the built-in `summarize_file`, `find_unused`, and
+  `impact_of_changing` prompts; `prompts/get` returns a user-message template
+  that directs clients toward the matching cdidx tools.
 - `protocolVersion` is **negotiated**, not hardcoded (#1554). The server
   maintains `McpServer.SupportedProtocolVersions` (newest first:
   `2025-03-26`, `2024-11-05`), reads the client's requested

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 - `.sln` / `.csproj`-aware `--project <name|path>` filters for indexing and
   query commands, with `--solution <path>` when a workspace has multiple
   solution files.
-- MCP server for AI clients such as Claude Code, Cursor, and Windsurf.
+- MCP server for AI clients such as Claude Code, Cursor, and Windsurf,
+  including tools, indexed-file resources, and canned analysis prompts.
 - Local suggestion history can be listed, inspected, and exported with
   `cdidx suggestions`.
 - Parallel full-scan extraction with configurable `--parallelism`, incremental refreshes
@@ -118,6 +119,10 @@ scripts, CI, or AI tools. Use `rg` when you only need a one-off text scan.
 - 78 detected languages, with symbol and graph support where available.
 - MCP `tools/list` descriptions include a `Language support:` clause sourced
   from the same language registries as `cdidx languages`.
+- MCP `resources/list` exposes indexed files as `cdidx://file/<path>` resources,
+  `resources/read` returns indexed file text, and `prompts/list` advertises
+  starter prompts such as `summarize_file`, `find_unused`, and
+  `impact_of_changing`.
 
 ## Documentation
 
@@ -250,6 +255,7 @@ cdidx mcp
   index と query コマンドを特定の .NET project 配下へ絞り込めます。
   workspace に solution が複数ある場合は `--solution <path>` を指定します。
 - Claude Code、Cursor、Windsurf などの AI クライアント向け MCP サーバー。
+  tools、インデックス済みファイル resources、定型分析 prompts を提供します。
 - `cdidx suggestions` でローカルの提案履歴を一覧表示、詳細表示、エクスポート可能。
 - `--files` と `--commits` による差分更新、および `--watch` による継続更新モード。
 - `status --check` による DB と作業ツリーの完全一致確認。`--stale-after` /
@@ -285,6 +291,10 @@ cdidx mcp
 - 78 言語を検出し、対応言語ではシンボルとグラフも利用可能。
 - MCP の `tools/list` 説明には、`cdidx languages` と同じ言語レジストリから
   生成した `Language support:` 句を含めます。
+- MCP の `resources/list` はインデックス済みファイルを `cdidx://file/<path>`
+  resources として公開し、`resources/read` はファイル本文を返します。
+  `prompts/list` は `summarize_file`、`find_unused`、`impact_of_changing`
+  などの starter prompt を公開します。
 
 ## ドキュメント
 

--- a/changelog.d/unreleased/1682.fixed.md
+++ b/changelog.d/unreleased/1682.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1682
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - README.md
+---
+
+## English
+
+- **MCP now advertises built-in prompts (#1682)** — `initialize` advertises prompts, `prompts/list` exposes starter analysis prompts, and `prompts/get` returns message templates for common cdidx workflows.
+
+## 日本語
+
+- **MCP が組み込み prompts を advertise します (#1682)** — `initialize` は prompts を advertise し、`prompts/list` は starter analysis prompt を公開し、`prompts/get` は cdidx の一般的な workflow 向け message template を返します。

--- a/changelog.d/unreleased/1683.fixed.md
+++ b/changelog.d/unreleased/1683.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1683
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - README.md
+---
+
+## English
+
+- **MCP indexed files are exposed as resources (#1683)** — `initialize` advertises resources, `resources/list` returns indexed files as `cdidx://file/<path>` URIs, and `resources/read` returns indexed file text.
+
+## 日本語
+
+- **MCP がインデックス済みファイルを resources として公開します (#1683)** — `initialize` は resources を advertise し、`resources/list` はインデックス済みファイルを `cdidx://file/<path>` URI として返し、`resources/read` はファイル本文を返します。

--- a/changelog.d/unreleased/1784.fixed.md
+++ b/changelog.d/unreleased/1784.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1784
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - README.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **MCP capability discovery now covers resources and prompts (#1784)** — method-not-found guidance, docs, and regression coverage now reflect the supported `resources/*` and `prompts/*` surfaces.
+
+## 日本語
+
+- **MCP capability discovery が resources と prompts を含むようになりました (#1784)** — method-not-found guidance、docs、回帰テストが、対応済みの `resources/*` と `prompts/*` surface を反映するようになりました。

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -728,10 +728,14 @@ public partial class McpServer : IDisposable
             "initialize" => HandleInitialize(id, request["params"]),
             "tools/list" => HandleToolsList(id),
             "tools/call" => HandleToolsCall(id, request["params"]),
+            "resources/list" => HandleResourcesList(id, request["params"]),
+            "resources/read" => HandleResourcesRead(id, request["params"]),
+            "prompts/list" => HandlePromptsList(id),
+            "prompts/get" => HandlePromptsGet(id, request["params"]),
             "ping" => CreateSuccessResponse(hasId, id, new JsonObject()),
             _ => CreateErrorResponse(hasId: true, id: id, code: -32601, message: $"Method not found: {method}",
                 category: McpErrorEnvelope.CategoryMethodNotFound,
-                suggestion: "Supported methods: initialize, tools/list, tools/call, ping, notifications/initialized, notifications/cancelled, notifications/shutdown.",
+                suggestion: "Supported methods: initialize, tools/list, tools/call, resources/list, resources/read, prompts/list, prompts/get, ping, notifications/initialized, notifications/cancelled, notifications/shutdown.",
                 retrySafe: false),
         });
     }
@@ -911,6 +915,15 @@ public partial class McpServer : IDisposable
                 ["tools"] = new JsonObject
                 {
                     ["listChanged"] = false
+                },
+                ["resources"] = new JsonObject
+                {
+                    ["subscribe"] = false,
+                    ["listChanged"] = false
+                },
+                ["prompts"] = new JsonObject
+                {
+                    ["listChanged"] = false
                 }
             },
             ["serverInfo"] = new JsonObject
@@ -974,6 +987,197 @@ public partial class McpServer : IDisposable
             return s;
         return null;
     }
+
+    private JsonNode HandleResourcesList(JsonNode? id, JsonNode? listParams)
+    {
+        const int pageSize = 200;
+        var offset = 0;
+        if (listParams?["cursor"] is JsonValue cursorValue
+            && cursorValue.TryGetValue<string>(out var cursor)
+            && int.TryParse(cursor, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+            && parsed > 0)
+        {
+            offset = parsed;
+        }
+
+        return WithDbReader(id, reader =>
+        {
+            var files = reader.ListFiles(limit: offset + pageSize + 1);
+            var page = files.Skip(offset).Take(pageSize).ToArray();
+            var resources = new JsonArray();
+            foreach (var file in page)
+            {
+                resources.Add(new JsonObject
+                {
+                    ["uri"] = BuildResourceUri(file.Path),
+                    ["name"] = file.Path,
+                    ["description"] = $"{file.Path} ({file.Lang ?? "unknown"}, {file.Lines} lines)",
+                    ["mimeType"] = GetResourceMimeType(file.Lang),
+                });
+            }
+
+            var result = new JsonObject
+            {
+                ["resources"] = resources,
+            };
+            if (offset + pageSize < files.Count)
+                result["nextCursor"] = (offset + pageSize).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            return CreateSuccessResponse(true, id, result);
+        });
+    }
+
+    private JsonNode HandleResourcesRead(JsonNode? id, JsonNode? readParams)
+    {
+        var uri = readParams?["uri"]?.GetValue<string>();
+        if (string.IsNullOrWhiteSpace(uri))
+            return CreateErrorResponse(hasId: true, id: id, code: -32602, message: "Missing resource uri",
+                category: McpErrorEnvelope.CategoryMissingParameter,
+                suggestion: "resources/read requires `params.uri` from resources/list, such as `cdidx://file/src/app.cs`.",
+                retrySafe: false);
+
+        if (!TryParseResourceUri(uri, out var path))
+            return CreateErrorResponse(hasId: true, id: id, code: -32602, message: $"Invalid resource uri: {uri}",
+                category: McpErrorEnvelope.CategoryInvalidArgument,
+                suggestion: "Use a cdidx file resource URI returned by resources/list (`cdidx://file/<indexed-path>`).",
+                retrySafe: false);
+
+        return WithDbReader(id, reader =>
+        {
+            var files = reader.ListFiles(query: path, limit: 2);
+            var file = files.FirstOrDefault(f => string.Equals(f.Path, path, StringComparison.Ordinal));
+            if (file == null)
+                return CreateErrorResponse(hasId: true, id: id, code: -32602, message: $"Resource not found: {uri}",
+                    category: McpErrorEnvelope.CategoryInvalidArgument,
+                    suggestion: "Call resources/list again and retry with one of the returned resource URIs.",
+                    retrySafe: true);
+
+            var excerpt = reader.GetExcerpt(file.Path, 1, Math.Max(1, file.Lines));
+            var contents = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["uri"] = BuildResourceUri(file.Path),
+                    ["mimeType"] = GetResourceMimeType(file.Lang),
+                    ["text"] = excerpt?.Content ?? string.Empty,
+                }
+            };
+            return CreateSuccessResponse(true, id, new JsonObject { ["contents"] = contents });
+        });
+    }
+
+    private JsonNode HandlePromptsList(JsonNode? id)
+    {
+        var prompts = new JsonArray
+        {
+            CreatePromptDefinition("summarize_file", "Summarize the API surface and responsibilities of an indexed file.", "path", "Indexed file path to summarize."),
+            CreatePromptDefinition("find_unused", "Find likely unused symbols in an optional language or path scope.", "scope", "Optional language, module, or path scope."),
+            CreatePromptDefinition("impact_of_changing", "Plan impact analysis for changing a symbol.", "symbol", "Symbol name to analyze."),
+        };
+        return CreateSuccessResponse(true, id, new JsonObject { ["prompts"] = prompts });
+    }
+
+    private JsonNode HandlePromptsGet(JsonNode? id, JsonNode? getParams)
+    {
+        var name = getParams?["name"]?.GetValue<string>();
+        if (string.IsNullOrWhiteSpace(name))
+            return CreateErrorResponse(hasId: true, id: id, code: -32602, message: "Missing prompt name",
+                category: McpErrorEnvelope.CategoryMissingParameter,
+                suggestion: "prompts/get requires `params.name`; call prompts/list to enumerate available names.",
+                retrySafe: false);
+
+        var args = getParams?["arguments"] as JsonObject;
+        string? ReadArg(string key)
+            => args != null && args.TryGetPropertyValue(key, out var node) && node is JsonValue value && value.TryGetValue<string>(out var s)
+                ? s
+                : null;
+
+        var text = name switch
+        {
+            "summarize_file" => $"Use the `outline` tool for `{ReadArg("path") ?? "<path>"}`, then use `excerpt` only for the ranges needed to summarize public API, key symbols, and responsibilities.",
+            "find_unused" => $"Use `unused_symbols` with the requested scope `{ReadArg("scope") ?? "<scope>"}`. Cross-check surprising results with `references` or `callers` before recommending deletions.",
+            "impact_of_changing" => $"Use `impact_analysis` for `{ReadArg("symbol") ?? "<symbol>"}`. Summarize direct callers, transitive callers, and files that likely need tests.",
+            _ => null,
+        };
+        if (text == null)
+            return CreateErrorResponse(hasId: true, id: id, code: -32602, message: $"Unknown prompt: {name}",
+                category: McpErrorEnvelope.CategoryInvalidArgument,
+                suggestion: "Call prompts/list and request one of the advertised prompt names.",
+                retrySafe: false);
+
+        var messages = new JsonArray
+        {
+            new JsonObject
+            {
+                ["role"] = "user",
+                ["content"] = new JsonObject
+                {
+                    ["type"] = "text",
+                    ["text"] = text,
+                },
+            },
+        };
+        return CreateSuccessResponse(true, id, new JsonObject
+        {
+            ["description"] = name,
+            ["messages"] = messages,
+        });
+    }
+
+    private static JsonObject CreatePromptDefinition(string name, string description, string argumentName, string argumentDescription)
+        => new()
+        {
+            ["name"] = name,
+            ["description"] = description,
+            ["arguments"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["name"] = argumentName,
+                    ["description"] = argumentDescription,
+                    ["required"] = false,
+                },
+            },
+        };
+
+    private static string BuildResourceUri(string path)
+        => "cdidx://file/" + string.Join('/', path.Split('/').Select(Uri.EscapeDataString));
+
+    private static bool TryParseResourceUri(string uri, out string path)
+    {
+        path = string.Empty;
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsed)
+            || !string.Equals(parsed.Scheme, "cdidx", StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(parsed.Host, "file", StringComparison.OrdinalIgnoreCase)
+            || string.IsNullOrWhiteSpace(parsed.AbsolutePath))
+        {
+            return false;
+        }
+
+        var decoded = Uri.UnescapeDataString(parsed.AbsolutePath.TrimStart('/'));
+        if (decoded.Length == 0 || decoded.Contains("..", StringComparison.Ordinal) || Path.IsPathRooted(decoded))
+            return false;
+        path = decoded;
+        return true;
+    }
+
+    private static string GetResourceMimeType(string? lang)
+        => lang?.ToLowerInvariant() switch
+        {
+            "csharp" => "text/x-csharp",
+            "fsharp" => "text/x-fsharp",
+            "vb" => "text/x-vb",
+            "javascript" => "text/javascript",
+            "typescript" => "text/typescript",
+            "json" => "application/json",
+            "markdown" => "text/markdown",
+            "python" => "text/x-python",
+            "rust" => "text/x-rust",
+            "shell" => "text/x-shellscript",
+            "sql" => "application/sql",
+            "yaml" => "application/yaml",
+            "xml" => "application/xml",
+            _ => "text/plain",
+        };
 
     /// <summary>
     /// Resolve the caller identity used by the per-(tool, caller) rate limiter from an

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -1028,7 +1028,7 @@ public partial class McpServer : IDisposable
 
     private JsonNode HandleResourcesRead(JsonNode? id, JsonNode? readParams)
     {
-        var uri = readParams?["uri"]?.GetValue<string>();
+        var uri = TryReadStringValue(readParams?["uri"]);
         if (string.IsNullOrWhiteSpace(uri))
             return CreateErrorResponse(hasId: true, id: id, code: -32602, message: "Missing resource uri",
                 category: McpErrorEnvelope.CategoryMissingParameter,
@@ -1078,7 +1078,7 @@ public partial class McpServer : IDisposable
 
     private JsonNode HandlePromptsGet(JsonNode? id, JsonNode? getParams)
     {
-        var name = getParams?["name"]?.GetValue<string>();
+        var name = TryReadStringValue(getParams?["name"]);
         if (string.IsNullOrWhiteSpace(name))
             return CreateErrorResponse(hasId: true, id: id, code: -32602, message: "Missing prompt name",
                 category: McpErrorEnvelope.CategoryMissingParameter,
@@ -1154,11 +1154,18 @@ public partial class McpServer : IDisposable
         }
 
         var decoded = Uri.UnescapeDataString(parsed.AbsolutePath.TrimStart('/'));
-        if (decoded.Length == 0 || decoded.Contains("..", StringComparison.Ordinal) || Path.IsPathRooted(decoded))
+        if (decoded.Length == 0
+            || Path.IsPathRooted(decoded)
+            || decoded.Split('/').Any(segment => segment.Length == 0 || segment is "." or ".."))
+        {
             return false;
+        }
         path = decoded;
         return true;
     }
+
+    private static string? TryReadStringValue(JsonNode? node)
+        => node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
 
     private static string GetResourceMimeType(string? lang)
         => lang?.ToLowerInvariant() switch

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -138,6 +138,64 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void Initialize_AdvertisesResourcesAndPrompts()
+    {
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        var capabilities = response["result"]!["capabilities"]!;
+        Assert.False(capabilities["tools"]!["listChanged"]!.GetValue<bool>());
+        Assert.False(capabilities["resources"]!["subscribe"]!.GetValue<bool>());
+        Assert.False(capabilities["resources"]!["listChanged"]!.GetValue<bool>());
+        Assert.False(capabilities["prompts"]!["listChanged"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void ResourcesList_ReturnsIndexedFilesAsResources()
+    {
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        var resource = response["result"]!["resources"]!.AsArray()
+            .Single(r => r!["name"]!.GetValue<string>() == "src/app.cs")!;
+        Assert.Equal("cdidx://file/src/app.cs", resource["uri"]!.GetValue<string>());
+        Assert.Equal("text/x-csharp", resource["mimeType"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ResourcesRead_ReturnsIndexedFileContent()
+    {
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"cdidx://file/src/app.cs"}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        var content = response["result"]!["contents"]!.AsArray().Single()!;
+        Assert.Equal("cdidx://file/src/app.cs", content["uri"]!.GetValue<string>());
+        Assert.Equal("text/x-csharp", content["mimeType"]!.GetValue<string>());
+        Assert.Contains("public class App", content["text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void PromptsListAndGet_ReturnPromptMessages()
+    {
+        var list = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}""")!;
+        var listResponse = _server.HandleMessage(list)!;
+
+        var names = listResponse["result"]!["prompts"]!.AsArray()
+            .Select(p => p!["name"]!.GetValue<string>())
+            .ToArray();
+        Assert.Contains("summarize_file", names);
+        Assert.Contains("find_unused", names);
+        Assert.Contains("impact_of_changing", names);
+
+        var get = JsonNode.Parse("""{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"impact_of_changing","arguments":{"symbol":"Run"}}}""")!;
+        var getResponse = _server.HandleMessage(get)!;
+        var message = getResponse["result"]!["messages"]!.AsArray().Single()!;
+        Assert.Equal("user", message["role"]!.GetValue<string>());
+        Assert.Contains("impact_analysis", message["content"]!["text"]!.GetValue<string>());
+        Assert.Contains("Run", message["content"]!["text"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void Initialize_RequestedCurrentProtocolVersion_EchoesBack()
     {
         // Issue #1554: when the client pins the current preferred version, the server

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -175,6 +175,16 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void ResourcesRead_NonStringUri_ReturnsInvalidParams()
+    {
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":42}}""")!;
+        var response = _server.HandleMessage(request)!;
+
+        Assert.Equal(-32602, response["error"]!["code"]!.GetValue<int>());
+        Assert.Equal("missing_parameter", response["error"]!["data"]!["category"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void PromptsListAndGet_ReturnPromptMessages()
     {
         var list = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}""")!;


### PR DESCRIPTION
## Summary
- Advertise MCP resources and prompts in initialize and method discovery guidance.
- Add resources/list and resources/read for indexed files using cdidx://file/<path> URIs.
- Add prompts/list and prompts/get starter analysis prompts.
- Document the MCP capability surface and add bilingual changelog fragments.

Fixes #1682
Fixes #1683
Fixes #1784

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests" -p:UseSharedCompilation=false
- dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false
- dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json

## Review
- Adversarial review attempted with codex exec, but the CLI returned a usage-limit error before producing a review.
- Manual adversarial review of origin/main..HEAD found no blocking/actionable issues after the non-string parameter handling fix.