### PR TITLE
Expose unused symbol bucket taxonomy

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -316,13 +316,19 @@ and then `cdidx validate` again.
 cdidx unused --lang csharp --exclude-tests
 cdidx unused --kind function --path src/ --limit 50
 cdidx unused --json --count
+cdidx unused --json --by-bucket
 ```
 
 `unused` compares definitions with indexed references and groups results by
-confidence. Public APIs, framework entrypoints, generated hooks, reflection, and
-configuration-based usage can be false positives. C# `nameof(...)`, `typeof(...)`,
-and direct reflection member-name literals such as `GetMethod("Foo")` are
-indexed, but dynamically constructed names still require manual review.
+confidence. JSON output includes `summary.by_bucket`, `summary.by_confidence`,
+and `bucket_taxonomy` for the `likely_unused_private`,
+`maybe_unused_nonpublic`, `public_or_exported_no_refs`, and
+`reflection_or_config_suspect` buckets; `--by-bucket` also groups returned
+symbols under those bucket keys. Public APIs, framework entrypoints, generated
+hooks, reflection, and configuration-based usage can be false positives. C#
+`nameof(...)`, `typeof(...)`, and direct reflection member-name literals such as
+`GetMethod("Foo")` are indexed, but dynamically constructed names still require
+manual review.
 
 ### Rank hotspots
 
@@ -2150,13 +2156,18 @@ hygiene の問題として扱い、修正後に `cdidx index .`、続いて `cdi
 cdidx unused --lang csharp --exclude-tests
 cdidx unused --kind function --path src/ --limit 50
 cdidx unused --json --count
+cdidx unused --json --by-bucket
 ```
 
 `unused` は definitions と indexed references を比較し、confidence ごとに結果を
-分類します。Public API、framework entrypoint、generated hook、reflection、config
-経由の使用は false positive になりえます。C# の `nameof(...)`、`typeof(...)`、
-`GetMethod("Foo")` のような直接的な reflection member-name literal は indexed されますが、
-動的に組み立てられる名前は手動確認が必要です。
+分類します。JSON 出力には `likely_unused_private`、`maybe_unused_nonpublic`、
+`public_or_exported_no_refs`、`reflection_or_config_suspect` bucket 用の
+`summary.by_bucket`、`summary.by_confidence`、`bucket_taxonomy` が含まれます。
+`--by-bucket` は返却された symbols も bucket key ごとに grouped します。Public API、
+framework entrypoint、generated hook、reflection、config 経由の使用は false positive
+になりえます。C# の `nameof(...)`、`typeof(...)`、`GetMethod("Foo")` のような
+直接的な reflection member-name literal は indexed されますが、動的に組み立てられる
+名前は手動確認が必要です。
 
 ### Hotspots を ranking する
 

--- a/changelog.d/unreleased/1633.added.md
+++ b/changelog.d/unreleased/1633.added.md
@@ -1,0 +1,18 @@
+---
+category: added
+issues:
+  - 1633
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Mcp/McpToolDefinitions.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Unused-symbol JSON now documents and summarizes buckets (#1633)** — `unused --json` and MCP `unused_symbols` now include `summary.by_bucket`, `summary.by_confidence`, and `bucket_taxonomy`; CLI users can also pass `--by-bucket` to group returned symbols by bucket.
+
+## 日本語
+
+- **未使用 symbol JSON が bucket の説明と集計を返すようになりました (#1633)** — `unused --json` と MCP `unused_symbols` は `summary.by_bucket`、`summary.by_confidence`、`bucket_taxonomy` を返します。CLI では `--by-bucket` により返却 symbol を bucket ごとに grouping できます。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -108,6 +108,7 @@ internal static class CliFlagSchema
     ];
     private static readonly string[] RawKindsCommands = ["callers", "callees"];
     private static readonly string[] RankByCommands = ["callers", "callees"];
+    private static readonly string[] ByBucketCommands = ["unused"];
 
     private static readonly string[] SinceCommands = ["search", "definition", "symbols", "files"];
     private static readonly string[] ByteFormatCommands = ["files", "map"];
@@ -194,6 +195,7 @@ internal static class CliFlagSchema
             new() { Name = "--kind", ValuePlaceholder = "<kind>", Description = "Filter by kind", Commands = Set(KindCommands) },
             new() { Name = "--visibility", ValuePlaceholder = "<visibility[,visibility]>", Description = "Filter by symbol visibility", Commands = Set(VisibilityCommands) },
             new() { Name = "--exclude-visibility", ValuePlaceholder = "<visibility[,visibility]>", Description = "Exclude symbol visibility", Commands = Set(VisibilityCommands) },
+            new() { Name = "--by-bucket", Description = "Unused: include per-bucket grouped result arrays in JSON output", Commands = Set(ByBucketCommands) },
             new() { Name = "--rank-by", ValuePlaceholder = "<weighted|count|kind>", Description = "Rank callers/callees by weighted structural score, raw count, or kind bucket", Commands = Set(RankByCommands) },
             new() { Name = "--raw-kinds", Description = "Show raw reference kinds instead of logical graph kinds", Commands = Set(RawKindsCommands) },
             new() { Name = "--count", Description = "Count only", Commands = Set(CountCommands) },

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -162,6 +162,7 @@ public static class QueryCommandRunner
         "--version",
         "-V",
         "--verbose",
+        "--by-bucket",
         "--group-by-name",
         "--with-paths",
         "--bytes",
@@ -3081,6 +3082,7 @@ public static class QueryCommandRunner
 
     public static int RunUnused(string[] cmdArgs, JsonSerializerOptions jsonOptions)
     {
+        var byBucket = cmdArgs.Any(arg => arg == "--by-bucket");
         var previewOptionError = ValidatePreviewOptions("unused", cmdArgs, allowMaxLineWidth: false, allowFocusOptions: false);
         if (previewOptionError != null)
         {
@@ -3124,6 +3126,8 @@ public static class QueryCommandRunner
                         ["count"] = countSummary.Count,
                         ["files"] = countSummary.FileCount,
                         ["returned_bucket_counts"] = JsonSerializer.SerializeToNode(new Dictionary<string, int>(), CliJsonSerializerContextFactory.Create(jsonOptions).DictionaryStringInt32),
+                        ["summary"] = BuildUnusedSummaryJson(Array.Empty<UnusedSymbolResult>(), jsonOptions),
+                        ["bucket_taxonomy"] = BuildUnusedBucketTaxonomyJson(),
                         ["graph_supported"] = graphSupported,
                         ["graph_support_reason"] = graphSupportReason,
                         ["graph_table_available"] = reader._hasReferencesTable,
@@ -3175,7 +3179,7 @@ public static class QueryCommandRunner
 
             if (options.Json)
             {
-                Console.WriteLine(BuildUnusedJsonPayload(results, graphSupported, graphSupportReason, sqlGraphSignal, reader._hasReferencesTable, jsonOptions));
+                Console.WriteLine(BuildUnusedJsonPayload(results, graphSupported, graphSupportReason, sqlGraphSignal, reader._hasReferencesTable, jsonOptions, byBucket: byBucket));
             }
             else
             {
@@ -3206,7 +3210,7 @@ public static class QueryCommandRunner
         });
     }
 
-    private static readonly string[] OrderedUnusedBuckets =
+    internal static readonly string[] OrderedUnusedBuckets =
     [
         "likely_unused_private",
         "maybe_unused_nonpublic",
@@ -3214,7 +3218,7 @@ public static class QueryCommandRunner
         "reflection_or_config_suspect",
     ];
 
-    private static Dictionary<string, int> BuildUnusedBucketCounts(IEnumerable<UnusedSymbolResult> results)
+    internal static Dictionary<string, int> BuildUnusedBucketCounts(IEnumerable<UnusedSymbolResult> results)
     {
         var grouped = results
             .GroupBy(result => result.UnusedBucket, StringComparer.Ordinal)
@@ -3228,7 +3232,60 @@ public static class QueryCommandRunner
         return ordered;
     }
 
-    private static string BuildUnusedJsonPayload(IEnumerable<UnusedSymbolResult> results, bool? graphSupported, string? graphSupportReason, SqlGraphContractSignal sqlGraphSignal, bool hasReferencesTable, JsonSerializerOptions jsonOptions, QueryCommandOptions? queryOptions = null)
+    internal static Dictionary<string, int> BuildUnusedConfidenceCounts(IEnumerable<UnusedSymbolResult> results)
+        => results
+            .GroupBy(result => result.UnusedConfidence, StringComparer.Ordinal)
+            .OrderBy(group => GetUnusedConfidenceOrder(group.Key))
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+
+    internal static JsonObject BuildUnusedSummaryJson(IEnumerable<UnusedSymbolResult> results, JsonSerializerOptions jsonOptions)
+    {
+        var resultList = results as List<UnusedSymbolResult> ?? results.ToList();
+        return new JsonObject
+        {
+            ["by_bucket"] = JsonSerializer.SerializeToNode(BuildUnusedBucketCounts(resultList), CliJsonSerializerContextFactory.Create(jsonOptions).DictionaryStringInt32),
+            ["by_confidence"] = JsonSerializer.SerializeToNode(BuildUnusedConfidenceCounts(resultList), CliJsonSerializerContextFactory.Create(jsonOptions).DictionaryStringInt32),
+        };
+    }
+
+    internal static JsonObject BuildUnusedBucketTaxonomyJson()
+    {
+        var taxonomy = new JsonObject();
+        foreach (var bucket in OrderedUnusedBuckets)
+            taxonomy[bucket] = new JsonObject
+            {
+                ["confidence"] = GetUnusedBucketConfidence(bucket),
+                ["description"] = GetUnusedBucketDescription(bucket),
+            };
+        return taxonomy;
+    }
+
+    private static int GetUnusedConfidenceOrder(string confidence) => confidence switch
+    {
+        "medium" => 0,
+        "low" => 1,
+        _ => 2,
+    };
+
+    private static string GetUnusedBucketConfidence(string bucket) => bucket switch
+    {
+        "likely_unused_private" => "medium",
+        "maybe_unused_nonpublic" => "low",
+        "public_or_exported_no_refs" => "low",
+        "reflection_or_config_suspect" => "low",
+        _ => "unknown",
+    };
+
+    private static string GetUnusedBucketDescription(string bucket) => bucket switch
+    {
+        "likely_unused_private" => "Private symbols with no indexed references; usually the highest-signal unused candidates.",
+        "maybe_unused_nonpublic" => "Internal, protected, or otherwise non-public symbols with no indexed references; review call paths and framework entry points before removal.",
+        "public_or_exported_no_refs" => "Public or exported symbols with no indexed references; may still be external API surface.",
+        "reflection_or_config_suspect" => "Symbols with no indexed references that look reachable through reflection, attributes, config, or binding conventions.",
+        _ => "Unknown unused-symbol bucket.",
+    };
+
+    private static string BuildUnusedJsonPayload(IEnumerable<UnusedSymbolResult> results, bool? graphSupported, string? graphSupportReason, SqlGraphContractSignal sqlGraphSignal, bool hasReferencesTable, JsonSerializerOptions jsonOptions, QueryCommandOptions? queryOptions = null, bool byBucket = false)
     {
         var resultList = results as List<UnusedSymbolResult> ?? results.ToList();
         var payload = new JsonObject
@@ -3237,8 +3294,12 @@ public static class QueryCommandRunner
             ["graph_supported"] = graphSupported,
             ["graph_support_reason"] = graphSupportReason,
             ["returned_bucket_counts"] = JsonSerializer.SerializeToNode(BuildUnusedBucketCounts(resultList), CliJsonSerializerContextFactory.Create(jsonOptions).DictionaryStringInt32),
+            ["summary"] = BuildUnusedSummaryJson(resultList, jsonOptions),
+            ["bucket_taxonomy"] = BuildUnusedBucketTaxonomyJson(),
             ["symbols"] = JsonSerializer.SerializeToNode(resultList, CliJsonSerializerContextFactory.Create(jsonOptions).ListUnusedSymbolResult)
         };
+        if (byBucket)
+            payload["by_bucket"] = BuildUnusedResultsByBucketJson(resultList, jsonOptions);
 
         if (!hasReferencesTable)
         {
@@ -3251,6 +3312,22 @@ public static class QueryCommandRunner
         if (queryOptions != null)
             payload["query_context"] = BuildQueryContextJson(queryOptions, jsonOptions);
         return payload.ToJsonString(jsonOptions);
+    }
+
+    private static JsonObject BuildUnusedResultsByBucketJson(IEnumerable<UnusedSymbolResult> results, JsonSerializerOptions jsonOptions)
+    {
+        var grouped = results
+            .GroupBy(result => result.UnusedBucket, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.Ordinal);
+        var byBucket = new JsonObject();
+        foreach (var bucket in OrderedUnusedBuckets)
+        {
+            if (grouped.TryGetValue(bucket, out var bucketResults))
+                byBucket[bucket] = JsonSerializer.SerializeToNode(bucketResults, CliJsonSerializerContextFactory.Create(jsonOptions).ListUnusedSymbolResult);
+            else
+                byBucket[bucket] = new JsonArray();
+        }
+        return byBucket;
     }
 
     private static string GetUnusedBucketHeading(string bucket) => bucket switch
@@ -3676,6 +3753,8 @@ public static class QueryCommandRunner
                     break;
                 case "--count":
                     countOnly = true;
+                    break;
+                case "--by-bucket":
                     break;
                 case "--no-dedup":
                     noDedup = true;

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -432,9 +432,11 @@ public partial class McpServer
                 "unused_symbols",
                 "Find symbols that are defined but never referenced in the indexed codebase. "
                 + "Useful for dead code detection. Results include confidence buckets so private hits rank ahead of public/exported suspects, and the lowest-confidence bucket is reserved for config-bound properties or C#-style attribute-adjacent reflection surfaces. Only meaningful for languages with reference extraction support. "
+                + "Structured output includes `summary.by_bucket`, `summary.by_confidence`, and `bucket_taxonomy`; bucket values are `likely_unused_private`, `maybe_unused_nonpublic`, `public_or_exported_no_refs`, and `reflection_or_config_suspect`. "
                 + "C# nameof/typeof and direct reflection member-name literals such as GetMethod(\"Foo\") are indexed as references; dynamically constructed reflection names can still require manual review. "
                 + "/ インデックス済みコードベースで定義されているが一度も参照されていないシンボルを検索する。"
                 + "デッドコード検出に有用。private 候補を public/exported suspect より前に返し、最低信頼 bucket は config-bound な property または C# 風 attribute 隣接の reflection surface 用に使う。参照抽出対応言語でのみ意味がある。"
+                + "構造化出力には `summary.by_bucket`、`summary.by_confidence`、`bucket_taxonomy` が含まれ、bucket 値は `likely_unused_private`、`maybe_unused_nonpublic`、`public_or_exported_no_refs`、`reflection_or_config_suspect`。"
                 + "C# の nameof/typeof と GetMethod(\"Foo\") のような直接の reflection member-name literal は参照として index されるが、動的に組み立てた reflection 名は手動確認が必要な場合がある。",
                 new JsonObject
                 {

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -2201,16 +2201,15 @@ public partial class McpServer
                     baseSqlGraphSignal,
                     results.Select(result => result.Lang),
                     lang);
-            var bucketCounts = results
-                .GroupBy(result => result.UnusedBucket, StringComparer.Ordinal)
-                .OrderBy(group => Array.IndexOf(new[] { "likely_unused_private", "maybe_unused_nonpublic", "public_or_exported_no_refs", "reflection_or_config_suspect" }, group.Key))
-                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+            var bucketCounts = QueryCommandRunner.BuildUnusedBucketCounts(results);
             var payload = new JsonObject
             {
                 ["count"] = results.Count,
                 ["graph_supported"] = graphSupported,
                 ["graph_support_reason"] = graphSupportReason,
                 ["returned_bucket_counts"] = JsonSerializer.SerializeToNode(bucketCounts, _jsonOptions),
+                ["summary"] = QueryCommandRunner.BuildUnusedSummaryJson(results, _jsonOptions),
+                ["bucket_taxonomy"] = QueryCommandRunner.BuildUnusedBucketTaxonomyJson(),
                 ["symbols"] = JsonSerializer.SerializeToNode(results, _jsonOptions)
             };
             AddSqlGraphContractSignal(payload, sqlGraphSignal);

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -6784,6 +6784,10 @@ public class McpServerTests : IDisposable
         Assert.Equal(1, structured["returned_bucket_counts"]!["maybe_unused_nonpublic"]!.GetValue<int>());
         Assert.Equal(6, structured["returned_bucket_counts"]!["public_or_exported_no_refs"]!.GetValue<int>());
         Assert.Equal(1, structured["returned_bucket_counts"]!["reflection_or_config_suspect"]!.GetValue<int>());
+        Assert.Equal(1, structured["summary"]!["by_bucket"]!["likely_unused_private"]!.GetValue<int>());
+        Assert.Equal(8, structured["summary"]!["by_confidence"]!["low"]!.GetValue<int>());
+        Assert.Equal("low", structured["bucket_taxonomy"]!["reflection_or_config_suspect"]!["confidence"]!.GetValue<string>());
+        Assert.Contains("reflection", structured["bucket_taxonomy"]!["reflection_or_config_suspect"]!["description"]!.GetValue<string>());
         Assert.Equal("Hidden", symbols[0]!["name"]!.GetValue<string>());
         Assert.Equal("likely_unused_private", symbols[0]!["unusedBucket"]!.GetValue<string>());
         Assert.Equal("medium", symbols[0]!["unusedConfidence"]!.GetValue<string>());

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -6458,6 +6458,10 @@ jobs:
             Assert.Equal(1, json.GetProperty("returned_bucket_counts").GetProperty("maybe_unused_nonpublic").GetInt32());
             Assert.Equal(6, json.GetProperty("returned_bucket_counts").GetProperty("public_or_exported_no_refs").GetInt32());
             Assert.Equal(1, json.GetProperty("returned_bucket_counts").GetProperty("reflection_or_config_suspect").GetInt32());
+            Assert.Equal(1, json.GetProperty("summary").GetProperty("by_bucket").GetProperty("likely_unused_private").GetInt32());
+            Assert.Equal(1, json.GetProperty("summary").GetProperty("by_confidence").GetProperty("medium").GetInt32());
+            Assert.Equal("medium", json.GetProperty("bucket_taxonomy").GetProperty("likely_unused_private").GetProperty("confidence").GetString());
+            Assert.Contains("external API", json.GetProperty("bucket_taxonomy").GetProperty("public_or_exported_no_refs").GetProperty("description").GetString());
             Assert.Equal("Hidden", symbols[0].GetProperty("name").GetString());
             Assert.Equal("likely_unused_private", symbols[0].GetProperty("unused_bucket").GetString());
             Assert.Equal("medium", symbols[0].GetProperty("unused_confidence").GetString());
@@ -6469,6 +6473,33 @@ jobs:
             Assert.Equal("public_or_exported_no_refs", symbols[7].GetProperty("unused_bucket").GetString());
             Assert.Equal("UseIOptions", symbols[8].GetProperty("name").GetString());
             Assert.Equal("public_or_exported_no_refs", symbols[8].GetProperty("unused_bucket").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunUnused_WithJsonByBucketGroupsReturnedSymbolsByTaxonomyBucket()
+    {
+        var (projectRoot, dbPath) = CreateUnusedFixtureDb();
+        try
+        {
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunUnused(
+                ["--db", dbPath, "--json", "--lang", "csharp", "--by-bucket"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+            var byBucket = json.GetProperty("by_bucket");
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal("Hidden", byBucket.GetProperty("likely_unused_private")[0].GetProperty("name").GetString());
+            Assert.Equal("InternalOnly", byBucket.GetProperty("maybe_unused_nonpublic")[0].GetProperty("name").GetString());
+            Assert.Equal(6, byBucket.GetProperty("public_or_exported_no_refs").GetArrayLength());
+            Assert.Equal("ConnectionString", byBucket.GetProperty("reflection_or_config_suspect")[0].GetProperty("name").GetString());
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Add unused-symbol JSON summary fields for bucket and confidence counts.
- Add a bucket taxonomy schema to CLI and MCP output, plus CLI --by-bucket grouped results.
- Document the taxonomy in USER_GUIDE.md.

Fixes #1633

## Validation
- dotnet build CodeIndex.sln
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "RunUnused|ToolsCall_UnusedSymbols"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbSchemaConstraintTests.InitializeSchema_LegacyNullableFileForeignKeys_AreCleanedAndConstrained"
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet restore CodeIndex.sln --locked-mode
- Codex adversarial review: No blocking/actionable issues found.

## Documentation / Changelog
- USER_GUIDE.md updated.
- changelog.d/unreleased/1633.added.md added.

## Follow-up candidates
- #2577 tracks the stale test lock file CI issue discovered while finalizing this PR.

## Notes
- Full cdidx index refresh was attempted but the existing workspace index remains stale/degraded for pre-existing mainline files and hotspot-family readiness; the changed files were refreshed with scoped index updates.
