### PR TITLE
Add official container image publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.cdidx/
+.github/
+.vs/
+.vscode/
+TestResults/
+**/bin/
+**/obj/
+**/.DS_Store
+*.user

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -871,6 +871,21 @@ jobs:
 
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Compute container tags
+        id: image-tags
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/widthdom/codeindex:${version}"
+            case "$version" in
+              *-*) ;;
+              *) echo "ghcr.io/widthdom/codeindex:latest" ;;
+            esac
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -887,9 +902,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/widthdom/codeindex:${{ steps.version.outputs.version }}
-            ghcr.io/widthdom/codeindex:latest
+          tags: ${{ steps.image-tags.outputs.tags }}
 
   publish-homebrew:
     if: github.repository == 'Widthdom/CodeIndex'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ permissions:
   contents: write
   id-token: write
   attestations: write
+  packages: write
 
 jobs:
   release:
@@ -845,6 +846,51 @@ jobs:
           dotnet nuget push nupkg/*.snupkg \
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json
+
+  publish-container:
+    if: github.repository == 'Widthdom/CodeIndex'
+    runs-on: ubuntu-latest
+    needs: create-release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag_name || github.ref_name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a v-prefixed SemVer version, got: ${TAG}" >&2
+            exit 1
+          fi
+
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/widthdom/codeindex:${{ steps.version.outputs.version }}
+            ghcr.io/widthdom/codeindex:latest
 
   publish-homebrew:
     if: github.repository == 'Widthdom/CodeIndex'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ permissions:
   contents: write
   id-token: write
   attestations: write
-  packages: write
 
 jobs:
   release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+
+WORKDIR /src
+COPY . .
+
+ARG TARGETARCH=amd64
+RUN dotnet restore src/CodeIndex/CodeIndex.csproj
+RUN case "$TARGETARCH" in \
+      amd64) rid="linux-musl-x64" ;; \
+      arm64) rid="linux-musl-arm64" ;; \
+      *) echo "Unsupported container architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    dotnet publish src/CodeIndex/CodeIndex.csproj \
+      --configuration Release \
+      --runtime "$rid" \
+      --self-contained true \
+      -p:PublishSingleFile=true \
+      -p:PublishTrimmed=true \
+      --output /out
+
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine AS runtime
+
+RUN apk add --no-cache ca-certificates git
+
+WORKDIR /repo
+COPY --from=build /out/ /usr/local/lib/cdidx/
+COPY LICENSE COMMERCIAL_LICENSE.md INTEGRATION_POLICY.md TRADEMARKS.md /usr/local/lib/cdidx/
+COPY LICENSES/ /usr/local/lib/cdidx/LICENSES/
+RUN ln -s /usr/local/lib/cdidx/cdidx /usr/local/bin/cdidx
+
+ENTRYPOINT ["cdidx"]
+CMD ["--help"]

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -129,6 +129,13 @@ cdidx .
 cdidx search "handleRequest"
 ```
 
+Or run the official container image without installing a local binary:
+
+```bash
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest search "handleRequest"
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest . --json
+```
+
 That is the whole loop:
 
 1. `cdidx .` builds or refreshes `.cdidx/codeindex.db`
@@ -140,6 +147,23 @@ a `67.0% [28/42]`-style progress line. If a large first index looks slow, rerun
 with `cdidx . --verbose` to see `[OK  ]`, `[SKIP]`, `[DEL ]`, and `[ERR ]`
 file statuses. Use incremental refreshes after the first run; see
 [Options](#options) for `--files` and `--commits`.
+
+## Container Image
+
+Release builds publish `ghcr.io/widthdom/codeindex:<version>` and
+`ghcr.io/widthdom/codeindex:latest`. The image sets `/repo` as its working
+directory and uses `cdidx` as the entrypoint, so pass normal cdidx arguments
+after the image name:
+
+```bash
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest . --json
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest search "authenticate"
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest mcp
+```
+
+Mount the repository read-write when indexing because `.cdidx/codeindex.db` is
+created beside the project. For read-only query containers, mount a repository
+that already includes a fresh `.cdidx/codeindex.db`.
 
 ## Shell completion
 
@@ -2171,6 +2195,13 @@ cdidx .
 cdidx search "handleRequest"
 ```
 
+ローカルに binary を入れず、公式 container image からも実行できます:
+
+```bash
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest search "handleRequest"
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest . --json
+```
+
 やることはこれだけです:
 
 1. `cdidx .` で `.cdidx/codeindex.db` を作成または更新
@@ -2182,6 +2213,23 @@ cdidx search "handleRequest"
 場合は `cdidx . --verbose` で再実行すると、`[OK  ]`、`[SKIP]`、`[DEL ]`、`[ERR ]`
 のファイル別ステータスを確認できます。初回以降は差分更新を使ってください。
 `--files` と `--commits` は [オプション一覧](#オプション一覧) を参照してください。
+
+## Container image
+
+リリースビルドは `ghcr.io/widthdom/codeindex:<version>` と
+`ghcr.io/widthdom/codeindex:latest` を公開します。image は `/repo` を working
+directory にし、`cdidx` を entrypoint にしているため、image 名の後ろに通常の
+cdidx 引数を渡します:
+
+```bash
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest . --json
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest search "authenticate"
+docker run --rm -v "$PWD:/repo" ghcr.io/widthdom/codeindex:latest mcp
+```
+
+indexing では `.cdidx/codeindex.db` を project 横に作成するため、repository は
+read-write で mount してください。read-only query container では、fresh な
+`.cdidx/codeindex.db` を含む repository を mount します。
 
 ## シェル補完
 

--- a/changelog.d/unreleased/1651.added.md
+++ b/changelog.d/unreleased/1651.added.md
@@ -1,0 +1,18 @@
+---
+category: added
+issues:
+  - 1651
+affected:
+  - Dockerfile
+  - .dockerignore
+  - .github/workflows/release.yml
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Official container image publishing (#1651)** — releases now build a Docker image from the repository Dockerfile and push `ghcr.io/widthdom/codeindex:<version>` plus `ghcr.io/widthdom/codeindex:latest`, with usage documented for CI and containerized MCP workflows.
+
+## 日本語
+
+- **公式 container image の公開 (#1651)** — release は repository の Dockerfile から Docker image を build し、`ghcr.io/widthdom/codeindex:<version>` と `ghcr.io/widthdom/codeindex:latest` を push するようになりました。CI と container 化した MCP workflow 向けの利用方法も文書化しました。

--- a/changelog.d/unreleased/1651.added.md
+++ b/changelog.d/unreleased/1651.added.md
@@ -7,6 +7,7 @@ affected:
   - .dockerignore
   - .github/workflows/release.yml
   - USER_GUIDE.md
+  - tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
 ---
 
 ## English

--- a/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
@@ -102,8 +102,10 @@ public class ReleaseWorkflowTests
         Assert.Contains("docker/login-action@v3", workflow);
         Assert.Contains("docker/build-push-action@v6", workflow);
         Assert.Contains("platforms: linux/amd64,linux/arm64", workflow);
-        Assert.Contains("ghcr.io/widthdom/codeindex:${{ steps.version.outputs.version }}", workflow);
+        Assert.Contains("ghcr.io/widthdom/codeindex:${version}", workflow);
         Assert.Contains("ghcr.io/widthdom/codeindex:latest", workflow);
+        Assert.Contains("tags: ${{ steps.image-tags.outputs.tags }}", workflow);
+        Assert.Contains("*-*) ;;", workflow);
         Assert.Contains("ARG TARGETARCH=amd64", dockerfile);
         Assert.Contains("linux-musl-x64", dockerfile);
         Assert.Contains("linux-musl-arm64", dockerfile);

--- a/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
@@ -89,6 +89,27 @@ public class ReleaseWorkflowTests
         Assert.DoesNotContain("--skip-duplicate", workflow);
     }
 
+    [Fact]
+    public void ReleaseWorkflow_PublishesOfficialContainerImage()
+    {
+        var root = GetRepositoryRoot();
+        var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "release.yml"));
+        var dockerfile = File.ReadAllText(Path.Combine(root, "Dockerfile"));
+
+        Assert.Contains("publish-container:", workflow);
+        Assert.Contains("needs: create-release", workflow);
+        Assert.Contains("packages: write", workflow);
+        Assert.Contains("docker/login-action@v3", workflow);
+        Assert.Contains("docker/build-push-action@v6", workflow);
+        Assert.Contains("platforms: linux/amd64,linux/arm64", workflow);
+        Assert.Contains("ghcr.io/widthdom/codeindex:${{ steps.version.outputs.version }}", workflow);
+        Assert.Contains("ghcr.io/widthdom/codeindex:latest", workflow);
+        Assert.Contains("ARG TARGETARCH=amd64", dockerfile);
+        Assert.Contains("linux-musl-x64", dockerfile);
+        Assert.Contains("linux-musl-arm64", dockerfile);
+        Assert.Contains("ENTRYPOINT [\"cdidx\"]", dockerfile);
+    }
+
     private static string GetRepositoryRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## Summary

- Add a multi-stage Dockerfile for the official cdidx container image.
- Publish GHCR images on releases for linux/amd64 and linux/arm64, tagging stable releases as latest.
- Document container usage and cover the release workflow contract in tests.

## Validation

- dotnet build CodeIndex.sln --configuration Release --no-restore
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --configuration Release --nologo --filter ReleaseWorkflowTests
- dotnet run --project tools/CodeIndex.Changelog -- check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml yaml ok"'
- docker build -t cdidx-issue1651-test . (blocked: Docker daemon is not running)
- dotnet test CodeIndex.sln --configuration Release --no-build --nologo (stopped after 14+ minutes with no failures reported; targeted release workflow tests passed)

## Documentation and changelog

- Updated USER_GUIDE.md with container image usage.
- Added changelog fragment changelog.d/unreleased/1651.added.md.

## Follow-up candidates

- None.

Fixes #1651