### PR TITLE
Fix console output synchronization

### DIFF
--- a/changelog.d/unreleased/1734.fixed.md
+++ b/changelog.d/unreleased/1734.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1734
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Program.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+---
+
+## English
+
+- **Console output is synchronized before spinner/progress rendering (#1734)** — `cdidx` now wraps stdout and stderr with synchronized writers at startup so spinner frames and main-thread progress lines are emitted as whole writes instead of interleaving characters.
+
+## 日本語
+
+- **スピナー / 進捗表示の前にコンソール出力を同期するようになりました (#1734)** — `cdidx` は起動時に stdout / stderr を同期 writer で包むため、スピナーフレームとメインスレッドの進捗行が文字単位で混ざらず、まとまった書き込みとして出力されます。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -103,6 +103,8 @@ public static class ConsoleUi
     private const int SpinnerStopDelayMs = 20;
     private const int ConsoleLineMargin = 1;
     private static readonly object TerminalLock = new();
+    private static TextWriter? _synchronizedOut;
+    private static TextWriter? _synchronizedError;
     private static readonly string[] ByteUnits = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
 
     private static readonly string[] DefaultBrailleSpinnerFrames =
@@ -126,6 +128,26 @@ public static class ConsoleUi
         return count == 0
             ? $"No {plural} found."
             : $"Found {Counted(count, singular, plural)}.";
+    }
+
+    internal static void EnsureConsoleWritersSynchronized()
+    {
+        lock (TerminalLock)
+        {
+            var output = Console.Out;
+            if (!ReferenceEquals(output, _synchronizedOut))
+            {
+                _synchronizedOut = TextWriter.Synchronized(output);
+                Console.SetOut(_synchronizedOut);
+            }
+
+            var error = Console.Error;
+            if (!ReferenceEquals(error, _synchronizedError))
+            {
+                _synchronizedError = TextWriter.Synchronized(error);
+                Console.SetError(_synchronizedError);
+            }
+        }
     }
 
     // --- Spinner / スピナー ---
@@ -185,6 +207,8 @@ public static class ConsoleUi
     /// </summary>
     public static CancellationTokenSource? StartSpinner(string message, string[] frames)
     {
+        EnsureConsoleWritersSynchronized();
+
         // Braille frames are single-char; themed frames are longer strings containing the display text
         // ブレイルフレームは1文字、テーマフレームは表示テキストを含む長い文字列
         bool isThemed = frames.Length > 0 && frames[0].Length > 2;

--- a/src/CodeIndex/Program.cs
+++ b/src/CodeIndex/Program.cs
@@ -5,4 +5,5 @@ using CodeIndex.Cli;
 // characters (box-drawing, block elements, etc.) to appear as '?'.
 // Windows のコンソールは既定で OEM コードページを使用するため、Unicode 文字が文字化けします。
 Console.OutputEncoding = Encoding.UTF8;
+ConsoleUi.EnsureConsoleWritersSynchronized();
 return ProgramRunner.Run(args);

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -220,6 +220,50 @@ public class ConsoleUiTests
     }
 
     [Fact]
+    public void EnsureConsoleWritersSynchronized_SerializesConcurrentWholeStringWrites()
+    {
+        using var output = new SlowChunkingTextWriter();
+        using var capture = ConsoleCapture.Start(output, error: null);
+        ConsoleUi.EnsureConsoleWritersSynchronized();
+
+        const int iterations = 40;
+        var left = new Thread(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+                Console.Write("[spinner-frame]\n");
+        });
+        var right = new Thread(() =>
+        {
+            for (var i = 0; i < iterations; i++)
+                Console.Write("[progress-line]\n");
+        });
+
+        left.Start();
+        right.Start();
+        left.Join();
+        right.Join();
+
+        var lines = output.ToString()
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(iterations * 2, lines.Length);
+        Assert.All(lines, line => Assert.True(
+            line is "[spinner-frame]" or "[progress-line]",
+            $"Unexpected interleaved line: {line}"));
+    }
+
+    [Fact]
+    public void StartSpinner_RedirectedOutput_UsesSynchronizedWriterBeforeFallbackLine()
+    {
+        using var output = new StringWriter();
+        using var capture = ConsoleCapture.Start(output, error: null);
+
+        var cts = ConsoleUi.StartSpinner("Indexing...", ["|"]);
+
+        Assert.Null(cts);
+        Assert.Contains("Indexing...", output.ToString());
+    }
+
+    [Fact]
     public void GetWindowWidth_ColumnsEnvVarSet_UsesColumnsValue()
     {
         WithColumnsEnvironment("200", () =>
@@ -1445,6 +1489,21 @@ public class ConsoleUiTests
             FlushCount++;
             base.Flush();
         }
+    }
+
+    private sealed class SlowChunkingTextWriter : TextWriter
+    {
+        private readonly StringBuilder builder = new();
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(char value)
+        {
+            builder.Append(value);
+            Thread.Sleep(1);
+        }
+
+        public override string ToString() => builder.ToString();
     }
 
     private static string CaptureUsageOutput(bool showBanner = true)


### PR DESCRIPTION
## Summary

- Synchronize `Console.Out` and `Console.Error` at CLI startup with `TextWriter.Synchronized`.
- Ensure spinner startup also synchronizes captured/redirected writers before fallback output.
- Add console regression coverage for concurrent whole-string writes and redirected spinner output.

## Validation

- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ConsoleUiTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter ConsoleUiTests --no-restore` (adversarial review)
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits fd8f40485bfd82f920e925799cc6ef53e0a9fbb9 --json`

Full `dotnet test CodeIndex.sln` was attempted but failed in existing Rust associated-type-default coverage (`SymbolExtractorTests.Extract_RustTraitAssociatedTypeDefaults_RecordsPropertySymbols`) and then did not terminate promptly; open related issues already exist: #2603, #2609, #2611.

## Documentation and Changelog

- Added changelog fragment: `changelog.d/unreleased/1734.fixed.md`
- No AGENTS.md, CLAUDE.md, or AGENT_GUIDE.md changes.

## Follow-up Candidates

- Existing Rust associated type default failures are tracked by #2603, #2609, and #2611.

Fixes #1734
