### PR TITLE
Fix Python decorator argument references

### DIFF
--- a/changelog.d/unreleased/2055.fixed.md
+++ b/changelog.d/unreleased/2055.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2055
+affected:
+  - src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Python decorator references now include decorator argument and composition callables (#2055)** — Python reference extraction now records callable symbols used inside parameterized decorators and composed decorator chains.
+
+## 日本語
+
+- **Python decorator references が decorator 引数と合成 chain 内の callable も含むようになりました (#2055)** — Python reference extraction は、parameterized decorator や composed decorator chain 内で使われる callable symbol も記録するようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -15,6 +15,9 @@ internal static class PythonReferenceExtractor
     private static readonly Regex DecoratorCallRegex = new(
         @"^\s*@(?<name>[_\p{L}]\w*(?:\.[_\p{L}]\w*)*)\s*\(",
         RegexOptions.Compiled);
+    private static readonly Regex PythonIdentifierRegex = new(
+        @"(?<![\w.])(?<name>[_\p{L}]\w*(?:\.[_\p{L}]\w*)*)",
+        RegexOptions.Compiled);
     private static readonly Regex BareRaiseTypeRegex = new(
         @"^\s*raise\s+(?<name>(?:[_\p{L}]\w*\.)*[_\p{Lu}]\w*)(?:\s+from\s+[_\p{L}]\w*)?\s*(?:#.*)?$",
         RegexOptions.Compiled);
@@ -262,6 +265,16 @@ internal static class PythonReferenceExtractor
                 continue;
 
             ReferenceExtractor.AddReference(references, seen, fileId, match, "decorator", context, lineNumber, container);
+            EmitDecoratorArgumentReferences(
+                preparedLine,
+                match,
+                references,
+                seen,
+                fileId,
+                context,
+                lineNumber,
+                container,
+                isIgnoredName);
         }
 
         foreach (Match match in DecoratorRegex.Matches(preparedLine))
@@ -274,6 +287,58 @@ internal static class PythonReferenceExtractor
 
             ReferenceExtractor.AddReference(references, seen, fileId, match, "decorator", context, lineNumber, container);
         }
+    }
+
+    private static void EmitDecoratorArgumentReferences(
+        string preparedLine,
+        Match decoratorMatch,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container,
+        Func<string, bool> isIgnoredName)
+    {
+        var decoratorName = decoratorMatch.Groups["name"].Value;
+        var argumentStart = preparedLine.IndexOf('(', decoratorMatch.Index + decoratorMatch.Length - 1);
+        if (argumentStart < 0)
+            return;
+
+        foreach (Match identifierMatch in PythonIdentifierRegex.Matches(preparedLine, argumentStart + 1))
+        {
+            var nameGroup = identifierMatch.Groups["name"];
+            var name = nameGroup.Value;
+            if (name == decoratorName || isIgnoredName(name) || IsPythonLiteralName(name))
+                continue;
+            if (IsKeywordArgumentName(preparedLine, nameGroup.Index + nameGroup.Length))
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameGroup.Index,
+                "call",
+                context,
+                lineNumber,
+                container,
+                "python");
+        }
+    }
+
+    private static bool IsKeywordArgumentName(string value, int afterNameIndex)
+    {
+        while (afterNameIndex < value.Length && char.IsWhiteSpace(value[afterNameIndex]))
+            afterNameIndex++;
+
+        return afterNameIndex < value.Length && value[afterNameIndex] == '=';
+    }
+
+    private static bool IsPythonLiteralName(string name)
+    {
+        return name is "True" or "False" or "None" or "Ellipsis";
     }
 
     public static void EmitRaiseReferences(

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -313,6 +313,8 @@ internal static class PythonReferenceExtractor
                 continue;
             if (IsKeywordArgumentName(preparedLine, nameGroup.Index + nameGroup.Length))
                 continue;
+            if (IsKeywordArgumentValue(preparedLine, nameGroup.Index))
+                continue;
 
             ReferenceExtractor.AddReference(
                 references,
@@ -320,7 +322,7 @@ internal static class PythonReferenceExtractor
                 fileId,
                 name,
                 nameGroup.Index,
-                "call",
+                IsCallTarget(preparedLine, nameGroup.Index + nameGroup.Length) ? "call" : "reference",
                 context,
                 lineNumber,
                 container,
@@ -334,6 +336,23 @@ internal static class PythonReferenceExtractor
             afterNameIndex++;
 
         return afterNameIndex < value.Length && value[afterNameIndex] == '=';
+    }
+
+    private static bool IsKeywordArgumentValue(string value, int nameIndex)
+    {
+        var beforeNameIndex = nameIndex - 1;
+        while (beforeNameIndex >= 0 && char.IsWhiteSpace(value[beforeNameIndex]))
+            beforeNameIndex--;
+
+        return beforeNameIndex >= 0 && value[beforeNameIndex] == '=';
+    }
+
+    private static bool IsCallTarget(string value, int afterNameIndex)
+    {
+        while (afterNameIndex < value.Length && char.IsWhiteSpace(value[afterNameIndex]))
+            afterNameIndex++;
+
+        return afterNameIndex < value.Length && value[afterNameIndex] == '(';
     }
 
     private static bool IsPythonLiteralName(string name)

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -313,7 +313,8 @@ internal static class PythonReferenceExtractor
                 continue;
             if (IsKeywordArgumentName(preparedLine, nameGroup.Index + nameGroup.Length))
                 continue;
-            if (IsKeywordArgumentValue(preparedLine, nameGroup.Index))
+            var isCallTarget = IsCallTarget(preparedLine, nameGroup.Index + nameGroup.Length);
+            if (IsKeywordArgumentValue(preparedLine, nameGroup.Index) && !isCallTarget)
                 continue;
 
             ReferenceExtractor.AddReference(
@@ -322,7 +323,7 @@ internal static class PythonReferenceExtractor
                 fileId,
                 name,
                 nameGroup.Index,
-                IsCallTarget(preparedLine, nameGroup.Index + nameGroup.Length) ? "call" : "reference",
+                isCallTarget ? "call" : "reference",
                 context,
                 lineNumber,
                 container,

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -893,6 +893,9 @@ public class ReferenceExtractorTests
                     return f
                 return wrap
 
+            def make_factory():
+                return target_func
+
             DEFAULT_TIMEOUT = 30
 
             @bare_decorator
@@ -912,6 +915,10 @@ public class ReferenceExtractorTests
             def configured_target():
                 pass
 
+            @cache_with(factory=make_factory())
+            def keyword_factory_target():
+                pass
+
             @staticmethod
             def method():
                 pass
@@ -928,7 +935,7 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "python", content);
         var references = ReferenceExtractor.Extract(1, "python", content, symbols);
 
-        Assert.Equal(8, references.Count(reference => reference.ReferenceKind == "decorator"));
+        Assert.Equal(9, references.Count(reference => reference.ReferenceKind == "decorator"));
         Assert.Contains(references, reference =>
             reference.SymbolName == "bare_decorator"
             && reference.ReferenceKind == "decorator");
@@ -959,6 +966,10 @@ public class ReferenceExtractorTests
             reference.SymbolName == "target_func"
             && reference.ReferenceKind == "reference"
             && reference.Context == "@cache_with(timeout=30)(memoize(target_func))");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "make_factory"
+            && reference.ReferenceKind == "call"
+            && reference.Context == "@cache_with(factory=make_factory())");
         Assert.DoesNotContain(references, reference =>
             reference.SymbolName == "DEFAULT_TIMEOUT"
             && reference.ReferenceKind == "call");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -893,6 +893,8 @@ public class ReferenceExtractorTests
                     return f
                 return wrap
 
+            DEFAULT_TIMEOUT = 30
+
             @bare_decorator
             @parametrized("value")
             def wrapped():
@@ -904,6 +906,10 @@ public class ReferenceExtractorTests
 
             @cache_with(timeout=30)(memoize(target_func))
             def composed_target():
+                pass
+
+            @cache_with(timeout=DEFAULT_TIMEOUT)
+            def configured_target():
                 pass
 
             @staticmethod
@@ -922,7 +928,7 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "python", content);
         var references = ReferenceExtractor.Extract(1, "python", content, symbols);
 
-        Assert.Equal(7, references.Count(reference => reference.ReferenceKind == "decorator"));
+        Assert.Equal(8, references.Count(reference => reference.ReferenceKind == "decorator"));
         Assert.Contains(references, reference =>
             reference.SymbolName == "bare_decorator"
             && reference.ReferenceKind == "decorator");
@@ -943,7 +949,7 @@ public class ReferenceExtractorTests
             && reference.ReferenceKind == "call");
         Assert.Contains(references, reference =>
             reference.SymbolName == "target_func"
-            && reference.ReferenceKind == "call"
+            && reference.ReferenceKind == "reference"
             && reference.Context == "@functools.wraps(target_func)");
         Assert.Contains(references, reference =>
             reference.SymbolName == "memoize"
@@ -951,8 +957,11 @@ public class ReferenceExtractorTests
             && reference.Context == "@cache_with(timeout=30)(memoize(target_func))");
         Assert.Contains(references, reference =>
             reference.SymbolName == "target_func"
-            && reference.ReferenceKind == "call"
+            && reference.ReferenceKind == "reference"
             && reference.Context == "@cache_with(timeout=30)(memoize(target_func))");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "DEFAULT_TIMEOUT"
+            && reference.ReferenceKind == "call");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -882,9 +882,28 @@ public class ReferenceExtractorTests
                     return f
                 return wrap
 
+            def target_func():
+                pass
+
+            def memoize(fn):
+                return fn
+
+            def cache_with(timeout):
+                def wrap(f):
+                    return f
+                return wrap
+
             @bare_decorator
             @parametrized("value")
             def wrapped():
+                pass
+
+            @functools.wraps(target_func)
+            def wrapped_target():
+                pass
+
+            @cache_with(timeout=30)(memoize(target_func))
+            def composed_target():
                 pass
 
             @staticmethod
@@ -903,7 +922,7 @@ public class ReferenceExtractorTests
         var symbols = SymbolExtractor.Extract(1, "python", content);
         var references = ReferenceExtractor.Extract(1, "python", content, symbols);
 
-        Assert.Equal(5, references.Count(reference => reference.ReferenceKind == "decorator"));
+        Assert.Equal(7, references.Count(reference => reference.ReferenceKind == "decorator"));
         Assert.Contains(references, reference =>
             reference.SymbolName == "bare_decorator"
             && reference.ReferenceKind == "decorator");
@@ -922,6 +941,18 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference =>
             reference.SymbolName == "parametrized"
             && reference.ReferenceKind == "call");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "target_func"
+            && reference.ReferenceKind == "call"
+            && reference.Context == "@functools.wraps(target_func)");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "memoize"
+            && reference.ReferenceKind == "call"
+            && reference.Context == "@cache_with(timeout=30)(memoize(target_func))");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "target_func"
+            && reference.ReferenceKind == "call"
+            && reference.Context == "@cache_with(timeout=30)(memoize(target_func))");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Capture callable symbols used inside Python parameterized decorators and composed decorator chains.
- Avoid polluting call graph edges with non-call keyword configuration values while still recording callable keyword values.
- Add regression coverage and a bilingual changelog fragment.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests"`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: two rounds completed; both actionable findings addressed.

## Documentation / Changelog

- Added `changelog.d/unreleased/2055.fixed.md`.

## Follow-up Candidates

- None.

Fixes #2055
