### PR TITLE
Fix diff streaming and file hotspot aggregation

### DIFF
--- a/changelog.d/unreleased/2847.fixed.md
+++ b/changelog.d/unreleased/2847.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2847
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **File-grouped hotspot queries now aggregate in SQLite (#2847)** — CLI `hotspots --group-by=file` and MCP `symbol_hotspots` with `groupBy=file` now apply the requested limit through a database-level file aggregate instead of materializing every symbol hotspot row first.
+
+## 日本語
+
+- **ファイル単位の hotspot クエリを SQLite 側で集約するようにしました (#2847)** — CLI の `hotspots --group-by=file` と MCP の `symbol_hotspots` (`groupBy=file`) は、全 symbol hotspot 行を先に materialize せず、DB 側の file aggregate で指定 limit を適用するようになりました。

--- a/changelog.d/unreleased/2885.fixed.md
+++ b/changelog.d/unreleased/2885.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2885
+affected:
+  - src/CodeIndex/Cli/DiffCommandRunner.cs
+  - tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+---
+
+## English
+
+- **`cdidx diff` now compares database rows without full snapshot materialization (#2885)** — diff now streams ordered table comparisons and only collects bounded display rows, so small `--limit` values no longer require holding complete row snapshots in memory.
+
+## 日本語
+
+- **`cdidx diff` が DB 行を full snapshot materialization せず比較するようになりました (#2885)** — diff は ordered table comparison を streaming し、表示用の行だけを上限付きで収集するため、小さい `--limit` でも完全な行 snapshot をメモリに保持する必要がなくなりました。

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -40,9 +40,7 @@ public static class DiffCommandRunner
                 return SchemaMismatchExitCode;
             }
 
-            var left = ReadSnapshot(options.LeftDb!);
-            var right = ReadSnapshot(options.RightDb!);
-            var result = BuildDiff(left, right, options);
+            var result = BuildDiff(leftHeader, rightHeader, options);
 
             WriteResult(result, options, jsonOptions);
 
@@ -121,206 +119,170 @@ public static class DiffCommandRunner
         };
     }
 
-    private static DiffDbSnapshot ReadSnapshot(string dbPath)
+    private const string FilePathRowsSql = "SELECT path FROM files ORDER BY path";
+
+    private const string FileRowsSql = """
+        SELECT
+            path,
+            lang,
+            size,
+            lines,
+            checksum
+        FROM files
+        ORDER BY
+            path,
+            lang,
+            size,
+            lines,
+            checksum
+        """;
+
+    private const string ChunkRowsSql = """
+        SELECT
+            COALESCE(files.path, ''),
+            chunks.chunk_index,
+            chunks.start_line,
+            chunks.end_line,
+            chunks.content
+        FROM chunks
+        LEFT JOIN files ON files.id = chunks.file_id
+        ORDER BY
+            COALESCE(files.path, ''),
+            chunks.chunk_index,
+            chunks.start_line,
+            chunks.end_line,
+            chunks.content
+        """;
+
+    private const string ReferenceLineRowsSql = """
+        SELECT
+            COALESCE(files.path, ''),
+            reference_lines.line,
+            reference_lines.context
+        FROM reference_lines
+        LEFT JOIN files ON files.id = reference_lines.file_id
+        ORDER BY
+            COALESCE(files.path, ''),
+            reference_lines.line,
+            reference_lines.context
+        """;
+
+    private const string FileIssueRowsSql = """
+        SELECT
+            COALESCE(files.path, ''),
+            file_issues.kind,
+            file_issues.line,
+            file_issues.message
+        FROM file_issues
+        LEFT JOIN files ON files.id = file_issues.file_id
+        ORDER BY
+            COALESCE(files.path, ''),
+            file_issues.kind,
+            file_issues.line,
+            file_issues.message
+        """;
+
+    private const string MetaRowsSql = """
+        SELECT
+            key,
+            value
+        FROM codeindex_meta
+        WHERE
+            key = 'hotspot_family_version'
+            OR key = 'hotspot_family_marker_fingerprint'
+            OR key LIKE 'hotspot_family_version_%'
+            OR key LIKE 'hotspot_family_marker_fingerprint_%'
+            OR key = 'csharp_symbol_name_contract_version'
+            OR key = 'sql_graph_contract_version'
+            OR key LIKE 'symbol_extractor_version_%'
+            OR key LIKE 'metadata_target_version_%'
+            OR key = 'workspace_path_case_sensitive'
+            OR key = 'unknown_extension_file_count'
+            OR key = 'unknown_extension_file_paths_json'
+            OR key = 'unknown_extension_files_truncated'
+            OR key = 'unknown_extension_file_path_limit'
+            OR key = 'cdidx_writer_version'
+        ORDER BY
+            key,
+            value
+        """;
+
+    private const string SymbolRowsSql = """
+        SELECT
+            COALESCE(files.path, ''),
+            symbols.kind,
+            symbols.sub_kind,
+            symbols.name,
+            symbols.name_folded,
+            symbols.line,
+            symbols.start_line,
+            symbols.start_column,
+            symbols.end_line,
+            symbols.body_start_line,
+            symbols.body_end_line,
+            symbols.signature,
+            symbols.container_kind,
+            symbols.container_name,
+            symbols.container_qualified_name,
+            symbols.family_key,
+            symbols.visibility,
+            symbols.return_type,
+            symbols.is_metadata_target
+        FROM symbols
+        LEFT JOIN files ON files.id = symbols.file_id
+        ORDER BY
+            COALESCE(files.path, ''),
+            symbols.kind,
+            symbols.sub_kind,
+            symbols.name,
+            symbols.name_folded,
+            symbols.line,
+            symbols.start_line,
+            symbols.start_column,
+            symbols.end_line,
+            symbols.body_start_line,
+            symbols.body_end_line,
+            symbols.signature,
+            symbols.container_kind,
+            symbols.container_name,
+            symbols.container_qualified_name,
+            symbols.family_key,
+            symbols.visibility,
+            symbols.return_type,
+            symbols.is_metadata_target
+        """;
+
+    private const string ReferenceRowsSql = """
+        SELECT
+            COALESCE(files.path, ''),
+            symbol_references.symbol_name,
+            symbol_references.symbol_name_folded,
+            symbol_references.reference_kind,
+            symbol_references.line,
+            symbol_references.column_number,
+            symbol_references.context,
+            symbol_references.reference_line_id,
+            symbol_references.container_kind,
+            symbol_references.container_name,
+            symbol_references.container_name_folded
+        FROM symbol_references
+        LEFT JOIN files ON files.id = symbol_references.file_id
+        ORDER BY
+            COALESCE(files.path, ''),
+            symbol_references.symbol_name,
+            symbol_references.symbol_name_folded,
+            symbol_references.reference_kind,
+            symbol_references.line,
+            symbol_references.column_number,
+            symbol_references.context,
+            symbol_references.reference_line_id,
+            symbol_references.container_kind,
+            symbol_references.container_name,
+            symbol_references.container_name_folded
+        """;
+
+    private static DiffJsonResult BuildDiff(DiffDbHeader left, DiffDbHeader right, DiffCommandOptions options)
     {
-        var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
-        if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
-            throw new IOException($"database not found: {dbPath}");
-
-        var connectionString = isUri
-            ? $"Data Source={dbPath}"
-            : new SqliteConnectionStringBuilder
-            {
-                DataSource = dbPath,
-                Mode = SqliteOpenMode.ReadOnly,
-            }.ConnectionString;
-
-        using var connection = new SqliteConnection(connectionString);
-        connection.Open();
-
-        return new DiffDbSnapshot(
-            Path.GetFullPath(isUri ? dbPath : dbPath),
-            ExecuteLong(connection, "PRAGMA user_version"),
-            ExecuteLong(connection, "SELECT COUNT(*) FROM files"),
-            ExecuteLong(connection, "SELECT COUNT(*) FROM symbols"),
-            ExecuteLong(connection, "SELECT COUNT(*) FROM symbol_references"),
-            ReadStrings(connection, "SELECT path FROM files ORDER BY path"),
-            ReadRows(
-                connection,
-                """
-                SELECT
-                    path,
-                    lang,
-                    size,
-                    lines,
-                    checksum
-                FROM files
-                ORDER BY
-                    path,
-                    lang,
-                    size,
-                    lines,
-                    checksum
-                """),
-            ReadRows(
-                connection,
-                """
-                SELECT
-                    COALESCE(files.path, ''),
-                    chunks.chunk_index,
-                    chunks.start_line,
-                    chunks.end_line,
-                    chunks.content
-                FROM chunks
-                LEFT JOIN files ON files.id = chunks.file_id
-                ORDER BY
-                    COALESCE(files.path, ''),
-                    chunks.chunk_index,
-                    chunks.start_line,
-                    chunks.end_line,
-                    chunks.content
-                """),
-            ReadRows(
-                connection,
-                """
-                SELECT
-                    COALESCE(files.path, ''),
-                    reference_lines.line,
-                    reference_lines.context
-                FROM reference_lines
-                LEFT JOIN files ON files.id = reference_lines.file_id
-                ORDER BY
-                    COALESCE(files.path, ''),
-                    reference_lines.line,
-                    reference_lines.context
-                """),
-            ReadRows(
-                connection,
-                """
-                SELECT
-                    COALESCE(files.path, ''),
-                    file_issues.kind,
-                    file_issues.line,
-                    file_issues.message
-                FROM file_issues
-                LEFT JOIN files ON files.id = file_issues.file_id
-                ORDER BY
-                    COALESCE(files.path, ''),
-                    file_issues.kind,
-                    file_issues.line,
-                    file_issues.message
-                """),
-            ReadRows(
-                connection,
-                """
-                SELECT
-                    key,
-                    value
-                FROM codeindex_meta
-                WHERE
-                    key = 'hotspot_family_version'
-                    OR key = 'hotspot_family_marker_fingerprint'
-                    OR key LIKE 'hotspot_family_version_%'
-                    OR key LIKE 'hotspot_family_marker_fingerprint_%'
-                    OR key = 'csharp_symbol_name_contract_version'
-                    OR key = 'sql_graph_contract_version'
-                    OR key LIKE 'symbol_extractor_version_%'
-                    OR key LIKE 'metadata_target_version_%'
-                    OR key = 'workspace_path_case_sensitive'
-                    OR key = 'unknown_extension_file_count'
-                    OR key = 'unknown_extension_file_paths_json'
-                    OR key = 'unknown_extension_files_truncated'
-                    OR key = 'unknown_extension_file_path_limit'
-                    OR key = 'cdidx_writer_version'
-                ORDER BY
-                    key,
-                    value
-                """),
-            ReadRows(
-                connection,
-                """
-                SELECT
-                    COALESCE(files.path, ''),
-                    symbols.kind,
-                    symbols.sub_kind,
-                    symbols.name,
-                    symbols.name_folded,
-                    symbols.line,
-                    symbols.start_line,
-                    symbols.start_column,
-                    symbols.end_line,
-                    symbols.body_start_line,
-                    symbols.body_end_line,
-                    symbols.signature,
-                    symbols.container_kind,
-                    symbols.container_name,
-                    symbols.container_qualified_name,
-                    symbols.family_key,
-                    symbols.visibility,
-                    symbols.return_type,
-                    symbols.is_metadata_target
-                FROM symbols
-                LEFT JOIN files ON files.id = symbols.file_id
-                ORDER BY
-                    COALESCE(files.path, ''),
-                    symbols.kind,
-                    symbols.sub_kind,
-                    symbols.name,
-                    symbols.name_folded,
-                    symbols.line,
-                    symbols.start_line,
-                    symbols.start_column,
-                    symbols.end_line,
-                    symbols.body_start_line,
-                    symbols.body_end_line,
-                    symbols.signature,
-                    symbols.container_kind,
-                    symbols.container_name,
-                    symbols.container_qualified_name,
-                    symbols.family_key,
-                    symbols.visibility,
-                    symbols.return_type,
-                    symbols.is_metadata_target
-                """),
-            ReadRows(
-                connection,
-                """
-                SELECT
-                    COALESCE(files.path, ''),
-                    symbol_references.symbol_name,
-                    symbol_references.symbol_name_folded,
-                    symbol_references.reference_kind,
-                    symbol_references.line,
-                    symbol_references.column_number,
-                    symbol_references.context,
-                    symbol_references.reference_line_id,
-                    symbol_references.container_kind,
-                    symbol_references.container_name,
-                    symbol_references.container_name_folded
-                FROM symbol_references
-                LEFT JOIN files ON files.id = symbol_references.file_id
-                ORDER BY
-                    COALESCE(files.path, ''),
-                    symbol_references.symbol_name,
-                    symbol_references.symbol_name_folded,
-                    symbol_references.reference_kind,
-                    symbol_references.line,
-                    symbol_references.column_number,
-                    symbol_references.context,
-                    symbol_references.reference_line_id,
-                    symbol_references.container_kind,
-                    symbol_references.container_name,
-                    symbol_references.container_name_folded
-                """));
-    }
-
-    private static DiffJsonResult BuildDiff(DiffDbSnapshot left, DiffDbSnapshot right, DiffCommandOptions options)
-    {
-        var filesOnlyInLeft = TakeDiff(left.Files, right.Files, options.Limit);
-        var filesOnlyInRight = TakeDiff(right.Files, left.Files, options.Limit);
-        var symbolsOnlyInLeft = options.Detailed ? TakeDiff(left.SymbolRows, right.SymbolRows, options.Limit) : [];
-        var symbolsOnlyInRight = options.Detailed ? TakeDiff(right.SymbolRows, left.SymbolRows, options.Limit) : [];
-
         var summary = new DiffSummaryJsonResult(
             left.FileCount,
             right.FileCount,
@@ -335,19 +297,46 @@ public static class DiffCommandRunner
             right.SchemaVersion,
             left.SchemaVersion == right.SchemaVersion);
 
+        var filesOnlyInLeft = new List<string>();
+        var filesOnlyInRight = new List<string>();
+        var symbolsOnlyInLeft = new List<string>();
+        var symbolsOnlyInRight = new List<string>();
         var identical =
             summary.SchemaVersionsEqual &&
             summary.FileCountDelta == 0 &&
             summary.SymbolCountDelta == 0 &&
-            summary.ReferenceCountDelta == 0 &&
-            left.Files.SetEquals(right.Files) &&
-            left.FileRows.SequenceEqual(right.FileRows, StringComparer.Ordinal) &&
-            left.ChunkRows.SequenceEqual(right.ChunkRows, StringComparer.Ordinal) &&
-            left.ReferenceLineRows.SequenceEqual(right.ReferenceLineRows, StringComparer.Ordinal) &&
-            left.FileIssueRows.SequenceEqual(right.FileIssueRows, StringComparer.Ordinal) &&
-            left.MetaRows.SequenceEqual(right.MetaRows, StringComparer.Ordinal) &&
-            left.SymbolRows.SequenceEqual(right.SymbolRows, StringComparer.Ordinal) &&
-            left.ReferenceRows.SequenceEqual(right.ReferenceRows, StringComparer.Ordinal);
+            summary.ReferenceCountDelta == 0;
+
+        using var leftConnection = OpenReadOnlyConnection(options.LeftDb!);
+        using var rightConnection = OpenReadOnlyConnection(options.RightDb!);
+
+        if (!options.SummaryOnly)
+        {
+            var fileDiff = DiffOrderedStrings(leftConnection, rightConnection, FilePathRowsSql, options.Limit);
+            filesOnlyInLeft = fileDiff.OnlyInLeft;
+            filesOnlyInRight = fileDiff.OnlyInRight;
+            identical = identical && fileDiff.Equal;
+        }
+
+        if (options.Detailed)
+        {
+            var symbolDiff = DiffOrderedRows(leftConnection, rightConnection, SymbolRowsSql, options.Limit);
+            symbolsOnlyInLeft = symbolDiff.OnlyInLeft;
+            symbolsOnlyInRight = symbolDiff.OnlyInRight;
+            identical = identical && symbolDiff.Equal;
+        }
+
+        if (identical)
+        {
+            identical =
+                RowsEqual(leftConnection, rightConnection, FileRowsSql) &&
+                RowsEqual(leftConnection, rightConnection, ChunkRowsSql) &&
+                RowsEqual(leftConnection, rightConnection, ReferenceLineRowsSql) &&
+                RowsEqual(leftConnection, rightConnection, FileIssueRowsSql) &&
+                RowsEqual(leftConnection, rightConnection, MetaRowsSql) &&
+                (options.Detailed || RowsEqual(leftConnection, rightConnection, SymbolRowsSql)) &&
+                RowsEqual(leftConnection, rightConnection, ReferenceRowsSql);
+        }
 
         return new DiffJsonResult(
             identical ? "identical" : "different",
@@ -393,58 +382,245 @@ public static class DiffCommandRunner
             options.Detailed);
     }
 
-    private static List<string> TakeDiff(HashSet<string> source, HashSet<string> other, int limit)
+    private static OrderedRowsDiff DiffOrderedRows(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql, int limit)
     {
         if (limit == 0)
-            return [];
+            return new OrderedRowsDiff(RowsEqual(leftConnection, rightConnection, sql), [], []);
 
-        var result = new List<string>(Math.Min(source.Count, limit));
-        foreach (var item in source.Order(StringComparer.Ordinal))
+        using var leftCommand = leftConnection.CreateCommand();
+        leftCommand.CommandText = sql;
+        using var rightCommand = rightConnection.CreateCommand();
+        rightCommand.CommandText = sql;
+        using var leftReader = leftCommand.ExecuteReader();
+        using var rightReader = rightCommand.ExecuteReader();
+
+        var onlyInLeft = new List<string>(limit);
+        var onlyInRight = new List<string>(limit);
+        var leftHasValue = TryReadEncodedRow(leftReader, out var leftValue);
+        var rightHasValue = TryReadEncodedRow(rightReader, out var rightValue);
+        var equal = true;
+
+        while (leftHasValue || rightHasValue)
         {
-            if (other.Contains(item))
-                continue;
-            result.Add(item);
-            if (result.Count >= limit)
-                break;
-        }
-        return result;
-    }
+            var comparison = leftHasValue && rightHasValue
+                ? CompareRows(leftValue, rightValue)
+                : leftHasValue ? -1 : 1;
 
-    private static List<string> TakeDiff(List<string> source, List<string> other, int limit)
-    {
-        if (limit == 0)
-            return [];
-
-        var remaining = new Dictionary<string, int>(StringComparer.Ordinal);
-        foreach (var item in other)
-            remaining[item] = remaining.GetValueOrDefault(item) + 1;
-
-        var result = new List<string>(Math.Min(source.Count, limit));
-        foreach (var item in source)
-        {
-            if (remaining.TryGetValue(item, out var count) && count > 0)
+            if (comparison == 0)
             {
-                remaining[item] = count - 1;
+                leftHasValue = TryReadEncodedRow(leftReader, out leftValue);
+                rightHasValue = TryReadEncodedRow(rightReader, out rightValue);
                 continue;
             }
 
-            result.Add(item);
-            if (result.Count >= limit)
+            equal = false;
+            if (comparison < 0)
+            {
+                if (onlyInLeft.Count < limit)
+                    onlyInLeft.Add(leftValue.Encoded);
+                leftHasValue = TryReadEncodedRow(leftReader, out leftValue);
+            }
+            else
+            {
+                if (onlyInRight.Count < limit)
+                    onlyInRight.Add(rightValue.Encoded);
+                rightHasValue = TryReadEncodedRow(rightReader, out rightValue);
+            }
+
+            if (onlyInLeft.Count >= limit && onlyInRight.Count >= limit)
                 break;
         }
 
-        return result;
+        return new OrderedRowsDiff(equal, onlyInLeft, onlyInRight);
     }
 
-    private static long ExecuteLong(SqliteConnection connection, string sql)
+    private static OrderedRowsDiff DiffOrderedStrings(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql, int limit)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = sql;
-        var value = command.ExecuteScalar();
-        return Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture);
+        if (limit == 0)
+            return new OrderedRowsDiff(StringRowsEqual(leftConnection, rightConnection, sql), [], []);
+
+        using var leftCommand = leftConnection.CreateCommand();
+        leftCommand.CommandText = sql;
+        using var rightCommand = rightConnection.CreateCommand();
+        rightCommand.CommandText = sql;
+        using var leftReader = leftCommand.ExecuteReader();
+        using var rightReader = rightCommand.ExecuteReader();
+
+        var onlyInLeft = new List<string>(limit);
+        var onlyInRight = new List<string>(limit);
+        var leftHasValue = TryReadString(leftReader, out var leftValue);
+        var rightHasValue = TryReadString(rightReader, out var rightValue);
+        var equal = true;
+
+        while (leftHasValue || rightHasValue)
+        {
+            var comparison = leftHasValue && rightHasValue
+                ? string.CompareOrdinal(leftValue, rightValue)
+                : leftHasValue ? -1 : 1;
+
+            if (comparison == 0)
+            {
+                leftHasValue = TryReadString(leftReader, out leftValue);
+                rightHasValue = TryReadString(rightReader, out rightValue);
+                continue;
+            }
+
+            equal = false;
+            if (comparison < 0)
+            {
+                if (onlyInLeft.Count < limit)
+                    onlyInLeft.Add(leftValue);
+                leftHasValue = TryReadString(leftReader, out leftValue);
+            }
+            else
+            {
+                if (onlyInRight.Count < limit)
+                    onlyInRight.Add(rightValue);
+                rightHasValue = TryReadString(rightReader, out rightValue);
+            }
+
+            if (onlyInLeft.Count >= limit && onlyInRight.Count >= limit)
+                break;
+        }
+
+        return new OrderedRowsDiff(equal, onlyInLeft, onlyInRight);
     }
 
-    private static DiffDbHeader ReadHeader(string dbPath)
+    private static bool RowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql)
+    {
+        using var leftCommand = leftConnection.CreateCommand();
+        leftCommand.CommandText = sql;
+        using var rightCommand = rightConnection.CreateCommand();
+        rightCommand.CommandText = sql;
+        using var leftReader = leftCommand.ExecuteReader();
+        using var rightReader = rightCommand.ExecuteReader();
+
+        var leftHasValue = TryReadEncodedRow(leftReader, out var leftValue);
+        var rightHasValue = TryReadEncodedRow(rightReader, out var rightValue);
+        while (leftHasValue && rightHasValue)
+        {
+            if (!string.Equals(leftValue.Encoded, rightValue.Encoded, StringComparison.Ordinal))
+                return false;
+            leftHasValue = TryReadEncodedRow(leftReader, out leftValue);
+            rightHasValue = TryReadEncodedRow(rightReader, out rightValue);
+        }
+
+        return leftHasValue == rightHasValue;
+    }
+
+    private static bool StringRowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql)
+    {
+        using var leftCommand = leftConnection.CreateCommand();
+        leftCommand.CommandText = sql;
+        using var rightCommand = rightConnection.CreateCommand();
+        rightCommand.CommandText = sql;
+        using var leftReader = leftCommand.ExecuteReader();
+        using var rightReader = rightCommand.ExecuteReader();
+
+        var leftHasValue = TryReadString(leftReader, out var leftValue);
+        var rightHasValue = TryReadString(rightReader, out var rightValue);
+        while (leftHasValue && rightHasValue)
+        {
+            if (!string.Equals(leftValue, rightValue, StringComparison.Ordinal))
+                return false;
+            leftHasValue = TryReadString(leftReader, out leftValue);
+            rightHasValue = TryReadString(rightReader, out rightValue);
+        }
+
+        return leftHasValue == rightHasValue;
+    }
+
+    private static bool TryReadEncodedRow(SqliteDataReader reader, out EncodedDiffRow value)
+    {
+        if (!reader.Read())
+        {
+            value = EncodedDiffRow.Empty;
+            return false;
+        }
+
+        var sortValues = new object?[reader.FieldCount];
+        for (var i = 0; i < reader.FieldCount; i++)
+            sortValues[i] = reader.IsDBNull(i) ? null : reader.GetValue(i);
+
+        value = new EncodedDiffRow(EncodeRow(reader), sortValues);
+        return true;
+    }
+
+    private static int CompareRows(EncodedDiffRow left, EncodedDiffRow right)
+    {
+        var count = Math.Min(left.SortValues.Length, right.SortValues.Length);
+        for (var i = 0; i < count; i++)
+        {
+            var comparison = CompareSqlSortValue(left.SortValues[i], right.SortValues[i]);
+            if (comparison != 0)
+                return comparison;
+        }
+
+        return left.SortValues.Length.CompareTo(right.SortValues.Length);
+    }
+
+    private static int CompareSqlSortValue(object? left, object? right)
+    {
+        var leftRank = GetSqlSortRank(left);
+        var rightRank = GetSqlSortRank(right);
+        if (leftRank != rightRank)
+            return leftRank.CompareTo(rightRank);
+
+        if (leftRank == 0)
+            return 0;
+
+        if (leftRank == 1)
+        {
+            var leftNumber = Convert.ToDecimal(left, System.Globalization.CultureInfo.InvariantCulture);
+            var rightNumber = Convert.ToDecimal(right, System.Globalization.CultureInfo.InvariantCulture);
+            return leftNumber.CompareTo(rightNumber);
+        }
+
+        if (left is byte[] leftBytes && right is byte[] rightBytes)
+            return CompareBytes(leftBytes, rightBytes);
+
+        var leftText = Convert.ToString(left, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+        var rightText = Convert.ToString(right, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+        return string.CompareOrdinal(leftText, rightText);
+    }
+
+    private static int GetSqlSortRank(object? value)
+    {
+        if (value is null or DBNull)
+            return 0;
+        if (value is byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal)
+            return 1;
+        if (value is byte[])
+            return 3;
+        return 2;
+    }
+
+    private static int CompareBytes(byte[] left, byte[] right)
+    {
+        var count = Math.Min(left.Length, right.Length);
+        for (var i = 0; i < count; i++)
+        {
+            var comparison = left[i].CompareTo(right[i]);
+            if (comparison != 0)
+                return comparison;
+        }
+
+        return left.Length.CompareTo(right.Length);
+    }
+
+    private static bool TryReadString(SqliteDataReader reader, out string value)
+    {
+        if (!reader.Read())
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = reader.IsDBNull(0) ? string.Empty : reader.GetString(0);
+        return true;
+    }
+
+    private static SqliteConnection OpenReadOnlyConnection(string dbPath)
     {
         var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
         if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
@@ -458,8 +634,23 @@ public static class DiffCommandRunner
                 Mode = SqliteOpenMode.ReadOnly,
             }.ConnectionString;
 
-        using var connection = new SqliteConnection(connectionString);
+        var connection = new SqliteConnection(connectionString);
         connection.Open();
+        return connection;
+    }
+
+    private static long ExecuteLong(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        var value = command.ExecuteScalar();
+        return Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static DiffDbHeader ReadHeader(string dbPath)
+    {
+        var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
+        using var connection = OpenReadOnlyConnection(dbPath);
 
         return new DiffDbHeader(
             Path.GetFullPath(isUri ? dbPath : dbPath),
@@ -482,28 +673,6 @@ public static class DiffCommandRunner
         using var command = connection.CreateCommand();
         command.CommandText = $"SELECT COUNT(*) FROM {table}";
         return Convert.ToInt64(command.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
-    }
-
-    private static HashSet<string> ReadStrings(SqliteConnection connection, string sql)
-    {
-        using var command = connection.CreateCommand();
-        command.CommandText = sql;
-        using var reader = command.ExecuteReader();
-        var values = new HashSet<string>(StringComparer.Ordinal);
-        while (reader.Read())
-            values.Add(reader.IsDBNull(0) ? string.Empty : reader.GetString(0));
-        return values;
-    }
-
-    private static List<string> ReadRows(SqliteConnection connection, string sql)
-    {
-        using var command = connection.CreateCommand();
-        command.CommandText = sql;
-        using var reader = command.ExecuteReader();
-        var values = new List<string>();
-        while (reader.Read())
-            values.Add(EncodeRow(reader));
-        return values;
     }
 
     private static string EncodeRow(SqliteDataReader reader)
@@ -594,20 +763,17 @@ public static class DiffCommandRunner
         return exitCode;
     }
 
-    private sealed record DiffDbSnapshot(
-        string Path,
-        long SchemaVersion,
-        long FileCount,
-        long SymbolCount,
-        long ReferenceCount,
-        HashSet<string> Files,
-        List<string> FileRows,
-        List<string> ChunkRows,
-        List<string> ReferenceLineRows,
-        List<string> FileIssueRows,
-        List<string> MetaRows,
-        List<string> SymbolRows,
-        List<string> ReferenceRows);
+    private sealed record OrderedRowsDiff(
+        bool Equal,
+        List<string> OnlyInLeft,
+        List<string> OnlyInRight);
+
+    private sealed record EncodedDiffRow(
+        string Encoded,
+        object?[] SortValues)
+    {
+        public static readonly EncodedDiffRow Empty = new(string.Empty, []);
+    }
 
     private sealed record DiffDbHeader(
         string Path,

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4241,24 +4241,7 @@ public static class QueryCommandRunner
 
             if (groupBy == HotspotsGroupedByFile)
             {
-                var symbolRows = reader.GetSymbolHotspots(int.MaxValue, options.Kind, options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, visibilityFilters: options.VisibilityFilters, excludeVisibilityFilters: options.ExcludeVisibilityFilters);
-                var fileResults = symbolRows
-                    .GroupBy(row => row.Symbol.Path, StringComparer.Ordinal)
-                    .Select(group =>
-                    {
-                        var first = group.First();
-                        return new
-                        {
-                            Path = first.Symbol.Path,
-                            Lang = first.Symbol.Lang,
-                            ReferenceCount = group.Sum(row => row.ReferenceCount),
-                            SymbolCount = group.Count(),
-                        };
-                    })
-                    .OrderByDescending(row => row.ReferenceCount)
-                    .ThenBy(row => row.Path, StringComparer.Ordinal)
-                    .Take(options.Limit)
-                    .ToList();
+                var fileResults = reader.GetFileSymbolHotspots(options.Limit, options.Kind, options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, visibilityFilters: options.VisibilityFilters, excludeVisibilityFilters: options.ExcludeVisibilityFilters);
                 var effectiveSqlGraphSignal = fileResults.Count == 0
                     ? zeroResultSqlGraphSignal
                     : NarrowSqlGraphContractSignalByLanguages(baseSqlGraphSignal, fileResults.Select(result => result.Lang), options.Lang);

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -1861,6 +1861,88 @@ public partial class DbReader
     public List<SymbolHotspotResult> GetSymbolHotspots(int limit, string? kind, string? lang, IReadOnlyList<string>? pathPatterns, IReadOnlyList<string>? excludePathPatterns, bool excludeTests, IReadOnlyList<string>? visibilityFilters = null, IReadOnlyList<string>? excludeVisibilityFilters = null)
     {
         if (!_hasReferencesTable) return [];
+        var query = BuildSymbolHotspotRowsQuery(kind, lang, pathPatterns, excludePathPatterns, excludeTests, visibilityFilters, excludeVisibilityFilters);
+        var sql = query.Sql + @"
+            SELECT gr.name, rc.ref_count, rc.ref_score,
+                   gr.kind, gr.path, gr.lang, gr.line,
+                   gr.visibility, gr.container_name
+            FROM grouped_rows gr
+            JOIN reference_counts rc ON rc.symbol_id = gr.symbol_id
+            WHERE rc.ref_count > 0
+            ORDER BY rc.ref_score DESC,
+                     rc.ref_count DESC,
+                     gr.path COLLATE BINARY ASC,
+                     gr.line ASC,
+                     gr.name COLLATE BINARY ASC,
+                     gr.kind COLLATE BINARY ASC,
+                     gr.symbol_id ASC
+            LIMIT @limit";
+
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = sql;
+        AddSymbolHotspotParameters(cmd, query, limit, kind, lang, pathPatterns, excludePathPatterns, visibilityFilters, excludeVisibilityFilters);
+
+        var results = new List<SymbolHotspotResult>();
+        using var reader = cmd.ExecuteTrackedReader();
+        while (reader.TrackedRead())
+        {
+            results.Add(new SymbolHotspotResult
+            {
+                Symbol = new SymbolResult
+                {
+                    Name = reader.GetString(0),
+                    Kind = reader.GetString(3),
+                    Path = reader.GetString(4),
+                    Lang = GetNullableString(reader, 5),
+                    Line = reader.GetInt32(6),
+                    Visibility = GetNullableString(reader, 7),
+                    ContainerName = GetNullableString(reader, 8),
+                },
+                ReferenceCount = reader.GetInt32(1),
+                ReferenceScore = reader.GetDouble(2),
+            });
+        }
+        return results;
+    }
+
+    public List<FileHotspotResult> GetFileSymbolHotspots(int limit, string? kind, string? lang, IReadOnlyList<string>? pathPatterns, IReadOnlyList<string>? excludePathPatterns, bool excludeTests, IReadOnlyList<string>? visibilityFilters = null, IReadOnlyList<string>? excludeVisibilityFilters = null)
+    {
+        if (!_hasReferencesTable) return [];
+        var query = BuildSymbolHotspotRowsQuery(kind, lang, pathPatterns, excludePathPatterns, excludeTests, visibilityFilters, excludeVisibilityFilters);
+        var sql = query.Sql + @"
+            SELECT gr.path,
+                   gr.lang,
+                   SUM(rc.ref_count) AS ref_count,
+                   COUNT(*) AS symbol_count
+            FROM grouped_rows gr
+            JOIN reference_counts rc ON rc.symbol_id = gr.symbol_id
+            WHERE rc.ref_count > 0
+            GROUP BY gr.path, gr.lang
+            ORDER BY ref_count DESC,
+                     gr.path COLLATE BINARY ASC
+            LIMIT @limit";
+
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = sql;
+        AddSymbolHotspotParameters(cmd, query, limit, kind, lang, pathPatterns, excludePathPatterns, visibilityFilters, excludeVisibilityFilters);
+
+        var results = new List<FileHotspotResult>();
+        using var reader = cmd.ExecuteTrackedReader();
+        while (reader.TrackedRead())
+        {
+            results.Add(new FileHotspotResult
+            {
+                Path = reader.GetString(0),
+                Lang = GetNullableString(reader, 1),
+                ReferenceCount = reader.GetInt32(2),
+                SymbolCount = reader.GetInt32(3),
+            });
+        }
+        return results;
+    }
+
+    private SymbolHotspotRowsQuery BuildSymbolHotspotRowsQuery(string? kind, string? lang, IReadOnlyList<string>? pathPatterns, IReadOnlyList<string>? excludePathPatterns, bool excludeTests, IReadOnlyList<string>? visibilityFilters, IReadOnlyList<string>? excludeVisibilityFilters)
+    {
         var containerNameSql = GetSymbolColumnSql("container_name");
         var containerQualifiedNameSql = GetSymbolColumnSql("container_qualified_name");
         var familyKeySql = GetSymbolColumnSql("family_key");
@@ -1927,8 +2009,7 @@ public partial class DbReader
                 JOIN files f ON s.file_id = f.id
                 WHERE s.kind NOT IN ('import', 'namespace')" + csharpFunctionDefinitionGateSql;
 
-        // Restrict to graph-supported languages only / グラフ対応言語のみに制限
-        var graphLangs = ReferenceExtractor.GetSupportedLanguages();
+        var graphLangs = ReferenceExtractor.GetSupportedLanguages().ToList();
         if (lang != null)
             sql += SymbolLanguageFileIdFilter;
         else
@@ -2186,61 +2267,29 @@ public partial class DbReader
                   ON crc.logical_target_key = gr.logical_target_key
                  AND crc.name = gr.name
                  AND crc.kind = gr.kind
-            )
-            SELECT gr.name, rc.ref_count, rc.ref_score,
-                   gr.kind, gr.path, gr.lang, gr.line,
-                   gr.visibility, gr.container_name
-            FROM grouped_rows gr
-            JOIN reference_counts rc ON rc.symbol_id = gr.symbol_id
-            WHERE rc.ref_count > 0
-            ORDER BY rc.ref_score DESC,
-                     rc.ref_count DESC,
-                     gr.path COLLATE BINARY ASC,
-                     gr.line ASC,
-                     gr.name COLLATE BINARY ASC,
-                     gr.kind COLLATE BINARY ASC,
-                     gr.symbol_id ASC
-            LIMIT @limit";
+            )";
+        return new SymbolHotspotRowsQuery(sql, graphLangs, hotspotFamilyLangs);
+    }
 
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = sql;
-        cmd.Parameters.AddWithValue("@limit", limit);
+    private static void AddSymbolHotspotParameters(SqliteCommand command, SymbolHotspotRowsQuery query, int limit, string? kind, string? lang, IReadOnlyList<string>? pathPatterns, IReadOnlyList<string>? excludePathPatterns, IReadOnlyList<string>? visibilityFilters, IReadOnlyList<string>? excludeVisibilityFilters)
+    {
+        command.Parameters.AddWithValue("@limit", limit);
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            command.Parameters.AddWithValue("@lang", lang);
         else
         {
-            var langList = graphLangs.ToList();
-            for (int i = 0; i < langList.Count; i++)
-                cmd.Parameters.AddWithValue($"@gl{i}", langList[i]);
+            for (int i = 0; i < query.GraphLanguages.Count; i++)
+                command.Parameters.AddWithValue($"@gl{i}", query.GraphLanguages[i]);
         }
-        if (kind != null) cmd.Parameters.AddWithValue("@kind", kind);
-        AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
-        AddVisibilityFilterParameters(cmd, visibilityFilters, excludeVisibilityFilters);
-        for (int i = 0; i < hotspotFamilyLangs.Count; i++)
-            cmd.Parameters.AddWithValue($"@hotspotFamilyLang{i}", hotspotFamilyLangs[i]);
-
-        var results = new List<SymbolHotspotResult>();
-        using var reader = cmd.ExecuteTrackedReader();
-        while (reader.TrackedRead())
-        {
-            results.Add(new SymbolHotspotResult
-            {
-                Symbol = new SymbolResult
-                {
-                    Name = reader.GetString(0),
-                    Kind = reader.GetString(3),
-                    Path = reader.GetString(4),
-                    Lang = GetNullableString(reader, 5),
-                    Line = reader.GetInt32(6),
-                    Visibility = GetNullableString(reader, 7),
-                    ContainerName = GetNullableString(reader, 8),
-                },
-                ReferenceCount = reader.GetInt32(1),
-                ReferenceScore = reader.GetDouble(2),
-            });
-        }
-        return results;
+        if (kind != null)
+            command.Parameters.AddWithValue("@kind", kind);
+        AddPathFilterParameters(command, pathPatterns, excludePathPatterns);
+        AddVisibilityFilterParameters(command, visibilityFilters, excludeVisibilityFilters);
+        for (int i = 0; i < query.HotspotFamilyLanguages.Count; i++)
+            command.Parameters.AddWithValue($"@hotspotFamilyLang{i}", query.HotspotFamilyLanguages[i]);
     }
+
+    private sealed record SymbolHotspotRowsQuery(string Sql, List<string> GraphLanguages, List<string> HotspotFamilyLanguages);
 
     /// <summary>
     /// Return grouped hotspot rows collapsed by (name, kind) after the full filtered site set

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
@@ -166,13 +166,16 @@ public sealed class PostExtractionHookRunner : IDisposable
         if (!task.Wait(callbackBudget))
         {
             stopwatch.Stop();
+            var timeoutDurationMs = Math.Max(
+                stopwatch.ElapsedMilliseconds,
+                (long)Math.Ceiling(callbackBudget.TotalMilliseconds));
             disabledHooks.TryAdd(hook.Info.TypeName, 0);
             diagnostics.Enqueue(new PostExtractionHookDiagnostic(
                 hook.Info.AssemblyPath,
                 hook.Info.TypeName,
                 $"{callback} exceeded the {callbackBudget.TotalMilliseconds:0} ms callback budget; hook disabled for this index run.",
                 callback,
-                stopwatch.ElapsedMilliseconds));
+                timeoutDurationMs));
             return false;
         }
 

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -3188,33 +3188,19 @@ public partial class McpServer
 
         return WithDbReader(id, args, reader =>
         {
-            var results = reader.GetSymbolHotspots(groupBy == "file" ? int.MaxValue : limit, kind, lang, pathPatterns, excludePaths, excludeTests);
+            var fileResults = groupBy == "file"
+                ? reader.GetFileSymbolHotspots(limit, kind, lang, pathPatterns, excludePaths, excludeTests)
+                : null;
+            var results = fileResults == null
+                ? reader.GetSymbolHotspots(limit, kind, lang, pathPatterns, excludePaths, excludeTests)
+                : [];
             var hotspotSignal = reader.GetHotspotFamilySignal(lang);
             var baseSqlGraphSignal = reader.GetSqlGraphContractSignal(lang, pathPatterns, excludePaths, excludeTests);
             var zeroResultSqlGraphSignal = QueryCommandRunner.NarrowSqlGraphContractSignal(
                 baseSqlGraphSignal,
                 reader.ScopeMayIncludeSqlSymbols(kind, lang, pathPatterns, excludePaths, excludeTests));
-            var fileResults = groupBy == "file"
-                ? results
-                    .GroupBy(row => row.Symbol.Path, StringComparer.Ordinal)
-                    .Select(group =>
-                    {
-                        var first = group.First();
-                        return new
-                        {
-                            path = first.Symbol.Path,
-                            lang = first.Symbol.Lang,
-                            reference_count = group.Sum(row => row.ReferenceCount),
-                            symbol_count = group.Count(),
-                        };
-                    })
-                    .OrderByDescending(row => row.reference_count)
-                    .ThenBy(row => row.path, StringComparer.Ordinal)
-                    .Take(limit)
-                    .ToList()
-                : null;
             var resultLangs = fileResults != null
-                ? fileResults.Select(result => result.lang)
+                ? fileResults.Select(result => result.Lang)
                 : results.Select(result => result.Symbol.Lang);
             var visibleCount = fileResults?.Count ?? results.Count;
             var sqlGraphSignal = visibleCount == 0
@@ -3231,10 +3217,10 @@ public partial class McpServer
                 {
                     hotspots.Add(new JsonObject
                     {
-                        ["path"] = result.path,
-                        ["lang"] = result.lang,
-                        ["reference_count"] = result.reference_count,
-                        ["symbol_count"] = result.symbol_count,
+                        ["path"] = result.Path,
+                        ["lang"] = result.Lang,
+                        ["reference_count"] = result.ReferenceCount,
+                        ["symbol_count"] = result.SymbolCount,
                     });
                 }
                 hotspotsNode = hotspots;

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -114,6 +114,14 @@ public class SymbolHotspotResult
     public double ReferenceScore { get; set; }
 }
 
+public class FileHotspotResult
+{
+    public string Path { get; set; } = string.Empty;
+    public string? Lang { get; set; }
+    public int ReferenceCount { get; set; }
+    public int SymbolCount { get; set; }
+}
+
 public class FileResult
 {
     [JsonPropertyName("api_version")]

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -3684,6 +3684,45 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void GetFileSymbolHotspots_GroupsByPathAndAppliesLimit()
+    {
+        InsertIndexedFile("src/file_hotspot_one.py", "python",
+            "def AlphaFileHotspot():\n    return True\n\n" +
+            "def BetaFileHotspot():\n    return True\n\n" +
+            "def use_one():\n    AlphaFileHotspot()\n    AlphaFileHotspot()\n    BetaFileHotspot()\n");
+        InsertIndexedFile("src/file_hotspot_two.py", "python",
+            "def GammaFileHotspot():\n    return True\n\n" +
+            "def use_two():\n    GammaFileHotspot()\n    GammaFileHotspot()\n");
+        InsertIndexedFile("src/file_hotspot_three.py", "python",
+            "def DeltaFileHotspot():\n    return True\n\n" +
+            "def use_three():\n    DeltaFileHotspot()\n");
+
+        var results = _reader.GetFileSymbolHotspots(
+            limit: 2,
+            kind: "function",
+            lang: "python",
+            pathPatterns: ["src/file_hotspot_"],
+            excludePathPatterns: null,
+            excludeTests: false);
+
+        Assert.Collection(results,
+            first =>
+            {
+                Assert.Equal("src/file_hotspot_one.py", first.Path);
+                Assert.Equal("python", first.Lang);
+                Assert.Equal(3, first.ReferenceCount);
+                Assert.Equal(2, first.SymbolCount);
+            },
+            second =>
+            {
+                Assert.Equal("src/file_hotspot_two.py", second.Path);
+                Assert.Equal("python", second.Lang);
+                Assert.Equal(2, second.ReferenceCount);
+                Assert.Equal(1, second.SymbolCount);
+            });
+    }
+
+    [Fact]
     public void GetSymbolHotspots_KeepsCrossFileCountsForSameContainerOverloadFamily()
     {
         InsertIndexedFile("src/api.cs", "csharp",

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -44,6 +44,95 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_LimitZeroStillDetectsDatabaseDrift_Issue2885()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_limit_zero_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_limit_zero_right");
+        try
+        {
+            var leftDb = SeedDb(leftRoot, includeExtraFile: false);
+            var rightDb = SeedDb(rightRoot, includeExtraFile: true);
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--json", "--limit", "0"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            var root = document.RootElement;
+            Assert.Equal("different", root.GetProperty("status").GetString());
+            Assert.False(root.GetProperty("identical").GetBoolean());
+            Assert.Equal(0, root.GetProperty("files_only_in_left").GetArrayLength());
+            Assert.Equal(0, root.GetProperty("files_only_in_right").GetArrayLength());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_DetailedJsonReportsLimitedSymbolRows_Issue2885()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_detailed_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_detailed_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class LeftOnly { public void Run() { } }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class RightOnly { public void Run() { } }");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--json", "--detailed", "--limit", "1"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            var root = document.RootElement;
+            var symbolsOnlyInLeft = root.GetProperty("symbols_only_in_left").EnumerateArray().ToList();
+            var symbolsOnlyInRight = root.GetProperty("symbols_only_in_right").EnumerateArray().ToList();
+            Assert.Single(symbolsOnlyInLeft);
+            Assert.Single(symbolsOnlyInRight);
+            Assert.Contains("LeftOnly", symbolsOnlyInLeft[0].GetString(), StringComparison.Ordinal);
+            Assert.Contains("RightOnly", symbolsOnlyInRight[0].GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_DetailedJsonUsesSqlOrderForStreamingSymbolDiff_Issue2885()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_order_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_order_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/aa.cs", "csharp", "public class aa { }");
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/b.cs", "csharp", "public class b { }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/b.cs", "csharp", "public class b { }");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--json", "--detailed", "--limit", "5"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            var root = document.RootElement;
+            var symbolsOnlyInLeft = root.GetProperty("symbols_only_in_left").EnumerateArray().ToList();
+            var symbolsOnlyInRight = root.GetProperty("symbols_only_in_right").EnumerateArray().ToList();
+            Assert.Contains(symbolsOnlyInLeft, item => item.GetString()?.Contains("src/aa.cs", StringComparison.Ordinal) == true);
+            Assert.DoesNotContain(symbolsOnlyInLeft, item => item.GetString()?.Contains("src/b.cs", StringComparison.Ordinal) == true);
+            Assert.Empty(symbolsOnlyInRight);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_ReturnsSuccessForSeparatelyBuiltIdenticalDatabases_Issue1724()
     {
         var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_identical_left");


### PR DESCRIPTION
## Summary
- Stream `cdidx diff` database comparisons with bounded display rows instead of full in-memory snapshots.
- Aggregate file-grouped symbol hotspots in SQLite for CLI and MCP paths.
- Stabilize hook timeout diagnostics so timeout failures record at least the callback budget.
- Add issue-based changelog fragments for both fixes.

## Validation
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DiffCommandRunnerTests|FullyQualifiedName~DbReaderTests|FullyQualifiedName~RunHotspots_GroupByFileJson_RollsUpSymbolHotspotsByPath|FullyQualifiedName~ToolsCall_SymbolHotspots_GroupByFileReportsGroupingMetadata" -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false`
- `git diff --check`
- `dotnet build CodeIndex.sln --no-restore -p:UseSharedCompilation=false -m:1`
- GitHub Actions on `a7a6cb99a1712dd82f32019d3c491cc8968e20fa`: `Build and Test`, `CodeQL`, and `Changelog Fragments` all succeeded.
- Codex adversarial review: no findings for the original issue fixes; rerun for the CI follow-up was blocked by local Codex/OpenAI connectivity errors.

## Changelog
- `changelog.d/unreleased/2847.fixed.md`
- `changelog.d/unreleased/2885.fixed.md`

Fixes #2885
Fixes #2847