### PR TITLE
Fix HTML slot indexing

### DIFF
--- a/changelog.d/unreleased/2107.fixed.md
+++ b/changelog.d/unreleased/2107.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2107
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **HTML slot declarations and projections are now indexed (#2107)** — `<slot name="...">` declarations are emitted as `property` symbols, unnamed default slots use `"(default)"`, and `slot="..."` projections are emitted as `reference` symbols.
+
+## 日本語
+
+- **HTML の slot 宣言と投影参照を index するようになりました (#2107)** — `<slot name="...">` 宣言は `property` symbol、名前なしの default slot は `"(default)"`、`slot="..."` の投影先は `reference` symbol として出力します。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -9,6 +9,8 @@ public static partial class SymbolExtractor
 {
     private static List<SymbolRecord> ExtractHtmlSymbols(long fileId, string[] lines)
     {
+        const string defaultSlotSymbolName = "(default)";
+
         // HTML needs proper tag-structure awareness so attribute lookalikes inside
         // other attributes' quoted values (e.g. `<link title="href=evil.css" href="/real.css">`)
         // don't leak phantom imports AND real attributes on the same tag aren't
@@ -73,6 +75,7 @@ public static partial class SymbolExtractor
 
             var tagName = maskedText[tagNameStart..tagNameEnd];
             var tagNameLower = tagName.ToLowerInvariant();
+            var sawNamedSlotDeclaration = false;
 
             // Emit custom Web Components (hyphenated opening tag) at the `<` position,
             // but skip the standard HTML/SVG/MathML tags that happen to contain a hyphen
@@ -221,6 +224,25 @@ public static partial class SymbolExtractor
                     emitKind = "property";
                     emittedNames = [attrValue.Trim()];
                 }
+                else if (attrNameLower == "name" && tagNameLower == "slot")
+                {
+                    var slotName = attrValue.Trim();
+                    if (slotName.Length > 0)
+                    {
+                        emitKind = "property";
+                        emittedNames = [slotName];
+                        sawNamedSlotDeclaration = true;
+                    }
+                }
+                else if (attrNameLower == "slot")
+                {
+                    var slotName = attrValue.Trim();
+                    if (slotName.Length > 0)
+                    {
+                        emitKind = "reference";
+                        emittedNames = [slotName];
+                    }
+                }
 
                 if (emitKind == null || emittedNames == null || emittedNames.Count == 0)
                     continue;
@@ -246,6 +268,22 @@ public static partial class SymbolExtractor
                         Signature = lines[signatureIndex].Trim(),
                     });
                 }
+            }
+
+            if (tagNameLower == "slot" && !sawNamedSlotDeclaration)
+            {
+                var startLine = FindHtmlLineNumber(lineStarts, pos);
+                var signatureIndex = Math.Clamp(startLine - 1, 0, lines.Length - 1);
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = defaultSlotSymbolName,
+                    Line = startLine,
+                    StartLine = startLine,
+                    EndLine = startLine,
+                    Signature = lines[signatureIndex].Trim(),
+                });
             }
 
             pos = cursor < maskedText.Length ? cursor + 1 : cursor;

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -22297,6 +22297,35 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Html_CapturesSlotDeclarationsAndProjectionReferences()
+    {
+        var content = """
+            <template id="card-template">
+              <slot name="header">Untitled</slot>
+              <slot></slot>
+              <slot name='footer'><slot name="nested"></slot></slot>
+            </template>
+            <article>
+              <h2 slot="header">Title</h2>
+              <p>Default content</p>
+              <span slot='footer'>Actions</span>
+              <slot slot="footer" name="forwarded"></slot>
+            </article>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "html", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "header");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "(default)");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "footer");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "nested");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "forwarded");
+        Assert.Equal(2, symbols.Count(s => s.Kind == "reference" && s.Name == "footer"));
+        Assert.Contains(symbols, s => s.Kind == "reference" && s.Name == "header");
+        Assert.DoesNotContain(symbols, s => s.Kind == "class" && s.Name == "slot");
+    }
+
+    [Fact]
     public void Extract_Html_CapturesAllSymbolsOnSameLine()
     {
         // Minified HTML or a single line with multiple landmark-bearing tags must


### PR DESCRIPTION
## Summary

- Index HTML `<slot name="...">` declarations as `property` symbols.
- Index unnamed default slots as `"(default)"` property symbols.
- Index `slot="..."` projection attributes as `reference` symbols.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Html_CapturesSlotDeclarationsAndProjectionReferences"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test`

## Documentation / Changelog

- Added `changelog.d/unreleased/2107.fixed.md`.
- No README update: this repository does not document each individual HTML symbol extraction rule in README.

## Review

- Manual adversarial review of `origin/main..HEAD`: no blocking/actionable issues found.
- `codex exec` adversarial review was attempted but blocked by the current Codex usage limit.

## Follow-up Candidates

- Existing issue #2528 already tracks the observed `cdidx index` stall on `QueryCommandRunnerTests.cs`; no duplicate issue was opened.

Fixes #2107
