### PR TITLE
Reject reversed ignore character ranges

### DIFF
--- a/changelog.d/unreleased/1624.fixed.md
+++ b/changelog.d/unreleased/1624.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1624
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Reversed ignore character ranges are now rejected (#1624)** — `.gitignore` and `.cdidxignore` patterns such as `[z-a]` are skipped with a warning instead of compiling into a matcher that silently matches nothing.
+
+## 日本語
+
+- **ignore ルールの逆順文字範囲を拒否するようにしました (#1624)** — `.gitignore` と `.cdidxignore` の `[z-a]` のような pattern は、何にも一致しない matcher として静かに受理されず、警告付きで skipped されます。

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -845,6 +845,9 @@ public class FileIndexer
 
         private static bool TryAppendCharacterClassRange(StringBuilder builder, char start, char end, bool ignoreCase)
         {
+            if (start > end)
+                throw new ArgumentException("reversed character class range");
+
             builder.Append(EscapeCharacterClassLiteral(start));
             builder.Append('-');
             builder.Append(EscapeCharacterClassLiteral(end));

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2266,6 +2266,7 @@ public class FileIndexerTests
             Assert.Equal(7, scanResult.Errors.Count);
             Assert.All(scanResult.Errors, error => Assert.Contains(".gitignore:", error.Path, StringComparison.Ordinal));
             Assert.All(scanResult.Errors, error => Assert.Contains("Invalid ignore rule skipped", error.Message, StringComparison.Ordinal));
+            Assert.Contains(scanResult.Errors, error => error.Message == "Invalid ignore rule skipped: reversed character class range");
             Assert.All(scanResult.Errors, error => Assert.Equal(FileIndexer.ScanIssueSeverity.Warning, error.Severity));
         }
         finally


### PR DESCRIPTION
## Summary

- Reject reversed ignore character-class ranges such as `[z-a]` during `.gitignore` / `.cdidxignore` parsing.
- Preserve the existing malformed-rule warning path and add coverage for the specific reversed-range diagnostic.
- Add bilingual changelog fragment `changelog.d/unreleased/1624.fixed.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests.ScanFilesDetailed_SkipsMalformedIgnoreRulesWithoutAborting"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests"`
- `dotnet build CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: `No blocking/actionable issues found.`

Full `dotnet test CodeIndex.sln` was attempted earlier but was stopped after running for more than 17 minutes alongside other long-running test hosts; the focused scanner coverage and build passed.

## Documentation / Changelog

- Added `changelog.d/unreleased/1624.fixed.md`.
- No README or guide update was needed because this aligns malformed ignore-rule handling with the existing warning behavior.

Fixes #1624
