### PR TITLE
Fix HttpMcpTransport request logger test ordering

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -46,6 +46,8 @@ The test project mirrors the production areas closely.
   publishes a trimmed RID-specific CLI and runs whichever entry point the SDK emits (`cdidx.dll` through `dotnet` or the native `cdidx`/`cdidx.exe` apphost). Do not assume every SDK/runtime pair writes a `cdidx.dll` into self-contained publish output.
 - `McpServerTests.cs`
   MCP JSON-RPC behavior and tool outputs.
+- `HttpMcpTransportTests.cs`
+  HTTP MCP transport behavior, including authentication responses, warm server reuse, concurrent requests, and request logging. Request-log assertions must validate recorded contents without assuming callback order between independently handled HTTP requests.
 - `GitHelperTests.cs`
   Git-specific behavior, including worktrees and commit-based updates.
 - `WorkspaceMetadataEnricherTests.cs`

--- a/changelog.d/unreleased/2432.fixed.md
+++ b/changelog.d/unreleased/2432.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2432
+affected:
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **HttpMcpTransport request-logger coverage is order-independent (#2432)** — the request logger regression test now asserts the recorded request contents without depending on asynchronous callback ordering.
+
+## 日本語
+
+- **HttpMcpTransport の request logger カバレッジが順序に依存しなくなりました (#2432)** — request logger の回帰テストは、非同期 callback の順序に依存せず記録内容を検証するようになりました。

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -107,7 +107,9 @@ public class HttpMcpTransportTests : IDisposable
         }
 
         var snapshot = await WaitForRequestLogRecordsAsync(records, 3);
+        Assert.Equal(3, snapshot.Length);
 
+        // Request logging can be observed from independently handled HTTP requests in any order.
         var missingPost = Assert.Single(snapshot, record =>
             record.AuthOutcome == "missing" &&
             record.StatusCode == (int)HttpStatusCode.Unauthorized &&
@@ -126,6 +128,8 @@ public class HttpMcpTransportTests : IDisposable
         var okPost = Assert.Single(snapshot, record =>
             record.AuthOutcome == "ok" &&
             record.RequestId == "7");
+        Assert.Equal("POST", okPost.Method);
+        Assert.Equal("/", okPost.Path);
         Assert.Equal((int)HttpStatusCode.OK, okPost.StatusCode);
     }
 


### PR DESCRIPTION
## Summary

- Make the HTTP MCP request logger regression test assert log contents without depending on callback ordering.
- Document the `HttpMcpTransportTests` request-log convention in the testing guide.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~HttpTransport_RequestLogger_RecordsMethodStatusDurationAndAuthOutcome`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~HttpMcpTransportTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Updated `TESTING_GUIDE.md`.
- Added `changelog.d/unreleased/2432.fixed.md`.

## Follow-up candidates

- None.

Fixes #2432
