### PR TITLE
Fix Python dataclass field extraction

### DIFF
--- a/changelog.d/unreleased/2057.fixed.md
+++ b/changelog.d/unreleased/2057.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2057
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+---
+
+## English
+
+- **Python dataclass field metadata is now indexed (#2057)** — `field(...)` class attributes are distinguished as dataclass fields, metadata keys are indexed, default factories are referenced, and imported `fields(MyClass)` introspection now links back to the dataclass.
+
+## 日本語
+
+- **Python dataclass field metadata を index するようにしました (#2057)** — `field(...)` class attribute を dataclass field として区別し、metadata key、default factory 参照、import 済み `fields(MyClass)` introspection から dataclass への参照を取得します。

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -922,8 +922,95 @@ internal static class PythonReferenceExtractor
     }
 
     public static void EmitDataclassFieldReferences(
+        string[] preparedLines,
+        string[] originalLines,
+        int lineIndex,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        var preparedLine = preparedLines[lineIndex];
+        if (!DataclassFieldCallRegex.IsMatch(preparedLine))
+            return;
+
+        var depth = 0;
+        var sawFieldCall = false;
+        var inString = false;
+        var quoteChar = '\0';
+
+        for (var currentLineIndex = lineIndex; currentLineIndex < preparedLines.Length; currentLineIndex++)
+        {
+            var currentPreparedLine = preparedLines[currentLineIndex];
+            var currentOriginalLine = originalLines[currentLineIndex];
+            var currentContext = currentOriginalLine.Trim();
+            var currentLineNumber = currentLineIndex + 1;
+
+            EmitDataclassFieldDefaultFactoryReferences(
+                currentPreparedLine,
+                references,
+                seen,
+                fileId,
+                currentContext,
+                currentLineNumber,
+                container,
+                isIgnoredName);
+            EmitDataclassFieldMetadataReferences(
+                currentOriginalLine,
+                references,
+                seen,
+                fileId,
+                currentContext,
+                currentLineNumber,
+                container,
+                isIgnoredName);
+
+            for (var column = 0; column < currentPreparedLine.Length; column++)
+            {
+                var ch = currentPreparedLine[column];
+                if (inString)
+                {
+                    if (ch == '\\')
+                    {
+                        column++;
+                        continue;
+                    }
+
+                    if (ch == quoteChar)
+                        inString = false;
+                    continue;
+                }
+
+                if (ch == '#')
+                    break;
+                if (ch is '\'' or '"')
+                {
+                    inString = true;
+                    quoteChar = ch;
+                    continue;
+                }
+
+                if (ch == '(')
+                {
+                    depth++;
+                    sawFieldCall = true;
+                }
+                else if (ch == ')' && depth > 0)
+                {
+                    depth--;
+                    if (sawFieldCall && depth == 0)
+                        return;
+                }
+            }
+
+            if (sawFieldCall && depth <= 0)
+                return;
+        }
+    }
+
+    private static void EmitDataclassFieldDefaultFactoryReferences(
         string preparedLine,
-        string originalLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -932,9 +1019,6 @@ internal static class PythonReferenceExtractor
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
-        if (!DataclassFieldCallRegex.IsMatch(preparedLine))
-            return;
-
         foreach (Match match in DataclassFieldDefaultFactoryRegex.Matches(preparedLine))
         {
             var name = match.Groups["name"].Value;
@@ -953,7 +1037,18 @@ internal static class PythonReferenceExtractor
                 container,
                 "python");
         }
+    }
 
+    private static void EmitDataclassFieldMetadataReferences(
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
         foreach (Match metadataMatch in DataclassFieldMetadataKeyRegex.Matches(originalLine))
         {
             var body = metadataMatch.Groups["body"];

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -108,11 +108,8 @@ internal static class PythonReferenceExtractor
     private static readonly Regex DataclassFieldDefaultFactoryRegex = new(
         @"\bdefault_factory\s*=\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{L}]\w*)",
         RegexOptions.Compiled);
-    private static readonly Regex DataclassFieldMetadataKeyRegex = new(
-        @"\bmetadata\s*=\s*\{(?<body>[^}\n]*)\}",
-        RegexOptions.Compiled);
-    private static readonly Regex PythonStringDictionaryKeyRegex = new(
-        @"(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*:",
+    private static readonly Regex DataclassFieldMetadataRegex = new(
+        @"\bmetadata\s*=\s*(?<values>\{)",
         RegexOptions.Compiled);
     private static readonly Regex AttrsFieldsTargetRegex = new(
         @"\b(?:attr|attrs)\.fields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
@@ -957,12 +954,11 @@ internal static class PythonReferenceExtractor
                 container,
                 isIgnoredName);
             EmitDataclassFieldMetadataReferences(
-                currentOriginalLine,
+                originalLines,
+                currentLineIndex,
                 references,
                 seen,
                 fileId,
-                currentContext,
-                currentLineNumber,
                 container,
                 isIgnoredName);
 
@@ -1040,36 +1036,113 @@ internal static class PythonReferenceExtractor
     }
 
     private static void EmitDataclassFieldMetadataReferences(
-        string originalLine,
+        string[] originalLines,
+        int lineIndex,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
-        string context,
-        int lineNumber,
         SymbolRecord? container,
         Func<string, bool> isIgnoredName)
     {
-        foreach (Match metadataMatch in DataclassFieldMetadataKeyRegex.Matches(originalLine))
-        {
-            var body = metadataMatch.Groups["body"];
-            foreach (Match keyMatch in PythonStringDictionaryKeyRegex.Matches(body.Value))
-            {
-                var name = keyMatch.Groups["name"].Value;
-                if (isIgnoredName(name))
-                    continue;
+        var metadataMatch = DataclassFieldMetadataRegex.Match(originalLines[lineIndex]);
+        if (!metadataMatch.Success)
+            return;
 
-                ReferenceExtractor.AddReference(
-                    references,
-                    seen,
-                    fileId,
-                    name,
-                    body.Index + keyMatch.Groups["name"].Index,
-                    "annotation",
-                    context,
-                    lineNumber,
-                    container,
-                    "python");
+        var currentLineIndex = lineIndex;
+        var currentColumn = metadataMatch.Groups["values"].Index;
+        var depth = 0;
+        var inString = false;
+        var quoteChar = '\0';
+        var stringStartColumn = -1;
+
+        while (currentLineIndex < originalLines.Length)
+        {
+            var currentLine = originalLines[currentLineIndex];
+            if (currentColumn >= currentLine.Length)
+            {
+                if (depth <= 0 && !inString)
+                    break;
+
+                currentLineIndex++;
+                currentColumn = 0;
+                continue;
             }
+
+            var ch = currentLine[currentColumn];
+            if (inString)
+            {
+                if (ch == '\\' && currentColumn + 1 < currentLine.Length)
+                {
+                    currentColumn += 2;
+                    continue;
+                }
+
+                if (ch == quoteChar)
+                {
+                    var afterStringColumn = currentColumn + 1;
+                    while (afterStringColumn < currentLine.Length && char.IsWhiteSpace(currentLine[afterStringColumn]))
+                        afterStringColumn++;
+
+                    if (afterStringColumn < currentLine.Length && currentLine[afterStringColumn] == ':')
+                    {
+                        var name = currentLine[stringStartColumn..currentColumn].Trim();
+                        if (name.Length > 0 && !isIgnoredName(name))
+                        {
+                            ReferenceExtractor.AddReference(
+                                references,
+                                seen,
+                                fileId,
+                                name,
+                                stringStartColumn,
+                                "annotation",
+                                currentLine.Trim(),
+                                currentLineIndex + 1,
+                                container,
+                                "python");
+                        }
+                    }
+
+                    inString = false;
+                    quoteChar = '\0';
+                    stringStartColumn = -1;
+                    currentColumn++;
+                    continue;
+                }
+
+                currentColumn++;
+                continue;
+            }
+
+            if (ch == '#')
+                break;
+
+            if (ch is '\'' or '"')
+            {
+                inString = true;
+                quoteChar = ch;
+                stringStartColumn = currentColumn + 1;
+                currentColumn++;
+                continue;
+            }
+
+            if (ch is '{' or '[' or '(')
+            {
+                depth++;
+                currentColumn++;
+                continue;
+            }
+
+            if (ch is '}' or ']' or ')')
+            {
+                if (depth > 0)
+                    depth--;
+                currentColumn++;
+                if (depth <= 0)
+                    break;
+                continue;
+            }
+
+            currentColumn++;
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -100,7 +100,19 @@ internal static class PythonReferenceExtractor
         @"\b(?:typing|typing_extensions)\.get_type_hints\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
     private static readonly Regex DataclassesFieldsTargetRegex = new(
-        @"\bdataclasses\.fields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        @"(?<!\.)\bfields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)|\bdataclasses\.fields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
+        RegexOptions.Compiled);
+    private static readonly Regex DataclassFieldCallRegex = new(
+        @"^\s*[_\p{L}]\w*\s*(?::\s*[^=]+)?=\s*(?:(?:dataclasses\.)?field)\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex DataclassFieldDefaultFactoryRegex = new(
+        @"\bdefault_factory\s*=\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{L}]\w*)",
+        RegexOptions.Compiled);
+    private static readonly Regex DataclassFieldMetadataKeyRegex = new(
+        @"\bmetadata\s*=\s*\{(?<body>[^}\n]*)\}",
+        RegexOptions.Compiled);
+    private static readonly Regex PythonStringDictionaryKeyRegex = new(
+        @"(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*:",
         RegexOptions.Compiled);
     private static readonly Regex AttrsFieldsTargetRegex = new(
         @"\b(?:attr|attrs)\.fields\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
@@ -906,6 +918,63 @@ internal static class PythonReferenceExtractor
                 lineNumber,
                 container,
                 "python");
+        }
+    }
+
+    public static void EmitDataclassFieldReferences(
+        string preparedLine,
+        string originalLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        if (!DataclassFieldCallRegex.IsMatch(preparedLine))
+            return;
+
+        foreach (Match match in DataclassFieldDefaultFactoryRegex.Matches(preparedLine))
+        {
+            var name = match.Groups["name"].Value;
+            if (isIgnoredName(name))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                match.Groups["name"].Index,
+                "call",
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+
+        foreach (Match metadataMatch in DataclassFieldMetadataKeyRegex.Matches(originalLine))
+        {
+            var body = metadataMatch.Groups["body"];
+            foreach (Match keyMatch in PythonStringDictionaryKeyRegex.Matches(body.Value))
+            {
+                var name = keyMatch.Groups["name"].Value;
+                if (isIgnoredName(name))
+                    continue;
+
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    name,
+                    body.Index + keyMatch.Groups["name"].Index,
+                    "annotation",
+                    context,
+                    lineNumber,
+                    container,
+                    "python");
+            }
         }
     }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -3119,6 +3119,16 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitDataclassFieldReferences(
+                    preparedLine,
+                    originalLine,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container,
+                    name => IsIgnoredCallName(language, name));
                 PythonReferenceExtractor.EmitAttrsFieldsReferences(
                     preparedLine,
                     references,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -3120,13 +3120,12 @@ public static partial class ReferenceExtractor
                     container,
                     name => IsIgnoredCallName(language, name));
                 PythonReferenceExtractor.EmitDataclassFieldReferences(
-                    preparedLine,
-                    originalLine,
+                    preparedLines,
+                    lines,
+                    i,
                     references,
                     seen,
                     fileId,
-                    context,
-                    lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
                 PythonReferenceExtractor.EmitAttrsFieldsReferences(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -16,6 +16,8 @@ public static partial class SymbolExtractor
     private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAnnotatedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*:\s*[^=].*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAssignedAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*=(?!=).*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonDataclassFieldAttributeRegex = new(@"^\s*(?<name>[_\p{L}]\w*)\s*(?::\s*[^=]+)?=\s*(?:(?:dataclasses\.)?field)\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonDataclassFieldMetadataRegex = new(@"\bmetadata\s*=\s*(?<values>\{)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassSlotsAssignmentRegex = new(@"^\s*__slots__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassMatchArgsAssignmentRegex = new(@"^\s*__match_args__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonClassAnnotationsAssignmentRegex = new(@"^\s*__annotations__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -381,6 +383,36 @@ public static partial class SymbolExtractor
                     continue;
                 }
 
+                var fieldMatch = PythonDataclassFieldAttributeRegex.Match(line);
+                if (fieldMatch.Success)
+                {
+                    AddPythonClassPropertySymbol(
+                        fileId,
+                        lines,
+                        symbols,
+                        fieldMatch.Groups["name"].Value,
+                        i,
+                        fieldMatch.Groups["name"].Index,
+                        subKind: "dataclass_field");
+
+                    var metadataKeys = TryExpandPythonDataclassFieldMetadataKeys(lines, i, fieldMatch.Groups["name"].Index);
+                    if (metadataKeys != null)
+                    {
+                        foreach (var key in metadataKeys)
+                        {
+                            AddPythonDataclassFieldMetadataSymbol(
+                                fileId,
+                                lines,
+                                symbols,
+                                key.Name,
+                                key.LineIndex,
+                                key.StartColumn);
+                        }
+                    }
+
+                    continue;
+                }
+
                 var match = PythonClassAnnotatedAttributeRegex.Match(line);
                 if (!match.Success)
                     match = PythonClassAssignedAttributeRegex.Match(line);
@@ -404,7 +436,8 @@ public static partial class SymbolExtractor
         List<SymbolRecord> symbols,
         string name,
         int lineIndex,
-        int startColumn)
+        int startColumn,
+        string? subKind = null)
     {
         AddSymbolRecord(
             symbols,
@@ -414,6 +447,34 @@ public static partial class SymbolExtractor
             {
                 FileId = fileId,
                 Kind = "property",
+                SubKind = subKind,
+                Name = name,
+                Line = lineIndex + 1,
+                StartLine = lineIndex + 1,
+                StartColumn = startColumn,
+                EndLine = lineIndex + 1,
+                Signature = lines[lineIndex].Trim(),
+            },
+            lines[lineIndex]);
+    }
+
+    private static void AddPythonDataclassFieldMetadataSymbol(
+        long fileId,
+        string[] lines,
+        List<SymbolRecord> symbols,
+        string name,
+        int lineIndex,
+        int startColumn)
+    {
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineIndex + 1,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "reference",
+                SubKind = "dataclass_field_metadata",
                 Name = name,
                 Line = lineIndex + 1,
                 StartLine = lineIndex + 1,
@@ -557,6 +618,73 @@ public static partial class SymbolExtractor
         }
 
         return entries.Count > 0 ? entries : null;
+    }
+
+    private static List<PythonExportSymbolEntry>? TryExpandPythonDataclassFieldMetadataKeys(
+        string[] lines,
+        int fieldLineIndex,
+        int fieldStartColumn)
+    {
+        var currentLineIndex = fieldLineIndex;
+        var currentColumn = fieldStartColumn;
+        var depth = 0;
+        var sawFieldCall = false;
+        var inString = false;
+        var quoteChar = '\0';
+
+        while (currentLineIndex < lines.Length)
+        {
+            var currentLine = lines[currentLineIndex];
+            var metadataMatch = PythonDataclassFieldMetadataRegex.Match(currentLine);
+            if (metadataMatch.Success)
+                return TryExpandPythonStringDictionaryKeys(lines, currentLineIndex, metadataMatch.Groups["values"].Index);
+
+            for (; currentColumn < currentLine.Length; currentColumn++)
+            {
+                var ch = currentLine[currentColumn];
+                if (inString)
+                {
+                    if (ch == '\\')
+                    {
+                        currentColumn++;
+                        continue;
+                    }
+
+                    if (ch == quoteChar)
+                        inString = false;
+                    continue;
+                }
+
+                if (ch == '#')
+                    break;
+                if (ch is '\'' or '"')
+                {
+                    inString = true;
+                    quoteChar = ch;
+                    continue;
+                }
+
+                if (ch == '(')
+                {
+                    depth++;
+                    sawFieldCall = true;
+                }
+                else if (ch == ')' && depth > 0)
+                {
+                    depth--;
+                    if (sawFieldCall && depth == 0)
+                        return null;
+                }
+            }
+
+            if (sawFieldCall && depth <= 0)
+                return null;
+
+            currentLineIndex++;
+            currentColumn = 0;
+        }
+
+        return null;
     }
 
     private static List<PythonExportSymbolEntry>? TryExpandPythonAllExportSymbols(string[] lines, int lineIndex)

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -67,7 +67,9 @@ public class ReferenceExtractorTests
             class Job:
                 callback: Callable[[Payload], Result] = field(
                     default_factory=list,
-                    metadata={"wire_name": "callback"},
+                    metadata={
+                        "wire_name": "callback",
+                    },
                 )
 
             def inspect_job():

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -58,6 +58,45 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonDataclassField_EmitsMetadataAndDefaultFactoryReferences()
+    {
+        const string content = """
+            from dataclasses import dataclass, field, fields
+
+            @dataclass
+            class Job:
+                callback: Callable[[Payload], Result] = field(default_factory=list, metadata={"wire_name": "callback"})
+
+            def inspect_job():
+                return fields(Job)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Payload"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Job");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Result"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Job");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "list"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "Job");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "wire_name"
+            && reference.ReferenceKind == "annotation"
+            && reference.ContainerName == "Job");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Job"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "inspect_job");
+    }
+
+    [Fact]
     public void BuildReferenceDedupeKey_IncludesFileIdAndLanguage()
     {
         var javaKey = ReferenceExtractor.BuildReferenceDedupeKey(1, "java", 3, 5, "type_reference", "Runner");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -65,7 +65,10 @@ public class ReferenceExtractorTests
 
             @dataclass
             class Job:
-                callback: Callable[[Payload], Result] = field(default_factory=list, metadata={"wire_name": "callback"})
+                callback: Callable[[Payload], Result] = field(
+                    default_factory=list,
+                    metadata={"wire_name": "callback"},
+                )
 
             def inspect_job():
                 return fields(Job)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -53,6 +53,39 @@ public class SymbolExtractorTests
         Assert.Contains(symbols, symbol => symbol.Kind == "class" && symbol.Name == "StructuralLineMasker");
     }
 
+    [Fact]
+    public void Extract_PythonDataclassField_IndexesFieldAndMetadataKeys()
+    {
+        const string content = """
+            from dataclasses import dataclass, field
+
+            @dataclass
+            class Job:
+                callback: Callable[[Payload], Result] = field(
+                    default_factory=list,
+                    metadata={"wire_name": "callback", "role": "handler"},
+                )
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        Assert.Contains(symbols, symbol =>
+            symbol.Kind == "property"
+            && symbol.SubKind == "dataclass_field"
+            && symbol.Name == "callback"
+            && symbol.Line == 5);
+        Assert.Contains(symbols, symbol =>
+            symbol.Kind == "reference"
+            && symbol.SubKind == "dataclass_field_metadata"
+            && symbol.Name == "wire_name"
+            && symbol.Line == 7);
+        Assert.Contains(symbols, symbol =>
+            symbol.Kind == "reference"
+            && symbol.SubKind == "dataclass_field_metadata"
+            && symbol.Name == "role"
+            && symbol.Line == 7);
+    }
+
     [Theory]
     [InlineData("csharp", "Pages/Product.razor")]
     [InlineData("csharp", "Views/Product.cshtml")]


### PR DESCRIPTION
## Summary
- Distinguish Python dataclass field(...) class attributes and index field metadata keys.
- Emit references for dataclass field default factories, metadata keys, and fields(MyClass) introspection.
- Add focused coverage for multiline dataclass field(...) calls and multiline metadata dictionaries.

Fixes #2057

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter Dataclass --no-restore -p:UseSharedCompilation=false
- dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false

## Documentation / changelog
- Added changelog fragment: changelog.d/unreleased/2057.fixed.md

## Review
- Adversarial review round 1 found multiline field references were missing; fixed.
- Adversarial review round 2 found multiline metadata dict references were missing; fixed.

## Follow-up candidates
- #2627