### PR TITLE
Skip unchanged files earlier in partial reindex

### DIFF
--- a/changelog.d/unreleased/1787.fixed.md
+++ b/changelog.d/unreleased/1787.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1787
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Partial `--files` updates now skip unchanged files before opening them (#1787)** — `cdidx index --files` compares stored modified time and size first, avoiding checksum reads and extraction for files whose stat data already proves unchanged.
+
+## 日本語
+
+- **部分的な `--files` 更新が未変更ファイルを開く前にスキップするようになりました (#1787)** — `cdidx index --files` は保存済みの更新時刻とサイズを先に比較し、stat 情報で未変更と判断できるファイルでは checksum 読み取りと抽出を避けます。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -1798,6 +1798,29 @@ public static class IndexCommandRunner
                     continue;
                 }
 
+                var statReusableLanguage = TryDetectStatReusableLanguage(absPath);
+                var statMatchedId = TryGetUnchangedFileIdFromStat(
+                    writer,
+                    projectRoot,
+                    absPath,
+                    statReusableLanguage,
+                    allowReuse: symbolKindFilterMatchesPrior
+                        && statReusableLanguage is not ("javascript" or "typescript")
+                        && (statReusableLanguage != "csharp" || csharpSymbolNameContractMatchesCurrent)
+                        && (statReusableLanguage != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
+                        && (statReusableLanguage != "sql" || sqlGraphContractMatchesCurrent));
+                if (statMatchedId != null)
+                {
+                    skipped++;
+                    if (options.Verbose && !options.Json && !options.Quiet)
+                    {
+                        PauseUpdateSpinnerForConsoleWrite();
+                        Console.WriteLine($"  [SKIP] {relPath} (unchanged)");
+                        ResumeUpdateSpinnerAfterConsoleWrite();
+                    }
+                    continue;
+                }
+
                 var (record, content, rawBytes, warning) = indexer.BuildRecordWithRawBytes(absPath);
 
                 if (warning != null && !options.Json && !options.Quiet)
@@ -4128,6 +4151,51 @@ public static class IndexCommandRunner
 
     private static bool IsCSharpIdentifierPart(char ch)
         => char.IsLetterOrDigit(ch) || ch == '_';
+
+    private static string? TryDetectStatReusableLanguage(string absolutePath)
+    {
+        if (string.Equals(Path.GetExtension(absolutePath), ".h", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var detection = FileIndexer.TryDetectLanguage(absolutePath);
+        return detection.Status == FileIndexer.FileProbeStatus.Supported
+            ? detection.Language
+            : null;
+    }
+
+    private static long? TryGetUnchangedFileIdFromStat(
+        DbWriter writer,
+        string projectRoot,
+        string absolutePath,
+        string? language,
+        bool allowReuse)
+    {
+        if (!allowReuse || language == null)
+            return null;
+
+        try
+        {
+            var info = new FileInfo(absolutePath);
+            if (!info.Exists)
+                return null;
+
+            var relativePath = FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectRoot, absolutePath));
+            return writer.GetUnchangedFileId(
+                relativePath,
+                info.LastWriteTimeUtc,
+                checksum: null,
+                size: info.Length,
+                language: language);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
 
     private sealed record CSharpStaticInterfaceWorkspaceSymbols(
         IReadOnlyList<SymbolRecord> Symbols,

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -1645,6 +1645,44 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_UpdateFiles_UnchangedStatMatch_SkipsWithoutOpeningFile()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        try
+        {
+            var sourcePath = Path.Combine(projectRoot, "app.py");
+            const string content = "def run():\n    return 1\n";
+            File.WriteAllText(sourcePath, content);
+            File.SetLastWriteTimeUtc(sourcePath, new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json", "--quiet"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            File.SetUnixFileMode(sourcePath, UnixFileMode.None);
+            try
+            {
+                var (exitCode, json) = RunAndCaptureJson([projectRoot, "--files", "app.py", "--json"]);
+
+                Assert.Equal(CommandExitCodes.Success, exitCode);
+                Assert.Equal("success", json.GetProperty("status").GetString());
+                Assert.Equal(0, json.GetProperty("summary").GetProperty("updated").GetInt32());
+                Assert.Equal(1, json.GetProperty("summary").GetProperty("skipped").GetInt32());
+            }
+            finally
+            {
+                File.SetUnixFileMode(sourcePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+            SqliteConnection.ClearAllPools();
+        }
+    }
+
+    [Fact]
     public void Run_UpdateFiles_RemovesOldPathWhenExtensionChanges()
     {
         var projectRoot = CreateTempProject();


### PR DESCRIPTION
## Summary

- Add a stat-based unchanged-file shortcut for `cdidx index --files` before opening files for checksum/content reads.
- Keep the shortcut behind the same reuse gates as the existing checksum path, and avoid `.h` files whose language detection depends on content.
- Add regression coverage proving unchanged `--files` updates skip without opening an unreadable file.

## Validation

- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~IndexCommandRunnerTests.Run_UpdateFiles_UnchangedStatMatch_SkipsWithoutOpeningFile"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~IndexCommandRunnerTests.Run_UpdateFiles"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`

## Documentation and Changelog

- Added changelog fragment: `changelog.d/unreleased/1787.fixed.md`
- No README/user guide update; this preserves existing CLI behavior and improves the unchanged-file fast path.

## Review

- Adversarial review result: No blocking/actionable issues found.
- Note: external `codex exec` review was attempted but blocked by usage limit, so the review was performed directly against `origin/main..HEAD` in this session.

Fixes #1787
