### PR TITLE
Add bounded regex timeouts for extraction

### DIFF
--- a/changelog.d/unreleased/2876.security.md
+++ b/changelog.d/unreleased/2876.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 2876
+affected:
+  - src/CodeIndex/Indexer/BoundedRegex.cs
+  - src/CodeIndex/Indexer/Symbols
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Bounded built-in symbol extraction regexes (#2876)** — built-in symbol extraction regular expressions now run with explicit match timeouts and fail closed on timeout instead of allowing hostile long lines to consume unbounded CPU.
+
+## 日本語
+
+- **組み込みシンボル抽出 regex に上限を設定しました (#2876)** — 組み込みシンボル抽出の正規表現に明示的な match timeout を設定し、悪意ある長い行が無制限に CPU を消費しないよう timeout 時は安全側で不一致として扱います。

--- a/changelog.d/unreleased/2887.security.md
+++ b/changelog.d/unreleased/2887.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 2887
+affected:
+  - src/CodeIndex/Indexer/References
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Bounded reference extraction regexes (#2887)** — reference extraction regular expressions, including static replace calls, now run through bounded match timeouts and fail closed on timeout for hostile long-line inputs.
+
+## 日本語
+
+- **参照抽出 regex に上限を設定しました (#2887)** — 静的な replace 呼び出しを含む参照抽出の正規表現を bounded match timeout 経由にし、悪意ある長い行で timeout した場合は安全側で処理を打ち切ります。

--- a/src/CodeIndex/Indexer/BoundedRegex.cs
+++ b/src/CodeIndex/Indexer/BoundedRegex.cs
@@ -49,7 +49,9 @@ internal sealed class BoundedRegex : BclRegex
     {
         try
         {
-            return BclRegex.Matches(input, pattern, options, DefaultMatchTimeout);
+            var matches = BclRegex.Matches(input, pattern, options, DefaultMatchTimeout);
+            _ = matches.Count;
+            return matches;
         }
         catch (RegexMatchTimeoutException)
         {
@@ -142,7 +144,9 @@ internal sealed class BoundedRegex : BclRegex
     {
         try
         {
-            return base.Matches(input);
+            var matches = base.Matches(input);
+            _ = matches.Count;
+            return matches;
         }
         catch (RegexMatchTimeoutException)
         {
@@ -154,7 +158,9 @@ internal sealed class BoundedRegex : BclRegex
     {
         try
         {
-            return base.Matches(input, startat);
+            var matches = base.Matches(input, startat);
+            _ = matches.Count;
+            return matches;
         }
         catch (RegexMatchTimeoutException)
         {

--- a/src/CodeIndex/Indexer/BoundedRegex.cs
+++ b/src/CodeIndex/Indexer/BoundedRegex.cs
@@ -1,0 +1,215 @@
+using System.Text.RegularExpressions;
+using BclMatch = System.Text.RegularExpressions.Match;
+using BclRegex = System.Text.RegularExpressions.Regex;
+
+namespace CodeIndex.Indexer;
+
+internal sealed class BoundedRegex : BclRegex
+{
+    internal static readonly TimeSpan DefaultMatchTimeout = TimeSpan.FromMilliseconds(250);
+
+    public BoundedRegex(string pattern)
+        : base(pattern, RegexOptions.None, DefaultMatchTimeout)
+    {
+    }
+
+    public BoundedRegex(string pattern, RegexOptions options)
+        : base(pattern, options, DefaultMatchTimeout)
+    {
+    }
+
+    public BoundedRegex(string pattern, RegexOptions options, TimeSpan matchTimeout)
+        : base(pattern, options, matchTimeout)
+    {
+    }
+
+    public static new string Escape(string str) => BclRegex.Escape(str);
+
+    public static new string Unescape(string str) => BclRegex.Unescape(str);
+
+    public static new Match Match(string input, string pattern) =>
+        Match(input, pattern, RegexOptions.None);
+
+    public static new Match Match(string input, string pattern, RegexOptions options)
+    {
+        try
+        {
+            return BclRegex.Match(input, pattern, options, DefaultMatchTimeout);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return BclMatch.Empty;
+        }
+    }
+
+    public static new MatchCollection Matches(string input, string pattern) =>
+        Matches(input, pattern, RegexOptions.None);
+
+    public static new MatchCollection Matches(string input, string pattern, RegexOptions options)
+    {
+        try
+        {
+            return BclRegex.Matches(input, pattern, options, DefaultMatchTimeout);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return EmptyMatches();
+        }
+    }
+
+    public static new bool IsMatch(string input, string pattern) =>
+        IsMatch(input, pattern, RegexOptions.None);
+
+    public static new bool IsMatch(string input, string pattern, RegexOptions options)
+    {
+        try
+        {
+            return BclRegex.IsMatch(input, pattern, options, DefaultMatchTimeout);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    public static new string Replace(string input, string pattern, string replacement) =>
+        Replace(input, pattern, replacement, RegexOptions.None);
+
+    public static new string Replace(string input, string pattern, string replacement, RegexOptions options)
+    {
+        try
+        {
+            return BclRegex.Replace(input, pattern, replacement, options, DefaultMatchTimeout);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return input;
+        }
+    }
+
+    public static new string Replace(string input, string pattern, MatchEvaluator evaluator) =>
+        Replace(input, pattern, evaluator, RegexOptions.None);
+
+    public static new string Replace(string input, string pattern, MatchEvaluator evaluator, RegexOptions options)
+    {
+        try
+        {
+            return BclRegex.Replace(input, pattern, evaluator, options, DefaultMatchTimeout);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return input;
+        }
+    }
+
+    public new Match Match(string input)
+    {
+        try
+        {
+            return base.Match(input);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return BclMatch.Empty;
+        }
+    }
+
+    public new Match Match(string input, int startat)
+    {
+        try
+        {
+            return base.Match(input, startat);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return BclMatch.Empty;
+        }
+    }
+
+    public new Match Match(string input, int beginning, int length)
+    {
+        try
+        {
+            return base.Match(input, beginning, length);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return BclMatch.Empty;
+        }
+    }
+
+    public new MatchCollection Matches(string input)
+    {
+        try
+        {
+            return base.Matches(input);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return EmptyMatches();
+        }
+    }
+
+    public new MatchCollection Matches(string input, int startat)
+    {
+        try
+        {
+            return base.Matches(input, startat);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return EmptyMatches();
+        }
+    }
+
+    public new bool IsMatch(string input)
+    {
+        try
+        {
+            return base.IsMatch(input);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    public new bool IsMatch(string input, int startat)
+    {
+        try
+        {
+            return base.IsMatch(input, startat);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    public new string Replace(string input, string replacement)
+    {
+        try
+        {
+            return base.Replace(input, replacement);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return input;
+        }
+    }
+
+    public new string Replace(string input, MatchEvaluator evaluator)
+    {
+        try
+        {
+            return base.Replace(input, evaluator);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return input;
+        }
+    }
+
+    private static MatchCollection EmptyMatches() =>
+        BclRegex.Matches(string.Empty, @"\b\B", RegexOptions.None, DefaultMatchTimeout);
+}

--- a/src/CodeIndex/Indexer/References/Languages/AssemblyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/AssemblyReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/BatchReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/BatchReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.Support.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.Support.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.ValueReceivers.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.ValueReceivers.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 using CSharpContainingTypeValueReceiverNames = CodeIndex.Indexer.ReferenceExtractor.CSharpContainingTypeValueReceiverNames;
 using CSharpFunctionValueReceiverNameRecord = CodeIndex.Indexer.ReferenceExtractor.CSharpFunctionValueReceiverNameRecord;

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/CppReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CppReferenceExtractor.cs
@@ -1,5 +1,6 @@
 using CodeIndex.Models;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DockerfileReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/ElixirReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/ElixirReferenceExtractor.cs
@@ -1,5 +1,6 @@
 using CodeIndex.Models;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/FSharpReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/References/Languages/GoReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/GoReferenceExtractor.cs
@@ -1,20 +1,22 @@
+using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;
 
 internal static class GoReferenceExtractor
 {
-    private static readonly System.Text.RegularExpressions.Regex GoroutineCallRegex = new(
+    private static readonly Regex GoroutineCallRegex = new(
         @"\bgo\s+(?<name>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*\(",
-        System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static readonly System.Text.RegularExpressions.Regex ChannelSendRegex = new(
+    private static readonly Regex ChannelSendRegex = new(
         @"(?<!<)(?<name>[A-Za-z_]\w*)\s*<-",
-        System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static readonly System.Text.RegularExpressions.Regex ChannelReceiveRegex = new(
+    private static readonly Regex ChannelReceiveRegex = new(
         @"(?<!<)<-\s*(?<name>[A-Za-z_]\w*)",
-        System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static bool[] BuildImportBlockLineMap(IReadOnlyList<string> originalLines)
         => LanguageReferenceExtractionSupport.BuildGoImportBlockLineMap(originalLines);
@@ -28,7 +30,7 @@ internal static class GoReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
     {
-        foreach (System.Text.RegularExpressions.Match match in GoroutineCallRegex.Matches(preparedLine))
+        foreach (Match match in GoroutineCallRegex.Matches(preparedLine))
         {
             var group = match.Groups["name"];
             var rawName = group.Value;
@@ -47,7 +49,7 @@ internal static class GoReferenceExtractor
                 resolveContainerForColumn(nameIndex));
         }
 
-        foreach (System.Text.RegularExpressions.Match match in ChannelSendRegex.Matches(preparedLine))
+        foreach (Match match in ChannelSendRegex.Matches(preparedLine))
         {
             ReferenceExtractor.AddReference(
                 references,
@@ -61,7 +63,7 @@ internal static class GoReferenceExtractor
                 resolveContainerForColumn(match.Groups["name"].Index));
         }
 
-        foreach (System.Text.RegularExpressions.Match match in ChannelReceiveRegex.Matches(preparedLine))
+        foreach (Match match in ChannelReceiveRegex.Matches(preparedLine))
         {
             if (!IsGoChannelReceiveArrow(preparedLine, match.Index))
                 continue;

--- a/src/CodeIndex/Indexer/References/Languages/GradleReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/GradleReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaScriptReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/KotlinReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/PerlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PerlReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PhpReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/PowerShellReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PowerShellReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PythonReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RubyReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/RustReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/ScalaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/ScalaReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/ShellReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/ShellReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.Patterns.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.Patterns.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
@@ -1,5 +1,6 @@
 using CodeIndex.Models;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/References/Languages/TerraformReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TerraformReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.Core.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.Core.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.PatternTypeReferences.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.TypeReferences.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Indexer.Extensibility;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/JvmMethodReferenceExtractor.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/References/Support/TrailingLambdaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Support/TrailingLambdaReferenceExtractor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/Symbols/CSharpSymbolNameNormalizer.cs
+++ b/src/CodeIndex/Indexer/Symbols/CSharpSymbolNameNormalizer.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Database;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Assembly.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Assembly.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.CSharpScanner.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cobol.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cobol.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cpp.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cpp.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Css.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Css.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Elixir.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Elixir.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.FSharp.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.FSharp.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Fortran.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Java.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Java.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.KotlinScala.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Pascal.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Pascal.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Perl.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Perl.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Php.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Razor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Razor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Ruby.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Rust.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Rust.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Shell.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Shell.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Smalltalk.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Smalltalk.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Sql.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Sql.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Svelte.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Svelte.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.VisualBasic.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.VisualBasic.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Models;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 using System.Runtime.CompilerServices;
 using CodeIndex.Indexer.Extensibility;
 using CodeIndex.Models;

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -1,4 +1,8 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using CodeIndex.Indexer;
 using CodeIndex.Indexer.Extensibility;
 using CodeIndex.Models;
@@ -19,6 +23,48 @@ public class ReferenceExtractorTests
 
         Assert.Throws<OperationCanceledException>(() =>
             ReferenceExtractor.Extract(1, "csharp", "public class App { }", [], cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public void BuiltInReferenceRegexes_HaveBoundedMatchTimeouts()
+    {
+        var regexes = EnumerateStaticRegexValues(
+            typeof(ReferenceExtractor).Assembly.GetTypes().Where(IsReferenceRegexOwnerType))
+            .ToList();
+
+        Assert.NotEmpty(regexes);
+
+        var infiniteTimeouts = regexes
+            .Where(item => item.Regex.MatchTimeout == Regex.InfiniteMatchTimeout)
+            .Select(item => item.Path)
+            .ToList();
+
+        Assert.True(
+            infiniteTimeouts.Count == 0,
+            "Built-in reference regexes must have explicit match timeouts: " + string.Join(", ", infiniteTimeouts));
+    }
+
+    [Fact]
+    public void Extract_BuiltInReferenceRegexes_AdversarialLongLinesDoNotThrow()
+    {
+        var pythonContent = "def use(value: '" + new string('A', 2000) + "'):\n    return value\n";
+        const string goContent = "func main() { go worker.Run(); ch <- value; value = <-ch }\n";
+
+        var stopwatch = Stopwatch.StartNew();
+        var exception = Record.Exception(() =>
+        {
+            var pythonSymbols = SymbolExtractor.Extract(1, "python", pythonContent);
+            ReferenceExtractor.Extract(1, "python", pythonContent, pythonSymbols);
+
+            var goSymbols = SymbolExtractor.Extract(2, "go", goContent);
+            ReferenceExtractor.Extract(2, "go", goContent, goSymbols);
+        });
+        stopwatch.Stop();
+
+        Assert.Null(exception);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+            $"Adversarial reference extraction took {stopwatch.Elapsed}.");
     }
 
     [Fact]
@@ -32992,6 +33038,104 @@ public class ReferenceExtractorTests
         Assert.DoesNotContain(references, r =>
             r.SymbolName == "seed"
             && r.ReferenceKind == "capture");
+    }
+
+    private static bool IsReferenceRegexOwnerType(Type type) =>
+        type.Namespace == "CodeIndex.Indexer"
+        && (type.Name.Contains("Reference", StringComparison.Ordinal)
+            || type.Name == "StructuralLineMasker"
+            || type.Name == "SqlNameResolver");
+
+    private static IEnumerable<(string Path, Regex Regex)> EnumerateStaticRegexValues(IEnumerable<Type> types)
+    {
+        foreach (var type in types)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                object? value;
+                try
+                {
+                    value = field.GetValue(null);
+                }
+                catch (TargetInvocationException)
+                {
+                    throw;
+                }
+
+                foreach (var item in EnumerateRegexValues(value, $"{type.Name}.{field.Name}", new HashSet<object>(ReferenceEqualityComparer.Instance)))
+                    yield return item;
+            }
+        }
+    }
+
+    private static IEnumerable<(string Path, Regex Regex)> EnumerateRegexValues(object? value, string path, HashSet<object> seen)
+    {
+        if (value is null)
+            yield break;
+
+        if (value is Regex regex)
+        {
+            yield return (path, regex);
+            yield break;
+        }
+
+        if (value is string or Type or MemberInfo or Delegate)
+            yield break;
+
+        var valueType = value.GetType();
+        if (valueType.IsPrimitive || valueType.IsEnum)
+            yield break;
+
+        if (!valueType.IsValueType && !seen.Add(value))
+            yield break;
+
+        if (value is IEnumerable enumerable)
+        {
+            var index = 0;
+            foreach (var item in enumerable)
+            {
+                foreach (var nested in EnumerateRegexValues(item, $"{path}[{index}]", seen))
+                    yield return nested;
+                index++;
+            }
+
+            yield break;
+        }
+
+        foreach (var field in valueType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            object? child;
+            try
+            {
+                child = field.GetValue(value);
+            }
+            catch (TargetInvocationException)
+            {
+                continue;
+            }
+
+            foreach (var nested in EnumerateRegexValues(child, $"{path}.{field.Name}", seen))
+                yield return nested;
+        }
+
+        foreach (var property in valueType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (property.GetIndexParameters().Length != 0)
+                continue;
+
+            object? child;
+            try
+            {
+                child = property.GetValue(value);
+            }
+            catch (TargetInvocationException)
+            {
+                continue;
+            }
+
+            foreach (var nested in EnumerateRegexValues(child, $"{path}.{property.Name}", seen))
+                yield return nested;
+        }
     }
 
     private static SymbolRecord Container(string name, string kind, int startLine, int endLine) =>

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Collections;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Text.Json;
 using CodeIndex.Indexer;
 using CodeIndex.Indexer.Extensibility;
@@ -22,6 +23,45 @@ public class SymbolExtractorTests
 
         Assert.Throws<OperationCanceledException>(() =>
             SymbolExtractor.Extract(1, "csharp", "public class App { }", cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public void BuiltInSymbolRegexes_HaveBoundedMatchTimeouts()
+    {
+        var regexes = EnumerateStaticRegexValues(
+            typeof(SymbolExtractor).Assembly.GetTypes().Where(IsSymbolRegexOwnerType))
+            .ToList();
+
+        Assert.NotEmpty(regexes);
+
+        var infiniteTimeouts = regexes
+            .Where(item => item.Regex.MatchTimeout == Regex.InfiniteMatchTimeout)
+            .Select(item => item.Path)
+            .ToList();
+
+        Assert.True(
+            infiniteTimeouts.Count == 0,
+            "Built-in symbol regexes must have explicit match timeouts: " + string.Join(", ", infiniteTimeouts));
+    }
+
+    [Fact]
+    public void Extract_BuiltInSymbolRegexes_AdversarialLongLinesDoNotThrow()
+    {
+        var typeScriptLine = "export const Component = React.memo<" + new string('A', 20000) + new string('<', 2000) + new string('>', 2000) + ">(value);";
+        var cssLine = ":root { --" + new string('a', 50000) + ": " + new string('(', 2000) + "; }";
+
+        var stopwatch = Stopwatch.StartNew();
+        var exception = Record.Exception(() =>
+        {
+            SymbolExtractor.Extract(1, "typescript", typeScriptLine);
+            SymbolExtractor.Extract(2, "css", cssLine);
+        });
+        stopwatch.Stop();
+
+        Assert.Null(exception);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+            $"Adversarial symbol extraction took {stopwatch.Elapsed}.");
     }
 
     [Fact]
@@ -25747,6 +25787,102 @@ public class SymbolExtractorTests
         finally
         {
             TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    private static bool IsSymbolRegexOwnerType(Type type) =>
+        type.Namespace == "CodeIndex.Indexer"
+        && (type.Name == "SymbolExtractor" || type.Name.EndsWith("SymbolNameNormalizer", StringComparison.Ordinal));
+
+    private static IEnumerable<(string Path, Regex Regex)> EnumerateStaticRegexValues(IEnumerable<Type> types)
+    {
+        foreach (var type in types)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                object? value;
+                try
+                {
+                    value = field.GetValue(null);
+                }
+                catch (TargetInvocationException)
+                {
+                    throw;
+                }
+
+                foreach (var item in EnumerateRegexValues(value, $"{type.Name}.{field.Name}", new HashSet<object>(ReferenceEqualityComparer.Instance)))
+                    yield return item;
+            }
+        }
+    }
+
+    private static IEnumerable<(string Path, Regex Regex)> EnumerateRegexValues(object? value, string path, HashSet<object> seen)
+    {
+        if (value is null)
+            yield break;
+
+        if (value is Regex regex)
+        {
+            yield return (path, regex);
+            yield break;
+        }
+
+        if (value is string or Type or MemberInfo or Delegate)
+            yield break;
+
+        var valueType = value.GetType();
+        if (valueType.IsPrimitive || valueType.IsEnum)
+            yield break;
+
+        if (!valueType.IsValueType && !seen.Add(value))
+            yield break;
+
+        if (value is IEnumerable enumerable)
+        {
+            var index = 0;
+            foreach (var item in enumerable)
+            {
+                foreach (var nested in EnumerateRegexValues(item, $"{path}[{index}]", seen))
+                    yield return nested;
+                index++;
+            }
+
+            yield break;
+        }
+
+        foreach (var field in valueType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            object? child;
+            try
+            {
+                child = field.GetValue(value);
+            }
+            catch (TargetInvocationException)
+            {
+                continue;
+            }
+
+            foreach (var nested in EnumerateRegexValues(child, $"{path}.{field.Name}", seen))
+                yield return nested;
+        }
+
+        foreach (var property in valueType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (property.GetIndexParameters().Length != 0)
+                continue;
+
+            object? child;
+            try
+            {
+                child = property.GetValue(value);
+            }
+            catch (TargetInvocationException)
+            {
+                continue;
+            }
+
+            foreach (var nested in EnumerateRegexValues(child, $"{path}.{property.Name}", seen))
+                yield return nested;
         }
     }
 


### PR DESCRIPTION
## Summary
- Added a bounded Regex wrapper for built-in extraction regexes so match operations use a finite timeout and fail closed on timeout.
- Switched built-in symbol and reference extractors to the bounded wrapper, including the Go reference regexes that previously used fully-qualified BCL Regex types.
- Added reflection/adversarial coverage plus changelog fragments for both issues.

## Validation
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false --filter "FullyQualifiedName~SymbolExtractorTests.BuiltInSymbolRegexes_HaveBoundedMatchTimeouts|FullyQualifiedName~SymbolExtractorTests.Extract_BuiltInSymbolRegexes_AdversarialLongLinesDoNotThrow"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false --filter "FullyQualifiedName~ReferenceExtractorTests.BuiltInReferenceRegexes_HaveBoundedMatchTimeouts|FullyQualifiedName~ReferenceExtractorTests.Extract_BuiltInReferenceRegexes_AdversarialLongLinesDoNotThrow"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false`
- Codex adversarial review: No blocking/actionable issues found.

Fixes #2876
Fixes #2887