### PR TITLE
Fix console capture test races

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -127,7 +127,7 @@ For boundary tests, use the smallest fixture that still crosses the boundary. If
 ### CLI and console tests
 
 - Capture stdout and stderr explicitly.
-- Lock console mutations with `TestConsoleLock.Gate`.
+- Prefer `ConsoleCapture` for simple stdout/stderr capture, and lock direct console mutations with `TestConsoleLock.Gate`.
 - Assert exit codes with `CommandExitCodes`.
 - For JSON output, parse it with `JsonDocument` instead of asserting raw strings.
 
@@ -305,7 +305,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 ### CLI / コンソール系テスト
 
 - stdout と stderr を明示的にキャプチャする。
-- コンソール差し替えは `TestConsoleLock.Gate` で直列化する。
+- 単純な stdout/stderr capture では `ConsoleCapture` を優先し、直接コンソールを差し替える場合は `TestConsoleLock.Gate` で直列化する。
 - 終了コードは `CommandExitCodes` で検証する。
 - JSON 出力は生文字列比較ではなく `JsonDocument` で解析して検証する。
 

--- a/changelog.d/unreleased/2548.fixed.md
+++ b/changelog.d/unreleased/2548.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2548
+affected:
+  - tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Console stream tests no longer race with shared capture helpers (#2548)** — tests that temporarily redirect `Console.Error` now use the shared serialized capture path or `TestConsoleLock.Gate`, preventing parallel test runs from restoring the wrong global writer.
+
+## 日本語
+
+- **Console stream のテストが共有 capture helper と競合しないようになりました (#2548)** — `Console.Error` を一時的に差し替えるテストは共有の直列化された capture 経路または `TestConsoleLock.Gate` を使うようになり、並列テスト実行で誤った global writer を復元する競合を防ぎます。

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -700,19 +700,22 @@ public class IndexCommandRunnerTests
     [Fact]
     public void ParseArgs_MaxFileBytesInvalidValue_IsIgnored()
     {
-        var originalErr = Console.Error;
-        using var stderr = new StringWriter();
-        try
+        lock (TestConsoleLock.Gate)
         {
-            Console.SetError(stderr);
-            var options = IndexCommandRunner.ParseArgs([".", "--max-file-bytes", "0"]);
+            var originalErr = Console.Error;
+            using var stderr = new StringWriter();
+            try
+            {
+                Console.SetError(stderr);
+                var options = IndexCommandRunner.ParseArgs([".", "--max-file-bytes", "0"]);
 
-            Assert.True(options.MaxFileSizeBytes is null or > 0);
-            Assert.Contains("invalid --max-file-bytes value", stderr.ToString());
-        }
-        finally
-        {
-            Console.SetError(originalErr);
+                Assert.True(options.MaxFileSizeBytes is null or > 0);
+                Assert.Contains("invalid --max-file-bytes value", stderr.ToString());
+            }
+            finally
+            {
+                Console.SetError(originalErr);
+            }
         }
     }
 
@@ -791,18 +794,21 @@ public class IndexCommandRunnerTests
     [Fact]
     public void ParseArgs_DurationFormatFlag_InvalidValue_IsIgnored()
     {
-        var originalErr = Console.Error;
-        using var stderr = new StringWriter();
-        try
+        lock (TestConsoleLock.Gate)
         {
-            Console.SetError(stderr);
-            var options = IndexCommandRunner.ParseArgs([".", "--duration-format", "bogus"]);
-            Assert.Equal(DurationOutputFormat.Auto, options.DurationFormat);
-            Assert.Contains("invalid --duration-format value", stderr.ToString());
-        }
-        finally
-        {
-            Console.SetError(originalErr);
+            var originalErr = Console.Error;
+            using var stderr = new StringWriter();
+            try
+            {
+                Console.SetError(stderr);
+                var options = IndexCommandRunner.ParseArgs([".", "--duration-format", "bogus"]);
+                Assert.Equal(DurationOutputFormat.Auto, options.DurationFormat);
+                Assert.Contains("invalid --duration-format value", stderr.ToString());
+            }
+            finally
+            {
+                Console.SetError(originalErr);
+            }
         }
     }
 

--- a/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+++ b/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
@@ -383,17 +383,7 @@ public class LegacySchemaMigrationTests : IDisposable
             pragma.ExecuteNonQuery();
         }
 
-        var originalError = Console.Error;
-        var capturedError = new StringWriter();
-        Console.SetError(capturedError);
-        try
-        {
-            db.TryMigrateForRead();
-        }
-        finally
-        {
-            Console.SetError(originalError);
-        }
+        var stderr = ConsoleCapture.CaptureError(db.TryMigrateForRead);
 
         // Structured failure: step description, SQLite error code, and an actionable hint
         // are all available to callers (CLI, MCP, programmatic) without reparsing stderr.
@@ -407,7 +397,6 @@ public class LegacySchemaMigrationTests : IDisposable
 
         // Single stderr line so the diagnostic is hard to miss but does not flood logs.
         // 1 行の stderr 警告。
-        var stderr = capturedError.ToString();
         Assert.Contains("schema migration step", stderr, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("BEGIN IMMEDIATE schema migration", stderr, StringComparison.Ordinal);
         Assert.Contains("SQLite error 8", stderr, StringComparison.Ordinal);
@@ -423,20 +412,10 @@ public class LegacySchemaMigrationTests : IDisposable
         // 正常完了時は LastMigrationFailure が null のまま — シグナルとして利用できる契約。
         using var db = new DbContext(_dbPath);
 
-        var originalError = Console.Error;
-        var capturedError = new StringWriter();
-        Console.SetError(capturedError);
-        try
-        {
-            db.TryMigrateForRead();
-        }
-        finally
-        {
-            Console.SetError(originalError);
-        }
+        var stderr = ConsoleCapture.CaptureError(db.TryMigrateForRead);
 
         Assert.Null(db.LastMigrationFailure);
-        Assert.DoesNotContain("schema migration step", capturedError.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("schema migration step", stderr, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Serialized remaining direct `Console.Error` test mutations behind `TestConsoleLock.Gate`.
- Moved legacy migration stderr capture onto the shared `ConsoleCapture` helper.
- Updated testing guidance and added `changelog.d/unreleased/2548.fixed.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleCaptureTests|FullyQualifiedName~LegacySchemaMigrationTests|FullyQualifiedName~IndexCommandRunnerTests.ParseArgs_MaxFileBytesInvalidValue_IsIgnored|FullyQualifiedName~IndexCommandRunnerTests.ParseArgs_DurationFormatFlag_InvalidValue_IsIgnored"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- Adversarial review: `No blocking/actionable issues found.`

Full `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj` was attempted, but unrelated failures were observed: FIFO dry-run hangs are already tracked by #2478, and the trimmed publish ILLink AccessViolation found during this run was filed as #2586.

## Documentation and Changelog

- Updated `TESTING_GUIDE.md`.
- Added `changelog.d/unreleased/2548.fixed.md`.

## Follow-up References

- #2478
- #2586

Fixes #2548
