### PR TITLE
Fix fold readiness snapshot check

### DIFF
--- a/changelog.d/unreleased/1758.fixed.md
+++ b/changelog.d/unreleased/1758.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1758
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Fold readiness now uses one SQLite snapshot (#1758)** — `AllFoldedColumnsBackfilled` now evaluates missing and stale folded-name rows inside a single read transaction, preventing transient `fold_ready` flips while fold data is being refreshed.
+
+## 日本語
+
+- **fold readiness が単一の SQLite snapshot を使うようになりました (#1758)** — `AllFoldedColumnsBackfilled` は missing / stale の folded-name 行判定を 1 つの read transaction 内で評価し、fold data 更新中の一時的な `fold_ready` 反転を防ぎます。

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1628,7 +1628,9 @@ public class DbWriter
             if (stampCurrentSymbolExtractorVersions)
                 StampSymbolExtractorVersions();
 
-            if (!AllFoldedColumnsBackfilled(requireCurrentFoldKeys: true))
+            if (!AllFoldedColumnsBackfilledCore(
+                    requireCurrentSymbolExtractorVersions: false,
+                    requireCurrentFoldKeys: true))
             {
                 if (ownTransaction)
                 {
@@ -2791,6 +2793,34 @@ public class DbWriter
         bool requireCurrentSymbolExtractorVersions = false,
         bool requireCurrentFoldKeys = false)
     {
+        if (IsInTransaction())
+            return AllFoldedColumnsBackfilledCore(requireCurrentSymbolExtractorVersions, requireCurrentFoldKeys);
+
+        bool ownTransaction = true;
+        Execute("BEGIN DEFERRED");
+        try
+        {
+            var result = AllFoldedColumnsBackfilledCore(requireCurrentSymbolExtractorVersions, requireCurrentFoldKeys);
+            Execute("COMMIT");
+            ownTransaction = false;
+            return result;
+        }
+        catch
+        {
+            if (ownTransaction)
+            {
+                try { Execute("ROLLBACK"); }
+                catch (SqliteException) { /* best effort */ }
+            }
+
+            throw;
+        }
+    }
+
+    private bool AllFoldedColumnsBackfilledCore(
+        bool requireCurrentSymbolExtractorVersions,
+        bool requireCurrentFoldKeys)
+    {
         if (requireCurrentSymbolExtractorVersions && !SymbolExtractorVersionsMatchCurrent())
             return false;
 
@@ -2855,13 +2885,41 @@ public class DbWriter
 
     public bool AllFoldedColumnsBackfilled(IReadOnlyCollection<string> requireCurrentSymbolExtractorLanguages)
     {
+        if (IsInTransaction())
+            return AllFoldedColumnsBackfilledCore(requireCurrentSymbolExtractorLanguages);
+
+        bool ownTransaction = true;
+        Execute("BEGIN DEFERRED");
+        try
+        {
+            var result = AllFoldedColumnsBackfilledCore(requireCurrentSymbolExtractorLanguages);
+            Execute("COMMIT");
+            ownTransaction = false;
+            return result;
+        }
+        catch
+        {
+            if (ownTransaction)
+            {
+                try { Execute("ROLLBACK"); }
+                catch (SqliteException) { /* best effort */ }
+            }
+
+            throw;
+        }
+    }
+
+    private bool AllFoldedColumnsBackfilledCore(IReadOnlyCollection<string> requireCurrentSymbolExtractorLanguages)
+    {
         if (requireCurrentSymbolExtractorLanguages.Count > 0
             && !SymbolExtractorVersionsMatchCurrent(requireCurrentSymbolExtractorLanguages))
         {
             return false;
         }
 
-        return AllFoldedColumnsBackfilled();
+        return AllFoldedColumnsBackfilledCore(
+            requireCurrentSymbolExtractorVersions: false,
+            requireCurrentFoldKeys: false);
     }
 
     public bool SymbolExtractorVersionsMatchCurrent()

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -2372,6 +2372,18 @@ public class DbReaderTests : IDisposable
                 cmd.ExecuteNonQuery();
             }
             Assert.False(writer.AllFoldedColumnsBackfilled());
+
+            // Issue #1758: the readiness predicate must also reject rows that are non-NULL
+            // but were folded with an older or otherwise incorrect fold key, and it must do
+            // that in the same read snapshot as the NULL check.
+            using (var cmd = db.Connection.CreateCommand())
+            {
+                cmd.CommandText = "UPDATE symbols SET name_folded = 'stale-fold-key' WHERE name = 'authenticate'";
+                cmd.ExecuteNonQuery();
+            }
+            Assert.True(writer.AllFoldedColumnsBackfilled());
+            Assert.False(writer.AllFoldedColumnsBackfilled(requireCurrentFoldKeys: true));
+            Assert.False(writer.MarkFoldReady());
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Wrap fold-readiness checks in a single SQLite read transaction when no outer writer transaction is active.
- Keep `MarkFoldReady` on its existing `BEGIN IMMEDIATE` path by sharing the core readiness predicate.
- Extend fold-readiness regression coverage for stale non-NULL folded keys.

## Validation

- `dotnet restore CodeIndex.sln --locked-mode`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.AllFoldedColumnsBackfilled_DetectsLegacyRowsWithNullFoldedValues" --no-restore -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbSchemaConstraintTests.InitializeSchema_LegacyNullableFileForeignKeys_AreCleanedAndConstrained" --no-restore`
- Previously also ran `DbReaderTests`, `ChangelogToolTests`, and `DbReaderTests.AllFoldedColumnsBackfilled_DetectsLegacyRowsWithNullFoldedValues|DatabaseTests`.

Full `dotnet test` was attempted before latest `origin/main` was merged, but it hit existing unrelated failures/hangs. After merging latest `origin/main`, locked restore and the previously failing schema-constraint regression pass locally.

## Documentation / Changelog

- Added `changelog.d/unreleased/1758.fixed.md`.
- No README/guide updates required; this changes an internal readiness race without changing CLI/MCP field names or user-facing command syntax.

## Review

- Codex adversarial review: `No blocking/actionable issues found.`

Fixes #1758
