### PR TITLE
Fix cancellable folded backfill

### DIFF
--- a/changelog.d/unreleased/1420.fixed.md
+++ b/changelog.d/unreleased/1420.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1420
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **`backfill-fold` now honors cancellation during folded-column rewrites (#1420)** — folded-name backfill checks Ctrl-C / SIGTERM cancellation while reading and updating symbol and reference rows, returns the interrupted exit code, and rolls back partial rewrite transactions.
+
+## 日本語
+
+- **`backfill-fold` が folded 列の再書き込み中にキャンセルを反映するようになりました (#1420)** — folded-name backfill は symbol / reference 行の読み取りと更新中に Ctrl-C / SIGTERM のキャンセルを確認し、中断用 exit code を返して途中までの再書き込み transaction を rollback します。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -469,10 +469,25 @@ public static class IndexCommandRunner
         return $"PID {holder.Pid.ToString(System.Globalization.CultureInfo.InvariantCulture)}, started {startedLocal.ToString("yyyy-MM-dd HH:mm:ss zzz", System.Globalization.CultureInfo.InvariantCulture)}";
     }
 
-    public static int RunBackfillFold(string[] cmdArgs, JsonSerializerOptions jsonOptions)
+    public static int RunBackfillFold(string[] cmdArgs, JsonSerializerOptions jsonOptions) =>
+        RunBackfillFold(cmdArgs, jsonOptions, cancellationForTesting: null);
+
+    internal static int RunBackfillFold(
+        string[] cmdArgs,
+        JsonSerializerOptions jsonOptions,
+        CancellationTokenSource? cancellationForTesting)
     {
         var options = ParseBackfillFoldArgs(cmdArgs);
         var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
+        using var ownedCancellation = cancellationForTesting == null ? new CancellationTokenSource() : null;
+        var backfillCancellation = cancellationForTesting ?? ownedCancellation!;
+        using var cancelKeyPressRegistration = cancellationForTesting == null
+            ? RegisterIndexCancelKeyPress(backfillCancellation)
+            : NullDisposable.Instance;
+        using var terminateSignalRegistration = cancellationForTesting == null
+            ? RegisterIndexTerminateSignal(backfillCancellation)
+            : NullDisposable.Instance;
+
         if (options.ShowHelp)
         {
             ConsoleUi.PrintUsage();
@@ -516,7 +531,9 @@ public static class IndexCommandRunner
             var rewriteAll = storedFoldVersion != currentFoldVersion
                 || storedFoldFingerprint != currentFoldFingerprint;
 
-            var (symbols, symbolReferences) = writer.BackfillFoldedColumns(rewriteAll);
+            var (symbols, symbolReferences) = writer.BackfillFoldedColumns(
+                rewriteAll,
+                backfillCancellation.Token);
             // MarkFoldReady re-verifies inside a BEGIN IMMEDIATE so a concurrent writer cannot
             // insert NULL-folded rows between the verify and the stamp. Issue #1535.
             // MarkFoldReady は BEGIN IMMEDIATE 内で再検証するため、concurrent writer による
@@ -558,6 +575,16 @@ public static class IndexCommandRunner
             }
 
             return CommandExitCodes.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                "folded-name backfill cancelled before it could complete.",
+                CommandExitCodes.CancelledBySignal,
+                "Rerun `cdidx backfill-fold` when you are ready to resume; the cancelled transaction was rolled back.",
+                CommandErrorCodes.Interrupted);
         }
         catch (Exception ex)
         {

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -13,6 +13,7 @@ public class DbWriter
 {
     private readonly SqliteConnection _conn;
     private readonly PreparedCommandCache? _commandCache;
+    internal static Action? FoldBackfillRowUpdatedForTesting { get; set; }
     private const int BatchSize = 500;
     private const int MaxSqlVariables = 999;
     private int _transactionDepth;
@@ -2609,16 +2610,20 @@ public class DbWriter
     /// true のとき、既に埋まっている folded 列も含めて全行再計算する（fold metadata 不一致時）。
     /// </param>
     /// <returns>Counts of symbol rows and reference rows rewritten.</returns>
-    public (int Symbols, int SymbolReferences) BackfillFoldedColumns(bool rewriteAll = false)
+    public (int Symbols, int SymbolReferences) BackfillFoldedColumns(
+        bool rewriteAll = false,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var txn = !IsInTransaction() ? BeginTransaction() : null;
-        var symbols = BackfillSymbolFoldedRows(rewriteAll);
-        var symbolReferences = BackfillReferenceFoldedRows(rewriteAll);
+        var symbols = BackfillSymbolFoldedRows(rewriteAll, cancellationToken);
+        var symbolReferences = BackfillReferenceFoldedRows(rewriteAll, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         txn?.Commit();
         return (symbols, symbolReferences);
     }
 
-    private int BackfillSymbolFoldedRows(bool rewriteAll)
+    private int BackfillSymbolFoldedRows(bool rewriteAll, CancellationToken cancellationToken)
     {
         var rows = new List<(long Id, string Name)>();
         using (var cmd = _conn.CreateCommand())
@@ -2628,7 +2633,10 @@ public class DbWriter
                 : "SELECT id, name FROM symbols WHERE name IS NOT NULL AND name_folded IS NULL";
             using var reader = cmd.ExecuteTrackedReader();
             while (reader.TrackedRead())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
                 rows.Add((reader.GetInt64(0), reader.GetString(1)));
+            }
         }
 
         if (rows.Count == 0)
@@ -2642,15 +2650,17 @@ public class DbWriter
 
         foreach (var row in rows)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             pFolded.Value = (object?)NameFold.Fold(row.Name) ?? DBNull.Value;
             pId.Value = row.Id;
             update.ExecuteNonQuery();
+            FoldBackfillRowUpdatedForTesting?.Invoke();
         }
 
         return rows.Count;
     }
 
-    private int BackfillReferenceFoldedRows(bool rewriteAll)
+    private int BackfillReferenceFoldedRows(bool rewriteAll, CancellationToken cancellationToken)
     {
         var rows = new List<(long Id, string? SymbolName, string? ContainerName)>();
         using (var cmd = _conn.CreateCommand())
@@ -2664,6 +2674,7 @@ public class DbWriter
             using var reader = cmd.ExecuteTrackedReader();
             while (reader.TrackedRead())
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 rows.Add((
                     reader.GetInt64(0),
                     reader.IsDBNull(1) ? null : reader.GetString(1),
@@ -2686,10 +2697,12 @@ public class DbWriter
 
         foreach (var row in rows)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             pSymbolNameFolded.Value = (object?)NameFold.Fold(row.SymbolName) ?? DBNull.Value;
             pContainerNameFolded.Value = (object?)NameFold.Fold(row.ContainerName) ?? DBNull.Value;
             pId.Value = row.Id;
             update.ExecuteNonQuery();
+            FoldBackfillRowUpdatedForTesting?.Invoke();
         }
 
         return rows.Count;

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2066,6 +2066,165 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void BackfillFoldedColumns_CancelledDuringSymbolLoop_RollsBackTransaction()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_backfill_cancel_symbols_{Guid.NewGuid():N}.db");
+        var cts = new CancellationTokenSource();
+        try
+        {
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db.Connection);
+                var fileId = writer.UpsertFile(new FileRecord
+                {
+                    Path = "src/app.py",
+                    Lang = "python",
+                    Size = 64,
+                    Lines = 2,
+                    Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                });
+                writer.InsertSymbols([
+                    new SymbolRecord { FileId = fileId, Kind = "function", Name = "first", Line = 1, StartLine = 1, EndLine = 1 },
+                    new SymbolRecord { FileId = fileId, Kind = "function", Name = "second", Line = 2, StartLine = 2, EndLine = 2 },
+                ]);
+
+                using (var clear = db.Connection.CreateCommand())
+                {
+                    clear.CommandText = "UPDATE symbols SET name_folded = NULL";
+                    clear.ExecuteNonQuery();
+                }
+
+                DbWriter.FoldBackfillRowUpdatedForTesting = cts.Cancel;
+
+                Assert.Throws<OperationCanceledException>(() => writer.BackfillFoldedColumns(rewriteAll: false, cts.Token));
+
+                using var count = db.Connection.CreateCommand();
+                count.CommandText = "SELECT COUNT(*) FROM symbols WHERE name_folded IS NOT NULL";
+                Assert.Equal(0L, (long)count.ExecuteScalar()!);
+            }
+        }
+        finally
+        {
+            DbWriter.FoldBackfillRowUpdatedForTesting = null;
+            cts.Dispose();
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void BackfillFoldedColumns_CancelledDuringReferenceLoop_RollsBackTransaction()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_backfill_cancel_refs_{Guid.NewGuid():N}.db");
+        var cts = new CancellationTokenSource();
+        try
+        {
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db.Connection);
+                var fileId = writer.UpsertFile(new FileRecord
+                {
+                    Path = "src/app.py",
+                    Lang = "python",
+                    Size = 64,
+                    Lines = 2,
+                    Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                });
+                writer.InsertReferences([
+                    new ReferenceRecord { FileId = fileId, SymbolName = "first", ReferenceKind = "call", Line = 1, Column = 1, Context = "first()" },
+                    new ReferenceRecord { FileId = fileId, SymbolName = "second", ReferenceKind = "call", Line = 2, Column = 1, Context = "second()" },
+                ]);
+
+                using (var clear = db.Connection.CreateCommand())
+                {
+                    clear.CommandText = "UPDATE symbol_references SET symbol_name_folded = NULL, container_name_folded = NULL";
+                    clear.ExecuteNonQuery();
+                }
+
+                DbWriter.FoldBackfillRowUpdatedForTesting = cts.Cancel;
+
+                Assert.Throws<OperationCanceledException>(() => writer.BackfillFoldedColumns(rewriteAll: false, cts.Token));
+
+                using var count = db.Connection.CreateCommand();
+                count.CommandText = "SELECT COUNT(*) FROM symbol_references WHERE symbol_name_folded IS NOT NULL OR container_name_folded IS NOT NULL";
+                Assert.Equal(0L, (long)count.ExecuteScalar()!);
+            }
+        }
+        finally
+        {
+            DbWriter.FoldBackfillRowUpdatedForTesting = null;
+            cts.Dispose();
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void RunBackfillFold_Cancelled_ReturnsInterruptedErrorCode()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_backfill_cancel_cli_{Guid.NewGuid():N}.db");
+        using var cts = new CancellationTokenSource();
+        try
+        {
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db.Connection);
+                var fileId = writer.UpsertFile(new FileRecord
+                {
+                    Path = "src/app.py",
+                    Lang = "python",
+                    Size = 64,
+                    Lines = 1,
+                    Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                });
+                writer.InsertSymbols([
+                    new SymbolRecord { FileId = fileId, Kind = "function", Name = "cancel_me", Line = 1, StartLine = 1, EndLine = 1 },
+                ]);
+
+                using var clear = db.Connection.CreateCommand();
+                clear.CommandText = "UPDATE symbols SET name_folded = NULL";
+                clear.ExecuteNonQuery();
+            }
+
+            cts.Cancel();
+
+            JsonElement json;
+            int exitCode;
+            lock (TestConsoleLock.Gate)
+            {
+                var originalOut = Console.Out;
+                using var writer = new StringWriter();
+                try
+                {
+                    Console.SetOut(writer);
+                    exitCode = IndexCommandRunner.RunBackfillFold(["--db", dbPath, "--json"], _jsonOptions, cts);
+                    using var document = JsonDocument.Parse(writer.ToString());
+                    json = document.RootElement.Clone();
+                }
+                finally
+                {
+                    Console.SetOut(originalOut);
+                }
+            }
+
+            Assert.Equal(CommandExitCodes.CancelledBySignal, exitCode);
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.Interrupted, json.GetProperty("error_code").GetString());
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
     public void RunBackfillFold_BlankFile_ReturnsDatabaseError()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_backfill_blank_{Guid.NewGuid():N}.db");


### PR DESCRIPTION
## Summary

- Add cancellation handling to backfill-fold so Ctrl-C/SIGTERM is observed while folded symbol/reference rows are read and rewritten.
- Keep folded-column rewrites inside the existing transaction boundary so mid-loop cancellation rolls back partial updates.
- Add cancellation/rollback regression coverage for symbol rows, reference rows, and the CLI JSON error path.

## Validation

- dotnet build
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~BackfillFold"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~BackfillFoldedColumns|FullyQualifiedName~RunBackfillFold_Cancelled"
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj
- codex adversarial review: No blocking/actionable issues found.

## Documentation and changelog

- Added changelog fragment: changelog.d/unreleased/1420.fixed.md
- No README/developer-guide update required; this preserves the existing backfill-fold command shape and improves cancellation behavior.

## Follow-up candidates

- None.

Fixes #1420
