### PR TITLE
Fix Markdown fenced code symbols

### DIFF
--- a/changelog.d/unreleased/2104.fixed.md
+++ b/changelog.d/unreleased/2104.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2104
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Markdown fenced code blocks are now navigable symbols (#2104)** — fenced Markdown code examples are indexed as `code` symbols using the fence language tag or `code` fallback, including heading context and block ranges.
+
+## 日本語
+
+- **Markdown fenced code block を navigable symbol として扱うようにしました (#2104)** — Markdown の fenced code example を、fence の language tag または `code` fallback を使った `code` symbol として index し、heading context と block range も保持します。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -266,11 +266,44 @@ public static partial class SymbolExtractor
         var inFence = false;
         var fenceChar = '\0';
         var fenceLength = 0;
+        var fenceSymbolIndex = -1;
 
         for (var i = 0; i < lines.Length; i++)
         {
-            if (TryToggleMarkdownFence(lines[i], inFence, fenceChar, fenceLength, out var nextFenceChar, out var nextFenceLength))
+            if (TryToggleMarkdownFence(lines[i], inFence, fenceChar, fenceLength, out var nextFenceChar, out var nextFenceLength, out var fenceInfo))
             {
+                if (!inFence)
+                {
+                    var codeSymbol = new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "code",
+                        Name = NormalizeMarkdownFenceInfo(fenceInfo),
+                        Line = i + 1,
+                        StartLine = i + 1,
+                        EndLine = lines.Length,
+                        BodyStartLine = i + 2,
+                        BodyEndLine = lines.Length,
+                        Signature = lines[i].Trim(),
+                    };
+
+                    if (headingStack.Count > 0)
+                    {
+                        var parent = symbols[headingStack.Peek().SymbolIndex];
+                        codeSymbol.ContainerKind = "heading";
+                        codeSymbol.ContainerName = parent.Name;
+                    }
+
+                    symbols.Add(codeSymbol);
+                    fenceSymbolIndex = symbols.Count - 1;
+                }
+                else if (fenceSymbolIndex >= 0)
+                {
+                    symbols[fenceSymbolIndex].EndLine = i + 1;
+                    symbols[fenceSymbolIndex].BodyEndLine = Math.Max(symbols[fenceSymbolIndex].BodyStartLine ?? i + 1, i);
+                    fenceSymbolIndex = -1;
+                }
+
                 inFence = nextFenceLength > 0;
                 fenceChar = nextFenceChar;
                 fenceLength = nextFenceLength;
@@ -374,7 +407,7 @@ public static partial class SymbolExtractor
 
         foreach (var line in lines)
         {
-            if (TryToggleMarkdownFence(line, inFence, fenceChar, fenceLength, out var nextFenceChar, out var nextFenceLength))
+            if (TryToggleMarkdownFence(line, inFence, fenceChar, fenceLength, out var nextFenceChar, out var nextFenceLength, out _))
             {
                 inFence = nextFenceLength > 0;
                 fenceChar = nextFenceChar;
@@ -435,10 +468,12 @@ public static partial class SymbolExtractor
         char fenceChar,
         int fenceLength,
         out char nextFenceChar,
-        out int nextFenceLength)
+        out int nextFenceLength,
+        out string fenceInfo)
     {
         nextFenceChar = '\0';
         nextFenceLength = 0;
+        fenceInfo = string.Empty;
 
         var index = 0;
         while (index < line.Length && index < 3 && line[index] == ' ')
@@ -465,10 +500,24 @@ public static partial class SymbolExtractor
         {
             nextFenceChar = marker;
             nextFenceLength = length - index;
+            fenceInfo = line[length..].Trim();
             return true;
         }
 
         return false;
+    }
+
+    private static string NormalizeMarkdownFenceInfo(string fenceInfo)
+    {
+        var normalized = fenceInfo.Trim();
+        if (normalized.Length == 0)
+            return "code";
+
+        var separatorIndex = normalized.IndexOfAny([' ', '\t', '\r', '\n']);
+        if (separatorIndex >= 0)
+            normalized = normalized[..separatorIndex];
+
+        return normalized.Length == 0 ? "code" : normalized;
     }
 
     private static bool TryParseMarkdownSetextHeading(string currentLine, string nextLine, out int level, out string headingText)

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -12485,7 +12485,7 @@ public class DbReaderTests : IDisposable
 
         Assert.NotNull(outline);
         Assert.Equal("docs/guide.md", outline!.Path);
-        Assert.Equal(4, outline.SymbolCount);
+        Assert.Equal(5, outline.SymbolCount);
         Assert.Collection(outline.Symbols,
             symbol =>
             {
@@ -12496,6 +12496,12 @@ public class DbReaderTests : IDisposable
             {
                 Assert.Equal("Details", symbol.Name);
                 Assert.Equal(1, symbol.Depth);
+            },
+            symbol =>
+            {
+                Assert.Equal("markdown", symbol.Name);
+                Assert.Equal("code", symbol.Kind);
+                Assert.Equal(2, symbol.Depth);
             },
             symbol =>
             {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14606,6 +14606,95 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Markdown_DetectsFencedCodeBlockSymbols()
+    {
+        const string content = """
+            # Guide
+
+            ```python
+            print("hello")
+            ```
+
+            ## Examples
+
+            ~~~bash title="setup"
+            echo ok
+            ~~~
+
+            ```
+            no language
+            ```
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "markdown", content);
+        var codeBlocks = symbols.Where(s => s.Kind == "code").ToList();
+
+        Assert.Equal(3, codeBlocks.Count);
+        Assert.Contains(codeBlocks, s =>
+            s.Name == "python"
+            && s.Line == 3
+            && s.StartLine == 3
+            && s.EndLine == 5
+            && s.BodyStartLine == 4
+            && s.BodyEndLine == 4
+            && s.ContainerName == "Guide"
+            && s.Signature == "```python");
+        Assert.Contains(codeBlocks, s =>
+            s.Name == "bash"
+            && s.Line == 9
+            && s.EndLine == 11
+            && s.BodyStartLine == 10
+            && s.BodyEndLine == 10
+            && s.ContainerName == "Examples"
+            && s.Signature == "~~~bash title=\"setup\"");
+        Assert.Contains(codeBlocks, s =>
+            s.Name == "code"
+            && s.Line == 13
+            && s.EndLine == 15
+            && s.BodyStartLine == 14
+            && s.BodyEndLine == 14
+            && s.ContainerName == "Examples");
+    }
+
+    [Fact]
+    public void Extract_Markdown_DetectsEmptyAndUnclosedFencedCodeBlockSymbols()
+    {
+        const string emptyFenceContent = """
+            # Guide
+
+            ```json
+            ```
+            """;
+        const string unclosedFenceContent = """
+            # Guide
+
+            ```dockerfile
+            FROM alpine
+            RUN true
+            """;
+
+        var emptyFenceSymbols = SymbolExtractor.Extract(1, "markdown", emptyFenceContent);
+        var emptyCodeBlock = Assert.Single(emptyFenceSymbols.Where(s => s.Kind == "code"));
+
+        Assert.Equal("json", emptyCodeBlock.Name);
+        Assert.Equal(3, emptyCodeBlock.StartLine);
+        Assert.Equal(4, emptyCodeBlock.EndLine);
+        Assert.Equal(4, emptyCodeBlock.BodyStartLine);
+        Assert.Equal(4, emptyCodeBlock.BodyEndLine);
+        Assert.Equal("Guide", emptyCodeBlock.ContainerName);
+
+        var unclosedFenceSymbols = SymbolExtractor.Extract(1, "markdown", unclosedFenceContent);
+        var unclosedCodeBlock = Assert.Single(unclosedFenceSymbols.Where(s => s.Kind == "code"));
+
+        Assert.Equal("dockerfile", unclosedCodeBlock.Name);
+        Assert.Equal(3, unclosedCodeBlock.StartLine);
+        Assert.Equal(5, unclosedCodeBlock.EndLine);
+        Assert.Equal(4, unclosedCodeBlock.BodyStartLine);
+        Assert.Equal(5, unclosedCodeBlock.BodyEndLine);
+        Assert.Equal("Guide", unclosedCodeBlock.ContainerName);
+    }
+
+    [Fact]
     public void Extract_Markdown_DetectsSetextHeadingsAndLocalAnchorReferences()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Index Markdown fenced code blocks as `code` symbols using the fence info language tag, or `code` when no language tag is present.
- Preserve Markdown heading context for fenced code block symbols and expose closed, empty, and unclosed fence ranges.
- Update Markdown outline expectations and add a bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Markdown|FullyQualifiedName~DbReaderTests.GetOutline_MarkdownHeadings" -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: `No blocking/actionable issues found.`

Note: a full `dotnet test CodeIndex.sln -p:UseSharedCompilation=false` run was attempted before the outline expectation update and reported the expected new outline count mismatch plus an existing wall-clock budget failure in `SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget` (26.21s > 20s). The affected test classes were then run by the adversarial review command and passed: 1555 tests, 0 failures.

## Documentation and Changelog

- Added `changelog.d/unreleased/2104.fixed.md`.
- No README change was made because the user-facing behavior is covered by the changelog fragment and there is no existing README section that enumerates Markdown symbol kinds.

## Follow-up Candidates

- None.

Fixes #2104
