### PR TITLE
Fix malformed db URI diagnostics

### DIFF
--- a/changelog.d/unreleased/1990.fixed.md
+++ b/changelog.d/unreleased/1990.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1990
+affected:
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/DbPathResolverTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Malformed `--db file:` URIs now fail with path-specific diagnostics (#1990)** — query commands report invalid SQLite file URI parsing and include the resolved `--db` path when a valid URI points at a missing database.
+
+## 日本語
+
+- **壊れた `--db file:` URI がパス固有の診断で失敗するようになりました (#1990)** — query コマンドは SQLite file URI の parse 失敗を明示し、有効な URI が存在しない database を指す場合は解決後の `--db` パスを表示します。

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -86,35 +86,55 @@ public static class DbPathResolver
     /// </summary>
     public static string NormalizeDbPath(string dbPath)
     {
+        if (TryNormalizeDbPath(dbPath, out var normalized, out var parseError))
+            return normalized;
+
+        if (parseError != null)
+            GlobalToolLog.Error($"db_path_uri_parse_failed db={QuoteLogValue(dbPath)} exception={QuoteLogValue(parseError.Message)}");
+
+        return dbPath;
+    }
+
+    internal static bool TryNormalizeDbPath(string dbPath, out string normalizedDbPath, out Exception? parseError)
+    {
+        normalizedDbPath = dbPath;
+        parseError = null;
         if (!dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
-            return dbPath;
+            return true;
+
         try
         {
             // Strip query params (?immutable=1 etc.) before URI parsing so LocalPath is clean.
             var qIdx = dbPath.IndexOf('?');
             var trimmed = qIdx >= 0 ? dbPath[..qIdx] : dbPath;
+            if (ContainsInvalidPercentEscape(trimmed))
+                throw new FormatException("Invalid percent escape in SQLite file URI.");
+
             if (!trimmed.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
             {
                 var relativePath = Uri.UnescapeDataString(trimmed["file:".Length..]);
-                return string.IsNullOrWhiteSpace(relativePath)
+                normalizedDbPath = string.IsNullOrWhiteSpace(relativePath)
                     ? dbPath
                     : Path.GetFullPath(relativePath);
+                return true;
             }
 
             var uri = new Uri(trimmed);
             if (!uri.IsFile)
-                return dbPath;
+                return true;
 
             var localPath = uri.LocalPath;
-            return string.IsNullOrWhiteSpace(localPath)
+            normalizedDbPath = string.IsNullOrWhiteSpace(localPath)
                 ? dbPath
                 : Path.IsPathRooted(localPath)
                     ? localPath
                     : Path.GetFullPath(localPath);
+            return true;
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentException or FormatException or UriFormatException)
         {
-            return dbPath;
+            parseError = ex;
+            return false;
         }
     }
 
@@ -289,8 +309,32 @@ public static class DbPathResolver
     private static bool PathsEqual(string left, string right)
         => PathCasing.PathsEqual(left, right);
 
+    private static string QuoteLogValue(string value) =>
+        "\"" + value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal).Replace("\r", "\\r", StringComparison.Ordinal).Replace("\n", "\\n", StringComparison.Ordinal) + "\"";
+
     private static bool IsUnderDirectory(string parentDirectory, string candidatePath)
         => PathCasing.IsPathEqualOrParent(parentDirectory, candidatePath);
+
+    private static bool ContainsInvalidPercentEscape(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] != '%')
+                continue;
+
+            if (i + 2 >= value.Length || !IsHexDigit(value[i + 1]) || !IsHexDigit(value[i + 2]))
+                return true;
+
+            i += 2;
+        }
+
+        return false;
+    }
+
+    private static bool IsHexDigit(char value) =>
+        value is >= '0' and <= '9'
+            or >= 'a' and <= 'f'
+            or >= 'A' and <= 'F';
 
     private static List<IndexedFileSample> TryReadIndexedFileSamples(string dbPath)
     {

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4254,9 +4254,25 @@ public static class QueryCommandRunner
             // are meaningless to the filesystem API but are understood by SQLite.
             // URI 形式の --db を受け入れるため、file: で始まる値は File.Exists チェックをスキップ。
             var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
-            if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
+            var fileExistsPath = dbPath;
+            if (isUri)
             {
-                Console.Error.WriteLine($"Error [{CommandErrorCodes.DbNotFound}]: database not found at {Path.GetFullPath(dbPath)}");
+                if (!DbPathResolver.TryNormalizeDbPath(dbPath, out fileExistsPath, out var parseError))
+                {
+                    Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: invalid --db file URI: {parseError?.Message ?? dbPath}");
+                    Console.Error.WriteLine($"Hint: pass a valid SQLite file URI such as `file:///absolute/path/to/codeindex.db?immutable=1`; the --db value resolved to: {dbPath}");
+                    GlobalToolLog.Error($"invalid_db_file_uri db={FormatLogValue(dbPath)} exception={FormatLogValue(parseError?.ToString() ?? "<unknown>")}");
+                    return CommandExitCodes.DatabaseError;
+                }
+            }
+
+            if (!fileExistsPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
+                && !File.Exists(LongPath.EnsureWindowsPrefix(fileExistsPath)))
+            {
+                var resolvedPath = Path.GetFullPath(fileExistsPath);
+                Console.Error.WriteLine($"Error [{CommandErrorCodes.DbNotFound}]: database not found at {resolvedPath}");
+                if (isUri)
+                    Console.Error.WriteLine($"Hint: the --db path resolved to: {resolvedPath}");
                 Console.Error.WriteLine("Hint: create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command.");
                 return CommandExitCodes.DatabaseError;
             }
@@ -6000,7 +6016,7 @@ public static class QueryCommandRunner
     // メッセージを揃え、ヒントの単一情報源を維持する。
     private static readonly Dictionary<string, string> MissingOptionValueHints = new(StringComparer.Ordinal)
     {
-        ["--db"] = "pass a path to a CodeIndex SQLite database, e.g. `--db .cdidx/codeindex.db`, or omit `--db` to use `.cdidx/codeindex.db`.",
+        ["--db"] = "pass a path to a CodeIndex SQLite database, e.g. `--db .cdidx/codeindex.db` or `--db file:///absolute/path/to/codeindex.db?immutable=1`, or omit `--db` to use `.cdidx/codeindex.db`.",
         ["--limit"] = "pass a positive integer, e.g. `--limit 20` (default 20).",
         ["--top"] = "pass a positive integer, e.g. `--top 20` (alias for `--limit`, default 20).",
         ["--lang"] = "pass a language identifier, e.g. `--lang csharp`. Run `cdidx languages` for the supported set.",

--- a/tests/CodeIndex.Tests/DbPathResolverTests.cs
+++ b/tests/CodeIndex.Tests/DbPathResolverTests.cs
@@ -88,6 +88,18 @@ public class DbPathResolverTests
     }
 
     [Fact]
+    public void TryNormalizeDbPath_MalformedFileUri_ReturnsParseErrorWithoutChangingValue()
+    {
+        const string malformedUri = "file:///tmp/codeindex%ZZ.db?immutable=1";
+
+        var resolved = DbPathResolver.TryNormalizeDbPath(malformedUri, out var normalized, out var parseError);
+
+        Assert.False(resolved);
+        Assert.Equal(malformedUri, normalized);
+        Assert.NotNull(parseError);
+    }
+
+    [Fact]
     public void ResolveProjectRootForQuery_PrefersStoredIndexedProjectRootMetadata()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_meta_root");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2582,6 +2582,21 @@ jobs:
     }
 
     [Fact]
+    public void WithDb_MalformedFileUriSurfacesDbPathParseError_Issue1990()
+    {
+        const string malformedUri = "file:///tmp/codeindex%ZZ.db?immutable=1";
+
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--db", malformedUri],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+        Assert.Contains($"Error [{CommandErrorCodes.DbError}]: invalid --db file URI:", stderr);
+        Assert.Contains("file:///absolute/path/to/codeindex.db?immutable=1", stderr);
+        Assert.Contains($"the --db value resolved to: {malformedUri}", stderr);
+    }
+
+    [Fact]
     public void WithDb_SqliteCantOpenSurfacesAccessOpenCategory_Issue2072()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue2072_cantopen");
@@ -2595,9 +2610,9 @@ jobs:
                 _jsonOptions));
 
             Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
-            Assert.Contains($"Error [{CommandErrorCodes.DbError}]: database access/open denied:", stderr);
-            Assert.Contains("verify parent directory permissions", stderr);
-            Assert.DoesNotContain("SQLite database error", stderr);
+            Assert.Contains($"Error [{CommandErrorCodes.DbNotFound}]: database not found at {Path.GetFullPath(Path.Combine(missingParent, "codeindex.db"))}", stderr);
+            Assert.Contains("Hint: the --db path resolved to:", stderr);
+            Assert.DoesNotContain("database access/open denied", stderr);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Validate malformed SQLite file URI percent escapes before opening `--db`.
- Report the normalized `--db` path when a valid file URI points to a missing database.
- Document the file URI form in the existing `--db` value hint.

## Validation
- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbPathResolverTests|FullyQualifiedName~QueryCommandRunnerTests.WithDb|FullyQualifiedName~QueryCommandRunnerTests.RunSearch_DbDoubleDashLiteralKeepsBothHints"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: No blocking/actionable issues found.

## Documentation and changelog
- Added `changelog.d/unreleased/1990.fixed.md`.
- Updated the `--db` value hint text with the expected `file:///absolute/path/to/codeindex.db?immutable=1` format.

## Follow-up candidates
- None.

Fixes #1990
