### PR TITLE
Fix NuGet publish version validation

### DIFF
--- a/.codex/workflows/release-changelog.md
+++ b/.codex/workflows/release-changelog.md
@@ -35,6 +35,11 @@ This command must:
   `.gitkeep`;
 - update the compare-link footer.
 
+The resulting release PR must include the `version.json` bump for the target
+version. The NuGet publish job validates that the pushed `v*` tag exactly
+matches `version.json` before packing, so do not tag a release from a commit
+where `version.json` still contains the previous version.
+
 ## Compare-link footer
 
 For a release from `1.16.0` to `1.17.0`, the footer must change from:
@@ -165,10 +170,15 @@ Failures usually only affect one of them.
   the missing files, then re-runs the CDN-propagation poll and `install.sh`
   verification.
 - **`publish-nuget` failed but the GitHub release succeeded.**
-  Re-run `publish-nuget` from the GitHub Actions UI. `dotnet nuget push` uses
-  `--skip-duplicate`, so already-pushed packages are not republished. Do not
-  delete and re-tag for a NuGet-only failure — the GitHub release is
-  already public and tag deletion would invalidate it for downstream installs.
+  First check the job log. The job fails before packing if `version.json` does
+  not match the tag, the tag is not a `v`-prefixed SemVer value, NuGet already
+  has that package version, or NuGet availability could not be verified. Do not
+  delete and re-tag for a NuGet-only failure — the GitHub release is already
+  public and tag deletion would invalidate it for downstream installs. If the
+  version already exists on NuGet, verify the package on nuget.org instead of
+  re-running the publish job. For transient network/API failures before publish,
+  re-run `publish-nuget` from the GitHub Actions UI after confirming the package
+  version is still absent.
 - **Install-verification step failed (e.g. `cdidx --version` mismatch, missing
   asset).** This means the published release is *not* usable. Investigate
   before announcing. If the cause is a transient CDN/network blip, re-run the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -536,9 +536,40 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
+          set -euo pipefail
           TAG="${{ inputs.tag_name || github.ref_name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a v-prefixed SemVer version, got: ${TAG}" >&2
+            exit 1
+          fi
+
           VERSION="${TAG#v}"
+          VERSION_JSON="$(jq -r '.version // empty' version.json)"
+          if [ "$VERSION_JSON" != "$VERSION" ]; then
+            echo "version.json (${VERSION_JSON}) does not match release tag ${TAG} (${VERSION})." >&2
+            echo "Run the release changelog preparation workflow and commit version.json before tagging." >&2
+            exit 1
+          fi
+
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify NuGet version is not already published
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          package_url="https://api.nuget.org/v3-flatcontainer/cdidx/${VERSION}/cdidx.${VERSION}.nupkg"
+          status="$(curl -sS -o /tmp/cdidx-nuget-head -w '%{http_code}' -I "$package_url")"
+          if [ "$status" = "200" ]; then
+            echo "NuGet package cdidx ${VERSION} is already published; refusing to mask this as a duplicate." >&2
+            exit 1
+          fi
+
+          if [ "$status" != "404" ]; then
+            echo "Could not verify NuGet package availability for cdidx ${VERSION}; HTTP ${status}." >&2
+            cat /tmp/cdidx-nuget-head >&2 || true
+            exit 1
+          fi
 
       # publish-nuget is a separate job with a fresh checkout, so the lock
       # file matches what is committed. RestorePackagesWithLockFile=true
@@ -560,9 +591,21 @@ jobs:
           -p:Version=${{ steps.version.outputs.version }}
           --output nupkg
 
+      - name: Verify packed NuGet package version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          expected_package="nupkg/cdidx.${VERSION}.nupkg"
+          if [ ! -f "$expected_package" ]; then
+            echo "Expected packed package ${expected_package} was not produced." >&2
+            printf 'Produced packages:\n' >&2
+            ls -la nupkg >&2
+            exit 1
+          fi
+
       - name: Publish to NuGet
         run: >
           dotnet nuget push nupkg/*.nupkg
           --api-key ${{ secrets.NUGET_API_KEY }}
           --source https://api.nuget.org/v3/index.json
-          --skip-duplicate

--- a/changelog.d/unreleased/2042.fixed.md
+++ b/changelog.d/unreleased/2042.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2042
+affected:
+  - .github/workflows/release.yml
+  - .codex/workflows/release-changelog.md
+  - tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+---
+
+## English
+
+- **NuGet publishing now validates release versions before pushing (#2042)** — the release workflow now rejects malformed tags, `version.json` mismatches, already-published NuGet versions, and unexpected package filenames before `dotnet nuget push` runs.
+
+## 日本語
+
+- **NuGet publish が push 前に release version を検証するようになりました (#2042)** — release workflow は `dotnet nuget push` 実行前に、壊れた tag、`version.json` の不一致、既に公開済みの NuGet version、想定外の package file name を拒否します。

--- a/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
@@ -54,6 +54,27 @@ public class ReleaseWorkflowTests
         Assert.Contains("'*.cdx.json'", workflow);
     }
 
+    // Issue #2042: NuGet publishing must fail before pack/push when the tag,
+    // version.json, or NuGet package state is inconsistent. A duplicate NuGet
+    // version is not a harmless re-run condition because it can mask tagging or
+    // version-sync mistakes.
+    // Issue #2042 対応: tag / version.json / NuGet package 状態が不整合な場合、
+    // pack/push 前に失敗させる。NuGet の duplicate version は harmless な再実行
+    // 条件ではなく、tag や version sync の誤りを隠し得る。
+    [Fact]
+    public void ReleaseWorkflow_ValidatesNuGetVersionBeforePublishing()
+    {
+        var workflow = File.ReadAllText(Path.Combine(GetRepositoryRoot(), ".github", "workflows", "release.yml"));
+
+        Assert.Contains("Release tag must be a v-prefixed SemVer version", workflow);
+        Assert.Contains("jq -r '.version // empty' version.json", workflow);
+        Assert.Contains("does not match release tag", workflow);
+        Assert.Contains("https://api.nuget.org/v3-flatcontainer/cdidx/${VERSION}/cdidx.${VERSION}.nupkg", workflow);
+        Assert.Contains("NuGet package cdidx ${VERSION} is already published", workflow);
+        Assert.Contains("Expected packed package ${expected_package} was not produced", workflow);
+        Assert.DoesNotContain("--skip-duplicate", workflow);
+    }
+
     private static string GetRepositoryRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## Summary

- Validate release tags against v-prefixed SemVer before NuGet packing.
- Compare the extracted release version with version.json and fail before pack on mismatch.
- Check nuget.org for an already-published cdidx version, verify the expected nupkg filename, and remove --skip-duplicate.
- Document the version.json release requirement and add a bilingual changelog fragment.

## Validation

- dotnet build CodeIndex.sln
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ReleaseWorkflowTests
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter FullyQualifiedName~ReleaseWorkflowTests (adversarial review)
- dotnet run --project tools/CodeIndex.Changelog -- check
- Adversarial review: No blocking/actionable issues found.

## Documentation / Changelog

- Updated .codex/workflows/release-changelog.md.
- Added changelog.d/unreleased/2042.fixed.md.

Fixes #2042
