### PR TITLE
Increase regex timeout headroom for SQL refs

### DIFF
--- a/changelog.d/unreleased/2949.fixed.md
+++ b/changelog.d/unreleased/2949.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2949
+affected:
+  - src/CodeIndex/Indexer/BoundedRegex.cs
+  - tests/CodeIndex.Tests/BoundedRegexTests.cs
+---
+
+## English
+
+- **SQL reference extraction is less likely to drop matches under full-suite CPU contention (#2949)** - bounded regex matching now keeps a larger but still finite default timeout, reducing intermittent missed SQL references during heavily loaded test and indexing runs.
+
+## 日本語
+
+- **full-suite の CPU 競合下で SQL reference 抽出が match を落としにくくなりました (#2949)** - bounded regex matching の既定 timeout を、有限のまま余裕を持たせた値に変更し、高負荷なテスト実行や index 実行中に SQL reference が断続的に欠ける問題を減らしました。

--- a/src/CodeIndex/Indexer/BoundedRegex.cs
+++ b/src/CodeIndex/Indexer/BoundedRegex.cs
@@ -6,7 +6,8 @@ namespace CodeIndex.Indexer;
 
 internal sealed class BoundedRegex : BclRegex
 {
-    internal static readonly TimeSpan DefaultMatchTimeout = TimeSpan.FromMilliseconds(250);
+    // Keep regex matches bounded, but leave enough scheduler headroom for full-suite CI contention.
+    internal static readonly TimeSpan DefaultMatchTimeout = TimeSpan.FromSeconds(1);
 
     public BoundedRegex(string pattern)
         : base(pattern, RegexOptions.None, DefaultMatchTimeout)

--- a/tests/CodeIndex.Tests/BoundedRegexTests.cs
+++ b/tests/CodeIndex.Tests/BoundedRegexTests.cs
@@ -1,0 +1,15 @@
+using CodeIndex.Indexer;
+
+namespace CodeIndex.Tests;
+
+public sealed class BoundedRegexTests
+{
+    [Fact]
+    public void DefaultMatchTimeout_KeepsBoundedMatchesFromTimingOutUnderNormalSchedulerContention()
+    {
+        Assert.InRange(
+            BoundedRegex.DefaultMatchTimeout,
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(5));
+    }
+}


### PR DESCRIPTION
## Summary

- Increase the bounded regex default timeout from 250 ms to 1 second so SQL reference extraction has more scheduler headroom under full-suite CPU contention.
- Add a focused regression guard for the bounded regex timeout budget.

## Root Cause

Regex timeouts are treated as no-match fallbacks. Under heavy test-suite load, the previous 250 ms budget could intermittently turn SQL reference matches into missing references.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-restore -p:UseSharedCompilation=false --filter "FullyQualifiedName~BoundedRegexTests|FullyQualifiedName~Extract_SQL_CreateIndexCapturesOnTableReference|FullyQualifiedName~RunReferences_ExactJson_SqlMergeTempTargetWithoutIntoResolvesTargetAndSource|FullyQualifiedName~RunReferences_ExactJson_SqlNonAsciiBareIdentifiersStayWhole|FullyQualifiedName~RunReferences_ExactJson_SqlMultilineSingleQuotedStringsStayOpaque"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false --no-restore`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false --no-restore`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Full `dotnet test CodeIndex.sln --no-restore -p:UseSharedCompilation=false` was attempted locally but did not produce a final summary before being stopped, so it is not counted as a passing validation.

## Documentation / Changelog

- Added `changelog.d/unreleased/2949.fixed.md`.
- No README or guide updates required; this only changes the bounded regex execution budget.

Fixes #2949