### PR TITLE
Harden cdidx report bundles

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1067,7 +1067,7 @@ cdidx report --output report.tgz
 cdidx report --output report.tgz --json
 ```
 
-`cdidx report --output <path>` packages a redacted `.tar.gz` you can attach to a GitHub issue. The bundle includes the cdidx version, .NET runtime, OS / process architecture, and a `schema.txt` listing each SQLite table with its row count (no user content). It also tails the recent cdidx lifecycle log (`stderr-yyyyMMdd.log`), with `cwd=` and `args=` lines replaced by `[redacted]` so working-directory paths and literal query strings never leave your machine.
+`cdidx report --output <path>` packages a redacted `.tar.gz` you can attach to a GitHub issue. The bundle includes the cdidx version, .NET runtime, OS / process architecture, and a `schema.txt` listing each SQLite table with its row count (no user content). It also tails the recent cdidx lifecycle log (`stderr-yyyyMMdd.log`), with the database path, lifecycle-log source directory, `cwd=`, and `args=` lines replaced by `[redacted]` so local filesystem paths and literal query strings never leave your machine.
 
 | Flag | Default | Effect |
 |---|---|---|
@@ -3172,7 +3172,7 @@ cdidx report --output report.tgz
 cdidx report --output report.tgz --json
 ```
 
-`cdidx report --output <path>` は GitHub Issue に添付できる匿名化済み `.tar.gz` を生成します。バンドルには cdidx のバージョン、.NET ランタイム、OS / プロセスアーキテクチャ、各 SQLite テーブル名と整数の行数のみを記録した `schema.txt`（ユーザコンテンツは含まれません）が入ります。さらに直近のライフサイクルログ（`stderr-yyyyMMdd.log`）の末尾も含まれますが、`cwd=` と `args=` 行は `[redacted]` に置換されるため、作業ディレクトリのパスや具体的なクエリ文字列が端末から外に出ることはありません。
+`cdidx report --output <path>` は GitHub Issue に添付できる匿名化済み `.tar.gz` を生成します。バンドルには cdidx のバージョン、.NET ランタイム、OS / プロセスアーキテクチャ、各 SQLite テーブル名と整数の行数のみを記録した `schema.txt`（ユーザコンテンツは含まれません）が入ります。さらに直近のライフサイクルログ（`stderr-yyyyMMdd.log`）の末尾も含まれますが、DB パス、ライフサイクルログの source directory、`cwd=`、`args=` 行は `[redacted]` に置換されるため、ローカルファイルシステムのパスや具体的なクエリ文字列が端末から外に出ることはありません。
 
 | フラグ | 既定値 | 効果 |
 |---|---|---|

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1071,7 +1071,7 @@ cdidx report --output report.tgz --json
 
 | Flag | Default | Effect |
 |---|---|---|
-| `--output <path>` / `-o <path>` | (required) | Destination `.tar.gz`. The directory is created if missing. |
+| `--output <path>` / `-o <path>` | (required) | Destination `.tar.gz`. The directory is created if missing; on POSIX, the archive and tar entries are owner-readable/writable only. |
 | `--db <path>` | `.cdidx/codeindex.db` | Override the database whose schema is summarized. If absent, `schema.txt` records that no DB was found. |
 | `--log-lines <n>` | `200` | How many trailing lifecycle-log lines to include (`0` disables the tail). |
 | `--no-log` | | Skip the lifecycle log entirely. |
@@ -3176,7 +3176,7 @@ cdidx report --output report.tgz --json
 
 | フラグ | 既定値 | 効果 |
 |---|---|---|
-| `--output <path>` / `-o <path>` | （必須） | 出力先 `.tar.gz`。親ディレクトリが無ければ作成します。 |
+| `--output <path>` / `-o <path>` | （必須） | 出力先 `.tar.gz`。親ディレクトリが無ければ作成します。POSIX では archive と tar entry は owner の読み書きのみになります。 |
 | `--db <path>` | `.cdidx/codeindex.db` | スキーマ要約対象の DB を上書きします。存在しなければ `schema.txt` に「DB が見つからなかった」旨が記録されます。 |
 | `--log-lines <n>` | `200` | ライフサイクルログ末尾を何行含めるか（`0` で末尾を含めません）。 |
 | `--no-log` | | ライフサイクルログを完全に省略します。 |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1067,7 +1067,7 @@ cdidx report --output report.tgz
 cdidx report --output report.tgz --json
 ```
 
-`cdidx report --output <path>` packages a redacted `.tar.gz` you can attach to a GitHub issue. The bundle includes the cdidx version, .NET runtime, OS / process architecture, and a `schema.txt` listing each SQLite table with its row count (no user content). It also tails the recent cdidx lifecycle log (`stderr-yyyyMMdd.log`), with the database path, lifecycle-log source directory, `cwd=`, and `args=` lines replaced by `[redacted]` so local filesystem paths and literal query strings never leave your machine.
+`cdidx report --output <path>` packages a redacted `.tar.gz` you can attach to a GitHub issue. The bundle includes the cdidx version, .NET runtime, OS / process architecture, and a `schema.txt` listing each SQLite table with its row count (no user content). It also tails the recent cdidx lifecycle log (`stderr-yyyyMMdd.log`), with the database path, lifecycle-log source directory, `process_path=`, `base_dir=`, `cwd=`, `db=`, `path=`, and `args=` lines replaced by `[redacted]` so local filesystem paths and literal query strings never leave your machine.
 
 | Flag | Default | Effect |
 |---|---|---|
@@ -3172,7 +3172,7 @@ cdidx report --output report.tgz
 cdidx report --output report.tgz --json
 ```
 
-`cdidx report --output <path>` は GitHub Issue に添付できる匿名化済み `.tar.gz` を生成します。バンドルには cdidx のバージョン、.NET ランタイム、OS / プロセスアーキテクチャ、各 SQLite テーブル名と整数の行数のみを記録した `schema.txt`（ユーザコンテンツは含まれません）が入ります。さらに直近のライフサイクルログ（`stderr-yyyyMMdd.log`）の末尾も含まれますが、DB パス、ライフサイクルログの source directory、`cwd=`、`args=` 行は `[redacted]` に置換されるため、ローカルファイルシステムのパスや具体的なクエリ文字列が端末から外に出ることはありません。
+`cdidx report --output <path>` は GitHub Issue に添付できる匿名化済み `.tar.gz` を生成します。バンドルには cdidx のバージョン、.NET ランタイム、OS / プロセスアーキテクチャ、各 SQLite テーブル名と整数の行数のみを記録した `schema.txt`（ユーザコンテンツは含まれません）が入ります。さらに直近のライフサイクルログ（`stderr-yyyyMMdd.log`）の末尾も含まれますが、DB パス、ライフサイクルログの source directory、`process_path=`、`base_dir=`、`cwd=`、`db=`、`path=`、`args=` 行は `[redacted]` に置換されるため、ローカルファイルシステムのパスや具体的なクエリ文字列が端末から外に出ることはありません。
 
 | フラグ | 既定値 | 効果 |
 |---|---|---|

--- a/changelog.d/unreleased/2836.security.md
+++ b/changelog.d/unreleased/2836.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 2836
+affected:
+  - src/CodeIndex/Cli/ReportCommandRunner.cs
+  - tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Report bundles now redact database and log-directory paths (#2836)** - `cdidx report` no longer writes local SQLite database paths or lifecycle-log source directories into the generated support bundle.
+
+## 日本語
+
+- **report bundle で DB パスとログディレクトリのパスを伏せるようになりました (#2836)** - `cdidx report` は生成するサポート用 bundle に、ローカル SQLite DB パスやライフサイクルログの source directory を書き込まなくなりました。

--- a/changelog.d/unreleased/2840.security.md
+++ b/changelog.d/unreleased/2840.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 2840
+affected:
+  - src/CodeIndex/Cli/ReportCommandRunner.cs
+  - tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Report log tails now redact lifecycle executable paths (#2840)** - `cdidx report` now redacts `process_path=`, `base_dir=`, and other path-bearing lifecycle fields by default, while `--include-args` only restores literal `args=` lines.
+
+## 日本語
+
+- **report のログ末尾でライフサイクル実行パスを伏せるようになりました (#2840)** - `cdidx report` は既定で `process_path=`、`base_dir=` などの path-bearing lifecycle fields を伏せ、`--include-args` は `args=` 行だけを literal に戻すようになりました。

--- a/changelog.d/unreleased/2841.security.md
+++ b/changelog.d/unreleased/2841.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 2841
+affected:
+  - src/CodeIndex/Cli/ReportCommandRunner.cs
+  - tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Report bundles now use owner-only permissions (#2841)** - `cdidx report` creates support archives and tar entries with user-read/write permissions only on POSIX filesystems.
+
+## 日本語
+
+- **report bundle が owner-only permission を使うようになりました (#2841)** - `cdidx report` は POSIX ファイルシステム上で、サポート用 archive と tar entry を user の読み書きのみの permission で作成します。

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -22,6 +22,7 @@ public static class ReportCommandRunner
 {
     internal const int DefaultLogLines = 200;
     internal const string RedactedPlaceholder = "[redacted]";
+    internal const UnixFileMode BundleFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
 
     public static int Run(string[] cmdArgs, JsonSerializerOptions jsonOptions, string? appVersion = null)
     {
@@ -314,7 +315,22 @@ public static class ReportCommandRunner
         if (!string.IsNullOrEmpty(dir))
             Directory.CreateDirectory(dir);
 
-        using var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        if (!OperatingSystem.IsWindows() && File.Exists(outputPath))
+            File.SetUnixFileMode(outputPath, BundleFileMode);
+
+        var streamOptions = new FileStreamOptions
+        {
+            Mode = FileMode.Create,
+            Access = FileAccess.Write,
+            Share = FileShare.None,
+        };
+        if (!OperatingSystem.IsWindows())
+            streamOptions.UnixCreateMode = BundleFileMode;
+
+        using var fileStream = new FileStream(outputPath, streamOptions);
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(outputPath, BundleFileMode);
+
         using var gz = new GZipStream(fileStream, CompressionLevel.Optimal);
         using var tar = new TarWriter(gz, TarEntryFormat.Pax, leaveOpen: true);
 
@@ -323,7 +339,7 @@ public static class ReportCommandRunner
             var entry = new PaxTarEntry(TarEntryType.RegularFile, name)
             {
                 DataStream = new MemoryStream(bytes, writable: false),
-                Mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead,
+                Mode = BundleFileMode,
                 ModificationTime = DateTimeOffset.UtcNow,
             };
             tar.WriteEntry(entry);

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -169,8 +169,8 @@ public static class ReportCommandRunner
         {
             sb.AppendLine("- `log/stderr-recent.log` — last N lines of the cdidx lifecycle log");
             sb.AppendLine(includeArgs
-                ? "  (includes literal `args=` lines; rerun without `--include-args` to redact them)."
-                : "  (`args=` lines are redacted; rerun with `--include-args` to keep them literal).");
+                ? "  (includes literal `args=` lines; path-bearing lifecycle fields stay redacted)."
+                : "  (`args=` and path-bearing lifecycle fields are redacted; rerun with `--include-args` to keep arguments literal).");
         }
         else
         {
@@ -180,6 +180,7 @@ public static class ReportCommandRunner
         sb.AppendLine("## Redactions");
         sb.AppendLine();
         sb.AppendLine("- Indexed source content, file paths, query strings, and `args=` lines are not included by default.");
+        sb.AppendLine("- Path-bearing lifecycle fields such as `process_path=`, `base_dir=`, `cwd=`, `db=`, and `path=` are redacted by default.");
         sb.AppendLine("- Schema reporting only emits table names and integer row counts.");
         return sb.ToString();
     }
@@ -277,7 +278,7 @@ public static class ReportCommandRunner
         sb.AppendLine();
         foreach (var line in collected)
         {
-            sb.AppendLine(includeArgs ? line : RedactSensitiveFields(line));
+            sb.AppendLine(includeArgs ? RedactPathFields(line) : RedactSensitiveFields(line));
         }
         linesIncluded = collected.Count;
         return sb.ToString();
@@ -286,7 +287,16 @@ public static class ReportCommandRunner
     internal static string RedactSensitiveFields(string line)
     {
         var redacted = RedactKeyValue(line, "args=");
-        redacted = RedactKeyValue(redacted, "cwd=");
+        return RedactPathFields(redacted);
+    }
+
+    private static string RedactPathFields(string line)
+    {
+        var redacted = RedactKeyValue(line, "cwd=");
+        redacted = RedactKeyValue(redacted, "process_path=");
+        redacted = RedactKeyValue(redacted, "base_dir=");
+        redacted = RedactKeyValue(redacted, "db=");
+        redacted = RedactKeyValue(redacted, "path=");
         return redacted;
     }
 

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -188,7 +188,7 @@ public static class ReportCommandRunner
     {
         if (!File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
         {
-            var missingText = $"no SQLite index found at: {dbPath}\nRun `cdidx index <projectPath>` first if you want schema details attached.\n";
+            var missingText = $"no SQLite index found at: {RedactedPlaceholder}\nRun `cdidx index <projectPath>` first if you want schema details attached.\n";
             return (missingText, new List<ReportSchemaTable>(), dbPath, false);
         }
 
@@ -228,7 +228,7 @@ public static class ReportCommandRunner
         }
 
         var sb = new StringBuilder();
-        sb.AppendLine($"database: {Path.GetFullPath(dbPath)}");
+        sb.AppendLine($"database: {RedactedPlaceholder}");
         sb.AppendLine($"tables  : {tables.Count}");
         sb.AppendLine();
         sb.AppendLine("name | row_count");
@@ -244,14 +244,14 @@ public static class ReportCommandRunner
         linesIncluded = 0;
         var logDir = GlobalToolLog.ResolveLogDirectoryForReport();
         if (string.IsNullOrWhiteSpace(logDir) || !Directory.Exists(logDir))
-            return $"no cdidx lifecycle log directory found (looked at: {logDir ?? "<unknown>"}).\n";
+            return $"no cdidx lifecycle log directory found (looked at: {RedactedPlaceholder}).\n";
 
         var logFiles = new DirectoryInfo(logDir)
             .EnumerateFiles("stderr-*.log", SearchOption.TopDirectoryOnly)
             .OrderByDescending(f => f.Name, StringComparer.Ordinal)
             .ToList();
         if (logFiles.Count == 0)
-            return $"no cdidx lifecycle log files found in: {logDir}\n";
+            return $"no cdidx lifecycle log files found in: {RedactedPlaceholder}\n";
 
         var collected = new LinkedList<string>();
         foreach (var file in logFiles)
@@ -273,7 +273,7 @@ public static class ReportCommandRunner
 
         var sb = new StringBuilder();
         sb.AppendLine($"# cdidx lifecycle log (last {collected.Count} lines, newest last)");
-        sb.AppendLine($"# source directory: {logDir}");
+        sb.AppendLine($"# source directory: {RedactedPlaceholder}");
         sb.AppendLine();
         foreach (var line in collected)
         {

--- a/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
@@ -197,7 +197,11 @@ public class ReportCommandRunnerTests
             Path.Combine(logDir, "stderr-20260516.log"),
             string.Join('\n',
                 "2026-05-16T03:00:00Z [INFO] session_start pid=1 version=1.21.0",
+                "2026-05-16T03:00:00Z [INFO] process_path=/Users/widthdom/.dotnet/tools/cdidx",
+                "2026-05-16T03:00:00Z [INFO] base_dir=/Users/widthdom/.dotnet/tools/.store/cdidx",
                 "2026-05-16T03:00:00Z [INFO] cwd=/Users/widthdom/secret",
+                "2026-05-16T03:00:00Z [ERROR] database_open_failed db=/Users/widthdom/secret/.cdidx/codeindex.db",
+                "2026-05-16T03:00:00Z [INFO] config_file_loaded path=/Users/widthdom/secret/.cdidx/config.json",
                 "2026-05-16T03:00:00Z [INFO] args=query \"SELECT * FROM secret\"",
                 "2026-05-16T03:00:01Z [ERROR] sample error",
                 ""));
@@ -220,8 +224,16 @@ public class ReportCommandRunnerTests
             Assert.Contains($"# source directory: {ReportCommandRunner.RedactedPlaceholder}", logText);
             Assert.Contains("args=[redacted]", logText);
             Assert.Contains("cwd=[redacted]", logText);
+            Assert.Contains("process_path=[redacted]", logText);
+            Assert.Contains("base_dir=[redacted]", logText);
+            Assert.Contains("db=[redacted]", logText);
+            Assert.Contains("path=[redacted]", logText);
             Assert.DoesNotContain(logDir, logText);
             Assert.DoesNotContain("/Users/widthdom/secret", logText);
+            Assert.DoesNotContain("/Users/widthdom/.dotnet/tools/cdidx", logText);
+            Assert.DoesNotContain("/Users/widthdom/.dotnet/tools/.store/cdidx", logText);
+            Assert.DoesNotContain("/Users/widthdom/secret/.cdidx/codeindex.db", logText);
+            Assert.DoesNotContain("/Users/widthdom/secret/.cdidx/config.json", logText);
             Assert.DoesNotContain("SELECT * FROM secret", logText);
             Assert.Contains("session_start", logText);
         }
@@ -233,14 +245,21 @@ public class ReportCommandRunnerTests
     }
 
     [Fact]
-    public void Run_IncludeArgs_PreservesLiteralArgsAndCwd()
+    public void Run_IncludeArgs_PreservesLiteralArgsButRedactsPaths()
     {
         var workDir = CreateWorkDir();
         var logDir = Path.Combine(workDir, "logs");
         Directory.CreateDirectory(logDir);
         File.WriteAllText(
             Path.Combine(logDir, "stderr-20260516.log"),
-            "2026-05-16T03:00:00Z [INFO] cwd=/tmp/keep-this\n2026-05-16T03:00:00Z [INFO] args=index .\n");
+            string.Join('\n',
+                "2026-05-16T03:00:00Z [INFO] process_path=/tmp/cdidx",
+                "2026-05-16T03:00:00Z [INFO] base_dir=/tmp/cdidx-store",
+                "2026-05-16T03:00:00Z [INFO] cwd=/tmp/keep-this",
+                "2026-05-16T03:00:00Z [ERROR] database_open_failed db=/tmp/keep-this/.cdidx/codeindex.db",
+                "2026-05-16T03:00:00Z [INFO] config_file_loaded path=/tmp/keep-this/.cdidx/config.json",
+                "2026-05-16T03:00:00Z [INFO] args=index .",
+                ""));
 
         var previousLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
         Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
@@ -257,9 +276,17 @@ public class ReportCommandRunnerTests
             Assert.Equal(CommandExitCodes.Success, exitCode);
             var entries = ReadTarGzEntries(output);
             var logText = Encoding.UTF8.GetString(entries["log/stderr-recent.log"]);
-            Assert.Contains("cwd=/tmp/keep-this", logText);
             Assert.Contains("args=index .", logText);
-            Assert.DoesNotContain("cwd=[redacted]", logText);
+            Assert.Contains("cwd=[redacted]", logText);
+            Assert.Contains("process_path=[redacted]", logText);
+            Assert.Contains("base_dir=[redacted]", logText);
+            Assert.Contains("db=[redacted]", logText);
+            Assert.Contains("path=[redacted]", logText);
+            Assert.DoesNotContain("/tmp/keep-this", logText);
+            Assert.DoesNotContain("/tmp/cdidx", logText);
+            Assert.DoesNotContain("/tmp/cdidx-store", logText);
+            Assert.DoesNotContain("/tmp/keep-this/.cdidx/codeindex.db", logText);
+            Assert.DoesNotContain("/tmp/keep-this/.cdidx/config.json", logText);
             Assert.DoesNotContain("args=[redacted]", logText);
         }
         finally
@@ -303,6 +330,46 @@ public class ReportCommandRunnerTests
 
         Assert.Contains("cwd=[redacted]", redacted);
         Assert.DoesNotContain("/private/foo/secret-project", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsProcessPathLine()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "2026-05-16T03:00:00Z [INFO] process_path=/Users/example/.dotnet/tools/cdidx");
+
+        Assert.Contains("process_path=[redacted]", redacted);
+        Assert.DoesNotContain("/Users/example/.dotnet/tools/cdidx", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsBaseDirLine()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "2026-05-16T03:00:00Z [INFO] base_dir=/Users/example/.dotnet/tools/.store/cdidx");
+
+        Assert.Contains("base_dir=[redacted]", redacted);
+        Assert.DoesNotContain("/Users/example/.dotnet/tools/.store/cdidx", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsDatabasePathLine()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "2026-05-16T03:00:00Z [ERROR] database_open_failed db=/Users/example/project/.cdidx/codeindex.db");
+
+        Assert.Contains("db=[redacted]", redacted);
+        Assert.DoesNotContain("/Users/example/project/.cdidx/codeindex.db", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsConfigPathLine()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "2026-05-16T03:00:00Z [INFO] config_file_loaded path=/Users/example/project/.cdidx/config.json");
+
+        Assert.Contains("path=[redacted]", redacted);
+        Assert.DoesNotContain("/Users/example/project/.cdidx/config.json", redacted);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
@@ -20,6 +20,17 @@ namespace CodeIndex.Tests;
 [Collection("SQLite pool sensitive")]
 public class ReportCommandRunnerTests
 {
+    private const UnixFileMode PermissionBits =
+        UnixFileMode.UserRead |
+        UnixFileMode.UserWrite |
+        UnixFileMode.UserExecute |
+        UnixFileMode.GroupRead |
+        UnixFileMode.GroupWrite |
+        UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead |
+        UnixFileMode.OtherWrite |
+        UnixFileMode.OtherExecute;
+
     private readonly JsonSerializerOptions _jsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -144,6 +155,39 @@ public class ReportCommandRunnerTests
             Assert.Contains("no SQLite index found", schemaText);
             Assert.Contains($"no SQLite index found at: {ReportCommandRunner.RedactedPlaceholder}", schemaText);
             Assert.DoesNotContain(missingDb, schemaText);
+        }
+        finally
+        {
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void Run_OutputArchiveAndEntriesUseOwnerOnlyPermissions()
+    {
+        var workDir = CreateWorkDir();
+        try
+        {
+            var output = Path.Combine(workDir, "bundle.tgz");
+
+            var (exitCode, _, _) = RunAndCaptureStreams([
+                "--output", output,
+                "--db", Path.Combine(workDir, "missing.db"),
+                "--no-log",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            if (!OperatingSystem.IsWindows())
+            {
+                var fileMode = File.GetUnixFileMode(output) & PermissionBits;
+                Assert.Equal(ReportCommandRunner.BundleFileMode, fileMode);
+            }
+
+            var entryModes = ReadTarGzEntryModes(output);
+            Assert.NotEmpty(entryModes);
+            Assert.All(
+                entryModes.Values,
+                mode => Assert.Equal(ReportCommandRunner.BundleFileMode, mode & PermissionBits));
         }
         finally
         {
@@ -467,6 +511,21 @@ public class ReportCommandRunnerTests
             using var buffer = new MemoryStream();
             entry.DataStream?.CopyTo(buffer);
             entries[entry.Name] = buffer.ToArray();
+        }
+        return entries;
+    }
+
+    private static Dictionary<string, UnixFileMode> ReadTarGzEntryModes(string path)
+    {
+        var entries = new Dictionary<string, UnixFileMode>(StringComparer.Ordinal);
+        using var fileStream = File.OpenRead(path);
+        using var gz = new GZipStream(fileStream, CompressionMode.Decompress);
+        using var tar = new TarReader(gz);
+        while (tar.GetNextEntry() is { } entry)
+        {
+            if (entry.EntryType != TarEntryType.RegularFile)
+                continue;
+            entries[entry.Name] = entry.Mode;
         }
         return entries;
     }

--- a/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
@@ -142,6 +142,8 @@ public class ReportCommandRunnerTests
 
             var schemaText = Encoding.UTF8.GetString(entries["schema.txt"]);
             Assert.Contains("no SQLite index found", schemaText);
+            Assert.Contains($"no SQLite index found at: {ReportCommandRunner.RedactedPlaceholder}", schemaText);
+            Assert.DoesNotContain(missingDb, schemaText);
         }
         finally
         {
@@ -174,6 +176,8 @@ public class ReportCommandRunnerTests
             Assert.Contains("files", schemaText);
             Assert.Contains("symbols", schemaText);
             Assert.Contains("row_count", schemaText);
+            Assert.Contains($"database: {ReportCommandRunner.RedactedPlaceholder}", schemaText);
+            Assert.DoesNotContain(dbPath, schemaText);
             Assert.DoesNotContain("no SQLite index found", schemaText);
         }
         finally
@@ -213,8 +217,10 @@ public class ReportCommandRunnerTests
             var entries = ReadTarGzEntries(output);
             Assert.True(entries.ContainsKey("log/stderr-recent.log"));
             var logText = Encoding.UTF8.GetString(entries["log/stderr-recent.log"]);
+            Assert.Contains($"# source directory: {ReportCommandRunner.RedactedPlaceholder}", logText);
             Assert.Contains("args=[redacted]", logText);
             Assert.Contains("cwd=[redacted]", logText);
+            Assert.DoesNotContain(logDir, logText);
             Assert.DoesNotContain("/Users/widthdom/secret", logText);
             Assert.DoesNotContain("SELECT * FROM secret", logText);
             Assert.Contains("session_start", logText);
@@ -253,7 +259,8 @@ public class ReportCommandRunnerTests
             var logText = Encoding.UTF8.GetString(entries["log/stderr-recent.log"]);
             Assert.Contains("cwd=/tmp/keep-this", logText);
             Assert.Contains("args=index .", logText);
-            Assert.DoesNotContain("[redacted]", logText);
+            Assert.DoesNotContain("cwd=[redacted]", logText);
+            Assert.DoesNotContain("args=[redacted]", logText);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Redact report schema database paths and lifecycle-log source paths.
- Redact path-bearing lifecycle fields (`process_path=`, `base_dir=`, `cwd=`, `db=`, `path=`) while preserving `--include-args` as the explicit opt-in for literal `args=`.
- Write report archives and tar entries with owner-only POSIX permissions.

## Validation

- `dotnet restore CodeIndex.sln --locked-mode`
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReportCommandRunnerTests" -p:UseSharedCompilation=false`
- `dotnet test -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review against `origin/main`; findings addressed.

## Docs / Changelog

- Updated `USER_GUIDE.md`.
- Added `changelog.d/unreleased/2836.security.md`.
- Added `changelog.d/unreleased/2840.security.md`.
- Added `changelog.d/unreleased/2841.security.md`.

## Follow-up

- #2918

Fixes #2836
Fixes #2840
Fixes #2841
