### PR TITLE
Fix flaky HTTP request logger test

### DIFF
--- a/changelog.d/unreleased/2419.fixed.md
+++ b/changelog.d/unreleased/2419.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2419
+affected:
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **Stabilized the HTTP MCP request logger regression test (#2419)** — the test now gives the asynchronous request log callback a longer full-suite grace period and reports the records it observed on timeout.
+
+## 日本語
+
+- **HTTP MCP request logger の回帰テストを安定化しました (#2419)** — 非同期 request log callback にフルスイート実行時の猶予を長めに取り、timeout 時には観測済み record を表示するようにしました。

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -106,8 +106,9 @@ public class HttpMcpTransportTests : IDisposable
             Assert.Equal(HttpStatusCode.OK, okResponse.StatusCode);
         }
 
-        // Issue #2434: the successful POST response can reach the client before its
-        // best-effort request log callback runs, so assert after the async sink catches up.
+        // Issue #2419: full-suite runs can be slow enough that the successful POST response
+        // reaches the client noticeably before its best-effort request log callback runs, so
+        // assert after the async sink catches up.
         var snapshot = await WaitForRequestLogRecordsAsync(records, 3);
         Assert.Equal(3, snapshot.Length);
 
@@ -364,7 +365,8 @@ public class HttpMcpTransportTests : IDisposable
         ConcurrentQueue<HttpMcpTransport.HttpRequestLogRecord> records,
         int expectedCount)
     {
-        for (var attempt = 0; attempt < 100; attempt++)
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < deadline)
         {
             if (records.Count >= expectedCount)
                 return records.ToArray();
@@ -373,7 +375,10 @@ public class HttpMcpTransportTests : IDisposable
         }
 
         var snapshot = records.ToArray();
-        Assert.Equal(expectedCount, snapshot.Length);
+        var observed = string.Join(
+            ", ",
+            snapshot.Select(record => $"{record.Method} {record.Path} {record.StatusCode} auth={record.AuthOutcome} id={record.RequestId ?? "<none>"}"));
+        Assert.Fail($"Expected {expectedCount} request log records, but observed {snapshot.Length}: {observed}");
         return snapshot;
     }
 


### PR DESCRIPTION
## Summary

- Extended the HTTP MCP request logger test grace period for async log delivery under full-suite load.
- Added timeout diagnostics that show the request log records observed before failure.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~HttpMcpTransportTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`

Full `dotnet test` was attempted, but an unrelated trimmed publish test failed because ILLink could not write `src/CodeIndex/obj/Debug/net8.0/osx-arm64/linked/cdidx.pdb` while another process held it.

## Documentation and changelog

- Added changelog fragment `changelog.d/unreleased/2419.fixed.md`.
- No documentation update needed; this is a test stability fix only.

## Adversarial review

- Manual adversarial review found no blocking/actionable issues.
- Codex adversarial review was attempted, but the usable diff-based run was blocked by the Codex usage limit.

Fixes #2419