### PR TITLE
[codex] Reject escaping DbPathResolver sample paths

### DIFF
--- a/changelog.d/unreleased/2866.security.md
+++ b/changelog.d/unreleased/2866.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 2866
+affected:
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - tests/CodeIndex.Tests/DbPathResolverTests.cs
+---
+
+## English
+
+- **DbPathResolver now ignores indexed-file samples that escape candidate roots (#2866)** — project-root probing for explicit `.cdidx/codeindex.db` paths now normalizes candidate sample paths and skips `../` or absolute-like entries before reading files.
+
+## 日本語
+
+- **DbPathResolver が candidate root 外へ逃げる indexed-file sample を無視するようになりました (#2866)** — 明示指定された `.cdidx/codeindex.db` の project-root 推定で、サンプルpathを正規化し、`../` や絶対path風の entries はファイル読取前にスキップします。

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -508,8 +508,9 @@ public static class DbPathResolver
         {
             try
             {
-                var absolutePath = Path.Combine(candidateRoot, sample.RelativePath.Replace('/', Path.DirectorySeparatorChar));
-                var ioPath = LongPath.EnsureWindowsPrefix(absolutePath);
+                if (!TryResolveIndexedFileSampleIoPath(candidateRoot, sample.RelativePath, out var ioPath))
+                    continue;
+
                 if (!File.Exists(ioPath))
                     continue;
 
@@ -531,6 +532,47 @@ public static class DbPathResolver
 
         return new SampleMatchResult(checksumMatches, pathExistsMatches);
     }
+
+    internal static bool TryResolveIndexedFileSampleIoPath(string candidateRoot, string sampleRelativePath, out string ioPath)
+    {
+        ioPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(sampleRelativePath) || IsRootedOrAbsoluteLikeSamplePath(sampleRelativePath))
+            return false;
+
+        try
+        {
+            var normalizedRoot = Path.GetFullPath(candidateRoot);
+            var relativePath = sampleRelativePath
+                .Replace('/', Path.DirectorySeparatorChar)
+                .Replace('\\', Path.DirectorySeparatorChar);
+            var absolutePath = Path.GetFullPath(Path.Combine(normalizedRoot, relativePath));
+            if (!IsUnderDirectory(normalizedRoot, absolutePath))
+                return false;
+
+            ioPath = LongPath.EnsureWindowsPrefix(absolutePath);
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsRootedOrAbsoluteLikeSamplePath(string samplePath)
+    {
+        if (Path.IsPathRooted(samplePath))
+            return true;
+
+        if (samplePath.StartsWith("/", StringComparison.Ordinal) || samplePath.StartsWith("\\", StringComparison.Ordinal))
+            return true;
+
+        return samplePath.Length >= 2
+            && IsAsciiLetter(samplePath[0])
+            && samplePath[1] == ':';
+    }
+
+    private static bool IsAsciiLetter(char value)
+        => value is >= 'a' and <= 'z' or >= 'A' and <= 'Z';
 
     private readonly record struct SampleMatchResult(int ChecksumMatches, int PathExistsMatches);
     private sealed record IndexedFileSample(string RelativePath, string Checksum);

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -542,9 +542,7 @@ public static class DbPathResolver
         try
         {
             var normalizedRoot = Path.GetFullPath(candidateRoot);
-            var relativePath = sampleRelativePath
-                .Replace('/', Path.DirectorySeparatorChar)
-                .Replace('\\', Path.DirectorySeparatorChar);
+            var relativePath = NormalizeSampleRelativePath(sampleRelativePath);
             var absolutePath = Path.GetFullPath(Path.Combine(normalizedRoot, relativePath));
             if (!IsUnderDirectory(normalizedRoot, absolutePath))
                 return false;
@@ -559,20 +557,12 @@ public static class DbPathResolver
     }
 
     private static bool IsRootedOrAbsoluteLikeSamplePath(string samplePath)
-    {
-        if (Path.IsPathRooted(samplePath))
-            return true;
+        => Path.IsPathRooted(samplePath);
 
-        if (samplePath.StartsWith("/", StringComparison.Ordinal) || samplePath.StartsWith("\\", StringComparison.Ordinal))
-            return true;
-
-        return samplePath.Length >= 2
-            && IsAsciiLetter(samplePath[0])
-            && samplePath[1] == ':';
-    }
-
-    private static bool IsAsciiLetter(char value)
-        => value is >= 'a' and <= 'z' or >= 'A' and <= 'Z';
+    private static string NormalizeSampleRelativePath(string sampleRelativePath)
+        => Path.DirectorySeparatorChar == '\\'
+            ? sampleRelativePath.Replace('/', Path.DirectorySeparatorChar)
+            : sampleRelativePath;
 
     private readonly record struct SampleMatchResult(int ChecksumMatches, int PathExistsMatches);
     private sealed record IndexedFileSample(string RelativePath, string Checksum);

--- a/tests/CodeIndex.Tests/DbPathResolverTests.cs
+++ b/tests/CodeIndex.Tests/DbPathResolverTests.cs
@@ -416,19 +416,59 @@ public class DbPathResolverTests
 
     [Theory]
     [InlineData("/outside.cs")]
-    [InlineData("\\outside.cs")]
-    [InlineData("C:/outside.cs")]
-    [InlineData(@"C:\outside.cs")]
-    [InlineData(@"\\server\share\outside.cs")]
-    public void TryResolveIndexedFileSampleIoPath_RejectsAbsoluteLikeSamples(string samplePath)
+    public void TryResolveIndexedFileSampleIoPath_RejectsRootedSamples(string samplePath)
     {
-        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_absolute_sample");
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_rooted_sample");
         try
         {
             var resolved = DbPathResolver.TryResolveIndexedFileSampleIoPath(projectRoot, samplePath, out var ioPath);
 
             Assert.False(resolved);
             Assert.Equal(string.Empty, ioPath);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void TryResolveIndexedFileSampleIoPath_OnWindowsRejectsDriveAndUncSamples()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_windows_absolute_sample");
+        try
+        {
+            foreach (var samplePath in new[] { "\\outside.cs", "C:/outside.cs", @"C:\outside.cs", @"\\server\share\outside.cs" })
+            {
+                var resolved = DbPathResolver.TryResolveIndexedFileSampleIoPath(projectRoot, samplePath, out var ioPath);
+
+                Assert.False(resolved);
+                Assert.Equal(string.Empty, ioPath);
+            }
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void TryResolveIndexedFileSampleIoPath_OnPosixPreservesBackslashInFilename()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_posix_backslash_sample");
+        try
+        {
+            const string samplePath = "back\\slash.py";
+            var resolved = DbPathResolver.TryResolveIndexedFileSampleIoPath(projectRoot, samplePath, out var ioPath);
+
+            Assert.True(resolved);
+            Assert.Equal(Path.GetFullPath(Path.Combine(projectRoot, samplePath)), ioPath);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/DbPathResolverTests.cs
+++ b/tests/CodeIndex.Tests/DbPathResolverTests.cs
@@ -359,6 +359,84 @@ public class DbPathResolverTests
     }
 
     [Fact]
+    public void ResolveProjectRootForQuery_ExplicitProjectLocalDbIgnoresEscapingSampleMatches()
+    {
+        var projectParent = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_escape_parent");
+        var staleParent = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_escape_stale_parent");
+        var projectRoot = Path.Combine(projectParent, "project");
+        var staleRoot = Path.Combine(staleParent, "stale");
+        var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+        try
+        {
+            Directory.CreateDirectory(projectRoot);
+            Directory.CreateDirectory(staleRoot);
+            Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+            Directory.CreateDirectory(Path.Combine(projectParent, "outside"));
+
+            const string outsideContent = "class Outside {}\n";
+            File.WriteAllText(Path.Combine(projectParent, "outside", "outside.cs"), outsideContent);
+
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db.Connection);
+                writer.SetMeta(DbContext.IndexedProjectRootMetaKey, staleRoot);
+            }
+            TestProjectHelper.InsertIndexedFile(dbPath, "../outside/outside.cs", "csharp", outsideContent);
+
+            var resolved = DbPathResolver.ResolveProjectRootForQuery(dbPath, dbPathExplicit: true);
+
+            Assert.Equal(staleRoot, resolved);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectParent);
+            TestProjectHelper.DeleteDirectory(staleParent);
+        }
+    }
+
+    [Theory]
+    [InlineData("../outside.cs")]
+    [InlineData("src/../../outside.cs")]
+    public void TryResolveIndexedFileSampleIoPath_RejectsEscapingRelativeSamples(string samplePath)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_escape_sample");
+        try
+        {
+            var resolved = DbPathResolver.TryResolveIndexedFileSampleIoPath(projectRoot, samplePath, out var ioPath);
+
+            Assert.False(resolved);
+            Assert.Equal(string.Empty, ioPath);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Theory]
+    [InlineData("/outside.cs")]
+    [InlineData("\\outside.cs")]
+    [InlineData("C:/outside.cs")]
+    [InlineData(@"C:\outside.cs")]
+    [InlineData(@"\\server\share\outside.cs")]
+    public void TryResolveIndexedFileSampleIoPath_RejectsAbsoluteLikeSamples(string samplePath)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_absolute_sample");
+        try
+        {
+            var resolved = DbPathResolver.TryResolveIndexedFileSampleIoPath(projectRoot, samplePath, out var ioPath);
+
+            Assert.False(resolved);
+            Assert.Equal(string.Empty, ioPath);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ResolveProjectRootForQuery_ExplicitProjectLocalReadOnlyUriWithoutMetadataReturnsNull()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_local_uri");


### PR DESCRIPTION
## Summary

- Hardened `DbPathResolver` explicit `.cdidx/codeindex.db` sample probing so DB-stored sample paths are normalized and must stay under each candidate root before any filesystem read.
- Preserved platform path semantics: Windows-style separators are handled on Windows, while POSIX backslash filenames remain literal.
- Added regressions for `../` escaping samples, rooted samples, Windows drive/UNC samples, and POSIX backslash filenames.

## Root Cause

`CountMatchingSamples` combined a candidate root with untrusted `files.path` values from the candidate DB and read the resulting path without first proving the normalized path stayed under that root.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbPathResolverTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review round 1 found a POSIX backslash regression; fixed in the follow-up commit.
- Codex adversarial review round 2: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/2866.security.md`.
- No README/user-guide change was needed because this does not change CLI flags, output shape, or documented user workflow.

## Follow-up Candidates

None.

Fixes #2866