### PR TITLE
Fix FTS5 optimize maintenance

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -66,6 +66,8 @@ Directory scan / shared path filter (built-in skip lists + `.gitignore` / `.cdid
 
 Scoped `--files` / `--commits` refreshes reuse the same path filter as full scans. Within each directory, `FileIndexer` loads `.gitignore` before `.cdidxignore`, appends both rule sets in that order, and honors later `!` patterns as re-includes. If a commit-scoped refresh includes `.gitignore` or `.cdidxignore` changes, `IndexCommandRunner` falls back to a full scan so newly ignored files are purged safely. Malformed ignore lines are reported as scan errors and skipped instead of aborting the whole run. On Windows, files and directories with Hidden or System attributes are rejected before language detection; clear those attributes before indexing project-owned sources because ignore rules cannot re-include them.
 
+Incremental refreshes that mutate `fts_chunks` increment `codeindex_meta.fts_incremental_writes_since_optimize`. When the counter reaches `DbWriter.DefaultFtsOptimizeIncrementalWriteThreshold`, the update path runs `INSERT INTO fts_chunks(fts_chunks) VALUES('optimize')`, resets the counter, and stamps `fts_last_optimized_at`. Users can run the same maintenance directly with `cdidx optimize --db <path>` or `cdidx index <projectPath> --optimize`; this may briefly hold the writer lock on large indexes.
+
 ### Extending the indexer
 
 Out-of-tree post-extraction hooks can implement `CodeIndex.Indexer.Hooks.IPostExtractionHook` in a `.dll` placed under `~/.config/cdidx/hooks/` (or the directory named by `CDIDX_HOOKS_DIR`). Hook assemblies are discovered in path order. Each concrete hook type is instantiated with a public parameterless constructor, then called after built-in symbol extraction and again after built-in reference extraction, before rows are persisted. Hooks receive a `FileContext` plus mutable `IList<SymbolRecord>` / `IList<ReferenceRecord>` values, so they can annotate extracted records, add synthetic symbols, or add domain-specific references.
@@ -2148,6 +2150,8 @@ cdidx ./myproject --files src/app.cs        # 特定ファイルのみ
 
 `--commits` は `git diff-tree --no-commit-id -r --name-only` で変更ファイルパスを解決します。
 `--changed-between` は `git diff --name-status -M <old-ref> <new-ref>` を使い、rename の旧パスと新パスを両方含めるため、古い indexed path も purge できます。
+
+FTS5 を変更する差分更新は `codeindex_meta.fts_incremental_writes_since_optimize` を増やします。カウンタが `DbWriter.DefaultFtsOptimizeIncrementalWriteThreshold` に達すると、更新経路は `INSERT INTO fts_chunks(fts_chunks) VALUES('optimize')` を実行し、カウンタをリセットして `fts_last_optimized_at` を記録します。ユーザーは `cdidx optimize --db <path>` または `cdidx index <projectPath> --optimize` で同じ maintenance を手動実行できます。大きな index では短時間 writer lock を保持する可能性があります。
 
 VB.NET のコンテナ系パターンは `RegexOptions.IgnoreCase` と `VisualBasicEnd` ベースの範囲追跡を使うため、`Partial` の大小文字差や複数ファイルにまたがる型ファミリーでも、安定した定義範囲と `hotspots` 集計用メタデータを維持できる。
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ of rebuilding; see
 [Incremental update reliability](USER_GUIDE.md#incremental-update-reliability).
 If you do need `--rebuild`, interactive terminals ask for confirmation before
 deleting the existing DB, and scripts/CI must pass `--yes` (or `--force`).
+Incremental refreshes keep an FTS5 maintenance counter and optimize internal
+segments opportunistically; run `cdidx optimize` or
+`cdidx index <projectPath> --optimize` to perform the same maintenance manually
+when a long-lived DB needs immediate compaction.
 If a directory cannot be scanned because of permissions or an I/O error,
 `cdidx` records the scan error, keeps scanning other directories, and writes a
 temporary `.cdidx/scan-checkpoint.json` so a same-HEAD retry can skip directories
@@ -258,6 +262,9 @@ cdidx mcp
 を参照してください。
 `--rebuild` が必要な場合、interactive terminal では既存 DB 削除前に確認を求め、
 script / CI では `--yes`（または `--force`）が必要です。
+差分更新では FTS5 maintenance counter を保持し、内部 segment をしきい値到達時に
+自動で optimize します。長期間使っている DB をすぐに compact したい場合は、
+`cdidx optimize` または `cdidx index <projectPath> --optimize` を実行してください。
 権限や I/O エラーでディレクトリを走査できない場合でも、`cdidx` は scan error を
 記録して他のディレクトリの走査を続け、同じ HEAD の再実行で成功済みディレクトリを
 読み飛ばせるように一時的な `.cdidx/scan-checkpoint.json` を書き込みます。

--- a/changelog.d/unreleased/1698.fixed.md
+++ b/changelog.d/unreleased/1698.fixed.md
@@ -1,0 +1,22 @@
+---
+category: fixed
+issues:
+  - 1698
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - README.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **FTS5 maintenance now runs after incremental indexing accumulates writes (#1698)** — incremental updates track FTS5 mutations, optimize when the maintenance threshold is reached, and expose manual `cdidx optimize` / `index --optimize` commands for long-lived indexes.
+
+## 日本語
+
+- **差分 indexing で書き込みが蓄積した後に FTS5 maintenance を実行するようになりました (#1698)** — 差分更新は FTS5 mutation を記録し、しきい値到達時に optimize します。長期間使う index 向けに手動の `cdidx optimize` / `index --optimize` も追加しました。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -52,7 +52,7 @@ internal static class CliFlagSchema
     // サブコマンド一覧の正本。ConsoleUi.Commands と一致することをテストで確認する。
     public static IReadOnlyList<string> AllCommands { get; } =
     [
-        "index", "backfill-fold", "search", "definition", "references", "callers", "callees",
+        "index", "backfill-fold", "optimize", "search", "definition", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
         "validate", "deps", "impact", "unused", "hotspots", "languages", "batch", "mcp", "db", "report", "license",
     ];
@@ -142,14 +142,14 @@ internal static class CliFlagSchema
 
     private static readonly string[] DbPathCommands =
     [
-        "index", "backfill-fold", "search", "definition", "references", "callers", "callees",
+        "index", "backfill-fold", "optimize", "search", "definition", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
         "validate", "deps", "impact", "unused", "hotspots", "db", "report", "batch", "mcp",
     ];
 
     private static readonly string[] JsonCommands =
     [
-        "index", "backfill-fold", "search", "definition", "references", "callers", "callees",
+        "index", "backfill-fold", "optimize", "search", "definition", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
         "validate", "deps", "impact", "unused", "hotspots", "languages", "db", "report",
     ];
@@ -223,6 +223,7 @@ internal static class CliFlagSchema
             new() { Name = "--log-path", Description = "Print the active persistent log directory", Commands = Set("status") },
             new() { Name = "--integrity-check", Description = "Run PRAGMA integrity_check on the database", Commands = Set("db") },
             new() { Name = "--rebuild", Description = "Delete existing DB and rebuild from scratch", Commands = Set("index") },
+            new() { Name = "--optimize", Description = "Optimize the existing FTS5 table without scanning files", Commands = Set("index") },
             new() { Name = "--dry-run", Description = "Scan files without writing", Commands = Set("index") },
             new() { Name = "--force", Description = "Bypass the per-database index lock", Commands = Set("index") },
             new() { Name = "--duration-format", ValuePlaceholder = "<auto|seconds|hms>", Description = "Index elapsed time display format", Commands = Set("index") },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -60,9 +60,10 @@ public static class ConsoleUi
 
     private static readonly (string Command, string Usage)[] CommandUsageLines =
     [
-        ("index", "cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--quiet] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]] [--watch [--debounce <ms>]]"),
+        ("index", "cdidx index <projectPath> [--db <path>] [--rebuild] [--optimize] [--verbose] [--dry-run] [--force] [--quiet] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]] [--watch [--debounce <ms>]]"),
         ("hooks", "cdidx hooks <install|uninstall|status> [--project <path>] [--force] [--json]"),
         ("backfill-fold", "cdidx backfill-fold [--db <path>] [--json]"),
+        ("optimize", "cdidx optimize [--db <path>] [--json]"),
         ("index-commits", "cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
         ("index-changed-between", "cdidx index <projectPath> --changed-between <old-ref> <new-ref> [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
         ("index-files", "cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
@@ -593,6 +594,7 @@ public static class ConsoleUi
         Console.WriteLine("Commands:");
         Console.WriteLine("  index <projectPath>        Build or update the index for a project");
         Console.WriteLine("  backfill-fold              Upgrade folded-name columns in an existing index DB");
+        Console.WriteLine("  optimize                   Optimize FTS5 segments in an existing index DB");
         Console.WriteLine("  search <query>             Full-text search across indexed chunks");
         Console.WriteLine("  definition <query>         Resolve symbol definitions with extracted ranges");
         Console.WriteLine("  references <query>         Find indexed references for a symbol (--kind uses reference kind)");
@@ -638,6 +640,7 @@ public static class ConsoleUi
         Console.WriteLine("  --files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed");
         Console.WriteLine("  --watch                    After the initial scan, stay running and reindex on file changes (FileSystemWatcher / inotify / FSEvents); rejects --commits / --changed-between / --files / --dry-run");
         Console.WriteLine("  --debounce <ms>            Watch only: coalesce bursts of file events into one update after <ms> of quiet (default: 500)");
+        Console.WriteLine("  --optimize                 index only: optimize the existing FTS5 table for this project's DB without scanning files");
         Console.WriteLine("  --color <when>             Color output: `auto` (default), `always`, or `never`; flag wins over `CLICOLOR_FORCE` / `NO_COLOR` / `CLICOLOR` env vars, which win over TTY auto-detect");
         Console.WriteLine("  --palette <name>           ANSI palette: `basic` (8-color, default fallback), `256`, or `truecolor`; flag wins over `CDIDX_COLOR_PALETTE` env var, which wins over `COLORTERM` / `TERM` auto-detect");
         Console.WriteLine("  --ascii                    Use ASCII spinner/progress glyphs instead of Unicode glyphs (also honors CDIDX_ASCII=1, NO_UNICODE, TERM=dumb, accessibility env hints, and non-UTF-8 locales)");
@@ -651,6 +654,7 @@ public static class ConsoleUi
         Console.WriteLine("  Use --commits with a project path after normal commits; git diff sees rename/delete paths too.");
         Console.WriteLine("  Use --changed-between <old-ref> <new-ref> after switching branches to refresh only changed files.");
         Console.WriteLine("  Use --files only for known in-place edits or new files; old rename/delete paths stay indexed unless also listed.");
+        Console.WriteLine("  Incremental writes optimize FTS5 opportunistically after a small maintenance threshold; run `cdidx optimize` for manual maintenance.");
         Console.WriteLine();
         Console.WriteLine("Query options:");
         Console.WriteLine("  --db <path>                Database file path (default: .cdidx/codeindex.db in current directory)");
@@ -692,6 +696,7 @@ public static class ConsoleUi
         Console.WriteLine("Examples:");
         Console.WriteLine("  cdidx ./myproject                             Index a project");
         Console.WriteLine("  cdidx backfill-fold                           Upgrade folded-name columns in an existing DB");
+        Console.WriteLine("  cdidx optimize                                Optimize FTS5 segments in an existing DB");
         Console.WriteLine("  cdidx index ./myproject --commits abc123      Update DB from one commit");
         Console.WriteLine("  cdidx index ./myproject --commits abc123 def456");
         Console.WriteLine("                                              Update DB from multiple commits");
@@ -875,7 +880,7 @@ public static class ConsoleUi
 
     private static readonly string[] Commands =
     [
-        "index", "backfill-fold", "search", "definition", "references", "callers", "callees",
+        "index", "backfill-fold", "optimize", "search", "definition", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
         "validate", "deps", "impact", "unused", "hotspots", "languages", "batch", "mcp", "db", "report", "license",
     ];

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -117,6 +117,17 @@ public static class IndexCommandRunner
             }
         }
 
+        if (options.OptimizeOnly && (options.DryRun || options.Watch || options.Rebuild || isUpdateMode))
+        {
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                "--optimize cannot be combined with --dry-run, --watch, --rebuild, --commits, --changed-between, or --files",
+                CommandExitCodes.UsageError,
+                "Use `cdidx optimize --db <path>` or `cdidx index <projectPath> --optimize` by itself.",
+                CommandErrorCodes.UsageError);
+        }
+
         if (options.Rebuild && isUpdateMode)
         {
             // Enumerate the three mutually-exclusive usage forms so the conflict error
@@ -229,9 +240,12 @@ public static class IndexCommandRunner
             Console.WriteLine();
             Console.WriteLine($"  Project : {Path.GetFullPath(options.ProjectPath!)}");
             Console.WriteLine($"  Output  : {resolvedDbPath}");
-            Console.WriteLine($"  Mode    : {mode}");
+            Console.WriteLine($"  Mode    : {(options.OptimizeOnly ? "optimize" : mode)}");
             Console.WriteLine();
         }
+
+        if (options.OptimizeOnly)
+            return RunOptimizeFtsForDb(resolvedDbPath, options.Json, jsonOptions, options.ProjectPath);
 
         var ignoreCase = GitHelper.ResolveIgnoreCase(options.ProjectPath);
         var ignoreRuleRoot = GitHelper.TryGetRepositoryRoot(options.ProjectPath) ?? Path.GetFullPath(options.ProjectPath!);
@@ -525,6 +539,109 @@ public static class IndexCommandRunner
     public static int RunBackfillFold(string[] cmdArgs, JsonSerializerOptions jsonOptions) =>
         RunBackfillFold(cmdArgs, jsonOptions, cancellationForTesting: null);
 
+    public static int RunOptimizeFts(string[] cmdArgs, JsonSerializerOptions jsonOptions)
+    {
+        var options = ParseOptimizeFtsArgs(cmdArgs);
+        if (options.ShowHelp)
+        {
+            ConsoleUi.PrintUsage();
+            return CommandExitCodes.Success;
+        }
+
+        if (options.ParseError != null)
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                options.ParseError,
+                CommandExitCodes.UsageError,
+                "Run `cdidx optimize --help` to see the supported command shape.",
+                CommandErrorCodes.UsageError);
+
+        if (DbPathResolver.UriRequestsReadOnly(options.DbPath))
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                $"database must be writable for optimize: {options.DbPath}",
+                CommandExitCodes.DatabaseError,
+                "Point `--db` at a writable filesystem path, or omit read-only URI parameters such as `immutable=1` / `mode=ro`.",
+                CommandErrorCodes.DbNotWritable);
+
+        return RunOptimizeFtsForDb(Path.GetFullPath(DbPathResolver.NormalizeDbPath(options.DbPath)), options.Json, jsonOptions, projectPath: null);
+    }
+
+    private static int RunOptimizeFtsForDb(string dbPath, bool json, JsonSerializerOptions jsonOptions, string? projectPath)
+    {
+        if (!DbContext.TryValidateExistingCodeIndexDb(dbPath, out var validationMessage, out var isNotFound))
+            return WriteCommandError(
+                json,
+                jsonOptions,
+                validationMessage,
+                isNotFound ? CommandExitCodes.NotFound : CommandExitCodes.DatabaseError,
+                isNotFound
+                    ? "Point `--db` at an existing `codeindex.db`, or run `cdidx index <projectPath>` first to create one."
+                    : "Point `--db` at an existing CodeIndex database created by `cdidx index`, then retry `cdidx optimize`.",
+                isNotFound ? CommandErrorCodes.DbNotFound : CommandErrorCodes.DbError);
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var lockPath = IndexLock.GetLockPath(dbPath);
+            using var indexLock = IndexLock.Acquire(lockPath, projectPath ?? Path.GetDirectoryName(dbPath) ?? Environment.CurrentDirectory);
+            using var db = new DbContext(dbPath);
+            db.InitializeSchema();
+            var writer = new DbWriter(db);
+            var before = writer.GetFtsIncrementalWritesSinceOptimize();
+            writer.OptimizeFts();
+            stopwatch.Stop();
+            var after = writer.GetFtsIncrementalWritesSinceOptimize();
+
+            if (json)
+            {
+                var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
+                Console.WriteLine(JsonSerializer.Serialize(
+                    new OptimizeFtsJsonResult("success", dbPath, before, after, stopwatch.ElapsedMilliseconds),
+                    jsonContext.OptimizeFtsJsonResult));
+            }
+            else
+            {
+                Console.WriteLine("Optimized FTS5 index.");
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("DB", dbPath, indent: "  "));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Writes before", before.ToString("N0", System.Globalization.CultureInfo.InvariantCulture), indent: "  "));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Writes after", after.ToString("N0", System.Globalization.CultureInfo.InvariantCulture), indent: "  "));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Elapsed", ConsoleUi.FormatDuration(stopwatch.Elapsed), indent: "  "));
+            }
+
+            return CommandExitCodes.Success;
+        }
+        catch (IndexLockConflictException ex)
+        {
+            var holderDescription = DescribeLockHolder(ex.Holder);
+            var message = string.IsNullOrEmpty(holderDescription)
+                ? "another cdidx index is already running on this database"
+                : $"another cdidx index is already running on this database ({holderDescription})";
+            return WriteCommandError(
+                json,
+                jsonOptions,
+                message,
+                CommandExitCodes.DatabaseError,
+                "Wait for the running index to finish, then retry `cdidx optimize`.",
+                CommandErrorCodes.DbLocked);
+        }
+        catch (Exception ex)
+        {
+            if (JsonOutputFailure.TryHandle(ex, out var exitCode))
+                return exitCode;
+
+            return WriteCommandError(
+                json,
+                jsonOptions,
+                $"failed to optimize FTS5 index: {ex.Message}",
+                CommandExitCodes.DatabaseError,
+                "Ensure no other writer is holding the database lock, then retry `cdidx optimize`.",
+                CommandErrorCodes.DbError);
+        }
+    }
+
     internal static int RunBackfillFold(
         string[] cmdArgs,
         JsonSerializerOptions jsonOptions,
@@ -667,13 +784,48 @@ public static class IndexCommandRunner
         "--yes", "--watch", "--debounce", "--duration-format", "--max-file-bytes",
         "--parallelism",
         "--commits", "--changed-between", "--files", "--solution", "--project",
-        "--include-symbol-kind", "--exclude-symbol-kind", "--help",
+        "--include-symbol-kind", "--exclude-symbol-kind", "--optimize", "--help",
     ];
 
     private static readonly string[] AcceptedBackfillFoldFlags =
     [
         "--db", "--json", "--help",
     ];
+
+    private static OptimizeFtsCommandOptions ParseOptimizeFtsArgs(string[] args)
+    {
+        var dbPath = Path.Combine(".cdidx", "codeindex.db");
+        bool json = false;
+        string? parseError = null;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--db" when i + 1 < args.Length:
+                    dbPath = args[++i];
+                    break;
+                case "--json":
+                    json = true;
+                    break;
+                case "--help" or "-h":
+                    return new OptimizeFtsCommandOptions { ShowHelp = true };
+                default:
+                    if (args[i].StartsWith("-", StringComparison.Ordinal))
+                        parseError ??= $"unknown option '{args[i]}'";
+                    else
+                        dbPath = args[i];
+                    break;
+            }
+        }
+
+        return new OptimizeFtsCommandOptions
+        {
+            DbPath = dbPath,
+            Json = json,
+            ParseError = parseError,
+        };
+    }
 
     private static void WriteUnknownIndexOptionSuggestion(string token)
     {
@@ -739,6 +891,7 @@ public static class IndexCommandRunner
         bool force = false;
         bool yes = false;
         bool watch = false;
+        bool optimizeOnly = false;
         int? watchDebounceMs = null;
         var durationFormat = DurationOutputFormat.Auto;
         long? maxFileSizeBytes = ReadMaxFileSizeBytesFromEnvironment();
@@ -801,6 +954,9 @@ public static class IndexCommandRunner
                     break;
                 case "--watch":
                     watch = true;
+                    break;
+                case "--optimize":
+                    optimizeOnly = true;
                     break;
                 case "--debounce" when i + 1 < args.Length:
                     if (int.TryParse(args[i + 1], System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsedDebounce) && parsedDebounce >= 0)
@@ -971,6 +1127,7 @@ public static class IndexCommandRunner
             Force = force,
             Yes = yes,
             Watch = watch,
+            OptimizeOnly = optimizeOnly,
             WatchDebounceMs = watchDebounceMs,
             DurationFormat = durationFormat,
             MaxFileSizeBytes = maxFileSizeBytes,
@@ -1960,8 +2117,12 @@ public static class IndexCommandRunner
         if (purgedRefs > 0 && !options.Json && !options.Quiet)
             Console.WriteLine($"  Purged {purgedRefs:N0} stale references (unsupported language)");
 
+        var ftsOptimizeRan = false;
         if (ftsMutated)
-            writer.OptimizeFts();
+        {
+            writer.RecordFtsIncrementalWrite();
+            ftsOptimizeRan = writer.OptimizeFtsIfIncrementalWriteThresholdReached();
+        }
         ThrowIfUpdateCancelled();
         // Only stamp readiness on a fully successful run (errors == 0). A partial / error
         // run leaves the DB unstamped so readers correctly treat graph / issues data as
@@ -2122,6 +2283,7 @@ public static class IndexCommandRunner
                     Warnings = warnings,
                     Errors = errors,
                     SymbolsDroppedByKindFilter = symbolsDroppedByKindFilter,
+                    FtsOptimizeRan = ftsOptimizeRan,
                 },
                 SymbolKindFilter = options.SymbolKindFilter.ToJsonResult(),
                 GraphTableAvailable = graphTableAvailableAfter,
@@ -2165,6 +2327,7 @@ public static class IndexCommandRunner
             if (warnings > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Warnings", $"{warnings:N0}", indent: "  "));
             if (errors > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Errors", $"{errors:N0}", indent: "  "));
             if (symbolsDroppedByKindFilter > 0) Console.WriteLine(ConsoleUi.FormatSummaryLine("Filtered symbols", $"{symbolsDroppedByKindFilter:N0}", indent: "  "));
+            if (ftsOptimizeRan) Console.WriteLine(ConsoleUi.FormatSummaryLine("FTS optimize", "completed", indent: "  "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("Graph", graphTableAvailableAfter ? "ready" : "degraded", indent: "  "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("Issues", issuesTableAvailableAfter ? "ready" : "degraded", indent: "  "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("SQL graph", sqlGraphContractReadyAfter ? "ready" : "degraded", indent: "  "));
@@ -4374,6 +4537,7 @@ public sealed class IndexCommandOptions
     public bool Force { get; init; }
     public bool Yes { get; init; }
     public bool Watch { get; init; }
+    public bool OptimizeOnly { get; init; }
     public int? WatchDebounceMs { get; init; }
     public DurationOutputFormat DurationFormat { get; init; } = DurationOutputFormat.Auto;
     public long? MaxFileSizeBytes { get; init; }
@@ -4453,6 +4617,14 @@ public sealed class SymbolKindFilter
 }
 
 public sealed class BackfillFoldCommandOptions
+{
+    public bool ShowHelp { get; init; }
+    public string DbPath { get; init; } = Path.Combine(".cdidx", "codeindex.db");
+    public bool Json { get; init; }
+    public string? ParseError { get; init; }
+}
+
+public sealed class OptimizeFtsCommandOptions
 {
     public bool ShowHelp { get; init; }
     public string DbPath { get; init; } = Path.Combine(".cdidx", "codeindex.db");

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -19,6 +19,13 @@ internal sealed record BackfillFoldJsonResult(
     [property: JsonPropertyName("user_version_after")] int UserVersionAfter,
     [property: JsonPropertyName("fold_ready")] bool FoldReady);
 
+internal sealed record OptimizeFtsJsonResult(
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("db_path")] string DbPath,
+    [property: JsonPropertyName("writes_since_optimize_before")] int WritesSinceOptimizeBefore,
+    [property: JsonPropertyName("writes_since_optimize_after")] int WritesSinceOptimizeAfter,
+    [property: JsonPropertyName("elapsed_ms")] long ElapsedMs);
+
 internal sealed record CommandErrorJsonResult(
     [property: JsonPropertyName("status")] string Status,
     [property: JsonPropertyName("message")] string Message,
@@ -139,6 +146,8 @@ internal sealed class IndexUpdateSummaryJsonResult
     public int Warnings { get; init; }
     public int Errors { get; init; }
     public int SymbolsDroppedByKindFilter { get; init; }
+    [JsonPropertyName("fts_optimize_ran")]
+    public bool FtsOptimizeRan { get; init; }
 }
 
 internal sealed class IndexFullScanSummaryJsonResult
@@ -316,6 +325,7 @@ internal sealed record VersionInfoJsonResult(
 [JsonSerializable(typeof(List<UnusedSymbolResult>))]
 [JsonSerializable(typeof(OutlineResult))]
 [JsonSerializable(typeof(OutlineSymbol))]
+[JsonSerializable(typeof(OptimizeFtsJsonResult))]
 [JsonSerializable(typeof(QueryCountResult))]
 [JsonSerializable(typeof(ReferenceResult))]
 [JsonSerializable(typeof(RepoEntrypointResult))]

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -173,6 +173,7 @@ internal static class ProgramRunner
                     "diff" => DiffCommandRunner.Run(subArgs, jsonOptions),
                     "hooks" => HookCommandRunner.Run(subArgs, jsonOptions),
                     "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, jsonOptions),
+                    "optimize" => IndexCommandRunner.RunOptimizeFts(subArgs, jsonOptions),
                     "db" => DbCommandRunner.RunIntegrityCheck(subArgs, jsonOptions),
                     "report" => ReportCommandRunner.Run(subArgs, jsonOptions, appVersion),
                     _ when IsProjectPathArg(commandName)

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -11,6 +11,10 @@ namespace CodeIndex.Database;
 /// </summary>
 public class DbWriter
 {
+    public const string FtsIncrementalWritesSinceOptimizeMetaKey = "fts_incremental_writes_since_optimize";
+    public const string FtsLastOptimizedAtMetaKey = "fts_last_optimized_at";
+    public const int DefaultFtsOptimizeIncrementalWriteThreshold = 25;
+
     private readonly SqliteConnection _conn;
     private readonly PreparedCommandCache? _commandCache;
     private readonly Action? _markWriteWork;
@@ -1459,6 +1463,35 @@ public class DbWriter
     public void OptimizeFts()
     {
         Execute("INSERT INTO fts_chunks(fts_chunks) VALUES('optimize')");
+        SetMeta(FtsIncrementalWritesSinceOptimizeMetaKey, "0");
+        SetMeta(FtsLastOptimizedAtMetaKey, DateTimeOffset.UtcNow.ToString("O", System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    public int GetFtsIncrementalWritesSinceOptimize()
+    {
+        var raw = GetMetaString(FtsIncrementalWritesSinceOptimizeMetaKey);
+        return int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var value) && value > 0
+            ? value
+            : 0;
+    }
+
+    public int RecordFtsIncrementalWrite()
+    {
+        var value = GetFtsIncrementalWritesSinceOptimize() + 1;
+        SetMeta(FtsIncrementalWritesSinceOptimizeMetaKey, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        return value;
+    }
+
+    public bool OptimizeFtsIfIncrementalWriteThresholdReached(int threshold = DefaultFtsOptimizeIncrementalWriteThreshold)
+    {
+        if (threshold <= 0)
+            throw new ArgumentOutOfRangeException(nameof(threshold));
+
+        if (GetFtsIncrementalWritesSinceOptimize() < threshold)
+            return false;
+
+        OptimizeFts();
+        return true;
     }
 
     // End-of-successful-index trust markers. The ready bits live in PRAGMA user_version so

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -28,11 +28,12 @@ public class ConsoleUiTests
 
         Assert.DoesNotContain("██████╗", output);
         Assert.Contains("Usage:", output);
-        Assert.Contains("cdidx index <projectPath> [--db <path>] [--rebuild] [--verbose] [--dry-run] [--force] [--quiet] [--json] [--duration-format <auto|seconds|hms>]", output);
+        Assert.Contains("cdidx index <projectPath> [--db <path>] [--rebuild] [--optimize] [--verbose] [--dry-run] [--force] [--quiet] [--json] [--duration-format <auto|seconds|hms>]", output);
         Assert.Contains("cdidx hooks <install|uninstall|status> [--project <path>] [--force] [--json]", output);
         Assert.Contains("cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]", output);
         Assert.Contains("cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>]", output);
         Assert.Contains("cdidx backfill-fold [--db <path>] [--json]", output);
+        Assert.Contains("cdidx optimize [--db <path>] [--json]", output);
         Assert.Contains("cdidx license", output);
         Assert.Contains("cdidx references <query>|--query <query>|-- <query>", output);
         Assert.Contains("cdidx callers <query>|--query <query>|-- <query>", output);
@@ -52,6 +53,7 @@ public class ConsoleUiTests
         Assert.Contains("--count                    Count only; search/definition/references/callers/callees/symbols/files/find/unused ignore --limit, impact/hotspots still use visible page counts", output);
         Assert.Contains("--commits <id> [id ...]    Update only files changed in the specified git commits (preferred after commits)", output);
         Assert.Contains("--files <path> [path ...]  Update only the specified files; old rename/delete paths are not purged unless also listed", output);
+        Assert.Contains("--optimize                 index only: optimize the existing FTS5 table for this project's DB without scanning files", output);
         Assert.Contains("--duration-format <format> Index elapsed time format: `auto` (default), `seconds`, or `hms`; JSON keeps raw elapsed_ms", output);
         Assert.Contains("--ascii                    Use ASCII spinner/progress glyphs", output);
         Assert.Contains("cdidx excerpt <path> --start <line> [--end <line>] [--before <n>] [--after <n>] [--max-line-width <n>] [--focus-line <line>] [--focus-column <n>] [--focus-length <n>] [--db <path>] [--json] [--verbose]", output);
@@ -75,6 +77,7 @@ public class ConsoleUiTests
         Assert.Contains("Collapse same-name hotspots across files", output);
         Assert.Contains("cdidx symbols Run --exact-name                Exact symbol-name match", output);
         Assert.Contains("backfill-fold", output);
+        Assert.Contains("optimize                   Optimize FTS5 segments in an existing index DB", output);
         Assert.Contains("find <query>               Find literal substring matches inside known indexed files", output);
         Assert.Contains("Prefer --exact-substring for search, keep --exact for find", output);
         Assert.Contains("impact <query>             Show transitive callers; type queries may return heuristic file-level dependency hints", output);

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -44,6 +44,33 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void OptimizeFts_ResetsIncrementalWriteCounterAndStampsTime()
+    {
+        Assert.Equal(0, _writer.GetFtsIncrementalWritesSinceOptimize());
+
+        Assert.Equal(1, _writer.RecordFtsIncrementalWrite());
+        Assert.Equal(2, _writer.RecordFtsIncrementalWrite());
+        Assert.Equal(2, _writer.GetFtsIncrementalWritesSinceOptimize());
+
+        _writer.OptimizeFts();
+
+        Assert.Equal(0, _writer.GetFtsIncrementalWritesSinceOptimize());
+        Assert.False(string.IsNullOrWhiteSpace(_db.GetMetaString(DbWriter.FtsLastOptimizedAtMetaKey)));
+    }
+
+    [Fact]
+    public void OptimizeFtsIfIncrementalWriteThresholdReached_RunsOnlyAtThreshold()
+    {
+        Assert.Equal(1, _writer.RecordFtsIncrementalWrite());
+        Assert.False(_writer.OptimizeFtsIfIncrementalWriteThresholdReached(threshold: 2));
+        Assert.Equal(1, _writer.GetFtsIncrementalWritesSinceOptimize());
+
+        Assert.Equal(2, _writer.RecordFtsIncrementalWrite());
+        Assert.True(_writer.OptimizeFtsIfIncrementalWriteThresholdReached(threshold: 2));
+        Assert.Equal(0, _writer.GetFtsIncrementalWritesSinceOptimize());
+    }
+
+    [Fact]
     public void Dispose_AfterWriteWork_RunsOptimizePragma()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"codeindex_optimize_write_test_{Guid.NewGuid():N}.db");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2256,6 +2256,193 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void RunOptimizeFts_ExistingDb_ResetsCounterAndEmitsJson()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_optimize_fts_{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db);
+                writer.RecordFtsIncrementalWrite();
+                writer.RecordFtsIncrementalWrite();
+            }
+
+            int exitCode;
+            JsonElement json;
+            lock (TestConsoleLock.Gate)
+            {
+                var originalOut = Console.Out;
+                try
+                {
+                    using var stdout = new StringWriter();
+                    Console.SetOut(stdout);
+                    exitCode = IndexCommandRunner.RunOptimizeFts(["--db", dbPath, "--json"], _jsonOptions);
+                    using var document = JsonDocument.Parse(stdout.ToString());
+                    json = document.RootElement.Clone();
+                }
+                finally
+                {
+                    Console.SetOut(originalOut);
+                }
+            }
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.Equal(2, json.GetProperty("writes_since_optimize_before").GetInt32());
+            Assert.Equal(0, json.GetProperty("writes_since_optimize_after").GetInt32());
+
+            using var verifyDb = new DbContext(dbPath);
+            Assert.Equal("0", verifyDb.GetMetaString(DbWriter.FtsIncrementalWritesSinceOptimizeMetaKey));
+            Assert.False(string.IsNullOrWhiteSpace(verifyDb.GetMetaString(DbWriter.FtsLastOptimizedAtMetaKey)));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void RunOptimizeFts_LockHeld_ReportsDbLocked()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_optimize_locked_{Guid.NewGuid():N}.db");
+        var lockPath = dbPath + ".lock";
+        try
+        {
+            using (var db = new DbContext(dbPath))
+                db.InitializeSchema();
+
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+            using (var holder = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            {
+                int exitCode;
+                JsonElement json;
+                lock (TestConsoleLock.Gate)
+                {
+                    var originalOut = Console.Out;
+                    try
+                    {
+                        using var stdout = new StringWriter();
+                        Console.SetOut(stdout);
+                        exitCode = IndexCommandRunner.RunOptimizeFts(["--db", dbPath, "--json"], _jsonOptions);
+                        using var document = JsonDocument.Parse(stdout.ToString());
+                        json = document.RootElement.Clone();
+                    }
+                    finally
+                    {
+                        Console.SetOut(originalOut);
+                    }
+                }
+
+                Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+                Assert.Equal("error", json.GetProperty("status").GetString());
+                Assert.Equal(CommandErrorCodes.DbLocked, json.GetProperty("error_code").GetString());
+                Assert.Contains("another cdidx index is already running", json.GetProperty("message").GetString());
+                Assert.Contains("retry `cdidx optimize`", json.GetProperty("hint").GetString());
+            }
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+            if (File.Exists(lockPath + ".info"))
+                File.Delete(lockPath + ".info");
+            if (File.Exists(lockPath))
+                File.Delete(lockPath);
+        }
+    }
+
+    [Fact]
+    public void RunOptimizeFts_ReadOnlyUri_ReturnsDbNotWritable()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_optimize_readonly_{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db);
+                writer.RecordFtsIncrementalWrite();
+            }
+
+            var dbUri = new Uri(dbPath).AbsoluteUri + "?immutable=1";
+            int exitCode;
+            JsonElement json;
+            lock (TestConsoleLock.Gate)
+            {
+                var originalOut = Console.Out;
+                try
+                {
+                    using var stdout = new StringWriter();
+                    Console.SetOut(stdout);
+                    exitCode = IndexCommandRunner.RunOptimizeFts(["--db", dbUri, "--json"], _jsonOptions);
+                    using var document = JsonDocument.Parse(stdout.ToString());
+                    json = document.RootElement.Clone();
+                }
+                finally
+                {
+                    Console.SetOut(originalOut);
+                }
+            }
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.DbNotWritable, json.GetProperty("error_code").GetString());
+            Assert.Contains("database must be writable for optimize", json.GetProperty("message").GetString());
+
+            using var verifyDb = new DbContext(dbPath);
+            Assert.Equal("1", verifyDb.GetMetaString(DbWriter.FtsIncrementalWritesSinceOptimizeMetaKey));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void Run_IndexOptimizeWithDryRun_ReturnsUsageErrorWithoutWriting()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { }\n");
+            var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db);
+                writer.RecordFtsIncrementalWrite();
+                writer.SetMeta(DbWriter.FtsLastOptimizedAtMetaKey, "sentinel");
+            }
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--optimize", "--dry-run", "--json"]);
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.UsageError, json.GetProperty("error_code").GetString());
+            Assert.Contains("--optimize cannot be combined", json.GetProperty("message").GetString());
+
+            using var verifyDb = new DbContext(dbPath);
+            Assert.Equal("1", verifyDb.GetMetaString(DbWriter.FtsIncrementalWritesSinceOptimizeMetaKey));
+            Assert.Equal("sentinel", verifyDb.GetMetaString(DbWriter.FtsLastOptimizedAtMetaKey));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunBackfillFold_BackfillsLegacyRowsAndStampsFoldReady()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_backfill_fold_{Guid.NewGuid():N}.db");


### PR DESCRIPTION
## Summary
- Add incremental FTS5 maintenance tracking and threshold-based optimize after mutating update runs.
- Add manual optimize entry points via `cdidx optimize` and `cdidx index <projectPath> --optimize`, with writer locking and dry-run/read-only safeguards.
- Update CLI help, docs, tests, and changelog fragment.

## Documentation / Changelog
- Updated `README.md` and `DEVELOPER_GUIDE.md` for the user-facing maintenance behavior.
- Added changelog fragment `changelog.d/unreleased/1698.fixed.md`.

Fixes #1698

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests.RunOptimizeFts|FullyQualifiedName~IndexCommandRunnerTests.Run_IndexOptimizeWithDryRun|FullyQualifiedName~ConsoleUiTests.PrintUsage_WithoutBanner|FullyQualifiedName~CliFlagSchemaTests|FullyQualifiedName~DatabaseTests.OptimizeFts"`
- `dotnet test CodeIndex.sln`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll optimize --db .cdidx/codeindex.db --json`
- Codex adversarial review: No blocking/actionable issues found.

## Follow-ups
- None.