### PR TITLE
Fix SQLite synchronous pragma concurrency issue

### DIFF
--- a/changelog.d/unreleased/2451.fixed.md
+++ b/changelog.d/unreleased/2451.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2451
+affected:
+  - src/CodeIndex/Database/DbContext.cs
+  - tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+---
+
+## English
+
+- **SQLite connection setup no longer fails when synchronous mode is blocked by an active transaction (#2451)** — `DbContext` now keeps the connection usable when SQLite rejects `PRAGMA synchronous=NORMAL` with the known "Safety level may not be changed inside a transaction" error during concurrent access.
+
+## 日本語
+
+- **active transaction により synchronous mode 設定が拒否されても SQLite 接続初期化が失敗しなくなりました (#2451)** — 並行アクセス中に SQLite が `PRAGMA synchronous=NORMAL` を既知の "Safety level may not be changed inside a transaction" エラーで拒否した場合でも、`DbContext` は接続を利用可能なまま維持します。

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -196,7 +196,7 @@ public class DbContext : IDisposable
             var journalMode = ExecuteScalar("PRAGMA journal_mode=WAL");
             if (!string.Equals(journalMode, "wal", StringComparison.OrdinalIgnoreCase))
                 Console.Error.WriteLine($"Warning: WAL mode not enabled (got '{journalMode}')");
-            Execute($"PRAGMA synchronous={DefaultSynchronousMode}");
+            ExecuteSynchronousPragmaWithFallback(Execute);
             Execute($"PRAGMA wal_autocheckpoint={DefaultWalAutocheckpointPages}");
         }
         catch (SqliteException ex) when (IsReadOnlyOpenError(ex))
@@ -221,6 +221,24 @@ public class DbContext : IDisposable
             EnsureForeignKeysEnabled();
         }
     }
+
+    internal static void ExecuteSynchronousPragmaWithFallback(Action<string> execute)
+    {
+        try
+        {
+            execute($"PRAGMA synchronous={DefaultSynchronousMode}");
+        }
+        catch (SqliteException ex) when (IsSafetyLevelTransactionError(ex))
+        {
+            // SQLite can reject PRAGMA synchronous while another pooled connection is in a
+            // transaction. Keep the connection usable; the setting is a durability/perf knob,
+            // not a schema precondition for readers.
+        }
+    }
+
+    internal static bool IsSafetyLevelTransactionError(SqliteException ex) =>
+        ex.SqliteErrorCode == 1 &&
+        ex.Message.Contains("Safety level may not be changed inside a transaction", StringComparison.OrdinalIgnoreCase);
 
     // SQLITE_READONLY(8), SQLITE_CANTOPEN(14), SQLITE_IOERR(10). A read-only filesystem
     // typically surfaces as CANTOPEN because -journal/-shm cannot be created.

--- a/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+++ b/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
@@ -553,6 +553,31 @@ public class LegacySchemaMigrationTests : IDisposable
     }
 
     [Fact]
+    public void DbContext_SynchronousPragma_AllowsSqliteSafetyLevelTransactionError()
+    {
+        var calls = 0;
+
+        DbContext.ExecuteSynchronousPragmaWithFallback(sql =>
+        {
+            calls++;
+            Assert.Equal($"PRAGMA synchronous={DbContext.DefaultSynchronousMode}", sql);
+            throw CreateSqliteException("Safety level may not be changed inside a transaction", 1);
+        });
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void DbContext_SynchronousPragma_RethrowsOtherSqliteErrors()
+    {
+        var ex = Assert.Throws<SqliteException>(() =>
+            DbContext.ExecuteSynchronousPragmaWithFallback(_ =>
+                throw CreateSqliteException("no such table: missing", 1)));
+
+        Assert.Contains("no such table", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryValidateExistingCodeIndexDb_RetriesTransientBusyOpen()
     {
         // backfill-fold validation must use the same retry/backoff path as the main open.
@@ -629,12 +654,15 @@ public class LegacySchemaMigrationTests : IDisposable
     }
 
     private static SqliteException CreateTransientBusyException()
+        => CreateSqliteException("busy", 5);
+
+    private static SqliteException CreateSqliteException(string message, int errorCode)
     {
         var exception = Activator.CreateInstance(
             typeof(SqliteException),
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
             binder: null,
-            args: ["busy", 5],
+            args: [message, errorCode],
             culture: null) as SqliteException;
 
         return exception ?? throw new InvalidOperationException("Failed to create SqliteException for retry test.");


### PR DESCRIPTION
## Summary

- Handle SQLite's known `PRAGMA synchronous=NORMAL` "Safety level may not be changed inside a transaction" failure during `DbContext` setup without aborting the connection.
- Add focused regression coverage for allowing only that specific synchronous-pragma error while rethrowing other SQLite setup failures.
- Add the bilingual changelog fragment for the fix.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~LegacySchemaMigrationTests|FullyQualifiedName~ConcurrencyTests"`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/2451.fixed.md`.
- No README or developer-guide changes were needed because this is a narrow crash fix for an existing documented SQLite setup policy.

## Follow-up Candidates

- None.

Fixes #2451
