### PR TITLE
Fix interrupted full index refresh rollback

### DIFF
--- a/changelog.d/unreleased/2366.fixed.md
+++ b/changelog.d/unreleased/2366.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2366
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Full index refresh now rolls back interrupted writes (#2366)** — full-scan indexing keeps its database write phase in one transaction and handles SIGTERM as a graceful interruption, so a killed refresh no longer leaves the existing index with cleared readiness metadata or partial writes.
+
+## 日本語
+
+- **full index refresh の中断時 write を rollback するようになりました (#2366)** — full-scan indexing の database write phase を 1 つの transaction にまとめ、SIGTERM を graceful interruption として扱うことで、kill された refresh が既存 index の readiness metadata を消したり partial write を残したりしないようにしました。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using CodeIndex.Database;
 using CodeIndex.Indexer;
@@ -14,6 +15,8 @@ namespace CodeIndex.Cli;
 /// </summary>
 public static class IndexCommandRunner
 {
+    internal static Action? FullScanWritePhaseStartedForTesting { get; set; }
+
     public static int Run(string[] indexArgs, JsonSerializerOptions jsonOptions) =>
         Run(indexArgs, jsonOptions, cancellationForTesting: null);
 
@@ -25,6 +28,9 @@ public static class IndexCommandRunner
         var indexCancellation = cancellationForTesting ?? ownedCancellation!;
         using var cancelKeyPressRegistration = cancellationForTesting == null
             ? RegisterIndexCancelKeyPress(indexCancellation)
+            : NullDisposable.Instance;
+        using var terminateSignalRegistration = cancellationForTesting == null
+            ? RegisterIndexTerminateSignal(indexCancellation)
             : NullDisposable.Instance;
 
         if (options.ShowHelp)
@@ -2248,6 +2254,25 @@ public static class IndexCommandRunner
         }
     }
 
+    private static IDisposable RegisterIndexTerminateSignal(CancellationTokenSource cancellation)
+    {
+        if (OperatingSystem.IsWindows())
+            return NullDisposable.Instance;
+
+        try
+        {
+            return PosixSignalRegistration.Create(PosixSignal.SIGTERM, context =>
+            {
+                context.Cancel = true;
+                cancellation.Cancel();
+            });
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return NullDisposable.Instance;
+        }
+    }
+
     private static int WriteDatabaseFilesystemError(bool json, JsonSerializerOptions jsonOptions, string dbPath, Exception ex)
     {
         var transient = ex is SqliteException { SqliteErrorCode: 5 or 6 };
@@ -2445,16 +2470,18 @@ public static class IndexCommandRunner
             Console.WriteLine();
         }
 
-        // Full-scan commits to mutating the DB from here on. Demote readiness just before
-        // the first write (PurgeStaleFiles). This is equivalent to clearing earlier in terms
-        // of the --rebuild crash-window guard (the --rebuild path already cleared before
-        // DropAll in RunIndex), but avoids downgrading a healthy DB if full-scan itself
-        // never reaches this point for any reason.
-        // 実書き込み直前で readiness をクリア。--rebuild 経路は RunIndex で既に clear 済み。
+        // Full-scan commits to mutating the DB from here on. Keep the whole write phase in
+        // one outer transaction so Ctrl-C/SIGTERM can roll back the readiness demotion,
+        // stale-file purge, and per-file writes instead of leaving a half-cleared index.
+        // full-scan の書き込み全体を outer transaction に入れ、中断時に readiness clear /
+        // purge / per-file write をまとめて rollback する。
         ThrowIfFullScanCancelled(0, files.Count);
+        using var fullScanTxn = writer.BeginTransaction();
         writer.ClearReadyFlags();
         writer.ClearHotspotFamilyReady();
         writer.ClearMetadataTargetReady();
+        FullScanWritePhaseStartedForTesting?.Invoke();
+        ThrowIfFullScanCancelled(0, files.Count);
 
         CancellationTokenSource? purgeCts = null;
         if (!options.Json && !options.Quiet)
@@ -3002,6 +3029,7 @@ public static class IndexCommandRunner
             // ここで stamp する。full scan / partial update を問わず最新の HEAD を保存する。
             StampIndexedHeadMetadata(writer, projectRoot);
         }
+        fullScanTxn.Commit();
         stopwatch.Stop();
         // Detect cwd drift between option-parsing and finalize. See RunUpdateMode for the
         // rationale; the warning is informational because we already absolutized paths.

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2604,6 +2604,64 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_FullScan_CancelledAfterReadinessDemotion_RollsBackExistingIndex()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            int initialReadiness;
+            using (var db = new DbContext(dbPath))
+                initialReadiness = db.GetUserVersion();
+            Assert.Equal(DbContext.CurrentSchemaVersion, initialReadiness);
+            Assert.Contains("app.cs", ReadIndexedPaths(dbPath));
+
+            File.WriteAllText(Path.Combine(projectRoot, "later.cs"), "public class Later { }\n");
+            using var cancellation = new CancellationTokenSource();
+            var hookInvoked = false;
+            IndexCommandRunner.FullScanWritePhaseStartedForTesting = () =>
+            {
+                hookInvoked = true;
+                cancellation.Cancel();
+            };
+
+            int interruptedExitCode;
+            lock (TestConsoleLock.Gate)
+            {
+                var originalOut = Console.Out;
+                using var stdout = new StringWriter();
+                try
+                {
+                    Console.SetOut(stdout);
+                    interruptedExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions, cancellation);
+                }
+                finally
+                {
+                    Console.SetOut(originalOut);
+                    IndexCommandRunner.FullScanWritePhaseStartedForTesting = null;
+                }
+            }
+
+            Assert.True(hookInvoked);
+            Assert.Equal(CommandExitCodes.Interrupted, interruptedExitCode);
+            using (var db = new DbContext(dbPath))
+                Assert.Equal(initialReadiness, db.GetUserVersion());
+            Assert.DoesNotContain("later.cs", ReadIndexedPaths(dbPath));
+        }
+        finally
+        {
+            IndexCommandRunner.FullScanWritePhaseStartedForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_UpdateMode_WithIndexingErrors_PrintsRecoveryWarning()
     {
         var projectRoot = CreateTempProject();


### PR DESCRIPTION
## Summary
- Wrap CLI full-scan database writes in an outer transaction so interrupted refreshes roll back readiness demotion, purge, and partial writes.
- Handle SIGTERM through the index cancellation path.
- Add regression coverage for cancellation immediately after readiness demotion.
- Add a bilingual changelog fragment.

Fixes #2366

## Changelog
- changelog.d/unreleased/2366.fixed.md

## Validation
- dotnet build CodeIndex.sln
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests.Run_FullScan_CancelledAfterReadinessDemotion_RollsBackExistingIndex"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests"
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet test CodeIndex.sln
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json

## Review
- Codex adversarial review completed: No blocking/actionable issues found.

## Follow-up candidates
- None.

## Notes
- AGENTS.md, CLAUDE.md, and AGENT_GUIDE.md were not modified.