### PR TITLE
Bound subprocess execution for git helpers and upgrade installer

### DIFF
--- a/changelog.d/unreleased/2827.fixed.md
+++ b/changelog.d/unreleased/2827.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2827
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **`cdidx upgrade` now launches the installer with `ArgumentList` and a timeout (#2827)** — the upgrade path avoids shell-joined installer arguments and terminates a stalled installer with a clear diagnostic instead of waiting indefinitely.
+
+## 日本語
+
+- **`cdidx upgrade` は installer を `ArgumentList` と timeout 付きで起動するようになりました (#2827)** — upgrade 経路は shell 連結の installer 引数を使わず、停止した installer を明確な診断付きで終了するため、無期限に待ち続けなくなりました。

--- a/changelog.d/unreleased/2832.fixed.md
+++ b/changelog.d/unreleased/2832.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2832
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+---
+
+## English
+
+- **Git helper subprocesses now have bounded runtime and capture size (#2832)** — git helper commands now fail with explicit diagnostics when a git subprocess times out or captured stdout/stderr exceeds the configured cap, preventing hung helpers and unbounded output accumulation.
+
+## 日本語
+
+- **Git helper の subprocess に実行時間とキャプチャサイズの上限を追加しました (#2832)** — git helper コマンドは git subprocess が timeout した場合や stdout/stderr のキャプチャが上限を超えた場合に明示的な診断で失敗するようになり、helper のハングと無制限の出力蓄積を防ぎます。

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -736,19 +736,26 @@ public static class GitHelper
         {
             MarkFailure($"git command timed out after {FormatDuration(GitCommandTimeout)}.");
             if (!process.WaitForExit(ToWaitMilliseconds(GitKillWaitTimeout)))
-                return (GitProcessFailureExitCode, stdout.ToString(), CombineCapturedError(stderr.ToString(), failureReason!));
+                return (GitProcessFailureExitCode, ReadCaptured(stdout), CombineCapturedError(ReadCaptured(stderr), failureReason!));
+            process.WaitForExit();
         }
         else
         {
             process.WaitForExit();
         }
 
-        var output = stdout.ToString();
-        var error = stderr.ToString();
+        var output = ReadCaptured(stdout);
+        var error = ReadCaptured(stderr);
         if (failureReason != null)
             return (GitProcessFailureExitCode, output, CombineCapturedError(error, failureReason));
 
         return (process.ExitCode, output, error);
+    }
+
+    private static string ReadCaptured(StringBuilder builder)
+    {
+        lock (builder)
+            return builder.ToString();
     }
 
     private static void AppendBoundedCapturedLine(

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -52,7 +52,14 @@ public static class GitHelper
     };
 
     internal const int MaxCapturedGitOutputChars = 1024 * 1024;
-    internal static TimeSpan GitCommandTimeout { get; set; } = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan DefaultGitCommandTimeout = TimeSpan.FromSeconds(60);
+    private static readonly AsyncLocal<TimeSpan?> GitCommandTimeoutOverride = new();
+    internal static TimeSpan GitCommandTimeout
+    {
+        get => GitCommandTimeoutOverride.Value ?? DefaultGitCommandTimeout;
+        set => GitCommandTimeoutOverride.Value = value;
+    }
+
     private static readonly TimeSpan GitKillWaitTimeout = TimeSpan.FromSeconds(5);
     private const int GitProcessFailureExitCode = -1;
 

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using CodeIndex.Indexer;
@@ -49,6 +50,11 @@ public static class GitHelper
         "AA",
         "UU",
     };
+
+    internal const int MaxCapturedGitOutputChars = 1024 * 1024;
+    internal static TimeSpan GitCommandTimeout { get; set; } = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan GitKillWaitTimeout = TimeSpan.FromSeconds(5);
+    private const int GitProcessFailureExitCode = -1;
 
     /// <summary>
     /// Resolve the common git directory for a project root, handling both normal repos and worktrees.
@@ -686,20 +692,117 @@ public static class GitHelper
         using var process = new Process { StartInfo = psi };
         var stdout = new StringBuilder();
         var stderr = new StringBuilder();
+        string? failureReason = null;
+        var failureLock = new object();
+
+        void MarkFailure(string reason)
+        {
+            lock (failureLock)
+            {
+                if (failureReason != null)
+                    return;
+                failureReason = reason;
+            }
+            TryKillProcessTree(process);
+        }
+
         // Always terminate captured lines with '\n' (not Environment.NewLine) so callers that
         // split on '\n' see identical output on Windows and POSIX — git writes LF-only to pipes.
         // キャプチャ行は常に '\n' 区切りにし、Windows/POSIX 双方で git のパイプ出力(LF)と一致させる。
-        process.OutputDataReceived += (_, e) => { if (e.Data != null) stdout.Append(e.Data).Append('\n'); };
-        process.ErrorDataReceived += (_, e) => { if (e.Data != null) stderr.Append(e.Data).Append('\n'); };
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+                AppendBoundedCapturedLine(stdout, e.Data, "stdout", MarkFailure);
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+                AppendBoundedCapturedLine(stderr, e.Data, "stderr", MarkFailure);
+        };
 
         if (!process.Start())
             return null;
 
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
-        process.WaitForExit();
+        if (!process.WaitForExit(ToWaitMilliseconds(GitCommandTimeout)))
+        {
+            MarkFailure($"git command timed out after {FormatDuration(GitCommandTimeout)}.");
+            if (!process.WaitForExit(ToWaitMilliseconds(GitKillWaitTimeout)))
+                return (GitProcessFailureExitCode, stdout.ToString(), CombineCapturedError(stderr.ToString(), failureReason!));
+        }
+        else
+        {
+            process.WaitForExit();
+        }
 
-        return (process.ExitCode, stdout.ToString(), stderr.ToString());
+        var output = stdout.ToString();
+        var error = stderr.ToString();
+        if (failureReason != null)
+            return (GitProcessFailureExitCode, output, CombineCapturedError(error, failureReason));
+
+        return (process.ExitCode, output, error);
+    }
+
+    private static void AppendBoundedCapturedLine(
+        StringBuilder builder,
+        string data,
+        string streamName,
+        Action<string> markFailure)
+    {
+        lock (builder)
+        {
+            var remaining = MaxCapturedGitOutputChars - builder.Length;
+            if (remaining <= 0)
+            {
+                markFailure(BuildCaptureLimitMessage(streamName));
+                return;
+            }
+
+            var required = data.Length + 1;
+            if (required <= remaining)
+            {
+                builder.Append(data).Append('\n');
+                return;
+            }
+
+            builder.Append(data.AsSpan(0, Math.Min(data.Length, remaining)));
+        }
+
+        markFailure(BuildCaptureLimitMessage(streamName));
+    }
+
+    private static string BuildCaptureLimitMessage(string streamName)
+        => $"git command captured {streamName} exceeded {MaxCapturedGitOutputChars.ToString(CultureInfo.InvariantCulture)} characters.";
+
+    private static string CombineCapturedError(string stderr, string diagnostic)
+        => string.IsNullOrWhiteSpace(stderr)
+            ? diagnostic
+            : stderr.TrimEnd('\r', '\n') + "\n" + diagnostic;
+
+    private static int ToWaitMilliseconds(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            return 1;
+        if (timeout.TotalMilliseconds >= int.MaxValue)
+            return int.MaxValue;
+        return Math.Max(1, (int)Math.Ceiling(timeout.TotalMilliseconds));
+    }
+
+    private static string FormatDuration(TimeSpan timeout)
+        => timeout.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture) + "s";
+
+    private static void TryKillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Best-effort cleanup only; callers receive the timeout/capture diagnostic.
+        }
     }
 
     private static bool ProbeFileSystemIgnoreCase(string projectRoot)

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -20,7 +20,7 @@ internal static class ProgramRunner
     internal const string QuietEnvironmentVariable = "CDIDX_QUIET";
     private const string InstallerScriptUrlTemplate = "https://raw.githubusercontent.com/Widthdom/CodeIndex/{0}/install.sh";
     private const long MaxInstallerScriptBytes = 1024 * 1024;
-    internal static TimeSpan InstallerRunTimeout { get; set; } = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan InstallerRunTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan InstallerKillWaitTimeout = TimeSpan.FromSeconds(5);
     internal static TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -20,6 +20,8 @@ internal static class ProgramRunner
     internal const string QuietEnvironmentVariable = "CDIDX_QUIET";
     private const string InstallerScriptUrlTemplate = "https://raw.githubusercontent.com/Widthdom/CodeIndex/{0}/install.sh";
     private const long MaxInstallerScriptBytes = 1024 * 1024;
+    internal static TimeSpan InstallerRunTimeout { get; set; } = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan InstallerKillWaitTimeout = TimeSpan.FromSeconds(5);
     internal static TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
     internal static int Run(
@@ -2209,19 +2211,8 @@ internal static class ProgramRunner
                     .GetResult();
             }
 
-            var startInfo = new ProcessStartInfo("bash", $"{QuoteShellArg(scriptPath)} {QuoteShellArg(result.LatestVersion)}")
-            {
-                UseShellExecute = false,
-            };
-            startInfo.Environment["CDIDX_INSTALL_DIR"] = installDir;
-            var process = Process.Start(startInfo);
-            if (process == null)
-            {
-                Console.Error.WriteLine("Error: failed to start install.sh for upgrade.");
-                return CommandExitCodes.DatabaseError;
-            }
-            process.WaitForExit();
-            return process.ExitCode;
+            var startInfo = CreateInstallerProcessStartInfo(scriptPath, result.LatestVersion, installDir);
+            return RunInstallerProcess(startInfo, InstallerRunTimeout);
         }
         catch (Exception ex)
         {
@@ -2233,6 +2224,40 @@ internal static class ProgramRunner
         {
             try { File.Delete(scriptPath); } catch { }
         }
+    }
+
+    internal static ProcessStartInfo CreateInstallerProcessStartInfo(string scriptPath, string releaseTag, string installDir)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "bash",
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(scriptPath);
+        startInfo.ArgumentList.Add(releaseTag);
+        startInfo.Environment["CDIDX_INSTALL_DIR"] = installDir;
+        return startInfo;
+    }
+
+    internal static int RunInstallerProcess(ProcessStartInfo startInfo, TimeSpan timeout)
+    {
+        using var process = Process.Start(startInfo);
+        if (process == null)
+        {
+            Console.Error.WriteLine("Error: failed to start install.sh for upgrade.");
+            return CommandExitCodes.DatabaseError;
+        }
+
+        if (process.WaitForExit(ToWaitMilliseconds(timeout)))
+            return process.ExitCode;
+
+        TryKillProcessTree(process);
+        if (!process.WaitForExit(ToWaitMilliseconds(InstallerKillWaitTimeout)))
+            Console.Error.WriteLine("Error: install.sh timed out and did not exit after cancellation.");
+        else
+            Console.Error.WriteLine($"Error: install.sh timed out after {FormatDuration(timeout)}.");
+        Console.Error.WriteLine("Hint: rerun `install.sh` manually for the desired release.");
+        return CommandExitCodes.DatabaseError;
     }
 
     internal static string BuildInstallerScriptUrl(string releaseTag)
@@ -2279,8 +2304,30 @@ internal static class ProgramRunner
         }
     }
 
-    private static string QuoteShellArg(string value)
-        => "'" + value.Replace("'", "'\\''", StringComparison.Ordinal) + "'";
+    private static int ToWaitMilliseconds(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            return 1;
+        if (timeout.TotalMilliseconds >= int.MaxValue)
+            return int.MaxValue;
+        return Math.Max(1, (int)Math.Ceiling(timeout.TotalMilliseconds));
+    }
+
+    private static string FormatDuration(TimeSpan timeout)
+        => timeout.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture) + "s";
+
+    private static void TryKillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Best-effort cleanup only; callers receive the timeout diagnostic.
+        }
+    }
 
     // `--version` is now build-aware so dev builds from main are not
     // indistinguishable from tagged releases in bug reports (#1550). Human

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -341,6 +341,63 @@ public class GitHelperTests : IDisposable
         }
     }
 
+    [Fact]
+    public void GetChangedFilesFromCommit_FailsWhenCapturedOutputExceedsLimit()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-output-cap");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatExceedsStdoutLimit(fakeGitDir);
+
+        var oldPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", fakeGitDir + Path.PathSeparator + oldPath);
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => GitHelper.GetChangedFilesFromCommit(repoDir, "0123456789abcdef"));
+
+            Assert.Contains("captured stdout exceeded", ex.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", oldPath);
+        }
+    }
+
+    [Fact]
+    public void GetChangedFilesFromCommit_FailsWhenGitCommandTimesOut()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo-timeout");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-timeout");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatHangsOnDiffTree(fakeGitDir);
+
+        var oldPath = Environment.GetEnvironmentVariable("PATH");
+        var oldTimeout = GitHelper.GitCommandTimeout;
+        Environment.SetEnvironmentVariable("PATH", fakeGitDir + Path.PathSeparator + oldPath);
+        GitHelper.GitCommandTimeout = TimeSpan.FromSeconds(1);
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => GitHelper.GetChangedFilesFromCommit(repoDir, "0123456789abcdef"));
+
+            Assert.Contains("timed out", ex.Message);
+        }
+        finally
+        {
+            GitHelper.GitCommandTimeout = oldTimeout;
+            Environment.SetEnvironmentVariable("PATH", oldPath);
+        }
+    }
+
     [Theory]
     [InlineData("feature")]
     [InlineData("v1.0.0")]
@@ -763,6 +820,54 @@ fi
 if [ "$1" = "diff-tree" ]; then
   perl -e 'print STDERR "x" x 131072'
   printf 'M\tchanged.txt\n'
+  exit 0
+fi
+exit 1
+""");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static void WriteFakeGitThatExceedsStdoutLimit(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, """
+#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  if [ "$2" = "--symbolic-full-name" ]; then
+    exit 0
+  fi
+  if [ "$2" = "--verify" ]; then
+    printf '%s\n' '0123456789abcdef0123456789abcdef01234567'
+    exit 0
+  fi
+fi
+if [ "$1" = "diff-tree" ]; then
+  perl -e 'for ($i = 0; $i < 80000; $i++) { print "M\tchanged_$i.txt\n" }'
+  exit 0
+fi
+exit 1
+""");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static void WriteFakeGitThatHangsOnDiffTree(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, """
+#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  if [ "$2" = "--symbolic-full-name" ]; then
+    exit 0
+  fi
+  if [ "$2" = "--verify" ]; then
+    printf '%s\n' '0123456789abcdef0123456789abcdef01234567'
+    exit 0
+  fi
+fi
+if [ "$1" = "diff-tree" ]; then
+  sleep 5
   exit 0
 fi
 exit 1

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -362,6 +362,56 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void CreateInstallerProcessStartInfo_UsesArgumentList()
+    {
+        var startInfo = ProgramRunner.CreateInstallerProcessStartInfo(
+            "/tmp/install script's path.sh",
+            "v1.27.0",
+            "/opt/cdidx install");
+
+        Assert.Equal("bash", startInfo.FileName);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.Equal(string.Empty, startInfo.Arguments);
+        Assert.Equal(["/tmp/install script's path.sh", "v1.27.0"], startInfo.ArgumentList.ToArray());
+        Assert.Equal("/opt/cdidx install", startInfo.Environment["CDIDX_INSTALL_DIR"]);
+    }
+
+    [Fact]
+    public void RunInstallerProcess_TimesOutHungInstaller()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        lock (TestConsoleLock.Gate)
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"cdidx_installer_timeout_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(root);
+            var script = Path.Combine(root, "install.sh");
+            try
+            {
+                File.WriteAllText(script, """
+#!/bin/sh
+sleep 5
+""");
+                File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+                var startInfo = ProgramRunner.CreateInstallerProcessStartInfo(script, "v1.27.0", root);
+
+                var (exitCode, stdout, stderr) = CaptureConsole(() =>
+                    ProgramRunner.RunInstallerProcess(startInfo, TimeSpan.FromMilliseconds(100)));
+
+                Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+                Assert.Empty(stdout);
+                Assert.Contains("install.sh timed out", stderr);
+                Assert.Contains("rerun `install.sh` manually", stderr);
+            }
+            finally
+            {
+                TestProjectHelper.DeleteDirectory(root);
+            }
+        }
+    }
+
+    [Fact]
     public async Task DownloadInstallerScriptAsync_CancelsStalledBody()
     {
         var path = Path.Combine(Path.GetTempPath(), $"cdidx-install-timeout-{Guid.NewGuid():N}.sh");


### PR DESCRIPTION
## Summary

- Bound GitHelper subprocess runtime and captured stdout/stderr, returning explicit diagnostics when timeout or capture limits are hit.
- Launch `cdidx upgrade` installer with `ProcessStartInfo.ArgumentList` and terminate stalled installer runs with a clear error.
- Added regression coverage for git timeout/output caps and upgrade installer argument/timeout behavior.

## Validation

- `dotnet build -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~GitHelperTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ProgramRunnerTests -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- Adversarial review: no blocking/actionable issues remain after fixes. External `codex exec review --base origin/main --ephemeral` was attempted twice but blocked by Codex usage/model availability limits in this environment.

## Documentation / Changelog

- Added `changelog.d/unreleased/2832.fixed.md`.
- Added `changelog.d/unreleased/2827.fixed.md`.
- No direct `CHANGELOG.md` update; ordinary issue-fix fragments were used.

## Follow-up Candidates

- None.

Fixes #2832
Fixes #2827