### PR TITLE
Fix type alias heritage references

### DIFF
--- a/changelog.d/unreleased/1976.fixed.md
+++ b/changelog.d/unreleased/1976.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 1976
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.Core.cs
+  - src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Type alias heritage references now include the underlying type (#1976)** — TypeScript `type Alias = Target` and Swift `typealias Alias = Target` indirection now emits an additional `type_reference` from alias-mediated heritage uses to the underlying type.
+
+## 日本語
+
+- **type alias 経由の継承参照で underlying type も記録するようになりました (#1976)** — TypeScript の `type Alias = Target` と Swift の `typealias Alias = Target` 経由の継承利用で、alias だけでなく underlying type への追加 `type_reference` も出力します。

--- a/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
@@ -13,6 +13,9 @@ internal static class SwiftReferenceExtractor
     private static readonly Regex PropertyWrapperAttributeRegex = new(
         @"@(?<name>[A-Z]\w*(?:\.[A-Z]\w*)?)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex TypeAliasRegex = new(
+        @"^\s*(?:(?:public|private|internal|open|fileprivate|package)\s+)?typealias\s+(?<alias>`[^`]+`|\w+)(?:\s*<[^=]+>)?\s*=\s*(?<target>.+)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly HashSet<string> NonWrapperPropertyAttributes = new(StringComparer.Ordinal)
     {
         "IBOutlet",
@@ -76,6 +79,89 @@ internal static class SwiftReferenceExtractor
             lineNumber,
             resolveContainerForColumn);
     }
+
+    public static Dictionary<string, string> BuildTypeAliasTargets(IReadOnlyList<string> preparedLines)
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var line in preparedLines)
+        {
+            var match = TypeAliasRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var target = match.Groups["target"].Value.Trim();
+            if (target.Length > 0)
+                aliases[TrimSwiftBackticks(match.Groups["alias"].Value)] = target;
+        }
+
+        return aliases;
+    }
+
+    public static void EmitAliasTargetReferences(
+        string preparedLine,
+        IReadOnlyDictionary<string, string> aliases,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (aliases.Count == 0 || TypeAliasRegex.IsMatch(preparedLine))
+            return;
+
+        foreach (var (alias, target) in aliases)
+        {
+            var searchStart = 0;
+            while (searchStart < preparedLine.Length)
+            {
+                var index = preparedLine.IndexOf(alias, searchStart, StringComparison.Ordinal);
+                if (index < 0)
+                    break;
+
+                searchStart = index + alias.Length;
+                if (!HasIdentifierBoundaries(preparedLine, index, alias.Length))
+                    continue;
+                var column = index + 1;
+                if (!references.Any(reference =>
+                        reference.FileId == fileId
+                        && reference.Line == lineNumber
+                        && reference.Column == column
+                        && reference.ReferenceKind == "type_reference"
+                        && string.Equals(reference.SymbolName, alias, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                    target,
+                    index,
+                    "swift",
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(index));
+            }
+        }
+    }
+
+    private static string TrimSwiftBackticks(string value) =>
+        value.Length >= 2 && value[0] == '`' && value[^1] == '`'
+            ? value[1..^1]
+            : value;
+
+    private static bool HasIdentifierBoundaries(string line, int start, int length)
+    {
+        var before = start == 0 ? '\0' : line[start - 1];
+        var afterIndex = start + length;
+        var after = afterIndex >= line.Length ? '\0' : line[afterIndex];
+        return !IsIdentifierPart(before) && !IsIdentifierPart(after);
+    }
+
+    private static bool IsIdentifierPart(char c) =>
+        c == '_' || char.IsLetterOrDigit(c);
 
     private static void EmitPropertyWrapperTypeReferences(
         string preparedLine,

--- a/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
@@ -5,6 +5,8 @@ namespace CodeIndex.Indexer;
 
 internal static class SwiftReferenceExtractor
 {
+    internal readonly record struct TypeAliasBinding(string Alias, string Target, int BindingLine, int? EndLine, int BraceDepth);
+
     private static readonly string[] DeclarationKeywords = ["let", "var"];
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
     private static readonly Regex PropertyWrapperDeclarationRegex = new(
@@ -80,18 +82,25 @@ internal static class SwiftReferenceExtractor
             resolveContainerForColumn);
     }
 
-    public static Dictionary<string, string> BuildTypeAliasTargets(IReadOnlyList<string> preparedLines)
+    public static IReadOnlyList<TypeAliasBinding> BuildTypeAliasTargets(IReadOnlyList<string> preparedLines)
     {
-        var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var line in preparedLines)
+        var aliases = new List<TypeAliasBinding>();
+        var braceDepths = BuildBraceDepthsBeforeLine(preparedLines);
+        for (var index = 0; index < preparedLines.Count; index++)
         {
+            var line = preparedLines[index];
             var match = TypeAliasRegex.Match(line);
             if (!match.Success)
                 continue;
 
             var target = match.Groups["target"].Value.Trim();
             if (target.Length > 0)
-                aliases[TrimSwiftBackticks(match.Groups["alias"].Value)] = target;
+                aliases.Add(new TypeAliasBinding(
+                    TrimSwiftBackticks(match.Groups["alias"].Value),
+                    target,
+                    index + 1,
+                    FindScopedAliasEndLine(preparedLines, braceDepths, index),
+                    braceDepths[index]));
         }
 
         return aliases;
@@ -99,7 +108,7 @@ internal static class SwiftReferenceExtractor
 
     public static void EmitAliasTargetReferences(
         string preparedLine,
-        IReadOnlyDictionary<string, string> aliases,
+        IReadOnlyList<TypeAliasBinding> aliases,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -110,7 +119,7 @@ internal static class SwiftReferenceExtractor
         if (aliases.Count == 0 || TypeAliasRegex.IsMatch(preparedLine))
             return;
 
-        foreach (var (alias, target) in aliases)
+        foreach (var alias in aliases.Select(binding => binding.Alias).Distinct(StringComparer.Ordinal))
         {
             var searchStart = 0;
             while (searchStart < preparedLine.Length)
@@ -133,8 +142,12 @@ internal static class SwiftReferenceExtractor
                     continue;
                 }
 
+                var binding = FindActiveTypeAliasBinding(aliases, alias, lineNumber);
+                if (binding is null)
+                    continue;
+
                 TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
-                    target,
+                    binding.Value.Target,
                     index,
                     "swift",
                     references,
@@ -145,6 +158,69 @@ internal static class SwiftReferenceExtractor
                     resolveContainerForColumn(index));
             }
         }
+    }
+
+    private static TypeAliasBinding? FindActiveTypeAliasBinding(
+        IReadOnlyList<TypeAliasBinding> aliases,
+        string alias,
+        int lineNumber)
+    {
+        TypeAliasBinding? best = null;
+        foreach (var binding in aliases)
+        {
+            if (!string.Equals(binding.Alias, alias, StringComparison.Ordinal)
+                || lineNumber <= binding.BindingLine
+                || (binding.EndLine is int endLine && lineNumber > endLine))
+            {
+                continue;
+            }
+
+            if (best is null
+                || binding.BraceDepth > best.Value.BraceDepth
+                || (binding.BraceDepth == best.Value.BraceDepth && binding.BindingLine > best.Value.BindingLine))
+            {
+                best = binding;
+            }
+        }
+
+        return best;
+    }
+
+    private static int? FindScopedAliasEndLine(
+        IReadOnlyList<string> preparedLines,
+        IReadOnlyList<int> braceDepths,
+        int bindingLineIndex)
+    {
+        var bindingDepth = braceDepths[bindingLineIndex];
+        if (bindingDepth <= 0)
+            return null;
+
+        for (var index = bindingLineIndex + 1; index < preparedLines.Count; index++)
+        {
+            if (braceDepths[index] < bindingDepth)
+                return index;
+        }
+
+        return preparedLines.Count;
+    }
+
+    private static int[] BuildBraceDepthsBeforeLine(IReadOnlyList<string> preparedLines)
+    {
+        var depths = new int[preparedLines.Count];
+        var depth = 0;
+        for (var index = 0; index < preparedLines.Count; index++)
+        {
+            depths[index] = depth;
+            foreach (var ch in preparedLines[index])
+            {
+                if (ch == '{')
+                    depth++;
+                else if (ch == '}' && depth > 0)
+                    depth--;
+            }
+        }
+
+        return depths;
     }
 
     private static string TrimSwiftBackticks(string value) =>

--- a/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
@@ -5,7 +5,14 @@ namespace CodeIndex.Indexer;
 
 internal static class SwiftReferenceExtractor
 {
-    internal readonly record struct TypeAliasBinding(string Alias, string Target, int BindingLine, int? EndLine, int BraceDepth);
+    internal readonly record struct LineRange(int StartLine, int EndLine);
+    internal readonly record struct TypeAliasBinding(
+        string Alias,
+        string Target,
+        int BindingLine,
+        int? EndLine,
+        int BraceDepth,
+        IReadOnlyList<LineRange> ShadowRanges);
 
     private static readonly string[] DeclarationKeywords = ["let", "var"];
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
@@ -17,6 +24,9 @@ internal static class SwiftReferenceExtractor
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex TypeAliasRegex = new(
         @"^\s*(?:(?:public|private|internal|open|fileprivate|package)\s+)?typealias\s+(?<alias>`[^`]+`|\w+)(?:\s*<[^=]+>)?\s*=\s*(?<target>.+)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex TypeDeclarationShadowRegex = new(
+        @"^\s*(?:(?:public|private|internal|open|fileprivate|package)\s+)?(?:final\s+)?(?:class|struct|enum|protocol)\s+(?<name>`[^`]+`|\w+)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly HashSet<string> NonWrapperPropertyAttributes = new(StringComparer.Ordinal)
     {
@@ -100,7 +110,8 @@ internal static class SwiftReferenceExtractor
                     target,
                     index + 1,
                     FindScopedAliasEndLine(preparedLines, braceDepths, index),
-                    braceDepths[index]));
+                    braceDepths[index],
+                    BuildTypeAliasShadowRanges(preparedLines, braceDepths, TrimSwiftBackticks(match.Groups["alias"].Value))));
         }
 
         return aliases;
@@ -170,7 +181,8 @@ internal static class SwiftReferenceExtractor
         {
             if (!string.Equals(binding.Alias, alias, StringComparison.Ordinal)
                 || lineNumber <= binding.BindingLine
-                || (binding.EndLine is int endLine && lineNumber > endLine))
+                || (binding.EndLine is int endLine && lineNumber > endLine)
+                || IsInsideScopedShadow(binding.ShadowRanges, lineNumber))
             {
                 continue;
             }
@@ -184,6 +196,89 @@ internal static class SwiftReferenceExtractor
         }
 
         return best;
+    }
+
+    private static IReadOnlyList<LineRange> BuildTypeAliasShadowRanges(
+        IReadOnlyList<string> preparedLines,
+        IReadOnlyList<int> braceDepths,
+        string alias)
+    {
+        var ranges = new List<LineRange>();
+        for (var index = 0; index < preparedLines.Count; index++)
+        {
+            var line = preparedLines[index];
+            var typeDeclaration = TypeDeclarationShadowRegex.Match(line);
+            if (typeDeclaration.Success && string.Equals(TrimSwiftBackticks(typeDeclaration.Groups["name"].Value), alias, StringComparison.Ordinal))
+            {
+                ranges.Add(new LineRange(index + 1, FindScopedAliasEndLine(preparedLines, braceDepths, index) ?? preparedLines.Count));
+                continue;
+            }
+
+            if (DeclaresGenericTypeParameter(line, alias))
+                ranges.Add(new LineRange(index + 1, FindScopedAliasEndLine(preparedLines, braceDepths, index) ?? index + 1));
+        }
+
+        return ranges;
+    }
+
+    private static bool DeclaresGenericTypeParameter(string line, string alias)
+    {
+        var openAngle = line.IndexOf('<');
+        if (openAngle < 0)
+            return false;
+
+        var closeAngle = line.IndexOf('>', openAngle + 1);
+        if (closeAngle <= openAngle)
+            return false;
+
+        var prefix = line[..openAngle];
+        if (!ContainsKeyword(prefix, "class")
+            && !ContainsKeyword(prefix, "struct")
+            && !ContainsKeyword(prefix, "enum")
+            && !ContainsKeyword(prefix, "protocol")
+            && !ContainsKeyword(prefix, "func")
+            && !ContainsKeyword(prefix, "typealias"))
+        {
+            return false;
+        }
+
+        foreach (var parameter in line.Substring(openAngle + 1, closeAngle - openAngle - 1).Split(','))
+        {
+            var name = parameter.Trim().Split([' ', ':', '='], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (string.Equals(TrimSwiftBackticks(name ?? string.Empty), alias, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsKeyword(string text, string keyword)
+    {
+        var searchStart = 0;
+        while (searchStart < text.Length)
+        {
+            var index = text.IndexOf(keyword, searchStart, StringComparison.Ordinal);
+            if (index < 0)
+                return false;
+
+            if (HasIdentifierBoundaries(text, index, keyword.Length))
+                return true;
+
+            searchStart = index + keyword.Length;
+        }
+
+        return false;
+    }
+
+    private static bool IsInsideScopedShadow(IReadOnlyList<LineRange> ranges, int lineNumber)
+    {
+        foreach (var range in ranges)
+        {
+            if (lineNumber >= range.StartLine && lineNumber <= range.EndLine)
+                return true;
+        }
+
+        return false;
     }
 
     private static int? FindScopedAliasEndLine(

--- a/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
@@ -12,7 +12,8 @@ internal static class SwiftReferenceExtractor
         int BindingLine,
         int? EndLine,
         int BraceDepth,
-        IReadOnlyList<LineRange> ShadowRanges);
+        IReadOnlyList<LineRange> ShadowRanges,
+        IReadOnlySet<string> TypeParameters);
 
     private static readonly string[] DeclarationKeywords = ["let", "var"];
     private static readonly string[] TypeOperatorKeywords = ["is", "as"];
@@ -23,7 +24,7 @@ internal static class SwiftReferenceExtractor
         @"@(?<name>[A-Z]\w*(?:\.[A-Z]\w*)?)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex TypeAliasRegex = new(
-        @"^\s*(?:(?:public|private|internal|open|fileprivate|package)\s+)?typealias\s+(?<alias>`[^`]+`|\w+)(?:\s*<[^=]+>)?\s*=\s*(?<target>.+)$",
+        @"^\s*(?:(?:public|private|internal|open|fileprivate|package)\s+)?typealias\s+(?<alias>`[^`]+`|\w+)(?<params>\s*<[^=]+>)?\s*=\s*(?<target>.+)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex TypeDeclarationShadowRegex = new(
         @"^\s*(?:(?:public|private|internal|open|fileprivate|package)\s+)?(?:final\s+)?(?:class|struct|enum|protocol)\s+(?<name>`[^`]+`|\w+)\b",
@@ -111,7 +112,8 @@ internal static class SwiftReferenceExtractor
                     index + 1,
                     FindScopedAliasEndLine(preparedLines, braceDepths, index),
                     braceDepths[index],
-                    BuildTypeAliasShadowRanges(preparedLines, braceDepths, TrimSwiftBackticks(match.Groups["alias"].Value))));
+                    BuildTypeAliasShadowRanges(preparedLines, braceDepths, TrimSwiftBackticks(match.Groups["alias"].Value)),
+                    ExtractGenericTypeParameters(match.Groups["params"].Value)));
         }
 
         return aliases;
@@ -166,7 +168,8 @@ internal static class SwiftReferenceExtractor
                     fileId,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(index));
+                    resolveContainerForColumn(index),
+                    binding.Value.TypeParameters);
             }
         }
     }
@@ -250,6 +253,24 @@ internal static class SwiftReferenceExtractor
         }
 
         return false;
+    }
+
+    private static IReadOnlySet<string> ExtractGenericTypeParameters(string parameters)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var openAngle = parameters.IndexOf('<');
+        var closeAngle = parameters.LastIndexOf('>');
+        if (openAngle < 0 || closeAngle <= openAngle)
+            return names;
+
+        foreach (var parameter in parameters.Substring(openAngle + 1, closeAngle - openAngle - 1).Split(','))
+        {
+            var name = parameter.Trim().Split([' ', ':', '='], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(name))
+                names.Add(TrimSwiftBackticks(name));
+        }
+
+        return names;
     }
 
     private static bool ContainsKeyword(string text, string keyword)

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -37,6 +37,9 @@ internal static class TypeScriptReferenceExtractor
         "keyof",
         "readonly",
     };
+    private static readonly Regex TypeAliasRegex = new(
+        @"^\s*(?:export\s+)?type\s+(?<alias>[A-Za-z_$][\w$]*)(?:\s*<[^=;]+>)?\s*=\s*(?<target>[^;]+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static IReadOnlyList<NamespaceAliasBinding> BuildNamespaceAliasBindings(
         IReadOnlyList<string> originalLines,
@@ -224,6 +227,103 @@ internal static class TypeScriptReferenceExtractor
             context,
             lineNumber,
             resolveContainerForColumn);
+    }
+
+    public static Dictionary<string, string> BuildTypeAliasTargets(IReadOnlyList<string> preparedLines)
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var line in preparedLines)
+        {
+            var match = TypeAliasRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            var target = TrimAliasTarget(match.Groups["target"].Value);
+            if (target.Length > 0)
+                aliases[match.Groups["alias"].Value] = target;
+        }
+
+        return aliases;
+    }
+
+    public static void EmitAliasTargetReferences(
+        string preparedLine,
+        IReadOnlyDictionary<string, string> aliases,
+        List<ReferenceRecord> references,
+        HashSet<string> seen,
+        long fileId,
+        string context,
+        int lineNumber,
+        Func<int, SymbolRecord?> resolveContainerForColumn)
+    {
+        if (aliases.Count == 0 || TypeAliasRegex.IsMatch(preparedLine))
+            return;
+
+        foreach (var (alias, target) in aliases)
+        {
+            var searchStart = 0;
+            while (searchStart < preparedLine.Length)
+            {
+                var index = preparedLine.IndexOf(alias, searchStart, StringComparison.Ordinal);
+                if (index < 0)
+                    break;
+
+                searchStart = index + alias.Length;
+                if (!HasIdentifierBoundaries(preparedLine, index, alias.Length))
+                    continue;
+                var column = index + 1;
+                if (!references.Any(reference =>
+                        reference.FileId == fileId
+                        && reference.Line == lineNumber
+                        && reference.Column == column
+                        && reference.ReferenceKind == "type_reference"
+                        && string.Equals(reference.SymbolName, alias, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
+                    target,
+                    index,
+                    "typescript",
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    resolveContainerForColumn(index));
+            }
+        }
+    }
+
+    private static string TrimAliasTarget(string target)
+    {
+        var equalsTarget = target.Trim();
+        var stop = equalsTarget.Length;
+        foreach (var keyword in new[] { "extends", "implements" })
+        {
+            var keywordIndex = FindTopLevelKeyword(equalsTarget, keyword);
+            if (keywordIndex >= 0)
+                stop = Math.Min(stop, keywordIndex);
+        }
+
+        return equalsTarget[..stop].Trim();
+    }
+
+    private static int FindTopLevelKeyword(string line, string keyword)
+    {
+        foreach (var index in TypedLanguageReferenceExtractor.EnumerateTopLevelKeywordIndices(line, keyword))
+            return index;
+
+        return -1;
+    }
+
+    private static bool HasIdentifierBoundaries(string line, int start, int length)
+    {
+        var before = start == 0 ? '\0' : line[start - 1];
+        var afterIndex = start + length;
+        var after = afterIndex >= line.Length ? '\0' : line[afterIndex];
+        return !IsTypeScriptIdentifierPart(before) && !IsTypeScriptIdentifierPart(after);
     }
 
     private static void EmitAsTypeReferences(

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -48,7 +48,7 @@ internal static class TypeScriptReferenceExtractor
         "readonly",
     };
     private static readonly Regex TypeAliasRegex = new(
-        @"^\s*(?:export\s+)?type\s+(?<alias>[A-Za-z_$][\w$]*)(?:\s*<[^=;]+>)?\s*=\s*(?<target>[^;]+)",
+        @"^\s*(?:export\s+)?type\s+(?<alias>[A-Za-z_$][\w$]*)(?:\s*<[^;]*>)?\s*=\s*(?<target>[^;]+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static IReadOnlyList<NamespaceAliasBinding> BuildNamespaceAliasBindings(

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -12,7 +12,8 @@ internal static class TypeScriptReferenceExtractor
         int BindingLine,
         int? EndLine,
         int BraceDepth,
-        IReadOnlyList<LineRange> ShadowRanges);
+        IReadOnlyList<LineRange> ShadowRanges,
+        IReadOnlySet<string> TypeParameters);
     internal sealed record NamespaceAliasBinding(
         string Alias,
         string ModuleSpecifier,
@@ -48,7 +49,7 @@ internal static class TypeScriptReferenceExtractor
         "readonly",
     };
     private static readonly Regex TypeAliasRegex = new(
-        @"^\s*(?:export\s+)?type\s+(?<alias>[A-Za-z_$][\w$]*)(?:\s*<[^;]*>)?\s*=\s*(?<target>[^;]+)",
+        @"^\s*(?:export\s+)?type\s+(?<alias>[A-Za-z_$][\w$]*)(?<params>\s*<[^;]*>)?\s*=\s*(?<target>[^;]+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static IReadOnlyList<NamespaceAliasBinding> BuildNamespaceAliasBindings(
@@ -258,7 +259,8 @@ internal static class TypeScriptReferenceExtractor
                     index + 1,
                     FindScopedAliasEndLine(preparedLines, braceDepths, index),
                     braceDepths[index],
-                    BuildTypeAliasShadowRanges(preparedLines, braceDepths, match.Groups["alias"].Value)));
+                    BuildTypeAliasShadowRanges(preparedLines, braceDepths, match.Groups["alias"].Value),
+                    ExtractGenericTypeParameters(match.Groups["params"].Value)));
         }
 
         return aliases;
@@ -313,7 +315,8 @@ internal static class TypeScriptReferenceExtractor
                     fileId,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(index));
+                    resolveContainerForColumn(index),
+                    binding.Value.TypeParameters);
             }
         }
     }
@@ -395,6 +398,24 @@ internal static class TypeScriptReferenceExtractor
         }
 
         return false;
+    }
+
+    private static IReadOnlySet<string> ExtractGenericTypeParameters(string parameters)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var openAngle = parameters.IndexOf('<');
+        var closeAngle = parameters.LastIndexOf('>');
+        if (openAngle < 0 || closeAngle <= openAngle)
+            return names;
+
+        foreach (var parameter in parameters.Substring(openAngle + 1, closeAngle - openAngle - 1).Split(','))
+        {
+            var name = parameter.Trim().Split([' ', '=', ':'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(name))
+                names.Add(name);
+        }
+
+        return names;
     }
 
     private static bool ContainsKeyword(string text, string keyword)

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -6,6 +6,7 @@ namespace CodeIndex.Indexer;
 internal static class TypeScriptReferenceExtractor
 {
     internal readonly record struct LineRange(int StartLine, int EndLine);
+    internal readonly record struct TypeAliasBinding(string Alias, string Target, int BindingLine, int? EndLine, int BraceDepth);
     internal sealed record NamespaceAliasBinding(
         string Alias,
         string ModuleSpecifier,
@@ -229,18 +230,25 @@ internal static class TypeScriptReferenceExtractor
             resolveContainerForColumn);
     }
 
-    public static Dictionary<string, string> BuildTypeAliasTargets(IReadOnlyList<string> preparedLines)
+    public static IReadOnlyList<TypeAliasBinding> BuildTypeAliasTargets(IReadOnlyList<string> preparedLines)
     {
-        var aliases = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var line in preparedLines)
+        var aliases = new List<TypeAliasBinding>();
+        var braceDepths = BuildBraceDepthsBeforeLine(preparedLines);
+        for (var index = 0; index < preparedLines.Count; index++)
         {
+            var line = preparedLines[index];
             var match = TypeAliasRegex.Match(line);
             if (!match.Success)
                 continue;
 
             var target = TrimAliasTarget(match.Groups["target"].Value);
             if (target.Length > 0)
-                aliases[match.Groups["alias"].Value] = target;
+                aliases.Add(new TypeAliasBinding(
+                    match.Groups["alias"].Value,
+                    target,
+                    index + 1,
+                    FindScopedAliasEndLine(preparedLines, braceDepths, index),
+                    braceDepths[index]));
         }
 
         return aliases;
@@ -248,7 +256,7 @@ internal static class TypeScriptReferenceExtractor
 
     public static void EmitAliasTargetReferences(
         string preparedLine,
-        IReadOnlyDictionary<string, string> aliases,
+        IReadOnlyList<TypeAliasBinding> aliases,
         List<ReferenceRecord> references,
         HashSet<string> seen,
         long fileId,
@@ -259,7 +267,7 @@ internal static class TypeScriptReferenceExtractor
         if (aliases.Count == 0 || TypeAliasRegex.IsMatch(preparedLine))
             return;
 
-        foreach (var (alias, target) in aliases)
+        foreach (var alias in aliases.Select(binding => binding.Alias).Distinct(StringComparer.Ordinal))
         {
             var searchStart = 0;
             while (searchStart < preparedLine.Length)
@@ -282,8 +290,12 @@ internal static class TypeScriptReferenceExtractor
                     continue;
                 }
 
+                var binding = FindActiveTypeAliasBinding(aliases, alias, lineNumber);
+                if (binding is null)
+                    continue;
+
                 TypedLanguageReferenceExtractor.EmitTypeExpressionReferences(
-                    target,
+                    binding.Value.Target,
                     index,
                     "typescript",
                     references,
@@ -294,6 +306,50 @@ internal static class TypeScriptReferenceExtractor
                     resolveContainerForColumn(index));
             }
         }
+    }
+
+    private static TypeAliasBinding? FindActiveTypeAliasBinding(
+        IReadOnlyList<TypeAliasBinding> aliases,
+        string alias,
+        int lineNumber)
+    {
+        TypeAliasBinding? best = null;
+        foreach (var binding in aliases)
+        {
+            if (!string.Equals(binding.Alias, alias, StringComparison.Ordinal)
+                || lineNumber <= binding.BindingLine
+                || (binding.EndLine is int endLine && lineNumber > endLine))
+            {
+                continue;
+            }
+
+            if (best is null
+                || binding.BraceDepth > best.Value.BraceDepth
+                || (binding.BraceDepth == best.Value.BraceDepth && binding.BindingLine > best.Value.BindingLine))
+            {
+                best = binding;
+            }
+        }
+
+        return best;
+    }
+
+    private static int? FindScopedAliasEndLine(
+        IReadOnlyList<string> preparedLines,
+        IReadOnlyList<int> braceDepths,
+        int bindingLineIndex)
+    {
+        var bindingDepth = braceDepths[bindingLineIndex];
+        if (bindingDepth <= 0)
+            return null;
+
+        for (var index = bindingLineIndex + 1; index < preparedLines.Count; index++)
+        {
+            if (braceDepths[index] < bindingDepth)
+                return index;
+        }
+
+        return preparedLines.Count;
     }
 
     private static string TrimAliasTarget(string target)

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -6,7 +6,13 @@ namespace CodeIndex.Indexer;
 internal static class TypeScriptReferenceExtractor
 {
     internal readonly record struct LineRange(int StartLine, int EndLine);
-    internal readonly record struct TypeAliasBinding(string Alias, string Target, int BindingLine, int? EndLine, int BraceDepth);
+    internal readonly record struct TypeAliasBinding(
+        string Alias,
+        string Target,
+        int BindingLine,
+        int? EndLine,
+        int BraceDepth,
+        IReadOnlyList<LineRange> ShadowRanges);
     internal sealed record NamespaceAliasBinding(
         string Alias,
         string ModuleSpecifier,
@@ -29,6 +35,9 @@ internal static class TypeScriptReferenceExtractor
     private static readonly Regex LocalDeclarationRegex = new(
         @"^\s*(?:(?:const|let|var)\s+|(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+|(?:export\s+)?(?:abstract\s+)?class\s+|(?:export\s+)?interface\s+|(?:export\s+)?type\s+)(?<name>[A-Za-z_$][\w$]*)\b",
         RegexOptions.Compiled);
+    private static readonly Regex TypeDeclarationShadowRegex = new(
+        @"^\s*(?:export\s+)?(?:abstract\s+)?(?:class|interface|enum)\s+(?<name>[A-Za-z_$][\w$]*)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly HashSet<string> MappedTypeClauseIgnoredSegments = new(StringComparer.Ordinal)
     {
         "as",
@@ -248,7 +257,8 @@ internal static class TypeScriptReferenceExtractor
                     target,
                     index + 1,
                     FindScopedAliasEndLine(preparedLines, braceDepths, index),
-                    braceDepths[index]));
+                    braceDepths[index],
+                    BuildTypeAliasShadowRanges(preparedLines, braceDepths, match.Groups["alias"].Value)));
         }
 
         return aliases;
@@ -318,7 +328,8 @@ internal static class TypeScriptReferenceExtractor
         {
             if (!string.Equals(binding.Alias, alias, StringComparison.Ordinal)
                 || lineNumber <= binding.BindingLine
-                || (binding.EndLine is int endLine && lineNumber > endLine))
+                || (binding.EndLine is int endLine && lineNumber > endLine)
+                || IsInsideScopedShadow(binding.ShadowRanges, lineNumber))
             {
                 continue;
             }
@@ -332,6 +343,76 @@ internal static class TypeScriptReferenceExtractor
         }
 
         return best;
+    }
+
+    private static IReadOnlyList<LineRange> BuildTypeAliasShadowRanges(
+        IReadOnlyList<string> preparedLines,
+        IReadOnlyList<int> braceDepths,
+        string alias)
+    {
+        var ranges = new List<LineRange>();
+        for (var index = 0; index < preparedLines.Count; index++)
+        {
+            var line = preparedLines[index];
+            var typeDeclaration = TypeDeclarationShadowRegex.Match(line);
+            if (typeDeclaration.Success && string.Equals(typeDeclaration.Groups["name"].Value, alias, StringComparison.Ordinal))
+            {
+                ranges.Add(new LineRange(index + 1, FindScopedAliasEndLine(preparedLines, braceDepths, index) ?? preparedLines.Count));
+                continue;
+            }
+
+            if (DeclaresGenericTypeParameter(line, alias))
+                ranges.Add(new LineRange(index + 1, FindScopedAliasEndLine(preparedLines, braceDepths, index) ?? index + 1));
+        }
+
+        return ranges;
+    }
+
+    private static bool DeclaresGenericTypeParameter(string line, string alias)
+    {
+        var openAngle = line.IndexOf('<');
+        if (openAngle < 0)
+            return false;
+
+        var closeAngle = line.IndexOf('>', openAngle + 1);
+        if (closeAngle <= openAngle)
+            return false;
+
+        var prefix = line[..openAngle];
+        if (!ContainsKeyword(prefix, "class")
+            && !ContainsKeyword(prefix, "interface")
+            && !ContainsKeyword(prefix, "function")
+            && !ContainsKeyword(prefix, "type"))
+        {
+            return false;
+        }
+
+        foreach (var parameter in line.Substring(openAngle + 1, closeAngle - openAngle - 1).Split(','))
+        {
+            var name = parameter.Trim().Split([' ', '='], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (string.Equals(name, alias, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsKeyword(string text, string keyword)
+    {
+        var searchStart = 0;
+        while (searchStart < text.Length)
+        {
+            var index = text.IndexOf(keyword, searchStart, StringComparison.Ordinal);
+            if (index < 0)
+                return false;
+
+            if (HasIdentifierBoundaries(text, index, keyword.Length))
+                return true;
+
+            searchStart = index + keyword.Length;
+        }
+
+        return false;
     }
 
     private static int? FindScopedAliasEndLine(

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.Core.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.Core.cs
@@ -37,6 +37,12 @@ public static partial class ReferenceExtractor
         var razorReferenceLines = preparedInput.RazorReferenceLines;
         var razorImplementedTypeNames = preparedInput.RazorImplementedTypeNames;
         var typeScriptNamespaceAliases = preparedInput.TypeScriptNamespaceAliases;
+        var typeScriptTypeAliases = language == "typescript"
+            ? TypeScriptReferenceExtractor.BuildTypeAliasTargets(preparedLines)
+            : null;
+        var swiftTypeAliases = language == "swift"
+            ? SwiftReferenceExtractor.BuildTypeAliasTargets(preparedLines)
+            : null;
         var jsTaggedTemplatesByLine = preparedInput.JsTaggedTemplatesByLine;
         // Pre-pass C# attribute analysis so cross-line `[\n Foo("x")\n]` and parameter
         // attributes `void M([Attr] T x)` are classified consistently with same-line `[Foo]`.
@@ -795,6 +801,16 @@ public static partial class ReferenceExtractor
                     context,
                     lineNumber,
                     ResolveContainerForCall);
+
+                TypeScriptReferenceExtractor.EmitAliasTargetReferences(
+                    preparedLine,
+                    typeScriptTypeAliases!,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
             }
             else if (language == "kotlin")
             {
@@ -818,6 +834,15 @@ public static partial class ReferenceExtractor
                     lineNumber,
                     ResolveContainerForCall,
                     ResolveSwiftPropertyContainerForCall);
+                SwiftReferenceExtractor.EmitAliasTargetReferences(
+                    preparedLine,
+                    swiftTypeAliases!,
+                    references,
+                    seen,
+                    fileId,
+                    context,
+                    lineNumber,
+                    ResolveContainerForCall);
             }
             else if (language == "rust")
             {

--- a/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/TypedLanguageReferenceExtractor.cs
@@ -33,7 +33,8 @@ internal static class TypedLanguageReferenceExtractor
                 fileId,
                 context,
                 lineNumber,
-                container))
+                container,
+                ignoredSegments))
         {
             return;
         }
@@ -59,7 +60,8 @@ internal static class TypedLanguageReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        SymbolRecord? container)
+        SymbolRecord? container,
+        IReadOnlySet<string>? ignoredSegments = null)
     {
         var leading = CountLeadingWhitespace(expression, 0, expression.Length);
         var trailing = CountTrailingWhitespace(expression, leading, expression.Length - leading);
@@ -95,7 +97,8 @@ internal static class TypedLanguageReferenceExtractor
             fileId,
             context,
             lineNumber,
-            container);
+            container,
+            ignoredSegments);
 
         var returnStart = SkipTypePrefixTrivia(normalizedExpression, arrowIndex + 2);
         if (returnStart >= normalizedExpression.Length)
@@ -114,7 +117,8 @@ internal static class TypedLanguageReferenceExtractor
             fileId,
             context,
             lineNumber,
-            container);
+            container,
+            ignoredSegments);
 
         return true;
     }
@@ -129,7 +133,8 @@ internal static class TypedLanguageReferenceExtractor
         long fileId,
         string context,
         int lineNumber,
-        SymbolRecord? container)
+        SymbolRecord? container,
+        IReadOnlySet<string>? ignoredSegments)
     {
         if (paramStart < 0 || paramEnd <= paramStart || paramStart >= expression.Length)
             return;
@@ -160,7 +165,8 @@ internal static class TypedLanguageReferenceExtractor
                 fileId,
                 context,
                 lineNumber,
-                container);
+                container,
+                ignoredSegments);
         }
     }
 

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -5807,8 +5807,9 @@ public class ReferenceExtractorTests
         const string content = """
             class DefaultKey {}
             class SomeType {}
-            type MyAlias<T = DefaultKey> = SomeType;
-            class Derived extends MyAlias {}
+            class Arg {}
+            type MyAlias<T = DefaultKey> = SomeType & Box<T>;
+            class Derived extends MyAlias<Arg> {}
             """;
 
         var symbols = SymbolExtractor.Extract(1, "typescript", content);
@@ -5817,12 +5818,17 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference =>
             reference.SymbolName == "DefaultKey"
             && reference.ReferenceKind == "type_reference"
-            && reference.Context == "type MyAlias<T = DefaultKey> = SomeType;");
+            && reference.Context == "type MyAlias<T = DefaultKey> = SomeType & Box<T>;");
         Assert.Contains(references, reference =>
             reference.SymbolName == "SomeType"
             && reference.ReferenceKind == "type_reference"
             && reference.ContainerName == "Derived"
-            && reference.Context == "class Derived extends MyAlias {}");
+            && reference.Context == "class Derived extends MyAlias<Arg> {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "T"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived"
+            && reference.Context == "class Derived extends MyAlias<Arg> {}");
     }
 
     [Fact]
@@ -26394,6 +26400,32 @@ public class ReferenceExtractorTests
 
         Assert.Single(expanded);
         Assert.Equal(8, expanded[0].Column);
+    }
+
+    [Fact]
+    public void Extract_SwiftGenericTypealiasHeritage_DoesNotEmitTypeParameterAsTarget()
+    {
+        const string content = """
+            class SomeType {}
+            class Box<T> {}
+            class Arg {}
+            typealias MyAlias<T> = SomeType & Box<T>
+            class Derived: MyAlias<Arg> {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        var references = ReferenceExtractor.Extract(1, "swift", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived"
+            && reference.Context == "class Derived: MyAlias<Arg> {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "T"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived"
+            && reference.Context == "class Derived: MyAlias<Arg> {}");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -5832,6 +5832,31 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptFunctionTypeAlias_DoesNotEmitTypeParameterAsTarget()
+    {
+        const string content = """
+            class SomeType {}
+            class Arg {}
+            type MyAlias<T> = (value: T) => SomeType;
+            class Derived extends MyAlias<Arg> {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived"
+            && reference.Context == "class Derived extends MyAlias<Arg> {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "T"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived"
+            && reference.Context == "class Derived extends MyAlias<Arg> {}");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeAliasShadowedByScope_UsesActiveAliasBinding()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -5802,6 +5802,30 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptTypeAliasWithGenericDefault_EmitsUnderlyingTypeReference()
+    {
+        const string content = """
+            class DefaultKey {}
+            class SomeType {}
+            type MyAlias<T = DefaultKey> = SomeType;
+            class Derived extends MyAlias {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "DefaultKey"
+            && reference.ReferenceKind == "type_reference"
+            && reference.Context == "type MyAlias<T = DefaultKey> = SomeType;");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived"
+            && reference.Context == "class Derived extends MyAlias {}");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeAliasShadowedByScope_UsesActiveAliasBinding()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -5841,6 +5841,34 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptTypeAliasShadowedByTypeDeclaration_DoesNotExpandOuterAlias()
+    {
+        const string content = """
+            class One {}
+            type MyAlias = One;
+            namespace Inner {
+                class MyAlias {}
+                export class B extends MyAlias {}
+            }
+            class Box<MyAlias> extends MyAlias {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "One"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "B"
+            && reference.Context == "export class B extends MyAlias {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "One"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Box"
+            && reference.Context == "class Box<MyAlias> extends MyAlias {}");
+    }
+
+    [Fact]
     public void Extract_CsharpIndentedRawStringBeforeBlockComment_DoesNotLeakXmlDocReferences()
     {
         // Regression: BuildCSharpBlockCommentLines must recognize the closing delimiter of an
@@ -26381,6 +26409,34 @@ public class ReferenceExtractorTests
             && reference.ReferenceKind == "type_reference"
             && reference.ContainerName == "B"
             && reference.Context == "class B: MyAlias {}");
+    }
+
+    [Fact]
+    public void Extract_SwiftTypealiasShadowedByTypeDeclaration_DoesNotExpandOuterAlias()
+    {
+        const string content = """
+            class One {}
+            typealias MyAlias = One
+            enum Inner {
+                class MyAlias {}
+                class B: MyAlias {}
+            }
+            class Box<MyAlias>: MyAlias {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        var references = ReferenceExtractor.Extract(1, "swift", content, symbols);
+
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "One"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "B"
+            && reference.Context == "class B: MyAlias {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "One"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Box"
+            && reference.Context == "class Box<MyAlias>: MyAlias {}");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -5802,6 +5802,45 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptTypeAliasShadowedByScope_UsesActiveAliasBinding()
+    {
+        const string content = """
+            class One {}
+            class Two {}
+            type MyAlias = One;
+            namespace Inner {
+                type MyAlias = Two;
+                export class B extends MyAlias {}
+            }
+            class A extends MyAlias {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "One"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "A"
+            && reference.Context == "class A extends MyAlias {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "Two"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "A"
+            && reference.Context == "class A extends MyAlias {}");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Two"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "B"
+            && reference.Context == "export class B extends MyAlias {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "One"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "B"
+            && reference.Context == "export class B extends MyAlias {}");
+    }
+
+    [Fact]
     public void Extract_CsharpIndentedRawStringBeforeBlockComment_DoesNotLeakXmlDocReferences()
     {
         // Regression: BuildCSharpBlockCommentLines must recognize the closing delimiter of an
@@ -26303,6 +26342,45 @@ public class ReferenceExtractorTests
 
         Assert.Single(expanded);
         Assert.Equal(8, expanded[0].Column);
+    }
+
+    [Fact]
+    public void Extract_SwiftTypealiasShadowedByScope_UsesActiveAliasBinding()
+    {
+        const string content = """
+            class One {}
+            class Two {}
+            typealias MyAlias = One
+            enum Inner {
+                typealias MyAlias = Two
+                class B: MyAlias {}
+            }
+            class A: MyAlias {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        var references = ReferenceExtractor.Extract(1, "swift", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "One"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "A"
+            && reference.Context == "class A: MyAlias {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "Two"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "A"
+            && reference.Context == "class A: MyAlias {}");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "Two"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "B"
+            && reference.Context == "class B: MyAlias {}");
+        Assert.DoesNotContain(references, reference =>
+            reference.SymbolName == "One"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "B"
+            && reference.Context == "class B: MyAlias {}");
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -5755,6 +5755,53 @@ public class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptTypeAliasHeritage_EmitsUnderlyingTypeReference()
+    {
+        const string content = """
+            class SomeType {}
+            type MyAlias = SomeType;
+            class Derived extends MyAlias {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "MyAlias"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived"
+            && reference.Context == "class Derived extends MyAlias {}");
+    }
+
+    [Fact]
+    public void Extract_TypeScriptTypeAliasMixedValueUse_OnlyExpandsTypePositionOccurrence()
+    {
+        const string content = """
+            class SomeType {}
+            type MyAlias = SomeType;
+            function get(value: unknown) { return value; }
+            const x: MyAlias = get(MyAlias);
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        var expanded = references
+            .Where(reference =>
+                reference.SymbolName == "SomeType"
+                && reference.ReferenceKind == "type_reference"
+                && reference.Context == "const x: MyAlias = get(MyAlias);")
+            .ToList();
+
+        Assert.Single(expanded);
+        Assert.Equal(10, expanded[0].Column);
+    }
+
+    [Fact]
     public void Extract_CsharpIndentedRawStringBeforeBlockComment_DoesNotLeakXmlDocReferences()
     {
         // Regression: BuildCSharpBlockCommentLines must recognize the closing delimiter of an
@@ -26209,6 +26256,53 @@ public class ReferenceExtractorTests
         Assert.Contains(references, reference =>
             reference.SymbolName == "NetworkLoader"
             && reference.ReferenceKind == "type_reference");
+    }
+
+    [Fact]
+    public void Extract_SwiftTypealiasHeritage_EmitsUnderlyingTypeReference()
+    {
+        const string content = """
+            class SomeType {}
+            typealias MyAlias = SomeType
+            class Derived: MyAlias {}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        var references = ReferenceExtractor.Extract(1, "swift", content, symbols);
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "MyAlias"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.ContainerName == "Derived"
+            && reference.Context == "class Derived: MyAlias {}");
+    }
+
+    [Fact]
+    public void Extract_SwiftTypealiasMixedValueUse_OnlyExpandsTypePositionOccurrence()
+    {
+        const string content = """
+            class SomeType {}
+            typealias MyAlias = SomeType
+            func get(_ value: Any) -> Any { value }
+            let x: MyAlias = get("MyAlias")
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+        var references = ReferenceExtractor.Extract(1, "swift", content, symbols);
+
+        var expanded = references
+            .Where(reference =>
+                reference.SymbolName == "SomeType"
+                && reference.ReferenceKind == "type_reference"
+                && reference.Context == "let x: MyAlias = get(\"MyAlias\")")
+            .ToList();
+
+        Assert.Single(expanded);
+        Assert.Equal(8, expanded[0].Column);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Expand TypeScript and Swift alias-mediated heritage type references to the underlying target type.
- Respect scoped alias shadowing, type/generic parameter shadowing, and suppress alias type parameters during generic/function alias expansion.
- Add changelog fragment for #1976.

## Validation
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReferenceExtractorTests" -p:UseSharedCompilation=false
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json
- Codex adversarial review performed; blocking findings were fixed during iteration.

Fixes #1976