### PR TITLE
Fix C# enum XML doc extraction

### DIFF
--- a/changelog.d/unreleased/2437.fixed.md
+++ b/changelog.d/unreleased/2437.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2437
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **C# enum extraction no longer treats XML documentation prose as enum members (#2437)** — enum member recovery now skips XML doc comment lines, preventing `unused` and symbol queries from reporting words in documentation as phantom enum symbols.
+
+## 日本語
+
+- **C# enum 抽出が XML ドキュメント本文を enum member として扱わなくなりました (#2437)** — enum member の回復処理で XML doc コメント行を除外し、`unused` や symbol 系クエリがドキュメント中の単語を phantom enum symbol として報告しないようにしました。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -143,7 +143,8 @@ public static partial class SymbolExtractor
 
             if (TryGetFirstNonWhitespaceColumn(maskedLine, lineScanStartColumn, scanEndColumnExclusive, out var firstNonWhitespaceColumn)
                 && column == firstNonWhitespaceColumn
-                && maskedLine[column] == '#')
+                && (maskedLine[column] == '#'
+                    || IsCSharpXmlDocCommentLine(rawLines[lineIndex], firstNonWhitespaceColumn)))
             {
                 currentStart = null;
                 parenDepth = 0;
@@ -219,6 +220,14 @@ public static partial class SymbolExtractor
 
         if (currentStart != null)
             TryAddCSharpEnumMemberFromSpan(fileId, enumSymbol, rawLines, enumScannerLines, currentStart.Value, (bodyEndLineIndex, bodyEndColumnExclusive), symbols);
+    }
+
+    private static bool IsCSharpXmlDocCommentLine(string rawLine, int firstNonWhitespaceColumn)
+    {
+        return firstNonWhitespaceColumn + 2 < rawLine.Length
+            && rawLine[firstNonWhitespaceColumn] == '/'
+            && rawLine[firstNonWhitespaceColumn + 1] == '/'
+            && rawLine[firstNonWhitespaceColumn + 2] == '/';
     }
 
     internal static string[] SanitizeCSharpLinesForCrossLineScan(string[] lines)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -16908,6 +16908,28 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_EnumMembers_DoNotUseXmlDocProseAsNames()
+    {
+        const string content = """
+            internal enum ColorMode
+            {
+                Auto = 0,
+                /// <summary>Use ANSI colors even when stdout is redirected.</summary>
+                Always = 1,
+                /// <summary>Disable ANSI colors even on a TTY.</summary>
+                Never = 2,
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Auto" && s.ContainerName == "ColorMode");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Always" && s.ContainerName == "ColorMode");
+        Assert.Contains(symbols, s => s.Kind == "enum" && s.Name == "Never" && s.ContainerName == "ColorMode");
+        Assert.DoesNotContain(symbols, s => s.Kind == "enum" && s.Name == "even" && s.ContainerName == "ColorMode");
+    }
+
+    [Fact]
     public void Extract_CSharp_DetectsPlainFieldDeclarations()
     {
         // Plain fields are now captured as kind `property` so definition/symbols/outline/


### PR DESCRIPTION
## Summary

- Skip C# XML documentation comment lines while recovering enum members.
- Add a regression test for XML-doc prose around enum members.
- Add changelog fragment `changelog.d/unreleased/2437.fixed.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter Extract_CSharp_EnumMembers_DoNotUseXmlDocProseAsNames`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll unused --lang csharp --exclude-tests --path src/CodeIndex/Cli/ConsoleUi.cs --json --limit 200`

## Documentation and changelog

- Added bilingual changelog fragment: `changelog.d/unreleased/2437.fixed.md`.
- No README/guide update required; this fixes extraction correctness without changing CLI flags or documented contracts.

## Review

- Adversarial review: No blocking/actionable issues found.

## Follow-up candidates

- None.

Fixes #2437