### PR TITLE
Fix update checker cancellation

### DIFF
--- a/changelog.d/unreleased/2908.fixed.md
+++ b/changelog.d/unreleased/2908.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 2908
+affected:
+  - src/CodeIndex/Cli/UpdateChecker.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Update checks now honor caller cancellation (#2908)** — stale-cache release lookups receive the caller-provided cancellation token, and caller-initiated cancellation is no longer swallowed as an update-check failure.
+
+## 日本語
+
+- **更新チェックが呼び出し元の cancellation を尊重するようになりました (#2908)** — cache が stale な release lookup に呼び出し元の cancellation token を渡し、呼び出し元からの cancellation を update-check failure として握りつぶさないようにしました。

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -30,7 +30,8 @@ internal static class ProgramRunner
         JsonSerializerOptions? jsonOptions = null,
         string? appVersion = null,
         string? configStartDirectory = null,
-        Action? beforeDispatchForTesting = null)
+        Action? beforeDispatchForTesting = null,
+        CancellationToken cancellationToken = default)
     {
         appVersion ??= ConsoleUi.LoadVersion();
 
@@ -130,7 +131,7 @@ internal static class ProgramRunner
 
         if (args[0] is "--version" or "-V")
         {
-            var versionExitCode = RunVersion(args[1..], jsonOptions, appVersion);
+            var versionExitCode = RunVersion(args[1..], jsonOptions, appVersion, cancellationToken);
             GlobalToolLog.Info($"command_complete exit_code={versionExitCode} version_only=true");
             EmitCommandMetric("version", args, commandStartTimestamp, commandStopwatch, versionExitCode);
             return versionExitCode;
@@ -138,7 +139,7 @@ internal static class ProgramRunner
 
         if (args[0] == "--check-updates")
         {
-            var updateExitCode = RunCheckUpdates(args[1..], jsonOptions, appVersion);
+            var updateExitCode = RunCheckUpdates(args[1..], jsonOptions, appVersion, cancellationToken);
             GlobalToolLog.Info($"command_complete exit_code={updateExitCode} check_updates=true");
             EmitCommandMetric("check-updates", args, commandStartTimestamp, commandStopwatch, updateExitCode);
             return updateExitCode;
@@ -239,7 +240,7 @@ internal static class ProgramRunner
                 "map" => a => QueryCommandRunner.RunMap(a, jsonOptions),
                 "inspect" => a => QueryCommandRunner.RunInspect(a, jsonOptions),
                 "outline" => a => QueryCommandRunner.RunOutline(a, jsonOptions),
-                "status" => a => QueryCommandRunner.RunStatus(a, jsonOptions, appVersion),
+                "status" => a => QueryCommandRunner.RunStatus(a, jsonOptions, appVersion, cancellationToken),
                 "validate" => a => QueryCommandRunner.RunValidate(a, jsonOptions),
                 "languages" => a => QueryCommandRunner.RunLanguages(a, jsonOptions),
                 "impact" => a => QueryCommandRunner.RunImpact(a, jsonOptions),
@@ -272,7 +273,7 @@ internal static class ProgramRunner
             {
                 exitCode = commandName switch
                 {
-                    "upgrade" => RunUpgrade(subArgs, jsonOptions, appVersion),
+                    "upgrade" => RunUpgrade(subArgs, jsonOptions, appVersion, cancellationToken),
                     "index" => IndexCommandRunner.Run(subArgs, jsonOptions),
                     "export" => ExportImportCommandRunner.RunExport(subArgs, jsonOptions, appVersion),
                     "import" => ExportImportCommandRunner.RunImport(subArgs, jsonOptions),
@@ -2285,7 +2286,11 @@ internal static class ProgramRunner
 
     internal readonly record struct AuditLogOptions(string? Path, long MaxBytes, bool IncludeValues);
 
-    internal static int RunCheckUpdates(string[] cmdArgs, JsonSerializerOptions jsonOptions, string appVersion)
+    internal static int RunCheckUpdates(
+        string[] cmdArgs,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken = default)
     {
         var wantsJson = false;
         foreach (var arg in cmdArgs)
@@ -2300,7 +2305,7 @@ internal static class ProgramRunner
             return CommandExitCodes.UsageError;
         }
 
-        var result = UpdateChecker.Check(appVersion);
+        var result = UpdateChecker.Check(appVersion, cancellationToken);
         if (wantsJson)
         {
             Console.WriteLine(JsonSerializer.Serialize(result, jsonOptions));
@@ -2316,7 +2321,11 @@ internal static class ProgramRunner
         return CommandExitCodes.Success;
     }
 
-    internal static int RunUpgrade(string[] cmdArgs, JsonSerializerOptions jsonOptions, string appVersion)
+    internal static int RunUpgrade(
+        string[] cmdArgs,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken = default)
     {
         var checkOnly = false;
         var wantsJson = false;
@@ -2343,7 +2352,7 @@ internal static class ProgramRunner
             return CommandExitCodes.UsageError;
         }
 
-        var result = UpdateChecker.Check(appVersion);
+        var result = UpdateChecker.Check(appVersion, cancellationToken);
         if (checkOnly || !result.UpdateAvailable || result.LatestVersion == null)
         {
             if (wantsJson)
@@ -2512,7 +2521,11 @@ internal static class ProgramRunner
     // ビルド情報付きにする (#1550)。人間出力は 1 行に保ち、install.sh の
     // reinstall validator が末尾診断文を誤って許容しないよう、括弧で囲った
     // メタデータ以外を許さない形に揃える。
-    internal static int RunVersion(string[] cmdArgs, JsonSerializerOptions jsonOptions, string? appVersion = null)
+    internal static int RunVersion(
+        string[] cmdArgs,
+        JsonSerializerOptions jsonOptions,
+        string? appVersion = null,
+        CancellationToken cancellationToken = default)
     {
         var wantsJson = false;
         foreach (var arg in cmdArgs)
@@ -2550,7 +2563,7 @@ internal static class ProgramRunner
             return CommandExitCodes.Success;
         }
 
-        var updateHint = UpdateChecker.GetNewerReleaseHint(metadata.Version);
+        var updateHint = UpdateChecker.GetNewerReleaseHint(metadata.Version, cancellationToken);
         Console.WriteLine(FormatVersionLine(metadata, updateHint));
         return CommandExitCodes.Success;
     }

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -2902,7 +2902,11 @@ public static class QueryCommandRunner
         return false;
     }
 
-    public static int RunStatus(string[] cmdArgs, JsonSerializerOptions jsonOptions, string? appVersion = null)
+    public static int RunStatus(
+        string[] cmdArgs,
+        JsonSerializerOptions jsonOptions,
+        string? appVersion = null,
+        CancellationToken cancellationToken = default)
     {
         var checkUpdates = cmdArgs.Contains("--check-updates", StringComparer.Ordinal);
         if (checkUpdates)
@@ -3015,7 +3019,7 @@ public static class QueryCommandRunner
             if (appVersion != null)
                 status.Version = appVersion;
             var updateResult = checkUpdates && appVersion != null
-                ? UpdateChecker.Check(appVersion)
+                ? UpdateChecker.Check(appVersion, cancellationToken)
                 : null;
             status.UpdateCheck = updateResult;
 

--- a/src/CodeIndex/Cli/UpdateChecker.cs
+++ b/src/CodeIndex/Cli/UpdateChecker.cs
@@ -15,25 +15,28 @@ internal static class UpdateChecker
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
     private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(2);
 
-    internal static string? GetNewerReleaseHint(string currentVersion)
+    internal static string? GetNewerReleaseHint(string currentVersion, CancellationToken cancellationToken = default)
         => GetNewerReleaseHint(
             currentVersion,
             ResolveDefaultCachePath(),
             DateTimeOffset.UtcNow,
-            FetchLatestReleaseTagAsync);
+            FetchLatestReleaseTagAsync,
+            cancellationToken);
 
-    internal static UpdateCheckResult Check(string currentVersion)
+    internal static UpdateCheckResult Check(string currentVersion, CancellationToken cancellationToken = default)
         => Check(
             currentVersion,
             ResolveDefaultCachePath(),
             DateTimeOffset.UtcNow,
-            FetchLatestReleaseTagAsync);
+            FetchLatestReleaseTagAsync,
+            cancellationToken);
 
     internal static UpdateCheckResult Check(
         string currentVersion,
         string cachePath,
         DateTimeOffset now,
-        Func<CancellationToken, Task<string?>> fetchLatestReleaseTagAsync)
+        Func<CancellationToken, Task<string?>> fetchLatestReleaseTagAsync,
+        CancellationToken cancellationToken = default)
     {
         if (IsDisabled())
             return new UpdateCheckResult(currentVersion, null, false, false, "disabled");
@@ -47,9 +50,13 @@ internal static class UpdateChecker
         {
             try
             {
-                latestTag = fetchLatestReleaseTagAsync(CancellationToken.None)
+                latestTag = fetchLatestReleaseTagAsync(cancellationToken)
                     .GetAwaiter()
                     .GetResult();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -72,7 +79,8 @@ internal static class UpdateChecker
         string currentVersion,
         string cachePath,
         DateTimeOffset now,
-        Func<CancellationToken, Task<string?>> fetchLatestReleaseTagAsync)
+        Func<CancellationToken, Task<string?>> fetchLatestReleaseTagAsync,
+        CancellationToken cancellationToken = default)
     {
         if (IsDisabled())
             return null;
@@ -92,9 +100,13 @@ internal static class UpdateChecker
         string? latestTag = null;
         try
         {
-            latestTag = fetchLatestReleaseTagAsync(CancellationToken.None)
+            latestTag = fetchLatestReleaseTagAsync(cancellationToken)
                 .GetAwaiter()
                 .GetResult();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -436,6 +436,58 @@ public class ProgramRunnerTests
         }
     }
 
+    [Fact]
+    public void UpdateChecker_Check_PassesCallerCancellationTokenToFetch()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"cdidx_update_check_{Guid.NewGuid():N}.json");
+        using var cts = new CancellationTokenSource();
+        CancellationToken observedToken = default;
+        try
+        {
+            var result = UpdateChecker.Check(
+                "1.10.0",
+                cachePath,
+                DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+                token =>
+                {
+                    observedToken = token;
+                    return Task.FromResult<string?>("v1.11.0");
+                },
+                cts.Token);
+
+            Assert.Equal(cts.Token, observedToken);
+            Assert.True(result.UpdateAvailable);
+        }
+        finally
+        {
+            if (File.Exists(cachePath))
+                File.Delete(cachePath);
+        }
+    }
+
+    [Fact]
+    public void UpdateChecker_Check_PropagatesCallerCancellation()
+    {
+        var cachePath = Path.Combine(Path.GetTempPath(), $"cdidx_update_check_{Guid.NewGuid():N}.json");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        try
+        {
+            Assert.Throws<OperationCanceledException>(() =>
+                UpdateChecker.Check(
+                    "1.10.0",
+                    cachePath,
+                    DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+                    token => throw new OperationCanceledException(token),
+                    cts.Token));
+        }
+        finally
+        {
+            if (File.Exists(cachePath))
+                File.Delete(cachePath);
+        }
+    }
+
     [Theory]
     [InlineData("v1.26.0", "https://raw.githubusercontent.com/Widthdom/CodeIndex/v1.26.0/install.sh")]
     [InlineData(" release/test ", "https://raw.githubusercontent.com/Widthdom/CodeIndex/release%2Ftest/install.sh")]
@@ -1689,6 +1741,23 @@ sleep 5
             _ => throw new InvalidOperationException("should not fetch"));
 
         Assert.Null(hint);
+    }
+
+    [Fact]
+    public void UpdateChecker_GetNewerReleaseHint_PropagatesCallerCancellation()
+    {
+        using var env = EnvironmentVariableScope.Capture(UpdateChecker.DisableEnvVar);
+        env.Set(UpdateChecker.DisableEnvVar, null);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            UpdateChecker.GetNewerReleaseHint(
+                "1.10.0",
+                Path.Combine(Path.GetTempPath(), $"cdidx_update_check_{Guid.NewGuid():N}.json"),
+                DateTimeOffset.UtcNow,
+                token => throw new OperationCanceledException(token),
+                cts.Token));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Thread caller-provided cancellation tokens through update-check entry points.
- Preserve timeout best-effort behavior while rethrowing caller-initiated cancellation.
- Add regression coverage for update-check token propagation and cancellation handling.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProgramRunnerTests"`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog
- Added `changelog.d/unreleased/2908.fixed.md`.

## Review
- Adversarial review found no blocking/actionable issues.
- `codex exec review --base origin/main` was attempted but could not complete because the Codex CLI reported a usage limit.

## Follow-up candidates
- None.

Fixes #2908