### PR TITLE
Fix platform path separator handling

### DIFF
--- a/changelog.d/unreleased/1715.fixed.md
+++ b/changelog.d/unreleased/1715.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 1715
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+---
+
+## English
+
+- **Ignore path normalization now respects POSIX backslashes (#1715)** — `.cdidxignore` and `.gitignore` comparisons no longer rewrite literal backslashes in POSIX filenames while Windows paths still normalize separators.
+
+## 日本語
+
+- **ignore path 正規化が POSIX の backslash を尊重するようになりました (#1715)** — `.cdidxignore` / `.gitignore` の比較で POSIX ファイル名内のリテラル backslash を書き換えず、Windows path では引き続き区切り文字を正規化します。

--- a/changelog.d/unreleased/1717.fixed.md
+++ b/changelog.d/unreleased/1717.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1717
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+---
+
+## English
+
+- **Project-root escape checks now reject backslash traversal (#1717)** — commit and file-scoped indexing paths treat `..\` traversal the same as `../` before accepting a relative target.
+
+## 日本語
+
+- **project root 外への escape 判定が backslash traversal を拒否するようになりました (#1717)** — commit / file scoped indexing path は relative target を受け入れる前に `..\` traversal を `../` と同じように扱います。

--- a/changelog.d/unreleased/1725.fixed.md
+++ b/changelog.d/unreleased/1725.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 1725
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+---
+
+## English
+
+- **CLI project-path detection now follows platform path syntax (#1725)** — Windows drive and UNC forms are recognized on Windows, while POSIX filenames containing literal backslashes are no longer treated as path syntax.
+
+## 日本語
+
+- **CLI の project path 判定がプラットフォーム別の path 構文に沿うようになりました (#1725)** — Windows では drive / UNC 形式を認識し、POSIX ではリテラル backslash を含むファイル名を path 構文として扱わないようになりました。

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -365,8 +365,16 @@ public static partial class IndexCommandRunner
             && matchesCurrent;
     }
 
-    private static bool IsOutsideProjectRoot(string relativePath) =>
-        relativePath == ".." || relativePath.StartsWith("../", StringComparison.Ordinal);
+    internal static bool IsOutsideProjectRoot(string relativePath)
+    {
+        if (Path.IsPathRooted(relativePath))
+            return true;
+
+        var normalized = OperatingSystem.IsWindows()
+            ? relativePath.Replace('\\', '/')
+            : relativePath;
+        return normalized == ".." || normalized.StartsWith("../", StringComparison.Ordinal);
+    }
 
     private static bool ContainsIgnoreFilePath(IEnumerable<string> paths)
         => paths.Any(FileIndexer.IsIgnoreFilePath);

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -298,8 +298,30 @@ internal static class ProgramRunner
         }
     }
 
-    internal static bool IsProjectPathArg(string arg) =>
-        !arg.StartsWith('-') && (Directory.Exists(arg) || arg.Contains('/') || arg.Contains('\\') || arg == ".");
+    internal static bool IsProjectPathArg(string arg)
+    {
+        if (arg.StartsWith('-'))
+            return false;
+
+        if (arg == "." || Directory.Exists(arg) || Path.IsPathRooted(arg) || Path.IsPathFullyQualified(arg))
+            return true;
+
+        if (arg.Contains(Path.DirectorySeparatorChar))
+            return true;
+
+        if (Path.AltDirectorySeparatorChar != '\0'
+            && Path.AltDirectorySeparatorChar != Path.DirectorySeparatorChar
+            && arg.Contains(Path.AltDirectorySeparatorChar))
+            return true;
+
+        return OperatingSystem.IsWindows()
+            && (IsWindowsDrivePath(arg) || arg.StartsWith(@"\\", StringComparison.Ordinal));
+    }
+
+    private static bool IsWindowsDrivePath(string arg) =>
+        arg.Length >= 2
+        && arg[1] == ':'
+        && ((arg[0] >= 'A' && arg[0] <= 'Z') || (arg[0] >= 'a' && arg[0] <= 'z'));
 
     internal static void EnsureRedirectedStdoutUsesUtf8()
     {

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -2523,8 +2523,8 @@ public class FileIndexer
         }
     }
 
-    private static string NormalizeIgnorePath(string path)
-        => path.Replace('\\', '/').TrimEnd('/');
+    internal static string NormalizeIgnorePath(string path)
+        => NormalizePathSeparators(path).TrimEnd('/');
 
     /// <summary>
     /// Normalize OS path separators to '/' for DB storage and lookup.

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -18,6 +18,17 @@ namespace CodeIndex.Tests;
 public class FileIndexerTests
 {
     [Fact]
+    public void NormalizeIgnorePath_PosixPreservesLiteralBackslash()
+    {
+        var normalized = FileIndexer.NormalizeIgnorePath(@"weird\name.py/");
+
+        if (OperatingSystem.IsWindows())
+            Assert.Equal("weird/name.py", normalized);
+        else
+            Assert.Equal(@"weird\name.py", normalized);
+    }
+
+    [Fact]
     public void ScanFilesDetailed_CancelledToken_ThrowsBeforeEnumeration()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx-cancel-scan-{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -41,6 +41,44 @@ public class IndexCommandRunnerTests
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
     };
 
+    [Theory]
+    [InlineData("..")]
+    [InlineData("../evil.txt")]
+    [InlineData(@"..\evil.txt")]
+    [InlineData(@"..\..\evil.txt")]
+    public void IsOutsideProjectRoot_ParentTraversalSeparators_ReturnsTrue(string relativePath)
+    {
+        if (relativePath.Contains('\\') && !OperatingSystem.IsWindows())
+            return;
+
+        Assert.True(IndexCommandRunner.IsOutsideProjectRoot(relativePath));
+    }
+
+    [Fact]
+    public void IsOutsideProjectRoot_PosixLiteralBackslashPath_ReturnsFalse()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        Assert.False(IndexCommandRunner.IsOutsideProjectRoot(@"..\evil.txt"));
+    }
+
+    [Fact]
+    public void IsOutsideProjectRoot_RootedPath_ReturnsTrue()
+    {
+        var rootedPath = OperatingSystem.IsWindows()
+            ? @"C:\Windows\evil.txt"
+            : "/etc/passwd";
+
+        Assert.True(IndexCommandRunner.IsOutsideProjectRoot(rootedPath));
+    }
+
+    [Fact]
+    public void IsOutsideProjectRoot_NormalRelativePath_ReturnsFalse()
+    {
+        Assert.False(IndexCommandRunner.IsOutsideProjectRoot("src/app.cs"));
+    }
+
     [Fact]
     public void ParseArgs_HelpFlagSetsShowHelp()
     {

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -12,6 +12,36 @@ namespace CodeIndex.Tests;
 public class ProgramRunnerTests
 {
     [Theory]
+    [InlineData("foo.cs", false)]
+    [InlineData("./foo", true)]
+    [InlineData(".", true)]
+    public void IsProjectPathArg_CommonForms_ReturnsExpectedValue(string arg, bool expected)
+    {
+        Assert.Equal(expected, ProgramRunner.IsProjectPathArg(arg));
+    }
+
+    [Fact]
+    public void IsProjectPathArg_PosixLiteralBackslashFileName_IsNotPathSyntax()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        Assert.False(ProgramRunner.IsProjectPathArg(@"weird\name.txt"));
+    }
+
+    [Theory]
+    [InlineData(@"C:\foo")]
+    [InlineData("C:")]
+    [InlineData(@"\\server\share\foo")]
+    public void IsProjectPathArg_WindowsPathForms_ReturnTrueOnWindows(string arg)
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        Assert.True(ProgramRunner.IsProjectPathArg(arg));
+    }
+
+    [Theory]
     [InlineData("--json")]
     [InlineData("--json=array")]
     [InlineData("--json-envelope")]


### PR DESCRIPTION
## Summary

- Preserve literal POSIX backslashes when normalizing ignore-rule comparison paths.
- Harden project-root escape checks so Windows backslash traversal is rejected without treating POSIX backslashes as separators.
- Update CLI project path detection to use platform path syntax and Windows drive/UNC recognition.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests.NormalizeIgnorePath_PosixPreservesLiteralBackslash|FullyQualifiedName~IndexCommandRunnerTests.IsOutsideProjectRoot|FullyQualifiedName~ProgramRunnerTests.IsProjectPathArg" -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits a57ed0cce0f9fd2f855eca6842ea0ba1539486eb 88652f15e2447ceb6057a2f8f625a6f8f292a58c 2aa93b66fdc26ce2b2e639691343779419ba3bc8 --json`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Added `changelog.d/unreleased/1715.fixed.md`.
- Added `changelog.d/unreleased/1717.fixed.md`.
- Added `changelog.d/unreleased/1725.fixed.md`.

## Follow-up Candidates

- Existing full-index stall issues were already present as #2710 and #2717; no new issue was opened.

Fixes #1715
Fixes #1717
Fixes #1725
