### PR TITLE
Tighten global tool log permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ If a directory cannot be scanned because of permissions or an I/O error,
 `cdidx` records the scan error, keeps scanning other directories, and writes a
 temporary `.cdidx/scan-checkpoint.json` so a same-HEAD retry can skip directories
 that already completed successfully.
+On POSIX systems, persistent global tool stderr logs are forced to owner-only
+`0600` permissions on every open, including existing date-stamped log files.
 Terminals that request ASCII-only output with `--ascii`, `CDIDX_ASCII=1`,
 `NO_UNICODE`, `TERM=dumb`, accessibility env hints, or a non-UTF-8 locale render
 spinner frames as `|` / `/` / `-` / `\` and progress bars with `#` / `-` instead
@@ -275,6 +277,8 @@ script / CI では `--yes`（または `--force`）が必要です。
 権限や I/O エラーでディレクトリを走査できない場合でも、`cdidx` は scan error を
 記録して他のディレクトリの走査を続け、同じ HEAD の再実行で成功済みディレクトリを
 読み飛ばせるように一時的な `.cdidx/scan-checkpoint.json` を書き込みます。
+POSIX 環境では、persistent global tool stderr log は開くたびに所有者のみ読み書き可能な
+`0600` 権限へ補正され、既存の日付付き log file も同じ扱いになります。
 `--ascii`、`CDIDX_ASCII=1`、`NO_UNICODE`、`TERM=dumb`、accessibility 系の環境変数、
 または非 UTF-8 locale により ASCII-only 出力が要求されている端末では、スピナーは
 `|` / `/` / `-` / `\`、進捗バーは `#` / `-` で描画されます。Unicode を利用できる端末でも

--- a/changelog.d/unreleased/1797.security.md
+++ b/changelog.d/unreleased/1797.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 1797
+affected:
+  - src/CodeIndex/Cli/GlobalToolLog.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - README.md
+---
+
+## English
+
+- **Global tool stderr logs are now owner-only on POSIX (#1797)** — `cdidx` forces persistent global stderr log files, including existing date-stamped logs, to `0600` permissions whenever logging starts.
+
+## 日本語
+
+- **POSIX 環境の global tool stderr log を所有者専用にしました (#1797)** — `cdidx` は persistent global stderr log を開始するたびに、既存の日付付き log も含めて `0600` 権限へ補正します。

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -21,11 +21,13 @@ internal static class GlobalToolLog
 
             var logDirectory = ResolveLogDirectory();
             Directory.CreateDirectory(logDirectory);
+            HardenLogFiles(logDirectory);
             var logPath = Path.Combine(logDirectory, $"stderr-{DateTime.UtcNow:yyyyMMdd}.log");
             var writer = new StreamWriter(new FileStream(logPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite), new UTF8Encoding(false))
             {
                 AutoFlush = true,
             };
+            SetLogFilePermissions(logPath);
             PruneOldLogs(logDirectory);
 
             var session = new Session(writer, logPath);
@@ -241,6 +243,37 @@ internal static class GlobalToolLog
 
             foreach (var file in oldLogs)
                 file.Delete();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best-effort only / ベストエフォートのみ
+        }
+    }
+
+    private static void HardenLogFiles(string logDirectory)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            foreach (var file in new DirectoryInfo(logDirectory).EnumerateFiles("stderr-*.log", SearchOption.TopDirectoryOnly))
+                SetLogFilePermissions(file.FullName);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best-effort only / ベストエフォートのみ
+        }
+    }
+
+    private static void SetLogFilePermissions(string logPath)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            File.SetUnixFileMode(logPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -139,6 +139,51 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void Run_ForcedGlobalToolLogging_OnUnix_HardensExistingAndCurrentLogFiles()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_permissions_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(logDir);
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_FORCE_GLOBAL_TOOL_LOG",
+            "CDIDX_DISABLE_PERSISTENT_LOG",
+            "CDIDX_GLOBAL_TOOL_LOG_DIR");
+
+        try
+        {
+            var oldLogPath = Path.Combine(logDir, "stderr-20240101.log");
+            File.WriteAllText(oldLogPath, "old log");
+            File.SetUnixFileMode(oldLogPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead |
+                UnixFileMode.OtherRead);
+
+            env.Set("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
+            env.Set("CDIDX_DISABLE_PERSISTENT_LOG", null);
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+
+            var (exitCode, _, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                ["definitely-not-a-command"],
+                appVersion: "1.10.0"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Contains("Unknown command: definitely-not-a-command", stderr);
+
+            var expectedMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            Assert.Equal(expectedMode, File.GetUnixFileMode(oldLogPath));
+
+            var currentLogPath = Directory.GetFiles(logDir, $"stderr-{DateTime.UtcNow:yyyyMMdd}.log", SearchOption.TopDirectoryOnly).Single();
+            Assert.Equal(expectedMode, File.GetUnixFileMode(currentLogPath));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(logDir);
+        }
+    }
+
+    [Fact]
     public void Run_ForcedGlobalToolLogging_WritesUnhandledExceptionChain()
     {
         var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_global_tool_log_exception_chain_{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

- Harden persistent global tool stderr log files to `0600` on POSIX whenever logging starts.
- Apply the same permission correction to existing `stderr-*.log` files in the log directory.
- Document the POSIX log permission behavior and add a security changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProgramRunnerTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false --no-restore`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false` before merging latest `origin/main`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `README.md`.
- Added `changelog.d/unreleased/1797.security.md`.

## Follow-up Candidates

- None.

Fixes #1797
