### PR TITLE
Add JSON array output for search

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -230,6 +230,20 @@ Stable since values are intentionally not repeated in this guide because the
 release changelog is the source of truth for when each command first shipped.
 Run `cdidx --help` for the full syntax line for every command.
 
+## JSON output format
+
+Most query commands emit one complete JSON value when `--json` is set. `search
+--json` is intentionally stream-oriented: it writes one `CompactSearchResult`
+per line as newline-delimited JSON (ndjson), then a final `{"done":true,...}`
+line. Stream consumers can parse each line as it arrives; array-oriented tools
+can use `jq -s '.'` or pass `--json=array` to `search` to emit the result set as
+one JSON array.
+
+```bash
+cdidx search authenticate --json          # ndjson stream, one result per line
+cdidx search authenticate --json=array    # single JSON array
+```
+
 ## Flag compatibility and migrations
 
 `--exact` remains accepted for compatibility, but new usage should prefer the
@@ -2049,6 +2063,20 @@ cdidx index . --quiet
 Stable since の値はこのガイドでは重複管理しません。各コマンドがいつ入ったかは
 release changelog を source of truth とします。完全な syntax line は `cdidx --help`
 を参照してください。
+
+## JSON 出力形式
+
+ほとんどの query command は `--json` 指定時に 1 つの完全な JSON 値を出力します。
+`search --json` は stream 向けの形式で、1 行に 1 件の `CompactSearchResult` を
+newline-delimited JSON (ndjson) として出力し、最後に `{"done":true,...}` 行を
+出力します。stream consumer は各行を到着順に parse できます。array 前提の tool
+では `jq -s '.'` を使うか、`search` に `--json=array` を渡すと result set を
+1 つの JSON array として出力できます。
+
+```bash
+cdidx search authenticate --json          # ndjson stream、1 行 1 result
+cdidx search authenticate --json=array    # 単一 JSON array
+```
 
 ## フラグ互換性と移行
 

--- a/changelog.d/unreleased/1850.fixed.md
+++ b/changelog.d/unreleased/1850.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1850
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Search JSON output now documents and supports array mode (#1850)** — `search --json` is documented as newline-delimited JSON, and `search --json=array` emits one top-level JSON array for consumers that require a single JSON value.
+
+## 日本語
+
+- **search の JSON 出力契約を文書化し array mode を追加しました (#1850)** — `search --json` が newline-delimited JSON であることを明記し、単一の JSON 値を必要とする consumer 向けに `search --json=array` が top-level JSON array を出力するようになりました。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -178,7 +178,7 @@ internal static class CliFlagSchema
         {
             new() { Name = "--db", ValuePlaceholder = "<path>", Description = "Database path", Commands = Set(DbPathCommands) },
             new() { Name = "--data-dir", ValuePlaceholder = "<dir>", Description = "Directory containing codeindex.db; overrides CDIDX_DATA_DIR/XDG/workspace defaults", Commands = Set(DataDirCommands) },
-            new() { Name = "--json", Description = "JSON output", Commands = Set(JsonCommands) },
+            new() { Name = "--json", Description = "JSON output; search also accepts --json=array for a single JSON array", Commands = Set(JsonCommands) },
             new() { Name = "--profile", Description = "Emit SQL timing and EXPLAIN QUERY PLAN profile JSON after the normal result", Commands = Set(ProfileCommands) },
             new() { Name = "--verbose", Description = "Emit query debug diagnostics to stderr, or _debug JSON when combined with --json", Commands = Set(VerboseQueryCommands.Concat(new[] { "index" }).ToArray()) },
             new() { Name = "--slow-query-ms", ValuePlaceholder = "<n>", Description = "Log profiled SQL statements at or above this millisecond threshold", Commands = Set(ProfileCommands) },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -67,7 +67,7 @@ public static class ConsoleUi
         ("index-commits", "cdidx index <projectPath> --commits <id> [id ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
         ("index-changed-between", "cdidx index <projectPath> --changed-between <old-ref> <new-ref> [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
         ("index-files", "cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run] [--json] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
-        ("search", "cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup] [--no-visibility-rank]"),
+        ("search", "cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json[=ndjson|array]] [--verbose] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup] [--no-visibility-rank]"),
         ("definition", "cdidx definition <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--exact|--exact-name] [--count] [--since <datetime>]"),
         ("references", "cdidx references <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--max-line-width <n>] [--exact|--exact-name] [--count]"),
         ("callers", "cdidx callers <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--kind <kind>] [--rank-by <weighted|count|kind>] [--raw-kinds] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--exact|--exact-name] [--count]"),
@@ -658,7 +658,7 @@ public static class ConsoleUi
         Console.WriteLine();
         Console.WriteLine("Query options:");
         Console.WriteLine("  --db <path>                Database file path (default: .cdidx/codeindex.db in current directory)");
-        Console.WriteLine("  --json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)");
+        Console.WriteLine("  --json                     Output as JSON (search streams ndjson by default; use search --json=array for one array)");
         Console.WriteLine("  --verbose                  Query commands: emit debug diagnostics to stderr; with --json, append an _debug JSON object");
         Console.WriteLine("  --profile                  Read commands: append SQL timing, row-count, and EXPLAIN QUERY PLAN JSON after the normal result");
         Console.WriteLine("  --slow-query-ms <n>        Read commands: log profiled SQL statements that take at least <n> ms (use 0 to log every statement)");
@@ -708,6 +708,7 @@ public static class ConsoleUi
         Console.WriteLine("  cdidx search \"auth*\"                          Prefix shorthand in literal-safe mode");
         Console.WriteLine("  cdidx search --query --path --path README.md   Search for a literal option token");
         Console.WriteLine("  cdidx search \"Run();\" --exact-substring        Case-sensitive exact substring search");
+        Console.WriteLine("  cdidx search authenticate --json=array         Emit search results as one JSON array");
         Console.WriteLine("  cdidx search authenticate --profile            Append SQL profile JSON for slow-query debugging");
         Console.WriteLine("  cdidx search authenticate --verbose            Emit query debug diagnostics on stderr");
         Console.WriteLine("  cdidx definition ResolveGitCommonDir --body   Show a symbol definition and body");

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -272,6 +272,7 @@ internal sealed record VersionInfoJsonResult(
 [JsonSerializable(typeof(CallerResult))]
 [JsonSerializable(typeof(CliJsonMessage))]
 [JsonSerializable(typeof(CompactSearchResult))]
+[JsonSerializable(typeof(CompactSearchResult[]))]
 [JsonSerializable(typeof(CommandErrorJsonResult))]
 [JsonSerializable(typeof(DbIntegrityCheckJsonResult))]
 [JsonSerializable(typeof(DefinitionResult))]

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -31,6 +31,8 @@ public static class QueryCommandRunner
     private const string HotspotsGroupedBySymbol = "symbol";
     private const string HotspotsGroupedByFile = "file";
     private const string HotspotsGroupedByStatement = "statement";
+    private const string JsonOutputFormatNdjson = "ndjson";
+    private const string JsonOutputFormatArray = "array";
     private static readonly Dictionary<string, string[]> LanguageDisplayAliases = new(StringComparer.Ordinal)
     {
         ["javascript"] = ["js", "jsx", "cjs", "mjs"],
@@ -165,6 +167,8 @@ public static class QueryCommandRunner
         "--bytes",
         "--profile",
     ];
+    private static readonly HashSet<string> InlineValueOptions =
+        new(ValueTakingOptions.Concat(["--json"]), StringComparer.Ordinal);
     private const string FindUsage = "Usage: cdidx find <query> --path <glob> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--exclude-path <glob>] [--exclude-tests] [--before <n>] [--after <n>] [--max-line-width <n>] [--exact] [--count]\n       cdidx find --query <query> --path <glob> [...]\n       cdidx find [options] -- <query>";
 
     public static int RunBatch(string[] cmdArgs, JsonSerializerOptions jsonOptions)
@@ -381,8 +385,17 @@ public static class QueryCommandRunner
             {
                 if (options.Json)
                 {
-                    Console.WriteLine(BuildJsonZeroResultPayload(reader, jsonOptions, resultsKey: "results", query: options.Query, queryOptions: options).ToJsonString(jsonOptions));
-                    jsonDoneCount = 0;
+                    if (options.JsonOutputFormat == JsonOutputFormatArray)
+                    {
+                        Console.WriteLine(JsonSerializer.Serialize(
+                            Array.Empty<CompactSearchResult>(),
+                            CliJsonSerializerContextFactory.Create(jsonOptions).CompactSearchResultArray));
+                    }
+                    else
+                    {
+                        Console.WriteLine(BuildJsonZeroResultPayload(reader, jsonOptions, resultsKey: "results", query: options.Query, queryOptions: options).ToJsonString(jsonOptions));
+                        jsonDoneCount = 0;
+                    }
                 }
                 else if (!options.Json)
                 {
@@ -395,11 +408,23 @@ public static class QueryCommandRunner
 
             if (options.Json)
             {
-                foreach (var r in results)
+                var compactResults = results
+                    .Select(r => SearchSnippetFormatter.ToCompactResult(r, options.Query, options.SnippetLines, exact, options.MaxLineWidth, r.Lang, options.SnippetFocus))
+                    .ToArray();
+                if (options.JsonOutputFormat == JsonOutputFormatArray)
+                {
                     Console.WriteLine(JsonSerializer.Serialize(
-                        SearchSnippetFormatter.ToCompactResult(r, options.Query, options.SnippetLines, exact, options.MaxLineWidth, r.Lang, options.SnippetFocus),
-                        CliJsonSerializerContextFactory.Create(jsonOptions).CompactSearchResult));
-                jsonDoneCount = results.Count;
+                        compactResults,
+                        CliJsonSerializerContextFactory.Create(jsonOptions).CompactSearchResultArray));
+                }
+                else
+                {
+                    foreach (var result in compactResults)
+                        Console.WriteLine(JsonSerializer.Serialize(
+                            result,
+                            CliJsonSerializerContextFactory.Create(jsonOptions).CompactSearchResult));
+                    jsonDoneCount = compactResults.Length;
+                }
             }
             else
             {
@@ -417,7 +442,7 @@ public static class QueryCommandRunner
             return CommandExitCodes.Success;
         }, exitCode =>
         {
-            if (options.Json && jsonDoneCount.HasValue)
+            if (options.Json && options.JsonOutputFormat == JsonOutputFormatNdjson && jsonDoneCount.HasValue)
                 WriteJsonStreamDone(jsonDoneCount.Value, jsonOptions);
         });
     }
@@ -3345,6 +3370,7 @@ public static class QueryCommandRunner
         string? dbPath = null;
         string? dataDir = null;
         bool? json = null;
+        string jsonOutputFormat = JsonOutputFormatNdjson;
         int limit = 20;
         string? lang = null;
         string? kind = null;
@@ -3502,7 +3528,19 @@ public static class QueryCommandRunner
                         AddParseError(dataDirError!);
                     break;
                 case "--json":
-                    json = true;
+                    if (inlineValue == null)
+                    {
+                        json = true;
+                    }
+                    else if (TryParseJsonOutputFormat(inlineValue, out var parsedJsonOutputFormat))
+                    {
+                        json = true;
+                        jsonOutputFormat = parsedJsonOutputFormat;
+                    }
+                    else
+                    {
+                        AddParseError($"Error: --json format must be one of ndjson or array, got '{inlineValue}'. Hint: use `--json` or `--json=ndjson` for newline-delimited JSON, or `--json=array` for a single JSON array.");
+                    }
                     break;
                 case "--limit":
                 case "--top":
@@ -3943,6 +3981,7 @@ public static class QueryCommandRunner
             DataDir = dbResolution.DataDir,
             DataDirSource = dbResolution.DataDirSource,
             Json = json ?? jsonDefault,
+            JsonOutputFormat = jsonOutputFormat,
             Limit = limit,
             Lang = lang,
             Kind = kind,
@@ -4004,6 +4043,23 @@ public static class QueryCommandRunner
             ValidatePathGlobPattern("--path", pattern, addParseError);
         foreach (var pattern in excludePaths)
             ValidatePathGlobPattern("--exclude-path", pattern, addParseError);
+    }
+
+    private static bool TryParseJsonOutputFormat(string rawValue, out string format)
+    {
+        if (string.Equals(rawValue, JsonOutputFormatArray, StringComparison.OrdinalIgnoreCase))
+        {
+            format = JsonOutputFormatArray;
+            return true;
+        }
+        if (string.Equals(rawValue, JsonOutputFormatNdjson, StringComparison.OrdinalIgnoreCase))
+        {
+            format = JsonOutputFormatNdjson;
+            return true;
+        }
+
+        format = JsonOutputFormatNdjson;
+        return false;
     }
 
     private static void ValidatePathGlobPattern(string optionName, string pattern, Action<string> addParseError)
@@ -4709,6 +4765,14 @@ public static class QueryCommandRunner
                 : arg;
             if (arg.StartsWith("--check=", StringComparison.Ordinal) && supported.Contains("--check"))
                 normalizedArg = "--check";
+            if (normalizedArg == "--json" && !string.Equals(arg, "--json", StringComparison.Ordinal) && commandName != "search")
+            {
+                CommandErrorWriter.Write(
+                    "--json=<format> is only supported by 'search'.",
+                    "use plain `--json` here, or rerun search with `--json=array`.",
+                    GetUsageLineOrThrow(commandName));
+                return true;
+            }
 
             if (supported.Contains(normalizedArg))
             {
@@ -6291,7 +6355,7 @@ public static class QueryCommandRunner
             return false;
 
         var candidate = token[..separator];
-        if (!ValueTakingOptions.Contains(candidate))
+        if (!InlineValueOptions.Contains(candidate))
             return false;
 
         optionName = candidate;
@@ -6355,6 +6419,7 @@ public sealed class QueryCommandOptions
     public string? DataDir { get; init; }
     public string? DataDirSource { get; init; }
     public bool Json { get; init; }
+    public string JsonOutputFormat { get; init; } = "ndjson";
     public int Limit { get; init; } = 20;
     public string? Lang { get; init; }
     public string? Kind { get; init; }

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -38,7 +38,7 @@ public class ConsoleUiTests
         Assert.Contains("cdidx references <query>|--query <query>|-- <query>", output);
         Assert.Contains("cdidx callers <query>|--query <query>|-- <query>", output);
         Assert.Contains("cdidx callees <query>|--query <query>|-- <query>", output);
-        Assert.Contains("cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup] [--no-visibility-rank]", output);
+        Assert.Contains("cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json[=ndjson|array]] [--verbose] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup] [--no-visibility-rank]", output);
         Assert.Contains("cdidx definition <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--exact|--exact-name] [--count] [--since <datetime>]", output);
         Assert.Contains("cdidx references <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--max-line-width <n>] [--exact|--exact-name] [--count]", output);
         Assert.Contains("cdidx inspect <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--max-line-width <n>] [--exact|--exact-name]", output);
@@ -67,7 +67,7 @@ public class ConsoleUiTests
         Assert.DoesNotContain("cdidx validate [--db <path>] [--json] [--limit <n>] [--lang <lang>]", output);
         Assert.Contains("cdidx unused [--db <path>] [--json] [--verbose] [--limit <n>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count]", output);
         Assert.Contains("cdidx hotspots [--db <path>] [--json] [--verbose] [--limit <n>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count] [--group-by <symbol|file|statement>] [--group-by-name]", output);
-        Assert.Contains("--json                     Output as JSON (streaming hits use JSON lines; counts/summaries use one object)", output);
+        Assert.Contains("--json                     Output as JSON (search streams ndjson by default; use search --json=array for one array)", output);
         Assert.Contains("--lang <lang>              Filter by language (aliases: bat, cmd, cshtml, razor, ts, tsx, cts, mts)", output);
         Assert.Contains("--bytes                    Show raw byte counts in human output for files/map instead of binary units; JSON always keeps raw integer bytes", output);
         Assert.Contains("--group-by-name            hotspots: collapse rows sharing (name, kind) across files into one line", output);
@@ -112,7 +112,7 @@ public class ConsoleUiTests
     {
         var output = CaptureUsageOutput(showBanner: false);
 
-        Assert.Contains("cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup] [--no-visibility-rank]", output);
+        Assert.Contains("cdidx search <query>|--query <query>|-- <query> [--db <path>] [--json[=ndjson|array]] [--verbose] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--since <datetime>] [--no-dedup] [--no-visibility-rank]", output);
         Assert.Contains("cdidx symbols [query|--query <query>|-- <query>] [--name <name>] [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--exact|--exact-name] [--count] [--since <datetime>]", output);
         Assert.Contains("cdidx files [query|--query <query>|-- <query>] [--db <path>] [--json] [--verbose] [--limit <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count] [--since <datetime>] [--bytes]", output);
         Assert.Contains("cdidx hotspots [--db <path>] [--json] [--verbose] [--limit <n>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count]", output);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -192,6 +192,82 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSearch_JsonArrayEmitsSingleArray_Issue1850()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_json_array");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/auth.cs",
+                "csharp",
+                """
+                public class AuthFixture
+                {
+                    public void Authenticate() { }
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Authenticate", "--db", dbPath, "--lang", "csharp", "--exact", "--json=array"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = JsonDocument.Parse(stdout);
+            Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+            Assert.Single(document.RootElement.EnumerateArray());
+            Assert.DoesNotContain("\"done\"", stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_JsonArrayNoResultsEmitsEmptyArray_Issue1850()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_json_array_empty");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/auth.cs",
+                "csharp",
+                "public class AuthFixture { }\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Missing", "--db", dbPath, "--json=array"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.NotFound, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = JsonDocument.Parse(stdout);
+            Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+            Assert.Empty(document.RootElement.EnumerateArray());
+            Assert.DoesNotContain("\"done\"", stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_JsonFormatRejectsUnknownValue_Issue1850()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["Authenticate", "--json=pretty"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("--json format must be one of ndjson or array", stderr);
+    }
+
+    [Fact]
     public void RunSearch_ProfileEmitsSqlPhasesAndQueryPlan_Issue1643()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_profile");


### PR DESCRIPTION
## Summary

- Add `cdidx search --json=array` for callers that need one JSON array instead of streamed NDJSON.
- Keep existing `cdidx search --json` behavior as the default NDJSON stream with the final `done` sentinel.
- Document the JSON output choices and add the unreleased changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests|FullyQualifiedName~RunSearch_JsonArray|FullyQualifiedName~RunSearch_JsonFormat|FullyQualifiedName~CliFlagSchemaTests" -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search QueryCommandRunner --json=array --limit 1`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search QueryCommandRunner --json --limit 1`
- Codex adversarial review: `No blocking/actionable issues found.`

Full release test was also attempted, but unrelated existing/base-environment failures stopped completion: SQLite legacy schema constraint setup, trimmed publish ILLink access violation, and FIFO dry-run hang tests. The targeted tests and release build for this change pass.

## Documentation and Changelog

- `USER_GUIDE.md`
- `changelog.d/unreleased/1850.fixed.md`

Fixes #1850
