### PR TITLE
Fix release JSON smoke check temp handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,20 +499,23 @@ jobs:
 
           # CLI --json must work on the published trimmed self-contained release.
           # Every CLI JSON DTO is covered by the source-generated serializer context.
-          set +e
-          "$CDIDX_INSTALL_DIR/cdidx" status --json >/tmp/cdidx_json_stdout.txt 2>/tmp/cdidx_json_stderr.txt
-          JSON_EXIT="$?"
-          set -e
-          [ "$JSON_EXIT" -eq 0 ] \
-            || { echo "Expected status --json to exit 0, got $JSON_EXIT" >&2; cat /tmp/cdidx_json_stderr.txt >&2; exit 1; }
-          [ -s /tmp/cdidx_json_stdout.txt ] \
-            || { echo "Expected status --json stdout to contain a JSON object" >&2; cat /tmp/cdidx_json_stderr.txt >&2; exit 1; }
-          [ ! -s /tmp/cdidx_json_stderr.txt ] \
-            || { echo "Expected no stderr for status --json" >&2; cat /tmp/cdidx_json_stderr.txt >&2; exit 1; }
-          grep -F -- '"files":' /tmp/cdidx_json_stdout.txt >/dev/null \
-            || { echo "status --json stdout did not include files" >&2; cat /tmp/cdidx_json_stdout.txt >&2; exit 1; }
-          grep -F -- '"version":' /tmp/cdidx_json_stdout.txt >/dev/null \
-            || { echo "status --json stdout did not include version" >&2; cat /tmp/cdidx_json_stdout.txt >&2; exit 1; }
+          json_temp_dir="${RUNNER_TEMP:?RUNNER_TEMP must be set by GitHub Actions}"
+          mkdir -p "$json_temp_dir"
+          json_stdout="$json_temp_dir/cdidx_json_stdout.txt"
+          json_stderr="$json_temp_dir/cdidx_json_stderr.txt"
+          if ! "$CDIDX_INSTALL_DIR/cdidx" status --json >"$json_stdout" 2>"$json_stderr"; then
+            echo "Expected status --json to exit 0" >&2
+            cat "$json_stderr" >&2
+            exit 1
+          fi
+          [ -s "$json_stdout" ] \
+            || { echo "Expected status --json stdout to contain a JSON object" >&2; cat "$json_stderr" >&2; exit 1; }
+          [ ! -s "$json_stderr" ] \
+            || { echo "Expected no stderr for status --json" >&2; cat "$json_stderr" >&2; exit 1; }
+          grep -F -- '"files":' "$json_stdout" >/dev/null \
+            || { echo "status --json stdout did not include files" >&2; cat "$json_stdout" >&2; exit 1; }
+          grep -F -- '"version":' "$json_stdout" >/dev/null \
+            || { echo "status --json stdout did not include version" >&2; cat "$json_stdout" >&2; exit 1; }
 
   publish-nuget:
     if: github.repository == 'Widthdom/CodeIndex'

--- a/changelog.d/unreleased/1464.fixed.md
+++ b/changelog.d/unreleased/1464.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1464
+affected:
+  - .github/workflows/release.yml
+---
+
+## English
+
+- **Release JSON smoke checks now use the GitHub Actions runner temp directory (#1464)** — the published-release verification writes `status --json` capture files under `$RUNNER_TEMP` and fails immediately when the command cannot produce JSON.
+
+## 日本語
+
+- **リリースの JSON smoke check が GitHub Actions の runner temp directory を使うようになりました (#1464)** — 公開済みリリース検証は `status --json` の capture file を `$RUNNER_TEMP` 配下へ書き込み、JSON を生成できない場合は即座に失敗します。


### PR DESCRIPTION
## Summary

- Write release JSON smoke-check capture files under `$RUNNER_TEMP` instead of `/tmp`.
- Replace the `set +e` block with an explicit `if ! ...; then` failure path so JSON command failures are not hidden.
- Add the bilingual changelog fragment for #1464.

## Validation

- `dotnet build`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index /Users/widthdom/Projects/mine/cdidx/CodeIndex5th --rebuild --json`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Added `changelog.d/unreleased/1464.fixed.md`.
- No AGENTS.md, CLAUDE.md, or AGENT_GUIDE.md changes.

## Follow-up Candidates

- None.

Fixes #1464
