### PR TITLE
Document HTTP MCP request logger wait

### DIFF
--- a/changelog.d/unreleased/2434.fixed.md
+++ b/changelog.d/unreleased/2434.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2434
+affected:
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **HTTP MCP request logger test waits for async log delivery (#2434)** — the request logger coverage now documents and validates the brief async delay between an HTTP response and its best-effort log callback.
+
+## 日本語
+
+- **HTTP MCP request logger テストが非同期ログ配送を待つことを明示しました (#2434)** — HTTP 応答と best-effort ログ callback の短い非同期遅延をテスト上で明示し、検証するようにしました。

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -106,6 +106,8 @@ public class HttpMcpTransportTests : IDisposable
             Assert.Equal(HttpStatusCode.OK, okResponse.StatusCode);
         }
 
+        // Issue #2434: the successful POST response can reach the client before its
+        // best-effort request log callback runs, so assert after the async sink catches up.
         var snapshot = await WaitForRequestLogRecordsAsync(records, 3);
 
         var missingPost = Assert.Single(snapshot, record =>


### PR DESCRIPTION
## Summary

- Document why the HTTP MCP request logger test waits for async log delivery before asserting records.
- Add the bilingual changelog fragment for the issue.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~HttpMcpTransportTests.HttpTransport_RequestLogger_RecordsMethodStatusDurationAndAuthOutcome`
- `dotnet test`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/2434.fixed.md`.
- No changes to `AGENTS.md`, `CLAUDE.md`, or `AGENT_GUIDE.md`.

## Follow-up Candidates

- None.

Fixes #2434
