### PR TITLE
Fix CLI JSON and terminal output controls

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -97,6 +97,12 @@ Usage: <command shape>
 
 When an error code is available, the first line is `Error [<code>]: <message>`. Use `CommandErrorWriter` for new CLI parse, validation, and filesystem preflight errors so `ProgramRunner`, `IndexCommandRunner`, and query runners keep the same format. JSON error payloads continue to use `CommandErrorJsonResult`.
 
+### CLI output encoding and terminal controls
+
+CLI JSON output must be machine-clean: redirected stdout is written as UTF-8 without a BOM, and JSON-mode commands must not emit ANSI escape sequences even when `--color=always` or `CLICOLOR_FORCE=1` would color human output. Keep JSON-safe styling suppression close to shared formatting helpers such as `ConsoleUi.ColorizeKind` so future query output paths inherit the invariant.
+
+Interactive terminal controls are allowed only when stdout is not redirected or captured, terminal capability hints are present, and the environment has not opted out. Treat `TERM=dumb`, truthy `CI`, missing Unix terminal hints, `NO_COLOR`, and `CLICOLOR=0` as reasons to suppress ANSI/progress controls unless an explicitly human-facing override is documented for that control.
+
 ### C# / .NET integration
 
 `SolutionProjectResolver` parses the plain-text `.sln` `Project(...) = "...", "...csproj"` entries and resolves C# / F# / VB project files. When exactly one `.sln` exists at the workspace root, `--project <name|path>` uses it automatically; otherwise callers can pass `--solution <path>`.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Output controls:
 |---|---|
 | Owner-only persistent stderr logs on POSIX | Global tool stderr logs are forced to `0600` permissions on every open, including existing date-stamped log files. |
 | ASCII-only terminal output | Use `--ascii`, `CDIDX_ASCII=1`, `NO_UNICODE`, `TERM=dumb`, accessibility env hints, or a non-UTF-8 locale. Spinners use pipe, slash, dash, and backslash frames; progress bars use `#` / `-`; very narrow terminals fall back to percentage-only progress. |
+| Color and terminal capability | `--color auto` emits ANSI only for capable interactive terminals; `TERM=dumb`, `CI=true`, missing Unix terminal hints, `NO_COLOR`, or `CLICOLOR=0` disable ANSI/progress control sequences. `--palette basic|256|truecolor` can override the `COLORTERM` / `TERM` color-depth detection. |
+| UTF-8 JSON pipelines | CLI `--json` output is written as UTF-8 without a BOM and never includes ANSI escape sequences, even when color is forced for human output. |
 | Script-friendly query pipelines | Use `--quiet`, `-q`, `--silent`, or `CDIDX_QUIET=1` to suppress informational stderr text while preserving errors. `--quiet` takes precedence over `--verbose`. |
 
 Use `cdidx` when a repository will be searched repeatedly from terminals,
@@ -256,6 +258,8 @@ cdidx mcp
 |---|---|
 | POSIX の persistent stderr log を owner-only にする | global tool stderr log は開くたびに `0600` 権限へ補正され、既存の日付付き log file も同じ扱いになります。 |
 | ASCII-only 端末で崩れない表示にする | `--ascii`、`CDIDX_ASCII=1`、`NO_UNICODE`、`TERM=dumb`、accessibility 系の環境変数、非 UTF-8 locale を使います。スピナーは pipe、slash、dash、backslash の frame、進捗バーは `#` / `-` になり、幅が非常に狭い端末では percentage-only になります。 |
+| color と端末 capability | `--color auto` は対応する interactive terminal でだけ ANSI を出力します。`TERM=dumb`、`CI=true`、Unix で端末 hint が無い場合、`NO_COLOR`、`CLICOLOR=0` では ANSI / progress 制御シーケンスを抑止します。`--palette basic|256|truecolor` で `COLORTERM` / `TERM` による color-depth 判定を上書きできます。 |
+| UTF-8 JSON pipeline | CLI の `--json` 出力は BOM なし UTF-8 で書き出され、human output 向けに色を強制していても ANSI escape sequence を含みません。 |
 | script 向け query pipeline の stderr を静かにする | `--quiet`、`-q`、`--silent`、`CDIDX_QUIET=1` で informational stderr を抑制し、error 行だけを残します。`--quiet` は `--verbose` より優先されます。 |
 
 ターミナル、スクリプト、CI、AI ツールから同じリポジトリを繰り返し検索する

--- a/changelog.d/unreleased/1833.fixed.md
+++ b/changelog.d/unreleased/1833.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1833
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - README.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Interactive terminal detection now honors CI and terminal opt-outs (#1833)** — `TERM=dumb`, truthy `CI`, missing Unix terminal hints, redirected stdout, and test captures suppress spinner/progress control sequences.
+
+## 日本語
+
+- **interactive terminal 判定が CI と端末 opt-out を尊重するようになりました (#1833)** — `TERM=dumb`、truthy な `CI`、Unix で端末 hint が無い場合、redirect stdout、test capture では spinner/progress 制御シーケンスを抑止します。

--- a/changelog.d/unreleased/1834.fixed.md
+++ b/changelog.d/unreleased/1834.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1834
+affected:
+  - README.md
+---
+
+## English
+
+- **Documented color-depth controls for ANSI output (#1834)** — README output controls now describe `COLORTERM` / `TERM` palette detection and the `--palette basic|256|truecolor` override.
+
+## 日本語
+
+- **ANSI 出力の color-depth 制御を文書化しました (#1834)** — README の出力制御に `COLORTERM` / `TERM` による palette 判定と `--palette basic|256|truecolor` override を記載しました。

--- a/changelog.d/unreleased/1953.fixed.md
+++ b/changelog.d/unreleased/1953.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1953
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - README.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Redirected CLI output now uses UTF-8 without a BOM (#1953)** — JSON pipelines receive stable UTF-8 bytes instead of falling back to the host console code page.
+
+## 日本語
+
+- **redirect された CLI 出力を BOM なし UTF-8 で書くようになりました (#1953)** — JSON pipeline が host console code page にフォールバックせず、安定した UTF-8 byte を受け取れます。

--- a/changelog.d/unreleased/1956.fixed.md
+++ b/changelog.d/unreleased/1956.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1956
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+---
+
+## English
+
+- **JSON output now suppresses ANSI styling even when color is forced (#1956)** — `--json` commands keep shared symbol-kind formatting machine-clean while preserving forced color for human output.
+
+## 日本語
+
+- **color を強制していても JSON 出力では ANSI styling を抑止するようになりました (#1956)** — `--json` コマンドは共有の symbol-kind 表示を machine-clean に保ちつつ、人間向け出力の強制 color は維持します。

--- a/changelog.d/unreleased/2676.fixed.md
+++ b/changelog.d/unreleased/2676.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2676
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/ConcurrencyTests.cs
+---
+
+## English
+
+- **Ready-bit updates no longer start raw nested SQLite transactions (#2676)** — concurrent writers now use provider-managed immediate transactions for `PRAGMA user_version` updates.
+
+## 日本語
+
+- **ready-bit 更新で raw な nested SQLite transaction を開始しないようになりました (#2676)** — concurrent writer は `PRAGMA user_version` 更新に provider-managed immediate transaction を使います。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -108,6 +108,7 @@ public static class ConsoleUi
     private static TextWriter? _synchronizedOut;
     private static TextWriter? _synchronizedError;
     private static readonly string[] ByteUnits = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
+    private static readonly AsyncLocal<int> JsonOutputDepth = new();
 
     private static readonly string[] DefaultBrailleSpinnerFrames =
     [
@@ -150,6 +151,15 @@ public static class ConsoleUi
                 Console.SetError(_synchronizedError);
             }
         }
+    }
+
+    internal static IDisposable SuppressAnsiForJsonOutput(bool enabled)
+    {
+        if (!enabled)
+            return NoopDisposable.Instance;
+
+        JsonOutputDepth.Value++;
+        return new JsonOutputScope();
     }
 
     // --- Spinner / スピナー ---
@@ -1586,7 +1596,7 @@ public static class ConsoleUi
     public static string ColorizeKind(string kind, int padWidth = 0)
     {
         var padded = padWidth > 0 ? kind.PadRight(padWidth) : kind;
-        if (ShouldUseColor())
+        if (JsonOutputDepth.Value <= 0 && ShouldUseColor())
         {
             var color = GetKindColorCode(kind, ResolveColorPalette());
             if (color.Length > 0)
@@ -1653,6 +1663,7 @@ public static class ConsoleUi
             Console.Out.Encoding,
             Console.Out is StringWriter,
             HasTerminalEnvironmentHint(),
+            IsTerminalEnvironmentDisabled(),
             OperatingSystem.IsWindows());
 
     internal static bool ShouldUseInteractiveConsole(
@@ -1660,9 +1671,13 @@ public static class ConsoleUi
         Encoding outputEncoding,
         bool isTextWriterCapture,
         bool hasTerminalEnvironmentHint,
+        bool isTerminalEnvironmentDisabled,
         bool isWindows)
     {
         if (isOutputRedirected)
+            return false;
+
+        if (isTerminalEnvironmentDisabled)
             return false;
 
         // StringWriter-based test capture leaves the process console attached, so
@@ -1673,7 +1688,7 @@ public static class ConsoleUi
         if (isTextWriterCapture)
             return false;
 
-        return true;
+        return isWindows || hasTerminalEnvironmentHint;
     }
 
     internal static bool ShouldUseAnsiOutput()
@@ -1682,6 +1697,7 @@ public static class ConsoleUi
             Console.Out.Encoding,
             Console.Out is StringWriter,
             HasTerminalEnvironmentHint(),
+            IsTerminalEnvironmentDisabled(),
             OperatingSystem.IsWindows(),
             GetWindowsVirtualTerminalProcessingEnabled());
 
@@ -1690,10 +1706,11 @@ public static class ConsoleUi
         Encoding outputEncoding,
         bool isTextWriterCapture,
         bool hasTerminalEnvironmentHint,
+        bool isTerminalEnvironmentDisabled,
         bool isWindows,
         bool windowsVirtualTerminalProcessingEnabled)
     {
-        if (!ShouldUseInteractiveConsole(isOutputRedirected, outputEncoding, isTextWriterCapture, hasTerminalEnvironmentHint, isWindows))
+        if (!ShouldUseInteractiveConsole(isOutputRedirected, outputEncoding, isTextWriterCapture, hasTerminalEnvironmentHint, isTerminalEnvironmentDisabled, isWindows))
             return false;
 
         if (!isWindows)
@@ -1736,6 +1753,19 @@ public static class ConsoleUi
         var term = Environment.GetEnvironmentVariable("TERM");
         return !string.IsNullOrWhiteSpace(term)
             && !term.Equals("dumb", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsTerminalEnvironmentDisabled()
+        => IsDumbTerminal() || IsCiEnvironment();
+
+    private static bool IsCiEnvironment()
+    {
+        var ci = Environment.GetEnvironmentVariable("CI");
+        return !string.IsNullOrEmpty(ci)
+            && !ci.Equals("0", StringComparison.OrdinalIgnoreCase)
+            && !ci.Equals("false", StringComparison.OrdinalIgnoreCase)
+            && !ci.Equals("no", StringComparison.OrdinalIgnoreCase)
+            && !ci.Equals("off", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool GetWindowsVirtualTerminalProcessingEnabled()
@@ -1893,5 +1923,22 @@ public static class ConsoleUi
 
         width = 0;
         return false;
+    }
+
+    private sealed class JsonOutputScope : IDisposable
+    {
+        public void Dispose()
+        {
+            if (JsonOutputDepth.Value > 0)
+                JsonOutputDepth.Value--;
+        }
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+        public void Dispose()
+        {
+        }
     }
 }

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -41,6 +41,7 @@ internal static class ProgramRunner
         if (configResult.Loaded)
             GlobalToolLog.Info($"config_file_loaded path={configResult.Path}");
         jsonOptions ??= CreateDefaultJsonOptions();
+        EnsureRedirectedStdoutUsesUtf8();
 
         var quiet = TryConsumeQuietFlag(ref args) || IsTruthyEnvironmentVariable(QuietEnvironmentVariable);
         using var quietScope = quiet ? QuietStderrScope.Start() : null;
@@ -71,6 +72,7 @@ internal static class ProgramRunner
         using var metricsSession = MetricsSink.TryStart(metricsPath);
 
         TryConsumeDebugUnsafeFlag(ref args);
+        using var jsonAnsiScope = ConsoleUi.SuppressAnsiForJsonOutput(ContainsJsonOutputFlag(args));
 
         var commandStopwatch = Stopwatch.StartNew();
         var commandStartTimestamp = DateTimeOffset.UtcNow;
@@ -257,6 +259,41 @@ internal static class ProgramRunner
 
     internal static bool IsProjectPathArg(string arg) =>
         !arg.StartsWith('-') && (Directory.Exists(arg) || arg.Contains('/') || arg.Contains('\\') || arg == ".");
+
+    internal static void EnsureRedirectedStdoutUsesUtf8()
+    {
+        if (!Console.IsOutputRedirected || Console.Out is StringWriter)
+            return;
+
+        var utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        if (Console.Out.Encoding.CodePage == utf8NoBom.CodePage)
+            return;
+
+        var writer = new StreamWriter(Console.OpenStandardOutput(), utf8NoBom)
+        {
+            AutoFlush = true
+        };
+        Console.SetOut(TextWriter.Synchronized(writer));
+    }
+
+    internal static bool ContainsJsonOutputFlag(IEnumerable<string> args)
+    {
+        var passthrough = false;
+        foreach (var arg in args)
+        {
+            if (passthrough)
+                continue;
+            if (arg == "--")
+            {
+                passthrough = true;
+                continue;
+            }
+            if (arg == "--json" || arg.StartsWith("--json=", StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
 
     internal static bool TryConsumeQuietFlag(ref string[] args)
     {

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -262,7 +262,7 @@ internal static class ProgramRunner
 
     internal static void EnsureRedirectedStdoutUsesUtf8()
     {
-        if (!Console.IsOutputRedirected || Console.Out is StringWriter)
+        if (!Console.IsOutputRedirected || Console.Out is StringWriter || Console.Out.GetType().Assembly != typeof(Console).Assembly)
             return;
 
         var utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
@@ -288,7 +288,9 @@ internal static class ProgramRunner
                 passthrough = true;
                 continue;
             }
-            if (arg == "--json" || arg.StartsWith("--json=", StringComparison.Ordinal))
+            if (arg == "--json"
+                || arg.StartsWith("--json=", StringComparison.Ordinal)
+                || arg == JsonEnvelopeWrapper.EnvelopeFlag)
                 return true;
         }
 

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -340,6 +340,14 @@ public class DbWriter
         cmd.ExecuteNonQuery();
     }
 
+    private void Execute(string sql, SqliteTransaction? transaction)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.Transaction = transaction;
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
     private void RunPassiveWalCheckpoint()
     {
         using var cmd = _conn.CreateCommand();
@@ -3170,23 +3178,28 @@ public class DbWriter
         // the faster writer's flag. Wrap the read-modify-write in BEGIN IMMEDIATE so
         // SQLite's reserved write lock serialises it across processes (issue #1513).
         bool ownTransaction = !IsInTransaction();
+        bool beganTransaction = ownTransaction;
+        SqliteTransaction? transaction = null;
         if (ownTransaction)
-            Execute("BEGIN IMMEDIATE");
+            transaction = _conn.BeginTransaction(deferred: false);
+        else
+            transaction = _activeTransaction;
         try
         {
             int current;
             using (var read = _conn.CreateCommand())
             {
+                read.Transaction = transaction;
                 read.CommandText = "PRAGMA user_version";
                 var raw = read.ExecuteScalar();
                 current = raw is long l ? (int)l : (raw is int i ? i : 0);
             }
             int next = current | flag;
             if (next != current)
-                Execute($"PRAGMA user_version = {next}");
+                Execute($"PRAGMA user_version = {next}", transaction);
             if (ownTransaction)
             {
-                Execute("COMMIT");
+                transaction!.Commit();
                 ownTransaction = false;
             }
         }
@@ -3194,9 +3207,14 @@ public class DbWriter
         {
             if (ownTransaction)
             {
-                try { Execute("ROLLBACK"); } catch (SqliteException) { /* best effort */ }
+                try { transaction?.Rollback(); } catch (SqliteException) { /* best effort */ }
             }
             throw;
+        }
+        finally
+        {
+            if (beganTransaction)
+                transaction?.Dispose();
         }
     }
 

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -970,6 +970,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.UTF8,
             isTextWriterCapture: false,
             hasTerminalEnvironmentHint: true,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true));
     }
 
@@ -981,6 +982,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.Unicode,
             isTextWriterCapture: true,
             hasTerminalEnvironmentHint: false,
+            isTerminalEnvironmentDisabled: false,
             isWindows: false));
     }
 
@@ -992,6 +994,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.Unicode,
             isTextWriterCapture: true,
             hasTerminalEnvironmentHint: true,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true));
     }
 
@@ -1003,7 +1006,32 @@ public class ConsoleUiTests
             outputEncoding: Encoding.Unicode,
             isTextWriterCapture: false,
             hasTerminalEnvironmentHint: true,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true));
+    }
+
+    [Fact]
+    public void ShouldUseInteractiveConsole_DumbOrCiEnvironment_DisablesInteractiveOutput()
+    {
+        Assert.False(ConsoleUi.ShouldUseInteractiveConsole(
+            isOutputRedirected: false,
+            outputEncoding: Encoding.UTF8,
+            isTextWriterCapture: false,
+            hasTerminalEnvironmentHint: true,
+            isTerminalEnvironmentDisabled: true,
+            isWindows: false));
+    }
+
+    [Fact]
+    public void ShouldUseInteractiveConsole_UnixWithoutTerminalHint_DisablesInteractiveOutput()
+    {
+        Assert.False(ConsoleUi.ShouldUseInteractiveConsole(
+            isOutputRedirected: false,
+            outputEncoding: Encoding.UTF8,
+            isTextWriterCapture: false,
+            hasTerminalEnvironmentHint: false,
+            isTerminalEnvironmentDisabled: false,
+            isWindows: false));
     }
 
     [Fact]
@@ -1014,6 +1042,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.Unicode,
             isTextWriterCapture: true,
             hasTerminalEnvironmentHint: true,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true,
             windowsVirtualTerminalProcessingEnabled: true));
     }
@@ -1026,6 +1055,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.Unicode,
             isTextWriterCapture: false,
             hasTerminalEnvironmentHint: false,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true,
             windowsVirtualTerminalProcessingEnabled: true));
     }
@@ -1038,6 +1068,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.UTF8,
             isTextWriterCapture: false,
             hasTerminalEnvironmentHint: false,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true,
             windowsVirtualTerminalProcessingEnabled: true));
 
@@ -1046,6 +1077,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.UTF8,
             isTextWriterCapture: false,
             hasTerminalEnvironmentHint: true,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true,
             windowsVirtualTerminalProcessingEnabled: false));
 
@@ -1054,6 +1086,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.UTF8,
             isTextWriterCapture: false,
             hasTerminalEnvironmentHint: false,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true,
             windowsVirtualTerminalProcessingEnabled: false));
     }
@@ -1066,6 +1099,7 @@ public class ConsoleUiTests
             outputEncoding: Encoding.UTF8,
             isTextWriterCapture: false,
             hasTerminalEnvironmentHint: true,
+            isTerminalEnvironmentDisabled: false,
             isWindows: true,
             windowsVirtualTerminalProcessingEnabled: true));
     }
@@ -1309,6 +1343,23 @@ public class ConsoleUiTests
 
         Assert.Contains("\x1b[36m", output);
         Assert.Contains("\x1b[0m", output);
+    }
+
+    [Fact]
+    public void ColorizeKind_JsonOutputScopeSuppressesAnsiEvenWhenForced()
+    {
+        using var env = new ColorEnvironmentScope();
+        ConsoleUi.SetColorMode(ColorMode.Always);
+
+        using (ConsoleUi.SuppressAnsiForJsonOutput(enabled: true))
+        {
+            var output = ConsoleUi.ColorizeKind("class");
+
+            Assert.Equal("class", output);
+            Assert.DoesNotContain('\x1b', output);
+        }
+
+        Assert.Contains("\x1b[36m", ConsoleUi.ColorizeKind("class"));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -10,6 +10,21 @@ namespace CodeIndex.Tests;
 [Collection("SQLite pool sensitive")]
 public class ProgramRunnerTests
 {
+    [Theory]
+    [InlineData("--json")]
+    [InlineData("--json=array")]
+    [InlineData("--json-envelope")]
+    public void ContainsJsonOutputFlag_JsonModes_ReturnsTrue(string jsonFlag)
+    {
+        Assert.True(ProgramRunner.ContainsJsonOutputFlag(["search", "Needle", jsonFlag]));
+    }
+
+    [Fact]
+    public void ContainsJsonOutputFlag_AfterPassthrough_ReturnsFalse()
+    {
+        Assert.False(ProgramRunner.ContainsJsonOutputFlag(["search", "--", "--json"]));
+    }
+
     [Fact]
     public void TryConsumeQueryTraceFlag_StripsTraceAndPreservesEscapedQuery()
     {


### PR DESCRIPTION
## Summary

- Suppress ANSI styling for JSON-producing CLI modes, including `--json-envelope`, even when color is forced.
- Enforce UTF-8 no-BOM stdout for real redirected CLI output while preserving test/captured writers.
- Tighten interactive terminal detection for `TERM=dumb`, CI, missing Unix terminal hints, redirected output, and captured output.
- Fix the macOS/net9.0 CI failure by moving ready-bit updates to provider-managed immediate SQLite transactions (#2676).
- Document the CLI output contract and add issue-specific changelog fragments.

## Validation

- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~ConsoleUiTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~ProgramRunnerTests|FullyQualifiedName~ConsoleUiTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -f net9.0 --no-restore --filter "FullyQualifiedName~ConcurrencyTests.SetReadyBit_ConcurrentWriters_DoNotLoseFlags"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -f net9.0 --no-build --filter "FullyQualifiedName~ConcurrencyTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: first pass found a `--json-envelope` ANSI-suppression gap; fixed in `Handle JSON envelope console output (#1956)`. Second pass reported `No blocking/actionable issues found.`
- Codex adversarial review for #2676 CI fix: `No blocking/actionable issues found.`

## Documentation and changelog

- Updated `README.md` output controls in English and Japanese.
- Updated `DEVELOPER_GUIDE.md` with CLI JSON encoding and terminal-control implementation rules.
- Added changelog fragments:
  - `changelog.d/unreleased/1833.fixed.md`
  - `changelog.d/unreleased/1834.fixed.md`
  - `changelog.d/unreleased/1953.fixed.md`
  - `changelog.d/unreleased/1956.fixed.md`
  - `changelog.d/unreleased/2676.fixed.md`

## Issues

Fixes #1956
Fixes #1953
Fixes #1833
Fixes #1834
Fixes #2676

## Follow-up candidates

- None.
