### PR TITLE
Fix Rust raw-string attribute phantom imports

### DIFF
--- a/changelog.d/unreleased/1441.fixed.md
+++ b/changelog.d/unreleased/1441.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1441
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust raw-string attributes no longer emit phantom imports (#1441)** — Rust reference extraction now masks attribute bodies before scanning `use` statements, so `#[doc = r"use foo::bar;"]` no longer creates a false import/reference.
+
+## 日本語
+
+- **Rust の raw string 属性から phantom import が生成されないようになりました (#1441)** — Rust の参照抽出は `use` 文スキャン前に属性本文をマスクするため、`#[doc = r"use foo::bar;"]` が誤った import/reference を生成しなくなりました。

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -56,6 +56,130 @@ internal static class RustReferenceExtractor
         @"(?<![\w$])(?<name>(?:(?:r#)?\w+::)*r#\w+(?:::(?:r#)?\w+)*)(?:<[^>\n]+>)?\s*\(",
         RegexOptions.Compiled);
 
+    public static string MaskAttributeBodies(string line)
+    {
+        var masked = default(char[]);
+        for (var index = 0; index < line.Length; index++)
+        {
+            if (line[index] != '#')
+                continue;
+
+            var cursor = index + 1;
+            while (cursor < line.Length && char.IsWhiteSpace(line[cursor]))
+                cursor++;
+            if (cursor < line.Length && line[cursor] == '!')
+            {
+                cursor++;
+                while (cursor < line.Length && char.IsWhiteSpace(line[cursor]))
+                    cursor++;
+            }
+
+            if (cursor >= line.Length || line[cursor] != '[')
+                continue;
+
+            masked ??= line.ToCharArray();
+            var end = FindAttributeEnd(line, cursor);
+            ReplaceWithSpaces(masked, index, end > cursor ? end - index + 1 : line.Length - index);
+            index = end > cursor ? end : line.Length;
+        }
+
+        return masked == null ? line : new string(masked);
+    }
+
+    private static int FindAttributeEnd(string line, int openBracket)
+    {
+        var depth = 0;
+        for (var index = openBracket; index < line.Length; index++)
+        {
+            var c = line[index];
+            if (c == 'r')
+            {
+                var rawEnd = TrySkipRawString(line, index);
+                if (rawEnd > index)
+                {
+                    index = rawEnd;
+                    continue;
+                }
+            }
+
+            if (c == '"' || c == '\'')
+            {
+                index = SkipQuotedString(line, index, c);
+                continue;
+            }
+
+            if (c == '[')
+            {
+                depth++;
+                continue;
+            }
+
+            if (c != ']')
+                continue;
+
+            depth--;
+            if (depth == 0)
+                return index;
+        }
+
+        return -1;
+    }
+
+    private static int TrySkipRawString(string line, int start)
+    {
+        var cursor = start + 1;
+        while (cursor < line.Length && line[cursor] == '#')
+            cursor++;
+        if (cursor >= line.Length || line[cursor] != '"')
+            return -1;
+
+        var hashCount = cursor - start - 1;
+        for (var index = cursor + 1; index < line.Length; index++)
+        {
+            if (line[index] == '"' && HasHashRun(line, index + 1, hashCount))
+                return index + hashCount;
+        }
+
+        return line.Length - 1;
+    }
+
+    private static bool HasHashRun(string line, int start, int hashCount)
+    {
+        if (start + hashCount > line.Length)
+            return false;
+        for (var offset = 0; offset < hashCount; offset++)
+        {
+            if (line[start + offset] != '#')
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int SkipQuotedString(string line, int start, char quote)
+    {
+        for (var index = start + 1; index < line.Length; index++)
+        {
+            if (line[index] == '\\')
+            {
+                index++;
+                continue;
+            }
+
+            if (line[index] == quote)
+                return index;
+        }
+
+        return line.Length - 1;
+    }
+
+    private static void ReplaceWithSpaces(char[] chars, int start, int length)
+    {
+        var end = Math.Min(chars.Length, start + length);
+        for (var index = start; index < end; index++)
+            chars[index] = ' ';
+    }
+
     public static void EmitAdditionalCallReferences(string preparedLine, Action<string, int> addCallLikeReference)
     {
         foreach (Match match in RawIdentifierCallRegex.Matches(preparedLine))

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1976,8 +1976,9 @@ public static partial class ReferenceExtractor
                 var rustEnumContainer = rustEnumCandidates != null
                     ? FindInnermostContainer(rustEnumCandidates, lineNumber)
                     : null;
+                var rustTypePositionLine = RustReferenceExtractor.MaskAttributeBodies(preparedLine);
                 RustReferenceExtractor.EmitTypePositionReferences(
-                    preparedLine,
+                    rustTypePositionLine,
                     references,
                     seen,
                     fileId,

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -17996,6 +17996,28 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustAttributeRawString_DoesNotLeakPhantomUseReferences()
+    {
+        const string content = """
+            #[doc = r"use baz::qux;"]
+            pub fn f() {
+                real_call();
+            }
+
+            use crate::actual::Thing;
+
+            fn real_call() {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.DoesNotContain(references, r => r.SymbolName == "qux");
+        Assert.Contains(references, r => r.SymbolName == "Thing" && r.ReferenceKind == "reference");
+        Assert.Contains(references, r => r.SymbolName == "real_call" && r.ContainerName == "f");
+    }
+
+    [Fact]
     public void Extract_JsTemplateLiteral_DoesNotLeakPhantomCallsButKeepsInterpolationCalls()
     {
         // Regression for issue #291: multi-line JS/TS template literal bodies must


### PR DESCRIPTION
## Summary
- Mask Rust attribute bodies before Rust type/use-position reference scanning so raw-string doc attributes cannot emit phantom `use` references.
- Add regression coverage for `#[doc = r"use baz::qux;"]` while keeping real `use` and call references.
- Add bilingual changelog fragment `changelog.d/unreleased/1441.fixed.md`.

Fixes #1441

## Validation
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_Rust" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Adversarial review: `No blocking/actionable issues found.`

## Notes
- A full `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false` run was attempted but stopped after several minutes of no test progress/output; focused Rust extractor tests and full `ReferenceExtractorTests` review pass completed successfully.
- `AGENTS.md`, `CLAUDE.md`, and `AGENT_GUIDE.md` were not modified.