### PR TITLE
Add CI guard for release build analyzer regressions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -181,6 +181,10 @@ jobs:
       - name: Verify formatting
         run: dotnet format whitespace CodeIndex.sln --verify-no-changes --no-restore --verbosity minimal
 
+      - name: Verify Release solution build
+        if: matrix.os == 'ubuntu-latest' && matrix.test-framework == 'net8.0'
+        run: dotnet build CodeIndex.sln --configuration Release --no-restore -p:UseSharedCompilation=false
+
       - name: Verify developer task wrapper
         if: matrix.os == 'ubuntu-latest' && matrix.test-framework == 'net8.0'
         run: make lint

--- a/changelog.d/unreleased/2791.internal.md
+++ b/changelog.d/unreleased/2791.internal.md
@@ -1,0 +1,15 @@
+---
+category: internal
+issues:
+  - 2791
+affected:
+  - .github/workflows/dotnet.yml
+---
+
+## English
+
+- **CI now guards the Release solution build used to catch AOT analyzer regressions (#2791)** — the ubuntu net8.0 lane runs the documented Release solution build command with shared compilation disabled, so IL3050 regressions in JSON serialization call sites fail during CI instead of surfacing later in pre-PR validation.
+
+## 日本語
+
+- **AOT analyzer 退行を検出する Release solution build を CI で検証するようにしました (#2791)** — ubuntu net8.0 lane で shared compilation を無効にしたドキュメント記載の Release solution build コマンドを実行し、JSON serialization call site の IL3050 退行が PR 前検証で後から見つかるのではなく CI 上で失敗するようにしました。


### PR DESCRIPTION
## Summary

- Add a ubuntu net8.0 CI guard that runs the documented Release solution build with shared compilation disabled.
- Add an internal changelog fragment for the CI regression guard.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln --configuration Release --no-restore -p:UseSharedCompilation=false`
- `dotnet format whitespace CodeIndex.sln --verify-no-changes --no-restore --verbosity minimal`
- `make lint`
- `dotnet build src/CodeIndex/CodeIndex.csproj`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and Changelog

- Added `changelog.d/unreleased/2791.internal.md`.
- No docs changes were needed because the documented Release build command remains unchanged; this PR adds CI coverage for it.

## Review

- Adversarial review: No blocking/actionable issues found.

## Follow-up Candidates

- None.

Fixes #2791
