### PR TITLE
Fix SQL quoted qualified name matching

### DIFF
--- a/changelog.d/unreleased/2101.fixed.md
+++ b/changelog.d/unreleased/2101.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2101
+affected:
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - src/CodeIndex/Indexer/References/Support/SqlNameResolver.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **SQL quoted qualified names now respect dialect matching rules (#2101)** — schema-qualified SQL references keep MySQL backtick and T-SQL bracket matching case-insensitive while preserving PostgreSQL double-quoted identifier case sensitivity.
+
+## 日本語
+
+- **SQL の引用付き qualified name が dialect ごとの照合規則を尊重するようになりました (#2101)** — schema 修飾された SQL 参照では MySQL のバッククォートと T-SQL のブラケットは大文字小文字を区別しない照合を維持しつつ、PostgreSQL の二重引用符付き識別子は大文字小文字を区別します。

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -648,6 +648,10 @@ public class DbContext : IDisposable
                     ? segmentCount
                     : null));
         connection.CreateFunction(
+            "sql_reference_matches_target_at",
+            (string? symbolName, string? context, string? containerName, long? columnNumber, string? targetName) =>
+                SqlNameResolver.ReferenceMatchesTargetAtColumn(symbolName, context, containerName, ToNullableInt(columnNumber), targetName) ? 1 : 0);
+        connection.CreateFunction(
             "sql_allow_leaf_fallback_at",
             (string? symbolName, string? context, string? containerName, long? columnNumber) =>
                 SqlNameResolver.AllowLeafFallbackAtColumn(symbolName, context, containerName, ToNullableInt(columnNumber)) ? 1 : 0);

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -2570,7 +2570,7 @@ public partial class DbReader
                       WHERE sr.symbol_name = s.name
                          OR (f.lang = 'sql' AND rf.lang = 'sql' AND (
                                 (sql_resolve_reference_segment_count_at(sr.symbol_name, " + ReferenceContextSql("sr") + @", sr.container_name, sr.column_number) = sql_segment_count(s.name)
-                                 AND sql_resolve_reference_name_at(sr.symbol_name, " + ReferenceContextSql("sr") + @", sr.container_name, sr.column_number) = sql_normalize_name(s.name) COLLATE NOCASE)
+                                 AND sql_reference_matches_target_at(sr.symbol_name, " + ReferenceContextSql("sr") + @", sr.container_name, sr.column_number, s.name) = 1)
                          OR (sql_segment_count(sr.symbol_name) = 1
                             AND sql_allow_leaf_fallback_at(sr.symbol_name, " + ReferenceContextSql("sr") + @", sr.container_name, sr.column_number) = 1
                             AND sr.symbol_name = sql_leaf_name(s.name) COLLATE NOCASE
@@ -2580,7 +2580,7 @@ public partial class DbReader
                                     JOIN files f_exact ON f_exact.id = s_exact.file_id
                                     WHERE f_exact.lang = 'sql'
                                       AND sql_segment_count(s_exact.name) = sql_resolve_reference_segment_count_at(sr.symbol_name, " + ReferenceContextSql("sr") + @", sr.container_name, sr.column_number)
-                                     AND sql_normalize_name(s_exact.name) = sql_resolve_reference_name_at(sr.symbol_name, " + ReferenceContextSql("sr") + @", sr.container_name, sr.column_number) COLLATE NOCASE
+                                     AND sql_reference_matches_target_at(sr.symbol_name, " + ReferenceContextSql("sr") + @", sr.container_name, sr.column_number, s_exact.name) = 1
                                 ))
                          ))
                   )";
@@ -2726,7 +2726,7 @@ public partial class DbReader
                   WHERE sr.symbol_name = s.name
                      OR (f.lang = 'sql' AND rf.lang = 'sql' AND (
                             (sql_resolve_reference_segment_count_at(sr.symbol_name, " + contextSql + @", sr.container_name, sr.column_number) = sql_segment_count(s.name)
-                             AND sql_resolve_reference_name_at(sr.symbol_name, " + contextSql + @", sr.container_name, sr.column_number) = sql_normalize_name(s.name) COLLATE NOCASE)
+                             AND sql_reference_matches_target_at(sr.symbol_name, " + contextSql + @", sr.container_name, sr.column_number, s.name) = 1)
                          OR (sql_segment_count(sr.symbol_name) = 1
                             AND sql_allow_leaf_fallback_at(sr.symbol_name, " + contextSql + @", sr.container_name, sr.column_number) = 1
                             AND sr.symbol_name = sql_leaf_name(s.name) COLLATE NOCASE
@@ -2736,7 +2736,7 @@ public partial class DbReader
                                     JOIN files f_exact ON f_exact.id = s_exact.file_id
                                     WHERE f_exact.lang = 'sql'
                                       AND sql_segment_count(s_exact.name) = sql_resolve_reference_segment_count_at(sr.symbol_name, " + contextSql + @", sr.container_name, sr.column_number)
-                                      AND sql_normalize_name(s_exact.name) = sql_resolve_reference_name_at(sr.symbol_name, " + contextSql + @", sr.container_name, sr.column_number) COLLATE NOCASE
+                                      AND sql_reference_matches_target_at(sr.symbol_name, " + contextSql + @", sr.container_name, sr.column_number, s_exact.name) = 1
                                 ))
                      ))
               )";

--- a/src/CodeIndex/Indexer/References/Support/SqlNameResolver.cs
+++ b/src/CodeIndex/Indexer/References/Support/SqlNameResolver.cs
@@ -5,11 +5,17 @@ namespace CodeIndex.Indexer;
 
 internal static class SqlNameResolver
 {
-    private readonly record struct SqlNameParts(string NormalizedName, string LeafName, int SegmentCount, bool HasCaseSensitiveQuote);
+    private readonly record struct SqlNameParts(
+        string NormalizedName,
+        string LeafName,
+        int SegmentCount,
+        IReadOnlyList<string> Segments,
+        IReadOnlyList<bool> CaseSensitiveSegments);
     private readonly record struct QualifiedNameMatch(
         string NormalizedName,
         int SegmentCount,
-        bool HasCaseSensitiveQuote,
+        IReadOnlyList<string> Segments,
+        IReadOnlyList<bool> CaseSensitiveSegments,
         int StartIndex,
         int EndIndexExclusive,
         int LeafStartIndex,
@@ -35,7 +41,7 @@ internal static class SqlNameResolver
 
         return TryGetQualifiedNameAtColumn(context, columnNumber, out var match)
             && match.SegmentCount == queryParts.SegmentCount
-            && NamesEqual(match.NormalizedName, queryParts.NormalizedName, match.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote);
+            && QualifiedNamesEqual(match.Segments, match.CaseSensitiveSegments, queryParts.Segments, queryParts.CaseSensitiveSegments);
     }
 
     public static bool ContextContainsQualifiedNameLikeAtColumn(string? context, string? query, int? columnNumber)
@@ -46,7 +52,7 @@ internal static class SqlNameResolver
 
         return TryGetQualifiedNameAtColumn(context, columnNumber, out var match)
             && match.SegmentCount == queryParts.SegmentCount
-            && NamesEqual(match.NormalizedName, queryParts.NormalizedName, match.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote);
+            && QualifiedNamesEqual(match.Segments, match.CaseSensitiveSegments, queryParts.Segments, queryParts.CaseSensitiveSegments);
     }
 
     public static bool ContextContainsQualifiedName(string? context, string? query)
@@ -58,7 +64,7 @@ internal static class SqlNameResolver
         foreach (var candidate in EnumerateQualifiedNameMatches(context))
         {
             if (candidate.SegmentCount == queryParts.SegmentCount
-                && NamesEqual(candidate.NormalizedName, queryParts.NormalizedName, candidate.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote))
+                && QualifiedNamesEqual(candidate.Segments, candidate.CaseSensitiveSegments, queryParts.Segments, queryParts.CaseSensitiveSegments))
             {
                 return true;
             }
@@ -115,7 +121,7 @@ internal static class SqlNameResolver
         if (leafName.Length > 0 && columnNumber.HasValue && columnNumber.Value > 0)
         {
             if (TryGetQualifiedNameAtColumn(context, columnNumber, out var match)
-                && NamesEqual(GetLeafName(match.NormalizedName), leafName, match.HasCaseSensitiveQuote || ParseParts(symbolName).HasCaseSensitiveQuote))
+                && LeafNamesEqual(match.Segments, match.CaseSensitiveSegments, ParseParts(symbolName)))
             {
                 return match.NormalizedName;
             }
@@ -176,11 +182,11 @@ internal static class SqlNameResolver
         if (resolved.Length == 0)
             return false;
 
-        var preserveCase = targetParts.HasCaseSensitiveQuote;
         if (TryGetQualifiedNameAtColumn(context, columnNumber, out var match))
-            preserveCase |= match.HasCaseSensitiveQuote;
+            return QualifiedNamesEqual(match.Segments, match.CaseSensitiveSegments, targetParts.Segments, targetParts.CaseSensitiveSegments);
 
-        return NamesEqual(resolved, targetParts.NormalizedName, preserveCase);
+        var resolvedParts = ParseParts(resolved);
+        return QualifiedNamesEqual(resolvedParts.Segments, resolvedParts.CaseSensitiveSegments, targetParts.Segments, targetParts.CaseSensitiveSegments);
     }
 
     public static bool AllowLeafFallbackAtColumn(string? symbolName, string? context, string? containerName, int? columnNumber)
@@ -192,7 +198,7 @@ internal static class SqlNameResolver
         var leafName = GetLeafName(symbolName);
         if (leafName.Length > 0
             && TryGetQualifiedNameAtColumn(context, columnNumber, out var match)
-            && NamesEqual(GetLeafName(match.NormalizedName), leafName, match.HasCaseSensitiveQuote || ParseParts(symbolName).HasCaseSensitiveQuote))
+            && LeafNamesEqual(match.Segments, match.CaseSensitiveSegments, ParseParts(symbolName)))
         {
             return false;
         }
@@ -217,11 +223,8 @@ internal static class SqlNameResolver
         if (!TryGetQualifiedNameAtColumn(context, columnNumber, out var match))
             return false;
 
-        var preserveCase = match.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote;
-        var foldedCandidate = preserveCase ? match.NormalizedName : NameFold.Fold(match.NormalizedName) ?? match.NormalizedName;
-        var foldedQuery = preserveCase ? queryParts.NormalizedName : NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
         return match.SegmentCount == queryParts.SegmentCount
-            && string.Equals(foldedCandidate, foldedQuery, StringComparison.Ordinal);
+            && QualifiedNamesEqualFolded(match.Segments, match.CaseSensitiveSegments, queryParts.Segments, queryParts.CaseSensitiveSegments);
     }
 
     public static bool ContextContainsQualifiedNameLikeFoldedAtColumn(string? context, string? query, int? columnNumber)
@@ -232,11 +235,8 @@ internal static class SqlNameResolver
         if (!TryGetQualifiedNameAtColumn(context, columnNumber, out var match))
             return false;
 
-        var preserveCase = match.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote;
-        var foldedCandidate = preserveCase ? match.NormalizedName : NameFold.Fold(match.NormalizedName) ?? match.NormalizedName;
-        var foldedQuery = preserveCase ? queryParts.NormalizedName : NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
         return match.SegmentCount == queryParts.SegmentCount
-            && string.Equals(foldedCandidate, foldedQuery, StringComparison.Ordinal);
+            && QualifiedNamesEqualFolded(match.Segments, match.CaseSensitiveSegments, queryParts.Segments, queryParts.CaseSensitiveSegments);
     }
 
     public static bool ContextContainsQualifiedNameFolded(string? context, string? query)
@@ -247,11 +247,8 @@ internal static class SqlNameResolver
 
         foreach (var candidate in EnumerateQualifiedNameMatches(context))
         {
-            var preserveCase = candidate.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote;
-            var foldedCandidate = preserveCase ? candidate.NormalizedName : NameFold.Fold(candidate.NormalizedName) ?? candidate.NormalizedName;
-            var foldedQuery = preserveCase ? queryParts.NormalizedName : NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
             if (candidate.SegmentCount == queryParts.SegmentCount
-                && string.Equals(foldedCandidate, foldedQuery, StringComparison.Ordinal))
+                && QualifiedNamesEqualFolded(candidate.Segments, candidate.CaseSensitiveSegments, queryParts.Segments, queryParts.CaseSensitiveSegments))
             {
                 return true;
             }
@@ -292,13 +289,14 @@ internal static class SqlNameResolver
     private static SqlNameParts ParseParts(string? qualifiedName)
     {
         if (string.IsNullOrWhiteSpace(qualifiedName))
-            return new SqlNameParts(string.Empty, string.Empty, 0, false);
+            return new SqlNameParts(string.Empty, string.Empty, 0, [], []);
 
         var trimmed = qualifiedName.Trim();
         var segments = new List<string>();
+        var caseSensitiveSegments = new List<bool>();
         var current = new StringBuilder();
         char quote = '\0';
-        var hasCaseSensitiveQuote = false;
+        var currentHasCaseSensitiveQuote = false;
 
         for (var i = 0; i < trimmed.Length; i++)
         {
@@ -350,26 +348,27 @@ internal static class SqlNameResolver
             if (ch is '[' or '"' or '`')
             {
                 quote = ch;
-                hasCaseSensitiveQuote |= ch == '"';
+                currentHasCaseSensitiveQuote |= ch == '"';
                 continue;
             }
 
             if (ch == '.')
             {
-                AppendNormalizedSegment(segments, current);
+                AppendNormalizedSegment(segments, caseSensitiveSegments, current, currentHasCaseSensitiveQuote);
+                currentHasCaseSensitiveQuote = false;
                 continue;
             }
 
             current.Append(ch);
         }
 
-        AppendNormalizedSegment(segments, current);
+        AppendNormalizedSegment(segments, caseSensitiveSegments, current, currentHasCaseSensitiveQuote);
         var segmentCount = segments.Count;
         if (segmentCount == 0)
-            return new SqlNameParts(string.Empty, string.Empty, 0, hasCaseSensitiveQuote);
+            return new SqlNameParts(string.Empty, string.Empty, 0, [], []);
 
         var normalized = string.Join(".", segments);
-        return new SqlNameParts(normalized, segments[^1], segmentCount, hasCaseSensitiveQuote);
+        return new SqlNameParts(normalized, segments[^1], segmentCount, segments, caseSensitiveSegments);
     }
 
     private static IEnumerable<string> EnumerateQualifiedNames(string text)
@@ -413,11 +412,14 @@ internal static class SqlNameResolver
         return containerParts.NormalizedName[..(lastDot + 1)] + normalizedSymbolName;
     }
 
-    private static void AppendNormalizedSegment(List<string> segments, StringBuilder current)
+    private static void AppendNormalizedSegment(List<string> segments, List<bool> caseSensitiveSegments, StringBuilder current, bool hasCaseSensitiveQuote)
     {
         var value = current.ToString().Trim();
         if (value.Length > 0)
+        {
             segments.Add(value);
+            caseSensitiveSegments.Add(hasCaseSensitiveQuote);
+        }
         current.Clear();
     }
 
@@ -445,10 +447,10 @@ internal static class SqlNameResolver
         match = default;
 
         var segments = new List<string>();
+        var caseSensitiveSegments = new List<bool>();
         var index = startIndex;
         var leafStartIndex = startIndex;
         var leafEndIndexExclusive = startIndex;
-        var hasCaseSensitiveQuote = false;
         while (true)
         {
             var segmentStartIndex = index;
@@ -456,7 +458,7 @@ internal static class SqlNameResolver
                 return false;
 
             segments.Add(segment);
-            hasCaseSensitiveQuote |= segmentHasCaseSensitiveQuote;
+            caseSensitiveSegments.Add(segmentHasCaseSensitiveQuote);
             leafStartIndex = segmentStartIndex;
             leafEndIndexExclusive = index;
             var scan = index;
@@ -484,7 +486,7 @@ internal static class SqlNameResolver
         if (normalizedName.Length == 0)
             return false;
 
-        match = new QualifiedNameMatch(normalizedName, segments.Count, hasCaseSensitiveQuote, startIndex, index, leafStartIndex, leafEndIndexExclusive);
+        match = new QualifiedNameMatch(normalizedName, segments.Count, segments, caseSensitiveSegments, startIndex, index, leafStartIndex, leafEndIndexExclusive);
         return true;
     }
 
@@ -597,7 +599,8 @@ internal static class SqlNameResolver
             match = new QualifiedNameMatch(
                 normalizedName,
                 i + 1,
-                matchedSegments.Any(part => part.HasCaseSensitiveQuote),
+                matchedSegments.Select(part => part.Name).ToList(),
+                matchedSegments.Select(part => part.HasCaseSensitiveQuote).ToList(),
                 startIndex,
                 segment.EndIndexExclusive,
                 segment.StartIndex,
@@ -616,6 +619,64 @@ internal static class SqlNameResolver
         => ch is '_' or '$' or '#'
            || char.IsLetterOrDigit(ch);
 
-    private static bool NamesEqual(string left, string right, bool preserveCase)
-        => string.Equals(left, right, preserveCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+    private static bool LeafNamesEqual(
+        IReadOnlyList<string> leftSegments,
+        IReadOnlyList<bool> leftCaseSensitiveSegments,
+        SqlNameParts rightParts)
+        => rightParts.SegmentCount > 0
+           && leftSegments.Count > 0
+           && SegmentsEqual(
+               leftSegments[^1],
+               leftCaseSensitiveSegments.Count > 0 && leftCaseSensitiveSegments[^1],
+               rightParts.LeafName,
+               rightParts.CaseSensitiveSegments.Count > 0 && rightParts.CaseSensitiveSegments[^1]);
+
+    private static bool QualifiedNamesEqual(
+        IReadOnlyList<string> leftSegments,
+        IReadOnlyList<bool> leftCaseSensitiveSegments,
+        IReadOnlyList<string> rightSegments,
+        IReadOnlyList<bool> rightCaseSensitiveSegments)
+    {
+        if (leftSegments.Count != rightSegments.Count)
+            return false;
+
+        for (var i = 0; i < leftSegments.Count; i++)
+        {
+            if (!SegmentsEqual(
+                    leftSegments[i],
+                    i < leftCaseSensitiveSegments.Count && leftCaseSensitiveSegments[i],
+                    rightSegments[i],
+                    i < rightCaseSensitiveSegments.Count && rightCaseSensitiveSegments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool QualifiedNamesEqualFolded(
+        IReadOnlyList<string> leftSegments,
+        IReadOnlyList<bool> leftCaseSensitiveSegments,
+        IReadOnlyList<string> rightSegments,
+        IReadOnlyList<bool> rightCaseSensitiveSegments)
+    {
+        if (leftSegments.Count != rightSegments.Count)
+            return false;
+
+        for (var i = 0; i < leftSegments.Count; i++)
+        {
+            var preserveCase = (i < leftCaseSensitiveSegments.Count && leftCaseSensitiveSegments[i])
+                || (i < rightCaseSensitiveSegments.Count && rightCaseSensitiveSegments[i]);
+            var left = preserveCase ? leftSegments[i] : NameFold.Fold(leftSegments[i]) ?? leftSegments[i];
+            var right = preserveCase ? rightSegments[i] : NameFold.Fold(rightSegments[i]) ?? rightSegments[i];
+            if (!string.Equals(left, right, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool SegmentsEqual(string left, bool leftCaseSensitive, string right, bool rightCaseSensitive)
+        => string.Equals(left, right, leftCaseSensitive || rightCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
 }

--- a/src/CodeIndex/Indexer/References/Support/SqlNameResolver.cs
+++ b/src/CodeIndex/Indexer/References/Support/SqlNameResolver.cs
@@ -5,10 +5,11 @@ namespace CodeIndex.Indexer;
 
 internal static class SqlNameResolver
 {
-    private readonly record struct SqlNameParts(string NormalizedName, string LeafName, int SegmentCount);
+    private readonly record struct SqlNameParts(string NormalizedName, string LeafName, int SegmentCount, bool HasCaseSensitiveQuote);
     private readonly record struct QualifiedNameMatch(
         string NormalizedName,
         int SegmentCount,
+        bool HasCaseSensitiveQuote,
         int StartIndex,
         int EndIndexExclusive,
         int LeafStartIndex,
@@ -34,7 +35,7 @@ internal static class SqlNameResolver
 
         return TryGetQualifiedNameAtColumn(context, columnNumber, out var match)
             && match.SegmentCount == queryParts.SegmentCount
-            && string.Equals(match.NormalizedName, queryParts.NormalizedName, StringComparison.OrdinalIgnoreCase);
+            && NamesEqual(match.NormalizedName, queryParts.NormalizedName, match.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote);
     }
 
     public static bool ContextContainsQualifiedNameLikeAtColumn(string? context, string? query, int? columnNumber)
@@ -45,7 +46,7 @@ internal static class SqlNameResolver
 
         return TryGetQualifiedNameAtColumn(context, columnNumber, out var match)
             && match.SegmentCount == queryParts.SegmentCount
-            && string.Equals(match.NormalizedName, queryParts.NormalizedName, StringComparison.OrdinalIgnoreCase);
+            && NamesEqual(match.NormalizedName, queryParts.NormalizedName, match.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote);
     }
 
     public static bool ContextContainsQualifiedName(string? context, string? query)
@@ -57,7 +58,7 @@ internal static class SqlNameResolver
         foreach (var candidate in EnumerateQualifiedNameMatches(context))
         {
             if (candidate.SegmentCount == queryParts.SegmentCount
-                && string.Equals(candidate.NormalizedName, queryParts.NormalizedName, StringComparison.OrdinalIgnoreCase))
+                && NamesEqual(candidate.NormalizedName, queryParts.NormalizedName, candidate.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote))
             {
                 return true;
             }
@@ -114,7 +115,7 @@ internal static class SqlNameResolver
         if (leafName.Length > 0 && columnNumber.HasValue && columnNumber.Value > 0)
         {
             if (TryGetQualifiedNameAtColumn(context, columnNumber, out var match)
-                && string.Equals(GetLeafName(match.NormalizedName), leafName, StringComparison.OrdinalIgnoreCase))
+                && NamesEqual(GetLeafName(match.NormalizedName), leafName, match.HasCaseSensitiveQuote || ParseParts(symbolName).HasCaseSensitiveQuote))
             {
                 return match.NormalizedName;
             }
@@ -160,6 +161,28 @@ internal static class SqlNameResolver
         return GetSegmentCount(ResolveReferenceName(symbolName, context, containerName));
     }
 
+    public static bool ReferenceMatchesTargetAtColumn(
+        string? symbolName,
+        string? context,
+        string? containerName,
+        int? columnNumber,
+        string? targetName)
+    {
+        var targetParts = ParseParts(targetName);
+        if (targetParts.NormalizedName.Length == 0)
+            return false;
+
+        var resolved = ResolveReferenceNameAtColumn(symbolName, context, containerName, columnNumber);
+        if (resolved.Length == 0)
+            return false;
+
+        var preserveCase = targetParts.HasCaseSensitiveQuote;
+        if (TryGetQualifiedNameAtColumn(context, columnNumber, out var match))
+            preserveCase |= match.HasCaseSensitiveQuote;
+
+        return NamesEqual(resolved, targetParts.NormalizedName, preserveCase);
+    }
+
     public static bool AllowLeafFallbackAtColumn(string? symbolName, string? context, string? containerName, int? columnNumber)
     {
         var normalizedSymbolName = NormalizeQualifiedName(symbolName);
@@ -169,7 +192,7 @@ internal static class SqlNameResolver
         var leafName = GetLeafName(symbolName);
         if (leafName.Length > 0
             && TryGetQualifiedNameAtColumn(context, columnNumber, out var match)
-            && string.Equals(GetLeafName(match.NormalizedName), leafName, StringComparison.OrdinalIgnoreCase))
+            && NamesEqual(GetLeafName(match.NormalizedName), leafName, match.HasCaseSensitiveQuote || ParseParts(symbolName).HasCaseSensitiveQuote))
         {
             return false;
         }
@@ -194,8 +217,9 @@ internal static class SqlNameResolver
         if (!TryGetQualifiedNameAtColumn(context, columnNumber, out var match))
             return false;
 
-        var foldedCandidate = NameFold.Fold(match.NormalizedName) ?? match.NormalizedName;
-        var foldedQuery = NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
+        var preserveCase = match.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote;
+        var foldedCandidate = preserveCase ? match.NormalizedName : NameFold.Fold(match.NormalizedName) ?? match.NormalizedName;
+        var foldedQuery = preserveCase ? queryParts.NormalizedName : NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
         return match.SegmentCount == queryParts.SegmentCount
             && string.Equals(foldedCandidate, foldedQuery, StringComparison.Ordinal);
     }
@@ -208,8 +232,9 @@ internal static class SqlNameResolver
         if (!TryGetQualifiedNameAtColumn(context, columnNumber, out var match))
             return false;
 
-        var foldedCandidate = NameFold.Fold(match.NormalizedName) ?? match.NormalizedName;
-        var foldedQuery = NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
+        var preserveCase = match.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote;
+        var foldedCandidate = preserveCase ? match.NormalizedName : NameFold.Fold(match.NormalizedName) ?? match.NormalizedName;
+        var foldedQuery = preserveCase ? queryParts.NormalizedName : NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
         return match.SegmentCount == queryParts.SegmentCount
             && string.Equals(foldedCandidate, foldedQuery, StringComparison.Ordinal);
     }
@@ -220,10 +245,11 @@ internal static class SqlNameResolver
         if (queryParts.NormalizedName.Length == 0 || queryParts.SegmentCount <= 1 || string.IsNullOrWhiteSpace(context))
             return false;
 
-        var foldedQuery = NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
         foreach (var candidate in EnumerateQualifiedNameMatches(context))
         {
-            var foldedCandidate = NameFold.Fold(candidate.NormalizedName) ?? candidate.NormalizedName;
+            var preserveCase = candidate.HasCaseSensitiveQuote || queryParts.HasCaseSensitiveQuote;
+            var foldedCandidate = preserveCase ? candidate.NormalizedName : NameFold.Fold(candidate.NormalizedName) ?? candidate.NormalizedName;
+            var foldedQuery = preserveCase ? queryParts.NormalizedName : NameFold.Fold(queryParts.NormalizedName) ?? queryParts.NormalizedName;
             if (candidate.SegmentCount == queryParts.SegmentCount
                 && string.Equals(foldedCandidate, foldedQuery, StringComparison.Ordinal))
             {
@@ -266,12 +292,13 @@ internal static class SqlNameResolver
     private static SqlNameParts ParseParts(string? qualifiedName)
     {
         if (string.IsNullOrWhiteSpace(qualifiedName))
-            return new SqlNameParts(string.Empty, string.Empty, 0);
+            return new SqlNameParts(string.Empty, string.Empty, 0, false);
 
         var trimmed = qualifiedName.Trim();
         var segments = new List<string>();
         var current = new StringBuilder();
         char quote = '\0';
+        var hasCaseSensitiveQuote = false;
 
         for (var i = 0; i < trimmed.Length; i++)
         {
@@ -323,6 +350,7 @@ internal static class SqlNameResolver
             if (ch is '[' or '"' or '`')
             {
                 quote = ch;
+                hasCaseSensitiveQuote |= ch == '"';
                 continue;
             }
 
@@ -338,10 +366,10 @@ internal static class SqlNameResolver
         AppendNormalizedSegment(segments, current);
         var segmentCount = segments.Count;
         if (segmentCount == 0)
-            return new SqlNameParts(string.Empty, string.Empty, 0);
+            return new SqlNameParts(string.Empty, string.Empty, 0, hasCaseSensitiveQuote);
 
         var normalized = string.Join(".", segments);
-        return new SqlNameParts(normalized, segments[^1], segmentCount);
+        return new SqlNameParts(normalized, segments[^1], segmentCount, hasCaseSensitiveQuote);
     }
 
     private static IEnumerable<string> EnumerateQualifiedNames(string text)
@@ -420,13 +448,15 @@ internal static class SqlNameResolver
         var index = startIndex;
         var leafStartIndex = startIndex;
         var leafEndIndexExclusive = startIndex;
+        var hasCaseSensitiveQuote = false;
         while (true)
         {
             var segmentStartIndex = index;
-            if (!TryReadQualifiedNameSegment(text, ref index, out var segment))
+            if (!TryReadQualifiedNameSegment(text, ref index, out var segment, out var segmentHasCaseSensitiveQuote))
                 return false;
 
             segments.Add(segment);
+            hasCaseSensitiveQuote |= segmentHasCaseSensitiveQuote;
             leafStartIndex = segmentStartIndex;
             leafEndIndexExclusive = index;
             var scan = index;
@@ -454,13 +484,14 @@ internal static class SqlNameResolver
         if (normalizedName.Length == 0)
             return false;
 
-        match = new QualifiedNameMatch(normalizedName, segments.Count, startIndex, index, leafStartIndex, leafEndIndexExclusive);
+        match = new QualifiedNameMatch(normalizedName, segments.Count, hasCaseSensitiveQuote, startIndex, index, leafStartIndex, leafEndIndexExclusive);
         return true;
     }
 
-    private static bool TryReadQualifiedNameSegment(string text, ref int index, out string segment)
+    private static bool TryReadQualifiedNameSegment(string text, ref int index, out string segment, out bool hasCaseSensitiveQuote)
     {
         segment = string.Empty;
+        hasCaseSensitiveQuote = false;
         if (index >= text.Length)
             return false;
 
@@ -468,6 +499,7 @@ internal static class SqlNameResolver
         var quote = text[index];
         if (quote is '[' or '"' or '`')
         {
+            hasCaseSensitiveQuote = quote == '"';
             index++;
             while (index < text.Length)
             {
@@ -528,15 +560,15 @@ internal static class SqlNameResolver
         out QualifiedNameMatch match)
     {
         match = default;
-        var segments = new List<(string Name, int StartIndex, int EndIndexExclusive)>();
+        var segments = new List<(string Name, bool HasCaseSensitiveQuote, int StartIndex, int EndIndexExclusive)>();
         var index = startIndex;
         while (true)
         {
             var segmentStartIndex = index;
-            if (!TryReadQualifiedNameSegment(text, ref index, out var segment))
+            if (!TryReadQualifiedNameSegment(text, ref index, out var segment, out var segmentHasCaseSensitiveQuote))
                 return false;
 
-            segments.Add((segment, segmentStartIndex, index));
+            segments.Add((segment, segmentHasCaseSensitiveQuote, segmentStartIndex, index));
             var scan = index;
             while (scan < text.Length && char.IsWhiteSpace(text[scan]))
                 scan++;
@@ -560,10 +592,12 @@ internal static class SqlNameResolver
             if (zeroBasedColumn < segment.StartIndex || zeroBasedColumn >= segment.EndIndexExclusive)
                 continue;
 
-            var normalizedName = string.Join(".", segments.Take(i + 1).Select(part => part.Name));
+            var matchedSegments = segments.Take(i + 1).ToList();
+            var normalizedName = string.Join(".", matchedSegments.Select(part => part.Name));
             match = new QualifiedNameMatch(
                 normalizedName,
                 i + 1,
+                matchedSegments.Any(part => part.HasCaseSensitiveQuote),
                 startIndex,
                 segment.EndIndexExclusive,
                 segment.StartIndex,
@@ -581,4 +615,7 @@ internal static class SqlNameResolver
     private static bool IsSqlIdentifierChar(char ch)
         => ch is '_' or '$' or '#'
            || char.IsLetterOrDigit(ch);
+
+    private static bool NamesEqual(string left, string right, bool preserveCase)
+        => string.Equals(left, right, preserveCase ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
 }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -25108,6 +25108,13 @@ public class ReferenceExtractorTests
         Assert.False(SqlNameResolver.ContextContainsQualifiedNameFoldedAtColumn(postgresContext, "\"sales\".\"orders\"", postgresColumn));
         Assert.True(SqlNameResolver.ReferenceMatchesTargetAtColumn("Orders", postgresContext, null, postgresColumn, "Sales.Orders"));
         Assert.False(SqlNameResolver.ReferenceMatchesTargetAtColumn("Orders", postgresContext, null, postgresColumn, "sales.orders"));
+
+        const string mixedPostgresContext = "SELECT * FROM \"Sales\".orders;";
+        const int mixedPostgresColumn = 24;
+        Assert.True(SqlNameResolver.ContextContainsQualifiedNameFoldedAtColumn(mixedPostgresContext, "\"Sales\".ORDERS", mixedPostgresColumn));
+        Assert.False(SqlNameResolver.ContextContainsQualifiedNameFoldedAtColumn(mixedPostgresContext, "\"sales\".orders", mixedPostgresColumn));
+        Assert.True(SqlNameResolver.ReferenceMatchesTargetAtColumn("orders", mixedPostgresContext, null, mixedPostgresColumn, "\"Sales\".ORDERS"));
+        Assert.False(SqlNameResolver.ReferenceMatchesTargetAtColumn("orders", mixedPostgresContext, null, mixedPostgresColumn, "\"sales\".orders"));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -25089,6 +25089,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void SqlNameResolver_QuotedQualifiedNames_PreserveDialectSpecificMatching()
+    {
+        const string mysqlContext = "SELECT * FROM `mydb`.`mytbl`;";
+        const int mysqlColumn = 28;
+        Assert.Equal("mydb.mytbl", SqlNameResolver.ResolveReferenceNameAtColumn("mytbl", mysqlContext, null, mysqlColumn));
+        Assert.True(SqlNameResolver.ContextContainsQualifiedNameFoldedAtColumn(mysqlContext, "`MYDB`.`MYTBL`", mysqlColumn));
+
+        const string tsqlContext = "SELECT * FROM [sales data].[order table];";
+        const int tsqlColumn = 35;
+        Assert.Equal("sales data.order table", SqlNameResolver.ResolveReferenceNameAtColumn("order table", tsqlContext, null, tsqlColumn));
+        Assert.True(SqlNameResolver.ContextContainsQualifiedNameFoldedAtColumn(tsqlContext, "[SALES DATA].[ORDER TABLE]", tsqlColumn));
+
+        const string postgresContext = "SELECT * FROM \"Sales\".\"Orders\";";
+        const int postgresColumn = 24;
+        Assert.Equal("Sales.Orders", SqlNameResolver.ResolveReferenceNameAtColumn("Orders", postgresContext, null, postgresColumn));
+        Assert.True(SqlNameResolver.ContextContainsQualifiedNameFoldedAtColumn(postgresContext, "\"Sales\".\"Orders\"", postgresColumn));
+        Assert.False(SqlNameResolver.ContextContainsQualifiedNameFoldedAtColumn(postgresContext, "\"sales\".\"orders\"", postgresColumn));
+        Assert.True(SqlNameResolver.ReferenceMatchesTargetAtColumn("Orders", postgresContext, null, postgresColumn, "Sales.Orders"));
+        Assert.False(SqlNameResolver.ReferenceMatchesTargetAtColumn("Orders", postgresContext, null, postgresColumn, "sales.orders"));
+    }
+
+    [Fact]
     public void Extract_SqlHashCommentedCall_DoesNotEmitReference()
     {
         // MySQL / MariaDB accept `#` as a line comment in addition to ANSI `--`. The SQL-aware


### PR DESCRIPTION
## Summary
- Preserve case-sensitive matching for PostgreSQL double-quoted SQL qualified names while keeping MySQL backtick and T-SQL bracket matching case-insensitive.
- Use the same dialect-aware resolver path for SQL unused-symbol exact matching.
- Add regression coverage and a bilingual changelog fragment.

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_Sql|FullyQualifiedName~ReferenceExtractorTests.Extract_SQL|FullyQualifiedName~ReferenceExtractorTests.SqlNameResolver|FullyQualifiedName~SymbolExtractorTests.Extract_RustTraitAssociatedTypeDefaults_RecordsPropertySymbols"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.SqlQualifiedNames|FullyQualifiedName~ReferenceExtractorTests.SqlNameResolver_QuotedQualifiedNames"
- dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false
- dotnet run --project tools/CodeIndex.Changelog -- check
- codex adversarial review: No blocking/actionable issues found.

## Documentation / Changelog
- Added changelog fragment: changelog.d/unreleased/2101.fixed.md
- No README/guide changes required; this is a bug fix to existing SQL matching behavior.

## Follow-up candidates
- None.

Fixes #2101