### PR TITLE
Fix Rust conditional derives and unsafe indexing

### DIFF
--- a/changelog.d/unreleased/2052.fixed.md
+++ b/changelog.d/unreleased/2052.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2052
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust multiline conditional derives now emit trait type references (#2052)** - `cfg_attr(..., derive(...))` attributes spanning multiple lines and nested cfg predicates now index every derived trait, including qualified trait paths.
+
+## 日本語
+
+- **Rust の複数行条件付き derive が trait 型参照を出すようになりました (#2052)** - 複数行にまたがる `cfg_attr(..., derive(...))` とネストした cfg 条件でも、修飾付き trait path を含めて各 derive trait をインデックスします。

--- a/changelog.d/unreleased/2053.fixed.md
+++ b/changelog.d/unreleased/2053.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2053
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Rust unsafe blocks and mutable reference types are now indexed (#2053)** - `unsafe { ... }` regions are emitted as scoped containers, and `&mut Type` positions now keep the referenced type visible for unsafe-code audits.
+
+## 日本語
+
+- **Rust の unsafe block と mutable reference 型をインデックスするようになりました (#2053)** - `unsafe { ... }` 領域をスコープ付きコンテナとして出力し、`&mut Type` 位置の参照型も unsafe コード監査で見えるようにしました。

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -584,6 +584,9 @@ internal static class RustReferenceExtractor
     {
         foreach (Match match in MutableReferenceTypeRegex.Matches(preparedLine))
         {
+            if (!IsMutableReferenceTypeContext(preparedLine, match.Index))
+                continue;
+
             var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, match.Index + match.Length);
             var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
             if (typeEnd <= typeStart)
@@ -600,6 +603,22 @@ internal static class RustReferenceExtractor
                 lineNumber,
                 resolveContainerForColumn(typeStart));
         }
+    }
+
+    private static bool IsMutableReferenceTypeContext(string preparedLine, int ampersandIndex)
+    {
+        var cursor = ampersandIndex - 1;
+        while (cursor >= 0 && char.IsWhiteSpace(preparedLine[cursor]))
+            cursor--;
+
+        if (cursor < 0)
+            return false;
+        if (preparedLine[cursor] == ':')
+            return true;
+
+        return preparedLine[cursor] == '>'
+            && cursor > 0
+            && preparedLine[cursor - 1] == '-';
     }
 
     private static void EmitLifetimeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -56,6 +56,157 @@ internal static class RustReferenceExtractor
         @"(?<![\w$])(?<name>(?:(?:r#)?\w+::)*r#\w+(?:::(?:r#)?\w+)*)(?:<[^>\n]+>)?\s*\(",
         RegexOptions.Compiled);
 
+    public static void EmitMultilineAttributeReferences(
+        string[] preparedLines,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        Func<int, int, SymbolRecord?> resolveContainer)
+    {
+        for (var lineIndex = 0; lineIndex < preparedLines.Length; lineIndex++)
+        {
+            var line = preparedLines[lineIndex];
+            for (var column = 0; column < line.Length; column++)
+            {
+                if (line[column] != '#')
+                    continue;
+
+                var openBracket = FindRustAttributeOpenBracket(line, column);
+                if (openBracket < 0)
+                    continue;
+
+                var (attribute, endLineIndex, endColumn) = ReadRustAttribute(preparedLines, lineIndex, openBracket);
+                EmitDeriveReferencesFromAttribute(
+                    attribute,
+                    lineIndex,
+                    openBracket,
+                    references,
+                    seen,
+                    fileId,
+                    resolveContainer);
+
+                if (endLineIndex == lineIndex)
+                    column = Math.Max(column, endColumn);
+                else
+                    break;
+            }
+        }
+    }
+
+    private static int FindRustAttributeOpenBracket(string line, int hashIndex)
+    {
+        var cursor = hashIndex + 1;
+        while (cursor < line.Length && char.IsWhiteSpace(line[cursor]))
+            cursor++;
+        if (cursor < line.Length && line[cursor] == '!')
+        {
+            cursor++;
+            while (cursor < line.Length && char.IsWhiteSpace(line[cursor]))
+                cursor++;
+        }
+
+        return cursor < line.Length && line[cursor] == '[' ? cursor : -1;
+    }
+
+    private static (string Attribute, int EndLineIndex, int EndColumn) ReadRustAttribute(
+        string[] lines,
+        int startLineIndex,
+        int openBracket)
+    {
+        var parts = new List<string>();
+        var depth = 0;
+        for (var lineIndex = startLineIndex; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var startColumn = lineIndex == startLineIndex ? openBracket : 0;
+            parts.Add(line[startColumn..]);
+
+            for (var column = startColumn; column < line.Length; column++)
+            {
+                var c = line[column];
+                if (c == 'r')
+                {
+                    var rawEnd = TrySkipRawString(line, column);
+                    if (rawEnd > column)
+                    {
+                        column = rawEnd;
+                        continue;
+                    }
+                }
+
+                if (c == '"' || c == '\'')
+                {
+                    column = SkipQuotedString(line, column, c);
+                    continue;
+                }
+
+                if (c == '[' || c == '(')
+                {
+                    depth++;
+                    continue;
+                }
+
+                if (c != ']' && c != ')')
+                    continue;
+
+                depth--;
+                if (c == ']' && depth == 0)
+                    return (string.Join('\n', parts), lineIndex, column);
+            }
+        }
+
+        return (string.Join('\n', parts), lines.Length - 1, lines[^1].Length);
+    }
+
+    private static void EmitDeriveReferencesFromAttribute(
+        string attribute,
+        int startLineIndex,
+        int startColumn,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        Func<int, int, SymbolRecord?> resolveContainer)
+    {
+        var deriveIndex = FindRustAttributeDeriveIndex(attribute);
+        if (deriveIndex < 0)
+            return;
+
+        var openParen = SkipWhitespace(attribute, deriveIndex + "derive".Length);
+        if (openParen >= attribute.Length || attribute[openParen] != '(')
+            return;
+
+        var closeParen = FindMatchingDelimiter(attribute, openParen, '(', ')');
+        if (closeParen <= openParen)
+            return;
+
+        var typesStart = openParen + 1;
+        var (lineNumber, column) = GetLineColumn(attribute, startLineIndex, startColumn, typesStart);
+        EmitDeriveTypeList(
+            attribute.Substring(typesStart, closeParen - typesStart),
+            column,
+            references,
+            seen,
+            fileId,
+            attribute.Trim(),
+            lineNumber,
+            resolveContainer(lineNumber, column));
+    }
+
+    private static int FindRustAttributeDeriveIndex(string attribute)
+    {
+        for (var index = 0; index < attribute.Length; index++)
+        {
+            if (!IsIdentifierAt(attribute, index, "derive"))
+                continue;
+
+            var cursor = SkipWhitespace(attribute, index + "derive".Length);
+            if (cursor < attribute.Length && attribute[cursor] == '(')
+                return index;
+        }
+
+        return -1;
+    }
+
     public static string MaskAttributeBodies(string line)
     {
         var masked = default(char[]);
@@ -235,10 +386,29 @@ internal static class RustReferenceExtractor
         string context,
         int lineNumber,
         SymbolRecord? container)
+        => EmitDeriveTypeList(
+            typesGroup.Value,
+            typesGroup.Index,
+            references,
+            seen,
+            fileId,
+            context,
+            lineNumber,
+            container);
+
+    private static void EmitDeriveTypeList(
+        string types,
+        int typesStartIndex,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        SymbolRecord? container)
     {
-        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(typesGroup.Value))
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(types))
         {
-            var fragment = typesGroup.Value.Substring(segmentStart, segmentLength);
+            var fragment = types.Substring(segmentStart, segmentLength);
             var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, 0);
             var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
             if (typeEnd <= typeStart)
@@ -246,7 +416,7 @@ internal static class RustReferenceExtractor
 
             TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
                 fragment.Substring(typeStart, typeEnd - typeStart),
-                typesGroup.Index + segmentStart + typeStart,
+                typesStartIndex + segmentStart + typeStart,
                 "rust",
                 references,
                 seen,
@@ -255,6 +425,79 @@ internal static class RustReferenceExtractor
                 lineNumber,
                 container);
         }
+    }
+
+    private static int FindMatchingDelimiter(string text, int openIndex, char open, char close)
+    {
+        var depth = 0;
+        for (var index = openIndex; index < text.Length; index++)
+        {
+            var c = text[index];
+            if (c == 'r')
+            {
+                var rawEnd = TrySkipRawString(text, index);
+                if (rawEnd > index)
+                {
+                    index = rawEnd;
+                    continue;
+                }
+            }
+
+            if (c == '"' || c == '\'')
+            {
+                index = SkipQuotedString(text, index, c);
+                continue;
+            }
+
+            if (c == open)
+            {
+                depth++;
+                continue;
+            }
+
+            if (c != close)
+                continue;
+
+            depth--;
+            if (depth == 0)
+                return index;
+        }
+
+        return -1;
+    }
+
+    private static bool IsIdentifierAt(string text, int index, string identifier)
+    {
+        if (index > 0 && IsRustIdentifierPart(text[index - 1]))
+            return false;
+        if (index + identifier.Length > text.Length)
+            return false;
+        if (!text.AsSpan(index, identifier.Length).SequenceEqual(identifier))
+            return false;
+        return index + identifier.Length >= text.Length || !IsRustIdentifierPart(text[index + identifier.Length]);
+    }
+
+    private static (int LineNumber, int Column) GetLineColumn(
+        string text,
+        int startLineIndex,
+        int startColumn,
+        int offset)
+    {
+        var lineNumber = startLineIndex + 1;
+        var column = startColumn;
+        for (var index = 0; index < offset && index < text.Length; index++)
+        {
+            if (text[index] == '\n')
+            {
+                lineNumber++;
+                column = 0;
+                continue;
+            }
+
+            column++;
+        }
+
+        return (lineNumber, column);
     }
 
     public static void EmitTypePositionReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -40,6 +40,9 @@ internal static class RustReferenceExtractor
     private static readonly Regex StructLiteralRegex = new(
         $@"(?<![\w$])(?<name>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:::\s*<(?<args>[^>\n]+)>)?\s*\{{",
         RegexOptions.Compiled);
+    private static readonly Regex MutableReferenceTypeRegex = new(
+        $@"&\s*mut\s+(?<type>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)",
+        RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
     // Capture path-qualified macro names so `std::println!`, `log::info!`, and `my_macro!`
@@ -532,7 +535,37 @@ internal static class RustReferenceExtractor
         EmitAssociatedValueReceiverTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitStructLiteralInstantiationReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn, enumContainer);
         EmitImplAndTraitTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+        EmitMutableReferenceTypeReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
         EmitGenericBoundReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+    }
+
+    private static void EmitMutableReferenceTypeReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        foreach (Match match in MutableReferenceTypeRegex.Matches(preparedLine))
+        {
+            var typeGroup = match.Groups["type"];
+            var typeName = NormalizeIdentifier(typeGroup.Value);
+            if (typeName == "self" || typeName == "Self")
+                continue;
+
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                typeName,
+                typeGroup.Index,
+                "type_reference",
+                context,
+                lineNumber,
+                resolveContainerForColumn(typeGroup.Index));
+        }
     }
 
     private static void EmitLifetimeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -41,7 +41,7 @@ internal static class RustReferenceExtractor
         $@"(?<![\w$])(?<name>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)(?:::\s*<(?<args>[^>\n]+)>)?\s*\{{",
         RegexOptions.Compiled);
     private static readonly Regex MutableReferenceTypeRegex = new(
-        $@"&\s*mut\s+(?<type>{RustIdentifierPattern}(?:::{RustIdentifierPattern})*)",
+        @"&\s*mut\b",
         RegexOptions.Compiled);
 
     // Rust macro calls use `!` plus one of `()`, `[]`, or `{}` instead of the shared trailing `(`.
@@ -182,17 +182,16 @@ internal static class RustReferenceExtractor
         if (closeParen <= openParen)
             return;
 
-        var typesStart = openParen + 1;
-        var (lineNumber, column) = GetLineColumn(attribute, startLineIndex, startColumn, typesStart);
-        EmitDeriveTypeList(
-            attribute.Substring(typesStart, closeParen - typesStart),
-            column,
+        EmitMultilineDeriveTypeList(
+            attribute,
+            openParen + 1,
+            closeParen,
+            startLineIndex,
+            startColumn,
             references,
             seen,
             fileId,
-            attribute.Trim(),
-            lineNumber,
-            resolveContainer(lineNumber, column));
+            resolveContainer);
     }
 
     private static int FindRustAttributeDeriveIndex(string attribute)
@@ -430,6 +429,41 @@ internal static class RustReferenceExtractor
         }
     }
 
+    private static void EmitMultilineDeriveTypeList(
+        string attribute,
+        int typesStart,
+        int typesEnd,
+        int attributeStartLineIndex,
+        int attributeStartColumn,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        Func<int, int, SymbolRecord?> resolveContainer)
+    {
+        var types = attribute.Substring(typesStart, typesEnd - typesStart);
+        foreach (var (segmentStart, segmentLength) in ReferenceExtractor.SplitTopLevelCommaSpans(types))
+        {
+            var fragment = types.Substring(segmentStart, segmentLength);
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(fragment, 0);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(fragment, typeStart);
+            if (typeEnd <= typeStart)
+                continue;
+
+            var absoluteTypeStart = typesStart + segmentStart + typeStart;
+            var (lineNumber, column) = GetLineColumn(attribute, attributeStartLineIndex, attributeStartColumn, absoluteTypeStart);
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                fragment.Substring(typeStart, typeEnd - typeStart),
+                column,
+                "rust",
+                references,
+                seen,
+                fileId,
+                attribute.Trim(),
+                lineNumber,
+                resolveContainer(lineNumber, column));
+        }
+    }
+
     private static int FindMatchingDelimiter(string text, int openIndex, char open, char close)
     {
         var depth = 0;
@@ -550,21 +584,21 @@ internal static class RustReferenceExtractor
     {
         foreach (Match match in MutableReferenceTypeRegex.Matches(preparedLine))
         {
-            var typeGroup = match.Groups["type"];
-            var typeName = NormalizeIdentifier(typeGroup.Value);
-            if (typeName == "self" || typeName == "Self")
+            var typeStart = TypedLanguageReferenceExtractor.SkipTypePrefixTrivia(preparedLine, match.Index + match.Length);
+            var typeEnd = TypedLanguageReferenceExtractor.FindTypeExpressionEnd(preparedLine, typeStart);
+            if (typeEnd <= typeStart)
                 continue;
 
-            ReferenceExtractor.AddReference(
+            TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                preparedLine.Substring(typeStart, typeEnd - typeStart),
+                typeStart,
+                "rust",
                 references,
                 seen,
                 fileId,
-                typeName,
-                typeGroup.Index,
-                "type_reference",
                 context,
                 lineNumber,
-                resolveContainerForColumn(typeGroup.Index));
+                resolveContainerForColumn(typeStart));
         }
     }
 

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1141,6 +1141,15 @@ public static partial class ReferenceExtractor
                 references,
                 seen);
         }
+        else if (language == "rust")
+        {
+            RustReferenceExtractor.EmitMultilineAttributeReferences(
+                preparedLines,
+                references,
+                seen,
+                fileId,
+                (lineNumber, _) => FindInnermostContainer(containerCandidates, lineNumber));
+        }
         var pendingCSharpMultiLineTypePattern = default(CSharpMultiLineTypePatternState);
         var pendingCSharpWhereConstraint = language == "csharp" ? new CSharpWhereConstraintState() : null;
         var csharpLocalNamesByFunction = language == "csharp"

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1395,7 +1395,7 @@ public static partial class SymbolExtractor
             // fn with expanded modifiers: async, const, unsafe, default, extern (ABI optional) /
             // 拡張修飾子: async, const, unsafe, default, extern（ABI は省略可）
             new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:(?:async|const|unsafe|default|extern(?:\s+""[^""]+"")?)\s+)*fn\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
-            new("class",    new Regex(@"^\s*(?<name>unsafe)\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
+            new("class",    new Regex(@"\b(?<name>unsafe)\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             new("struct",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:struct|union)\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("enum",     new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?enum\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum variants / `Red`, `Ok(T)`, `Circle { radius: f64 }`, `Point`

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1392,6 +1392,7 @@ public static partial class SymbolExtractor
             // fn with expanded modifiers: async, const, unsafe, default, extern (ABI optional) /
             // 拡張修飾子: async, const, unsafe, default, extern（ABI は省略可）
             new("function", new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:(?:async|const|unsafe|default|extern(?:\s+""[^""]+"")?)\s+)*fn\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
+            new("class",    new Regex(@"^\s*(?<name>unsafe)\s*\{", RegexOptions.Compiled), BodyStyle.Brace),
             new("struct",   new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?(?:struct|union)\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             new("enum",     new Regex(@"^\s*(?:(?<visibility>pub(?:\([^)]*\))?)\s+)?enum\s+(?<name>(?:r#)?\w+)", RegexOptions.Compiled), BodyStyle.Brace, "visibility"),
             // Enum variants / `Red`, `Ok(T)`, `Circle { radius: f64 }`, `Point`

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -31378,6 +31378,22 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustMutableBorrowExpression_DoesNotEmitTypeReference()
+    {
+        const string content = """
+            fn demo(buffer: &mut Buffer) {
+                take(&mut buffer);
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Buffer" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "buffer" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustLifetimeParameters_CaptureExplicitLifetimeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -31281,6 +31281,9 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "Debug" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Clone" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Serialize" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Debug" && r.Line == 4 && r.Column == 9);
+        Assert.Contains(references, r => r.SymbolName == "Clone" && r.Line == 5 && r.Column == 9);
+        Assert.Contains(references, r => r.SymbolName == "Serialize" && r.Line == 6 && r.Column == 16);
         Assert.DoesNotContain(references, r => r.SymbolName == "cfg_attr" && r.ReferenceKind == "type_reference");
     }
 
@@ -31352,8 +31355,26 @@ public class ReferenceExtractorTests
         var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
 
         Assert.Contains(references, r => r.SymbolName == "Buffer" && r.ReferenceKind == "type_reference");
-        Assert.Contains(references, r => r.SymbolName == "crate::io::Cursor" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Cursor" && r.ReferenceKind == "type_reference");
         Assert.DoesNotContain(references, r => r.SymbolName == "mut" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_RustMutableDynAndImplReferences_CaptureTraitType()
+    {
+        const string content = """
+            fn demo(writer: &mut dyn Write, parser: &mut impl Parser) {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Write" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Parser" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(
+            references,
+            r => r.ReferenceKind == "type_reference" && (r.SymbolName is "dyn" or "impl" or "mut"));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -31289,6 +31289,23 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustMutableReferenceTypes_CaptureReferencedType()
+    {
+        const string content = """
+            fn demo(buffer: &mut Buffer) {
+                let next: &mut crate::io::Cursor = todo!();
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Buffer" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "crate::io::Cursor" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "mut" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustLifetimeParameters_CaptureExplicitLifetimeReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -31210,6 +31210,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_RustMultilineCfgAttrDeriveAttributes_CaptureTraitTypeReferences()
+    {
+        const string content = """
+            #[cfg_attr(
+                all(test, not(miri)),
+                derive(
+                    Debug,
+                    Clone,
+                    serde::Serialize
+                )
+            )]
+            struct User;
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+        var references = ReferenceExtractor.Extract(1, "rust", content, symbols);
+
+        Assert.Contains(references, r => r.SymbolName == "Debug" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Clone" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Serialize" && r.ReferenceKind == "type_reference");
+        Assert.DoesNotContain(references, r => r.SymbolName == "cfg_attr" && r.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
     public void Extract_RustAttributes_CaptureAnnotationReferences()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14571,6 +14571,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Rust_DetectsUnsafeBlockInExpression()
+    {
+        const string content = """
+            fn demo() {
+                let value = unsafe {
+                    read_raw()
+                };
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+
+        var unsafeBlock = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "unsafe");
+        Assert.Equal(2, unsafeBlock.Line);
+        Assert.Equal(2, unsafeBlock.BodyStartLine);
+        Assert.Equal(4, unsafeBlock.BodyEndLine);
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsPubUseStatements()
     {
         var content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -14471,6 +14471,25 @@ public class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Rust_DetectsUnsafeBlockContainer()
+    {
+        const string content = """
+            fn demo() {
+                unsafe {
+                    let p = Box::leak(Box::new(42));
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "rust", content);
+
+        var unsafeBlock = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "unsafe");
+        Assert.Equal(2, unsafeBlock.Line);
+        Assert.Equal(2, unsafeBlock.BodyStartLine);
+        Assert.Equal(4, unsafeBlock.BodyEndLine);
+    }
+
+    [Fact]
     public void Extract_Rust_DetectsPubUseStatements()
     {
         var content = """


### PR DESCRIPTION
## Summary
- Index Rust multiline `cfg_attr(..., derive(...))` trait references with correct source positions.
- Index Rust `unsafe { ... }` blocks as scoped containers, including expression-position blocks.
- Emit Rust mutable reference target types for `&mut Type` while avoiding mutable-borrow expression false positives.

## Changelog
- `changelog.d/unreleased/2052.fixed.md`
- `changelog.d/unreleased/2053.fixed.md`

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "RustMultilineCfgAttrDeriveAttributes|RustMutableReferenceTypes|RustMutableDynAndImplReferences|RustMutableBorrowExpression"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "Rust_DetectsUnsafeBlockContainer|Rust_DetectsUnsafeBlockInExpression"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RustMutableReferenceTypes|FullyQualifiedName~RustMutableDynAndImpl|FullyQualifiedName~RustMultilineCfgAttr|FullyQualifiedName~UnsafeBlock"`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: `No blocking/actionable issues found.`

Full `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false` was attempted earlier, showed no failures while running, but was stopped after a long silent run before a final test summary.

Fixes #2052
Fixes #2053