### PR TITLE
[codex] Fix atomic state writes

### DIFF
--- a/changelog.d/unreleased/2828.fixed.md
+++ b/changelog.d/unreleased/2828.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 2828
+affected:
+  - src/CodeIndex/Cli/AtomicFileWriter.cs
+  - src/CodeIndex/Cli/DataDirectorySecurity.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - src/CodeIndex/Cli/UpdateChecker.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+---
+
+## English
+
+- **Small persistent state writes now use flushed atomic replacement (#2828)** — active workspace, lock metadata, suggestion store, update-cache, and scan-checkpoint writes now go through a temp-file, flush-to-disk, and rename path with best-effort temp cleanup on failure.
+
+## 日本語
+
+- **小さな永続状態ファイルの書き込みをflush付きatomic置換にしました (#2828)** — active workspace、lock metadata、suggestion store、update-cache、scan-checkpoint の書き込みは、一時ファイル、ディスクflush、renameを経由し、失敗時は一時ファイルをベストエフォートで掃除するようになりました。

--- a/src/CodeIndex/Cli/AtomicFileWriter.cs
+++ b/src/CodeIndex/Cli/AtomicFileWriter.cs
@@ -1,0 +1,77 @@
+using System.Text;
+using System.Text.Json;
+using CodeIndex.Indexer;
+
+namespace CodeIndex.Cli;
+
+internal static class AtomicFileWriter
+{
+    public static void WriteText(string path, string contents, Encoding encoding, Action<string>? applyFileMode = null)
+    {
+        Write(
+            path,
+            stream =>
+            {
+                using var writer = new StreamWriter(stream, encoding, bufferSize: 1024, leaveOpen: true);
+                writer.Write(contents);
+                writer.Flush();
+            },
+            applyFileMode);
+    }
+
+    public static void WriteJson<T>(string path, T value, JsonSerializerOptions? options = null, Action<string>? applyFileMode = null)
+    {
+        Write(path, stream => JsonSerializer.Serialize(stream, value, options), applyFileMode);
+    }
+
+    public static void Write(string path, Action<Stream> writeContents, Action<string>? applyFileMode = null)
+    {
+        ArgumentNullException.ThrowIfNull(writeContents);
+
+        var tempPath = BuildTempPath(path);
+        var ioTempPath = LongPath.EnsureWindowsPrefix(tempPath);
+        var ioTargetPath = LongPath.EnsureWindowsPrefix(path);
+        var moved = false;
+
+        try
+        {
+            using (var stream = new FileStream(ioTempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                applyFileMode?.Invoke(ioTempPath);
+                writeContents(stream);
+                stream.Flush(flushToDisk: true);
+            }
+
+            File.Move(ioTempPath, ioTargetPath, overwrite: true);
+            moved = true;
+            applyFileMode?.Invoke(ioTargetPath);
+        }
+        catch
+        {
+            if (!moved)
+                TryDelete(ioTempPath);
+            throw;
+        }
+    }
+
+    private static string BuildTempPath(string path)
+    {
+        var directory = Path.GetDirectoryName(path);
+        var fileName = Path.GetFileName(path);
+        var tempFileName = $".{fileName}.{Guid.NewGuid():N}.tmp";
+        return string.IsNullOrEmpty(directory)
+            ? tempFileName
+            : Path.Combine(directory, tempFileName);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -52,13 +52,8 @@ internal static class DataDirectorySecurity
 
     public static void WritePrivateText(string path, string contents, Encoding? encoding = null)
     {
-        var ioPath = LongPath.EnsureWindowsPrefix(path);
-        using var stream = File.Open(ioPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
-        ApplyPrivateFileMode(ioPath);
-        stream.SetLength(0);
         var outputEncoding = encoding is null || encoding.CodePage == Encoding.UTF8.CodePage ? Utf8NoBom : encoding;
-        using var writer = new StreamWriter(stream, outputEncoding);
-        writer.Write(contents);
+        AtomicFileWriter.WriteText(path, contents, outputEncoding, ApplyPrivateFileMode);
     }
 
     public static string? ReadTextWithinLimit(string path, int maxBytes, FileShare share = FileShare.Read)

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -333,7 +333,7 @@ public static partial class IndexCommandRunner
                     .Where(directory => directory.Length > 0)
                     .OrderBy(directory => directory, StringComparer.Ordinal)
                     .ToList());
-            File.WriteAllText(path, JsonSerializer.Serialize(checkpoint, new JsonSerializerOptions { WriteIndented = true }));
+            AtomicFileWriter.WriteJson(path, checkpoint, new JsonSerializerOptions { WriteIndented = true });
         }
         catch (IOException)
         {

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -728,27 +728,7 @@ public class SuggestionStore
             Directory.CreateDirectory(dir);
 
         NormalizeRecordDefaults(records);
-
-        var tempPath = _filePath + ".tmp";
-        try
-        {
-            using (var stream = new FileStream(
-                       tempPath,
-                       FileMode.Create,
-                       FileAccess.Write,
-                       FileShare.None))
-            {
-                JsonSerializer.Serialize(stream, records, s_jsonOptions);
-                stream.Flush(flushToDisk: true);
-            }
-
-            File.Move(tempPath, _filePath, overwrite: true);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            try { File.Delete(tempPath); } catch (Exception deleteEx) when (deleteEx is IOException or UnauthorizedAccessException) { /* best-effort cleanup / ベストエフォートのクリーンアップ */ }
-            throw;
-        }
+        AtomicFileWriter.WriteJson(_filePath, records, s_jsonOptions);
     }
 
     private static bool HasUpstreamSubmission(SuggestionRecord record) =>

--- a/src/CodeIndex/Cli/UpdateChecker.cs
+++ b/src/CodeIndex/Cli/UpdateChecker.cs
@@ -219,7 +219,7 @@ internal static class UpdateChecker
                 checked_at = cache.CheckedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture),
                 latest_tag = cache.LatestTag,
             };
-            File.WriteAllText(cachePath, JsonSerializer.Serialize(payload));
+            AtomicFileWriter.WriteJson(cachePath, payload);
         }
         catch
         {

--- a/tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
+++ b/tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
@@ -87,6 +87,29 @@ public class DataDirectorySecurityTests
     }
 
     [Fact]
+    public void WritePrivateText_MoveFailure_DoesNotLeaveTempFile()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_sensitive_file_atomic_{Guid.NewGuid():N}");
+        var path = Path.Combine(root, "metadata.info");
+        try
+        {
+            Directory.CreateDirectory(path);
+
+            var ex = Record.Exception(() => DataDirectorySecurity.WritePrivateText(path, "secret"));
+
+            Assert.NotNull(ex);
+            Assert.DoesNotContain(
+                Directory.EnumerateFiles(root),
+                file => Path.GetFileName(file).EndsWith(".tmp", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReadTextWithinLimit_WhenFileExceedsLimit_ReturnsNull()
     {
         var root = Path.Combine(Path.GetTempPath(), $"cdidx_bounded_read_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -855,14 +855,15 @@ public class SuggestionStoreTests : IDisposable
         // 一時ファイルへの書き込みは成功するが、ディレクトリに対する rename は失敗するため、
         // `.cdidx/` に孤児が蓄積しないよう一時ファイルがクリーンアップされる必要がある (#1574)。
         var filePath = Path.Combine(_tempDir, "suggestions-codeindex.json");
-        var tmpPath = filePath + ".tmp";
         Directory.CreateDirectory(filePath);
 
         var record = MakeRecord("other", null, "Move failure cleanup");
         var ex = Record.Exception(() => _store.TryAdd(record));
 
         Assert.NotNull(ex);
-        Assert.False(File.Exists(tmpPath), $"Orphan .tmp file should be cleaned up after Move failure: {tmpPath}");
+        Assert.DoesNotContain(
+            Directory.EnumerateFiles(_tempDir),
+            file => Path.GetFileName(file).EndsWith(".tmp", StringComparison.Ordinal));
     }
 
     // --- Helpers / ヘルパー ---


### PR DESCRIPTION
## Summary

- Added a shared atomic file writer that writes to a same-directory temp file, flushes to disk, then renames over the target with best-effort temp cleanup.
- Routed small persistent state writes through it: active workspace/private text writes, suggestion store, update-check cache, and scan checkpoints.
- Added focused cleanup coverage and kept the existing suggestion-store atomic write behavior covered.

## Documentation and changelog

- Added `changelog.d/unreleased/2828.fixed.md`.
- No README/guide update: this changes durability of existing state writes, not a CLI flag, command contract, or documented workflow.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DataDirectorySecurityTests|FullyQualifiedName~SuggestionStoreTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~UpdateChecker"`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

Full Release test run was attempted with the repository runsettings, but it was not a clean validation signal in this local environment: it produced unrelated extractor/concurrency failures while other CodeIndex worktree test runs were also active, then stalled. Representative failed tests passed when rerun individually.

## Follow-up candidates

None.

Fixes #2828
