### PR TITLE
Fix SQL dollar-quoted body scanning

### DIFF
--- a/changelog.d/unreleased/1442.fixed.md
+++ b/changelog.d/unreleased/1442.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1442
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Sql.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **PostgreSQL dollar-quoted function bodies now ignore nested different tags (#1442)** — SQL body range detection now closes a dollar-quoted procedure body only on the same opening tag text, so `$inner$ ... $inner$` literals inside a `$body$ ... $body$` function no longer truncate symbol ranges or drop trailing reference containers.
+
+## 日本語
+
+- **PostgreSQL の dollar-quoted 関数本体が内側の別タグを無視するようになりました (#1442)** — SQL 本体範囲の検出は開きタグと同じ文字列だけで dollar-quoted プロシージャ本体を閉じるため、`$body$ ... $body$` 関数内の `$inner$ ... $inner$` リテラルでシンボル範囲が途中で切れたり、後続参照のコンテナが落ちたりしなくなりました。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Sql.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Sql.cs
@@ -74,33 +74,16 @@ public static partial class SymbolExtractor
 
             var masked = MaskSqlLineForBodyScan(raw, ref blockCommentDepth);
 
-            // Detect any unpaired dollar-quote opening on this line. Paired openings on the same
-            // line (e.g. `AS $$ SELECT 1 $$`) are consumed without opening cross-line state.
-            // 同一行でペアにならない dollar-quote 開きを検出する。同じ行で開閉が揃う（`AS $$ SELECT 1 $$`）
-            // 場合はクロス行状態を開かずそのまま消費する。
-            var dollarMatches = SqlDollarTagRegex.Matches(masked);
-            if (dollarMatches.Count > 0)
+            // Detect an unpaired dollar-quote opening on this line. Once a tag opens, only the same
+            // tag text can close it; different tags inside the body are literal text in PostgreSQL
+            // and must not terminate the procedure body early.
+            // 同一行でペアにならない dollar-quote 開きを検出する。いったん開いたら同じタグ文字列だけで閉じる。
+            // 本体内の異なるタグは PostgreSQL ではリテラルなので、プロシージャ本体を早期終了させない。
+            openDollarTag = FindUnclosedSqlDollarTag(masked);
+            if (openDollarTag != null)
             {
-                var tagCounts = new Dictionary<string, int>(StringComparer.Ordinal);
-                foreach (Match m in dollarMatches)
-                    tagCounts[m.Value] = tagCounts.TryGetValue(m.Value, out var c) ? c + 1 : 1;
-
-                string? stillOpen = null;
-                foreach (var kv in tagCounts)
-                {
-                    if (kv.Value % 2 != 0)
-                    {
-                        stillOpen = kv.Key;
-                        break;
-                    }
-                }
-
-                if (stillOpen != null)
-                {
-                    openDollarTag = stillOpen;
-                    endLine = i + 1;
-                    continue;
-                }
+                endLine = i + 1;
+                continue;
             }
 
             if (i > startIndex)
@@ -133,6 +116,27 @@ public static partial class SymbolExtractor
         }
 
         return (endLine, bodyStartLine, endLine);
+    }
+
+    private static string? FindUnclosedSqlDollarTag(string maskedLine)
+    {
+        int searchFrom = 0;
+
+        while (searchFrom < maskedLine.Length)
+        {
+            var open = SqlDollarTagRegex.Match(maskedLine, searchFrom);
+            if (!open.Success)
+                return null;
+
+            string tag = open.Value;
+            int closeIndex = maskedLine.IndexOf(tag, open.Index + open.Length, StringComparison.Ordinal);
+            if (closeIndex < 0)
+                return tag;
+
+            searchFrom = closeIndex + tag.Length;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -25125,6 +25125,35 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SqlPostgresDollarQuotedBody_IgnoresNestedDifferentDollarTag()
+    {
+        // issue #1442: `$inner$ ... $inner$` text inside a `$body$ ... $body$` function body must
+        // not close the outer body range, or calls after the inner literal lose their container.
+        // issue #1442: `$body$ ... $body$` 関数本体内の `$inner$ ... $inner$` テキストで外側の
+        // 本体範囲を閉じると、後続の呼び出しがコンテナから外れるため、同一タグだけを閉じタグにする。
+        const string content = """
+            CREATE OR REPLACE FUNCTION public.fn_outer() RETURNS text LANGUAGE plpgsql AS $body$
+            DECLARE
+                s text := $inner$hello $inner$;
+            BEGIN
+                PERFORM public.fn_inner();
+                RETURN s;
+            END
+            $body$;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        var bodyCall = Assert.Single(references.Where(r =>
+            r.SymbolName == "fn_inner" &&
+            r.ReferenceKind == "call" &&
+            r.Line == 5));
+        Assert.Equal("function", bodyCall.ContainerKind);
+        Assert.Equal("public.fn_outer", bodyCall.ContainerName);
+    }
+
+    [Fact]
     public void Extract_CsharpAttribute_ClassifiedAsAttribute()
     {
         // issue #293: `[Obsolete("msg")]` must produce an `attribute` reference, not a phantom `call`.


### PR DESCRIPTION
## Summary

- Fix SQL procedure body scanning so PostgreSQL dollar-quoted bodies only close on the matching opening tag text.
- Add regression coverage for `$inner$ ... $inner$` literal text inside a `$body$ ... $body$` function body.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_SqlPostgresDollarQuotedBody"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/1442.fixed.md`

## Follow-up Candidates

- None.

Fixes #1442
