### PR TITLE
Fix C# polymorphic impact traversal

### DIFF
--- a/changelog.d/unreleased/2060.fixed.md
+++ b/changelog.d/unreleased/2060.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2060
+affected:
+  - src/CodeIndex/Database/DbReader.CSharpResolution.cs
+  - src/CodeIndex/Database/DbReader.GraphQueries.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **C# caller and impact queries now follow polymorphic dispatch to concrete implementations (#2060)** — exact graph traversal expands implementation method queries through inherited abstract base methods and implemented interface methods, so callers of the static base/interface target are reachable from the concrete override.
+
+## 日本語
+
+- **C# の callers / impact が polymorphic dispatch を具象実装まで追跡するようになりました (#2060)** — exact graph traversal で実装メソッドの検索時に継承元の abstract base method と実装 interface method へ展開し、静的な base / interface target を呼ぶ caller が具象 override から到達可能になります。

--- a/src/CodeIndex/Database/DbReader.CSharpResolution.cs
+++ b/src/CodeIndex/Database/DbReader.CSharpResolution.cs
@@ -158,6 +158,17 @@ public partial class DbReader
         return inheritedContainingTypes;
     }
 
+    private HashSet<string> GetPolymorphicCSharpContainingTypes(CSharpContainingTypeScope containingTypeScope)
+    {
+        var inheritedContainingTypes = new HashSet<string>(StringComparer.Ordinal);
+        var visited = new HashSet<string>(StringComparer.Ordinal)
+        {
+            containingTypeScope.QualifiedName,
+        };
+        CollectPolymorphicCSharpContainingTypes(containingTypeScope, inheritedContainingTypes, visited);
+        return inheritedContainingTypes;
+    }
+
     private List<string> GetCSharpPolymorphicDispatchSymbolNames(string symbolName)
     {
         var memberName = SqlNameResolver.GetLeafName(symbolName);
@@ -204,7 +215,7 @@ public partial class DbReader
             if (containingTypeScope == null)
                 continue;
 
-            foreach (var inheritedContainingType in GetInheritedCSharpContainingTypes(containingTypeScope))
+            foreach (var inheritedContainingType in GetPolymorphicCSharpContainingTypes(containingTypeScope))
             {
                 var inheritedMemberName = CombineDbQualifiedName(inheritedContainingType, memberName);
                 if (!string.IsNullOrWhiteSpace(inheritedMemberName))
@@ -276,13 +287,23 @@ public partial class DbReader
 
     private void CollectInheritedCSharpContainingTypes(CSharpContainingTypeScope containingTypeScope, HashSet<string> inheritedContainingTypes, HashSet<string> visited)
     {
+        var directBaseScope = ResolveDirectCSharpBaseContainingTypeScope(containingTypeScope);
+        if (directBaseScope == null || !visited.Add(directBaseScope.QualifiedName))
+            return;
+
+        inheritedContainingTypes.Add(directBaseScope.QualifiedName);
+        CollectInheritedCSharpContainingTypes(directBaseScope, inheritedContainingTypes, visited);
+    }
+
+    private void CollectPolymorphicCSharpContainingTypes(CSharpContainingTypeScope containingTypeScope, HashSet<string> inheritedContainingTypes, HashSet<string> visited)
+    {
         foreach (var inheritedScope in ResolveDirectCSharpInheritedContainingTypeScopes(containingTypeScope))
         {
             if (!visited.Add(inheritedScope.QualifiedName))
                 continue;
 
             inheritedContainingTypes.Add(inheritedScope.QualifiedName);
-            CollectInheritedCSharpContainingTypes(inheritedScope, inheritedContainingTypes, visited);
+            CollectPolymorphicCSharpContainingTypes(inheritedScope, inheritedContainingTypes, visited);
         }
     }
 

--- a/src/CodeIndex/Database/DbReader.CSharpResolution.cs
+++ b/src/CodeIndex/Database/DbReader.CSharpResolution.cs
@@ -158,14 +158,167 @@ public partial class DbReader
         return inheritedContainingTypes;
     }
 
-    private void CollectInheritedCSharpContainingTypes(CSharpContainingTypeScope containingTypeScope, HashSet<string> inheritedContainingTypes, HashSet<string> visited)
+    private List<string> GetCSharpPolymorphicDispatchSymbolNames(string symbolName)
     {
-        var directBaseScope = ResolveDirectCSharpBaseContainingTypeScope(containingTypeScope);
-        if (directBaseScope == null || !visited.Add(directBaseScope.QualifiedName))
+        var memberName = SqlNameResolver.GetLeafName(symbolName);
+        if (string.IsNullOrWhiteSpace(memberName))
+            return [];
+
+        var containingTypeNames = new List<string>();
+        var lastDot = symbolName.LastIndexOf('.');
+        var hasExplicitContainingType = lastDot > 0;
+        if (hasExplicitContainingType)
+        {
+            var explicitContainingTypeName = symbolName[..lastDot];
+            containingTypeNames.Add(explicitContainingTypeName);
+        }
+        else
+        {
+            using var cmd = _conn.CreateCommand();
+            cmd.CommandText = @"
+                SELECT s.container_qualified_name
+                FROM symbols s
+                JOIN files f ON s.file_id = f.id
+                WHERE f.lang = 'csharp'
+                  AND s.kind IN ('function', 'property')
+                  AND s.container_qualified_name IS NOT NULL
+                  AND s.container_qualified_name != ''
+                  AND s.name = @memberName COLLATE NOCASE
+                GROUP BY s.container_qualified_name";
+            cmd.Parameters.AddWithValue("@memberName", memberName);
+
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
+                containingTypeNames.Add(reader.GetString(0));
+        }
+
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var containingTypeName in containingTypeNames)
+        {
+            AddCSharpBaseListDispatchNames(containingTypeName, memberName, names);
+        }
+
+        foreach (var containingTypeName in containingTypeNames)
+        {
+            var containingTypeScope = GetCSharpContainingTypeScope(containingTypeName);
+            if (containingTypeScope == null)
+                continue;
+
+            foreach (var inheritedContainingType in GetInheritedCSharpContainingTypes(containingTypeScope))
+            {
+                var inheritedMemberName = CombineDbQualifiedName(inheritedContainingType, memberName);
+                if (!string.IsNullOrWhiteSpace(inheritedMemberName))
+                    names.Add(inheritedMemberName);
+                if (!hasExplicitContainingType)
+                    names.Add(memberName);
+            }
+        }
+
+        return names.ToList();
+    }
+
+    private void AddCSharpBaseListDispatchNames(string containingTypeName, string memberName, HashSet<string> names)
+    {
+        var signature = GetCSharpContainingTypeScope(containingTypeName)?.Signature;
+        if (!string.IsNullOrWhiteSpace(signature))
+        {
+            AddCSharpBaseListDispatchNamesFromSignature(containingTypeName, memberName, signature, names);
+            return;
+        }
+
+        var shortTypeName = GetLastQualifiedSegment(containingTypeName);
+        if (string.IsNullOrWhiteSpace(shortTypeName))
             return;
 
-        inheritedContainingTypes.Add(directBaseScope.QualifiedName);
-        CollectInheritedCSharpContainingTypes(directBaseScope, inheritedContainingTypes, visited);
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT s.signature
+            FROM symbols s
+            JOIN files f ON s.file_id = f.id
+            WHERE f.lang = 'csharp'
+              AND s.kind IN ('class', 'struct', 'interface')
+              AND (s.name = @shortTypeName COLLATE NOCASE OR s.name = @containingTypeName COLLATE NOCASE)
+            LIMIT 1";
+        cmd.Parameters.AddWithValue("@shortTypeName", shortTypeName);
+        cmd.Parameters.AddWithValue("@containingTypeName", containingTypeName);
+
+        signature = cmd.ExecuteScalar() as string;
+        if (string.IsNullOrWhiteSpace(signature))
+            return;
+
+        AddCSharpBaseListDispatchNamesFromSignature(containingTypeName, memberName, signature, names);
+    }
+
+    private static void AddCSharpBaseListDispatchNamesFromSignature(string containingTypeName, string memberName, string signature, HashSet<string> names)
+    {
+        var namespacePrefix = string.Empty;
+        var lastDot = containingTypeName.LastIndexOf('.');
+        if (lastDot > 0)
+            namespacePrefix = containingTypeName[..lastDot];
+
+        foreach (var baseTypeReference in ParseCSharpBaseTypeReferences(signature))
+        {
+            var normalizedBase = NormalizeCSharpBaseTypeReference(baseTypeReference);
+            if (string.IsNullOrWhiteSpace(normalizedBase))
+                continue;
+
+            var inheritedMemberName = CombineDbQualifiedName(normalizedBase, memberName);
+            if (!string.IsNullOrWhiteSpace(inheritedMemberName))
+                names.Add(inheritedMemberName);
+            if (!string.IsNullOrWhiteSpace(namespacePrefix) && !SqlNameResolver.HasQualifier(normalizedBase))
+            {
+                inheritedMemberName = CombineDbQualifiedName(CombineDbQualifiedName(namespacePrefix, normalizedBase), memberName);
+                if (!string.IsNullOrWhiteSpace(inheritedMemberName))
+                    names.Add(inheritedMemberName);
+            }
+        }
+    }
+
+    private void CollectInheritedCSharpContainingTypes(CSharpContainingTypeScope containingTypeScope, HashSet<string> inheritedContainingTypes, HashSet<string> visited)
+    {
+        foreach (var inheritedScope in ResolveDirectCSharpInheritedContainingTypeScopes(containingTypeScope))
+        {
+            if (!visited.Add(inheritedScope.QualifiedName))
+                continue;
+
+            inheritedContainingTypes.Add(inheritedScope.QualifiedName);
+            CollectInheritedCSharpContainingTypes(inheritedScope, inheritedContainingTypes, visited);
+        }
+    }
+
+    private List<CSharpContainingTypeScope> ResolveDirectCSharpInheritedContainingTypeScopes(CSharpContainingTypeScope containingTypeScope)
+    {
+        if (containingTypeScope.Kind is not ("class" or "struct" or "interface"))
+            return [];
+
+        var baseTypeReferences = ParseCSharpBaseTypeReferences(containingTypeScope.Signature);
+        if (baseTypeReferences.Count == 0)
+            return [];
+
+        var scopes = new List<CSharpContainingTypeScope>();
+        foreach (var baseTypeReference in baseTypeReferences)
+        {
+            var inheritedQualifiedName = ResolveScopedCSharpContainingTypeQualifiedName(
+                containingTypeScope.Path,
+                containingTypeScope.DeclarationLine,
+                baseTypeReference);
+            if (string.IsNullOrWhiteSpace(inheritedQualifiedName))
+                continue;
+
+            var inheritedScope = GetCSharpContainingTypeScope(inheritedQualifiedName);
+            if (inheritedScope == null)
+                continue;
+            if (containingTypeScope.Kind == "class" && inheritedScope.Kind is not ("class" or "interface"))
+                continue;
+            if (containingTypeScope.Kind == "struct" && inheritedScope.Kind != "interface")
+                continue;
+            if (containingTypeScope.Kind == "interface" && inheritedScope.Kind != "interface")
+                continue;
+
+            scopes.Add(inheritedScope);
+        }
+
+        return scopes;
     }
 
     private CSharpContainingTypeScope? GetCSharpContainingTypeScope(string qualifiedName)
@@ -652,8 +805,14 @@ public partial class DbReader
 
     private static string? ParseCSharpBaseTypeReference(string? signature)
     {
+        var references = ParseCSharpBaseTypeReferences(signature);
+        return references.Count == 0 ? null : references[0];
+    }
+
+    private static List<string> ParseCSharpBaseTypeReferences(string? signature)
+    {
         if (string.IsNullOrWhiteSpace(signature))
-            return null;
+            return [];
 
         var text = signature.TrimEnd();
         if (text.EndsWith("{", StringComparison.Ordinal))
@@ -661,15 +820,22 @@ public partial class DbReader
 
         var colonIndex = FindCSharpBaseListColonIndex(text);
         if (colonIndex < 0)
-            return null;
+            return [];
 
         var baseList = text[(colonIndex + 1)..];
         var whereIndex = baseList.IndexOf(" where ", StringComparison.Ordinal);
         if (whereIndex >= 0)
             baseList = baseList[..whereIndex];
 
-        var firstEntry = TakeFirstCSharpBaseListEntry(baseList).Trim();
-        return firstEntry.Length == 0 ? null : firstEntry;
+        var entries = new List<string>();
+        foreach (var entry in EnumerateCSharpBaseListEntries(baseList))
+        {
+            var trimmed = entry.Trim();
+            if (trimmed.Length > 0)
+                entries.Add(trimmed);
+        }
+
+        return entries;
     }
 
     private static int FindCSharpBaseListColonIndex(string signature)
@@ -714,9 +880,18 @@ public partial class DbReader
 
     private static string TakeFirstCSharpBaseListEntry(string baseList)
     {
+        foreach (var entry in EnumerateCSharpBaseListEntries(baseList))
+            return entry;
+
+        return baseList;
+    }
+
+    private static IEnumerable<string> EnumerateCSharpBaseListEntries(string baseList)
+    {
         var angleDepth = 0;
         var parenDepth = 0;
         var squareDepth = 0;
+        var start = 0;
         for (var i = 0; i < baseList.Length; i++)
         {
             switch (baseList[i])
@@ -744,12 +919,15 @@ public partial class DbReader
                     break;
                 case ',':
                     if (angleDepth == 0 && parenDepth == 0 && squareDepth == 0)
-                        return baseList[..i];
+                    {
+                        yield return baseList[start..i];
+                        start = i + 1;
+                    }
                     break;
             }
         }
 
-        return baseList;
+        yield return baseList[start..];
     }
 
     private static string NormalizeCSharpBaseTypeReference(string typeReference)

--- a/src/CodeIndex/Database/DbReader.GraphQueries.cs
+++ b/src/CodeIndex/Database/DbReader.GraphQueries.cs
@@ -798,17 +798,25 @@ public partial class DbReader
         // caller 側も leaf `--exact` と同じく FoldReady なら folded equality、legacy DB では
         // `COLLATE NOCASE` fallback。definition と caller 行の casing 差もここで吸収する。
         var allowSqlLeafFallback = !SqlNameResolver.HasQualifier(symbolName);
+        var polymorphicCSharpSymbolNames = lang is null or "csharp"
+            ? GetCSharpPolymorphicDispatchSymbolNames(symbolName)
+            : [];
+        var polymorphicNameCondition = polymorphicCSharpSymbolNames.Count == 0
+            ? string.Empty
+            : _foldReady
+                ? " OR (f.lang = 'csharp' AND r.symbol_name_folded IN (" + string.Join(", ", polymorphicCSharpSymbolNames.Select((_, i) => $"@polymorphicSymbolNameFolded{i}")) + "))"
+                : " OR (f.lang = 'csharp' AND r.symbol_name COLLATE NOCASE IN (" + string.Join(", ", polymorphicCSharpSymbolNames.Select((_, i) => $"@polymorphicSymbolName{i}")) + "))";
         var nameCondition = _foldReady
             ? allowSqlLeafFallback
                 ? @"
-              AND (r.symbol_name_folded = @symbolNameFolded OR (f.lang = 'sql' AND r.symbol_name_folded = @symbolNameLeafFolded))"
+              AND (r.symbol_name_folded = @symbolNameFolded OR (f.lang = 'sql' AND r.symbol_name_folded = @symbolNameLeafFolded)" + polymorphicNameCondition + ")"
                 : @"
-              AND (((f.lang = 'sql') AND sql_context_has_name_folded_at(" + contextSql + @", @symbolName, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name_folded = @symbolNameFolded))"
+              AND (((f.lang = 'sql') AND sql_context_has_name_folded_at(" + contextSql + @", @symbolName, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name_folded = @symbolNameFolded)" + polymorphicNameCondition + ")"
             : allowSqlLeafFallback
                 ? @"
-              AND (r.symbol_name = @symbolName COLLATE NOCASE OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@symbolName) COLLATE NOCASE))"
+              AND (r.symbol_name = @symbolName COLLATE NOCASE OR (f.lang = 'sql' AND r.symbol_name = sql_leaf_name(@symbolName) COLLATE NOCASE)" + polymorphicNameCondition + ")"
                 : @"
-              AND (((f.lang = 'sql') AND sql_context_has_name_at(" + contextSql + @", @symbolName, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name = @symbolName COLLATE NOCASE))";
+              AND (((f.lang = 'sql') AND sql_context_has_name_at(" + contextSql + @", @symbolName, r.column_number) = 1) OR ((f.lang != 'sql') AND r.symbol_name = @symbolName COLLATE NOCASE)" + polymorphicNameCondition + ")";
 
         // impact BFS must share the call-graph contract with `callers`/`callees`/`hotspots`,
         // so event subscriptions (`Click += OnClick`) also participate in the transitive
@@ -848,6 +856,13 @@ public partial class DbReader
         cmd.Parameters.AddWithValue("@symbolNameLeafFolded", NameFold.Fold(SqlNameResolver.GetLeafName(symbolName)) ?? SqlNameResolver.GetLeafName(symbolName));
         if (_foldReady)
             cmd.Parameters.AddWithValue("@symbolNameFolded", NameFold.Fold(symbolName) ?? symbolName);
+        for (var i = 0; i < polymorphicCSharpSymbolNames.Count; i++)
+        {
+            if (_foldReady)
+                cmd.Parameters.AddWithValue($"@polymorphicSymbolNameFolded{i}", NameFold.Fold(polymorphicCSharpSymbolNames[i]) ?? polymorphicCSharpSymbolNames[i]);
+            else
+                cmd.Parameters.AddWithValue($"@polymorphicSymbolName{i}", polymorphicCSharpSymbolNames[i]);
+        }
         if (lang != null)
             cmd.Parameters.AddWithValue("@lang", lang);
         AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -405,6 +405,18 @@ public class DbReaderTests : IDisposable
         _writer.InsertReferences(references);
     }
 
+    private void InsertManualReferences(string path, IReadOnlyList<ReferenceRecord> references)
+    {
+        using var cmd = _db.Connection.CreateCommand();
+        cmd.CommandText = "SELECT id FROM files WHERE path = @path";
+        cmd.Parameters.AddWithValue("@path", path);
+        var fileId = (long)cmd.ExecuteScalar()!;
+        foreach (var reference in references)
+            reference.FileId = fileId;
+
+        _writer.InsertReferences(references);
+    }
+
     private void InsertManualReference(string path, string lang, string? containerKind, string? containerName, string target, string kind)
     {
         var fileId = _writer.UpsertFile(new FileRecord
@@ -2876,6 +2888,203 @@ public class DbReaderTests : IDisposable
         Assert.Equal("Run", caller.CalleeName);
         Assert.Equal("call", caller.ReferenceKind);
         Assert.Equal(1, caller.ReferenceCount);
+    }
+
+    [Fact]
+    public void GetTransitiveCallers_CSharpExact_MapsInterfaceDispatchToConcreteImplementation()
+    {
+        InsertIndexedFile("src/PolymorphicDispatch.cs", "csharp",
+            """
+            namespace Demo;
+
+            public interface IWorker
+            {
+                void Execute();
+            }
+
+            public sealed class Worker : IWorker
+            {
+                public void Execute() { }
+            }
+
+            public sealed class Coordinator
+            {
+                public void Run(IWorker worker)
+                {
+                    worker.Execute();
+                }
+            }
+            """);
+        InsertManualReferences("src/PolymorphicDispatch.cs",
+        [
+            new ReferenceRecord
+            {
+                SymbolName = "Demo.IWorker.Execute",
+                ReferenceKind = "call",
+                Line = 16,
+                Column = 16,
+                Context = "worker.Execute();",
+                ContainerKind = "function",
+                ContainerName = "Run",
+            },
+        ]);
+
+        var impact = _reader.GetTransitiveCallers("Demo.Worker.Execute", maxDepth: 2, lang: "csharp", pathPatterns: ["PolymorphicDispatch.cs"]);
+
+        var caller = Assert.Single(impact.Results);
+        Assert.Equal("Run", caller.CallerName);
+        Assert.Equal(1, caller.Depth);
+    }
+
+    [Fact]
+    public void GetTransitiveCallers_CSharpExact_FollowsAbstractBaseDispatchToConcreteOverride()
+    {
+        InsertIndexedFile("src/AbstractDispatch.cs", "csharp",
+            """
+            namespace Demo;
+
+            public abstract class BaseJob
+            {
+                public abstract void Execute();
+            }
+
+            public sealed class Job : BaseJob
+            {
+                public override void Execute() { }
+            }
+
+            public sealed class Scheduler
+            {
+                public void Schedule(BaseJob job)
+                {
+                    job.Execute();
+                }
+            }
+            """);
+        InsertManualReferences("src/AbstractDispatch.cs",
+        [
+            new ReferenceRecord
+            {
+                SymbolName = "Demo.BaseJob.Execute",
+                ReferenceKind = "call",
+                Line = 16,
+                Column = 13,
+                Context = "job.Execute();",
+                ContainerKind = "function",
+                ContainerName = "Schedule",
+            },
+        ]);
+
+        var impact = _reader.GetTransitiveCallers("Demo.Job.Execute", maxDepth: 2, lang: "csharp", pathPatterns: ["AbstractDispatch.cs"]);
+
+        var caller = Assert.Single(impact.Results);
+        Assert.Equal("Schedule", caller.CallerName);
+        Assert.Equal(1, caller.Depth);
+    }
+
+    [Fact]
+    public void GetTransitiveCallers_CSharpExact_DoesNotMixUnrelatedSameNameHierarchies()
+    {
+        InsertIndexedFile("src/UnrelatedDispatch.cs", "csharp",
+            """
+            namespace Demo;
+
+            public interface IWorker
+            {
+                void Execute();
+            }
+
+            public sealed class Worker : IWorker
+            {
+                public void Execute() { }
+            }
+
+            public interface IOtherWorker
+            {
+                void Execute();
+            }
+
+            public sealed class OtherWorker : IOtherWorker
+            {
+                public void Execute() { }
+            }
+
+            public sealed class Coordinator
+            {
+                public void RunOther(IOtherWorker worker)
+                {
+                    worker.Execute();
+                }
+            }
+            """);
+        InsertManualReferences("src/UnrelatedDispatch.cs",
+        [
+            new ReferenceRecord
+            {
+                SymbolName = "Demo.IOtherWorker.Execute",
+                ReferenceKind = "call",
+                Line = 24,
+                Column = 16,
+                Context = "worker.Execute();",
+                ContainerKind = "function",
+                ContainerName = "RunOther",
+            },
+        ]);
+
+        var impact = _reader.GetTransitiveCallers("Demo.Worker.Execute", maxDepth: 2, lang: "csharp", pathPatterns: ["UnrelatedDispatch.cs"]);
+
+        Assert.Empty(impact.Results);
+    }
+
+    [Fact]
+    public void GetTransitiveCallers_CSharpExact_DoesNotUseBaseListFromDuplicateShortTypeName()
+    {
+        InsertIndexedFile("src/DuplicateShortTypeDispatch.cs", "csharp",
+            """
+            namespace Other;
+
+            public interface IWorker
+            {
+                void Execute();
+            }
+
+            public sealed class Worker : IWorker
+            {
+                public void Execute() { }
+            }
+
+            public sealed class Coordinator
+            {
+                public void Run(IWorker worker)
+                {
+                    worker.Execute();
+                }
+            }
+
+            namespace Demo;
+
+            public sealed class Worker
+            {
+                public void Execute() { }
+            }
+            """);
+        InsertManualReferences("src/DuplicateShortTypeDispatch.cs",
+        [
+            new ReferenceRecord
+            {
+                SymbolName = "Other.IWorker.Execute",
+                ReferenceKind = "call",
+                Line = 16,
+                Column = 16,
+                Context = "worker.Execute();",
+                ContainerKind = "function",
+                ContainerName = "Run",
+            },
+        ]);
+
+        var impact = _reader.GetTransitiveCallers("Demo.Worker.Execute", maxDepth: 2, lang: "csharp", pathPatterns: ["DuplicateShortTypeDispatch.cs"]);
+
+        Assert.Empty(impact.Results);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Expand C# impact traversal so concrete implementation queries also match calls recorded against inherited abstract/interface method targets.
- Include implemented interfaces when walking C# containing type inheritance.
- Add regression coverage for interface dispatch, abstract base dispatch, same-name hierarchy false positives, and duplicate short type names.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.GetTransitiveCallers_CSharpExact_MapsInterfaceDispatchToConcreteImplementation|FullyQualifiedName~DbReaderTests.GetTransitiveCallers_CSharpExact_FollowsAbstractBaseDispatchToConcreteOverride|FullyQualifiedName~DbReaderTests.GetTransitiveCallers_CSharpExact_DoesNotMixUnrelatedSameNameHierarchies|FullyQualifiedName~DbReaderTests.GetTransitiveCallers_CSharpExact_DoesNotUseBaseListFromDuplicateShortTypeName"`
- Adversarial review: two actionable findings found and addressed.

## Documentation and Changelog

- Added `changelog.d/unreleased/2060.fixed.md`.
- No README/guide updates were needed because this fixes existing graph traversal behavior without changing CLI flags or documented command contracts.

Fixes #2060

## Follow-up Candidates

- None.
