### PR TITLE
Fix SQLite pool cleanup in tests

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -88,8 +88,9 @@ Prefer the existing helper before writing new setup code.
 - `CreateProjectDb(projectRoot)` creates `<projectRoot>/.cdidx/codeindex.db`, initializes schema, and seeds `codeindex_meta.indexed_project_root` to match the project root.
 - `InsertIndexedFile(...)` inserts a realistic indexed file with content-derived checksum, chunks, symbols, and references, and now passes the file path into Python symbol extraction so `__init__.py`-based re-export tests can exercise qualified package names.
 - `RunGit(...)` executes git without shell quoting issues.
-- `DeleteDirectory(path)` retries temp-project cleanup and normalizes attributes. To avoid process-global cross-test interference, it only clears SQLite pools as a Windows-specific retry fallback after a delete failure.
+- `DeleteDirectory(path)` retries temp-project cleanup and normalizes attributes. To avoid process-global cross-test interference, it only requests SQLite pool cleanup through `SqlitePoolCleanup` as a Windows-specific retry fallback after a delete failure.
 - `DeleteFile(path)` retries standalone temp-DB cleanup and uses the same Windows-specific SQLite pool release fallback when pooled handles block deletion.
+- `SqlitePoolCleanup` centralizes the Windows SQLite pool workaround for tests. Tests that own a temporary SQLite file for their whole lifetime can enter an exclusive owner lease and dispose it idempotently before deleting the file, instead of calling `SqliteConnection.ClearAllPools()` directly from `Dispose`.
 - Tests that intentionally call `SqliteConnection.ClearAllPools()`, mutate process-global environment variables, or override the process current directory are grouped into the non-parallel `SQLite pool sensitive` xUnit collection. Add new tests with those hazards to that collection instead of letting them run in parallel with unrelated classes.
 
 Use these helpers when possible so test behavior stays consistent across files and operating systems.

--- a/changelog.d/unreleased/2035.fixed.md
+++ b/changelog.d/unreleased/2035.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 2035
+affected:
+  - tests/CodeIndex.Tests/SqlitePoolCleanup.cs
+  - tests/CodeIndex.Tests/TestProjectHelper.cs
+  - tests/CodeIndex.Tests/DbRecoveryTests.cs
+  - tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+  - tests/CodeIndex.Tests/ConcurrencyTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **SQLite pool cleanup in tests is centralized and idempotent (#2035)** — Windows-only pool release now flows through a shared test helper so fixture disposal can run safely without scattering process-global `ClearAllPools()` calls.
+
+## 日本語
+
+- **テストの SQLite pool cleanup を集中管理し、冪等にしました (#2035)** — Windows 限定の pool 解放を共通 test helper 経由にし、fixture dispose が安全に複数回呼ばれても process-global な `ClearAllPools()` 呼び出しが分散しないようにしました。

--- a/tests/CodeIndex.Tests/ConcurrencyTests.cs
+++ b/tests/CodeIndex.Tests/ConcurrencyTests.cs
@@ -548,6 +548,6 @@ public class ConcurrencyTests : IDisposable
         _disposed = true;
         _db.Dispose();
         _sqlitePoolOwner.Dispose();
-        TestProjectHelper.DeleteFile(_dbPath);
+        try { TestProjectHelper.DeleteFile(_dbPath); } catch { }
     }
 }

--- a/tests/CodeIndex.Tests/ConcurrencyTests.cs
+++ b/tests/CodeIndex.Tests/ConcurrencyTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using CodeIndex.Database;
 using CodeIndex.Models;
-using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Tests;
 
@@ -14,10 +13,13 @@ public class ConcurrencyTests : IDisposable
 {
     private readonly string _dbPath;
     private readonly DbContext _db;
+    private readonly IDisposable _sqlitePoolOwner;
+    private bool _disposed;
 
     public ConcurrencyTests()
     {
         _dbPath = Path.Combine(Path.GetTempPath(), $"codeindex_concurrency_{Guid.NewGuid():N}.db");
+        _sqlitePoolOwner = SqlitePoolCleanup.EnterExclusiveOwner();
         _db = new DbContext(_dbPath);
         _db.InitializeSchema();
     }
@@ -540,8 +542,12 @@ public class ConcurrencyTests : IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         _db.Dispose();
-        SqliteConnection.ClearAllPools();
-        try { File.Delete(_dbPath); } catch { }
+        _sqlitePoolOwner.Dispose();
+        TestProjectHelper.DeleteFile(_dbPath);
     }
 }

--- a/tests/CodeIndex.Tests/DbRecoveryTests.cs
+++ b/tests/CodeIndex.Tests/DbRecoveryTests.cs
@@ -1,6 +1,5 @@
 using CodeIndex.Cli;
 using CodeIndex.Database;
-using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Tests;
 
@@ -12,10 +11,13 @@ namespace CodeIndex.Tests;
 public class DbRecoveryTests : IDisposable
 {
     private readonly string _dbPath;
+    private readonly IDisposable _sqlitePoolOwner;
+    private bool _disposed;
 
     public DbRecoveryTests()
     {
         _dbPath = Path.Combine(Path.GetTempPath(), $"codeindex_recovery_{Guid.NewGuid():N}.db");
+        _sqlitePoolOwner = SqlitePoolCleanup.EnterExclusiveOwner();
     }
 
     [Fact]
@@ -44,7 +46,7 @@ public class DbRecoveryTests : IDisposable
 
         // Release all pooled connections so Windows can overwrite the file
         // プール済み接続をすべて解放し、Windowsでファイル上書きを可能にする
-        SqliteConnection.ClearAllPools();
+        SqlitePoolCleanup.ClearPoolsForWindowsFileRelease(callerOwnsExclusiveAccess: true);
 
         // Corrupt it by overwriting / 上書きして破損させる
         File.WriteAllBytes(_dbPath, new byte[] { 0x00, 0x01, 0x02, 0x03 });
@@ -86,7 +88,11 @@ public class DbRecoveryTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
-        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { }
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _sqlitePoolOwner.Dispose();
+        TestProjectHelper.DeleteFile(_dbPath);
     }
 }

--- a/tests/CodeIndex.Tests/DbRecoveryTests.cs
+++ b/tests/CodeIndex.Tests/DbRecoveryTests.cs
@@ -93,6 +93,6 @@ public class DbRecoveryTests : IDisposable
 
         _disposed = true;
         _sqlitePoolOwner.Dispose();
-        TestProjectHelper.DeleteFile(_dbPath);
+        try { TestProjectHelper.DeleteFile(_dbPath); } catch { }
     }
 }

--- a/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+++ b/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
@@ -18,18 +18,25 @@ public class LegacySchemaMigrationTests : IDisposable
 {
     private readonly string _dbDir;
     private readonly string _dbPath;
+    private readonly IDisposable _sqlitePoolOwner;
+    private bool _disposed;
 
     public LegacySchemaMigrationTests()
     {
         _dbDir = Path.Combine(Path.GetTempPath(), $"codeindex_legacy_upgrade_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_dbDir);
         _dbPath = Path.Combine(_dbDir, "codeindex.db");
+        _sqlitePoolOwner = SqlitePoolCleanup.EnterExclusiveOwner();
         SeedLegacyDb(_dbPath);
     }
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _sqlitePoolOwner.Dispose();
         try
         {
             if (Directory.Exists(_dbDir))
@@ -39,7 +46,7 @@ public class LegacySchemaMigrationTests : IDisposable
                 {
                     try { File.SetUnixFileMode(_dbDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); } catch { }
                 }
-                Directory.Delete(_dbDir, recursive: true);
+                TestProjectHelper.DeleteDirectory(_dbDir);
             }
         }
         catch { /* ignore */ }
@@ -54,7 +61,7 @@ public class LegacySchemaMigrationTests : IDisposable
         // no checksum / indexed_at on files. This mirrors what older cdidx binaries produced.
         // 旧 cdidx が生成していたスキーマ。追加カラム・テーブルをすべて欠落させる。
         var builder = new SqliteConnectionStringBuilder { DataSource = dbPath };
-        using var conn = new SqliteConnection(builder.ConnectionString);
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection(builder.ConnectionString);
         conn.Open();
         Exec(conn, @"CREATE TABLE files (
                         id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -176,7 +183,7 @@ public class LegacySchemaMigrationTests : IDisposable
             PRAGMA wal_checkpoint(TRUNCATE);
             """;
         cmd.ExecuteNonQuery();
-        SqliteConnection.ClearAllPools();
+        SqlitePoolCleanup.ClearPoolsForWindowsFileRelease(callerOwnsExclusiveAccess: true);
     }
 
     private static void DropSymbolExactFallbackIndex(string dbPath)

--- a/tests/CodeIndex.Tests/SqlitePoolCleanup.cs
+++ b/tests/CodeIndex.Tests/SqlitePoolCleanup.cs
@@ -1,0 +1,59 @@
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Tests;
+
+internal static class SqlitePoolCleanup
+{
+    private static readonly object Gate = new();
+    private static int _activeExclusiveOwners;
+    private static bool _clearPending;
+
+    internal static IDisposable EnterExclusiveOwner()
+    {
+        lock (Gate)
+        {
+            _activeExclusiveOwners++;
+        }
+
+        return new Lease();
+    }
+
+    internal static void ClearPoolsForWindowsFileRelease(bool callerOwnsExclusiveAccess = false)
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        lock (Gate)
+        {
+            if (_activeExclusiveOwners > 0 && !callerOwnsExclusiveAccess)
+            {
+                _clearPending = true;
+                return;
+            }
+
+            SqliteConnection.ClearAllPools();
+        }
+    }
+
+    private sealed class Lease : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            lock (Gate)
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+                _activeExclusiveOwners--;
+                if (_activeExclusiveOwners == 0 && _clearPending)
+                {
+                    _clearPending = false;
+                    SqliteConnection.ClearAllPools();
+                }
+            }
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/TestProjectHelper.cs
+++ b/tests/CodeIndex.Tests/TestProjectHelper.cs
@@ -146,18 +146,27 @@ internal static class TestProjectHelper
         {
             try
             {
+                if (attempt > 0)
+                    SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
+
                 File.SetAttributes(path, FileAttributes.Normal);
                 File.Delete(path);
                 return;
             }
-            catch (IOException) when (attempt < 4)
+            catch (IOException)
             {
                 SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
+                if (attempt == 4)
+                    return;
+
                 Thread.Sleep(100);
             }
-            catch (UnauthorizedAccessException) when (attempt < 4)
+            catch (UnauthorizedAccessException)
             {
                 SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
+                if (attempt == 4)
+                    return;
+
                 Thread.Sleep(100);
             }
         }

--- a/tests/CodeIndex.Tests/TestProjectHelper.cs
+++ b/tests/CodeIndex.Tests/TestProjectHelper.cs
@@ -153,20 +153,14 @@ internal static class TestProjectHelper
                 File.Delete(path);
                 return;
             }
-            catch (IOException)
+            catch (IOException) when (attempt < 4)
             {
                 SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
-                if (attempt == 4)
-                    return;
-
                 Thread.Sleep(100);
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException) when (attempt < 4)
             {
                 SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
-                if (attempt == 4)
-                    return;
-
                 Thread.Sleep(100);
             }
         }

--- a/tests/CodeIndex.Tests/TestProjectHelper.cs
+++ b/tests/CodeIndex.Tests/TestProjectHelper.cs
@@ -4,7 +4,6 @@ using System.Text;
 using CodeIndex.Database;
 using CodeIndex.Indexer;
 using CodeIndex.Models;
-using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Tests;
 
@@ -125,15 +124,13 @@ internal static class TestProjectHelper
                 // handles may still need releasing, so escalate only on retry.
                 // 毎回の cleanup で SQLite pool を落とすと並列テスト全体へ波及するため、
                 // 通常経路では触らない。Windows で削除失敗したときだけ最終手段として解放する。
-                if (OperatingSystem.IsWindows())
-                    SqliteConnection.ClearAllPools();
+                SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
                 Thread.Sleep(100);
                 ClearAttributes(path);
             }
             catch (UnauthorizedAccessException) when (attempt < 4)
             {
-                if (OperatingSystem.IsWindows())
-                    SqliteConnection.ClearAllPools();
+                SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
                 Thread.Sleep(100);
                 ClearAttributes(path);
             }
@@ -155,14 +152,12 @@ internal static class TestProjectHelper
             }
             catch (IOException) when (attempt < 4)
             {
-                if (OperatingSystem.IsWindows())
-                    SqliteConnection.ClearAllPools();
+                SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
                 Thread.Sleep(100);
             }
             catch (UnauthorizedAccessException) when (attempt < 4)
             {
-                if (OperatingSystem.IsWindows())
-                    SqliteConnection.ClearAllPools();
+                SqlitePoolCleanup.ClearPoolsForWindowsFileRelease();
                 Thread.Sleep(100);
             }
         }


### PR DESCRIPTION
## Summary

- Centralize Windows-only SQLite pool release for tests in `SqlitePoolCleanup`.
- Make the #2035 fixture disposals idempotent and route cleanup through `TestProjectHelper`.
- Document the test helper policy and add the unreleased changelog fragment.

## Validation

- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --no-build --filter "FullyQualifiedName~DbRecoveryTests|FullyQualifiedName~LegacySchemaMigrationTests|FullyQualifiedName~ConcurrencyTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --no-build`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Updated `TESTING_GUIDE.md`.
- Added `changelog.d/unreleased/2035.fixed.md`.

## Follow-up Candidates

- None.

Fixes #2035
