### PR TITLE
Fix Terraform and Dart reference extraction

### DIFF
--- a/changelog.d/unreleased/1480.fixed.md
+++ b/changelog.d/unreleased/1480.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1480
+affected:
+  - src/CodeIndex/Indexer/References/Languages/TerraformReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Terraform reference extraction now covers colon-qualified providers and module outputs (#1480)** — Terraform references now include colon-qualified provider resource types such as `aws:s3_bucket` and module output paths such as `module.web.outputs.endpoint`.
+
+## 日本語
+
+- **Terraform の参照抽出がコロン付き provider と module output に対応しました (#1480)** — Terraform references は `aws:s3_bucket` のようなコロン付き provider resource type と `module.web.outputs.endpoint` のような module output path を抽出するようになりました。

--- a/changelog.d/unreleased/1483.fixed.md
+++ b/changelog.d/unreleased/1483.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 1483
+affected:
+  - src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Dart reference extraction now records structural Dart 3 relationships (#1483)** — Dart references now mark sealed subtype, extension, mixin, and named-constructor relationships with dedicated reference kinds.
+
+## 日本語
+
+- **Dart の参照抽出が Dart 3 の構造的な関係を記録するようになりました (#1483)** — Dart references は sealed subtype、extension、mixin、named constructor の関係を専用 reference kind で記録するようになりました。

--- a/src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
@@ -1,9 +1,26 @@
+using System.Text.RegularExpressions;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;
 
 internal static class DartReferenceExtractor
 {
+    private static readonly Regex SealedSubtypeRegex = new(
+        @"^\s*(?:base\s+|final\s+|interface\s+|abstract\s+)*class\s+[A-Za-z_]\w*\s+extends\s+(?<name>[A-Za-z_]\w*)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ExtensionOnRegex = new(
+        @"^\s*extension(?:\s+[A-Za-z_]\w*)?\s+on\s+(?<name>[A-Za-z_]\w*)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex MixinListRegex = new(
+        @"^\s*(?:base\s+|final\s+|interface\s+|abstract\s+|sealed\s+)*class\s+[A-Za-z_]\w*[^{;]*\bwith\s+(?<names>[A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex NamedConstructorCallRegex = new(
+        @"(?<![\w.])(?<name>[A-Z][A-Za-z_]\w*\.[A-Za-z_]\w*)\s*\(",
+        RegexOptions.Compiled);
+
     public static void EmitTypePositionReferences(
         string preparedLine,
         List<ReferenceRecord> references,
@@ -13,6 +30,8 @@ internal static class DartReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
     {
+        EmitSpecialReferences(preparedLine, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
+
         LanguageReferenceExtractionSupport.EmitTypePositionReferences(
             "dart",
             preparedLine,
@@ -24,5 +43,64 @@ internal static class DartReferenceExtractor
             lineNumber,
             resolveContainerForColumn,
             container: null);
+    }
+
+    private static void EmitSpecialReferences(
+        string preparedLine,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        EmitSingleMatch(SealedSubtypeRegex, "sealed_subtype");
+        EmitSingleMatch(ExtensionOnRegex, "extension_of");
+        EmitMixinReferences();
+        EmitNamedConstructorCalls();
+
+        void EmitSingleMatch(Regex regex, string referenceKind)
+        {
+            var match = regex.Match(preparedLine);
+            if (!match.Success)
+                return;
+
+            Add(match.Groups["name"].Value, match.Groups["name"].Index, referenceKind);
+        }
+
+        void EmitMixinReferences()
+        {
+            var match = MixinListRegex.Match(preparedLine);
+            if (!match.Success)
+                return;
+
+            var names = match.Groups["names"];
+            foreach (Match name in Regex.Matches(names.Value, @"[A-Za-z_]\w*"))
+                Add(name.Value, names.Index + name.Index, "mixin_in");
+        }
+
+        void EmitNamedConstructorCalls()
+        {
+            foreach (Match match in NamedConstructorCallRegex.Matches(preparedLine))
+            {
+                var name = match.Groups["name"];
+                Add(name.Value, name.Index, "named_ctor_call");
+            }
+        }
+
+        void Add(string name, int nameIndex, string referenceKind)
+        {
+            ReferenceExtractor.AddReference(
+                references,
+                seen,
+                fileId,
+                name,
+                nameIndex,
+                referenceKind,
+                context,
+                lineNumber,
+                resolveContainerForColumn(nameIndex + 1),
+                "dart");
+        }
     }
 }

--- a/src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
@@ -6,7 +6,7 @@ namespace CodeIndex.Indexer;
 internal static class DartReferenceExtractor
 {
     private static readonly Regex SealedSubtypeRegex = new(
-        @"^\s*(?:base\s+|final\s+|interface\s+|abstract\s+)*class\s+[A-Za-z_]\w*\s+extends\s+(?<name>[A-Za-z_]\w*)",
+        @"^\s*(?:base\s+|final\s+|interface\s+|abstract\s+)*sealed\s+class\s+[A-Za-z_]\w*\s+extends\s+(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled);
 
     private static readonly Regex ExtensionOnRegex = new(

--- a/src/CodeIndex/Indexer/References/Languages/TerraformReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TerraformReferenceExtractor.cs
@@ -21,18 +21,23 @@ internal static class TerraformReferenceExtractor
         @"(?<![\w.])module\.(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled);
 
+    private static readonly Regex ModuleOutputReferenceRegex = new(
+        @"(?<![\w.])module\.[A-Za-z_]\w*\.outputs\.(?<name>[A-Za-z_]\w*)",
+        RegexOptions.Compiled);
+
     private static readonly Regex DataReferenceRegex = new(
         @"(?<![\w.])data\.[A-Za-z_]\w*\.(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled);
 
     private static readonly Regex ResourceReferenceRegex = new(
-        @"(?<![\w.])(?<type>[A-Za-z_]\w*_[A-Za-z_]\w*)\.(?<name>[A-Za-z_]\w*)",
+        @"(?<![\w.])(?<type>[A-Za-z_][\w:]*_[A-Za-z_]\w*)\.(?<name>[A-Za-z_]\w*)",
         RegexOptions.Compiled);
 
     private static readonly ReferencePattern[] ReferencePatterns =
     [
         new(VarReferenceRegex),
         new(LocalReferenceRegex),
+        new(ModuleOutputReferenceRegex),
         new(ModuleReferenceRegex),
         new(DataReferenceRegex),
         new(ResourceReferenceRegex, SkipSpecialReferencePrefix: true),

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13416,6 +13416,11 @@ public class ReferenceExtractorTests
     public void Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors()
     {
         const string content = """
+            sealed class Shape {}
+            class Circle extends Shape with Paintable, Serializable {}
+            extension ShapeFormatting on Shape {
+              String label() => Shape.label();
+            }
             class Screen extends BaseScreen with Trackable implements RouteAware {
               @override
               Widget build(BuildContext context) {
@@ -13437,11 +13442,18 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "BaseScreen" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Trackable" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RouteAware" && r.ReferenceKind == "type_reference");
+        Assert.Contains(references, r => r.SymbolName == "Shape" && r.ReferenceKind == "sealed_subtype");
+        Assert.Contains(references, r => r.SymbolName == "Shape" && r.ReferenceKind == "extension_of");
+        Assert.Contains(references, r => r.SymbolName == "Paintable" && r.ReferenceKind == "mixin_in");
+        Assert.Contains(references, r => r.SymbolName == "Serializable" && r.ReferenceKind == "mixin_in");
+        Assert.Contains(references, r => r.SymbolName == "Trackable" && r.ReferenceKind == "mixin_in");
+        Assert.Contains(references, r => r.SymbolName == "Shape.label" && r.ReferenceKind == "named_ctor_call");
         Assert.Contains(references, r => r.SymbolName == "BuildContext" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "User" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "override" && r.ReferenceKind == "annotation");
         Assert.Contains(references, r => r.SymbolName == "UserCard" && r.ReferenceKind == "instantiate");
         Assert.Contains(references, r => r.SymbolName == "User.fromJson" && r.ReferenceKind == "instantiate");
+        Assert.Contains(references, r => r.SymbolName == "User.fromJson" && r.ReferenceKind == "named_ctor_call");
         Assert.Contains(references, r => r.SymbolName == "afterRaw" && r.ReferenceKind == "call");
         Assert.DoesNotContain(references, r => r.SymbolName == "Phantom");
         Assert.DoesNotContain(references, r => r.SymbolName == "fromJson" && r.ReferenceKind == "instantiate");

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2933,6 +2933,18 @@ public class ReferenceExtractorTests
             output "instance_ids" {
               value = aws_instance.web[*].id
             }
+
+            resource "aws:s3_bucket" "data" {
+              bucket = "example-data"
+            }
+
+            output "endpoint" {
+              value = module.network.outputs.endpoint
+            }
+
+            output "bucket" {
+              value = aws:s3_bucket.data.id
+            }
             """;
 
         var symbols = SymbolExtractor.Extract(1, "terraform", content);
@@ -2950,7 +2962,7 @@ public class ReferenceExtractorTests
         Assert.Single(references.Where(reference =>
             reference.SymbolName == "ubuntu"
             && reference.ReferenceKind == "reference"));
-        Assert.Equal(2, references.Count(reference =>
+        Assert.Equal(3, references.Count(reference =>
             reference.SymbolName == "network"
             && reference.ReferenceKind == "reference"));
         Assert.Single(references.Where(reference =>
@@ -2959,9 +2971,15 @@ public class ReferenceExtractorTests
         Assert.Single(references.Where(reference =>
             reference.SymbolName == "foo"
             && reference.ReferenceKind == "reference"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "endpoint"
+            && reference.ReferenceKind == "reference"));
+        Assert.Single(references.Where(reference =>
+            reference.SymbolName == "data"
+            && reference.ReferenceKind == "reference"));
         Assert.DoesNotContain(references, reference =>
             reference.ReferenceKind == "call"
-            && reference.SymbolName is "region" or "instance_count" or "common_tags" or "ubuntu" or "network" or "web" or "foo");
+            && reference.SymbolName is "region" or "instance_count" or "common_tags" or "ubuntu" or "network" or "web" or "foo" or "endpoint" or "data");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -13417,7 +13417,7 @@ public class ReferenceExtractorTests
     {
         const string content = """
             sealed class Shape {}
-            class Circle extends Shape with Paintable, Serializable {}
+            sealed class Circle extends Shape with Paintable, Serializable {}
             extension ShapeFormatting on Shape {
               String label() => Shape.label();
             }
@@ -13443,6 +13443,7 @@ public class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "Trackable" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "RouteAware" && r.ReferenceKind == "type_reference");
         Assert.Contains(references, r => r.SymbolName == "Shape" && r.ReferenceKind == "sealed_subtype");
+        Assert.DoesNotContain(references, r => r.SymbolName == "BaseScreen" && r.ReferenceKind == "sealed_subtype");
         Assert.Contains(references, r => r.SymbolName == "Shape" && r.ReferenceKind == "extension_of");
         Assert.Contains(references, r => r.SymbolName == "Paintable" && r.ReferenceKind == "mixin_in");
         Assert.Contains(references, r => r.SymbolName == "Serializable" && r.ReferenceKind == "mixin_in");


### PR DESCRIPTION
## Summary

- Add Terraform reference extraction for colon-qualified provider resource types and `module.<name>.outputs.<key>` paths.
- Add Dart-specific structural references for sealed subtype, extension target, mixin list, and named constructor calls.
- Add bilingual changelog fragments for both issue fixes.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_Terraform_DottedReferences_AreReferenced|FullyQualifiedName~ReferenceExtractorTests.Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests.Extract_DartDetailedReferences_CapturesTypePositionsAnnotationsAndConstructors"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Full `dotnet test` was also attempted, but a pre-existing unrelated `CdidxConfigFileTests.Run_MalformedConfigFile_FailsWithUsageError` failure appeared with empty stderr before the run was stopped after it had already failed.

## Documentation and Changelog

- `changelog.d/unreleased/1480.fixed.md`
- `changelog.d/unreleased/1483.fixed.md`

## Review

Adversarial review found one actionable issue in the first pass: Dart `sealed_subtype` was over-emitted for ordinary `extends` clauses. This PR now restricts it to sealed subtype declarations and adds a negative assertion.

Fixes #1480
Fixes #1483
