### PR TITLE
Fix spinner warning output race

### DIFF
--- a/changelog.d/unreleased/1627.fixed.md
+++ b/changelog.d/unreleased/1627.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1627
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+---
+
+## English
+
+- **Serialized spinner and warning terminal writes (#1627)** — spinner/progress updates and warning emission now share a terminal lock so warnings are not overwritten or visually interleaved with spinner frames.
+
+## 日本語
+
+- **spinner と warning の端末書き込みを直列化しました (#1627)** — spinner/progress 更新と warning 出力が端末用 lock を共有するようになり、warning が spinner frame に上書きされたり視覚的に混在したりしないようになりました。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -100,6 +100,7 @@ public static class ConsoleUi
     private const int SpinnerFrameDelayMs = 100;
     private const int SpinnerStopDelayMs = 20;
     private const int ConsoleLineMargin = 1;
+    private static readonly object TerminalLock = new();
     private static readonly string[] ByteUnits = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
 
     private static readonly string[] DefaultBrailleSpinnerFrames =
@@ -201,8 +202,11 @@ public static class ConsoleUi
             {
                 var frame = frames[i % frames.Length];
                 var line = isThemed ? $"\r{frame}" : $"\r{frame} {message}";
-                Console.Write(line);
-                Console.Out.Flush();
+                lock (TerminalLock)
+                {
+                    Console.Write(line);
+                    Console.Out.Flush();
+                }
                 i++;
                 try { Task.Delay(SpinnerFrameDelayMs, ct).Wait(ct); } catch (OperationCanceledException) { break; }
             }
@@ -222,8 +226,11 @@ public static class ConsoleUi
         Thread.Sleep(SpinnerStopDelayMs);
         if (ShouldUseInteractiveConsole())
         {
-            Console.Write($"\r{new string(' ', GetWindowWidth() - ConsoleLineMargin)}\r");
-            Console.Out.Flush();
+            lock (TerminalLock)
+            {
+                Console.Write($"\r{new string(' ', GetWindowWidth() - ConsoleLineMargin)}\r");
+                Console.Out.Flush();
+            }
         }
         cts.Dispose();
     }
@@ -334,13 +341,16 @@ public static class ConsoleUi
 
         if (!redirected)
         {
-            output.Write($"\r{line}");
-            output.Flush();
-            _lastProgressLineLength = line.Length;
-            if (current == total)
+            lock (TerminalLock)
             {
-                output.WriteLine();
-                _lastProgressLineLength = 0;
+                output.Write($"\r{line}");
+                output.Flush();
+                _lastProgressLineLength = line.Length;
+                if (current == total)
+                {
+                    output.WriteLine();
+                    _lastProgressLineLength = 0;
+                }
             }
         }
         else
@@ -386,6 +396,14 @@ public static class ConsoleUi
     /// </summary>
     public static void ClearProgressLine()
     {
+        lock (TerminalLock)
+        {
+            ClearProgressLineCore();
+        }
+    }
+
+    private static void ClearProgressLineCore()
+    {
         if (ShouldUseInteractiveConsole() && _lastProgressLineLength > 0)
         {
             Console.Write($"\r{new string(' ', _lastProgressLineLength)}\r");
@@ -400,8 +418,13 @@ public static class ConsoleUi
     /// </summary>
     public static void PrintWarning(string message)
     {
-        ClearProgressLine();
-        Console.Error.WriteLine($"  [WARN] {message}");
+        lock (TerminalLock)
+        {
+            ClearProgressLineCore();
+            Console.Error.WriteLine($"  [WARN] {message}");
+            Console.Error.Flush();
+            Console.Out.Flush();
+        }
     }
 
     // --- Banner / バナー ---

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -203,6 +203,34 @@ public class ConsoleUiTests
     }
 
     [Fact]
+    public void PrintWarning_FlushesBothConsoleStreams()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalError = Console.Error;
+            using var output = new FlushCountingTextWriter();
+            using var error = new FlushCountingTextWriter();
+            try
+            {
+                Console.SetOut(output);
+                Console.SetError(error);
+
+                ConsoleUi.PrintWarning("watch out");
+
+                Assert.Contains("[WARN] watch out", error.ToString());
+                Assert.True(error.FlushCount > 0);
+                Assert.True(output.FlushCount > 0);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
+            }
+        }
+    }
+
+    [Fact]
     public void GetWindowWidth_ColumnsEnvVarSet_UsesColumnsValue()
     {
         WithColumnsEnvironment("200", () =>
@@ -1408,6 +1436,17 @@ public class ConsoleUiTests
             ConsoleUi.SetColorPalette(_originalPalette);
             if (_lockTaken)
                 Monitor.Exit(TestConsoleLock.Gate);
+        }
+    }
+
+    private sealed class FlushCountingTextWriter : StringWriter
+    {
+        public int FlushCount { get; private set; }
+
+        public override void Flush()
+        {
+            FlushCount++;
+            base.Flush();
         }
     }
 


### PR DESCRIPTION
## Summary

- Serialize spinner/progress terminal writes and warning emission through a shared console lock.
- Flush stdout and stderr after warnings so warning output is not visually interleaved with spinner frames.
- Add a focused `ConsoleUiTests` coverage point and an unreleased bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter ConsoleUiTests -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter FullyQualifiedName~SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget -p:UseSharedCompilation=false`
- `codex exec "Follow .codex/workflows/adversarial-review.md. Review only origin/main..HEAD in /Users/widthdom/Projects/mine/cdidx/CodeIndex8th. Output only the required adversarial review result."`

## Documentation and Changelog

- Added `changelog.d/unreleased/1627.fixed.md`.
- No docs update required; this preserves intended CLI output behavior and fixes terminal write ordering.

## Notes

- The full Release test run printed one transient performance-budget failure for `SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget` (`23.17s`, expected `<20s`) but the test process exited 0, and the same test passed when rerun directly (`5s`).

Fixes #1627
