### PR TITLE
Require confirmation for rebuild indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ with `--files`, `--commits`, or `--changed-between <old-ref> <new-ref>` instead
 of rebuilding; see
 [Quick Start](USER_GUIDE.md#quick-start) and
 [Incremental update reliability](USER_GUIDE.md#incremental-update-reliability).
+If you do need `--rebuild`, interactive terminals ask for confirmation before
+deleting the existing DB, and scripts/CI must pass `--yes` (or `--force`).
 If a directory cannot be scanned because of permissions or an I/O error,
 `cdidx` records the scan error, keeps scanning other directories, and writes a
 temporary `.cdidx/scan-checkpoint.json` so a same-HEAD retry can skip directories
@@ -237,6 +239,8 @@ cdidx mcp
 [クイックスタート](USER_GUIDE.md#クイックスタート) と
 [インクリメンタル更新の信頼性](USER_GUIDE.md#インクリメンタル更新の信頼性)
 を参照してください。
+`--rebuild` が必要な場合、interactive terminal では既存 DB 削除前に確認を求め、
+script / CI では `--yes`（または `--force`）が必要です。
 権限や I/O エラーでディレクトリを走査できない場合でも、`cdidx` は scan error を
 記録して他のディレクトリの走査を続け、同じ HEAD の再実行で成功済みディレクトリを
 読み飛ばせるように一時的な `.cdidx/scan-checkpoint.json` を書き込みます。

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -890,7 +890,8 @@ cdidx report --output report.tgz --json
 | `--focus-line <line>` | `excerpt` | Line inside the requested excerpt whose focused column should stay visible when `--max-line-width` clamps long single-line content; requires `--focus-column` (max: 10000000) |
 | `--focus-column <n>` | `excerpt` | Column inside the focused line to keep centered when `--max-line-width` clamps long single-line content; must be within that line's length (max: 100000) |
 | `--focus-length <n>` | `excerpt` | Width of the focused span when `--max-line-width` clamps long single-line content (default: 1, max: 100000; requires `--focus-column`) |
-| `--rebuild` | `index` | Delete existing DB and rebuild |
+| `--rebuild` | `index` | Delete existing DB and rebuild. Interactive terminals prompt for confirmation; non-interactive runs must also pass `--yes` (or `--force`) and otherwise exit with code 64. |
+| `--yes` | `index` | Confirm `--rebuild` in non-interactive scripts and CI. |
 | `--verbose` | `index` | Show per-file status (`[OK  ]`/`[SKIP]`/`[DEL ]`/`[ERR ]`) |
 | `--commits <id...>` | `index` | Update only files changed in specified commits. Prefer this after a normal commit because git history includes rename/delete paths. |
 | `--changed-between <old-ref> <new-ref>` | `index` | Update only files changed between two git refs. Useful after branch switches when tooling knows the previous and current refs; rename old and new paths are both considered. |
@@ -2638,7 +2639,8 @@ cdidx report --output report.tgz --json
 | `--focus-line <line>` | `excerpt` | `--max-line-width` で長い1行を切り詰める際に、注目列を表示に残したい抜粋内の行。`--focus-column` 必須（最大: 10000000） |
 | `--focus-column <n>` | `excerpt` | `--max-line-width` で長い1行を切り詰める際に、中央付近へ残したい列。対象行の長さ以内である必要があります（最大: 100000） |
 | `--focus-length <n>` | `excerpt` | `--max-line-width` で長い1行を切り詰める際の注目範囲の幅（デフォルト: 1、最大: 100000、`--focus-column` 必須） |
-| `--rebuild` | `index` | 既存DBを削除して再構築 |
+| `--rebuild` | `index` | 既存DBを削除して再構築。interactive terminal では確認プロンプトを出し、non-interactive 実行では `--yes`（または `--force`）がないと終了コード 64 で拒否する。 |
+| `--yes` | `index` | non-interactive script / CI で `--rebuild` を確認済みとして実行する。 |
 | `--verbose` | `index` | ファイルごとのステータス表示（`[OK  ]`/`[SKIP]`/`[DEL ]`/`[ERR ]`） |
 | `--commits <id...>` | `index` | 指定コミットの変更ファイルのみ更新。通常のコミット後はこちらを推奨。rename/delete の旧パスも git 履歴から拾える。 |
 | `--changed-between <old-ref> <new-ref>` | `index` | 2つの git ref 間で変更されたファイルのみ更新。ブランチ切り替え前後の ref が分かる workflow 向け。rename の旧パスと新パスを両方考慮する。 |

--- a/changelog.d/unreleased/1706.fixed.md
+++ b/changelog.d/unreleased/1706.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 1706
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/CommandExitCodes.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - README.md
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`index --rebuild` now requires explicit confirmation (#1706)** — interactive terminals prompt before deleting the existing index, while non-interactive runs must pass `--yes` or `--force` and otherwise fail with exit code 64.
+
+## 日本語
+
+- **`index --rebuild` は明示的な確認を要求するようになりました (#1706)** — interactive terminal では既存 index の削除前に確認し、non-interactive 実行では `--yes` または `--force` がない場合に終了コード 64 で失敗します。

--- a/src/CodeIndex/Cli/CommandExitCodes.cs
+++ b/src/CodeIndex/Cli/CommandExitCodes.cs
@@ -15,6 +15,7 @@ public static class CommandExitCodes
     public const int TransientDatabaseError = 6;
     public const int InvalidArgument = 7;
     public const int CancelledBySignal = 8;
+    public const int ExUsage = 64;
     public const int Interrupted = CancelledBySignal;
     public const int LegacyInterrupted = 130;
 }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -24,6 +24,8 @@ public static class IndexCommandRunner
         IReadOnlyList<string> Directories);
 
     internal static Action? FullScanWritePhaseStartedForTesting { get; set; }
+    internal static Func<bool> IsInputRedirectedForTesting { get; set; } = () => Console.IsInputRedirected;
+    internal static Func<string?> ReadLineForTesting { get; set; } = Console.ReadLine;
 
     public static int Run(string[] indexArgs, JsonSerializerOptions jsonOptions) =>
         Run(indexArgs, jsonOptions, cancellationForTesting: null);
@@ -144,6 +146,41 @@ public static class IndexCommandRunner
                 CommandExitCodes.UsageError,
                 "Rerun `cdidx index <projectPath> --commits <commit-id> [commit-id ...]` with 7-40 hex commit object IDs.",
                 CommandErrorCodes.UsageError);
+        }
+
+        if (options.Rebuild && !options.Yes && !options.Force)
+        {
+            var resolvedPreviewDbPath = Path.GetFullPath(DbPathResolver.NormalizeDbPath(dbPath));
+            var estimate = TryReadPriorFullScanEstimate(resolvedPreviewDbPath);
+            var estimateSuffix = estimate == null
+                ? string.Empty
+                : $" Estimated time on prior full scan: {ConsoleUi.FormatDuration(estimate.Value, options.DurationFormat)}.";
+            var warning = $"This will DELETE the existing index at {resolvedPreviewDbPath} and re-scan from scratch.{estimateSuffix}";
+
+            if (IsInputRedirectedForTesting())
+            {
+                return WriteCommandError(
+                    options.Json,
+                    jsonOptions,
+                    $"{warning} Pass --yes to confirm --rebuild in non-interactive environments.",
+                    CommandExitCodes.ExUsage,
+                    "Rerun with `--yes` to rebuild, or use `--files`, `--commits`, or `--changed-between` for an incremental refresh.",
+                    CommandErrorCodes.UsageError);
+            }
+
+            Console.Error.Write($"{warning} Proceed? [y/N] ");
+            var answer = ReadLineForTesting();
+            if (!string.Equals(answer, "y", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(answer, "yes", StringComparison.OrdinalIgnoreCase))
+            {
+                return WriteCommandError(
+                    options.Json,
+                    jsonOptions,
+                    "index rebuild cancelled",
+                    CommandExitCodes.ExUsage,
+                    "Rerun with `--yes` to confirm, or use an incremental refresh mode.",
+                    CommandErrorCodes.UsageError);
+            }
         }
 
         if (options.ChangedBetweenSpecified && options.ChangedBetweenRefs.Count != 2)
@@ -611,7 +648,7 @@ public static class IndexCommandRunner
     private static readonly string[] AcceptedIndexFlags =
     [
         "--db", "--rebuild", "--verbose", "--json", "--dry-run", "--force",
-        "--watch", "--debounce", "--duration-format", "--max-file-bytes",
+        "--yes", "--watch", "--debounce", "--duration-format", "--max-file-bytes",
         "--parallelism",
         "--commits", "--changed-between", "--files", "--solution", "--project", "--help",
     ];
@@ -643,6 +680,36 @@ public static class IndexCommandRunner
         return eq < 0 ? token : token[..eq];
     }
 
+    private static TimeSpan? TryReadPriorFullScanEstimate(string resolvedDbPath)
+    {
+        if (!File.Exists(resolvedDbPath))
+            return null;
+
+        try
+        {
+            var builder = new SqliteConnectionStringBuilder
+            {
+                DataSource = resolvedDbPath,
+                Mode = SqliteOpenMode.ReadOnly,
+            };
+            using var connection = new SqliteConnection(builder.ConnectionString);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT value FROM codeindex_meta WHERE key = @key";
+            command.Parameters.AddWithValue("@key", DbContext.LastFullScanElapsedMsMetaKey);
+            var raw = command.ExecuteScalar() as string;
+            if (long.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var elapsedMs)
+                && elapsedMs >= 0)
+                return TimeSpan.FromMilliseconds(elapsedMs);
+        }
+        catch
+        {
+            // Legacy, corrupt, or locked DBs should not hide the destructive rebuild warning.
+        }
+
+        return null;
+    }
+
     public static IndexCommandOptions ParseArgs(string[] args)
     {
         string? projectPath = null;
@@ -653,6 +720,7 @@ public static class IndexCommandRunner
         bool quiet = false;
         bool dryRun = false;
         bool force = false;
+        bool yes = false;
         bool watch = false;
         int? watchDebounceMs = null;
         var durationFormat = DurationOutputFormat.Auto;
@@ -694,6 +762,9 @@ public static class IndexCommandRunner
                     break;
                 case "--force":
                     force = true;
+                    break;
+                case "--yes":
+                    yes = true;
                     break;
                 case "--watch":
                     watch = true;
@@ -833,6 +904,7 @@ public static class IndexCommandRunner
             EasterEgg = easterEgg,
             DryRun = dryRun,
             Force = force,
+            Yes = yes,
             Watch = watch,
             WatchDebounceMs = watchDebounceMs,
             DurationFormat = durationFormat,
@@ -3144,6 +3216,9 @@ public static class IndexCommandRunner
             // 非 git workspace で null になった場合はキーごとクリアされる。Issue #1508。
             writer.SetMeta(DbContext.IndexedHeadCommitMetaKey, currentHeadCommit);
             writer.SetMeta(DbContext.IndexedHeadCommitBranchMetaKey, GitHelper.TryGetHeadBranch(projectRoot));
+            writer.SetMeta(
+                DbContext.LastFullScanElapsedMsMetaKey,
+                stopwatch.ElapsedMilliseconds.ToString(System.Globalization.CultureInfo.InvariantCulture));
             // #1509: also stamp the always-updated "last indexed HEAD" triple (SHA + branch +
             // timestamp). Unlike #1508's IndexedHeadCommitMetaKey which only fires here on
             // full scans, this triple is also stamped at the end of incremental update runs
@@ -3938,6 +4013,7 @@ public sealed class IndexCommandOptions
     public string? EasterEgg { get; init; }
     public bool DryRun { get; init; }
     public bool Force { get; init; }
+    public bool Yes { get; init; }
     public bool Watch { get; init; }
     public int? WatchDebounceMs { get; init; }
     public DurationOutputFormat DurationFormat { get; init; } = DurationOutputFormat.Auto;

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -897,6 +897,7 @@ public class DbContext : IDisposable
     public const string IndexedHeadShaMetaKey = "indexed_head_sha";
     public const string IndexedHeadBranchMetaKey = "indexed_head_branch";
     public const string IndexedHeadTimestampMetaKey = "indexed_head_timestamp";
+    public const string LastFullScanElapsedMsMetaKey = "last_full_scan_elapsed_ms";
     // Issue #1585: count of files seen by the most recent successful full-repository scan
     // whose non-empty extension did not map to a known language. This is a scan coverage
     // signal, not an indexed-file count, and is omitted by readers until a current index pass

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -86,6 +86,14 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void ParseArgs_YesFlag_SetsYes()
+    {
+        var options = IndexCommandRunner.ParseArgs([".", "--rebuild", "--yes"]);
+        Assert.True(options.Rebuild);
+        Assert.True(options.Yes);
+    }
+
+    [Fact]
     public void ParseArgs_NoForceFlag_DefaultsToFalse()
     {
         var options = IndexCommandRunner.ParseArgs(["."]);
@@ -122,6 +130,53 @@ public class IndexCommandRunnerTests
         }
         finally
         {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_RebuildWithoutConfirmationOnNonTty_ReturnsExUsage()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.py"), "print('hello')\n");
+
+            IndexCommandRunner.IsInputRedirectedForTesting = () => true;
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--json"]);
+
+            Assert.Equal(CommandExitCodes.ExUsage, exitCode);
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Contains("Pass --yes", json.GetProperty("message").GetString());
+            Assert.Contains("--files", json.GetProperty("hint").GetString());
+        }
+        finally
+        {
+            IndexCommandRunner.IsInputRedirectedForTesting = () => Console.IsInputRedirected;
+            IndexCommandRunner.ReadLineForTesting = Console.ReadLine;
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_RebuildWithYesOnNonTty_Succeeds()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.py"), "print('hello')\n");
+
+            IndexCommandRunner.IsInputRedirectedForTesting = () => true;
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--yes", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.Equal("rebuild", json.GetProperty("mode").GetString());
+        }
+        finally
+        {
+            IndexCommandRunner.IsInputRedirectedForTesting = () => Console.IsInputRedirected;
+            IndexCommandRunner.ReadLineForTesting = Console.ReadLine;
             DeleteDirectory(projectRoot);
         }
     }
@@ -5539,7 +5594,7 @@ public class IndexCommandRunnerTests
             File.WriteAllText(Path.Combine(projectRoot, "extra.cs"), "public class Extra { }");
 
             // Rebuild: should drop and re-scan all files / rebuild: 全削除して全ファイル再スキャン
-            var (exitCode2, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--json"]);
+            var (exitCode2, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--yes", "--json"]);
             Assert.Equal(CommandExitCodes.Success, exitCode2);
             Assert.Equal("rebuild", json.GetProperty("mode").GetString());
             // After rebuild, all files should be scanned (not skipped)
@@ -5561,7 +5616,7 @@ public class IndexCommandRunnerTests
         {
             File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { }");
 
-            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--json"]);
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--yes", "--json"]);
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal("success", json.GetProperty("status").GetString());
@@ -6106,7 +6161,7 @@ public class IndexCommandRunnerTests
             originalMode = File.GetUnixFileMode(unreadableDir);
             File.SetUnixFileMode(unreadableDir, UnixFileMode.None);
 
-            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--json"]);
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--yes", "--json"]);
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal("partial", json.GetProperty("status").GetString());
@@ -6770,7 +6825,7 @@ public class IndexCommandRunnerTests
 
             // --rebuild already wipes the DB, so HEAD divergence is irrelevant on that path.
             // --rebuild は DB を消すため HEAD 差分の警告は不要。
-            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--json"]);
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--rebuild", "--yes", "--json"]);
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.False(json.GetProperty("head_changed").GetBoolean());
             Assert.Equal(JsonValueKind.Null, json.GetProperty("head_change_notice").ValueKind);


### PR DESCRIPTION
## Summary

- Require explicit confirmation before `cdidx index --rebuild` deletes and rebuilds an existing index.
- Add `--yes` for non-interactive rebuilds, keep `--force` as an override, and return exit code 64 when confirmation is missing.
- Persist and display the prior full-scan duration estimate when available.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test`

## Documentation and Changelog

- Updated `README.md` and `USER_GUIDE.md`.
- Added changelog fragment `changelog.d/unreleased/1706.fixed.md`.

## Review

- Codex adversarial review was attempted with `codex exec` and `codex exec review --uncommitted`, but both runs failed before review output due the account usage limit.
- Manual adversarial review against the workflow found and fixed one actionable issue: the rebuild estimate reader now opens SQLite read-only so the confirmation prompt cannot mutate the DB before the user confirms.

## Follow-up Candidates

- None.

Fixes #1706
