### PR TITLE
Fix Python dynamic import indexing

### DIFF
--- a/changelog.d/unreleased/2056.fixed.md
+++ b/changelog.d/unreleased/2056.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2056
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+---
+
+## English
+
+- **Python dynamic import literals are now indexed (#2056)** — `importlib.import_module(...)`, `importlib.util.find_spec(...)`, and `__import__(...)` string-literal module names now produce import symbols and references, while `importlib` calls remain visible in the reference graph.
+
+## 日本語
+
+- **Python の dynamic import literal を index するようになりました (#2056)** — `importlib.import_module(...)`、`importlib.util.find_spec(...)`、`__import__(...)` の文字列 literal モジュール名が import symbol / reference として記録され、`importlib` 呼び出しも reference graph に残るようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -114,6 +114,12 @@ internal static class PythonReferenceExtractor
     private static readonly Regex ContextlibSuppressTypeRegex = new(
         @"\bcontextlib\.suppress\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
+    private static readonly Regex ImportlibDynamicImportRegex = new(
+        @"\bimportlib(?:\.util)?\.(?:import_module|find_spec)\s*\(\s*(?:(?<quote>['""])(?<module>[^'""]+)\k<quote>)?",
+        RegexOptions.Compiled);
+    private static readonly Regex BuiltinDynamicImportRegex = new(
+        @"(?<!\.)\b__import__\s*\(\s*(?<quote>['""])(?<module>[^'""]+)\k<quote>",
+        RegexOptions.Compiled);
 
     private static string NormalizePythonAnnotationExpression(string expression)
     {
@@ -1018,6 +1024,63 @@ internal static class PythonReferenceExtractor
                 fileId,
                 name,
                 match.Groups["name"].Index,
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    public static void EmitDynamicImportReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
+    {
+        foreach (Match match in ImportlibDynamicImportRegex.Matches(preparedLine))
+        {
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                "importlib",
+                match.Index,
+                "call",
+                context,
+                lineNumber,
+                container,
+                "python");
+
+            var moduleGroup = match.Groups["module"];
+            if (moduleGroup.Success && moduleGroup.Value.Length > 0)
+            {
+                ReferenceExtractor.AddReference(
+                    references,
+                    seen,
+                    fileId,
+                    moduleGroup.Value,
+                    moduleGroup.Index,
+                    "import",
+                    context,
+                    lineNumber,
+                    container,
+                    "python");
+            }
+        }
+
+        foreach (Match match in BuiltinDynamicImportRegex.Matches(preparedLine))
+        {
+            var moduleGroup = match.Groups["module"];
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                moduleGroup.Value,
+                moduleGroup.Index,
+                "import",
                 context,
                 lineNumber,
                 container,

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -115,9 +115,15 @@ internal static class PythonReferenceExtractor
         @"\bcontextlib\.suppress\s*\(\s*(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)",
         RegexOptions.Compiled);
     private static readonly Regex ImportlibDynamicImportRegex = new(
-        @"\bimportlib(?:\.util)?\.(?:import_module|find_spec)\s*\(\s*(?:(?<quote>['""])(?<module>[^'""]+)\k<quote>)?",
+        @"\bimportlib(?:\.util)?\.(?:import_module|find_spec)\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex ImportlibDynamicImportLiteralRegex = new(
+        @"\bimportlib(?:\.util)?\.(?:import_module|find_spec)\s*\(\s*(?<quote>['""])(?<module>[^'""]+)\k<quote>",
         RegexOptions.Compiled);
     private static readonly Regex BuiltinDynamicImportRegex = new(
+        @"(?<!\.)\b__import__\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex BuiltinDynamicImportLiteralRegex = new(
         @"(?<!\.)\b__import__\s*\(\s*(?<quote>['""])(?<module>[^'""]+)\k<quote>",
         RegexOptions.Compiled);
 
@@ -1033,6 +1039,7 @@ internal static class PythonReferenceExtractor
 
     public static void EmitDynamicImportReferences(
         string preparedLine,
+        string originalLine,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -1054,7 +1061,11 @@ internal static class PythonReferenceExtractor
                 container,
                 "python");
 
-            var moduleGroup = match.Groups["module"];
+            var literalMatch = ImportlibDynamicImportLiteralRegex.Match(originalLine, match.Index);
+            if (!literalMatch.Success || literalMatch.Index != match.Index)
+                continue;
+
+            var moduleGroup = literalMatch.Groups["module"];
             if (moduleGroup.Success && moduleGroup.Value.Length > 0)
             {
                 ReferenceExtractor.AddReference(
@@ -1073,7 +1084,11 @@ internal static class PythonReferenceExtractor
 
         foreach (Match match in BuiltinDynamicImportRegex.Matches(preparedLine))
         {
-            var moduleGroup = match.Groups["module"];
+            var literalMatch = BuiltinDynamicImportLiteralRegex.Match(originalLine, match.Index);
+            if (!literalMatch.Success || literalMatch.Index != match.Index)
+                continue;
+
+            var moduleGroup = literalMatch.Groups["module"];
             ReferenceExtractor.AddReference(
                 references,
                 seen,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -3155,6 +3155,14 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     container,
                     name => IsIgnoredCallName(language, name));
+                PythonReferenceExtractor.EmitDynamicImportReferences(
+                    context,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    container);
                 if (pythonHeaderMap.HasValue)
                     RemapPythonLogicalHeaderReferences(references, pythonReferenceStart, pythonHeaderMap.Value, lines);
             }

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -3156,7 +3156,8 @@ public static partial class ReferenceExtractor
                     container,
                     name => IsIgnoredCallName(language, name));
                 PythonReferenceExtractor.EmitDynamicImportReferences(
-                    context,
+                    preparedLine,
+                    originalLine,
                     references,
                     seen,
                     fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -11,6 +11,7 @@ public static partial class SymbolExtractor
     private readonly record struct PythonExportSymbolEntry(string Name, int LineIndex, int StartColumn);
     private static readonly Regex PythonDirectImportRegex = new(@"^import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonFromImportRegex = new(@"^from\s+(?<module>(?:\.+[\w.]*|[\w.]+))\s+import\s+(?<imports>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex PythonDynamicImportLiteralRegex = new(@"\b(?:importlib\.import_module|importlib\.util\.find_spec|__import__)\s*\(\s*(?<quote>['""])(?<module>[^'""]+)\k<quote>", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAssignmentRegex = new(@"^\s*__all__\s*(?:\+?=)\s*(?<values>.+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllAppendRegex = new(@"^\s*__all__\.append\(\s*(?<quote>['""])(?<name>[^'""]+)\k<quote>\s*\)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex PythonAllExtendRegex = new(@"^\s*__all__\.extend\(\s*(?<values>.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -193,6 +194,20 @@ public static partial class SymbolExtractor
 
         var entries = new List<PythonImportSymbolEntry>();
         var seenNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (Match match in PythonDynamicImportLiteralRegex.Matches(statement))
+        {
+            AddPythonImportEntry(
+                line,
+                absoluteStartColumn,
+                match.Groups["module"].Value,
+                entries,
+                seenNames,
+                ref absoluteStartColumn);
+        }
+
+        if (entries.Count > 0)
+            return entries;
 
         var directImportMatch = PythonDirectImportRegex.Match(statement);
         if (directImportMatch.Success)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -813,7 +813,7 @@ public static partial class SymbolExtractor
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?(?:TypeVar|ParamSpec|TypeVarTuple)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?Final(?:\[[^\]]+\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:from\s+(?<name>(?:\.+[\w.]*|[\w.]+))\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
-            new("import",   new Regex(@"\b(?:importlib\.import_module|importlib\.util\.find_spec|__import__)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"^\s*(?:[_\p{L}]\w*\s*=\s*)?(?:importlib\.import_module|importlib\.util\.find_spec|__import__)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cobol"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -813,6 +813,7 @@ public static partial class SymbolExtractor
             new("import",   new Regex(@"^\s*(?<name>\w+)\s*=\s*(?:(?:typing|typing_extensions)\.)?(?:TypeVar|ParamSpec|TypeVarTuple)\s*\(", RegexOptions.Compiled), BodyStyle.None),
             new("property", new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?Final(?:\[[^\]]+\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:from\s+(?<name>(?:\.+[\w.]*|[\w.]+))\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
+            new("import",   new Regex(@"\b(?:importlib\.import_module|importlib\.util\.find_spec|__import__)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
         ],
         ["cobol"] =
         [

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1156,6 +1156,8 @@ public class ReferenceExtractorTests
                 __import__('legacy.loader')
                 importlib.util.find_spec("optional.backend")
                 importlib.import_module(module_name)
+                note = "importlib.import_module('not.real')"
+                # importlib.import_module("commented.out")
             """;
 
         var symbols = SymbolExtractor.Extract(1, "python", content);
@@ -1180,6 +1182,8 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, reference =>
             reference.SymbolName == "module_name"
             && reference.ReferenceKind == "import");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "not.real");
+        Assert.DoesNotContain(references, reference => reference.SymbolName == "commented.out");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1146,6 +1146,43 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonDynamicImports_EmitImportAndImportlibReferences()
+    {
+        const string content = """
+            import importlib
+
+            def load(module_name):
+                importlib.import_module("plugins.alpha")
+                __import__('legacy.loader')
+                importlib.util.find_spec("optional.backend")
+                importlib.import_module(module_name)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var references = ReferenceExtractor.Extract(1, "python", content, symbols);
+
+        Assert.Equal(3, references.Count(reference =>
+            reference.SymbolName == "importlib"
+            && reference.ReferenceKind == "call"
+            && reference.ContainerName == "load"));
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "plugins.alpha"
+            && reference.ReferenceKind == "import"
+            && reference.ContainerName == "load");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "legacy.loader"
+            && reference.ReferenceKind == "import"
+            && reference.ContainerName == "load");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "optional.backend"
+            && reference.ReferenceKind == "import"
+            && reference.ContainerName == "load");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "module_name"
+            && reference.ReferenceKind == "import");
+    }
+
+    [Fact]
     public void Extract_PythonStringifiedAnnotations_CapturesNestedForwardReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -860,18 +860,24 @@ public class SymbolExtractorTests
     {
         var content = """
             importlib.import_module("plugins.alpha")
+            loaded = importlib.import_module("plugins.beta")
             __import__('legacy.loader')
             importlib.util.find_spec("optional.backend")
             importlib.import_module(module_name)
+            note = "importlib.import_module('not.real')"
+            # importlib.import_module("commented.out")
             """;
 
         var symbols = SymbolExtractor.Extract(1, "python", content);
         var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
 
         Assert.Contains("plugins.alpha", imports);
+        Assert.Contains("plugins.beta", imports);
         Assert.Contains("legacy.loader", imports);
         Assert.Contains("optional.backend", imports);
         Assert.DoesNotContain("module_name", imports);
+        Assert.DoesNotContain("not.real", imports);
+        Assert.DoesNotContain("commented.out", imports);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -856,6 +856,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Python_IndexesDynamicImportLiteralModules()
+    {
+        var content = """
+            importlib.import_module("plugins.alpha")
+            __import__('legacy.loader')
+            importlib.util.find_spec("optional.backend")
+            importlib.import_module(module_name)
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+        var imports = symbols.Where(symbol => symbol.Kind == "import").Select(symbol => symbol.Name).ToList();
+
+        Assert.Contains("plugins.alpha", imports);
+        Assert.Contains("legacy.loader", imports);
+        Assert.Contains("optional.backend", imports);
+        Assert.DoesNotContain("module_name", imports);
+    }
+
+    [Fact]
     public void Extract_Python_IndexesAllExportsFromInitModules()
     {
         var content = """


### PR DESCRIPTION
## Summary

- Index literal Python dynamic imports from `importlib.import_module`, `importlib.util.find_spec`, and `__import__`.
- Emit reference entries for literal dynamic imports while avoiding comments, string literals, and variable module names.
- Add regression coverage for symbol extraction and reference extraction.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Python_IndexesDynamicImportLiteralModules|FullyQualifiedName~ReferenceExtractorTests.Extract_PythonDynamicImports_EmitImportAndImportlibReferences"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~SymbolExtractorTests.Extract_Python|FullyQualifiedName~ReferenceExtractorTests.Extract_Python"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits ce49d3efe1ae42cef0e0ff92e3cbc64a1677f167 --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: No blocking/actionable issues found.

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/2056.fixed.md`

## Follow-up Candidates

- None.

Fixes #2056
