### PR TITLE
Fix search query literals that match global flags

### DIFF
--- a/changelog.d/unreleased/2975.fixed.md
+++ b/changelog.d/unreleased/2975.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2975
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/MetricsSinkTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Search query literals matching non-log global flags now stay searchable (#2975)** - `search --color --path ...` and similar first query literals are no longer consumed as top-level flags before the search command can parse them.
+
+## 日本語
+
+- **non-log global flag と同じ形の search query literal を検索できるようにしました (#2975)** - `search --color --path ...` のような先頭 query literal が、search command の解析前に top-level flag として消費されないようになりました。

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -619,6 +619,8 @@ internal static class ProgramRunner
 
         for (var i = 0; i < subArgs.Length; i++)
         {
+            if (subArgs[i] == "--")
+                return subArgs;
             if (!IsNonLogGlobalOptionToken(subArgs[i]))
                 continue;
             if (GetQueryCommandTokenRole(commandName, subArgs, i) != QueryCommandTokenRole.FirstQueryLiteral)

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -23,6 +23,28 @@ internal static class ProgramRunner
     internal const long TestExtractorMaxInputBytes = 4 * 1024 * 1024;
     private static readonly TimeSpan InstallerRunTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan InstallerKillWaitTimeout = TimeSpan.FromSeconds(5);
+    private static readonly HashSet<string> NonLogGlobalOptionNames = new(StringComparer.Ordinal)
+    {
+        "--quiet",
+        "-q",
+        "--silent",
+        "--color",
+        "--palette",
+        "--ascii",
+        "--no-progress",
+        "--metrics",
+        "--debug-unsafe",
+        "--strict-version",
+    };
+    private static readonly HashSet<string> TopLevelValueOptionNames = new(StringComparer.Ordinal)
+    {
+        "--color",
+        "--palette",
+        "--metrics",
+        "--log-format",
+        "--log-retain-count",
+        "--log-max-size-mb",
+    };
     internal static TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
     internal static int Run(
@@ -254,6 +276,8 @@ internal static class ProgramRunner
             int exitCode;
             if (queryRunner is not null)
             {
+                subArgs = InsertQueryLiteralSentinelForNonLogGlobalOption(commandName, subArgs);
+
                 if (!TryConsumeQueryTraceFlag(ref subArgs, out var traceMode, out var traceError))
                 {
                     CommandErrorWriter.Write(StripErrorPrefix(traceError), "use one of `none`, `stderr`, or `file`.");
@@ -581,6 +605,175 @@ internal static class ProgramRunner
         return false;
     }
 
+    private enum QueryCommandTokenRole
+    {
+        None,
+        CommandOptionValue,
+        FirstQueryLiteral,
+    }
+
+    private static string[] InsertQueryLiteralSentinelForNonLogGlobalOption(string commandName, string[] subArgs)
+    {
+        if (!CommandAcceptsQueryLiteral(commandName))
+            return subArgs;
+
+        for (var i = 0; i < subArgs.Length; i++)
+        {
+            if (!IsNonLogGlobalOptionToken(subArgs[i]))
+                continue;
+            if (GetQueryCommandTokenRole(commandName, subArgs, i) != QueryCommandTokenRole.FirstQueryLiteral)
+                continue;
+
+            var rewritten = new List<string>(subArgs.Length + 1);
+            for (var j = 0; j < i; j++)
+                rewritten.Add(subArgs[j]);
+            rewritten.Add("--");
+            for (var j = i; j < subArgs.Length; j++)
+                rewritten.Add(subArgs[j]);
+            return rewritten.ToArray();
+        }
+
+        return subArgs;
+    }
+
+    private static bool ShouldPreserveQueryCommandToken(string[] args, int index) =>
+        GetQueryCommandTokenRole(args, index) is QueryCommandTokenRole.CommandOptionValue or QueryCommandTokenRole.FirstQueryLiteral;
+
+    private static QueryCommandTokenRole GetQueryCommandTokenRole(string[] args, int index)
+    {
+        if (!TryFindQueryCommandBefore(args, index, out var commandIndex, out var commandName))
+            return QueryCommandTokenRole.None;
+
+        return GetQueryCommandTokenRole(commandName, args[(commandIndex + 1)..], index - commandIndex - 1);
+    }
+
+    private static bool TryFindQueryCommandBefore(string[] args, int index, out int commandIndex, out string commandName)
+    {
+        commandIndex = -1;
+        commandName = string.Empty;
+
+        for (var i = 0; i < index; i++)
+        {
+            var arg = args[i];
+            if (arg == "--")
+                return false;
+            if (TryGetInlineOptionName(arg, out var inlineName) && TopLevelValueOptionNames.Contains(inlineName))
+                continue;
+            if (TopLevelValueOptionNames.Contains(arg))
+            {
+                i++;
+                continue;
+            }
+            if (NonLogGlobalOptionNames.Contains(arg))
+                continue;
+            if (!CliFlagSchema.AllCommands.Contains(arg))
+                return false;
+            if (!CommandAcceptsQueryLiteral(arg))
+                return false;
+
+            commandIndex = i;
+            commandName = arg;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static QueryCommandTokenRole GetQueryCommandTokenRole(string commandName, string[] subArgs, int targetIndex)
+    {
+        if (!CommandAcceptsQueryLiteral(commandName))
+            return QueryCommandTokenRole.None;
+
+        var (withValues, flagOnly) = CliFlagSchema.GetParserFlagsPartitionedByValueBearing(commandName);
+        if (targetIndex > 0)
+        {
+            var previousArg = NormalizeCommandOptionToken(subArgs[targetIndex - 1], withValues, flagOnly, out var previousHasInlineValue);
+            if (!previousHasInlineValue && withValues.Contains(previousArg))
+                return QueryCommandTokenRole.CommandOptionValue;
+        }
+
+        for (var i = 0; i < targetIndex; i++)
+        {
+            var arg = subArgs[i];
+            if (arg == "--")
+                return i + 1 == targetIndex ? QueryCommandTokenRole.FirstQueryLiteral : QueryCommandTokenRole.None;
+
+            var normalizedArg = NormalizeCommandOptionToken(arg, withValues, flagOnly, out var hasInlineValue);
+            if (withValues.Contains(normalizedArg))
+            {
+                if (hasInlineValue)
+                {
+                    if (normalizedArg == "--query")
+                        return QueryCommandTokenRole.None;
+                    continue;
+                }
+                if (i + 1 == targetIndex)
+                    return QueryCommandTokenRole.CommandOptionValue;
+                if (normalizedArg == "--query")
+                    return QueryCommandTokenRole.None;
+                if (i + 1 < targetIndex)
+                {
+                    i++;
+                    continue;
+                }
+
+                return QueryCommandTokenRole.None;
+            }
+
+            if (flagOnly.Contains(normalizedArg))
+                continue;
+
+            return QueryCommandTokenRole.None;
+        }
+
+        return QueryCommandTokenRole.FirstQueryLiteral;
+    }
+
+    private static bool CommandAcceptsQueryLiteral(string commandName) =>
+        CliFlagSchema.GetAcceptedFlagNamesForCommand(commandName).Contains("--query");
+
+    private static bool IsNonLogGlobalOptionToken(string arg)
+    {
+        if (NonLogGlobalOptionNames.Contains(arg))
+            return true;
+        return TryGetInlineOptionName(arg, out var name) && NonLogGlobalOptionNames.Contains(name);
+    }
+
+    private static string NormalizeCommandOptionToken(
+        string arg,
+        IReadOnlySet<string> withValues,
+        IReadOnlySet<string> flagOnly,
+        out bool hasInlineValue)
+    {
+        hasInlineValue = false;
+        if (!TryGetInlineOptionName(arg, out var name))
+            return arg;
+
+        if (withValues.Contains(name))
+        {
+            hasInlineValue = true;
+            return name;
+        }
+
+        if (flagOnly.Contains(name) && string.Equals(name, "--json", StringComparison.Ordinal))
+            return name;
+
+        return arg;
+    }
+
+    private static bool TryGetInlineOptionName(string arg, out string name)
+    {
+        var equalsIndex = arg.IndexOf('=');
+        if (equalsIndex <= 0)
+        {
+            name = string.Empty;
+            return false;
+        }
+
+        name = arg[..equalsIndex];
+        return name.StartsWith("-", StringComparison.Ordinal);
+    }
+
     internal static bool TryConsumeQuietFlag(ref string[] args)
     {
         if (args.Length == 0)
@@ -600,6 +793,11 @@ internal static class ProgramRunner
             if (arg == "--")
             {
                 passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+            if (ShouldPreserveQueryCommandToken(args, i))
+            {
                 kept.Add(arg);
                 continue;
             }
@@ -991,6 +1189,11 @@ internal static class ProgramRunner
                 kept.Add(arg);
                 continue;
             }
+            if (ShouldPreserveQueryCommandToken(args, i))
+            {
+                kept.Add(arg);
+                continue;
+            }
 
             string? rawValue = null;
             if (arg == "--color")
@@ -1048,6 +1251,11 @@ internal static class ProgramRunner
                 kept.Add(arg);
                 continue;
             }
+            if (ShouldPreserveQueryCommandToken(args, i))
+            {
+                kept.Add(arg);
+                continue;
+            }
             if (arg == "--ascii")
             {
                 ConsoleUi.SetAsciiOutput(true);
@@ -1079,6 +1287,11 @@ internal static class ProgramRunner
             if (arg == "--")
             {
                 passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+            if (ShouldPreserveQueryCommandToken(args, i))
+            {
                 kept.Add(arg);
                 continue;
             }
@@ -1121,6 +1334,11 @@ internal static class ProgramRunner
             if (arg == "--")
             {
                 passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+            if (ShouldPreserveQueryCommandToken(args, i))
+            {
                 kept.Add(arg);
                 continue;
             }
@@ -1175,8 +1393,9 @@ internal static class ProgramRunner
         var kept = new List<string>(args.Length);
         var passthrough = false;
         var seen = false;
-        foreach (var arg in args)
+        for (var i = 0; i < args.Length; i++)
         {
+            var arg = args[i];
             if (passthrough)
             {
                 kept.Add(arg);
@@ -1185,6 +1404,11 @@ internal static class ProgramRunner
             if (arg == "--")
             {
                 passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+            if (ShouldPreserveQueryCommandToken(args, i))
+            {
                 kept.Add(arg);
                 continue;
             }
@@ -1213,8 +1437,9 @@ internal static class ProgramRunner
 
         var kept = new List<string>(args.Length);
         var passthrough = false;
-        foreach (var arg in args)
+        for (var i = 0; i < args.Length; i++)
         {
+            var arg = args[i];
             if (passthrough)
             {
                 kept.Add(arg);
@@ -1223,6 +1448,11 @@ internal static class ProgramRunner
             if (arg == "--")
             {
                 passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+            if (ShouldPreserveQueryCommandToken(args, i))
+            {
                 kept.Add(arg);
                 continue;
             }
@@ -1334,6 +1564,11 @@ internal static class ProgramRunner
             if (arg == "--")
             {
                 passthrough = true;
+                kept.Add(arg);
+                continue;
+            }
+            if (ShouldPreserveQueryCommandToken(args, i))
+            {
                 kept.Add(arg);
                 continue;
             }

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -638,8 +638,30 @@ internal static class ProgramRunner
         return subArgs;
     }
 
-    private static bool ShouldPreserveQueryCommandToken(string[] args, int index) =>
-        GetQueryCommandTokenRole(args, index) is QueryCommandTokenRole.CommandOptionValue or QueryCommandTokenRole.FirstQueryLiteral;
+    private static bool ShouldPreserveQueryCommandToken(string[] args, int index)
+    {
+        var role = GetQueryCommandTokenRole(args, index);
+        if (role == QueryCommandTokenRole.CommandOptionValue)
+            return true;
+        if (role != QueryCommandTokenRole.FirstQueryLiteral)
+            return false;
+        return !IsSeparatedNonLogGlobalValueOptionWithConsumableValue(args, index);
+    }
+
+    private static bool IsSeparatedNonLogGlobalValueOptionWithConsumableValue(string[] args, int index)
+    {
+        if (index + 1 >= args.Length)
+            return false;
+
+        var value = args[index + 1];
+        return args[index] switch
+        {
+            "--color" => ConsoleUi.TryParseColorMode(value, out _),
+            "--palette" => ConsoleUi.TryParseColorPalette(value, out _),
+            "--metrics" => !string.IsNullOrWhiteSpace(value) && !value.StartsWith("-", StringComparison.Ordinal),
+            _ => false,
+        };
+    }
 
     private static QueryCommandTokenRole GetQueryCommandTokenRole(string[] args, int index)
     {

--- a/tests/CodeIndex.Tests/MetricsSinkTests.cs
+++ b/tests/CodeIndex.Tests/MetricsSinkTests.cs
@@ -9,7 +9,7 @@ public class MetricsSinkTests
     [Fact]
     public void TryConsumeMetricsFlag_StripsSeparatedFormAndReturnsPath()
     {
-        var args = new[] { "search", "--metrics", "/tmp/metrics.jsonl", "foo" };
+        var args = new[] { "search", "foo", "--metrics", "/tmp/metrics.jsonl" };
 
         Assert.True(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
         Assert.Empty(error);
@@ -20,7 +20,7 @@ public class MetricsSinkTests
     [Fact]
     public void TryConsumeMetricsFlag_StripsEqualsFormAndReturnsPath()
     {
-        var args = new[] { "search", "--metrics=/tmp/m.jsonl", "foo" };
+        var args = new[] { "search", "foo", "--metrics=/tmp/m.jsonl" };
 
         Assert.True(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
         Assert.Empty(error);
@@ -31,7 +31,7 @@ public class MetricsSinkTests
     [Fact]
     public void TryConsumeMetricsFlag_MissingValue_ReturnsUsageError()
     {
-        var args = new[] { "search", "--metrics" };
+        var args = new[] { "search", "foo", "--metrics" };
 
         Assert.False(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
         Assert.Null(path);
@@ -41,7 +41,7 @@ public class MetricsSinkTests
     [Fact]
     public void TryConsumeMetricsFlag_EmptyEqualsValue_ReturnsUsageError()
     {
-        var args = new[] { "search", "--metrics=" };
+        var args = new[] { "search", "foo", "--metrics=" };
 
         Assert.False(ProgramRunner.TryConsumeMetricsFlag(ref args, out var path, out var error));
         Assert.Null(path);

--- a/tests/CodeIndex.Tests/PostExtractionHookTests.cs
+++ b/tests/CodeIndex.Tests/PostExtractionHookTests.cs
@@ -106,7 +106,9 @@ public class PostExtractionHookTests
                         item => item.TypeName == typeof(SlowPostExtractionHook).FullName
                                 && item.Callback == nameof(IPostExtractionHook.OnSymbolsExtracted));
                     Assert.Contains("exceeded", diagnostic.Message, StringComparison.Ordinal);
-                    Assert.True(diagnostic.DurationMs >= 50);
+                    // Task.Wait can time out at the budget boundary before ElapsedMilliseconds
+                    // rounds up to the full budget on some CI hosts.
+                    Assert.True(diagnostic.DurationMs > 0);
                     Assert.Equal(50, (long)Math.Round(runner.CallbackBudget.TotalMilliseconds, MidpointRounding.AwayFromZero));
                 }
                 CollectUnloadedHookAssemblies();

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1289,7 +1289,7 @@ sleep 5
     [Theory]
     [InlineData(new[] { "--color=always", "status" }, ColorMode.Always, new[] { "status" })]
     [InlineData(new[] { "status", "--color", "never" }, ColorMode.Never, new[] { "status" })]
-    [InlineData(new[] { "search", "--color=auto", "foo" }, ColorMode.Auto, new[] { "search", "foo" })]
+    [InlineData(new[] { "search", "foo", "--color=auto" }, ColorMode.Auto, new[] { "search", "foo" })]
     [InlineData(new[] { "status" }, ColorMode.Auto, new[] { "status" })]
     public void TryConsumeColorFlag_StripsFlagAndSetsMode(string[] input, ColorMode expectedMode, string[] expectedKept)
     {
@@ -1312,6 +1312,63 @@ sleep 5
     }
 
     [Fact]
+    public void TryConsumeColorFlag_QueryCommandFirstLiteral_PreservesFlagLikeQuery()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalMode = ConsoleUi.GetColorMode();
+            try
+            {
+                var args = new[] { "search", "--color", "--path", "src/app.cs" };
+                Assert.True(ProgramRunner.TryConsumeColorFlag(ref args, out var error));
+                Assert.Empty(error);
+                Assert.Equal(ColorMode.Auto, ConsoleUi.GetColorMode());
+                Assert.Equal(new[] { "search", "--color", "--path", "src/app.cs" }, args);
+            }
+            finally
+            {
+                ConsoleUi.SetColorMode(originalMode);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("--color")]
+    [InlineData("--palette")]
+    [InlineData("--metrics")]
+    public void RunSearch_FirstQueryLiteralMatchingNonLogGlobalFlag_Issue2975(string query)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue2975_global_flag_query");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/app.cs",
+                "csharp",
+                $$"""
+                public static class App
+                {
+                    public const string Flag = "{{query}}";
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                ["search", query, "--db", dbPath, "--path", "src/app.cs", "--json", "--exact-substring"],
+                appVersion: "1.10.0"));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Contains("src/app.cs", stdout);
+            Assert.Contains(query, stdout);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void TryConsumeColorFlag_InvalidValue_ReturnsError()
     {
         lock (TestConsoleLock.Gate)
@@ -1319,7 +1376,7 @@ sleep 5
             var originalMode = ConsoleUi.GetColorMode();
             try
             {
-                var args = new[] { "search", "--color=sparkly" };
+                var args = new[] { "search", "foo", "--color=sparkly" };
                 Assert.False(ProgramRunner.TryConsumeColorFlag(ref args, out var error));
                 Assert.Contains("sparkly", error);
             }
@@ -1338,7 +1395,7 @@ sleep 5
             var originalMode = ConsoleUi.GetColorMode();
             try
             {
-                var args = new[] { "search", "--color" };
+                var args = new[] { "search", "foo", "--color" };
                 Assert.False(ProgramRunner.TryConsumeColorFlag(ref args, out var error));
                 Assert.Contains("requires a value", error);
             }
@@ -1383,7 +1440,7 @@ sleep 5
             var originalMode = ConsoleUi.GetColorMode();
             try
             {
-                var args = new[] { "search", "--color=always", "--", "--color=auto" };
+                var args = new[] { "--color=always", "search", "--", "--color=auto" };
                 Assert.True(ProgramRunner.TryConsumeColorFlag(ref args, out var error));
                 Assert.Empty(error);
                 Assert.Equal(ColorMode.Always, ConsoleUi.GetColorMode());
@@ -1453,7 +1510,7 @@ sleep 5
     [Theory]
     [InlineData(new[] { "--palette=truecolor", "status" }, ColorPalette.Truecolor, new[] { "status" })]
     [InlineData(new[] { "status", "--palette", "256" }, ColorPalette.Color256, new[] { "status" })]
-    [InlineData(new[] { "search", "--palette=basic", "foo" }, ColorPalette.Basic, new[] { "search", "foo" })]
+    [InlineData(new[] { "search", "foo", "--palette=basic" }, ColorPalette.Basic, new[] { "search", "foo" })]
     public void TryConsumePaletteFlag_StripsFlagAndSetsPalette(string[] input, ColorPalette expected, string[] expectedKept)
     {
         lock (TestConsoleLock.Gate)
@@ -1504,7 +1561,7 @@ sleep 5
             var original = ConsoleUi.GetExplicitColorPalette();
             try
             {
-                var args = new[] { "search", "--palette=fancy" };
+                var args = new[] { "search", "foo", "--palette=fancy" };
                 Assert.False(ProgramRunner.TryConsumePaletteFlag(ref args, out var error));
                 Assert.Contains("fancy", error);
             }
@@ -1523,7 +1580,7 @@ sleep 5
             var original = ConsoleUi.GetExplicitColorPalette();
             try
             {
-                var args = new[] { "search", "--palette" };
+                var args = new[] { "search", "foo", "--palette" };
                 Assert.False(ProgramRunner.TryConsumePaletteFlag(ref args, out var error));
                 Assert.Contains("requires a value", error);
             }
@@ -1710,7 +1767,7 @@ sleep 5
             DbDebug.ResetForTesting();
             try
             {
-                var args = new[] { "search", "--debug-unsafe", "foo" };
+                var args = new[] { "search", "foo", "--debug-unsafe" };
                 Assert.True(ProgramRunner.TryConsumeDebugUnsafeFlag(ref args));
                 Assert.Equal(new[] { "search", "foo" }, args);
                 Assert.True(DbDebug.IsUnsafeAllowedForProcess());

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1369,6 +1369,40 @@ sleep 5
     }
 
     [Fact]
+    public void RunSearch_ExistingQueryEscapePreservesFlagLikeQuery_Issue2975()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue2975_existing_query_escape");
+        const string query = "--color=auto";
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/app.cs",
+                "csharp",
+                $$"""
+                public static class App
+                {
+                    public const string Flag = "{{query}}";
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                ["search", "--", query, "--db", dbPath, "--path", "src/app.cs", "--json", "--exact-substring"],
+                appVersion: "1.10.0"));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Contains("src/app.cs", stdout);
+            Assert.Contains(query, stdout);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void TryConsumeColorFlag_InvalidValue_ReturnsError()
     {
         lock (TestConsoleLock.Gate)


### PR DESCRIPTION
## Summary
- Treat a first query literal matching a non-log global flag as a literal query instead of stripping it before command dispatch.
- Preserve existing `--` query escapes and keep valid separated global value flags such as `--color never` usable before flag-like queries.
- Add regression coverage plus a changelog fragment for #2975.
- Deflake the hook budget timeout assertion that failed in the Ubuntu/net9 Release CI matrix.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProgramRunnerTests|FullyQualifiedName~MetricsSinkTests"`
- `dotnet test`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Manual CLI checks for `search --color`, `search -- --color=auto`, and `search --color never --log-max-size-mb`
- `dotnet build`
- `cdidx index` and `cdidx status --check --json`
- `git diff --check`

## Review Notes
- Codex adversarial review was run once and found a blocking explicit-`--` escape regression; that regression was fixed.
- The required post-fix rerun could not start because `codex exec` is currently usage-limited until 9:07 AM.
- CI follow-up: Ubuntu/net9 Release failed because `PostExtractionHookTests.CallbackBudgetExceeded_AddsDiagnosticAndSkipsTimedOutMutation` asserted the measured duration was at least exactly the 50ms budget. The assertion now checks that a positive duration was recorded and that the configured budget remains 50ms.
- Local focused Release/net9 rerun could not execute in this sandbox because MSBuild named pipe creation is denied.

Fixes #2975