### PR TITLE
Publish NuGet symbol package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -597,18 +597,29 @@ jobs:
         run: |
           set -euo pipefail
           expected_package="nupkg/cdidx.${VERSION}.nupkg"
+          expected_symbols="nupkg/cdidx.${VERSION}.snupkg"
           if [ ! -f "$expected_package" ]; then
             echo "Expected packed package ${expected_package} was not produced." >&2
             printf 'Produced packages:\n' >&2
             ls -la nupkg >&2
             exit 1
           fi
+          if [ ! -f "$expected_symbols" ]; then
+            echo "Expected packed symbol package ${expected_symbols} was not produced." >&2
+            printf 'Produced packages:\n' >&2
+            ls -la nupkg >&2
+            exit 1
+          fi
 
       - name: Publish to NuGet
-        run: >
-          dotnet nuget push nupkg/*.nupkg
-          --api-key ${{ secrets.NUGET_API_KEY }}
-          --source https://api.nuget.org/v3/index.json
+        run: |
+          set -euo pipefail
+          dotnet nuget push nupkg/*.nupkg \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --source https://api.nuget.org/v3/index.json
+          dotnet nuget push nupkg/*.snupkg \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --source https://api.nuget.org/v3/index.json
 
   publish-homebrew:
     if: github.repository == 'Widthdom/CodeIndex'

--- a/changelog.d/unreleased/1599.fixed.md
+++ b/changelog.d/unreleased/1599.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1599
+affected:
+  - src/CodeIndex/CodeIndex.csproj
+  - .github/workflows/release.yml
+---
+
+## English
+
+- **NuGet releases now publish symbol packages (#1599)** — release packing now produces a `.snupkg` alongside the `.nupkg`, verifies both artifacts, and pushes both packages to NuGet.org so downstream consumers can debug with symbols.
+
+## 日本語
+
+- **NuGet リリースでシンボルパッケージを公開するようになりました (#1599)** — release packing は `.nupkg` と並行して `.snupkg` を生成し、両方の成果物を検証して NuGet.org に push するため、下流利用者がシンボル付きでデバッグできるようになります。

--- a/src/CodeIndex/CodeIndex.csproj
+++ b/src/CodeIndex/CodeIndex.csproj
@@ -39,6 +39,8 @@
     <PackageReleaseNotes>See https://github.com/Widthdom/CodeIndex/blob/main/CHANGELOG.md for release notes.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>cdidx-icon.png</PackageIcon>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Enable `.snupkg` symbol package generation for the `cdidx` NuGet package.
- Verify both `.nupkg` and `.snupkg` artifacts in the release workflow.
- Push both package artifacts to NuGet.org during release publishing.

## Validation

- `dotnet build`
- `dotnet pack src/CodeIndex/CodeIndex.csproj --configuration Release -p:Version=0.0.0-test --output /private/tmp/cdidx-pack-1599-clean`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

Note: a full `dotnet test` run was attempted earlier, but it remained running for over 16 minutes amid other long-running local test processes and was stopped. This change is release packaging only; the focused pack/build validation above verifies the affected behavior.

## Documentation and Changelog

- Added `changelog.d/unreleased/1599.fixed.md`.
- No README or developer-guide update was needed because this changes release packaging artifacts rather than CLI behavior or documented user workflow.

Fixes #1599
