### PR TITLE
Fix hook, package, and ctags safety issues

### DIFF
--- a/changelog.d/unreleased/2851.fixed.md
+++ b/changelog.d/unreleased/2851.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2851
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **ctags export now rejects database and SQLite sidecar output paths (#2851)** — `cdidx export ctags --output` now refuses the active `codeindex.db`, `codeindex.db-wal`, and `codeindex.db-shm` paths before opening the database, preventing accidental index truncation.
+
+## 日本語
+
+- **ctags export が database と SQLite sidecar の output path を拒否するようになりました (#2851)** — `cdidx export ctags --output` は database を開く前に active な `codeindex.db`、`codeindex.db-wal`、`codeindex.db-shm` を拒否し、誤って index を truncate することを防ぎます。

--- a/changelog.d/unreleased/2859.fixed.md
+++ b/changelog.d/unreleased/2859.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2859
+affected:
+  - src/CodeIndex/Cli/HookCommandRunner.cs
+  - tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+---
+
+## English
+
+- **Hook install and uninstall now preserve chained pre-commit hooks more safely (#2859)** — `cdidx hooks install` stages the managed hook before replacing an existing custom hook, and `cdidx hooks uninstall` atomically restores chained hooks instead of deleting the managed hook first.
+
+## 日本語
+
+- **hook install / uninstall が chained pre-commit hook をより安全に保持するようになりました (#2859)** — `cdidx hooks install` は managed hook を staging してから既存 custom hook を置換し、`cdidx hooks uninstall` は managed hook を先に削除せず chained hook を atomic に復元します。

--- a/changelog.d/unreleased/2893.fixed.md
+++ b/changelog.d/unreleased/2893.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2893
+affected:
+  - tools/CodeIndex.PackageNormalize/PackageNormalizeCli.cs
+  - tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+---
+
+## English
+
+- **Package normalization now removes partial `.normalize-tmp` files on failure (#2893)** — failed ZIP validation, XML rewriting, stream copying, or package replacement now best-effort deletes the temporary normalized package instead of leaving stale artifacts beside the package.
+
+## 日本語
+
+- **package normalization が失敗時に partial な `.normalize-tmp` を削除するようになりました (#2893)** — ZIP validation、XML rewrite、stream copy、package replacement が失敗した場合、package の隣に stale artifact を残さず temporary normalized package を best-effort で削除します。

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -169,9 +169,7 @@ internal static class ExportImportCommandRunner
 
         var fullSourceDbPath = Path.GetFullPath(normalizedDbPath);
         var fullOutputPath = Path.GetFullPath(outputPath);
-        if (IsSamePath(fullOutputPath, fullSourceDbPath)
-            || IsSamePath(fullOutputPath, fullSourceDbPath + "-wal")
-            || IsSamePath(fullOutputPath, fullSourceDbPath + "-shm"))
+        if (IsDatabaseOrSqliteSidecarPath(fullOutputPath, fullSourceDbPath))
         {
             return WriteError("export archive path must not be the source database or a SQLite sidecar.", "choose a separate archive path, for example `codeindex.cdidx.zip`.", "cdidx export <archive> [--db <path>] [--json]");
         }
@@ -240,6 +238,13 @@ internal static class ExportImportCommandRunner
 
         dbPath ??= DbPathResolver.ResolveForQuery(Environment.CurrentDirectory, explicitDbPath: null, explicitDataDir: null).DbPath;
         var normalizedDbPath = DbPathResolver.NormalizeDbPath(dbPath);
+        var fullSourceDbPath = Path.GetFullPath(normalizedDbPath);
+        var fullOutputPath = Path.GetFullPath(outputPath);
+        if (IsDatabaseOrSqliteSidecarPath(fullOutputPath, fullSourceDbPath))
+        {
+            return WriteError("ctags output path must not be the source database or a SQLite sidecar.", "choose a separate tags path, for example `tags`.", "cdidx export ctags [--output <path>] [--db <path>]");
+        }
+
         if (!DbContext.TryValidateExistingCodeIndexDb(normalizedDbPath, out var validationMessage, out _))
             return WriteError(validationMessage, "run `cdidx index <projectPath>` first or pass `--db <path>`.", "cdidx export ctags [--output <path>] [--db <path>]");
 
@@ -523,6 +528,11 @@ internal static class ExportImportCommandRunner
             Path.GetFullPath(left).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
             Path.GetFullPath(right).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
             OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
+    private static bool IsDatabaseOrSqliteSidecarPath(string path, string dbPath)
+        => IsSamePath(path, dbPath)
+            || IsSamePath(path, dbPath + "-wal")
+            || IsSamePath(path, dbPath + "-shm");
 
     private static string SanitizeCtagsField(string value)
         => value.Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');

--- a/src/CodeIndex/Cli/HookCommandRunner.cs
+++ b/src/CodeIndex/Cli/HookCommandRunner.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using CodeIndex.Indexer;
 
@@ -88,14 +89,13 @@ public static class HookCommandRunner
             {
                 if (File.Exists(ioChainedHookPath) && !options.Force)
                     return WriteResult(options.Json, jsonOptions, "error", $"chained hook already exists: {chainedHookPath}", projectPath, hookPath, chainedHookPath, CommandExitCodes.UsageError);
-                if (File.Exists(ioChainedHookPath))
-                    File.Delete(ioChainedHookPath);
-                File.Move(ioHookPath, ioChainedHookPath);
+
+                ReplaceCustomHookWithManagedHook(hooksDir, hookPath, chainedHookPath);
+                return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, chainedHookPath, CommandExitCodes.Success);
             }
         }
 
-        File.WriteAllText(ioHookPath, BuildHookScript(chainedHookPath));
-        MakeExecutable(ioHookPath);
+        AtomicFileWriter.WriteText(hookPath, BuildHookScript(chainedHookPath), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), MakeExecutable);
 
         return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, File.Exists(ioChainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
     }
@@ -110,9 +110,15 @@ public static class HookCommandRunner
         if (!IsManagedHookFile(ioHookPath) && !options.Force)
             return WriteResult(options.Json, jsonOptions, "error", "pre-commit hook is not managed by cdidx; pass --force to remove it", projectPath, hookPath, null, CommandExitCodes.UsageError);
 
-        File.Delete(ioHookPath);
         if (File.Exists(ioChainedHookPath))
-            File.Move(ioChainedHookPath, ioHookPath);
+        {
+            File.Replace(ioChainedHookPath, ioHookPath, destinationBackupFileName: null, ignoreMetadataErrors: true);
+            MakeExecutable(ioHookPath);
+        }
+        else
+        {
+            File.Delete(ioHookPath);
+        }
 
         return WriteResult(options.Json, jsonOptions, "uninstalled", "cdidx pre-commit hook uninstalled", projectPath, hookPath, null, CommandExitCodes.Success);
     }
@@ -141,6 +147,60 @@ public static class HookCommandRunner
     {
         var content = DataDirectorySecurity.ReadTextWithinLimit(ioHookPath, MaxHookMarkerBytes, FileShare.ReadWrite);
         return content is not null && IsManagedHook(content);
+    }
+
+    private static void ReplaceCustomHookWithManagedHook(string hooksDir, string hookPath, string chainedHookPath)
+    {
+        var stagedHookPath = Path.Combine(hooksDir, $".{HookName}.{Guid.NewGuid():N}.tmp");
+        var ioStagedHookPath = LongPath.EnsureWindowsPrefix(stagedHookPath);
+        var ioHookPath = LongPath.EnsureWindowsPrefix(hookPath);
+        var ioChainedHookPath = LongPath.EnsureWindowsPrefix(chainedHookPath);
+        var stagedHookMoved = false;
+
+        try
+        {
+            WriteStagedHookScript(ioStagedHookPath, chainedHookPath);
+            File.Replace(ioStagedHookPath, ioHookPath, ioChainedHookPath, ignoreMetadataErrors: true);
+            stagedHookMoved = true;
+            MakeExecutable(ioHookPath);
+        }
+        finally
+        {
+            if (!stagedHookMoved)
+                TryDeleteFile(ioStagedHookPath);
+        }
+    }
+
+    private static void WriteStagedHookScript(string ioStagedHookPath, string chainedHookPath)
+    {
+        using (var stream = new FileStream(ioStagedHookPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        {
+            using (var writer = new StreamWriter(
+                stream,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                bufferSize: 1024,
+                leaveOpen: true))
+            {
+                writer.Write(BuildHookScript(chainedHookPath));
+                writer.Flush();
+            }
+
+            stream.Flush(flushToDisk: true);
+        }
+
+        MakeExecutable(ioStagedHookPath);
+    }
+
+    private static void TryDeleteFile(string ioPath)
+    {
+        try
+        {
+            if (File.Exists(ioPath))
+                File.Delete(ioPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
     }
 
     private static string BuildHookScript(string chainedHookPath)

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -5,6 +5,39 @@ namespace CodeIndex.Tests;
 
 public class ExportImportCommandRunnerTests
 {
+    [Theory]
+    [InlineData("")]
+    [InlineData("-wal")]
+    [InlineData("-shm")]
+    public void RunExportCtags_RejectsDatabaseAndSidecarOutputPaths(string outputSuffix)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("ctags_output_guard");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var outputPath = dbPath + outputSuffix;
+            var outputExisted = File.Exists(outputPath);
+            var outputBytes = outputExisted ? File.ReadAllBytes(outputPath) : null;
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunExport(
+                    ["ctags", "--db", dbPath, "--output", outputPath],
+                    new JsonSerializerOptions(),
+                    "test"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains("ctags output path must not be the source database or a SQLite sidecar", stderr);
+            Assert.Equal(outputExisted, File.Exists(outputPath));
+            if (outputBytes != null)
+                Assert.Equal(outputBytes, File.ReadAllBytes(outputPath));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Fact]
     public void WriteExportArchiveFile_FailurePreservesExistingArchive()
     {

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -17,7 +17,9 @@ public class ExportImportCommandRunnerTests
             var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
             var outputPath = dbPath + outputSuffix;
             var outputExisted = File.Exists(outputPath);
-            var outputBytes = outputExisted ? File.ReadAllBytes(outputPath) : null;
+            var outputInfo = outputExisted ? new FileInfo(outputPath) : null;
+            var outputLength = outputInfo?.Length;
+            var outputLastWriteUtc = outputInfo?.LastWriteTimeUtc;
 
             var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
                 ExportImportCommandRunner.RunExport(
@@ -29,8 +31,12 @@ public class ExportImportCommandRunnerTests
             Assert.Equal(string.Empty, stdout);
             Assert.Contains("ctags output path must not be the source database or a SQLite sidecar", stderr);
             Assert.Equal(outputExisted, File.Exists(outputPath));
-            if (outputBytes != null)
-                Assert.Equal(outputBytes, File.ReadAllBytes(outputPath));
+            if (outputInfo != null)
+            {
+                outputInfo.Refresh();
+                Assert.Equal(outputLength, outputInfo.Length);
+                Assert.Equal(outputLastWriteUtc, outputInfo.LastWriteTimeUtc);
+            }
         }
         finally
         {

--- a/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
@@ -85,6 +85,64 @@ public class HookCommandRunnerTests
             Assert.True(File.Exists(chainedHookPath));
             Assert.Contains("echo existing", File.ReadAllText(chainedHookPath));
             Assert.Contains(chainedHookPath, File.ReadAllText(hookPath));
+            AssertNoHookTempFiles(hooksDir);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Hooks_InstallForce_ReplacesExistingChainedHookAtomically()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("hook_force_chain");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            var hooksDir = Path.Combine(projectRoot, ".git", "hooks");
+            Directory.CreateDirectory(hooksDir);
+            var hookPath = Path.Combine(hooksDir, "pre-commit");
+            var chainedHookPath = Path.Combine(hooksDir, "pre-commit.cdidx-chain");
+            File.WriteAllText(hookPath, "#!/bin/sh\necho current\n");
+            File.WriteAllText(chainedHookPath, "#!/bin/sh\necho stale\n");
+
+            var exitCode = RunHooksAndCaptureStreams(["install", "--project", projectRoot, "--force"]).ExitCode;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Contains("BEGIN CDIDX MANAGED PRE-COMMIT", File.ReadAllText(hookPath));
+            Assert.Contains("echo current", File.ReadAllText(chainedHookPath));
+            Assert.DoesNotContain("echo stale", File.ReadAllText(chainedHookPath));
+            AssertNoHookTempFiles(hooksDir);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Hooks_Uninstall_RestoresChainedPreCommitHook()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("hook_uninstall_chain");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            var hooksDir = Path.Combine(projectRoot, ".git", "hooks");
+            Directory.CreateDirectory(hooksDir);
+            var hookPath = Path.Combine(hooksDir, "pre-commit");
+            var chainedHookPath = Path.Combine(hooksDir, "pre-commit.cdidx-chain");
+            File.WriteAllText(hookPath, "#!/bin/sh\necho existing\n");
+
+            Assert.Equal(CommandExitCodes.Success, RunHooksAndCaptureStreams(["install", "--project", projectRoot]).ExitCode);
+            var uninstallExit = RunHooksAndCaptureStreams(["uninstall", "--project", projectRoot]).ExitCode;
+
+            Assert.Equal(CommandExitCodes.Success, uninstallExit);
+            Assert.True(File.Exists(hookPath));
+            Assert.False(File.Exists(chainedHookPath));
+            Assert.Contains("echo existing", File.ReadAllText(hookPath));
+            Assert.DoesNotContain("BEGIN CDIDX MANAGED PRE-COMMIT", File.ReadAllText(hookPath));
+            AssertNoHookTempFiles(hooksDir);
         }
         finally
         {
@@ -192,4 +250,7 @@ public class HookCommandRunnerTests
         command.Parameters.AddWithValue("$path", relativePath);
         return (long)command.ExecuteScalar()!;
     }
+
+    private static void AssertNoHookTempFiles(string hooksDir)
+        => Assert.Empty(Directory.GetFiles(hooksDir, ".pre-commit.*.tmp"));
 }

--- a/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
@@ -252,6 +252,7 @@ public class ReleaseWorkflowTests
             var exception = Assert.Throws<InvalidOperationException>(() => PackageCorePropertiesNormalizer.NormalizePackage(packagePath, limits));
             Assert.Contains("[Content_Types].xml", exception.Message);
             Assert.Contains("text limit of 5 characters", exception.Message);
+            Assert.False(File.Exists(packagePath + ".normalize-tmp"));
         }
         finally
         {

--- a/tools/CodeIndex.PackageNormalize/PackageNormalizeCli.cs
+++ b/tools/CodeIndex.PackageNormalize/PackageNormalizeCli.cs
@@ -41,50 +41,61 @@ public static class PackageCorePropertiesNormalizer
 
         var fullPath = Path.GetFullPath(packagePath);
         var tempPath = fullPath + ".normalize-tmp";
-        if (File.Exists(tempPath))
-            File.Delete(tempPath);
+        var completed = false;
 
-        using (var sourceStream = File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-        using (var sourceArchive = new ZipArchive(sourceStream, ZipArchiveMode.Read, leaveOpen: false))
+        try
         {
-            var originalCorePropertiesPath = ValidateSourceArchive(sourceArchive, packagePath, limits);
-            ValidateEntryNamesBeforeRewrite(sourceArchive, originalCorePropertiesPath);
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
 
-            using var destinationStream = File.Open(tempPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
-            using var destinationArchive = new ZipArchive(destinationStream, ZipArchiveMode.Create, leaveOpen: false);
-            var readBudget = new PackageNormalizeReadBudget(limits);
-            var usedNames = new HashSet<string>(StringComparer.Ordinal);
-
-            foreach (var sourceEntry in sourceArchive.Entries)
+            using (var sourceStream = File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var sourceArchive = new ZipArchive(sourceStream, ZipArchiveMode.Read, leaveOpen: false))
             {
-                var destinationName = sourceEntry.FullName == originalCorePropertiesPath
-                    ? CanonicalCorePropertiesPath
-                    : sourceEntry.FullName;
+                var originalCorePropertiesPath = ValidateSourceArchive(sourceArchive, packagePath, limits);
+                ValidateEntryNamesBeforeRewrite(sourceArchive, originalCorePropertiesPath);
 
-                if (!usedNames.Add(destinationName))
-                    throw new InvalidOperationException($"Duplicate ZIP entry after normalization: {destinationName}");
+                using var destinationStream = File.Open(tempPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+                using var destinationArchive = new ZipArchive(destinationStream, ZipArchiveMode.Create, leaveOpen: false);
+                var readBudget = new PackageNormalizeReadBudget(limits);
+                var usedNames = new HashSet<string>(StringComparer.Ordinal);
 
-                var destinationEntry = destinationArchive.CreateEntry(destinationName, CompressionLevel.Optimal);
-                destinationEntry.LastWriteTime = StableZipTimestamp;
-                destinationEntry.ExternalAttributes = sourceEntry.ExternalAttributes;
-
-                using var rawSourceEntryStream = sourceEntry.Open();
-                using var sourceEntryStream = new BudgetedEntryReadStream(rawSourceEntryStream, sourceEntry, readBudget);
-                using var destinationEntryStream = destinationEntry.Open();
-
-                if (NeedsXmlReferenceRewrite(sourceEntry.FullName))
+                foreach (var sourceEntry in sourceArchive.Entries)
                 {
-                    using var writer = new StreamWriter(destinationEntryStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: false);
-                    writer.Write(RewriteCorePropertiesReferences(ReadXmlEntryText(sourceEntry, sourceEntryStream, limits), originalCorePropertiesPath));
-                }
-                else
-                {
-                    CopyEntry(sourceEntryStream, destinationEntryStream);
+                    var destinationName = sourceEntry.FullName == originalCorePropertiesPath
+                        ? CanonicalCorePropertiesPath
+                        : sourceEntry.FullName;
+
+                    if (!usedNames.Add(destinationName))
+                        throw new InvalidOperationException($"Duplicate ZIP entry after normalization: {destinationName}");
+
+                    var destinationEntry = destinationArchive.CreateEntry(destinationName, CompressionLevel.Optimal);
+                    destinationEntry.LastWriteTime = StableZipTimestamp;
+                    destinationEntry.ExternalAttributes = sourceEntry.ExternalAttributes;
+
+                    using var rawSourceEntryStream = sourceEntry.Open();
+                    using var sourceEntryStream = new BudgetedEntryReadStream(rawSourceEntryStream, sourceEntry, readBudget);
+                    using var destinationEntryStream = destinationEntry.Open();
+
+                    if (NeedsXmlReferenceRewrite(sourceEntry.FullName))
+                    {
+                        using var writer = new StreamWriter(destinationEntryStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: false);
+                        writer.Write(RewriteCorePropertiesReferences(ReadXmlEntryText(sourceEntry, sourceEntryStream, limits), originalCorePropertiesPath));
+                    }
+                    else
+                    {
+                        CopyEntry(sourceEntryStream, destinationEntryStream);
+                    }
                 }
             }
-        }
 
-        File.Move(tempPath, fullPath, overwrite: true);
+            File.Move(tempPath, fullPath, overwrite: true);
+            completed = true;
+        }
+        finally
+        {
+            if (!completed)
+                TryDeleteFile(tempPath);
+        }
     }
 
     private static string ValidateSourceArchive(ZipArchive sourceArchive, string packagePath, PackageNormalizeLimits limits)
@@ -231,6 +242,18 @@ public static class PackageCorePropertiesNormalizer
                 return;
 
             destinationEntryStream.Write(buffer, 0, bytesRead);
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
         }
     }
 


### PR DESCRIPTION
## Summary

- Stage and atomically replace managed pre-commit hooks so custom chained hooks are preserved during install and uninstall.
- Delete package `.normalize-tmp` files on failed normalization or replacement.
- Reject `cdidx export ctags --output` paths that point at the active database or SQLite sidecars before opening the database.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~HookCommandRunnerTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReleaseWorkflowTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ExportImportCommandRunnerTests" -p:UseSharedCompilation=false`
- `dotnet build -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Added `changelog.d/unreleased/2859.fixed.md`.
- Added `changelog.d/unreleased/2893.fixed.md`.
- Added `changelog.d/unreleased/2851.fixed.md`.
- No `README.md`, `AGENT.md`, `AGENTS.md`, `CLAUDE.md`, or `AGENT_GUIDE.md` changes were made.

## Follow-up candidates

- None.

Fixes #2859
Fixes #2893
Fixes #2851
