### PR TITLE
Fix subcommand help usage

### DIFF
--- a/changelog.d/unreleased/1693.fixed.md
+++ b/changelog.d/unreleased/1693.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1693
+affected:
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramCliTests.cs
+---
+
+## English
+
+- **Subcommand help now prints command-specific usage (#1693)** — `cdidx <command> --help` now shows the matching command's synopsis instead of the full top-level help block.
+
+## 日本語
+
+- **サブコマンド help がコマンド別の usage を表示するようになりました (#1693)** — `cdidx <command> --help` はトップレベル help 全体ではなく、対象コマンドの synopsis を表示するようになりました。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -54,7 +54,7 @@ internal static class CliFlagSchema
     [
         "index", "backfill-fold", "optimize", "search", "definition", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
-        "validate", "deps", "impact", "unused", "hotspots", "languages", "batch", "mcp", "db", "vacuum", "report", "license",
+        "validate", "deps", "impact", "unused", "hotspots", "languages", "batch", "mcp", "completions", "db", "vacuum", "report", "license",
     ];
 
     // Commands that accept the `--` end-of-options marker so a user can pass a literal

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -93,6 +93,7 @@ public static class ConsoleUi
         ("languages", "cdidx languages [--json]"),
         ("batch", "cdidx batch [--db <path>]  # reads JSON string arrays from stdin, one query command per line"),
         ("mcp", "cdidx mcp [--db <path>]"),
+        ("completions", "cdidx completions <shell>"),
         ("license", "cdidx license"),
     ];
 
@@ -770,6 +771,35 @@ public static class ConsoleUi
         return null;
     }
 
+    public static bool PrintCommandUsage(string command)
+    {
+        var usages = GetCommandUsageLines(command);
+        if (usages.Count == 0)
+            return false;
+
+        Console.WriteLine("Usage:");
+        foreach (var usage in usages)
+            Console.WriteLine($"  {usage}");
+        Console.WriteLine();
+        Console.WriteLine("Run `cdidx --help` to show all commands and shared options.");
+        return true;
+    }
+
+    private static IReadOnlyList<string> GetCommandUsageLines(string command)
+    {
+        var usages = new List<string>();
+        foreach (var (name, usage) in CommandUsageLines)
+        {
+            if (string.Equals(name, command, StringComparison.Ordinal)
+                || string.Equals(command, "index", StringComparison.Ordinal) && name.StartsWith("index-", StringComparison.Ordinal))
+            {
+                usages.Add(usage);
+            }
+        }
+
+        return usages;
+    }
+
     // --- Did-you-mean / もしかして ---
 
     /// <summary>
@@ -886,7 +916,7 @@ public static class ConsoleUi
     [
         "index", "backfill-fold", "optimize", "search", "definition", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
-        "validate", "deps", "impact", "unused", "hotspots", "languages", "batch", "mcp", "db", "vacuum", "report", "license",
+        "validate", "deps", "impact", "unused", "hotspots", "languages", "batch", "mcp", "completions", "db", "vacuum", "report", "license",
     ];
 
     /// <summary>

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -87,6 +87,14 @@ internal static class ProgramRunner
 
         if (args[0] is "--license" or "license")
         {
+            if (args[0] == "license" && args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
+            {
+                ConsoleUi.PrintCommandUsage("license");
+                GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} subcommand_help=true");
+                EmitCommandMetric("license", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
+                return CommandExitCodes.Success;
+            }
+
             ConsoleUi.PrintLicenseSummary();
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} license_only=true");
             EmitCommandMetric("license", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
@@ -103,7 +111,7 @@ internal static class ProgramRunner
                 return CommandExitCodes.Success;
             }
 
-            var exitCode = RunCompletions(args[1..]);
+            var exitCode = RunCompletions(args[1..], args[0] == "completions" ? "completions" : "--completions");
             GlobalToolLog.Info($"command_complete exit_code={exitCode} command=completions");
             EmitCommandMetric("completions", args, commandStartTimestamp, commandStopwatch, exitCode);
             return exitCode;
@@ -1087,28 +1095,29 @@ internal static class ProgramRunner
         return $"cdidx v{metadata.Version} (commit {commit}, built {buildDate}, {dirty}){suffix}";
     }
 
-    private static int RunCompletions(string[] cmdArgs)
+    private static int RunCompletions(string[] cmdArgs, string commandName = "--completions")
     {
+        var usage = $"cdidx {commandName} <shell>";
         if (cmdArgs.Length == 0)
             return CommandErrorWriter.Write(
-                "--completions requires a shell value.",
+                $"{commandName} requires a shell value.",
                 CommandExitCodes.UsageError,
                 "rerun with one of `bash`, `zsh`, `fish`, or `powershell`.",
-                "cdidx --completions <shell>");
+                usage);
 
         if (cmdArgs[0].StartsWith("-", StringComparison.Ordinal))
             return CommandErrorWriter.Write(
-                $"--completions requires a shell value, got option-like token '{cmdArgs[0]}'.",
+                $"{commandName} requires a shell value, got option-like token '{cmdArgs[0]}'.",
                 CommandExitCodes.UsageError,
                 "rerun with one of `bash`, `zsh`, `fish`, or `powershell`.",
-                "cdidx --completions <shell>");
+                usage);
 
         if (cmdArgs.Length > 1)
             return CommandErrorWriter.Write(
-                $"--completions accepts exactly one shell value, got extra {ConsoleUi.Counted(cmdArgs.Length - 1, "argument")}: {string.Join(", ", cmdArgs.Skip(1).Select(arg => $"`{arg}`"))}.",
+                $"{commandName} accepts exactly one shell value, got extra {ConsoleUi.Counted(cmdArgs.Length - 1, "argument")}: {string.Join(", ", cmdArgs.Skip(1).Select(arg => $"`{arg}`"))}.",
                 CommandExitCodes.UsageError,
                 "rerun with exactly one shell name: `bash`, `zsh`, `fish`, or `powershell`.",
-                "cdidx --completions <shell>");
+                usage);
 
         if (ConsoleUi.PrintCompletions(cmdArgs[0]))
             return CommandExitCodes.Success;
@@ -1117,7 +1126,7 @@ internal static class ProgramRunner
             $"unsupported completion shell `{cmdArgs[0]}`.",
             CommandExitCodes.UsageError,
             "rerun with one of `bash`, `zsh`, `fish`, or `powershell`.",
-            "cdidx --completions <shell>");
+            usage);
     }
 
     private static string StripErrorPrefix(string message)

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -93,8 +93,16 @@ internal static class ProgramRunner
             return CommandExitCodes.Success;
         }
 
-        if (args[0] == "--completions")
+        if (args[0] is "--completions" or "completions")
         {
+            if (args[0] == "completions" && args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
+            {
+                ConsoleUi.PrintCommandUsage("completions");
+                GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} subcommand_help=true");
+                EmitCommandMetric("completions", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
+                return CommandExitCodes.Success;
+            }
+
             var exitCode = RunCompletions(args[1..]);
             GlobalToolLog.Info($"command_complete exit_code={exitCode} command=completions");
             EmitCommandMetric("completions", args, commandStartTimestamp, commandStopwatch, exitCode);
@@ -103,7 +111,8 @@ internal static class ProgramRunner
 
         if (args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
         {
-            ConsoleUi.PrintUsage(showBanner: true);
+            if (!ConsoleUi.PrintCommandUsage(args[0]))
+                ConsoleUi.PrintUsage(showBanner: true);
             GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} subcommand_help=true");
             EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
             return CommandExitCodes.Success;

--- a/tests/CodeIndex.Tests/ProgramCliTests.cs
+++ b/tests/CodeIndex.Tests/ProgramCliTests.cs
@@ -128,6 +128,40 @@ public class ProgramCliTests
         Assert.DoesNotContain("Unknown shell", stderr);
     }
 
+    [Theory]
+    [InlineData("index", "cdidx index <projectPath>")]
+    [InlineData("search", "cdidx search <query>")]
+    [InlineData("references", "cdidx references <query>")]
+    [InlineData("callers", "cdidx callers <query>")]
+    [InlineData("callees", "cdidx callees <query>")]
+    [InlineData("impact", "cdidx impact <query>")]
+    [InlineData("unused", "cdidx unused")]
+    [InlineData("validate", "cdidx validate")]
+    [InlineData("backfill-fold", "cdidx backfill-fold")]
+    [InlineData("outline", "cdidx outline <path>")]
+    [InlineData("inspect", "cdidx inspect <query>")]
+    [InlineData("definition", "cdidx definition <query>")]
+    [InlineData("find", "cdidx find <query>")]
+    [InlineData("excerpt", "cdidx excerpt <path>")]
+    [InlineData("hotspots", "cdidx hotspots")]
+    [InlineData("deps", "cdidx deps")]
+    [InlineData("map", "cdidx map")]
+    [InlineData("status", "cdidx status")]
+    [InlineData("completions", "cdidx completions <shell>")]
+    public void SubcommandHelp_PrintsCommandSpecificUsage(string command, string expectedUsage)
+    {
+        var (exitCode, stdout, stderr) = RunCliInSubprocess([command, "--help"]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        Assert.Contains("Usage:", stdout);
+        Assert.Contains(expectedUsage, stdout);
+        Assert.Contains("Run `cdidx --help`", stdout);
+        Assert.DoesNotContain("Commands:", stdout);
+        Assert.DoesNotContain("Index and update options:", stdout);
+        Assert.DoesNotContain("██████╗", stdout);
+    }
+
     [Fact]
     public void Completions_ExtraArgsReturnUsageError()
     {

--- a/tests/CodeIndex.Tests/ProgramCliTests.cs
+++ b/tests/CodeIndex.Tests/ProgramCliTests.cs
@@ -148,6 +148,7 @@ public class ProgramCliTests
     [InlineData("map", "cdidx map")]
     [InlineData("status", "cdidx status")]
     [InlineData("completions", "cdidx completions <shell>")]
+    [InlineData("license", "cdidx license")]
     public void SubcommandHelp_PrintsCommandSpecificUsage(string command, string expectedUsage)
     {
         var (exitCode, stdout, stderr) = RunCliInSubprocess([command, "--help"]);
@@ -160,6 +161,20 @@ public class ProgramCliTests
         Assert.DoesNotContain("Commands:", stdout);
         Assert.DoesNotContain("Index and update options:", stdout);
         Assert.DoesNotContain("██████╗", stdout);
+    }
+
+    [Theory]
+    [InlineData("completions")]
+    [InlineData("completions", "--json")]
+    [InlineData("completions", "bash", "extra")]
+    public void CompletionsCommand_ErrorsUseCommandUsage(params string[] args)
+    {
+        var (exitCode, stdout, stderr) = RunCliInSubprocess(args);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("Usage: cdidx completions <shell>", stderr);
+        Assert.DoesNotContain("Usage: cdidx --completions <shell>", stderr);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Print command-specific usage for `cdidx <command> --help` instead of the full top-level help.
- Add `completions` as a command alias for shell completion generation while preserving the legacy `--completions` behavior.
- Cover command-specific help and alias-specific completion errors in CLI regression tests.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProgramCliTests.SubcommandHelp_PrintsCommandSpecificUsage|FullyQualifiedName~ProgramCliTests.CompletionsCommand_ErrorsUseCommandUsage|FullyQualifiedName~ProgramCliTests.Completions_HelpLikeValueReturnsCompletionsError|FullyQualifiedName~CliFlagSchemaTests" -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Smoke checks: `cdidx search --help`, `cdidx index --help`, `cdidx license --help`, `cdidx completions --help`, `cdidx completions --json`

## Documentation and Changelog

- Added changelog fragment `changelog.d/unreleased/1693.fixed.md`.
- No docs changes were required because this only changes CLI help output discoverability.

## Review

- Adversarial review found actionable issues for `license --help` and `completions` alias usage errors; both were fixed.
- A follow-up review found the branch was behind `origin/main` and showed unrelated reverted changes in the diff; latest `origin/main` was merged until `origin/main..HEAD` only contained the #1693 files.

Fixes #1693
