### PR TITLE
Fix durable suggestion writes

### DIFF
--- a/changelog.d/unreleased/1410.fixed.md
+++ b/changelog.d/unreleased/1410.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1410
+affected:
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+---
+
+## English
+
+- **Suggestion storage now flushes temp files before replacement (#1410)** — local suggestion writes serialize to a temp file, flush it to disk before renaming, and preserve zero-byte stores as `.bak` files instead of silently treating them as empty.
+
+## 日本語
+
+- **提案ストアが置換前に一時ファイルをディスクへ flush するようになりました (#1410)** — ローカル提案の書き込みは一時ファイルへ serialize して rename 前にディスクへ flush し、zero-byte のストアは空として黙って扱わず `.bak` として退避します。

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -379,6 +379,12 @@ public class SuggestionStore
         if (!File.Exists(ioPath))
             return new List<SuggestionRecord>();
 
+        if (new FileInfo(ioPath).Length == 0)
+        {
+            PreserveCorruptFile();
+            return new List<SuggestionRecord>();
+        }
+
         var json = File.ReadAllText(ioPath);
         if (string.IsNullOrWhiteSpace(json))
             return new List<SuggestionRecord>();
@@ -547,7 +553,10 @@ public class SuggestionStore
 
         var snapshot = File.ReadAllBytes(ioPath);
         if (snapshot.Length == 0)
+        {
+            PreserveCorruptFile();
             return new List<SuggestionRecord>();
+        }
 
         if (IsEmptyOrJsonWhitespace(snapshot))
             return new List<SuggestionRecord>();
@@ -650,10 +659,18 @@ public class SuggestionStore
         NormalizeRecordDefaults(records);
 
         var tempPath = _filePath + ".tmp";
-        var json = JsonSerializer.Serialize(records, s_jsonOptions);
         try
         {
-            File.WriteAllText(tempPath, json);
+            using (var stream = new FileStream(
+                       tempPath,
+                       FileMode.Create,
+                       FileAccess.Write,
+                       FileShare.None))
+            {
+                JsonSerializer.Serialize(stream, records, s_jsonOptions);
+                stream.Flush(flushToDisk: true);
+            }
+
             File.Move(tempPath, _filePath, overwrite: true);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -646,6 +646,34 @@ public class SuggestionStoreTests : IDisposable
     }
 
     [Fact]
+    public void ZeroByteFile_IsPreservedAsBackup()
+    {
+        var filePath = Path.Combine(_tempDir, "suggestions-codeindex.json");
+        var backupPath = filePath + ".bak";
+        File.WriteAllBytes(filePath, Array.Empty<byte>());
+
+        var all = _store.LoadAll();
+
+        Assert.Empty(all);
+        Assert.True(File.Exists(backupPath), "Zero-byte file should be preserved as .bak");
+        Assert.False(File.Exists(filePath), "Original zero-byte file should be removed");
+    }
+
+    [Fact]
+    public void FilteredZeroByteFile_IsPreservedAsBackup()
+    {
+        var filePath = Path.Combine(_tempDir, "suggestions-codeindex.json");
+        var backupPath = filePath + ".bak";
+        File.WriteAllBytes(filePath, Array.Empty<byte>());
+
+        var all = _store.LoadByCategory("other");
+
+        Assert.Empty(all);
+        Assert.True(File.Exists(backupPath), "Zero-byte file should be preserved as .bak");
+        Assert.False(File.Exists(filePath), "Original zero-byte file should be removed");
+    }
+
+    [Fact]
     public void AtomicWrite_SurvivesAddAfterCorruption()
     {
         // After corruption recovery, new suggestions should work normally


### PR DESCRIPTION
## Summary
- Flush suggestion temp-file writes to disk before replacing the live suggestions file.
- Preserve zero-byte suggestion stores as .bak files instead of treating them as empty.
- Add regression coverage and an unreleased changelog fragment for #1410.

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter SuggestionStoreTests
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter SuggestionStoreTests -p:UseSharedCompilation=false
- dotnet run --project tools/CodeIndex.Changelog -- check
- codex adversarial review: No blocking/actionable issues found.

Note: dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false was attempted before rebasing onto the updated origin/main, but it produced no completion output for over 8 minutes and was stopped; focused Release tests passed afterward.

## Documentation and changelog
- Added changelog fragment: changelog.d/unreleased/1410.fixed.md
- No documentation updates were needed; this preserves the existing suggestion-store interface and hardens persistence/recovery behavior.

## Follow-up candidates
- None.

Fixes #1410