### PR TITLE
Centralize test environment cleanup

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -92,6 +92,7 @@ Prefer the existing helper before writing new setup code.
 - `DeleteFile(path)` retries standalone temp-DB cleanup and uses the same Windows-specific SQLite pool release fallback when pooled handles block deletion.
 - `SqlitePoolCleanup` centralizes the Windows SQLite pool workaround for tests. Tests that own a temporary SQLite file for their whole lifetime can enter an exclusive owner lease and dispose it idempotently before deleting the file, instead of calling `SqliteConnection.ClearAllPools()` directly from `Dispose`.
 - Tests that intentionally call `SqliteConnection.ClearAllPools()`, mutate process-global environment variables, or override the process current directory are grouped into the non-parallel `SQLite pool sensitive` xUnit collection. Add new tests with those hazards to that collection instead of letting them run in parallel with unrelated classes.
+- Tests that mutate process-global environment variables should use `EnvironmentVariableScope.Capture(...)` so the original values are restored from a single disposable cleanup path even if setup or assertions fail.
 
 Use these helpers when possible so test behavior stays consistent across files and operating systems.
 
@@ -270,6 +271,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 - `DeleteDirectory(path)` は temp project cleanup のリトライと属性正規化を扱います。プロセス全体への干渉を避けるため、SQLite pool の解放は Windows で削除に失敗した場合のリトライ時だけに限定します。
 - `DeleteFile(path)` は standalone な temp DB cleanup をリトライし、pooled handle が削除を妨げる場合は同じ Windows 向け SQLite pool 解放フォールバックを使います。
 - `SqliteConnection.ClearAllPools()` を意図的に呼ぶテスト、process-global な環境変数を変更するテスト、プロセスのカレントディレクトリを上書きするテストは、xUnit の non-parallel collection `SQLite pool sensitive` にまとめます。これらのハザードを持つ新しいテストも、この collection に入れて無関係なクラスとの並列実行を避けてください。
+- Process-global な環境変数を変更するテストでは `EnvironmentVariableScope.Capture(...)` を使い、setup や assertion が失敗しても単一の disposable cleanup 経路で元の値へ戻してください。
 
 テスト挙動をファイル間・OS間で揃えるため、可能な限りこれらを使ってください。
 

--- a/changelog.d/unreleased/2032.fixed.md
+++ b/changelog.d/unreleased/2032.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 2032
+affected:
+  - tests/CodeIndex.Tests/EnvironmentVariableScope.cs
+  - tests/CodeIndex.Tests/EnvironmentVariableScopeTests.cs
+  - tests/CodeIndex.Tests/DbDebugTests.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Environment variable cleanup in tests is centralized (#2032)** — tests that mutate process environment now use a shared disposable scope to restore original values even when setup or assertions fail.
+
+## 日本語
+
+- **テストの環境変数 cleanup を集中管理しました (#2032)** — process 環境を変更するテストで共通の disposable scope を使い、setup や assertion が失敗しても元の値へ戻すようにしました。

--- a/tests/CodeIndex.Tests/DbDebugTests.cs
+++ b/tests/CodeIndex.Tests/DbDebugTests.cs
@@ -25,7 +25,8 @@ public class DbDebugTests
     [Fact]
     public void DumpToStderr_NoOp_WhenDisabled()
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", null);
         DbDebug.ResetContext();
         var output = CaptureStderr(() => DbDebug.DumpToStderr(new InvalidOperationException("boom")));
         Assert.Empty(output);
@@ -39,7 +40,8 @@ public class DbDebugTests
     [InlineData("on")]
     public void IsEnabled_AcceptsTruthyDebugValues(string value)
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", value);
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", value);
         try
         {
             DbDebug.ResetForTesting();
@@ -48,7 +50,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetForTesting();
         }
     }
@@ -61,7 +62,8 @@ public class DbDebugTests
     [InlineData("off")]
     public void IsEnabled_AcceptsFalsyDebugValues(string value)
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", value);
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", value);
         try
         {
             DbDebug.ResetForTesting();
@@ -70,7 +72,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetForTesting();
         }
     }
@@ -78,7 +79,8 @@ public class DbDebugTests
     [Fact]
     public void IsEnabled_InvalidDebugValue_WarnsOnceAndFallsBackToOff()
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", "maybe");
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", "maybe");
         try
         {
             DbDebug.ResetForTesting();
@@ -91,7 +93,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetForTesting();
         }
     }
@@ -99,7 +100,8 @@ public class DbDebugTests
     [Fact]
     public void DumpToStderr_RedactsTextByDefault()
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", "1");
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", "1");
         try
         {
             DbDebug.ResetContext();
@@ -136,7 +138,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetContext();
         }
     }
@@ -144,7 +145,8 @@ public class DbDebugTests
     [Fact]
     public void DumpToStderr_RedactedMode_UsesPathShapeForPathValues()
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", "1");
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", "1");
         try
         {
             DbDebug.ResetContext();
@@ -173,7 +175,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetContext();
         }
     }
@@ -181,7 +182,8 @@ public class DbDebugTests
     [Fact]
     public void DumpToStderr_UnsafeMode_IncludesRawContent()
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", "unsafe");
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", "unsafe");
         DbDebug.EnableUnsafeForProcess();
         try
         {
@@ -205,7 +207,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetContext();
             DbDebug.ResetForTesting();
         }
@@ -220,7 +221,8 @@ public class DbDebugTests
         // redacted mode and emits a one-shot stderr warning. The capture has to
         // wrap the tracking calls too because the downgrade warning fires the
         // first time ResolveMode runs (here: during ExecuteTrackedReader).
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", "unsafe");
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", "unsafe");
         DbDebug.ResetForTesting();
         try
         {
@@ -252,7 +254,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetContext();
             DbDebug.ResetForTesting();
         }
@@ -261,7 +262,8 @@ public class DbDebugTests
     [Fact]
     public void DumpToStderr_UnsafeDowngradeWarning_EmittedOnlyOnce()
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", "unsafe");
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", "unsafe");
         DbDebug.ResetForTesting();
         try
         {
@@ -297,7 +299,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetContext();
             DbDebug.ResetForTesting();
         }
@@ -306,7 +307,8 @@ public class DbDebugTests
     [Fact]
     public void DumpToStderr_DoesNotDumpStaleStateAfterReset()
     {
-        Environment.SetEnvironmentVariable("CDIDX_DEBUG", "1");
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", "1");
         try
         {
             DbDebug.ResetContext();
@@ -334,7 +336,6 @@ public class DbDebugTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_DEBUG", null);
             DbDebug.ResetContext();
         }
     }

--- a/tests/CodeIndex.Tests/EnvironmentVariableScope.cs
+++ b/tests/CodeIndex.Tests/EnvironmentVariableScope.cs
@@ -1,0 +1,39 @@
+namespace CodeIndex.Tests;
+
+internal sealed class EnvironmentVariableScope : IDisposable
+{
+    private readonly Dictionary<string, string?> _originalValues;
+    private bool _disposed;
+
+    private EnvironmentVariableScope(IEnumerable<string> names)
+    {
+        _originalValues = names
+            .Distinct(StringComparer.Ordinal)
+            .ToDictionary(name => name, Environment.GetEnvironmentVariable, StringComparer.Ordinal);
+    }
+
+    internal static EnvironmentVariableScope Capture(params string[] names) => new(names);
+
+    internal void Set(string name, string? value)
+    {
+        ThrowIfDisposed();
+        Environment.SetEnvironmentVariable(name, value);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        foreach (var (name, value) in _originalValues)
+            Environment.SetEnvironmentVariable(name, value);
+
+        _disposed = true;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(EnvironmentVariableScope));
+    }
+}

--- a/tests/CodeIndex.Tests/EnvironmentVariableScopeTests.cs
+++ b/tests/CodeIndex.Tests/EnvironmentVariableScopeTests.cs
@@ -1,0 +1,41 @@
+namespace CodeIndex.Tests;
+
+[Collection("SQLite pool sensitive")]
+public class EnvironmentVariableScopeTests
+{
+    [Fact]
+    public void Dispose_RestoresOriginalValue()
+    {
+        var name = $"CDIDX_TEST_SCOPE_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(name, "before");
+        try
+        {
+            using (var env = EnvironmentVariableScope.Capture(name))
+            {
+                env.Set(name, "during");
+                Assert.Equal("during", Environment.GetEnvironmentVariable(name));
+            }
+
+            Assert.Equal("before", Environment.GetEnvironmentVariable(name));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+    }
+
+    [Fact]
+    public void Dispose_RestoresMissingValue()
+    {
+        var name = $"CDIDX_TEST_SCOPE_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(name, null);
+
+        using (var env = EnvironmentVariableScope.Capture(name))
+        {
+            env.Set(name, "during");
+            Assert.Equal("during", Environment.GetEnvironmentVariable(name));
+        }
+
+        Assert.Null(Environment.GetEnvironmentVariable(name));
+    }
+}

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -18,22 +18,15 @@ namespace CodeIndex.Tests;
 [Collection("SQLite pool sensitive")]
 public class GitHubIssueReporterTests : IDisposable
 {
-    // Save original env vars to restore after each test
-    // 各テスト後にリストアするため元の環境変数を保存
-    private readonly string? _originalCdidxToken;
-    private readonly string? _originalGhToken;
-
-    public GitHubIssueReporterTests()
-    {
-        _originalCdidxToken = Environment.GetEnvironmentVariable("CDIDX_GITHUB_TOKEN");
-        _originalGhToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-    }
+    private readonly EnvironmentVariableScope _env = EnvironmentVariableScope.Capture(
+        "CDIDX_GITHUB_TOKEN",
+        "GITHUB_TOKEN");
 
     [Fact]
     public void ResolveToken_NeitherSet_ReturnsNull()
     {
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", null);
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", null);
+        _env.Set("CDIDX_GITHUB_TOKEN", null);
+        _env.Set("GITHUB_TOKEN", null);
 
         Assert.Null(GitHubIssueReporter.ResolveToken());
     }
@@ -41,8 +34,8 @@ public class GitHubIssueReporterTests : IDisposable
     [Fact]
     public void ResolveToken_CdidxTokenSet_ReturnsCdidxToken()
     {
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_cdidx_test_token");
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", null);
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_cdidx_test_token");
+        _env.Set("GITHUB_TOKEN", null);
 
         Assert.Equal("ghp_cdidx_test_token", GitHubIssueReporter.ResolveToken());
     }
@@ -54,8 +47,8 @@ public class GitHubIssueReporterTests : IDisposable
         // from silently publishing to an external repository.
         // 汎用 GITHUB_TOKEN は使わない — CI の環境トークンが意図せず
         // 外部リポジトリに公開されることを防ぐ。
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", null);
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", "ghp_github_test_token");
+        _env.Set("CDIDX_GITHUB_TOKEN", null);
+        _env.Set("GITHUB_TOKEN", "ghp_github_test_token");
 
         Assert.Null(GitHubIssueReporter.ResolveToken());
     }
@@ -63,8 +56,8 @@ public class GitHubIssueReporterTests : IDisposable
     [Fact]
     public void ResolveToken_CdidxTokenSet_IgnoresGenericToken()
     {
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_cdidx_preferred");
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", "ghp_github_fallback");
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_cdidx_preferred");
+        _env.Set("GITHUB_TOKEN", "ghp_github_fallback");
 
         Assert.Equal("ghp_cdidx_preferred", GitHubIssueReporter.ResolveToken());
     }
@@ -72,8 +65,8 @@ public class GitHubIssueReporterTests : IDisposable
     [Fact]
     public void ResolveToken_EmptyString_ReturnsNull()
     {
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "");
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", "");
+        _env.Set("CDIDX_GITHUB_TOKEN", "");
+        _env.Set("GITHUB_TOKEN", "");
 
         Assert.Null(GitHubIssueReporter.ResolveToken());
     }
@@ -81,8 +74,8 @@ public class GitHubIssueReporterTests : IDisposable
     [Fact]
     public void ResolveToken_WhitespaceOnly_ReturnsNull()
     {
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "   ");
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", "   ");
+        _env.Set("CDIDX_GITHUB_TOKEN", "   ");
+        _env.Set("GITHUB_TOKEN", "   ");
 
         Assert.Null(GitHubIssueReporter.ResolveToken());
     }
@@ -164,7 +157,7 @@ public class GitHubIssueReporterTests : IDisposable
         // がレスポンスが消失し、ローカルでは SubmittedToGitHub=false のまま。
         // 再試行時はハッシュ検索による冪等性チェックが既存 Issue を見つけ、
         // 重複作成を回避すること。
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
 
         var handler = new RecordingHandler();
         handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
@@ -206,7 +199,7 @@ public class GitHubIssueReporterTests : IDisposable
         // GitHub Search は作成直後の Issue を反映するまで遅延し得る。
         // Search が空でも、label 付き Issue の直接一覧で提案ハッシュを持つ
         // 既存 Issue を検出し、重複作成を防ぐこと。
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
 
         var record = MakeRecordWithKnownHash();
         var handler = new RecordingHandler();
@@ -256,7 +249,7 @@ public class GitHubIssueReporterTests : IDisposable
         // does not break the normal create path.
         // ベースライン: 検索結果が空なら POST /issues に進む。今回追加した検索
         // ステップが通常の作成パスを壊さないことを確認する。
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
 
         var handler = new RecordingHandler();
         handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
@@ -305,7 +298,7 @@ public class GitHubIssueReporterTests : IDisposable
         // legitimate first submission. The create POST proceeds as before.
         // 検索 API 失敗（5xx, レート制限など）でも正規の新規送信は阻害しない。
         // 検索失敗時は通常の POST 作成パスに進むこと。
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
 
         var handler = new RecordingHandler();
         handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
@@ -340,7 +333,7 @@ public class GitHubIssueReporterTests : IDisposable
     [Fact]
     public async Task TryCreateIssueDetailedAsync_CreateApiFails_ReturnsDiagnosticError()
     {
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
 
         var handler = new RecordingHandler();
         handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
@@ -423,9 +416,7 @@ public class GitHubIssueReporterTests : IDisposable
 
     public void Dispose()
     {
-        // Restore original env vars / 元の環境変数をリストア
-        Environment.SetEnvironmentVariable("CDIDX_GITHUB_TOKEN", _originalCdidxToken);
-        Environment.SetEnvironmentVariable("GITHUB_TOKEN", _originalGhToken);
+        _env.Dispose();
         // Defensive: never leak the override into other tests.
         // 防御的: オーバーライドを他テストに残さない。
         GitHubIssueReporter.s_httpClientOverride = null;

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -55,15 +55,16 @@ public class ProgramRunnerTests
     {
         var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_{Guid.NewGuid():N}");
         Directory.CreateDirectory(logDir);
-        var originalForce = Environment.GetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG");
-        var originalDisable = Environment.GetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG");
-        var originalLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_FORCE_GLOBAL_TOOL_LOG",
+            "CDIDX_DISABLE_PERSISTENT_LOG",
+            "CDIDX_GLOBAL_TOOL_LOG_DIR");
 
         try
         {
-            Environment.SetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
-            Environment.SetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG", null);
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+            env.Set("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
+            env.Set("CDIDX_DISABLE_PERSISTENT_LOG", null);
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
                 ["definitely-not-a-command"],
@@ -82,9 +83,6 @@ public class ProgramRunnerTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG", originalForce);
-            Environment.SetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG", originalDisable);
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", originalLogDir);
             TestProjectHelper.DeleteDirectory(logDir);
         }
     }
@@ -94,9 +92,10 @@ public class ProgramRunnerTests
     {
         var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_prune_{Guid.NewGuid():N}");
         Directory.CreateDirectory(logDir);
-        var originalForce = Environment.GetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG");
-        var originalDisable = Environment.GetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG");
-        var originalLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_FORCE_GLOBAL_TOOL_LOG",
+            "CDIDX_DISABLE_PERSISTENT_LOG",
+            "CDIDX_GLOBAL_TOOL_LOG_DIR");
 
         try
         {
@@ -106,9 +105,9 @@ public class ProgramRunnerTests
                 File.WriteAllText(Path.Combine(logDir, $"stderr-{date:yyyyMMdd}.log"), $"old {i}");
             }
 
-            Environment.SetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
-            Environment.SetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG", null);
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+            env.Set("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
+            env.Set("CDIDX_DISABLE_PERSISTENT_LOG", null);
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
 
             var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(
                 ["definitely-not-a-command"],
@@ -129,9 +128,6 @@ public class ProgramRunnerTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG", originalForce);
-            Environment.SetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG", originalDisable);
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", originalLogDir);
             TestProjectHelper.DeleteDirectory(logDir);
         }
     }
@@ -141,15 +137,16 @@ public class ProgramRunnerTests
     {
         var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_disabled_{Guid.NewGuid():N}");
         Directory.CreateDirectory(logDir);
-        var originalForce = Environment.GetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG");
-        var originalDisable = Environment.GetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG");
-        var originalLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_FORCE_GLOBAL_TOOL_LOG",
+            "CDIDX_DISABLE_PERSISTENT_LOG",
+            "CDIDX_GLOBAL_TOOL_LOG_DIR");
 
         try
         {
-            Environment.SetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
-            Environment.SetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG", "1");
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+            env.Set("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
+            env.Set("CDIDX_DISABLE_PERSISTENT_LOG", "1");
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
                 ["definitely-not-a-command"],
@@ -162,9 +159,6 @@ public class ProgramRunnerTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG", originalForce);
-            Environment.SetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG", originalDisable);
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", originalLogDir);
             TestProjectHelper.DeleteDirectory(logDir);
         }
     }
@@ -179,15 +173,16 @@ public class ProgramRunnerTests
     {
         var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_disabled_bool_{Guid.NewGuid():N}");
         Directory.CreateDirectory(logDir);
-        var originalForce = Environment.GetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG");
-        var originalDisable = Environment.GetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG");
-        var originalLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_FORCE_GLOBAL_TOOL_LOG",
+            "CDIDX_DISABLE_PERSISTENT_LOG",
+            "CDIDX_GLOBAL_TOOL_LOG_DIR");
 
         try
         {
-            Environment.SetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
-            Environment.SetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG", disabledValue);
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+            env.Set("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
+            env.Set("CDIDX_DISABLE_PERSISTENT_LOG", disabledValue);
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
                 ["definitely-not-a-command"],
@@ -200,9 +195,6 @@ public class ProgramRunnerTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_FORCE_GLOBAL_TOOL_LOG", originalForce);
-            Environment.SetEnvironmentVariable("CDIDX_DISABLE_PERSISTENT_LOG", originalDisable);
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", originalLogDir);
             TestProjectHelper.DeleteDirectory(logDir);
         }
     }


### PR DESCRIPTION
## Summary

- Add `EnvironmentVariableScope` for disposable test environment variable restoration.
- Migrate the Issue #2032 test classes away from duplicated manual env cleanup.
- Document the test helper convention and add a bilingual changelog fragment.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~EnvironmentVariableScopeTests|FullyQualifiedName~DbDebugTests|FullyQualifiedName~GitHubIssueReporterTests|FullyQualifiedName~ProgramRunnerTests"`
- `dotnet test`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `TESTING_GUIDE.md`.
- Added `changelog.d/unreleased/2032.fixed.md`.

## Follow-up Candidates

- None.

Fixes #2032
