### PR TITLE
Add changelog entry for issue 2580

### DIFF
--- a/changelog.d/unreleased/2580.fixed.md
+++ b/changelog.d/unreleased/2580.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2580
+affected:
+  - tests/CodeIndex.Tests/packages.lock.json
+  - tests/CodeIndex.Tests/PackagesLockTests.cs
+---
+
+## English
+
+- **Synchronized the test project lock file for .NET 9 restore (#2580)** — the `net9.0` lock-file entries now include the direct `System.Net.Http` and `System.Text.RegularExpressions` test references, keeping locked CI restores green.
+
+## 日本語
+
+- **.NET 9 restore 向けにテストプロジェクトの lock file を同期しました (#2580)** — `net9.0` の lock-file entries に direct test reference の `System.Net.Http` と `System.Text.RegularExpressions` を含め、CI の locked restore が通る状態を維持します。


### PR DESCRIPTION
## Summary

- Add the missing #2580 changelog fragment for the net9.0 test lock-file synchronization that is already present on latest `origin/main`.
- Document that the test lock file now includes the direct `System.Net.Http` and `System.Text.RegularExpressions` references needed for locked restore.

## Validation

- `dotnet restore CodeIndex.sln --locked-mode`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~PackagesLockTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Added `changelog.d/unreleased/2580.fixed.md`.
- No `CHANGELOG.md` edit; this is an ordinary issue-fix PR using the fragment workflow.

## Follow-up candidates

- None.

Fixes #2580
