### PR TITLE
Add SQL FK regression coverage for #1443

### DIFF
--- a/changelog.d/unreleased/1443.fixed.md
+++ b/changelog.d/unreleased/1443.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1443
+affected:
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **SQL foreign-key reference coverage is now regression-tested for ALTER TABLE ADD CONSTRAINT (#1443)** — the SQL reference extractor test suite now locks inline and ALTER-style foreign-key references to the referenced table.
+
+## 日本語
+
+- **SQL foreign key reference の ALTER TABLE ADD CONSTRAINT 対応を回帰テストで固定しました (#1443)** — SQL reference extractor のテストで、inline と ALTER 形式の foreign key が参照先 table を参照として拾うことを固定しました。

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -14719,6 +14719,26 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SQL_AlterTableAddConstraintForeignKeyCapturesReferencedTable()
+    {
+        const string content = """
+            CREATE TABLE orders (id int PRIMARY KEY);
+            CREATE TABLE order_items (order_id int REFERENCES orders(id));
+            ALTER TABLE order_items ADD CONSTRAINT fk_order
+                FOREIGN KEY (order_id) REFERENCES orders(id);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "sql", content);
+        var references = ReferenceExtractor.Extract(1, "sql", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "order_items" && r.ReferenceKind == "reference" && r.Line == 3);
+        Assert.Equal(2, references.Count(r => r.SymbolName == "orders" && r.ReferenceKind == "reference"));
+        Assert.Contains(references, r => r.SymbolName == "orders" && r.ReferenceKind == "reference" && r.Line == 2);
+        Assert.Contains(references, r => r.SymbolName == "orders" && r.ReferenceKind == "reference" && r.Line == 4);
+        Assert.DoesNotContain(references, r => r.SymbolName == "fk_order" && r.ReferenceKind == "reference");
+    }
+
+    [Fact]
     public void Extract_SQL_DropTableCapturesAllTargetReferences()
     {
         // T-SQL teardown migrations should still be searchable by the table names they touch,


### PR DESCRIPTION
## Summary

- Adds regression coverage for SQL `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES ...` extraction.
- Verifies inline and ALTER-style foreign keys both emit references to the referenced table.
- Adds a bilingual changelog fragment for #1443.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/1443.fixed.md`.
- No README or developer-guide updates were needed because this only locks existing SQL reference extraction behavior with regression coverage.

## Follow-up candidates

- None.

Fixes #1443
