### PR TITLE
Add Homebrew release publishing

### DIFF
--- a/.codex/workflows/release-changelog.md
+++ b/.codex/workflows/release-changelog.md
@@ -155,8 +155,8 @@ the tag in place.
 
 ### Partial-failure recovery
 
-The `Release` workflow has three post-tag jobs: the `release` build/publish
-matrix and two jobs that depend on it (`create-release`, `publish-nuget`).
+The `Release` workflow has four post-tag jobs: the `release` build/publish
+matrix, `create-release`, `publish-nuget`, and `publish-homebrew`.
 Failures usually only affect one of them.
 
 - **One `release` matrix lane (Linux/Windows/macOS publish) failed.**
@@ -179,6 +179,16 @@ Failures usually only affect one of them.
   re-running the publish job. For transient network/API failures before publish,
   re-run `publish-nuget` from the GitHub Actions UI after confirming the package
   version is still absent.
+- **`publish-homebrew` failed but the GitHub release succeeded.**
+  First check the job log. The job runs after `create-release` and requires the
+  `homebrew-production` environment plus `HOMEBREW_TAP_TOKEN` access to update
+  the `Widthdom/homebrew-tap` `codeindex` formula. Do not delete and re-tag for
+  a Homebrew-only failure — the GitHub release is already public and the tag is
+  the source of truth for direct installers and NuGet. If the formula update
+  already landed, verify the tap instead of re-running the job. For transient
+  GitHub/API failures before the tap changes, re-run `publish-homebrew` from the
+  GitHub Actions UI. For a formula conflict or bad generated formula, fix the
+  tap with an auditable follow-up commit/PR and reference the release tag.
 - **Install-verification step failed (e.g. `cdidx --version` mismatch, missing
   asset).** This means the published release is *not* usable. Investigate
   before announcing. If the cause is a transient CDN/network blip, re-run the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -609,3 +609,37 @@ jobs:
           dotnet nuget push nupkg/*.nupkg
           --api-key ${{ secrets.NUGET_API_KEY }}
           --source https://api.nuget.org/v3/index.json
+
+  publish-homebrew:
+    if: github.repository == 'Widthdom/CodeIndex'
+    runs-on: ubuntu-latest
+    needs: create-release
+    environment: homebrew-production
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag_name || github.ref }}
+
+      - name: Extract release tag
+        id: release
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag_name || github.ref_name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a v-prefixed SemVer version, got: ${TAG}" >&2
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Bump Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v5
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          tap: Widthdom/homebrew-tap
+          formula: codeindex
+          tag: ${{ steps.release.outputs.tag }}
+          revision: ${{ steps.release.outputs.revision }}

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -678,10 +678,11 @@ The direct MCP graph tools (`references`, `callers`, `callees`) also emit `graph
 ## Release Workflow
 
 The version string has a single source of truth: `version.json` at the repository root.
-Official GitHub Release and NuGet publishing jobs are restricted to the
-canonical `Widthdom/CodeIndex` repository. Do not reuse the official release
-workflow, NuGet package ID, or cdidx/CodeIndex branding for derivative
-distributions without a separate written agreement.
+Official GitHub Release, NuGet publishing, and Homebrew tap update jobs are
+restricted to the canonical `Widthdom/CodeIndex` repository. Do not reuse the
+official release workflow, NuGet package ID, Homebrew tap/formula, or
+cdidx/CodeIndex branding for derivative distributions without a separate
+written agreement.
 
 ### Version flow
 
@@ -703,8 +704,8 @@ The version numbers below use `1.9.0` only as an example. Replace them with the 
 2. Review the generated `CHANGELOG.md`, `version.json`, and `changelog.d/unreleased/` diff. Do not hand-edit release headings or compare links unless you are fixing a tool bug; fix fragments or the tool input and rerun `prepare` instead.
 3. Run the release validation from `.codex/workflows/release-changelog.md` (`restore`, `build`, `test`, and `pack` in Release configuration).
 4. Commit the generated release prep, for example `Prepare release v1.9.0`.
-5. After the release PR merges, tag the merge commit `v1.9.0` and push the tag. `.github/workflows/release.yml` triggers on `v*` tags and builds the per-platform tarballs plus the NuGet package.
-6. After the release is published, run the one-liner installer on a clean machine and verify `cdidx --version` prints the released version before announcing it.
+5. After the release PR merges, tag the merge commit `v1.9.0` and push the tag. `.github/workflows/release.yml` triggers on `v*` tags, builds the per-platform tarballs, publishes the NuGet package, and bumps the `Widthdom/homebrew-tap` `codeindex` formula with `HOMEBREW_TAP_TOKEN`.
+6. After the release is published, run the one-liner installer and the Homebrew install path on a clean machine and verify `cdidx --version` prints the released version before announcing it.
 
 If a clean install reports `cdidx v0.0.0`, treat it as a release regression: either the tarball did not bundle `version.json`, or `install.sh` did not copy it next to the binary. Use `CLOUD_BOOTSTRAP_PROMPT.md` for the clean-install smoke path.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ and [cdidx vs VS Code workspace index](USER_GUIDE.md#cdidx-vs-vs-code-workspace-
 ## Quick Start
 
 ```bash
-# Install is usually seconds.
+# Install is usually seconds. Homebrew is available on macOS/Linux:
+brew install widthdom/tap/codeindex
+
+# Or install directly from the signed GitHub release assets:
 curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash
 
 # First index: ~30-60s on small repos; minutes or longer on 100k-file trees.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -117,7 +117,10 @@ For implementation details (schema, indexing pipeline, MCP behavior), see [DEVEL
 ## First Query Quick Start
 
 ```bash
-# One-liner install (no .NET required; usually seconds)
+# Homebrew install (macOS/Linux)
+brew install widthdom/tap/codeindex
+
+# Or one-liner install from GitHub release assets (no .NET required; usually seconds)
 curl -fsSL https://raw.githubusercontent.com/Widthdom/CodeIndex/main/install.sh | bash
 
 # First index: ~30-60s on small repos; minutes or longer on 100k-file trees.

--- a/changelog.d/unreleased/1652.added.md
+++ b/changelog.d/unreleased/1652.added.md
@@ -8,6 +8,7 @@ affected:
   - USER_GUIDE.md
   - docs/platform-support.md
   - DEVELOPER_GUIDE.md
+  - .codex/workflows/release-changelog.md
 ---
 
 ## English

--- a/changelog.d/unreleased/1652.added.md
+++ b/changelog.d/unreleased/1652.added.md
@@ -1,0 +1,19 @@
+---
+category: added
+issues:
+  - 1652
+affected:
+  - .github/workflows/release.yml
+  - README.md
+  - USER_GUIDE.md
+  - docs/platform-support.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Homebrew release publishing is now wired into tagged releases (#1652)** — tagged releases now bump the `Widthdom/homebrew-tap` `codeindex` formula after GitHub release assets are published, and the install docs list the Homebrew path for macOS/Linux users.
+
+## 日本語
+
+- **タグ付きリリースで Homebrew formula を更新するようになりました (#1652)** — GitHub release asset の公開後に `Widthdom/homebrew-tap` の `codeindex` formula を更新し、macOS/Linux ユーザー向けの Homebrew install 経路をドキュメントに追加しました。

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -16,11 +16,17 @@ GitHub releases publish and checksum these first-class runtime identifiers:
 | `win-x64` | `CodeIndex-win-x64.zip` | 64-bit Windows. |
 | `win-arm64` | `CodeIndex-win-arm64.zip` | Windows on ARM64. |
 
-The one-line `install.sh` installer supports the Unix tarball path for Linux and
-macOS. It validates the detected RID against the official release asset list
-before downloading, so unsupported RIDs fail with platform guidance instead of a
-release-asset 404. Windows users should install from the release ZIP, use the
-NuGet global tool, or build from source.
+Homebrew users on macOS/Linux can install from the official tap:
+
+```bash
+brew install widthdom/tap/codeindex
+```
+
+The one-line `install.sh` installer also supports the Unix tarball path for
+Linux and macOS. It validates the detected RID against the official release
+asset list before downloading, so unsupported RIDs fail with platform guidance
+instead of a release-asset 404. Windows users should install from the release
+ZIP, use the NuGet global tool, or build from source.
 
 ## Not Published As Release Assets
 
@@ -67,7 +73,13 @@ checksum 対象にしています。
 | `win-x64` | `CodeIndex-win-x64.zip` | 64-bit Windows 向けです。 |
 | `win-arm64` | `CodeIndex-win-arm64.zip` | Windows on ARM64 向けです。 |
 
-ワンライナーの `install.sh` は Linux と macOS の Unix tarball 経路を対象に
+macOS/Linux の Homebrew ユーザーは、公式 tap から install できます。
+
+```bash
+brew install widthdom/tap/codeindex
+```
+
+ワンライナーの `install.sh` も Linux と macOS の Unix tarball 経路を対象に
 しています。download 前に検出 RID を公式 release asset 一覧と照合するため、
 未対応 RID は release asset の 404 ではなく platform guidance として失敗します。
 Windows では release ZIP、NuGet global tool、または source build を使ってください。

--- a/tests/CodeIndex.Tests/packages.lock.json
+++ b/tests/CodeIndex.Tests/packages.lock.json
@@ -1249,6 +1249,49 @@
           "Microsoft.TestPlatform.TestHost": "17.8.0"
         }
       },
+      "System.Net.Http": {
+        "type": "Direct",
+        "requested": "[4.3.4, )",
+        "resolved": "4.3.4",
+        "contentHash": "aOa2d51SEbmM+H+Csw7yJOuNZoHkrP2XnAurye5HWYgGVVU54YZDvsLUYRv6h18X3sPnjNCANmN7ZhIPiqMcjA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.1",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.DiagnosticSource": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Direct",
+        "requested": "[4.3.1, )",
+        "resolved": "4.3.1",
+        "contentHash": "N0kNRrWe4+nXOWlpLT4LAY5brb8caNFlUuIRpraCVMDLYutKkol1aV079rQjLuSxKMJT2SpBQsYX9xbcTMmzwg==",
+        "dependencies": {
+          "System.Runtime": "4.3.1"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.5.3, )",
@@ -1319,13 +1362,13 @@
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+        "resolved": "1.1.1",
+        "contentHash": "TMBuzAHpTenGbGgk0SMTwyEkyijY/Eae4ZGsFNYJvAr/LDn1ku3Etp3FPxChmDp5HHF3kzJuoaa08N0xjqAJfQ=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+        "resolved": "1.1.3",
+        "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
@@ -1418,18 +1461,18 @@
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "HdSSp5MnJSsg08KMfZThpuLPJpPwE5hBXvHwoKWosyHHfe8Mh5WKT0ylEOf6yNzX6Ngjxe4Whkafh5q7Ymac4Q=="
+        "resolved": "4.3.2",
+        "contentHash": "7VSGO0URRKoMEAq0Sc9cRz8mb6zbyx/BZDEWhgPdzzpmFhkam3fJ1DAGWFXBI4nGlma+uPKpfuMQP5LXRnOH5g=="
       },
       "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "+yH1a49wJMy8Zt4yx5RhJrxO/DBDByAiCzNwiETI+1S4mPdCu0OY4djdciC7Vssk0l22wQaDLrXxXkp+3+7bVA=="
+        "resolved": "4.3.2",
+        "contentHash": "0oAaTAm6e2oVH+/Zttt0cuhGaePQYKII1dY8iaqP7CvOpVKgLybKRFvQjXR2LtxXOXTVPNv14j0ot8uV+HrUmw=="
       },
       "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "c3YNH1GQJbfIPJeCnr4avseugSqPrxwIqzthYyZDN6EuOyNOzq+y2KSUfRcXauya1sF4foESTgwM5e1A8arAKw=="
+        "resolved": "4.3.2",
+        "contentHash": "G24ibsCNi5Kbz0oXWynBoRgtGvsw5ZSVEWjv13/KiCAM8C6wz9zzcCniMeQFIkJ2tasjo2kXlvlBZhplL51kGg=="
       },
       "runtime.native.System": {
         "type": "Transitive",
@@ -1468,30 +1511,30 @@
       },
       "runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "NS1U+700m4KFRHR5o4vo9DSlTmlCKu/u7dtE5sUHVIPB+xpXxYQvgBgA6wEIeCz6Yfn0Z52/72WYsToCEPJnrw==",
+        "resolved": "4.3.2",
+        "contentHash": "QR1OwtwehHxSeQvZKXe+iSd+d3XZNkEcuWMFYa2i0aG1l+lR739HPicKMlTbJst3spmeekDVBUS7SeS26s4U/g==",
         "dependencies": {
-          "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
-          "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+          "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2",
+          "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
       "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "b3pthNgxxFcD+Pc0WSEoC0+md3MyhRS6aCEeenvNE3Fdw1HyJ18ZhRFVJJzIeR/O/jpxPboB805Ho0T3Ul7w8A=="
+        "resolved": "4.3.2",
+        "contentHash": "I+GNKGg2xCHueRd1m9PzeEW7WLbNNLznmTuEi8/vZX71HudUbx1UTwlGkiwMri7JLl8hGaIAWnA/GONhu+LOyQ=="
       },
       "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "KeLz4HClKf+nFS7p/6Fi/CqyLXh81FpiGzcmuS8DGi9lUqSnZ6Es23/gv2O+1XVGfrbNmviF7CckBpavkBoIFQ=="
+        "resolved": "4.3.2",
+        "contentHash": "1Z3TAq1ytS1IBRtPXJvEUZdVsfWfeNEhBkbiOCGEl9wwAfsjP2lz3ZFDx5tq8p60/EqbS0HItG5piHuB71RjoA=="
       },
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
         "type": "Transitive",
@@ -1500,28 +1543,28 @@
       },
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "X7IdhILzr4ROXd8mI1BUCQMSHSQwelUlBjF1JyTKCjXaOGn2fB4EKBxQbCK2VjO3WaWIdlXZL3W6TiIVnrhX4g=="
+        "resolved": "4.3.2",
+        "contentHash": "6mU/cVmmHtQiDXhnzUImxIcDL48GbTk+TsptXyJA+MIOG9LRjPoAQC/qBFB7X+UNyK86bmvGwC8t+M66wsYC8w=="
       },
       "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "nyFNiCk/r+VOiIqreLix8yN+q3Wga9+SE8BCgkf+2BwEKiNx6DyvFjCgkfV743/grxv8jHJ8gUK4XEQw7yzRYg=="
+        "resolved": "4.3.2",
+        "contentHash": "vjwG0GGcTW/PPg6KVud8F9GLWYuAV1rrw1BKAqY0oh4jcUqg15oYF1+qkGR2x2ZHM4DQnWKQ7cJgYbfncz/lYg=="
       },
       "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ytoewC6wGorL7KoCAvRfsgoJPJbNq+64k2SqW6JcOAebWsFUvCCYgfzQMrnpvPiEl4OrblUlhF2ji+Q1+SVLrQ=="
+        "resolved": "4.3.2",
+        "contentHash": "7KMFpTkHC/zoExs+PwP8jDCWcrK9H6L7soowT80CUx3e+nxP/AFnq0AQAW5W76z2WYbLAYCRyPfwYFG6zkvQRw=="
       },
       "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "I8bKw2I8k58Wx7fMKQJn2R8lamboCAiHfHeV/pS65ScKWMMI0+wJkLYlEKvgW1D/XvSl/221clBoR2q9QNNM7A=="
+        "resolved": "4.3.2",
+        "contentHash": "xrlmRCnKZJLHxyyLIqkZjNXqgxnKdZxfItrPkjI+6pkRo5lHX8YvSZlWrSI5AVwLMi4HbNWP7064hcAWeZKp5w=="
       },
       "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "VB5cn/7OzUfzdnC8tqAIMQciVLiq2epm2NrAm1E9OjNRyG4lVhfR61SMcLizejzQP8R8Uf/0l5qOIbUEi+RdEg=="
+        "resolved": "4.3.2",
+        "contentHash": "leXiwfiIkW7Gmn7cgnNcdtNAU70SjmKW3jxGj1iKHOvdn0zRWsgv/l2OJUO5zdGdiv2VRFnAsxxhDgMzofPdWg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -1817,39 +1860,6 @@
         "resolved": "4.5.3",
         "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
       },
-      "System.Net.Http": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "sYg+FtILtRQuYWSIAuNOELwVuVsxVyJGWQyOnlAzhV4xvhyFnON1bAzYYC+jjRW8JREM45R0R5Dgi8MTC5sEwA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.DiagnosticSource": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Globalization.Extensions": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.Net.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.OpenSsl": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "runtime.native.System": "4.3.0",
-          "runtime.native.System.Net.Http": "4.3.0",
-          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
-        }
-      },
       "System.Net.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2011,11 +2021,11 @@
       },
       "System.Runtime": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
+        "resolved": "4.3.1",
+        "contentHash": "abhfv1dTK6NXOmu4bgHIONxHyEqFjW8HwXPmpY9gmll+ix9UNo4XDcmzJn6oLooftxNssVHdJC1pGT9jkSynQg==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0"
+          "Microsoft.NETCore.Platforms": "1.1.1",
+          "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
       "System.Runtime.Extensions": {
@@ -2239,14 +2249,6 @@
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0",
           "System.Text.Encoding": "4.3.0"
-        }
-      },
-      "System.Text.RegularExpressions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "RpT2DA+L660cBt1FssIE9CAGpLFdFPuheB7pLpKpn6ZXNby7jDERe8Ua/Ne2xGiwLVG2JOqziiaVCGDon5sKFA==",
-        "dependencies": {
-          "System.Runtime": "4.3.0"
         }
       },
       "System.Threading": {


### PR DESCRIPTION
## Summary

- Add a `publish-homebrew` release job that bumps the `Widthdom/homebrew-tap` `codeindex` formula after GitHub release assets are published.
- Document the Homebrew install path in README, USER_GUIDE, platform support docs, and release maintainer guidance.
- Add release recovery guidance for Homebrew-only failures.
- Refresh the test project lock file after PR CI exposed stale `net9.0` direct package references; see #2568.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet restore CodeIndex.sln --locked-mode`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parses"'`
- Codex adversarial review: first pass found missing Homebrew recovery docs; second pass reported `No blocking/actionable issues found.`

## Documentation and changelog

- Updated README, USER_GUIDE, docs/platform-support.md, DEVELOPER_GUIDE.md, and `.codex/workflows/release-changelog.md`.
- Added changelog fragment `changelog.d/unreleased/1652.added.md`.
- No separate changelog fragment for #2568 because it is a CI lock-file maintenance fix with no user-visible behavior change.

## Follow-up candidates

- Scoop, winget, apt/dnf, and AUR distribution remain out of scope for this PR.

Fixes #1652
Fixes #2568
