### PR TITLE
Fix CSS media feature symbol extraction

### DIFF
--- a/changelog.d/unreleased/2105.fixed.md
+++ b/changelog.d/unreleased/2105.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2105
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Css.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **CSS media features are now searchable as symbols (#2105)** — `@media` feature names such as `min-width`, `prefers-color-scheme`, `orientation`, range-style `width`, and custom media feature names are indexed as `property` symbols while literal values and boolean operators are skipped.
+
+## 日本語
+
+- **CSS media feature を symbol として検索できるようにしました (#2105)** — `@media` 内の `min-width`、`prefers-color-scheme`、`orientation`、range 形式の `width`、custom media feature 名を `property` symbol として index し、値リテラルや boolean operator は除外します。

--- a/changelog.d/unreleased/2611.fixed.md
+++ b/changelog.d/unreleased/2611.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2611
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Rust associated type defaults are indexed under trait containers again (#2611)** — the post-processing pass now handles Rust traits stored as `protocol` symbols, so defaults such as `type Output = ();` produce property symbols with the correct trait container.
+
+## 日本語
+
+- **Rust associated type default を trait container 配下で再び index するようにしました (#2611)** — 後処理が `protocol` symbol として保存された Rust trait も対象にするようになり、`type Output = ();` のような default が正しい trait container を持つ property symbol になります。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Css.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Css.cs
@@ -276,6 +276,7 @@ public static partial class SymbolExtractor
 
     private static readonly Regex CssFontFaceDeclarationRegex = new(@"(?:^|[;{])\s*font-family\s*:", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     private static readonly Regex CssInlineCustomPropertyRegex = new(@"(?<name>--[\w-]+)\s*:", RegexOptions.Compiled);
+    private static readonly Regex CssMediaFeatureNameRegex = new(@"^\s*(?:not\s+)?(?<name>--[\w-]+|[A-Za-z_][\w-]*)(?=\s*(?::|[<>]=?|=|$))|[<>]=?\s*(?<name>--[\w-]+|[A-Za-z_][\w-]*)(?=\s*(?:[<>]=?|$))", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     private static string ResolveCssSymbolName(string matchLine, string name, string[] lines, int startIndex, int endLine)
     {
@@ -285,6 +286,79 @@ public static partial class SymbolExtractor
         return TryGetCssFontFaceFamilyName(lines, startIndex, endLine, out var fontFamily)
             ? fontFamily
             : string.Empty;
+    }
+
+    private static void TryAddCssMediaFeatureSymbols(
+        long fileId,
+        string rawLine,
+        string maskedLine,
+        int lineIndex,
+        List<SymbolRecord> symbols,
+        HashSet<string>? cssSeenSymbols)
+    {
+        var trimmedMaskedLine = maskedLine.TrimStart();
+        if (!trimmedMaskedLine.StartsWith("@media", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var blockStart = maskedLine.IndexOf('{');
+        if (blockStart < 0)
+            blockStart = maskedLine.Length;
+
+        var query = maskedLine[..blockStart];
+        for (var index = 0; index < query.Length; index++)
+        {
+            if (query[index] != '(')
+                continue;
+
+            var featureStart = index + 1;
+            var depth = 1;
+            index++;
+            while (index < query.Length && depth > 0)
+            {
+                if (query[index] == '(')
+                    depth++;
+                else if (query[index] == ')')
+                    depth--;
+
+                index++;
+            }
+
+            if (depth != 0)
+                break;
+
+            var featureText = query[featureStart..(index - 1)];
+            if (string.IsNullOrWhiteSpace(featureText))
+                continue;
+
+            var match = CssMediaFeatureNameRegex.Match(featureText);
+            if (match.Success)
+            {
+                var name = match.Groups["name"].Value;
+                if (string.Equals(name, "and", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "or", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(name, "not", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var featureColumn = featureStart + match.Groups["name"].Index;
+                AddSymbolRecord(
+                    symbols,
+                    cssSeenSymbols,
+                    lineIndex + 1,
+                    new SymbolRecord
+                    {
+                        FileId = fileId,
+                        Kind = "property",
+                        Name = name,
+                        Line = lineIndex + 1,
+                        StartLine = lineIndex + 1,
+                        StartColumn = featureColumn,
+                        EndLine = lineIndex + 1,
+                        Signature = rawLine.Trim(),
+                    });
+            }
+        }
     }
 
     private static bool TryGetCssFontFaceFamilyName(string[] lines, int startIndex, int endLine, out string fontFamily)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -10052,7 +10052,7 @@ public static partial class SymbolExtractor
     private static void ExtractRustAssociatedTypeDefaultSymbols(long fileId, string[] lines, string[] structuralLines, List<SymbolRecord> symbols)
     {
         var traits = symbols
-            .Where(symbol => symbol.Kind == "interface"
+            .Where(symbol => symbol.Kind is "interface" or "protocol"
                 && symbol.BodyStartLine is > 0
                 && symbol.BodyEndLine is > 0)
             .OrderBy(symbol => symbol.StartLine)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3461,6 +3461,20 @@ public static partial class SymbolExtractor
                     }
 
                     if (lang == "css"
+                        && pattern.Kind == "namespace"
+                        && pattern.BodyStyle == BodyStyle.Brace
+                        && cssScannerLines != null)
+                    {
+                        TryAddCssMediaFeatureSymbols(
+                            fileId,
+                            line,
+                            cssScannerLines[i],
+                            i,
+                            symbols,
+                            cssSeenSymbols);
+                    }
+
+                    if (lang == "css"
                         && pattern.Kind == "class"
                         && pattern.BodyStyle == BodyStyle.Brace
                         && cssScannerLines != null)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -21470,6 +21470,37 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSS_CapturesMediaFeatureNamesButNotValuesOrOperators()
+    {
+        var content = """
+            @media (min-width: 768px) and (prefers-color-scheme: dark), not screen and (orientation: landscape) {
+              .responsive {
+                color: red;
+              }
+            }
+
+            @supports (display: grid) {
+              @media (width >= 40rem) and (--narrow) {
+                .nested-media {
+                  display: grid;
+                }
+              }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "min-width");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "prefers-color-scheme");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "orientation");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "width");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "--narrow");
+        Assert.DoesNotContain(symbols, s =>
+            s.Kind == "property"
+            && s.Name is "768px" or "dark" or "landscape" or "and" or "not" or "or");
+    }
+
+    [Fact]
     public void Extract_CSS_DoesNotLeakNestedSelectorsAfterSameLineGroupingAndQualifiedRule()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14382,13 +14382,13 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, s =>
             s.Kind == "property"
             && s.Name == "Output"
-            && s.ContainerKind == "interface"
+            && s.ContainerKind == "protocol"
             && s.ContainerName == "Builder"
             && s.ReturnType == "()");
         Assert.Contains(symbols, s =>
             s.Kind == "property"
             && s.Name == "Error"
-            && s.ContainerKind == "interface"
+            && s.ContainerKind == "protocol"
             && s.ContainerName == "Builder"
             && s.ReturnType == "String");
         Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == "Pending");


### PR DESCRIPTION
## Summary
- index CSS @media feature names as property symbols
- skip media feature literal values and boolean operators
- add CSS symbol extraction coverage
- fix Rust associated type default extraction for trait containers stored as protocol symbols

## Documentation / changelog
- Added changelog fragment: changelog.d/unreleased/2105.fixed.md
- Added changelog fragment: changelog.d/unreleased/2611.fixed.md

Fixes #2105
Fixes #2611

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSS_CapturesMediaFeatureNamesButNotValuesOrOperators"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --filter "FullyQualifiedName~SymbolExtractorTests.Extract_RustTraitAssociatedTypeDefaults_RecordsPropertySymbols"
- codex adversarial review: No blocking/actionable issues found.

## Follow-up candidates
- None.

## Notes
- The Rust fix addresses the Build and Test net9.0 CI failure observed on this PR after issue #2611 was filed.