### PR TITLE
Fix Python metaclass hook references

### DIFF
--- a/changelog.d/unreleased/2058.fixed.md
+++ b/changelog.d/unreleased/2058.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2058
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python metaclass and `__init_subclass__` references are now emitted (#2058)** — mixed class headers such as `class Derived(Base, Mixin, metaclass=Meta)` now emit references for both base classes and the metaclass, and `super().__init_subclass__()` now records a call edge to the lifecycle hook.
+
+## 日本語
+
+- **Python の metaclass と `__init_subclass__` 参照を出力するようになりました (#2058)** — `class Derived(Base, Mixin, metaclass=Meta)` のような混在 class header で base class と metaclass の両方を参照として出し、`super().__init_subclass__()` から lifecycle hook への call edge も記録します。

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -55,7 +55,7 @@ internal static class PythonReferenceExtractor
         @"^\s*class\s+\w+\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)\s*\)\s*:",
         RegexOptions.Compiled);
     private static readonly Regex MultipleClassBaseTypesRegex = new(
-        @"^\s*class\s+\w+\s*\((?<types>[^=)]*,[^=)]*)\)\s*:",
+        @"^\s*class\s+\w+\s*\((?<types>[^)]*,[^)]*)\)\s*:",
         RegexOptions.Compiled);
     private static readonly Regex ClassMetaclassTypeRegex = new(
         @"^\s*class\s+\w+\s*\([^)]*\bmetaclass\s*=\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
@@ -514,6 +514,8 @@ internal static class PythonReferenceExtractor
                 var name = typeMatch.Groups["name"].Value;
                 if (isIgnoredName(name))
                     continue;
+                if (IsPythonClassHeaderKeywordArgument(typesGroup.Value, typeMatch.Groups["name"].Index))
+                    continue;
 
                 var nameIndex = typesGroup.Index + typeMatch.Groups["name"].Index;
                 ReferenceExtractor.AddTypeReferenceSegments(
@@ -546,6 +548,31 @@ internal static class PythonReferenceExtractor
                 resolveContainerForReference(match.Groups["name"].Index) ?? container,
                 "python");
         }
+    }
+
+    private static bool IsPythonClassHeaderKeywordArgument(string headerArguments, int nameIndex)
+    {
+        for (var i = nameIndex - 1; i >= 0; i--)
+        {
+            var ch = headerArguments[i];
+            if (char.IsWhiteSpace(ch))
+                continue;
+            if (ch == '=')
+                return true;
+            break;
+        }
+
+        for (var i = nameIndex; i < headerArguments.Length; i++)
+        {
+            var ch = headerArguments[i];
+            if (char.IsLetterOrDigit(ch) || ch == '_' || ch == '.')
+                continue;
+            if (char.IsWhiteSpace(ch))
+                continue;
+            return ch == '=';
+        }
+
+        return false;
     }
 
     public static void EmitFunctionReturnReferences(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -190,7 +190,7 @@ public static partial class ReferenceExtractor
         // Python contextual keywords / Python の文脈キーワード
         ["python"] = new HashSet<string>(StringComparer.Ordinal)
         {
-            "raise", "yield", "from",
+            "raise", "yield", "from", "super",
         },
         // Ruby contextual keywords / Ruby の文脈キーワード
         ["ruby"] = new HashSet<string>(StringComparer.Ordinal)
@@ -3149,7 +3149,6 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
-
                 if (pythonHeaderMap.HasValue)
                     RemapPythonLogicalHeaderReferences(references, pythonReferenceStart, pythonHeaderMap.Value, lines);
             }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1091,6 +1091,61 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonMixedBasesAndMetaclass_EmitsBaseAndMetaclassReferences()
+    {
+        const string content = """
+            class Derived(Base, Mixin, metaclass=Meta):
+                pass
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Base"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Mixin"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Meta"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "metaclass"
+            && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_PythonSuperInitSubclass_EmitsHookCallReference()
+    {
+        const string content = """
+            class Base:
+                def __init_subclass__(cls) -> None:
+                    pass
+
+            class Child(Base):
+                def __init_subclass__(cls) -> None:
+                    super().__init_subclass__()
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        var hookCall = Assert.Single(references, reference =>
+            reference.SymbolName == "__init_subclass__"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "__init_subclass__"
+            && reference.Line == 7);
+        Assert.Equal(17, hookCall.Column);
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "super"
+            && reference.ReferenceKind == "call");
+    }
+
+    [Fact]
     public void Extract_PythonStringifiedAnnotations_CapturesNestedForwardReferences()
     {
         const string content = """


### PR DESCRIPTION
## Summary

- Emit Python base-class references from mixed `class Derived(Base, Mixin, metaclass=Meta)` headers without treating keyword arguments as base types.
- Suppress phantom Python `super` call rows while preserving the `__init_subclass__` hook call edge from `super().__init_subclass__()`.
- Add regression coverage for mixed metaclass headers and `super().__init_subclass__()` calls.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Added bilingual changelog fragment: `changelog.d/unreleased/2058.fixed.md`
- No README or guide updates required; this is extractor behavior covered by tests and changelog.

## Follow-up Candidates

- None.

Fixes #2058
