### PR TITLE
Fix Scala braceless class ranges

### DIFF
--- a/changelog.d/unreleased/2446.fixed.md
+++ b/changelog.d/unreleased/2446.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2446
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Scala braceless classes no longer swallow following declarations (#2446)** — Scala `class Config(value: String)` declarations without an explicit body now stay as one-line top-level symbols, so a following `object Config { ... }` remains a top-level companion.
+
+## 日本語
+
+- **Scala の body なし class が後続宣言を飲み込まないようになりました (#2446)** — 明示的な body を持たない Scala の `class Config(value: String)` 宣言を 1 行の top-level symbol として扱うことで、後続の `object Config { ... }` が top-level companion として維持されます。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
@@ -194,8 +194,9 @@ public static partial class SymbolExtractor
         return false;
     }
 
-    private static bool TryFindScalaBracelessClassEndLine(string line, int startColumn)
+    private static bool TryFindScalaBracelessClassEndLine(string[] lines, int startIndex, int startColumn)
     {
+        var line = lines[startIndex];
         var parenDepth = 0;
         var bracketDepth = 0;
         var inBlockComment = false;
@@ -295,7 +296,30 @@ public static partial class SymbolExtractor
                 return false;
         }
 
-        return parenDepth == 0 && bracketDepth == 0 && !inBlockComment && !inString && !inChar;
+        if (parenDepth != 0 || bracketDepth != 0 || inBlockComment || inString || inChar)
+            return false;
+
+        var trimmed = line.TrimEnd();
+        if (trimmed.EndsWith("extends", StringComparison.Ordinal)
+            || trimmed.EndsWith("with", StringComparison.Ordinal)
+            || trimmed.EndsWith("derives", StringComparison.Ordinal)
+            || trimmed.EndsWith(':'))
+        {
+            return false;
+        }
+
+        for (var nextIndex = startIndex + 1; nextIndex < lines.Length; nextIndex++)
+        {
+            var nextLine = lines[nextIndex].TrimStart();
+            if (nextLine.Length == 0 || nextLine.StartsWith("//", StringComparison.Ordinal))
+                continue;
+
+            return !(nextLine.StartsWith("extends ", StringComparison.Ordinal)
+                || nextLine.StartsWith("with ", StringComparison.Ordinal)
+                || nextLine.StartsWith("derives ", StringComparison.Ordinal));
+        }
+
+        return true;
     }
 
 }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
@@ -194,4 +194,108 @@ public static partial class SymbolExtractor
         return false;
     }
 
+    private static bool TryFindScalaBracelessClassEndLine(string line, int startColumn)
+    {
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        var inBlockComment = false;
+        var inString = false;
+        var inChar = false;
+
+        for (var i = Math.Max(0, startColumn); i < line.Length; i++)
+        {
+            var c = line[i];
+
+            if (inBlockComment)
+            {
+                if (c == '*' && i + 1 < line.Length && line[i + 1] == '/')
+                {
+                    inBlockComment = false;
+                    i++;
+                }
+                continue;
+            }
+
+            if (inString)
+            {
+                if (c == '\\' && i + 1 < line.Length)
+                {
+                    i++;
+                    continue;
+                }
+
+                if (c == '"')
+                    inString = false;
+                continue;
+            }
+
+            if (inChar)
+            {
+                if (c == '\\' && i + 1 < line.Length)
+                {
+                    i++;
+                    continue;
+                }
+
+                if (c == '\'')
+                    inChar = false;
+                continue;
+            }
+
+            if (c == '/' && i + 1 < line.Length)
+            {
+                if (line[i + 1] == '/')
+                    break;
+
+                if (line[i + 1] == '*')
+                {
+                    inBlockComment = true;
+                    i++;
+                    continue;
+                }
+            }
+
+            if (c == '"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                inChar = true;
+                continue;
+            }
+
+            if (c == '(')
+            {
+                parenDepth++;
+                continue;
+            }
+
+            if (c == ')' && parenDepth > 0)
+            {
+                parenDepth--;
+                continue;
+            }
+
+            if (c == '[')
+            {
+                bracketDepth++;
+                continue;
+            }
+
+            if (c == ']' && bracketDepth > 0)
+            {
+                bracketDepth--;
+                continue;
+            }
+
+            if (c == '{' && parenDepth == 0 && bracketDepth == 0)
+                return false;
+        }
+
+        return parenDepth == 0 && bracketDepth == 0 && !inBlockComment && !inString && !inChar;
+    }
+
 }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
@@ -194,132 +194,156 @@ public static partial class SymbolExtractor
         return false;
     }
 
-    private static bool TryFindScalaBracelessClassEndLine(string[] lines, int startIndex, int startColumn)
+    private static int? TryFindScalaBracelessClassEndLine(string[] lines, int startIndex, int startColumn)
     {
-        var line = lines[startIndex];
         var parenDepth = 0;
         var bracketDepth = 0;
         var inBlockComment = false;
         var inString = false;
         var inChar = false;
 
-        for (var i = Math.Max(0, startColumn); i < line.Length; i++)
+        for (var lineIndex = startIndex; lineIndex < lines.Length; lineIndex++)
         {
-            var c = line[i];
+            var line = lines[lineIndex];
+            var scanStart = lineIndex == startIndex ? Math.Max(0, startColumn) : 0;
 
-            if (inBlockComment)
+            for (var i = scanStart; i < line.Length; i++)
             {
-                if (c == '*' && i + 1 < line.Length && line[i + 1] == '/')
-                {
-                    inBlockComment = false;
-                    i++;
-                }
-                continue;
-            }
+                var c = line[i];
 
-            if (inString)
-            {
-                if (c == '\\' && i + 1 < line.Length)
+                if (inBlockComment)
                 {
-                    i++;
+                    if (c == '*' && i + 1 < line.Length && line[i + 1] == '/')
+                    {
+                        inBlockComment = false;
+                        i++;
+                    }
                     continue;
                 }
 
-                if (c == '"')
-                    inString = false;
-                continue;
-            }
-
-            if (inChar)
-            {
-                if (c == '\\' && i + 1 < line.Length)
+                if (inString)
                 {
-                    i++;
+                    if (c == '\\' && i + 1 < line.Length)
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    if (c == '"')
+                        inString = false;
+                    continue;
+                }
+
+                if (inChar)
+                {
+                    if (c == '\\' && i + 1 < line.Length)
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    if (c == '\'')
+                        inChar = false;
+                    continue;
+                }
+
+                if (c == '/' && i + 1 < line.Length)
+                {
+                    if (line[i + 1] == '/')
+                        break;
+
+                    if (line[i + 1] == '*')
+                    {
+                        inBlockComment = true;
+                        i++;
+                        continue;
+                    }
+                }
+
+                if (c == '"')
+                {
+                    inString = true;
                     continue;
                 }
 
                 if (c == '\'')
-                    inChar = false;
-                continue;
-            }
-
-            if (c == '/' && i + 1 < line.Length)
-            {
-                if (line[i + 1] == '/')
-                    break;
-
-                if (line[i + 1] == '*')
                 {
-                    inBlockComment = true;
-                    i++;
+                    inChar = true;
                     continue;
                 }
+
+                if (c == '(')
+                {
+                    parenDepth++;
+                    continue;
+                }
+
+                if (c == ')' && parenDepth > 0)
+                {
+                    parenDepth--;
+                    continue;
+                }
+
+                if (c == '[')
+                {
+                    bracketDepth++;
+                    continue;
+                }
+
+                if (c == ']' && bracketDepth > 0)
+                {
+                    bracketDepth--;
+                    continue;
+                }
+
+                if (c == '{' && parenDepth == 0 && bracketDepth == 0)
+                    return null;
             }
 
-            if (c == '"')
+            if (parenDepth != 0 || bracketDepth != 0 || inBlockComment || inString || inChar)
+                continue;
+
+            var trimmed = line.TrimEnd();
+            if (trimmed.EndsWith("extends", StringComparison.Ordinal)
+                || trimmed.EndsWith("with", StringComparison.Ordinal)
+                || trimmed.EndsWith("derives", StringComparison.Ordinal)
+                || trimmed.EndsWith(':'))
             {
-                inString = true;
                 continue;
             }
 
-            if (c == '\'')
+            var nextLine = TryGetNextScalaHeaderLine(lines, lineIndex + 1);
+            if (nextLine is null)
+                return lineIndex;
+
+            if (nextLine.StartsWith("extends ", StringComparison.Ordinal)
+                || nextLine.StartsWith("with ", StringComparison.Ordinal)
+                || nextLine.StartsWith("derives ", StringComparison.Ordinal))
             {
-                inChar = true;
                 continue;
             }
 
-            if (c == '(')
-            {
-                parenDepth++;
-                continue;
-            }
+            if (nextLine.StartsWith('{'))
+                return null;
 
-            if (c == ')' && parenDepth > 0)
-            {
-                parenDepth--;
-                continue;
-            }
-
-            if (c == '[')
-            {
-                bracketDepth++;
-                continue;
-            }
-
-            if (c == ']' && bracketDepth > 0)
-            {
-                bracketDepth--;
-                continue;
-            }
-
-            if (c == '{' && parenDepth == 0 && bracketDepth == 0)
-                return false;
+            return lineIndex;
         }
 
-        if (parenDepth != 0 || bracketDepth != 0 || inBlockComment || inString || inChar)
-            return false;
+        return null;
+    }
 
-        var trimmed = line.TrimEnd();
-        if (trimmed.EndsWith("extends", StringComparison.Ordinal)
-            || trimmed.EndsWith("with", StringComparison.Ordinal)
-            || trimmed.EndsWith("derives", StringComparison.Ordinal)
-            || trimmed.EndsWith(':'))
+    private static string? TryGetNextScalaHeaderLine(string[] lines, int startIndex)
+    {
+        for (var i = startIndex; i < lines.Length; i++)
         {
-            return false;
-        }
-
-        for (var nextIndex = startIndex + 1; nextIndex < lines.Length; nextIndex++)
-        {
-            var nextLine = lines[nextIndex].TrimStart();
+            var nextLine = lines[i].TrimStart();
             if (nextLine.Length == 0 || nextLine.StartsWith("//", StringComparison.Ordinal))
                 continue;
 
-            return !(nextLine.StartsWith("extends ", StringComparison.Ordinal)
-                || nextLine.StartsWith("with ", StringComparison.Ordinal)
-                || nextLine.StartsWith("derives ", StringComparison.Ordinal));
+            return nextLine;
         }
 
-        return true;
+        return null;
     }
 
 }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2758,14 +2758,15 @@ public static partial class SymbolExtractor
                     var rangeLines = lang == "css" && cssScannerLines != null
                         ? cssScannerLines
                         : structuralLines;
+                    var scalaBracelessClassEndLine = lang == "scala" && pattern.Kind == "class"
+                        ? TryFindScalaBracelessClassEndLine(lines, i, absoluteStartColumn)
+                        : null;
                     var (endLine, bodyStartLine, bodyEndLine) = lang is "kotlin" or "scala"
                         && pattern.Kind == "function"
                         && TryFindKotlinScalaExpressionBodyEndLine(line, absoluteStartColumn)
                             ? (i + 1, null, null)
-                            : lang == "scala"
-                                && pattern.Kind == "class"
-                                && TryFindScalaBracelessClassEndLine(lines, i, absoluteStartColumn)
-                                    ? (i + 1, null, null)
+                            : scalaBracelessClassEndLine.HasValue
+                                    ? (scalaBracelessClassEndLine.Value + 1, null, null)
                                     : ResolveRange(rangeLines, i, pattern.BodyStyle, lang, absoluteStartColumn);
                     if (fortranContinuationCandidate != null)
                         endLine = Math.Max(endLine, fortranContinuationCandidate.Value.LastConsumedLineIndex + 1);

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2764,7 +2764,7 @@ public static partial class SymbolExtractor
                             ? (i + 1, null, null)
                             : lang == "scala"
                                 && pattern.Kind == "class"
-                                && TryFindScalaBracelessClassEndLine(line, absoluteStartColumn)
+                                && TryFindScalaBracelessClassEndLine(lines, i, absoluteStartColumn)
                                     ? (i + 1, null, null)
                                     : ResolveRange(rangeLines, i, pattern.BodyStyle, lang, absoluteStartColumn);
                     if (fortranContinuationCandidate != null)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2762,7 +2762,11 @@ public static partial class SymbolExtractor
                         && pattern.Kind == "function"
                         && TryFindKotlinScalaExpressionBodyEndLine(line, absoluteStartColumn)
                             ? (i + 1, null, null)
-                            : ResolveRange(rangeLines, i, pattern.BodyStyle, lang, absoluteStartColumn);
+                            : lang == "scala"
+                                && pattern.Kind == "class"
+                                && TryFindScalaBracelessClassEndLine(line, absoluteStartColumn)
+                                    ? (i + 1, null, null)
+                                    : ResolveRange(rangeLines, i, pattern.BodyStyle, lang, absoluteStartColumn);
                     if (fortranContinuationCandidate != null)
                         endLine = Math.Max(endLine, fortranContinuationCandidate.Value.LastConsumedLineIndex + 1);
                     var startLine = i + 1;

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20354,6 +20354,21 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Scala_WrappedClassHeaderKeepsBodyRange()
+    {
+        var content = """
+            class Service
+              extends Base {
+              def run(): Int = 1
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "scala", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Service" && s.StartLine == 1 && s.EndLine == 4 && s.BodyStartLine == 2 && s.BodyEndLine == 4);
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "run" && s.ContainerKind == "class" && s.ContainerName == "Service");
+    }
+
+    [Fact]
     public void Extract_Dart_DetectsClassFunctionAndMixin()
     {
         // Dart: class, mixin, function / Dart: クラス、mixin、関数

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20329,7 +20329,7 @@ public class SymbolExtractorTests
         var content = """
             package example
 
-            class Config(value: String) {}
+            class Config(value: String)
             object Config extends App {
               def load(): Config = Config("default")
             }
@@ -20344,8 +20344,8 @@ public class SymbolExtractorTests
             """;
         var symbols = SymbolExtractor.Extract(1, "scala", content);
 
-        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Config" && s.SubKind == "has_companion_object");
-        Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "Config" && s.SubKind == "companion_object");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Config" && s.SubKind == "has_companion_object" && s.StartLine == 3 && s.EndLine == 3 && s.BodyStartLine == null && s.BodyEndLine == null);
+        Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "Config" && s.SubKind == "companion_object" && s.ContainerKind == null && s.ContainerName == null);
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "load" && s.ContainerKind == "object" && s.ContainerName == "Config");
         Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "PackageRegistry");
         Assert.Contains(symbols, s => s.Kind == "interface" && s.Name == "Status");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -20369,6 +20369,24 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Scala_WrappedBracelessConstructorDoesNotContainCompanion()
+    {
+        var content = """
+            class Config(
+              value: String
+            )
+            object Config {
+              def load(): Config = Config("default")
+            }
+            """;
+        var symbols = SymbolExtractor.Extract(1, "scala", content);
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Config" && s.SubKind == "has_companion_object" && s.StartLine == 1 && s.EndLine == 3 && s.BodyStartLine == null && s.BodyEndLine == null);
+        Assert.Contains(symbols, s => s.Kind == "object" && s.Name == "Config" && s.SubKind == "companion_object" && s.ContainerKind == null && s.ContainerName == null);
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "load" && s.ContainerKind == "object" && s.ContainerName == "Config");
+    }
+
+    [Fact]
     public void Extract_Dart_DetectsClassFunctionAndMixin()
     {
         // Dart: class, mixin, function / Dart: クラス、mixin、関数


### PR DESCRIPTION
## Summary

- Keep Scala braceless class declarations from extending into following top-level declarations.
- Preserve wrapped Scala class headers with real bodies, including `extends`/`with`/`derives` continuation lines.
- Add Scala extractor regression coverage and a bilingual changelog fragment.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Scala" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests" -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/2446.fixed.md`.

## Review

- Codex adversarial review round 1 found wrapped Scala class headers could regress; fixed with continuation handling and a test.
- Codex adversarial review round 2 found wrapped braceless primary constructors still reproduced the issue; fixed with multi-line braceless header handling and a test.

Fixes #2446
