### PR TITLE
Fix flaky process-global tests

### DIFF
--- a/changelog.d/unreleased/2747.fixed.md
+++ b/changelog.d/unreleased/2747.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2747
+affected:
+  - tests
+---
+
+## English
+
+- **Stabilized process-global test parallelism (#2747)** — Moved `FileIndexerTests`, `CdidxConfigFileTests`, and `GlobalToolLogTests` into the existing non-parallel test collection because they temporarily change process current directory, environment, or console state.
+
+## 日本語
+
+- **process-global state を触るテストの並列実行を安定化しました (#2747)** — `FileIndexerTests`、`CdidxConfigFileTests`、`GlobalToolLogTests` は一時的に process current directory、environment、console state を変更するため、既存の非並列 test collection に移しました。

--- a/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
+++ b/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
@@ -2,6 +2,7 @@ using CodeIndex.Cli;
 
 namespace CodeIndex.Tests;
 
+[Collection("SQLite pool sensitive")]
 public class CdidxConfigFileTests
 {
     [Fact]

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -15,6 +15,7 @@ namespace CodeIndex.Tests;
 /// Tests for FileIndexer.
 /// FileIndexerのテスト。
 /// </summary>
+[Collection("SQLite pool sensitive")]
 public class FileIndexerTests
 {
     [Fact]

--- a/tests/CodeIndex.Tests/GlobalToolLogTests.cs
+++ b/tests/CodeIndex.Tests/GlobalToolLogTests.cs
@@ -5,6 +5,7 @@ using CodeIndex.Cli;
 
 namespace CodeIndex.Tests;
 
+[Collection("SQLite pool sensitive")]
 public class GlobalToolLogTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

- Moved `FileIndexerTests`, `CdidxConfigFileTests`, and `GlobalToolLogTests` into the existing non-parallel `SQLite pool sensitive` collection.
- Kept process-global current-directory, environment, and console state tests serialized with the CLI/indexer tests they can interfere with.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests.DetectLanguage_WorkspaceLangMapYaml_AliasesExtension|FullyQualifiedName~IndexCommandRunnerTests.Run_FullScan_WithOversizedFile_PrintsSkipWarningWithoutRecoveryWarning|FullyQualifiedName~CdidxConfigFileTests.Run_MalformedConfigFile_FailsWithUsageError|FullyQualifiedName~GlobalToolLogTests.TryStart_ErrorMirrorIgnoresDisposedOriginalConsoleWriter"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --settings tests/CodeIndex.Tests/CodeIndex.Tests.runsettings --blame-hang --blame-hang-timeout 5m`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: No blocking/actionable issues found.

## Documentation and changelog

- Added `changelog.d/unreleased/2747.fixed.md`.
- No user-facing docs changed; this is a test-suite stability fix and follows the existing `TESTING_GUIDE.md` shared-state convention.

## Follow-up candidates

- None.

Fixes #2747
