### PR TITLE
Add lock restore regression coverage for issue 2577

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -58,6 +58,8 @@ The test project mirrors the production areas closely.
   Source code leak prevention: allowed natural-language inputs vs rejected code blocks (fenced, indented, import runs, etc.).
 - `GitHubIssueReporterTests.cs`
   GitHub token resolution logic (CDIDX_GITHUB_TOKEN only; generic GITHUB_TOKEN is ignored), outbound code scrubbing, idempotency checks, and rate-limit diagnostics.
+- `PackagesLockTests.cs`
+  NuGet lock-file guard coverage for direct package references that must remain synchronized across all target frameworks, including the net9.0 compatibility references that keep locked CI restore green.
 - `ConcurrencyTests.cs`
   Concurrent read and read-during-write scenarios (WAL mode validation), including the issue #180 bug-catching snapshot-isolation regressions for all three multi-statement reader entry points: (1) `GetStatus` seeds `refs == files * refsPerFile` and asserts every concurrent observation preserves that invariant; (2) `AnalyzeSymbol` seeds one symbol `S` plus matching reference/caller pairs, toggles a second file symmetrically, and asserts `references.Count == callers.Count` across every `inspect`/`analyze_symbol` bundle; (3) `GetRepoMap` seeds a baseline modified timestamp and toggles a newer file, asserting `latest_modified == workspace_latest_modified` across every map call. Each test fails without the DEFERRED-transaction wrap on the matching reader and passes with it.
 - `PerformanceTests.cs`
@@ -237,6 +239,8 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
   ソースコード漏洩防止: 許容される自然言語入力 vs 拒否されるコードブロック（フェンス、インデント、import連打等）。
 - `GitHubIssueReporterTests.cs`
   GitHubトークン解決ロジック（CDIDX_GITHUB_TOKENのみ。汎用GITHUB_TOKENは無視）。
+- `PackagesLockTests.cs`
+  すべての target framework で同期が必要な direct package reference の NuGet lock-file guard。CI の locked restore を通すための net9.0 compatibility reference も対象です。
 - `ConcurrencyTests.cs`
   並行読み取りと書き込み中読み取りシナリオ（WALモード検証）。issue #180 の bug-catching な snapshot 隔離回帰テストを 3 つの multi-statement reader 経路について含む。(1) `GetStatus` は `refs == files * refsPerFile` の seed 不変条件を立て、並行観測が常にこの条件を維持することを要求する。(2) `AnalyzeSymbol` はシンボル `S` に対して reference/caller を対称に 1 対 1 で seed し、もう 1 ファイルを対称に toggle することで `inspect` / `analyze_symbol` bundle の `references.Count == callers.Count` を常に保証する。(3) `GetRepoMap` はベースラインの modified と新しい toggle 対象ファイルを用意し、`latest_modified == workspace_latest_modified` が常に一致することを要求する。各テストは対応する reader の DEFERRED transaction を外すと落ち、戻すと通ることを確認済み。
 - `PerformanceTests.cs`

--- a/changelog.d/unreleased/2577.fixed.md
+++ b/changelog.d/unreleased/2577.fixed.md
@@ -4,6 +4,8 @@ issues:
   - 2577
 affected:
   - tests/CodeIndex.Tests/packages.lock.json
+  - tests/CodeIndex.Tests/PackagesLockTests.cs
+  - TESTING_GUIDE.md
 ---
 
 ## English

--- a/changelog.d/unreleased/2577.fixed.md
+++ b/changelog.d/unreleased/2577.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2577
+affected:
+  - tests/CodeIndex.Tests/packages.lock.json
+---
+
+## English
+
+- **CodeIndex.Tests locked restore now includes net9.0 direct test dependencies (#2577)** — the test project lock file is synchronized with the net9.0 `System.Net.Http` and `System.Text.RegularExpressions` package references so CI locked restore can pass.
+
+## 日本語
+
+- **CodeIndex.Tests の locked restore が net9.0 の直接 test dependency を含むようになりました (#2577)** — test project の lock file が net9.0 の `System.Net.Http` / `System.Text.RegularExpressions` package reference と同期され、CI の locked restore が通るようになりました。

--- a/tests/CodeIndex.Tests/PackagesLockTests.cs
+++ b/tests/CodeIndex.Tests/PackagesLockTests.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using Xunit;
+
+namespace CodeIndex.Tests;
+
+public class PackagesLockTests
+{
+    [Theory]
+    [InlineData("System.Net.Http", "4.3.4")]
+    [InlineData("System.Text.RegularExpressions", "4.3.1")]
+    public void CodeIndexTests_Net9LockFile_IncludesDirectCompatibilityReferences(string packageName, string version)
+    {
+        var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../.."));
+        var lockFilePath = Path.Combine(projectDirectory, "packages.lock.json");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(lockFilePath));
+        var net9Dependencies = document.RootElement
+            .GetProperty("dependencies")
+            .GetProperty("net9.0");
+
+        Assert.True(net9Dependencies.TryGetProperty(packageName, out var package), $"{packageName} is missing from net9.0 lock dependencies.");
+        Assert.Equal("Direct", package.GetProperty("type").GetString());
+        Assert.Equal($"[{version}, )", package.GetProperty("requested").GetString());
+        Assert.Equal(version, package.GetProperty("resolved").GetString());
+    }
+}


### PR DESCRIPTION
## Summary

- Add a regression test that asserts the CodeIndex.Tests net9.0 lock-file entries for `System.Net.Http` and `System.Text.RegularExpressions` stay direct and synchronized.
- Document the new lock-file guard in `TESTING_GUIDE.md`.
- Add the bilingual changelog fragment for #2577.

## Validation

- `dotnet restore CodeIndex.sln --locked-mode`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter FullyQualifiedName~PackagesLockTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Updated `TESTING_GUIDE.md`.
- Added `changelog.d/unreleased/2577.fixed.md`.

## Notes

- `origin/main` already contained the lock-file synchronization in `b883f619` (`Update test lock file after main merge`); this PR adds regression coverage and the required changelog fragment for #2577.

Fixes #2577
