### PR TITLE
Fix MCP response recovery failures

### DIFF
--- a/changelog.d/unreleased/2009.fixed.md
+++ b/changelog.d/unreleased/2009.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2009
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP response write failures are now reported as write-stage failures (#2009)** — `ProcessLineAsync` logs response write errors separately so diagnostics distinguish client connection failures from request parsing and handling failures.
+
+## 日本語
+
+- **MCP 応答書き込み失敗を write 段階の失敗として報告するようになりました (#2009)** — `ProcessLineAsync` は応答書き込みエラーを個別に記録し、クライアント接続失敗をリクエストの parse / handle 失敗と区別できるようになりました。

--- a/changelog.d/unreleased/2017.fixed.md
+++ b/changelog.d/unreleased/2017.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2017
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP response serialization failures now return a minimal JSON-RPC error (#2017)** — failures from the response serializer are logged and fall back to serializer-independent JSON so clients receive an internal error when possible.
+
+## 日本語
+
+- **MCP 応答 serialization 失敗時に最小 JSON-RPC error を返すようになりました (#2017)** — 応答 serializer の失敗を記録し、serializer に依存しない JSON へフォールバックすることで、可能な場合はクライアントが internal error を受け取れるようになりました。

--- a/changelog.d/unreleased/2018.fixed.md
+++ b/changelog.d/unreleased/2018.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2018
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP line response writes are now guarded (#2018)** — closed or unavailable client output no longer cascades into the outer request recovery path after the oversized-message or normal response path has already produced a response.
+
+## 日本語
+
+- **MCP line 応答の書き込みを保護するようになりました (#2018)** — oversized message や通常応答の生成後にクライアント出力が閉じていても、outer request recovery path へ連鎖しないようになりました。

--- a/changelog.d/unreleased/2019.fixed.md
+++ b/changelog.d/unreleased/2019.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2019
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP request ids are retained before handler errors (#2019)** — `ProcessFrame` now captures the response id before dispatch and returns `id: null` for malformed non-object JSON values when error recovery needs a response.
+
+## 日本語
+
+- **MCP request id を handler error 前に保持するようになりました (#2019)** — `ProcessFrame` は dispatch 前に応答 id を退避し、non-object JSON のような不正入力でも error recovery が必要な場合は `id: null` を返します。

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -442,7 +442,7 @@ public partial class McpServer : IDisposable
                         _concurrencyGate.Release();
                     }
 
-                    await transport.WriteFrameAsync(response, loopToken).ConfigureAwait(false);
+                    await WriteFrameSafelyAsync(transport, response, loopToken).ConfigureAwait(false);
 
                     // `notifications/shutdown` flips `_running` inside `HandleMessage`; exit the loop
                     // immediately so a subsequent slow `ReadFrameAsync` does not extend the lifetime
@@ -492,7 +492,7 @@ public partial class McpServer : IDisposable
                 await writeGate.WaitAsync(loopToken).ConfigureAwait(false);
                 try
                 {
-                    await transport.WriteFrameAsync(response, loopToken).ConfigureAwait(false);
+                    await WriteFrameSafelyAsync(transport, response, loopToken).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -522,7 +522,7 @@ public partial class McpServer : IDisposable
                     await writeGate.WaitAsync(loopToken).ConfigureAwait(false);
                     try
                     {
-                        await transport.WriteFrameAsync(response, loopToken).ConfigureAwait(false);
+                        await WriteFrameSafelyAsync(transport, response, loopToken).ConfigureAwait(false);
                     }
                     finally
                     {
@@ -561,6 +561,22 @@ public partial class McpServer : IDisposable
             {
                 Console.Error.WriteLine(BuildResponseWriteErrorLog(ex.Message));
             }
+        }
+    }
+
+    private static async Task WriteFrameSafelyAsync(IMcpTransport transport, string? response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await transport.WriteFrameAsync(response, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            Console.Error.WriteLine(BuildResponseWriteErrorLog("write operation was canceled"));
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+        {
+            Console.Error.WriteLine(BuildResponseWriteErrorLog(ex.Message));
         }
     }
 

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -552,7 +552,16 @@ public partial class McpServer : IDisposable
     {
         var response = ProcessFrame(line);
         if (response != null)
-            await writer.WriteLineAsync(response).ConfigureAwait(false);
+        {
+            try
+            {
+                await writer.WriteLineAsync(response).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException or OperationCanceledException)
+            {
+                Console.Error.WriteLine(BuildResponseWriteErrorLog(ex.Message));
+            }
+        }
     }
 
     /// <summary>
@@ -580,14 +589,17 @@ public partial class McpServer : IDisposable
         }
 
         JsonNode? request = null;
+        var responseHasId = true;
+        JsonNode? responseId = null;
         try
         {
             request = JsonNode.Parse(line);
             if (request == null)
                 return null;
 
+            ExtractResponseId(request, out responseHasId, out responseId);
             var response = HandleMessage(request);
-            return response != null ? _serializeResponse(response) : null;
+            return response != null ? SerializeResponseOrFallback(response, responseHasId, responseId) : null;
         }
         catch (JsonException ex)
         {
@@ -609,18 +621,57 @@ public partial class McpServer : IDisposable
             // 例外型のみを返し、SQLite の "near 'foo': syntax error" などを通じた
             // 内容漏れを防ぐ（#1530）。
             Console.Error.WriteLine(BuildUnhandledLoopErrorLog(ex.Message));
-            if (request is JsonObject requestObj && requestObj.TryGetPropertyValue("id", out var requestId))
-            {
-                var classification = McpErrorEnvelope.ClassifyException(ex);
-                var errorResponse = CreateErrorResponse(true, requestId, classification.JsonRpcCode,
-                    BuildSanitizedLoopErrorMessage(ex),
-                    category: classification.Category,
-                    suggestion: classification.Suggestion,
-                    retrySafe: classification.RetrySafe);
-                return errorResponse.ToJsonString(_jsonOptions);
-            }
-            return null;
+            var classification = McpErrorEnvelope.ClassifyException(ex);
+            var errorResponse = CreateErrorResponse(responseHasId, responseId, classification.JsonRpcCode,
+                BuildSanitizedLoopErrorMessage(ex),
+                category: classification.Category,
+                suggestion: classification.Suggestion,
+                retrySafe: classification.RetrySafe);
+            return SerializeResponseOrFallback(errorResponse, responseHasId, responseId);
         }
+    }
+
+    private string SerializeResponseOrFallback(JsonNode response, bool hasId, JsonNode? id)
+    {
+        try
+        {
+            return _serializeResponse(response);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(BuildResponseSerializationErrorLog(ex.Message));
+            return BuildMinimalInternalErrorResponse(hasId, id, ex);
+        }
+    }
+
+    private static void ExtractResponseId(JsonNode request, out bool hasId, out JsonNode? id)
+    {
+        if (request is JsonObject obj && obj.TryGetPropertyValue("id", out var requestId))
+        {
+            hasId = true;
+            id = requestId is null ? null : JsonNode.Parse(requestId.ToJsonString());
+            return;
+        }
+
+        // For malformed non-object JSON values, JSON-RPC error responses should still carry
+        // id:null instead of disappearing when handling or serialization fails.
+        hasId = true;
+        id = null;
+    }
+
+    private static string BuildMinimalInternalErrorResponse(bool hasId, JsonNode? id, Exception ex)
+    {
+        var message = $"Internal error while serializing MCP response ({ex.GetType().Name}). See cdidx server stderr for details.";
+        var builder = new StringBuilder("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":");
+        builder.Append(JsonSerializer.Serialize(message));
+        builder.Append('}');
+        if (hasId)
+        {
+            builder.Append(",\"id\":");
+            builder.Append(id is null ? "null" : id.ToJsonString());
+        }
+        builder.Append('}');
+        return builder.ToString();
     }
 
     /// <summary>
@@ -1691,6 +1742,12 @@ public partial class McpServer : IDisposable
 
     internal static string BuildUnhandledLoopErrorLog(string detail) =>
         $"[cdidx-mcp] Error: {detail}. This request was skipped; fix the request or inspect the server environment, then retry.";
+
+    internal static string BuildResponseSerializationErrorLog(string detail) =>
+        $"[cdidx-mcp] Error serializing response: {detail}. Returning a minimal JSON-RPC error response when possible.";
+
+    internal static string BuildResponseWriteErrorLog(string detail) =>
+        $"[cdidx-mcp] Error writing response: {detail}. The request was handled but the client connection may already be closed.";
 
     internal static string BuildToolErrorLog(string toolName, string detail) =>
         $"[cdidx-mcp] Tool error ({toolName}): {detail}. Fix the tool arguments, refresh the index if needed, then retry.";

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -646,10 +646,12 @@ public partial class McpServer : IDisposable
 
     private static void ExtractResponseId(JsonNode request, out bool hasId, out JsonNode? id)
     {
-        if (request is JsonObject obj && obj.TryGetPropertyValue("id", out var requestId))
+        if (request is JsonObject obj)
         {
-            hasId = true;
-            id = requestId is null ? null : JsonNode.Parse(requestId.ToJsonString());
+            if (TryGetRequestId(obj, out hasId, out var requestId))
+                id = requestId is null ? null : JsonNode.Parse(requestId.ToJsonString());
+            else
+                id = null;
             return;
         }
 

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -970,6 +970,20 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void ProcessFrame_ResponseSerializationFailureForInvalidRequestId_ReturnsErrorWithNullId()
+    {
+        using var server = new McpServer(_dbPath, ConsoleUi.LoadVersion(), false,
+            _ => throw new JsonException("serializer failed"));
+
+        var response = server.ProcessFrame("""{"jsonrpc":"2.0","id":false,"method":"tools/list"}""");
+
+        using var doc = JsonDocument.Parse(response!);
+        var root = doc.RootElement;
+        Assert.Equal(-32603, root.GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("id").ValueKind);
+    }
+
+    [Fact]
     public async Task ProcessLineAsync_ResponseWriteFailure_DoesNotThrow()
     {
         using var server = new McpServer(_dbPath, ConsoleUi.LoadVersion());

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json.Nodes;
 using System.Text.Json;
 using CodeIndex.Cli;
@@ -848,6 +849,26 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void BuildResponseSerializationErrorLog_IdentifiesResponseSerializationStage()
+    {
+        var message = McpServer.BuildResponseSerializationErrorLog("serializer failed");
+
+        Assert.Contains("Error serializing response", message);
+        Assert.Contains("serializer failed", message);
+        Assert.Contains("minimal JSON-RPC error response", message);
+    }
+
+    [Fact]
+    public void BuildResponseWriteErrorLog_IdentifiesResponseWriteStage()
+    {
+        var message = McpServer.BuildResponseWriteErrorLog("pipe closed");
+
+        Assert.Contains("Error writing response", message);
+        Assert.Contains("pipe closed", message);
+        Assert.Contains("client connection", message);
+    }
+
+    [Fact]
     public void BuildToolErrorLog_IsActionable()
     {
         var message = McpServer.BuildToolErrorLog("search", "bad db");
@@ -916,6 +937,46 @@ public class McpServerTests : IDisposable
         Assert.Contains("path='/var/cdidx/state.db'", message);
         Assert.Contains("hint='Close other cdidx invocations.'", message);
         Assert.Contains("server stderr", message);
+    }
+
+    [Fact]
+    public void ProcessFrame_ResponseSerializationFailure_ReturnsMinimalErrorWithRequestId()
+    {
+        using var server = new McpServer(_dbPath, ConsoleUi.LoadVersion(), false,
+            _ => throw new JsonException("serializer failed"));
+
+        var response = server.ProcessFrame("""{"jsonrpc":"2.0","id":42,"method":"tools/list"}""");
+
+        using var doc = JsonDocument.Parse(response!);
+        var root = doc.RootElement;
+        Assert.Equal("2.0", root.GetProperty("jsonrpc").GetString());
+        Assert.Equal(42, root.GetProperty("id").GetInt32());
+        Assert.Equal(-32603, root.GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Contains("serializing MCP response", root.GetProperty("error").GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public void ProcessFrame_ResponseSerializationFailureForNonObjectRequest_ReturnsErrorWithNullId()
+    {
+        using var server = new McpServer(_dbPath, ConsoleUi.LoadVersion(), false,
+            _ => throw new JsonException("serializer failed"));
+
+        var response = server.ProcessFrame("""["not","an","object"]""");
+
+        using var doc = JsonDocument.Parse(response!);
+        var root = doc.RootElement;
+        Assert.Equal(-32603, root.GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("id").ValueKind);
+    }
+
+    [Fact]
+    public async Task ProcessLineAsync_ResponseWriteFailure_DoesNotThrow()
+    {
+        using var server = new McpServer(_dbPath, ConsoleUi.LoadVersion());
+
+        await server.ProcessLineAsync(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list"}""",
+            new ThrowingTextWriter());
     }
 
     [Fact]
@@ -8564,5 +8625,13 @@ public class McpServerTests : IDisposable
         Assert.NotNull(argsCtor);
         var args = (ConsoleCancelEventArgs)argsCtor!.Invoke(new object[] { ConsoleSpecialKey.ControlC });
         del!.Invoke(null!, args);
+    }
+
+    private sealed class ThrowingTextWriter : TextWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override Task WriteLineAsync(string? value) =>
+            throw new IOException("pipe closed");
     }
 }

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -1382,6 +1382,62 @@ public class McpServerTests : IDisposable
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
+    private sealed class ThrowingWriteTransport : IMcpTransport
+    {
+        private readonly Queue<string?> _frames;
+
+        public ThrowingWriteTransport(string name, params string?[] frames)
+        {
+            Name = name;
+            _frames = new Queue<string?>(frames);
+            _frames.Enqueue(null);
+        }
+
+        public string Name { get; }
+        public string Endpoint => "throwing-write";
+        public int WriteCount { get; private set; }
+
+        public Task<string?> ReadFrameAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_frames.Count == 0 ? null : _frames.Dequeue());
+        }
+
+        public Task WriteFrameAsync(string? frame, CancellationToken cancellationToken)
+        {
+            WriteCount++;
+            throw new IOException("pipe closed");
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task RunAsync_SequentialTransportWriteFailure_DoesNotThrow()
+    {
+        using var server = new McpServer(_dbPath, ConsoleUi.LoadVersion());
+        var transport = new ThrowingWriteTransport(
+            "throwing-sequential",
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list"}""");
+
+        await server.RunAsync(transport, CancellationToken.None);
+
+        Assert.Equal(1, transport.WriteCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_StdioTransportWriteFailure_DoesNotThrow()
+    {
+        using var server = new McpServer(_dbPath, ConsoleUi.LoadVersion());
+        var transport = new ThrowingWriteTransport(
+            "stdio",
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list"}""");
+
+        await server.RunAsync(transport, CancellationToken.None);
+
+        Assert.Equal(1, transport.WriteCount);
+    }
+
     [Fact]
     public void Ping_ReturnsEmptyResult()
     {


### PR DESCRIPTION
## Summary

- Guard MCP response serialization with a serializer-independent minimal JSON-RPC fallback.
- Preserve validated request ids before dispatch so error recovery can respond with the right id or `id: null`.
- Guard legacy `ProcessLineAsync` and transport `WriteFrameAsync` response writes so closed clients do not cascade through request recovery.
- Add focused MCP regression coverage for serializer failures, malformed ids, non-object requests, and transport write failures.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests" -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false` was also run before the final transport-write review fix; it had one unrelated watch cancellation timeout, and the failing test passed on immediate targeted rerun.

## Documentation and Changelog

- `changelog.d/unreleased/2009.fixed.md`
- `changelog.d/unreleased/2017.fixed.md`
- `changelog.d/unreleased/2018.fixed.md`
- `changelog.d/unreleased/2019.fixed.md`

## Review

- Codex adversarial review completed after fixes: `No blocking/actionable issues found.`

## Follow-up Candidates

- #2470

Fixes #2009
Fixes #2017
Fixes #2018
Fixes #2019
