### PR TITLE
[codex] Document .NET 9 test coverage

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -10,9 +10,10 @@ dotnet test
 dotnet run --project src/CodeIndex -- <command> [options]
 ```
 
-Development, CI, and NuGet tool packaging target `net8.0`. Use a .NET 8.x SDK
-for supported and tested builds; newer major .NET releases are outside the
-supported/tested matrix until CI covers them.
+The production CLI and NuGet tool packaging target `net8.0`. The test project
+multi-targets `net8.0;net9.0`, and CI runs the test suite on both frameworks
+across Linux, Windows, and macOS. Use a .NET SDK that can restore and run both
+target frameworks when validating the full CI-equivalent test matrix.
 
 For test suite structure, shared helpers, and test-writing conventions, see [TESTING_GUIDE.md](TESTING_GUIDE.md).
 
@@ -1661,9 +1662,11 @@ dotnet test
 dotnet run --project src/CodeIndex -- <command> [options]
 ```
 
-開発、CI、NuGet ツールのパッケージングは `net8.0` を対象にしています。
-サポート済みかつテスト済みのビルドには .NET 8.x SDK を使ってください。
-CI で対象になるまでは、より新しいメジャー .NET リリースはサポート・テスト対象外です。
+製品版 CLI と NuGet ツールのパッケージングは `net8.0` を対象にしています。
+テストプロジェクトは `net8.0;net9.0` の multi-target で、CI は Linux、
+Windows、macOS の各 lane で両方の framework に対してテストスイートを実行します。
+CI 相当のフル検証を行う場合は、両方の target framework を restore / 実行できる
+.NET SDK を使ってください。
 
 テストスイートの構成、共有ヘルパー、テスト作法については [TESTING_GUIDE.md#テストガイド](TESTING_GUIDE.md#テストガイド) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CodeQL](https://github.com/Widthdom/CodeIndex/actions/workflows/codeql.yml/badge.svg)](https://github.com/Widthdom/CodeIndex/actions/workflows/codeql.yml)
 [![Release](https://github.com/Widthdom/CodeIndex/actions/workflows/release.yml/badge.svg)](https://github.com/Widthdom/CodeIndex/actions/workflows/release.yml)
 
-![.NET 8.x](https://img.shields.io/badge/.NET-8.x-512BD4?logo=dotnet&logoColor=white)
+![.NET 8.x / 9.x tests](https://img.shields.io/badge/.NET-8.x%20%2F%209.x%20tests-512BD4?logo=dotnet&logoColor=white)
 ![C#](https://img.shields.io/badge/C%23-12-239120?logo=csharp&logoColor=white)
 ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 ![License](https://img.shields.io/badge/License-FSL--1.1--ALv2-orange)
@@ -232,7 +232,7 @@ details.
 [![CodeQL](https://github.com/Widthdom/CodeIndex/actions/workflows/codeql.yml/badge.svg)](https://github.com/Widthdom/CodeIndex/actions/workflows/codeql.yml)
 [![Release](https://github.com/Widthdom/CodeIndex/actions/workflows/release.yml/badge.svg)](https://github.com/Widthdom/CodeIndex/actions/workflows/release.yml)
 
-![.NET 8.x](https://img.shields.io/badge/.NET-8.x-512BD4?logo=dotnet&logoColor=white)
+![.NET 8.x / 9.x tests](https://img.shields.io/badge/.NET-8.x%20%2F%209.x%20tests-512BD4?logo=dotnet&logoColor=white)
 ![C#](https://img.shields.io/badge/C%23-12-239120?logo=csharp&logoColor=white)
 ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 ![License](https://img.shields.io/badge/License-FSL--1.1--ALv2-orange)

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -19,7 +19,7 @@ Use the full suite by default. Use targeted filters only while iterating locally
 ## Test Stack
 
 - Framework: xUnit
-- Target framework: `net8.0`
+- Target frameworks: `net8.0` and `net9.0`
 - Main test project: `tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
 - Common direct test-only packages: `Microsoft.NET.Test.Sdk`, `xunit`, `xunit.runner.visualstudio`, `coverlet.collector`, `Microsoft.Data.Sqlite`, `FsCheck.Xunit`
 - These test-only packages are separate from the production dependency rule in `src/CodeIndex`, which still allows only `Microsoft.Data.Sqlite` at runtime.
@@ -204,8 +204,8 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 ## テストスタック
 
 - フレームワーク: xUnit
-- 対象フレームワーク: `net8.0`
 - メインのテストプロジェクト: `tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
+- 対象フレームワーク: `net8.0` と `net9.0`
 - 主な直接参照の test-only package: `Microsoft.NET.Test.Sdk`、`xunit`、`xunit.runner.visualstudio`、`coverlet.collector`、`Microsoft.Data.Sqlite`、`FsCheck.Xunit`
 - これらの test-only package は `src/CodeIndex` の本番依存ルールとは別であり、runtime 側は引き続き `Microsoft.Data.Sqlite` のみを許容する。
 - `FsCheck.Xunit` はランダム生成入力に対する普遍的不変条件（never-throws、idempotence、"出力が downstream consumer で parse 可能" 等）を表明する property-based テスト専用です。例ベースの `[Fact]` / `[Theory]` を置き換えるのではなく補完するもので、普遍量化された主張なら FsCheck、特定の具体ケースが契約なら例ベースという形で使い分けてください。

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -10,7 +10,7 @@ AI/MCP setup, language list, and troubleshooting details.
 [![CodeQL](https://github.com/Widthdom/CodeIndex/actions/workflows/codeql.yml/badge.svg)](https://github.com/Widthdom/CodeIndex/actions/workflows/codeql.yml)
 [![Release](https://github.com/Widthdom/CodeIndex/actions/workflows/release.yml/badge.svg)](https://github.com/Widthdom/CodeIndex/actions/workflows/release.yml)
 
-![.NET 8.x](https://img.shields.io/badge/.NET-8.x-512BD4?logo=dotnet&logoColor=white)
+![.NET 8.x / 9.x tests](https://img.shields.io/badge/.NET-8.x%20%2F%209.x%20tests-512BD4?logo=dotnet&logoColor=white)
 ![C#](https://img.shields.io/badge/C%23-12-239120?logo=csharp&logoColor=white)
 ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 ![License](https://img.shields.io/badge/License-FSL--1.1--ALv2-orange)
@@ -451,9 +451,9 @@ RUN export CDIDX_INSTALL_DIR=/usr/local/bin \
 ### Option B: NuGet Global Tool
 
 Requires the [.NET 8.x SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
-CodeIndex targets `net8.0`; .NET 8.x is the supported and tested SDK/runtime
-line. Newer major .NET releases are outside the supported/tested matrix until
-CI covers them.
+CodeIndex targets `net8.0`; .NET 8.x is the supported SDK/runtime line for the
+published tool, while the CI test suite also covers the test project on
+`net9.0`.
 
 ```bash
 dotnet tool install -g cdidx
@@ -1876,7 +1876,7 @@ The short version: `version.json` is the single source of truth, and the maintai
 <a id="cdidx日本語"></a>
 # cdidx（日本語）
 
-![.NET 8.x](https://img.shields.io/badge/.NET-8.x-512BD4?logo=dotnet&logoColor=white)
+![.NET 8.x / 9.x tests](https://img.shields.io/badge/.NET-8.x%20%2F%209.x%20tests-512BD4?logo=dotnet&logoColor=white)
 ![C#](https://img.shields.io/badge/C%23-12-239120?logo=csharp&logoColor=white)
 ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 ![License](https://img.shields.io/badge/License-FSL--1.1--ALv2-orange)
@@ -2305,9 +2305,9 @@ RUN export CDIDX_INSTALL_DIR=/usr/local/bin \
 ### 方法B: NuGet グローバルツール
 
 [.NET 8.x SDK](https://dotnet.microsoft.com/download/dotnet/8.0) が必要です。
-CodeIndex は `net8.0` を対象にしており、.NET 8.x がサポート済みかつ
-テスト済みの SDK/runtime 系列です。CI で対象になるまでは、より新しい
-メジャー .NET リリースはサポート・テスト対象外です。
+CodeIndex は `net8.0` を対象にしており、公開ツールのサポート対象
+SDK/runtime 系列は .NET 8.x です。一方で、CI のテストスイートは
+テストプロジェクトを `net9.0` でも検証します。
 
 ```bash
 dotnet tool install -g cdidx

--- a/changelog.d/unreleased/+net9-test-docs.docs.md
+++ b/changelog.d/unreleased/+net9-test-docs.docs.md
@@ -1,0 +1,16 @@
+---
+category: docs
+affected:
+  - DEVELOPER_GUIDE.md
+  - README.md
+  - TESTING_GUIDE.md
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Documented .NET 9 test coverage** — README, USER_GUIDE, DEVELOPER_GUIDE, and TESTING_GUIDE now distinguish the `net8.0` production tool target from the `net8.0` / `net9.0` test matrix.
+
+## 日本語
+
+- **.NET 9 のテストカバレッジを文書化しました** — README、USER_GUIDE、DEVELOPER_GUIDE、TESTING_GUIDE で、製品版ツールの `net8.0` target と `net8.0` / `net9.0` の test matrix を区別して説明するようにしました。

--- a/changelog.d/unreleased/1904.docs.md
+++ b/changelog.d/unreleased/1904.docs.md
@@ -10,8 +10,8 @@ affected:
 
 ## English
 
-- **Clarified the supported .NET line for NuGet tool installs (#1904)** — README and USER_GUIDE now consistently describe .NET 8.x as the supported and tested SDK/runtime line instead of mixing exact `.NET 8.0` and permissive `.NET 8+` wording.
+- **Clarified the supported .NET line for NuGet tool installs (#1904)** — README and USER_GUIDE now consistently describe .NET 8.x as the supported SDK/runtime line for the published tool instead of mixing exact `.NET 8.0` and permissive `.NET 8+` wording.
 
 ## 日本語
 
-- **NuGet ツールインストールでサポートする .NET 系列を明確化しました (#1904)** — README と USER_GUIDE は、`.NET 8.0` と `.NET 8+` の混在表記ではなく、.NET 8.x をサポート済みかつテスト済みの SDK/runtime 系列として一貫して説明するようになりました。
+- **NuGet ツールインストールでサポートする .NET 系列を明確化しました (#1904)** — README と USER_GUIDE は、`.NET 8.0` と `.NET 8+` の混在表記ではなく、公開ツールでサポートする SDK/runtime 系列を .NET 8.x として一貫して説明するようになりました。


### PR DESCRIPTION
## Summary

- Update README and USER_GUIDE badges to show that the project now has .NET 8.x / 9.x test coverage.
- Clarify that the published CLI/NuGet tool still targets `net8.0`, while the test project and CI matrix cover both `net8.0` and `net9.0`.
- Update the existing .NET support changelog wording and add a docs fragment for the .NET 9 test coverage documentation.

## Validation

- `git diff --check`
- `dotnet run --project tools/CodeIndex.Changelog -- check`

Not run: full build/test suite, because this PR only changes documentation and changelog fragments.

## Documentation and Changelog

- Updated `README.md`, `USER_GUIDE.md`, `DEVELOPER_GUIDE.md`, and `TESTING_GUIDE.md`.
- Added `changelog.d/unreleased/+net9-test-docs.docs.md`.
- Adjusted `changelog.d/unreleased/1904.docs.md` so the published-tool support wording does not conflict with the new .NET 9 test matrix.

## Follow-up Candidates

- None.