### PR TITLE
Honor XDG cache and runtime dirs for global logs

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -984,9 +984,11 @@ returns 2xx/3xx.
 
 For post-install troubleshooting on "silent" hosts that swallow terminal
 stderr, distributed/non-development executions also mirror stderr plus minimal
-lifecycle breadcrumbs to a per-user daily log. The log path is
-`%LOCALAPPDATA%\cdidx\logs\` on Windows, `~/Library/Logs/cdidx/` on macOS,
-and `$XDG_STATE_HOME/cdidx/logs/` (or `~/.local/state/cdidx/logs/`) on Linux.
+lifecycle breadcrumbs to a per-user daily log. The log path follows
+`CDIDX_GLOBAL_TOOL_LOG_DIR`, then `XDG_STATE_HOME/cdidx/logs/`,
+`XDG_CACHE_HOME/cdidx/logs/`, `XDG_RUNTIME_DIR/cdidx/logs/`, then the
+platform default: `%LOCALAPPDATA%\cdidx\logs\` on Windows,
+`~/Library/Logs/cdidx/` on macOS, or `~/.local/state/cdidx/logs/` on Linux.
 The file name is `stderr-YYYYMMDD.log`, and the logger keeps only the newest
 30 daily files. Repository-local development runs from `src/CodeIndex/bin/...`
 and `tests/.../bin/...` are excluded by default so ordinary build/test cycles
@@ -2434,9 +2436,11 @@ mock に頼らないリリース前検証として、`install.sh --reinstall-rea
 "silent host" で端末 stderr が握りつぶされるケースに備えて、配布済み/
 常用実行では stderr と最小限のライフサイクル情報をユーザー単位の日次
 ログにも複写するようになっている。保存先は Windows では
+`CDIDX_GLOBAL_TOOL_LOG_DIR`、`XDG_STATE_HOME/cdidx/logs/`、
+`XDG_CACHE_HOME/cdidx/logs/`、`XDG_RUNTIME_DIR/cdidx/logs/` の順に
+見つかった場所を使い、その後に platform default として Windows では
 `%LOCALAPPDATA%\cdidx\logs\`、macOS では `~/Library/Logs/cdidx/`、
-Linux では `$XDG_STATE_HOME/cdidx/logs/`（未設定時は
-`~/.local/state/cdidx/logs/`）で、ファイル名は `stderr-YYYYMMDD.log`。
+Linux では `~/.local/state/cdidx/logs/` を使う。ファイル名は `stderr-YYYYMMDD.log`。
 保持世代は新しい 30 ファイルまで。通常の開発/テストサイクルで
 ワークツリー直下に永続ログが増えないよう、`src/CodeIndex/bin/...`
 と `tests/.../bin/...` からのリポジトリ内開発実行は既定で対象外として

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1130,11 +1130,13 @@ Inside `batch_query`, each inner slot is also checked against the inner tool's b
 Persistent lifecycle logs are written to the first available directory in this order:
 
 1. `CDIDX_GLOBAL_TOOL_LOG_DIR` (`~`, `~/...`, `$HOME/...`, and `${HOME}/...` are expanded)
-2. Windows: `%LOCALAPPDATA%\cdidx\logs`
-3. macOS: `~/Library/Logs/cdidx`
-4. Linux and other Unix-like systems: `$XDG_STATE_HOME/cdidx/logs`
-5. Linux and other Unix-like systems without `XDG_STATE_HOME`: `~/.local/state/cdidx/logs`
-6. fallback: the OS local-app-data directory, then the temp directory under `cdidx/logs`
+2. `XDG_STATE_HOME/cdidx/logs`
+3. `XDG_CACHE_HOME/cdidx/logs`
+4. `XDG_RUNTIME_DIR/cdidx/logs`
+5. Windows: `%LOCALAPPDATA%\cdidx\logs`
+6. macOS: `~/Library/Logs/cdidx`
+7. Linux and other Unix-like systems without an XDG log directory: `~/.local/state/cdidx/logs`
+8. fallback: the OS local-app-data directory, then the temp directory under `cdidx/logs`
 
 Run `cdidx status --log-path` to print the active log directory without opening the index database. Add `--json` to receive `{"log_path":"..."}`. Set `CDIDX_DISABLE_PERSISTENT_LOG=1` to disable persistent lifecycle logs.
 
@@ -2924,11 +2926,13 @@ MCP ツールで catch-all まで突き抜けた例外（想定外の SQLite 例
 永続 lifecycle log は、利用可能な最初のディレクトリに書き込まれます。解決順は次のとおりです。
 
 1. `CDIDX_GLOBAL_TOOL_LOG_DIR`（`~`、`~/...`、`$HOME/...`、`${HOME}/...` は展開されます）
-2. Windows: `%LOCALAPPDATA%\cdidx\logs`
-3. macOS: `~/Library/Logs/cdidx`
-4. Linux などの Unix 系: `$XDG_STATE_HOME/cdidx/logs`
-5. `XDG_STATE_HOME` がない Linux などの Unix 系: `~/.local/state/cdidx/logs`
-6. fallback: OS の local-app-data ディレクトリ、それも無い場合は temp 配下の `cdidx/logs`
+2. `XDG_STATE_HOME/cdidx/logs`
+3. `XDG_CACHE_HOME/cdidx/logs`
+4. `XDG_RUNTIME_DIR/cdidx/logs`
+5. Windows: `%LOCALAPPDATA%\cdidx\logs`
+6. macOS: `~/Library/Logs/cdidx`
+7. XDG のログディレクトリがない Linux などの Unix 系: `~/.local/state/cdidx/logs`
+8. fallback: OS の local-app-data ディレクトリ、それも無い場合は temp 配下の `cdidx/logs`
 
 有効なログディレクトリだけを確認したい場合は `cdidx status --log-path` を実行してください。このコマンドは index database を開きません。`--json` を付けると `{"log_path":"..."}` を返します。永続 lifecycle log を無効化するには `CDIDX_DISABLE_PERSISTENT_LOG=1` を設定します。
 

--- a/changelog.d/unreleased/1894.fixed.md
+++ b/changelog.d/unreleased/1894.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 1894
+affected:
+  - src/CodeIndex/Cli/GlobalToolLog.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Persistent lifecycle logs now honor cache and runtime XDG directories (#1894)** — the global tool log directory resolver now checks `CDIDX_GLOBAL_TOOL_LOG_DIR`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, and `XDG_RUNTIME_DIR` before falling back to platform defaults, so container and CI deployments can choose a discoverable log tier without a cdidx-specific override.
+
+## 日本語
+
+- **永続 lifecycle log が cache / runtime の XDG ディレクトリも尊重するようになりました (#1894)** — global tool log のディレクトリ解決は platform default の前に `CDIDX_GLOBAL_TOOL_LOG_DIR`、`XDG_STATE_HOME`、`XDG_CACHE_HOME`、`XDG_RUNTIME_DIR` を確認するため、コンテナや CI 配備で cdidx 専用 override なしでも発見可能なログ階層を選べるようになりました。

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -168,6 +168,18 @@ internal static class GlobalToolLog
         if (!string.IsNullOrWhiteSpace(overrideDirectory))
             return Path.GetFullPath(ExpandUserLogDirectory(overrideDirectory));
 
+        var xdgStateHome = Environment.GetEnvironmentVariable("XDG_STATE_HOME");
+        if (!string.IsNullOrWhiteSpace(xdgStateHome))
+            return Path.Combine(xdgStateHome, "cdidx", "logs");
+
+        var xdgCacheHome = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+        if (!string.IsNullOrWhiteSpace(xdgCacheHome))
+            return Path.Combine(xdgCacheHome, "cdidx", "logs");
+
+        var xdgRuntimeDir = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
+        if (!string.IsNullOrWhiteSpace(xdgRuntimeDir))
+            return Path.Combine(xdgRuntimeDir, "cdidx", "logs");
+
         if (OperatingSystem.IsWindows())
         {
             var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
@@ -178,10 +190,6 @@ internal static class GlobalToolLog
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         if (OperatingSystem.IsMacOS() && !string.IsNullOrWhiteSpace(home))
             return Path.Combine(home, "Library", "Logs", "cdidx");
-
-        var xdgStateHome = Environment.GetEnvironmentVariable("XDG_STATE_HOME");
-        if (!string.IsNullOrWhiteSpace(xdgStateHome))
-            return Path.Combine(xdgStateHome, "cdidx", "logs");
 
         if (!string.IsNullOrWhiteSpace(home))
             return Path.Combine(home, ".local", "state", "cdidx", "logs");

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -85,19 +85,76 @@ public class ProgramRunnerTests
     [InlineData("${HOME}/cdidx-logs", "cdidx-logs")]
     public void GlobalToolLog_OverrideDirectory_ExpandsHomeShorthand(string overrideValue, string childDirectory)
     {
-        var originalLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_GLOBAL_TOOL_LOG_DIR",
+            "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_RUNTIME_DIR");
+        env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", overrideValue);
+        env.Set("XDG_STATE_HOME", null);
+        env.Set("XDG_CACHE_HOME", null);
+        env.Set("XDG_RUNTIME_DIR", null);
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        var resolved = GlobalToolLog.ResolveLogDirectoryForReport();
+
+        Assert.Equal(Path.GetFullPath(Path.Combine(home, childDirectory)), resolved);
+    }
+
+    [Theory]
+    [InlineData("XDG_STATE_HOME", "state-home")]
+    [InlineData("XDG_CACHE_HOME", "cache-home")]
+    [InlineData("XDG_RUNTIME_DIR", "runtime-dir")]
+    public void GlobalToolLog_XdgDirectory_UsesFirstConfiguredTier(string variableName, string directoryName)
+    {
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_GLOBAL_TOOL_LOG_DIR",
+            "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_RUNTIME_DIR");
+        env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", null);
+        env.Set("XDG_STATE_HOME", null);
+        env.Set("XDG_CACHE_HOME", null);
+        env.Set("XDG_RUNTIME_DIR", null);
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_xdg_{Guid.NewGuid():N}");
+        var selected = Path.Combine(root, directoryName);
         try
         {
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", overrideValue);
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            env.Set(variableName, selected);
 
             var resolved = GlobalToolLog.ResolveLogDirectoryForReport();
 
-            Assert.Equal(Path.GetFullPath(Path.Combine(home, childDirectory)), resolved);
+            Assert.Equal(Path.Combine(selected, "cdidx", "logs"), resolved);
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", originalLogDir);
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void GlobalToolLog_XdgDirectory_HonorsDocumentedPrecedence()
+    {
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_GLOBAL_TOOL_LOG_DIR",
+            "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_RUNTIME_DIR");
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_xdg_precedence_{Guid.NewGuid():N}");
+        try
+        {
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", null);
+            env.Set("XDG_STATE_HOME", Path.Combine(root, "state"));
+            env.Set("XDG_CACHE_HOME", Path.Combine(root, "cache"));
+            env.Set("XDG_RUNTIME_DIR", Path.Combine(root, "runtime"));
+
+            var resolved = GlobalToolLog.ResolveLogDirectoryForReport();
+
+            Assert.Equal(Path.Combine(root, "state", "cdidx", "logs"), resolved);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
         }
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -29513,34 +29513,65 @@ jobs:
     [InlineData("${HOME}/cdidx-logs", "cdidx-logs")]
     public void RunStatus_LogPath_ExpandsUserHomeOverrides(string overrideValue, string childDirectory)
     {
-        var originalLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
-        try
-        {
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", overrideValue);
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_GLOBAL_TOOL_LOG_DIR",
+            "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_RUNTIME_DIR");
+        env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", overrideValue);
+        env.Set("XDG_STATE_HOME", null);
+        env.Set("XDG_CACHE_HOME", null);
+        env.Set("XDG_RUNTIME_DIR", null);
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
-                ["--log-path"],
-                _jsonOptions));
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--log-path"],
+            _jsonOptions));
 
-            Assert.Equal(CommandExitCodes.Success, exitCode);
-            Assert.Equal(string.Empty, stderr);
-            Assert.Equal(Path.GetFullPath(Path.Combine(home, childDirectory)), stdout.Trim());
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", originalLogDir);
-        }
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        Assert.Equal(Path.GetFullPath(Path.Combine(home, childDirectory)), stdout.Trim());
     }
 
     [Fact]
     public void RunStatus_LogPath_JsonPrintsResolvedDirectoryWithoutDatabase()
     {
         var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_status_log_path_{Guid.NewGuid():N}");
-        var originalLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_GLOBAL_TOOL_LOG_DIR",
+            "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_RUNTIME_DIR");
+        env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+        env.Set("XDG_STATE_HOME", null);
+        env.Set("XDG_CACHE_HOME", null);
+        env.Set("XDG_RUNTIME_DIR", null);
+
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--log-path", "--json"],
+            _jsonOptions));
+
+        using var document = ParseJsonOutput(stdout);
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        Assert.Equal(Path.GetFullPath(logDir), document.RootElement.GetProperty("log_path").GetString());
+    }
+
+    [Fact]
+    public void RunStatus_LogPath_JsonHonorsXdgCacheHome()
+    {
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_GLOBAL_TOOL_LOG_DIR",
+            "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_RUNTIME_DIR");
+        var cacheHome = Path.Combine(Path.GetTempPath(), $"cdidx_status_log_path_xdg_cache_{Guid.NewGuid():N}");
         try
         {
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", null);
+            env.Set("XDG_STATE_HOME", null);
+            env.Set("XDG_CACHE_HOME", cacheHome);
+            env.Set("XDG_RUNTIME_DIR", Path.Combine(Path.GetTempPath(), "ignored-runtime"));
 
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
                 ["--log-path", "--json"],
@@ -29549,11 +29580,11 @@ jobs:
             using var document = ParseJsonOutput(stdout);
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal(string.Empty, stderr);
-            Assert.Equal(Path.GetFullPath(logDir), document.RootElement.GetProperty("log_path").GetString());
+            Assert.Equal(Path.Combine(cacheHome, "cdidx", "logs"), document.RootElement.GetProperty("log_path").GetString());
         }
         finally
         {
-            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", originalLogDir);
+            TestProjectHelper.DeleteDirectory(cacheHome);
         }
     }
 


### PR DESCRIPTION
## Summary

- Update global lifecycle log directory resolution to check `XDG_STATE_HOME`, `XDG_CACHE_HOME`, and `XDG_RUNTIME_DIR` before platform defaults.
- Add regression coverage for resolver precedence and `status --log-path --json` output.
- Document the updated log directory chain in English and Japanese docs.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProgramRunnerTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProgramRunnerTests|FullyQualifiedName~QueryCommandRunnerTests.RunStatus_LogPath" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false` (net9 passed; net8 had one publish-output file lock in the concurrent multi-target run)
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -f net8.0 -p:UseSharedCompilation=false`

## Documentation and Changelog

- Updated `USER_GUIDE.md` and `DEVELOPER_GUIDE.md`.
- Added `changelog.d/unreleased/1894.fixed.md`.

## Review

- Codex adversarial review against `origin/main..HEAD`: no blocking/actionable issues found.

Fixes #1894