### PR TITLE
Fix trimmed backfill-fold publish smoke test

### DIFF
--- a/changelog.d/unreleased/2584.fixed.md
+++ b/changelog.d/unreleased/2584.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2584
+affected:
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Trimmed backfill-fold publish smoke tests now execute the apphost when present (#2584)** — the test helper no longer runs a runtime-specific self-contained publish through the wrong `dotnet` runtime when the SDK emits both `cdidx` and `cdidx.dll`.
+
+## 日本語
+
+- **trimmed publish した backfill-fold の smoke test は apphost があればそれを実行するようになりました (#2584)** — SDK が `cdidx` と `cdidx.dll` の両方を出力する場合に、runtime 固有の self-contained publish を誤った `dotnet` runtime 経由で実行しないようにしました。

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -7862,13 +7862,13 @@ public class IndexCommandRunnerTests
         if (process.ExitCode != 0)
             throw new InvalidOperationException($"dotnet publish failed: {stdout}{stderr}".Trim());
 
-        var publishedDll = Path.Combine(outputDir, "cdidx.dll");
-        if (File.Exists(publishedDll))
-            return publishedDll;
-
         var publishedAppHost = Path.Combine(outputDir, OperatingSystem.IsWindows() ? "cdidx.exe" : "cdidx");
         if (File.Exists(publishedAppHost))
             return publishedAppHost;
+
+        var publishedDll = Path.Combine(outputDir, "cdidx.dll");
+        if (File.Exists(publishedDll))
+            return publishedDll;
 
         throw new InvalidOperationException(
             $"Published cdidx entry point not found. Expected {publishedDll} or {publishedAppHost}");


### PR DESCRIPTION
## Summary

- Prefer the published apphost over `cdidx.dll` when the trimmed self-contained publish emits both entry points.
- Add a bilingual changelog fragment for issue #2584.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --filter "FullyQualifiedName~IndexCommandRunnerTests.RunBackfillFold_PublishedTrimmedBinary_SerializesSuccessAndErrorJson"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~IndexCommandRunnerTests.RunBackfillFold_PublishedTrimmedBinary_SerializesSuccessAndErrorJson"`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false --framework net9.0 --filter "FullyQualifiedName~IndexCommandRunnerTests.RunBackfillFold_PublishedTrimmedBinary_SerializesSuccessAndErrorJson"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`

## Documentation / Changelog

- Added `changelog.d/unreleased/2584.fixed.md`.
- No user-facing docs were required; this fixes test publish entrypoint selection only.

## Review

- Adversarial review of `origin/main..HEAD`: No blocking/actionable issues found.
- Attempted `codex exec` adversarial review twice. The first attempt failed because `gpt-5-codex` is unsupported for this account; the second failed due to Codex CLI usage limits.

Fixes #2584