### PR TITLE
Fix scan checkpoint retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ with `--files`, `--commits`, or `--changed-between <old-ref> <new-ref>` instead
 of rebuilding; see
 [Quick Start](USER_GUIDE.md#quick-start) and
 [Incremental update reliability](USER_GUIDE.md#incremental-update-reliability).
+If a directory cannot be scanned because of permissions or an I/O error,
+`cdidx` records the scan error, keeps scanning other directories, and writes a
+temporary `.cdidx/scan-checkpoint.json` so a same-HEAD retry can skip directories
+that already completed successfully.
 Terminals that request ASCII-only output with `--ascii`, `CDIDX_ASCII=1`,
 `NO_UNICODE`, `TERM=dumb`, accessibility env hints, or a non-UTF-8 locale render
 spinner frames as `|` / `/` / `-` / `\` and progress bars with `#` / `-` instead
@@ -233,6 +237,9 @@ cdidx mcp
 [クイックスタート](USER_GUIDE.md#クイックスタート) と
 [インクリメンタル更新の信頼性](USER_GUIDE.md#インクリメンタル更新の信頼性)
 を参照してください。
+権限や I/O エラーでディレクトリを走査できない場合でも、`cdidx` は scan error を
+記録して他のディレクトリの走査を続け、同じ HEAD の再実行で成功済みディレクトリを
+読み飛ばせるように一時的な `.cdidx/scan-checkpoint.json` を書き込みます。
 `--ascii`、`CDIDX_ASCII=1`、`NO_UNICODE`、`TERM=dumb`、accessibility 系の環境変数、
 または非 UTF-8 locale により ASCII-only 出力が要求されている端末では、スピナーは
 `|` / `/` / `-` / `\`、進捗バーは `#` / `-` で描画されます。Unicode を利用できる端末でも

--- a/changelog.d/unreleased/2108.fixed.md
+++ b/changelog.d/unreleased/2108.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2108
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - README.md
+---
+
+## English
+
+- **Scan retries now checkpoint completed directories (#2108)** — full indexing records successfully scanned directories after directory scan errors and uses `.cdidx/scan-checkpoint.json` on same-HEAD retries to skip work that already completed.
+
+## 日本語
+
+- **scan retry で完了済みディレクトリを checkpoint するようになりました (#2108)** — full index 中にディレクトリ走査エラーが起きた場合、成功済みディレクトリを記録し、同じ HEAD の再実行では `.cdidx/scan-checkpoint.json` を使って完了済みの作業を読み飛ばします。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -14,6 +14,14 @@ namespace CodeIndex.Cli;
 /// </summary>
 public static class IndexCommandRunner
 {
+    private const int ScanCheckpointVersion = 1;
+    private const string ScanCheckpointFileName = "scan-checkpoint.json";
+
+    private sealed record ScanCheckpoint(
+        int Version,
+        string? GitHead,
+        IReadOnlyList<string> Directories);
+
     public static int Run(string[] indexArgs, JsonSerializerOptions jsonOptions) =>
         Run(indexArgs, jsonOptions, cancellationForTesting: null);
 
@@ -2267,6 +2275,79 @@ public static class IndexCommandRunner
         || ex is IOException
         || ex is SqliteException { SqliteErrorCode: 5 or 6 or 8 or 10 or 14 };
 
+    private static IReadOnlySet<string> LoadScanCheckpoint(string path, string? currentHead)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(currentHead) || !File.Exists(path))
+                return new HashSet<string>(StringComparer.Ordinal);
+
+            var checkpoint = JsonSerializer.Deserialize<ScanCheckpoint>(File.ReadAllText(path));
+            if (checkpoint is not { Version: ScanCheckpointVersion }
+                || !string.Equals(checkpoint.GitHead, currentHead, StringComparison.Ordinal)
+                || checkpoint.Directories is not { Count: > 0 })
+            {
+                return new HashSet<string>(StringComparer.Ordinal);
+            }
+
+            return checkpoint.Directories
+                .Where(directory => directory.Length > 0)
+                .ToHashSet(StringComparer.Ordinal);
+        }
+        catch (JsonException)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+        catch (IOException)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+    }
+
+    private static void SaveScanCheckpoint(string path, string? currentHead, IReadOnlySet<string> directories)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(currentHead))
+                return;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var checkpoint = new ScanCheckpoint(
+                ScanCheckpointVersion,
+                currentHead,
+                directories
+                    .Where(directory => directory.Length > 0)
+                    .OrderBy(directory => directory, StringComparer.Ordinal)
+                    .ToList());
+            File.WriteAllText(path, JsonSerializer.Serialize(checkpoint, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static void DeleteScanCheckpoint(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
     private static int RunFullScan(
         DbWriter writer,
         FileIndexer indexer,
@@ -2409,13 +2490,16 @@ public static class IndexCommandRunner
             throw new IndexInterruptedException(filesProcessed, filesTotal);
         }
 
+        var currentHeadForCheckpoint = GitHelper.TryGetHeadCommit(projectRoot);
+        var scanCheckpointPath = Path.Combine(projectRoot, ".cdidx", ScanCheckpointFileName);
+        var checkpointedDirectories = LoadScanCheckpoint(scanCheckpointPath, currentHeadForCheckpoint);
         WriteJsonLiveness("scanning files...");
         var scanHeartbeat = StartJsonPhaseHeartbeat("scanning files");
         FileIndexer.ScanFilesResult scanResult;
         try
         {
             ThrowIfFullScanCancelled(0, null);
-            scanResult = indexer.ScanFilesDetailed();
+            scanResult = indexer.ScanFilesDetailed(checkpointedDirectories, continueOnError: true);
             ThrowIfFullScanCancelled(0, null);
         }
         finally
@@ -2465,6 +2549,7 @@ public static class IndexCommandRunner
             .ToHashSet(StringComparer.Ordinal);
         if (scanResult.HadErrors)
         {
+            SaveScanCheckpoint(scanCheckpointPath, currentHeadForCheckpoint, scanResult.CheckpointedDirectories);
             retainedPaths.UnionWith(scanResult.ProbeFailedFilePaths);
 
             foreach (var relPath in scanResult.NonIndexablePaths)
@@ -2484,7 +2569,19 @@ public static class IndexCommandRunner
         }
         else
         {
-            purged = writer.PurgeFilesOutsideRetainedSet(retainedPaths);
+            if (checkpointedDirectories.Count > 0)
+            {
+                var authoritativeDirectories = scanResult.ListedDirectories
+                    .ToHashSet(StringComparer.Ordinal);
+                var attributePrunedDirectories = scanResult.AttributePrunedDirectories
+                    .ToHashSet(StringComparer.Ordinal);
+                purged = writer.PurgeFilesOutsideRetainedSetWithinListedDirectories(retainedPaths, authoritativeDirectories, attributePrunedDirectories);
+            }
+            else
+            {
+                purged = writer.PurgeFilesOutsideRetainedSet(retainedPaths);
+            }
+            DeleteScanCheckpoint(scanCheckpointPath);
         }
         if (purged > 0)
             WriteProjectRootOnce();

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -44,6 +44,7 @@ public class FileIndexer
         IReadOnlyList<string> ProbeFailedFilePaths,
         IReadOnlyList<string> ListedDirectories,
         IReadOnlyList<string> FullyScannedDirectories,
+        IReadOnlySet<string> CheckpointedDirectories,
         IReadOnlyList<string> AttributePrunedDirectories)
     {
         public bool HadErrors => Errors.Any(error => error.IsFatal);
@@ -1546,7 +1547,9 @@ public class FileIndexer
             : new PathFilterResult(PathFilterKind.None, errors);
     }
 
-    internal ScanFilesResult ScanFilesDetailed()
+    internal ScanFilesResult ScanFilesDetailed(
+        IReadOnlySet<string>? checkpointedDirectories = null,
+        bool continueOnError = true)
     {
         var files = new List<string>();
         var errors = new List<ScanError>();
@@ -1555,13 +1558,16 @@ public class FileIndexer
         var probeFailedFilePaths = new HashSet<string>(StringComparer.Ordinal);
         var listedDirectories = new HashSet<string>(StringComparer.Ordinal);
         var fullyScannedDirectories = new HashSet<string>(StringComparer.Ordinal);
+        var activeCheckpointedDirectories = checkpointedDirectories is { Count: > 0 }
+            ? new HashSet<string>(checkpointedDirectories, StringComparer.Ordinal)
+            : new HashSet<string>(StringComparer.Ordinal);
         var attributePrunedDirectories = new HashSet<string>(StringComparer.Ordinal);
         var visitedFileIdentities = new HashSet<FileIdentity>();
         var fullyScanned = true;
         var preloadResult = LoadAncestorIgnoreRules(errors, ref fullyScanned);
         if (preloadResult.IgnoreRulesAvailable)
         {
-            ScanDirectory(_projectRoot, files, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, visitedFileIdentities, preloadResult.Rules, isProjectRoot: true);
+            ScanDirectory(_projectRoot, files, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, activeCheckpointedDirectories, attributePrunedDirectories, visitedFileIdentities, preloadResult.Rules, isProjectRoot: true, continueOnError);
         }
         return new ScanFilesResult(
             files,
@@ -1571,6 +1577,7 @@ public class FileIndexer
             probeFailedFilePaths.ToList(),
             listedDirectories.ToList(),
             fullyScannedDirectories.ToList(),
+            activeCheckpointedDirectories.Concat(fullyScannedDirectories).ToHashSet(StringComparer.Ordinal),
             attributePrunedDirectories.ToList());
     }
 
@@ -1583,12 +1590,17 @@ public class FileIndexer
         HashSet<string> probeFailedFilePaths,
         HashSet<string> listedDirectories,
         HashSet<string> fullyScannedDirectories,
+        HashSet<string> checkpointedDirectories,
         HashSet<string> attributePrunedDirectories,
         HashSet<FileIdentity> visitedFileIdentities,
         IgnoreRuleSet activeIgnoreRules,
-        bool isProjectRoot = false)
+        bool isProjectRoot = false,
+        bool continueOnError = true)
     {
         var relativeDir = ToRelativePath(dir);
+
+        if (checkpointedDirectories.Contains(relativeDir))
+            return true;
 
         var filterKind = GetDirectoryFilterKind(dir, activeIgnoreRules, isProjectRoot);
         if (filterKind != PathFilterKind.None)
@@ -1598,7 +1610,7 @@ public class FileIndexer
             return true;
         }
 
-        return EnumerateDirectory(dir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, visitedFileIdentities, activeIgnoreRules);
+        return EnumerateDirectory(dir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, checkpointedDirectories, attributePrunedDirectories, visitedFileIdentities, activeIgnoreRules, continueOnError);
     }
 
     private bool EnumerateDirectory(
@@ -1610,9 +1622,11 @@ public class FileIndexer
         HashSet<string> probeFailedFilePaths,
         HashSet<string> listedDirectories,
         HashSet<string> fullyScannedDirectories,
+        HashSet<string> checkpointedDirectories,
         HashSet<string> attributePrunedDirectories,
         HashSet<FileIdentity> visitedFileIdentities,
-        IgnoreRuleSet inheritedIgnoreRules)
+        IgnoreRuleSet inheritedIgnoreRules,
+        bool continueOnError)
     {
         var fullyScanned = true;
         try
@@ -1743,7 +1757,10 @@ public class FileIndexer
                     continue;
                 }
 
-                fullyScanned &= ScanDirectory(subDir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, attributePrunedDirectories, visitedFileIdentities, activeIgnoreRules);
+                var childFullyScanned = ScanDirectory(subDir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, checkpointedDirectories, attributePrunedDirectories, visitedFileIdentities, activeIgnoreRules, continueOnError: continueOnError);
+                fullyScanned &= childFullyScanned;
+                if (!continueOnError && !childFullyScanned)
+                    break;
             }
         }
         catch (UnauthorizedAccessException)

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -1401,6 +1401,37 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void ScanFilesDetailed_CheckpointedDirectories_AreSkippedAndCarriedForward()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(tempDir, "cached"));
+            Directory.CreateDirectory(Path.Combine(tempDir, "fresh"));
+            File.WriteAllText(Path.Combine(tempDir, "cached", "old.py"), "print('old')");
+            File.WriteAllText(Path.Combine(tempDir, "fresh", "new.py"), "print('new')");
+
+            var result = new FileIndexer(tempDir).ScanFilesDetailed(
+                new HashSet<string>(StringComparer.Ordinal) { "cached" });
+            var files = result.Files
+                .Select(path => Path.GetRelativePath(tempDir, path).Replace('\\', '/'))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.Equal(["fresh/new.py"], files);
+            Assert.Contains("cached", result.CheckpointedDirectories);
+            Assert.Contains("fresh", result.CheckpointedDirectories);
+            Assert.DoesNotContain("cached", result.ListedDirectories);
+            Assert.DoesNotContain("cached", result.FullyScannedDirectories);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void ScanFiles_RespectsRootAnchoredGitignorePatterns()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -3890,6 +3890,59 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_FullScan_WritesCheckpointAndUsesItOnSuccessfulRetry()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        var srcDir = Path.Combine(projectRoot, "src");
+        var secretDir = Path.Combine(projectRoot, "secret");
+        var srcFile = Path.Combine(srcDir, "b.cs");
+        try
+        {
+            RunGit(projectRoot, "init");
+            RunGit(projectRoot, "config", "user.email", "test@example.com");
+            RunGit(projectRoot, "config", "user.name", "Test");
+            Directory.CreateDirectory(srcDir);
+            Directory.CreateDirectory(secretDir);
+            File.WriteAllText(srcFile, "public class B { }\n");
+            File.WriteAllText(Path.Combine(secretDir, "a.cs"), "public class A { }\n");
+            RunGit(projectRoot, "add", ".");
+            RunGit(projectRoot, "commit", "-m", "initial");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            SetUnixPermissions(secretDir, UnixFileMode.None);
+            var (partialExitCode, partialJson) = RunAndCaptureJson([projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, partialExitCode);
+            Assert.Equal("partial", partialJson.GetProperty("status").GetString());
+            var checkpointPath = Path.Combine(projectRoot, ".cdidx", "scan-checkpoint.json");
+            Assert.True(File.Exists(checkpointPath));
+
+            SetUnixPermissions(secretDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            File.Delete(srcFile);
+            var (retryExitCode, retryJson) = RunAndCaptureJson([projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, retryExitCode);
+            Assert.Equal("success", retryJson.GetProperty("status").GetString());
+            Assert.False(File.Exists(checkpointPath));
+
+            var indexedPaths = ReadIndexedPaths(Path.Combine(projectRoot, ".cdidx", "codeindex.db"));
+            Assert.Contains("src/b.cs", indexedPaths);
+            Assert.Contains("secret/a.cs", indexedPaths);
+        }
+        finally
+        {
+            if (Directory.Exists(secretDir))
+                SetUnixPermissions(secretDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_FullScan_PurgesStaleRowsWithinListedDirectoriesEvenWhenAnotherDirectoryIsUnreadable()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
## Summary
- add scan checkpoint tracking for full scans that encounter directory scan errors
- persist same-HEAD retry checkpoints in .cdidx/scan-checkpoint.json and clear them after a successful retry
- document the retry behavior and add a bilingual changelog fragment

Fixes #2108

## Documentation / Changelog
- README.md documents scan-error continuation and same-HEAD checkpoint retry behavior.
- changelog.d/unreleased/2108.fixed.md

## Validation
- dotnet test
- dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json

## Adversarial review
No blocking/actionable issues found.

## Follow-up candidates
- None.