### PR TITLE
[codex] Bound CLI diagnostic input sizes

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -3284,7 +3284,8 @@ Downstream users can add lightweight language support without rebuilding
   100 ms timeout;
 - `cdidx test-extractor --language <lang> --file <path> --json` runs symbol
   extraction without building an index, and `--expect-symbols <json>` compares
-  the extracted JSON to a fixture.
+  the extracted JSON to a fixture. The source and expectation files are capped
+  at 4 MiB each.
 
 Minimal examples:
 
@@ -3322,6 +3323,7 @@ a broken local experiment does not prevent indexing.
   プロセス全体では configured rule 128 件に制限され、regex match には 100 ms の timeout が付きます。
 - `cdidx test-extractor --language <lang> --file <path> --json` は index を作らずに
   symbol extraction だけを実行し、`--expect-symbols <json>` で fixture JSON と比較できます。
+  source と expectation file はそれぞれ 4 MiB に制限されます。
 
 各 regex は `name` という名前付き capture を公開することを推奨します。存在しない場合、
 `cdidx` は match 全体の文字列を symbol 名として使います。無効、symlink、過大、または

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ cdidx lsp --db .cdidx/codeindex.db
 Custom language loops can stay out of tree: put extension aliases in
 `.cdidx-langmap.yaml`, put regex symbol patterns in `.cdidx/patterns/*.yaml`,
 and run `cdidx test-extractor --language <lang> --file <path> --json` to test
-an extractor fixture without building a full index. Pattern sidecars are
+an extractor fixture without building a full index. `test-extractor` source and
+`--expect-symbols` files are capped at 4 MiB each. Pattern sidecars are
 limited to regular files under non-symlink pattern directories, size/count
 bounded per file and per process, and regex matches are time-limited. See
 [Custom Language Extraction](DEVELOPER_GUIDE.md#custom-language-extraction).
@@ -364,7 +365,8 @@ cdidx lsp --db .cdidx/codeindex.db
 カスタム言語の開発ループは out-of-tree で回せます。拡張子 alias は
 `.cdidx-langmap.yaml`、regex シンボルパターンは `.cdidx/patterns/*.yaml` に置き、
 `cdidx test-extractor --language <lang> --file <path> --json` で full index を作らずに
-extractor fixture を確認できます。pattern sidecar は symlink ではない pattern directory
+extractor fixture を確認できます。`test-extractor` の source と `--expect-symbols`
+ファイルはそれぞれ 4 MiB に制限されます。pattern sidecar は symlink ではない pattern directory
 配下の通常ファイルだけが対象で、size / count は file 単位と process 単位で制限され、
 regex match には timeout が付きます。詳細は
 [Custom Language Extraction](DEVELOPER_GUIDE.md#custom-language-extraction) を参照してください。

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -389,6 +389,7 @@ be audited whenever the matching help text changes.
 | Color mode | `auto`, overridden by `--color`, `CLICOLOR_FORCE`, `NO_COLOR`, or `CLICOLOR=0` | `ConsoleUi` |
 | ANSI palette | `basic` fallback, auto-upgraded from terminal hints unless overridden | `ConsoleUi` |
 | Report log tail | `200` lines (`--log-lines`) | report runner help |
+| JSON envelope capture | `10,485,760` characters | `JsonEnvelopeWrapper` |
 
 When a default changes, update the help text, this table, affected examples, and
 the changelog fragment in the same PR so users are not asked to reconcile
@@ -896,7 +897,7 @@ Use `--json` for machine-readable output (AI agents):
 {"path":"src/Auth/TokenService.cs","lang":"csharp","chunk_start_line":1,"chunk_end_line":80,"snippet_start_line":40,"snippet_end_line":47,"snippet":"if (claims.Count == 0)\\n    throw new InvalidOperationException();\\nreturn GenerateToken(claims);","match_lines":[42,47],"highlights":[{"line":47,"text":"return GenerateToken(claims);","terms":["GenerateToken"]}],"context_before":2,"context_after":3,"score":9.8}
 ```
 
-Add `--json-envelope` to wrap the per-line stream into a single document with a `metadata` block (command, `cdidx_version`, `elapsed_ms`, `db_path`, `result_count`, `exit_code`, optional `query_normalized` / `indexed_at_head_sha`) and a `results` array. The flag implies `--json` and works on every query command (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `excerpt`, `map`, `inspect`, `outline`, `status`, `validate`, `languages`, `impact`, `deps`, `unused`, `hotspots`). The flat NDJSON / array output stays the default for one release; the envelope will become the default in the next major release, at which point the flat form will be opt-in via `--json-flat`.
+Add `--json-envelope` to wrap the per-line stream into a single document with a `metadata` block (command, `cdidx_version`, `elapsed_ms`, `db_path`, `result_count`, `exit_code`, optional `query_normalized` / `indexed_at_head_sha`) and a `results` array. The flag implies `--json` and works on every query command (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `excerpt`, `map`, `inspect`, `outline`, `status`, `validate`, `languages`, `impact`, `deps`, `unused`, `hotspots`). Wrapped commands can capture up to 10,485,760 output characters; if the budget is exceeded, cdidx returns a JSON envelope with empty `results`, non-zero `metadata.exit_code`, and `metadata.error`, and suggests using `--limit` / `--top` or streaming `--json`. The flat NDJSON / array output stays the default for one release; the envelope will become the default in the next major release, at which point the flat form will be opt-in via `--json-flat`.
 
 Add `--profile` to any read command when debugging slow queries. It appends one JSON object after the normal result with `profile.phases` (`name`, `elapsed_ms`, `rows_scanned`), `profile.query_plan` (`EXPLAIN QUERY PLAN` rows), and `profile.queries` (the SQL text). Add `--slow-query-ms <n>` to log profiled SQL statements that meet the threshold to the persistent tool log.
 
@@ -2516,6 +2517,7 @@ render できます。
 | Color mode | `auto`。`--color` / `CLICOLOR_FORCE` / `NO_COLOR` / `CLICOLOR=0` で上書き | `ConsoleUi` |
 | ANSI palette | `basic` fallback。terminal hints で自動昇格、または明示上書き | `ConsoleUi` |
 | Report log tail | `200` lines（`--log-lines`） | report runner help |
+| JSON envelope capture | `10,485,760` 文字 | `JsonEnvelopeWrapper` |
 
 既定値を変更するときは、help text、この表、影響する examples、changelog fragment を
 同じ PR で更新してください。
@@ -3033,6 +3035,8 @@ src/Auth/TokenService.cs:42-58
 {"path":"src/Auth/Login.cs","start_line":15,"end_line":30,"content":"public bool Authenticate(...)...","lang":"csharp","score":12.5}
 {"path":"src/Auth/TokenService.cs","start_line":42,"end_line":58,"content":"public string GenerateToken(...)...","lang":"csharp","score":9.8}
 ```
+
+`--json-envelope` を追加すると、1 行ごとの stream を `metadata`（command、`cdidx_version`、`elapsed_ms`、`db_path`、`result_count`、`exit_code`、任意の `query_normalized` / `indexed_at_head_sha`）と `results` 配列を持つ 1 つの JSON document に包みます。この flag は `--json` を暗黙に有効化し、各 query command で使えます。wrapped command の捕捉出力は最大 10,485,760 文字です。超過した場合は、空の `results`、非 0 の `metadata.exit_code`、`metadata.error` を持つ JSON envelope を返し、`--limit` / `--top` または streaming `--json` の利用を促します。
 
 ### シンボル検索（関数、クラスなど）
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -388,7 +388,8 @@ be audited whenever the matching help text changes.
 | Status stale-after hint | `24h`, overridden by `--stale-after`, `CDIDX_STALE_AFTER`, or `.cdidxrc.json` | status runner |
 | Color mode | `auto`, overridden by `--color`, `CLICOLOR_FORCE`, `NO_COLOR`, or `CLICOLOR=0` | `ConsoleUi` |
 | ANSI palette | `basic` fallback, auto-upgraded from terminal hints unless overridden | `ConsoleUi` |
-| Report log tail | `200` lines (`--log-lines`) | report runner help |
+| Report log tail | `200` lines (`--log-lines`), clamped to `2000` | report runner help |
+| Report per-log tail read | `1,048,576` bytes | `ReportCommandRunner` |
 | JSON envelope capture | `10,485,760` characters | `JsonEnvelopeWrapper` |
 | CLI batch line | `1,048,576` characters | `QueryCommandRunner` |
 | CLI batch arguments | `256` arguments after command name | `QueryCommandRunner` |
@@ -1099,7 +1100,7 @@ cdidx report --output report.tgz --json
 |---|---|---|
 | `--output <path>` / `-o <path>` | (required) | Destination `.tar.gz`. The directory is created if missing; on POSIX, the archive and tar entries are owner-readable/writable only. |
 | `--db <path>` | `.cdidx/codeindex.db` | Override the database whose schema is summarized. If absent, `schema.txt` records that no DB was found. |
-| `--log-lines <n>` | `200` | How many trailing lifecycle-log lines to include (`0` disables the tail). |
+| `--log-lines <n>` | `200` | How many trailing lifecycle-log lines to include (`0` disables the tail; values above `2000` are clamped). Each log file contributes from a bounded 1,048,576-byte tail window instead of being loaded fully. |
 | `--no-log` | | Skip the lifecycle log entirely. |
 | `--include-args` | | Keep literal `cwd=` and `args=` values in the log tail (opt-in; share only with trusted recipients). |
 | `--json` | | Print a stable summary envelope (`output_path`, `version`, `files`, `schema_tables`, `log_lines_included`, `log_included`, `db_included`, `db_path`) instead of the human-friendly output. |
@@ -2520,7 +2521,8 @@ render できます。
 | Status stale-after hint | `24h`。`--stale-after` / `CDIDX_STALE_AFTER` / `.cdidxrc.json` で上書き | status runner |
 | Color mode | `auto`。`--color` / `CLICOLOR_FORCE` / `NO_COLOR` / `CLICOLOR=0` で上書き | `ConsoleUi` |
 | ANSI palette | `basic` fallback。terminal hints で自動昇格、または明示上書き | `ConsoleUi` |
-| Report log tail | `200` lines（`--log-lines`） | report runner help |
+| Report log tail | `200` lines（`--log-lines`）、最大 `2000` に clamp | report runner help |
+| Report per-log tail read | `1,048,576` bytes | `ReportCommandRunner` |
 | JSON envelope capture | `10,485,760` 文字 | `JsonEnvelopeWrapper` |
 | CLI batch line | `1,048,576` 文字 | `QueryCommandRunner` |
 | CLI batch arguments | command 名の後ろに `256` 引数 | `QueryCommandRunner` |
@@ -3241,7 +3243,7 @@ cdidx report --output report.tgz --json
 |---|---|---|
 | `--output <path>` / `-o <path>` | （必須） | 出力先 `.tar.gz`。親ディレクトリが無ければ作成します。POSIX では archive と tar entry は owner の読み書きのみになります。 |
 | `--db <path>` | `.cdidx/codeindex.db` | スキーマ要約対象の DB を上書きします。存在しなければ `schema.txt` に「DB が見つからなかった」旨が記録されます。 |
-| `--log-lines <n>` | `200` | ライフサイクルログ末尾を何行含めるか（`0` で末尾を含めません）。 |
+| `--log-lines <n>` | `200` | ライフサイクルログ末尾を何行含めるか（`0` で末尾を含めません。`2000` を超える値は clamp されます）。各ログファイルは全体を読み込まず、末尾 1,048,576 byte の範囲から収集します。 |
 | `--no-log` | | ライフサイクルログを完全に省略します。 |
 | `--include-args` | | ログ末尾の `cwd=` / `args=` 値を伏字化せずそのまま含めます（信頼できる相手にだけ使用してください）。 |
 | `--json` | | 人間向け出力の代わりに、安定したサマリ JSON（`output_path` / `version` / `files` / `schema_tables` / `log_lines_included` / `log_included` / `db_included` / `db_path`）を出力します。 |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -390,6 +390,8 @@ be audited whenever the matching help text changes.
 | ANSI palette | `basic` fallback, auto-upgraded from terminal hints unless overridden | `ConsoleUi` |
 | Report log tail | `200` lines (`--log-lines`) | report runner help |
 | JSON envelope capture | `10,485,760` characters | `JsonEnvelopeWrapper` |
+| CLI batch line | `1,048,576` characters | `QueryCommandRunner` |
+| CLI batch arguments | `256` arguments after command name | `QueryCommandRunner` |
 
 When a default changes, update the help text, this table, affected examples, and
 the changelog fragment in the same PR so users are not asked to reconcile
@@ -859,7 +861,9 @@ cdidx search "authenticate" --json --verbose
 For scripts or editor integrations that need several queries against the same
 index, `cdidx batch --db <path>` keeps one SQLite connection open and reads one
 JSON string array per stdin line. Each array starts with a query command name,
-followed by that command's normal arguments:
+followed by that command's normal arguments. Each stdin line is capped at
+1,048,576 characters, and each command can carry at most 256 arguments after
+the command name:
 
 ```bash
 printf '%s\n' \
@@ -2518,6 +2522,8 @@ render できます。
 | ANSI palette | `basic` fallback。terminal hints で自動昇格、または明示上書き | `ConsoleUi` |
 | Report log tail | `200` lines（`--log-lines`） | report runner help |
 | JSON envelope capture | `10,485,760` 文字 | `JsonEnvelopeWrapper` |
+| CLI batch line | `1,048,576` 文字 | `QueryCommandRunner` |
+| CLI batch arguments | command 名の後ろに `256` 引数 | `QueryCommandRunner` |
 
 既定値を変更するときは、help text、この表、影響する examples、changelog fragment を
 同じ PR で更新してください。
@@ -2998,7 +3004,8 @@ cdidx search "authenticate" --json --verbose
 
 同じインデックスに対して複数の query を投げる script や editor integration では、
 `cdidx batch --db <path>` を使うと 1 つの SQLite connection を開いたまま処理できます。
-stdin の各行は JSON 文字列配列で、先頭に query command 名、その後ろに通常の引数を並べます:
+stdin の各行は JSON 文字列配列で、先頭に query command 名、その後ろに通常の引数を並べます。
+各 stdin 行は 1,048,576 文字まで、各 command は command 名の後ろに最大 256 引数までです:
 
 ```bash
 printf '%s\n' \

--- a/changelog.d/unreleased/2837.fixed.md
+++ b/changelog.d/unreleased/2837.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 2837
+affected:
+  - src/CodeIndex/Cli/ReportCommandRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`cdidx report` now bounds lifecycle-log tail collection (#2837)** — `--log-lines` is clamped to 2000, and each lifecycle log file is tailed from a bounded 1,048,576-byte window instead of being loaded fully.
+
+## 日本語
+
+- **`cdidx report` の lifecycle log tail 収集に上限を設けました (#2837)** — `--log-lines` は最大 2000 に clamp され、各 lifecycle log file は全体を読み込まず 1,048,576 byte の bounded tail window から収集します。

--- a/changelog.d/unreleased/2891.fixed.md
+++ b/changelog.d/unreleased/2891.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2891
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **CLI batch input now rejects oversized JSONL records (#2891)** — `cdidx batch` reads stdin with a bounded line reader, rejects lines over 1,048,576 characters, and caps each command at 256 arguments after the command name before JSON array elements are copied.
+
+## 日本語
+
+- **CLI batch input が過大な JSONL record を拒否するようになりました (#2891)** — `cdidx batch` は bounded line reader で stdin を読み、1,048,576 文字を超える行を拒否し、JSON 配列要素をコピーする前に command 名の後ろの引数を 256 個までに制限します。

--- a/changelog.d/unreleased/2896.fixed.md
+++ b/changelog.d/unreleased/2896.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2896
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - README.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **`test-extractor` now bounds fixture file reads (#2896)** — source and `--expect-symbols` files are capped at 4 MiB each, and oversized files fail with a clear argument error before extraction or JSON comparison.
+
+## 日本語
+
+- **`test-extractor` の fixture file 読み込みに上限を設けました (#2896)** — source と `--expect-symbols` ファイルをそれぞれ 4 MiB に制限し、過大なファイルは extraction や JSON 比較の前に明確な引数エラーで失敗します。

--- a/changelog.d/unreleased/2901.fixed.md
+++ b/changelog.d/unreleased/2901.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2901
+affected:
+  - src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+  - tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`--json-envelope` now caps captured command output (#2901)** — wrapped query commands stop when the captured output exceeds 10,485,760 characters and return a JSON error envelope instead of materializing unbounded stdout.
+
+## 日本語
+
+- **`--json-envelope` が捕捉するコマンド出力に上限を設けました (#2901)** — wrapped query command の捕捉出力が 10,485,760 文字を超えた時点で停止し、無制限に stdout を materialize せず JSON error envelope を返します。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -302,7 +302,7 @@ internal static class CliFlagSchema
             new() { Name = "--output", ShortName = "-o", ValuePlaceholder = "<path>", Description = "Output bundle path", Commands = Set("report") },
             new() { Name = "--no-log", Description = "Exclude global tool log from bundle", Commands = Set("report") },
             new() { Name = "--include-args", Description = "Include args in bundle log", Commands = Set("report") },
-            new() { Name = "--log-lines", ValuePlaceholder = "<n>", Description = "Number of log lines to include in bundle", Commands = Set("report") },
+            new() { Name = "--log-lines", ValuePlaceholder = "<n>", Description = "Number of log lines to include in bundle (clamped to 2000)", Commands = Set("report") },
             new() { Name = "--transport", ValuePlaceholder = "<stdio|http>", Description = "MCP transport", Commands = Set("mcp") },
             new() { Name = "--http-listen", ValuePlaceholder = "<host:port>", Description = "MCP HTTP listen address", Commands = Set("mcp") },
         };

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -109,7 +109,7 @@ public static class ConsoleUi
         ("export", "cdidx export ctags [--output <path>] [--db <path>]"),
         ("import", "cdidx import <archive> [--db <path>] [--prune-paths] [--json]"),
         ("languages", "cdidx languages [--json]"),
-        ("batch", "cdidx batch [--db <path>]  # reads JSON string arrays from stdin, one query command per line"),
+        ("batch", "cdidx batch [--db <path>]  # reads JSON string arrays from stdin, one query command per line; max 1,048,576 chars/line and 256 arguments"),
         ("mcp", "cdidx mcp [--db <path>] [--transport stdio|http] [--http-listen <host:port>] [--audit-log <path>] [--audit-log-include-values] [--audit-log-max-bytes <n>] [--suggestion-dedup-threshold <0..1>]"),
         ("lsp", "cdidx lsp [--db <path>]"),
         ("completions", "cdidx completions <shell>"),

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -98,7 +98,7 @@ public static class ConsoleUi
         ("doctor", "cdidx doctor"),
         ("db", "cdidx db --integrity-check|schema|prune [--dry-run|--apply] [--db <path>] [--json] | cdidx db checkpoint [name] [--db <path>] [--json] | cdidx db checkpoints --list [--db <path>] [--json] | cdidx db restore <name> [--db <path>] [--json]"),
         ("diff", "cdidx diff <db1> <db2> [--json] [--summary-only] [--detailed] [--limit <n>]"),
-        ("report", "cdidx report --output <path> [--db <path>] [--json] [--log-lines <n>] [--no-log] [--include-args]"),
+        ("report", "cdidx report --output <path> [--db <path>] [--json] [--log-lines <n<=2000>] [--no-log] [--include-args]"),
         ("validate", "cdidx validate [--db <path>] [--json] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif>] [--verbose] [--kind <kind>] [--path <glob>]"),
         ("impact", "cdidx impact <query>|--query <query>|-- <query> [--db <path>] [--json] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--snippet-lines <n>] [--max-line-width <n>] [--max-hops <n>] [--count] [--with-paths]"),
         ("deps", "cdidx deps [--db <path>] [--json] [--format <dot|graphml|json-graph|edgelist>] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--reverse] [--cycles]"),

--- a/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+++ b/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
@@ -17,6 +17,7 @@ namespace CodeIndex.Cli;
 internal static class JsonEnvelopeWrapper
 {
     internal const string EnvelopeFlag = "--json-envelope";
+    internal const int MaxCapturedOutputChars = 10 * 1024 * 1024;
 
     private static readonly HashSet<string> WrappableCommands = new(StringComparer.Ordinal)
     {
@@ -78,18 +79,51 @@ internal static class JsonEnvelopeWrapper
             : explicitDbPath!;
 
         var originalOut = Console.Out;
-        using var captured = new StringWriter();
+        using var captured = new BoundedStringWriter(MaxCapturedOutputChars);
         var stopwatch = Stopwatch.StartNew();
         int exitCode;
+        JsonEnvelopeCaptureLimitExceededException? captureLimitExceeded = null;
         try
         {
             Console.SetOut(captured);
             exitCode = runInner(innerArgs);
         }
+        catch (JsonEnvelopeCaptureLimitExceededException ex)
+        {
+            captureLimitExceeded = ex;
+            exitCode = CommandExitCodes.InvalidArgument;
+        }
         finally
         {
             stopwatch.Stop();
             Console.SetOut(originalOut);
+        }
+
+        if (captureLimitExceeded is not null)
+        {
+            var message = $"--json-envelope captured output exceeded {captureLimitExceeded.MaxChars} characters.";
+            var hint = "Reduce the result set with --limit/--top or run the command with --json for streaming NDJSON output.";
+            Console.Error.WriteLine($"Error [{CommandErrorCodes.UsageError}]: {message}");
+            Console.Error.WriteLine($"Hint: {hint}");
+            var envelopeError = new JsonObject
+            {
+                ["message"] = message,
+                ["hint"] = hint,
+                ["error_code"] = CommandErrorCodes.UsageError,
+            };
+            var overflowEnvelope = BuildEnvelope(
+                command,
+                queryNormalized,
+                resolvedDbPath,
+                dbPathExplicit,
+                appVersion,
+                stopwatch.Elapsed.TotalMilliseconds,
+                new JsonArray(),
+                exitCode,
+                envelopeError);
+
+            Console.WriteLine(overflowEnvelope.ToJsonString(jsonOptions));
+            return exitCode;
         }
 
         var raw = captured.ToString();
@@ -116,7 +150,8 @@ internal static class JsonEnvelopeWrapper
         string appVersion,
         double elapsedMs,
         JsonArray results,
-        int exitCode)
+        int exitCode,
+        JsonObject? error = null)
     {
         var metadata = new JsonObject
         {
@@ -131,6 +166,8 @@ internal static class JsonEnvelopeWrapper
 
         if (!string.IsNullOrEmpty(queryNormalized))
             metadata["query_normalized"] = queryNormalized;
+        if (error is not null)
+            metadata["error"] = error;
 
         var indexedHead = SafeReadIndexedHead(dbPath, dbPathExplicit);
         if (!string.IsNullOrEmpty(indexedHead))
@@ -258,5 +295,50 @@ internal static class JsonEnvelopeWrapper
         }
         dbPath = null;
         return false;
+    }
+
+    private sealed class BoundedStringWriter(int maxChars) : StringWriter
+    {
+        private int _writtenChars;
+
+        public override void Write(char value)
+        {
+            EnsureCapacity(1);
+            base.Write(value);
+        }
+
+        public override void Write(string? value)
+        {
+            if (value is null)
+                return;
+            EnsureCapacity(value.Length);
+            base.Write(value);
+        }
+
+        public override void Write(char[]? buffer, int index, int count)
+        {
+            if (buffer is null)
+                return;
+            EnsureCapacity(count);
+            base.Write(buffer, index, count);
+        }
+
+        public override void Write(ReadOnlySpan<char> buffer)
+        {
+            EnsureCapacity(buffer.Length);
+            base.Write(buffer);
+        }
+
+        private void EnsureCapacity(int charCount)
+        {
+            if (charCount < 0 || _writtenChars > maxChars - charCount)
+                throw new JsonEnvelopeCaptureLimitExceededException(maxChars);
+            _writtenChars += charCount;
+        }
+    }
+
+    private sealed class JsonEnvelopeCaptureLimitExceededException(int maxChars) : Exception
+    {
+        public int MaxChars { get; } = maxChars;
     }
 }

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -20,6 +20,7 @@ internal static class ProgramRunner
     internal const string QuietEnvironmentVariable = "CDIDX_QUIET";
     private const string InstallerScriptUrlTemplate = "https://raw.githubusercontent.com/Widthdom/CodeIndex/{0}/install.sh";
     private const long MaxInstallerScriptBytes = 1024 * 1024;
+    internal const long TestExtractorMaxInputBytes = 4 * 1024 * 1024;
     private static readonly TimeSpan InstallerRunTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan InstallerKillWaitTimeout = TimeSpan.FromSeconds(5);
     internal static TimeProvider TimeProvider { get; set; } = TimeProvider.System;
@@ -386,14 +387,14 @@ internal static class ProgramRunner
 
         if (string.IsNullOrWhiteSpace(language) || string.IsNullOrWhiteSpace(file))
             return CommandErrorWriter.Write("test-extractor requires --language and --file.", CommandExitCodes.InvalidArgument, "use --language <lang> --file <path> [--expect-symbols <json>] [--json].");
-        if (!File.Exists(file))
-            return CommandErrorWriter.Write($"File not found: {file}", CommandExitCodes.NotFound);
+        if (!TryReadTestExtractorFile(file, "source", out var source, out var readExitCode))
+            return readExitCode;
 
-        var source = File.ReadAllText(file);
         var symbols = Indexer.SymbolExtractor.Extract(1, language, source, file);
         if (expect != null)
         {
-            var expected = File.ReadAllText(expect);
+            if (!TryReadTestExtractorFile(expect, "expected symbols", out var expected, out readExitCode))
+                return readExitCode;
             var actual = JsonSerializer.Serialize(symbols);
             if (!JsonEquivalent(expected, actual))
             {
@@ -406,6 +407,45 @@ internal static class ProgramRunner
         if (json || expect == null)
             Console.WriteLine(JsonSerializer.Serialize(symbols));
         return CommandExitCodes.Success;
+    }
+
+    private static bool TryReadTestExtractorFile(string path, string role, out string content, out int exitCode)
+    {
+        content = string.Empty;
+        exitCode = CommandExitCodes.Success;
+        var displayRole = $"test-extractor {role} file";
+        if (!File.Exists(LongPath.EnsureWindowsPrefix(path)))
+        {
+            exitCode = CommandErrorWriter.Write($"{displayRole} not found: {path}", CommandExitCodes.NotFound);
+            return false;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(LongPath.EnsureWindowsPrefix(path));
+            if (stream.Length > TestExtractorMaxInputBytes)
+            {
+                exitCode = CommandErrorWriter.Write(
+                    $"{displayRole} is too large: {stream.Length} bytes exceeds the {TestExtractorMaxInputBytes} byte limit.",
+                    CommandExitCodes.InvalidArgument,
+                    "Use a smaller extractor fixture or expectation file.");
+                return false;
+            }
+
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            content = reader.ReadToEnd();
+            return true;
+        }
+        catch (IOException ex)
+        {
+            exitCode = CommandErrorWriter.Write($"{displayRole} could not be read: {ex.Message}", CommandExitCodes.InvalidArgument);
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            exitCode = CommandErrorWriter.Write($"{displayRole} could not be read: {ex.Message}", CommandExitCodes.InvalidArgument);
+            return false;
+        }
     }
 
     private static bool TryConsumeInlineOrNext(string[] args, ref int index, string arg, string flag, out string value)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -21,6 +22,8 @@ public static class QueryCommandRunner
     internal const int DefaultQueryLimit = 20;
     internal const int DefaultMapLimit = 10;
     internal const int DefaultImpactLimit = 50;
+    internal const int BatchMaxLineChars = 1024 * 1024;
+    internal const int BatchMaxArgumentCount = 256;
     internal const string DefaultLimitEnvironmentVariable = "CDIDX_DEFAULT_LIMIT";
     internal const string DefaultSnippetLinesEnvironmentVariable = "CDIDX_DEFAULT_SNIPPET_LINES";
     internal const string DefaultMaxLineWidthEnvironmentVariable = "CDIDX_DEFAULT_MAX_LINE_WIDTH";
@@ -285,11 +288,18 @@ public static class QueryCommandRunner
             db.TryMigrateForRead();
             s_batchReader = new DbReader(db);
             var firstFailure = CommandExitCodes.Success;
-            string? line;
             var lineNumber = 0;
-            while ((line = Console.In.ReadLine()) != null)
+            while (TryReadBatchLine(Console.In, out var line, out var lineExceededLimit))
             {
                 lineNumber++;
+                if (lineExceededLimit)
+                {
+                    Console.Error.WriteLine($"Error: batch line {lineNumber} exceeds the {BatchMaxLineChars} character limit.");
+                    if (firstFailure == CommandExitCodes.Success)
+                        firstFailure = CommandExitCodes.UsageError;
+                    continue;
+                }
+
                 if (string.IsNullOrWhiteSpace(line))
                     continue;
 
@@ -313,6 +323,41 @@ public static class QueryCommandRunner
         }
     }
 
+    private static bool TryReadBatchLine(TextReader reader, out string? line, out bool exceededLimit)
+    {
+        line = null;
+        exceededLimit = false;
+        var builder = new StringBuilder();
+        while (true)
+        {
+            var next = reader.Read();
+            if (next < 0)
+            {
+                if (builder.Length == 0 && !exceededLimit)
+                    return false;
+                line = exceededLimit ? string.Empty : builder.ToString();
+                return true;
+            }
+
+            var ch = (char)next;
+            if (ch == '\n')
+            {
+                line = exceededLimit ? string.Empty : builder.ToString();
+                return true;
+            }
+
+            if (exceededLimit)
+                continue;
+            if (builder.Length >= BatchMaxLineChars)
+            {
+                exceededLimit = true;
+                continue;
+            }
+
+            builder.Append(ch);
+        }
+    }
+
     private static bool TryParseBatchLine(string line, int lineNumber, out string commandName, out string[] subArgs, out int exitCode)
     {
         commandName = string.Empty;
@@ -325,6 +370,11 @@ public static class QueryCommandRunner
             if (document.RootElement.ValueKind != JsonValueKind.Array || document.RootElement.GetArrayLength() == 0)
             {
                 Console.Error.WriteLine($"Error: batch line {lineNumber} must be a non-empty JSON string array.");
+                return false;
+            }
+            if (document.RootElement.GetArrayLength() > BatchMaxArgumentCount + 1)
+            {
+                Console.Error.WriteLine($"Error: batch line {lineNumber} must contain at most {BatchMaxArgumentCount} command arguments.");
                 return false;
             }
 

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -21,6 +21,8 @@ namespace CodeIndex.Cli;
 public static class ReportCommandRunner
 {
     internal const int DefaultLogLines = 200;
+    internal const int MaxLogLines = 2000;
+    internal const int MaxLogFileTailBytes = 1024 * 1024;
     internal const string RedactedPlaceholder = "[redacted]";
     internal const UnixFileMode BundleFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
 
@@ -260,16 +262,16 @@ public static class ReportCommandRunner
         {
             if (collected.Count >= maxLines)
                 break;
-            string[] lines;
+            IReadOnlyList<string> lines;
             try
             {
-                lines = File.ReadAllLines(file.FullName);
+                lines = ReadLogFileTailLines(file.FullName, maxLines - collected.Count);
             }
             catch (IOException)
             {
                 continue;
             }
-            for (var i = lines.Length - 1; i >= 0 && collected.Count < maxLines; i--)
+            for (var i = lines.Count - 1; i >= 0 && collected.Count < maxLines; i--)
                 collected.AddFirst(lines[i]);
         }
 
@@ -283,6 +285,55 @@ public static class ReportCommandRunner
         }
         linesIncluded = collected.Count;
         return sb.ToString();
+    }
+
+    internal static IReadOnlyList<string> ReadLogFileTailLines(string path, int maxLines)
+    {
+        if (maxLines <= 0)
+            return [];
+
+        using var stream = File.OpenRead(path);
+        var startOffset = Math.Max(0, stream.Length - MaxLogFileTailBytes);
+        stream.Seek(startOffset, SeekOrigin.Begin);
+        using var reader = new StreamReader(
+            stream,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: startOffset == 0,
+            bufferSize: 8192,
+            leaveOpen: false);
+        var text = reader.ReadToEnd();
+        if (startOffset > 0)
+        {
+            var firstNewline = text.IndexOf('\n', StringComparison.Ordinal);
+            if (firstNewline < 0)
+                return [];
+            text = text[(firstNewline + 1)..];
+        }
+
+        return TakeLastLines(text, maxLines);
+    }
+
+    private static IReadOnlyList<string> TakeLastLines(string text, int maxLines)
+    {
+        var lines = new List<string>();
+        var end = text.Length;
+        if (end > 0 && text[end - 1] == '\n')
+            end--;
+        while (end > 0 && lines.Count < maxLines)
+        {
+            var start = text.LastIndexOf('\n', end - 1);
+            var lineStart = start + 1;
+            var line = text[lineStart..end];
+            if (line.EndsWith('\r'))
+                line = line[..^1];
+            lines.Add(line);
+            if (start < 0)
+                break;
+            end = start;
+        }
+
+        lines.Reverse();
+        return lines;
     }
 
     internal static string RedactSensitiveFields(string line)
@@ -382,7 +433,7 @@ public static class ReportCommandRunner
                     if (!int.TryParse(args[++i], out var parsedLines) || parsedLines < 0)
                         options.ParseError = $"--log-lines requires a non-negative integer, got '{args[i]}'";
                     else
-                        options.LogLines = parsedLines;
+                        options.LogLines = Math.Min(parsedLines, MaxLogLines);
                     break;
                 case "--log-lines":
                     options.ParseError = "--log-lines requires a value";

--- a/tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
+++ b/tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
@@ -245,6 +245,30 @@ public class JsonEnvelopeWrapperTests
     }
 
     [Fact]
+    public void RunWrapped_CapturedOutputExceedsLimit_ReturnsJsonErrorEnvelope_Issue2901()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => JsonEnvelopeWrapper.RunWrapped(
+            "search",
+            ["Needle", "--json-envelope"],
+            "1.0.0",
+            _jsonOptions,
+            _ =>
+            {
+                Console.Write(new string('x', JsonEnvelopeWrapper.MaxCapturedOutputChars + 1));
+                return CommandExitCodes.Success;
+            }));
+
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+        Assert.Contains("--json-envelope captured output exceeded", stderr);
+        using var document = JsonDocument.Parse(stdout);
+        var metadata = document.RootElement.GetProperty("metadata");
+        Assert.Equal(CommandExitCodes.InvalidArgument, metadata.GetProperty("exit_code").GetInt32());
+        Assert.Equal(0, metadata.GetProperty("result_count").GetInt32());
+        Assert.Equal(CommandErrorCodes.UsageError, metadata.GetProperty("error").GetProperty("error_code").GetString());
+        Assert.Equal(0, document.RootElement.GetProperty("results").GetArrayLength());
+    }
+
+    [Fact]
     public void Symbols_WithEnvelope_NormalizesQueryFromExtraNames()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("envelope_symbols");

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -91,6 +91,64 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void Run_TestExtractor_SourceTooLarge_ReturnsInvalidArgument_Issue2896()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_test_extractor_large_source_{Guid.NewGuid():N}");
+            try
+            {
+                Directory.CreateDirectory(tempDir);
+                var file = Path.Combine(tempDir, "large.py");
+                File.WriteAllText(file, new string('x', (int)ProgramRunner.TestExtractorMaxInputBytes + 1));
+
+                var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                    ["test-extractor", "--language", "python", "--file", file, "--json"],
+                    appVersion: "1.10.0"));
+
+                Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+                Assert.Empty(stdout);
+                Assert.Contains("test-extractor source file is too large", stderr);
+                Assert.Contains($"{ProgramRunner.TestExtractorMaxInputBytes} byte limit", stderr);
+            }
+            finally
+            {
+                TestProjectHelper.DeleteDirectory(tempDir);
+            }
+        }
+    }
+
+    [Fact]
+    public void Run_TestExtractor_ExpectedSymbolsTooLarge_ReturnsInvalidArgument_Issue2896()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_test_extractor_large_expect_{Guid.NewGuid():N}");
+            try
+            {
+                Directory.CreateDirectory(tempDir);
+                var file = Path.Combine(tempDir, "app.py");
+                var expect = Path.Combine(tempDir, "expected.json");
+                File.WriteAllText(file, "def hello():\n    pass\n");
+                File.WriteAllText(expect, new string('x', (int)ProgramRunner.TestExtractorMaxInputBytes + 1));
+
+                var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                    ["test-extractor", "--language", "python", "--file", file, "--expect-symbols", expect],
+                    appVersion: "1.10.0"));
+
+                Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+                Assert.Empty(stdout);
+                Assert.Contains("test-extractor expected symbols file is too large", stderr);
+                Assert.Contains($"{ProgramRunner.TestExtractorMaxInputBytes} byte limit", stderr);
+            }
+            finally
+            {
+                TestProjectHelper.DeleteDirectory(tempDir);
+            }
+        }
+    }
+
+    [Fact]
     public void TryConsumeQueryTraceFlag_StripsTraceAndPreservesEscapedQuery()
     {
         string[] args = ["needle", "--trace=stderr", "--lang", "csharp", "--", "--trace=file"];

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -1246,6 +1246,60 @@ public class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunBatch_LineExceedsLimit_SkipsParsingAndContinues_Issue2891()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_batch_long_line");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var input = new string('x', QueryCommandRunner.BatchMaxLineChars + 1)
+                + "\n[\"status\",\"--json\"]\n";
+
+            var (exitCode, stdout, stderr) = CaptureConsoleWithInput(
+                input,
+                () => QueryCommandRunner.RunBatch(["--db", dbPath], _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Contains($"exceeds the {QueryCommandRunner.BatchMaxLineChars} character limit", stderr);
+            var lines = ParseJsonLines(stdout);
+            Assert.Single(lines);
+            using var statusDocument = lines[0];
+            Assert.True(statusDocument.RootElement.TryGetProperty("files", out _));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunBatch_ArgumentCountExceedsLimit_ReturnsUsageError_Issue2891()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_batch_too_many_args");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var values = Enumerable
+                .Range(0, QueryCommandRunner.BatchMaxArgumentCount + 2)
+                .Select(i => i == 0 ? "search" : $"arg{i}")
+                .ToArray();
+            var input = JsonSerializer.Serialize(values) + "\n";
+
+            var (exitCode, stdout, stderr) = CaptureConsoleWithInput(
+                input,
+                () => QueryCommandRunner.RunBatch(["--db", dbPath], _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains($"at most {QueryCommandRunner.BatchMaxArgumentCount} command arguments", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ParseArgs_ImpactDepthZeroIsRetainedWhenExplicit()
     {
         var options = QueryCommandRunner.ParseArgs(["RunImpact", "--depth", "0"], jsonDefault: false, allowNamedQuery: true);

--- a/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
@@ -79,6 +79,18 @@ public class ReportCommandRunnerTests
     }
 
     [Fact]
+    public void ParseArgs_LogLinesAboveMaximumClamps_Issue2837()
+    {
+        var options = ReportCommandRunner.ParseArgs([
+            "--output", "x.tgz",
+            "--log-lines", (ReportCommandRunner.MaxLogLines + 1).ToString(),
+        ]);
+
+        Assert.Equal(ReportCommandRunner.MaxLogLines, options.LogLines);
+        Assert.Null(options.ParseError);
+    }
+
+    [Fact]
     public void ParseArgs_LogLinesNegativeReportsError()
     {
         var options = ReportCommandRunner.ParseArgs(["--output", "x.tgz", "--log-lines", "-3"]);
@@ -306,6 +318,35 @@ public class ReportCommandRunnerTests
             Assert.DoesNotContain("/Users/widthdom/secret/.cdidx/config.json", logText);
             Assert.DoesNotContain("SELECT * FROM secret", logText);
             Assert.Contains("session_start", logText);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", previousLogDir);
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void BuildRecentLogTail_LargeLogReadsBoundedTail_Issue2837()
+    {
+        var workDir = CreateWorkDir();
+        var logDir = Path.Combine(workDir, "logs");
+        Directory.CreateDirectory(logDir);
+        File.WriteAllText(
+            Path.Combine(logDir, "stderr-20260517.log"),
+            new string('x', ReportCommandRunner.MaxLogFileTailBytes + 512)
+            + "\noldest-tail\nnewest-tail\n");
+
+        var previousLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+        try
+        {
+            var logText = ReportCommandRunner.BuildRecentLogTail(2, includeArgs: false, out var linesIncluded);
+
+            Assert.Equal(2, linesIncluded);
+            Assert.Contains("oldest-tail", logText);
+            Assert.Contains("newest-tail", logText);
+            Assert.DoesNotContain(new string('x', 128), logText);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Caps `--json-envelope` captured output and returns a structured JSON error envelope on overflow.
- Bounds `test-extractor`, CLI `batch`, and `report` diagnostic inputs before unbounded reads or JSON parsing.
- Updates user/developer docs and adds issue-based changelog fragments.

## Root Cause

Several diagnostic and integration paths read or captured caller-controlled input without a local budget: wrapped stdout, `test-extractor` fixture files, batch stdin JSONL lines/arguments, and report lifecycle-log tails.

## Validation

- `dotnet build`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~JsonEnvelopeWrapperTests|FullyQualifiedName~ProgramRunnerTests|FullyQualifiedName~QueryCommandRunnerTests|FullyQualifiedName~ReportCommandRunnerTests|FullyQualifiedName~ConsoleUiTests|FullyQualifiedName~CliFlagSchemaTests" -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false` (net8 passed; net9 had one parallel restore collision in a trimmed publish test)
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --filter "FullyQualifiedName~QueryCommandRunnerTests.RunPublishedTrimmedCli_SerializesQueryJsonAndErrorJson" -p:UseSharedCompilation=false`
- Adversarial review: No blocking/actionable issues found.

## Documentation and Changelog

- Updated `README.md`, `USER_GUIDE.md`, `DEVELOPER_GUIDE.md`, CLI usage, and flag schema where the new caps are user-facing.
- Added changelog fragments:
  - `changelog.d/unreleased/2901.fixed.md`
  - `changelog.d/unreleased/2896.fixed.md`
  - `changelog.d/unreleased/2891.fixed.md`
  - `changelog.d/unreleased/2837.fixed.md`

## Follow-up Candidates

None.

Fixes #2901
Fixes #2896
Fixes #2891
Fixes #2837
