### PR TITLE
[codex] Fix NuGet README release links

### DIFF
--- a/changelog.d/unreleased/+nuget-readme-tag-links.fixed.md
+++ b/changelog.d/unreleased/+nuget-readme-tag-links.fixed.md
@@ -1,0 +1,14 @@
+---
+category: fixed
+affected:
+  - docs/NUGET_README.md
+  - src/CodeIndex/CodeIndex.csproj
+---
+
+## English
+
+- **NuGet README links now point at the packaged release tag** - NuGet package README and release-note links are generated with the package version tag instead of `main`, so older package pages keep pointing at matching documentation.
+
+## 日本語
+
+- **NuGet README のリンクがパッケージ対象のリリースタグを指すようになりました** - NuGet package README と release note のリンクは `main` ではなくパッケージ version のタグで生成されるため、過去バージョンの package page から対応する documentation を参照できます。

--- a/docs/NUGET_README.md
+++ b/docs/NUGET_README.md
@@ -28,13 +28,13 @@ absolute GitHub URLs.
 
 | Document | Link |
 |---|---|
-| README | https://github.com/Widthdom/CodeIndex/blob/main/README.md |
-| User Guide | https://github.com/Widthdom/CodeIndex/blob/main/USER_GUIDE.md |
-| Platform Support | https://github.com/Widthdom/CodeIndex/blob/main/docs/platform-support.md |
-| Developer Guide | https://github.com/Widthdom/CodeIndex/blob/main/DEVELOPER_GUIDE.md |
-| Integration Policy | https://github.com/Widthdom/CodeIndex/blob/main/INTEGRATION_POLICY.md |
-| Security Policy | https://github.com/Widthdom/CodeIndex/blob/main/SECURITY.md |
-| Changelog | https://github.com/Widthdom/CodeIndex/blob/main/CHANGELOG.md |
+| README | https://github.com/Widthdom/CodeIndex/blob/{{RELEASE_REF}}/README.md |
+| User Guide | https://github.com/Widthdom/CodeIndex/blob/{{RELEASE_REF}}/USER_GUIDE.md |
+| Platform Support | https://github.com/Widthdom/CodeIndex/blob/{{RELEASE_REF}}/docs/platform-support.md |
+| Developer Guide | https://github.com/Widthdom/CodeIndex/blob/{{RELEASE_REF}}/DEVELOPER_GUIDE.md |
+| Integration Policy | https://github.com/Widthdom/CodeIndex/blob/{{RELEASE_REF}}/INTEGRATION_POLICY.md |
+| Security Policy | https://github.com/Widthdom/CodeIndex/blob/{{RELEASE_REF}}/SECURITY.md |
+| Changelog | https://github.com/Widthdom/CodeIndex/blob/{{RELEASE_REF}}/CHANGELOG.md |
 
 `cdidx` is distributed as a CLI and MCP server only. The NuGet package is a
 global tool package and does not provide a public library or SDK API.

--- a/src/CodeIndex/CodeIndex.csproj
+++ b/src/CodeIndex/CodeIndex.csproj
@@ -36,7 +36,10 @@
     <PackageProjectUrl>https://github.com/widthdom/codeindex</PackageProjectUrl>
     <RepositoryUrl>https://github.com/widthdom/codeindex</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>See https://github.com/Widthdom/CodeIndex/blob/main/CHANGELOG.md for release notes.</PackageReleaseNotes>
+    <NuGetReleaseRef>v$(Version)</NuGetReleaseRef>
+    <NuGetReadmeTemplatePath>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '..', '..', 'docs', 'NUGET_README.md'))</NuGetReadmeTemplatePath>
+    <NuGetReadmeOutputPath>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', 'obj', 'NuGet', 'NUGET_README.md'))</NuGetReadmeOutputPath>
+    <PackageReleaseNotes>See https://github.com/Widthdom/CodeIndex/blob/$(NuGetReleaseRef)/CHANGELOG.md for release notes.</PackageReleaseNotes>
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageIcon>cdidx-icon.png</PackageIcon>
   </PropertyGroup>
@@ -115,8 +118,16 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="GenerateNuGetReadme" BeforeTargets="GenerateNuspec">
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(NuGetReadmeOutputPath)'))" />
+    <WriteLinesToFile
+      File="$(NuGetReadmeOutputPath)"
+      Lines="$([System.IO.File]::ReadAllText('$(NuGetReadmeTemplatePath)').Replace('{{RELEASE_REF}}', '$(NuGetReleaseRef)'))"
+      Overwrite="true" />
+  </Target>
+
   <ItemGroup>
-    <None Include="..\..\docs\NUGET_README.md" Pack="true" PackagePath="\" />
+    <None Include="$(NuGetReadmeOutputPath)" Pack="true" PackagePath="\" />
     <None Include="..\..\docs\cdidx-icon.png" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <None Include="..\..\COMMERCIAL_LICENSE.md" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />


### PR DESCRIPTION
## Summary

- Generate the NuGet package README from `docs/NUGET_README.md` at pack time.
- Replace the README template placeholder with the package version tag, so NuGet pages link to matching release documentation instead of latest `main`.
- Point package release notes at the same version tag and add a changelog fragment.

## Validation

- `dotnet pack src/CodeIndex/CodeIndex.csproj --configuration Release --no-restore --output /private/tmp/cdidx-pack-check`
- `unzip -p /private/tmp/cdidx-pack-check/cdidx.1.24.5.nupkg NUGET_README.md` confirmed documentation links use `v1.24.5`.
- `unzip -p /private/tmp/cdidx-pack-check/cdidx.1.24.5.nupkg cdidx.nuspec` confirmed release notes use `v1.24.5`.
- `dotnet run --project tools/CodeIndex.Changelog -- check`

## Documentation and changelog

- Added `changelog.d/unreleased/+nuget-readme-tag-links.fixed.md`.
- Updated `docs/NUGET_README.md` to use the release-ref template placeholder.

## Follow-up candidates

- None.