### PR TITLE
Fix chunk search symbol ranking

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -422,6 +422,8 @@ FTS5 works through a **virtual table** — a table that looks and behaves like a
 
 Search result ordering must remain deterministic for identical inputs and an unchanged index. Ranking `ORDER BY` clauses should finish with stable persisted keys after user-visible relevance keys, so ties in FTS rank, file timestamp, and path never fall through to SQLite's implementation-defined row order. The chunk search `ORDER BY` ends with `f.path, c.id ASC` for this reason (#1731).
 
+Chunk search ranking uses symbol structure before falling back to bare BM25 ties. Exact and prefix symbol-name boosts distinguish a chunk that overlaps the matching symbol definition from a different chunk in the same file, then fall back to file-level symbol presence. When text relevance ties, chunks with query hits in overlapping symbol names/signatures, higher-value symbol kinds (class/interface/struct/enum, then function/method/property), and shallower overlapping symbol scopes rank ahead of comment-only or deeply nested matches. This keeps scope-root and definition-like results ahead of redundant inner or unstructured mentions while preserving deterministic fallback ordering.
+
 ### What is an inverted index?
 
 An inverted index maps each word (token) to the list of documents (or rows) that contain it — like the index at the back of a textbook.

--- a/changelog.d/unreleased/1958.fixed.md
+++ b/changelog.d/unreleased/1958.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 1958
+  - 1975
+  - 1977
+  - 2000
+affected:
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Chunk search now ranks symbol-structured matches ahead of generic text (#1958, #1975, #1977, #2000)** — search boosts now prefer chunks that overlap exact/prefix symbol definitions, structured symbol-name/signature hits, higher-value symbol kinds, and shallower scope roots before falling back to BM25 and stable tie-breakers.
+
+## 日本語
+
+- **チャンク検索で構造化されたシンボル一致を汎用テキストより優先するようになりました (#1958, #1975, #1977, #2000)** — 検索の boost は exact/prefix シンボル定義と重なるチャンク、シンボル名・シグネチャ上の一致、高価値のシンボル kind、浅い scope root を BM25 と安定 tie-breaker より前に優先します。

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -224,75 +224,19 @@ public partial class DbReader
     // バケット順位は LEFT JOIN 結果の NULL 判定だけで決まり、`f.id` ごとの再評価は不要。
     internal const string ExactSymbolMatchOrder = @"
         CASE
-            WHEN EXISTS (
-                SELECT 1
-                FROM symbols sx
-                WHERE sx.file_id = f.id
-                  AND sx.name = @rankingQuery COLLATE NOCASE
-                  AND COALESCE(sx.start_line, sx.line) <= c.end_line
-                  AND COALESCE(sx.end_line, sx.line) >= c.start_line
-            ) THEN 0
+            WHEN exact_symbol_chunk_match.chunk_id IS NOT NULL THEN 0
             WHEN exact_symbol_match.file_id IS NOT NULL THEN 1
             ELSE 2
         END";
     internal const string PrefixSymbolMatchOrder = @"
         CASE
-            WHEN EXISTS (
-                SELECT 1
-                FROM symbols sx
-                WHERE sx.file_id = f.id
-                  AND sx.name LIKE @rankingQueryPrefix ESCAPE '\' COLLATE NOCASE
-                  AND COALESCE(sx.start_line, sx.line) <= c.end_line
-                  AND COALESCE(sx.end_line, sx.line) >= c.start_line
-            ) THEN 0
+            WHEN prefix_symbol_chunk_match.chunk_id IS NOT NULL THEN 0
             WHEN prefix_symbol_match.file_id IS NOT NULL THEN 1
             ELSE 2
         END";
-    internal const string ChunkSymbolKindOrder = @"
-        COALESCE((
-            SELECT MIN(
-                CASE lower(COALESCE(sx.kind, ''))
-                    WHEN 'class' THEN 0
-                    WHEN 'interface' THEN 0
-                    WHEN 'struct' THEN 0
-                    WHEN 'enum' THEN 0
-                    WHEN 'function' THEN 1
-                    WHEN 'method' THEN 1
-                    WHEN 'test.method' THEN 1
-                    WHEN 'property' THEN 2
-                    WHEN 'field' THEN 2
-                    WHEN 'import' THEN 4
-                    WHEN 'reference' THEN 4
-                    ELSE 3
-                END)
-            FROM symbols sx
-            WHERE sx.file_id = f.id
-              AND COALESCE(sx.start_line, sx.line) <= c.end_line
-              AND COALESCE(sx.end_line, sx.line) >= c.start_line
-        ), 5)";
-    internal const string ChunkStructuredFieldOrder = @"
-        CASE
-            WHEN EXISTS (
-                SELECT 1
-                FROM symbols sx
-                WHERE sx.file_id = f.id
-                  AND COALESCE(sx.start_line, sx.line) <= c.end_line
-                  AND COALESCE(sx.end_line, sx.line) >= c.start_line
-                  AND (
-                      instr(lower(COALESCE(sx.name, '')), lower(@rankingQuery)) > 0 OR
-                      instr(lower(COALESCE(sx.signature, '')), lower(@rankingQuery)) > 0
-                  )
-            ) THEN 0
-            ELSE 1
-        END";
-    internal const string ChunkSymbolDepthOrder = @"
-        COALESCE((
-            SELECT MIN(sql_segment_count(COALESCE(NULLIF(sx.container_qualified_name, ''), NULLIF(sx.container_name, ''), sx.name)))
-            FROM symbols sx
-            WHERE sx.file_id = f.id
-              AND COALESCE(sx.start_line, sx.line) <= c.end_line
-              AND COALESCE(sx.end_line, sx.line) >= c.start_line
-        ), 999)";
+    internal const string ChunkSymbolKindOrder = "COALESCE(chunk_symbol_rank.kind_order, 5)";
+    internal const string ChunkStructuredFieldOrder = "COALESCE(chunk_symbol_rank.structured_field_order, 1)";
+    internal const string ChunkSymbolDepthOrder = "COALESCE(chunk_symbol_rank.depth_order, 999)";
 
     // Derived-table joins that supply the per-file match and visibility buckets referenced by
     // search ranking. GROUP BY keeps the symbol predicates out of the outer per-hit scan while
@@ -323,7 +267,55 @@ public partial class DbReader
             FROM symbols s_prefix
             WHERE name LIKE @rankingQueryPrefix ESCAPE '\' COLLATE NOCASE
             GROUP BY file_id
-        ) AS prefix_symbol_match ON prefix_symbol_match.file_id = f.id";
+        ) AS prefix_symbol_match ON prefix_symbol_match.file_id = f.id
+        LEFT JOIN (
+            SELECT c_exact.id AS chunk_id
+            FROM chunks c_exact
+            JOIN symbols s_exact_chunk ON s_exact_chunk.file_id = c_exact.file_id
+                AND COALESCE(s_exact_chunk.start_line, s_exact_chunk.line) <= c_exact.end_line
+                AND COALESCE(s_exact_chunk.end_line, s_exact_chunk.line) >= c_exact.start_line
+            WHERE s_exact_chunk.name = @rankingQuery COLLATE NOCASE
+            GROUP BY c_exact.id
+        ) AS exact_symbol_chunk_match ON exact_symbol_chunk_match.chunk_id = c.id
+        LEFT JOIN (
+            SELECT c_prefix.id AS chunk_id
+            FROM chunks c_prefix
+            JOIN symbols s_prefix_chunk ON s_prefix_chunk.file_id = c_prefix.file_id
+                AND COALESCE(s_prefix_chunk.start_line, s_prefix_chunk.line) <= c_prefix.end_line
+                AND COALESCE(s_prefix_chunk.end_line, s_prefix_chunk.line) >= c_prefix.start_line
+            WHERE s_prefix_chunk.name LIKE @rankingQueryPrefix ESCAPE '\' COLLATE NOCASE
+            GROUP BY c_prefix.id
+        ) AS prefix_symbol_chunk_match ON prefix_symbol_chunk_match.chunk_id = c.id
+        LEFT JOIN (
+            SELECT
+                c_rank.id AS chunk_id,
+                MIN(CASE
+                    WHEN instr(lower(COALESCE(s_rank.name, '')), lower(@rankingQuery)) > 0 OR
+                         instr(lower(COALESCE(s_rank.signature, '')), lower(@rankingQuery)) > 0
+                    THEN 0
+                    ELSE 1
+                END) AS structured_field_order,
+                MIN(CASE lower(COALESCE(s_rank.kind, ''))
+                    WHEN 'class' THEN 0
+                    WHEN 'interface' THEN 0
+                    WHEN 'struct' THEN 0
+                    WHEN 'enum' THEN 0
+                    WHEN 'function' THEN 1
+                    WHEN 'method' THEN 1
+                    WHEN 'test.method' THEN 1
+                    WHEN 'property' THEN 2
+                    WHEN 'field' THEN 2
+                    WHEN 'import' THEN 4
+                    WHEN 'reference' THEN 4
+                    ELSE 3
+                END) AS kind_order,
+                MIN(sql_segment_count(COALESCE(NULLIF(s_rank.container_qualified_name, ''), NULLIF(s_rank.container_name, ''), s_rank.name))) AS depth_order
+            FROM chunks c_rank
+            JOIN symbols s_rank ON s_rank.file_id = c_rank.file_id
+                AND COALESCE(s_rank.start_line, s_rank.line) <= c_rank.end_line
+                AND COALESCE(s_rank.end_line, s_rank.line) >= c_rank.start_line
+            GROUP BY c_rank.id
+        ) AS chunk_symbol_rank ON chunk_symbol_rank.chunk_id = c.id";
         }
     }
     private const string PathTextMatchOrder = @"

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -222,10 +222,77 @@ public partial class DbReader
     // once per query, using SARGable `name COLLATE NOCASE` / `name LIKE ... COLLATE NOCASE`
     // predicates so the planner can use the existing indexes.
     // バケット順位は LEFT JOIN 結果の NULL 判定だけで決まり、`f.id` ごとの再評価は不要。
-    internal const string ExactSymbolMatchOrder =
-        "CASE WHEN exact_symbol_match.file_id IS NULL THEN 1 ELSE 0 END";
-    internal const string PrefixSymbolMatchOrder =
-        "CASE WHEN prefix_symbol_match.file_id IS NULL THEN 1 ELSE 0 END";
+    internal const string ExactSymbolMatchOrder = @"
+        CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM symbols sx
+                WHERE sx.file_id = f.id
+                  AND sx.name = @rankingQuery COLLATE NOCASE
+                  AND COALESCE(sx.start_line, sx.line) <= c.end_line
+                  AND COALESCE(sx.end_line, sx.line) >= c.start_line
+            ) THEN 0
+            WHEN exact_symbol_match.file_id IS NOT NULL THEN 1
+            ELSE 2
+        END";
+    internal const string PrefixSymbolMatchOrder = @"
+        CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM symbols sx
+                WHERE sx.file_id = f.id
+                  AND sx.name LIKE @rankingQueryPrefix ESCAPE '\' COLLATE NOCASE
+                  AND COALESCE(sx.start_line, sx.line) <= c.end_line
+                  AND COALESCE(sx.end_line, sx.line) >= c.start_line
+            ) THEN 0
+            WHEN prefix_symbol_match.file_id IS NOT NULL THEN 1
+            ELSE 2
+        END";
+    internal const string ChunkSymbolKindOrder = @"
+        COALESCE((
+            SELECT MIN(
+                CASE lower(COALESCE(sx.kind, ''))
+                    WHEN 'class' THEN 0
+                    WHEN 'interface' THEN 0
+                    WHEN 'struct' THEN 0
+                    WHEN 'enum' THEN 0
+                    WHEN 'function' THEN 1
+                    WHEN 'method' THEN 1
+                    WHEN 'test.method' THEN 1
+                    WHEN 'property' THEN 2
+                    WHEN 'field' THEN 2
+                    WHEN 'import' THEN 4
+                    WHEN 'reference' THEN 4
+                    ELSE 3
+                END)
+            FROM symbols sx
+            WHERE sx.file_id = f.id
+              AND COALESCE(sx.start_line, sx.line) <= c.end_line
+              AND COALESCE(sx.end_line, sx.line) >= c.start_line
+        ), 5)";
+    internal const string ChunkStructuredFieldOrder = @"
+        CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM symbols sx
+                WHERE sx.file_id = f.id
+                  AND COALESCE(sx.start_line, sx.line) <= c.end_line
+                  AND COALESCE(sx.end_line, sx.line) >= c.start_line
+                  AND (
+                      instr(lower(COALESCE(sx.name, '')), lower(@rankingQuery)) > 0 OR
+                      instr(lower(COALESCE(sx.signature, '')), lower(@rankingQuery)) > 0
+                  )
+            ) THEN 0
+            ELSE 1
+        END";
+    internal const string ChunkSymbolDepthOrder = @"
+        COALESCE((
+            SELECT MIN(sql_segment_count(COALESCE(NULLIF(sx.container_qualified_name, ''), NULLIF(sx.container_name, ''), sx.name)))
+            FROM symbols sx
+            WHERE sx.file_id = f.id
+              AND COALESCE(sx.start_line, sx.line) <= c.end_line
+              AND COALESCE(sx.end_line, sx.line) >= c.start_line
+        ), 999)";
 
     // Derived-table joins that supply the per-file match and visibility buckets referenced by
     // search ranking. GROUP BY keeps the symbol predicates out of the outer per-hit scan while

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -660,7 +660,7 @@ public partial class DbReader
     private static string GetSearchOrderSql(int coverageTokenCount)
     {
         var coverageOrder = GetSearchCoverageOrderSql(coverageTokenCount);
-        return $"{PathBucketOrder}, {ExactSymbolMatchOrder}, {PrefixSymbolMatchOrder}, {SearchVisibilityOrder}, {PathTextMatchOrder}, {ChunkTextMatchOrder}, {coverageOrder}rank, f.modified DESC, f.path, c.id ASC";
+        return $"{PathBucketOrder}, {ExactSymbolMatchOrder}, {PrefixSymbolMatchOrder}, {SearchVisibilityOrder}, {PathTextMatchOrder}, {ChunkTextMatchOrder}, {ChunkStructuredFieldOrder}, {ChunkSymbolKindOrder}, {ChunkSymbolDepthOrder}, {coverageOrder}rank, f.modified DESC, f.path, c.id ASC";
     }
 
     private static string GetSearchCoverageOrderSql(int coverageTokenCount)

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -26,6 +26,83 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void Search_ExactSymbolBoostPrefersChunkContainingSymbol_Issue1977()
+    {
+        var fileId = InsertSearchFile(
+            [
+                new ChunkRecord { ChunkIndex = 0, StartLine = 1, EndLine = 10, Content = "UserManager usage" },
+                new ChunkRecord { ChunkIndex = 1, StartLine = 20, EndLine = 30, Content = "class UserManager" },
+            ],
+            [
+                new SymbolRecord { Kind = "class", Name = "UserManager", Line = 20, StartLine = 20, EndLine = 30 },
+            ]);
+
+        var reader = new DbReader(_db.Connection);
+        var results = reader.Search("UserManager", limit: 2, deduplicate: false);
+
+        Assert.Equal(fileId, Assert.Single(ReadFileIds()));
+        Assert.Equal(20, results[0].StartLine);
+    }
+
+    [Fact]
+    public void Search_SymbolKindWeightPrefersDefinitionsOverGenericMentions_Issue1958()
+    {
+        InsertSearchFile(
+            [
+                new ChunkRecord { ChunkIndex = 0, StartLine = 1, EndLine = 10, Content = "Manager" },
+                new ChunkRecord { ChunkIndex = 1, StartLine = 20, EndLine = 30, Content = "Manager" },
+            ],
+            [
+                new SymbolRecord { Kind = "reference", Name = "HelperReference", Line = 1, StartLine = 1, EndLine = 10 },
+                new SymbolRecord { Kind = "function", Name = "CreateManager", Line = 20, StartLine = 20, EndLine = 30 },
+            ]);
+
+        var reader = new DbReader(_db.Connection);
+        var results = reader.Search("Manager", limit: 2, deduplicate: false);
+
+        Assert.Equal(20, results[0].StartLine);
+    }
+
+    [Fact]
+    public void Search_NestingDepthPrefersScopeRootForOverlappingResults_Issue1975()
+    {
+        InsertSearchFile(
+            [
+                new ChunkRecord { ChunkIndex = 0, StartLine = 1, EndLine = 100, Content = "UserManager" },
+                new ChunkRecord { ChunkIndex = 1, StartLine = 20, EndLine = 40, Content = "UserManager" },
+            ],
+            [
+                new SymbolRecord { Kind = "class", Name = "UserManager", Line = 1, StartLine = 1, EndLine = 100 },
+                new SymbolRecord { Kind = "function", Name = "Login", Line = 20, StartLine = 20, EndLine = 40, ContainerQualifiedName = "UserManager" },
+            ]);
+
+        var reader = new DbReader(_db.Connection);
+        var results = reader.Search("UserManager", limit: 2);
+
+        var result = Assert.Single(results);
+        Assert.Equal(1, result.StartLine);
+    }
+
+    [Fact]
+    public void Search_StructuredFieldScorePrefersSymbolNameHitsOverCommentText_Issue2000()
+    {
+        InsertSearchFile(
+            [
+                new ChunkRecord { ChunkIndex = 0, StartLine = 1, EndLine = 10, Content = "Manager" },
+                new ChunkRecord { ChunkIndex = 1, StartLine = 20, EndLine = 30, Content = "Manager" },
+            ],
+            [
+                new SymbolRecord { Kind = "reference", Name = "CommentOnly", Line = 1, StartLine = 1, EndLine = 10 },
+                new SymbolRecord { Kind = "reference", Name = "BuildUserManagerValue", Line = 20, StartLine = 20, EndLine = 30 },
+            ]);
+
+        var reader = new DbReader(_db.Connection);
+        var results = reader.Search("Manager", limit: 2, deduplicate: false);
+
+        Assert.Equal(20, results[0].StartLine);
+    }
+
+    [Fact]
     public void InitializeSchema_CreatesAllTables()
     {
         // Verify tables exist by querying sqlite_master
@@ -42,6 +119,39 @@ public class DatabaseTests : IDisposable
         Assert.Contains("symbols", tables);
         Assert.Contains("symbol_references", tables);
         Assert.Contains("fts_chunks", tables);
+    }
+
+    private long InsertSearchFile(IReadOnlyList<ChunkRecord> chunks, IReadOnlyList<SymbolRecord> symbols)
+    {
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/search.cs",
+            Lang = "csharp",
+            Size = 100,
+            Lines = 120,
+            Modified = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Checksum = Guid.NewGuid().ToString("N"),
+        });
+
+        foreach (var chunk in chunks)
+            chunk.FileId = fileId;
+        foreach (var symbol in symbols)
+            symbol.FileId = fileId;
+
+        _writer.InsertChunks(chunks);
+        _writer.InsertSymbols(symbols);
+        return fileId;
+    }
+
+    private List<long> ReadFileIds()
+    {
+        using var cmd = _db.Connection.CreateCommand();
+        cmd.CommandText = "SELECT id FROM files ORDER BY id";
+        using var reader = cmd.ExecuteReader();
+        var ids = new List<long>();
+        while (reader.Read())
+            ids.Add(reader.GetInt64(0));
+        return ids;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Prefer chunks overlapping exact/prefix symbol definitions before file-level symbol matches.
- Add structured-field, symbol-kind, and shallow-scope ranking tiers for chunk search ties.
- Cover each requested ranking issue with regression tests and document the ranking contract.

Fixes #1977
Fixes #1975
Fixes #1958
Fixes #2000

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DatabaseTests.Search_" -p:UseSharedCompilation=false --no-restore
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DatabaseTests" -p:UseSharedCompilation=false --no-restore
- dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false
- dotnet run --project tools/CodeIndex.Changelog -- check
- adversarial review: No blocking/actionable issues found.

## Notes
- AGENTS.md, CLAUDE.md, and AGENT_GUIDE.md were not modified.
- Local cdidx index refresh with --changed-between stalled on IndexCommandRunner.cs; status remains stale/degraded in this workspace, but build/tests above passed.