### PR TITLE
Fix suggestion duplicate issue lookup

### DIFF
--- a/changelog.d/unreleased/2833.fixed.md
+++ b/changelog.d/unreleased/2833.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2833
+affected:
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+---
+
+## English
+
+- **Suggestion submission duplicate lookup now ignores closed issues and pull requests (#2833)** — GitHub duplicate checks now search only open issues and skip pull-request records so closed history no longer suppresses new actionable suggestions.
+
+## 日本語
+
+- **提案送信の重複 lookup が closed issue と pull request を無視するようになりました (#2833)** — GitHub の重複確認は open issue のみを検索し、pull request レコードを除外するため、closed 履歴によって新しい対応可能な提案が抑止されなくなりました。

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -206,7 +206,7 @@ internal static class GitHubIssueReporter
     }
 
     /// <summary>
-    /// Search the target GitHub repository for an existing Issue whose body
+    /// Search the target GitHub repository for an existing open Issue whose body
     /// contains the suggestion hash. The primary check uses GitHub Search;
     /// the backstop lists issues by the labels cdidx would apply so same-second retries
     /// are not exposed to Search indexing latency. Returns the html_url of the
@@ -214,7 +214,7 @@ internal static class GitHubIssueReporter
     /// search with. On API failure this returns null — the caller falls through
     /// to the normal create path so a GitHub-side lookup outage never blocks a
     /// legitimate first submission.
-    /// 当該提案ハッシュを含む既存 Issue を対象リポジトリから検索する。
+    /// 当該提案ハッシュを含む open 既存 Issue を対象リポジトリから検索する。
     /// 主経路は GitHub Search を使い、backstop として cdidx が付ける label の Issue を
     /// 直接一覧取得することで、同秒の再試行が Search の index 遅延に影響されない
     /// ようにする。一致した最初の Issue の html_url を返す。一致なし、またはハッシュが
@@ -245,7 +245,7 @@ internal static class GitHubIssueReporter
 
     private static async Task<string?> SearchExistingIssueByHashAsync(string hash, string token, CancellationToken cancellationToken)
     {
-        var query = Uri.EscapeDataString($"repo:{RepoOwner}/{RepoName} \"{hash}\" in:body");
+        var query = Uri.EscapeDataString($"repo:{RepoOwner}/{RepoName} is:issue is:open \"{hash}\" in:body");
         var url = $"{ApiBase}/search/issues?q={query}&per_page=1";
 
         using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
@@ -261,7 +261,14 @@ internal static class GitHubIssueReporter
         if (items == null || items.Count == 0)
             return null;
 
-        return items[0]?["html_url"]?.GetValue<string>();
+        foreach (var item in items)
+        {
+            var itemUrl = TryGetOpenIssueUrl(item);
+            if (itemUrl != null)
+                return itemUrl;
+        }
+
+        return null;
     }
 
     private static async Task<string?> ListExistingSuggestionIssueByHashAsync(
@@ -275,7 +282,7 @@ internal static class GitHubIssueReporter
             for (var page = 1; ; page++)
             {
                 var labels = Uri.EscapeDataString(label);
-                var url = $"{ApiBase}/repos/{RepoOwner}/{RepoName}/issues?labels={labels}&state=all&per_page=100&page={page}";
+                var url = $"{ApiBase}/repos/{RepoOwner}/{RepoName}/issues?labels={labels}&state=open&per_page=100&page={page}";
 
                 using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -292,8 +299,9 @@ internal static class GitHubIssueReporter
                 foreach (var item in items)
                 {
                     var body = item?["body"]?.GetValue<string>();
-                    if (body != null && body.Contains(hash, StringComparison.Ordinal))
-                        return item?["html_url"]?.GetValue<string>();
+                    var itemUrl = TryGetOpenIssueUrl(item);
+                    if (itemUrl != null && body != null && body.Contains(hash, StringComparison.Ordinal))
+                        return itemUrl;
                 }
 
                 if (items.Count < 100)
@@ -302,6 +310,18 @@ internal static class GitHubIssueReporter
         }
 
         return null;
+    }
+
+    private static string? TryGetOpenIssueUrl(JsonNode? item)
+    {
+        if (item == null || item["pull_request"] != null)
+            return null;
+
+        var state = item["state"]?.GetValue<string>();
+        if (state != null && !string.Equals(state, "open", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return item["html_url"]?.GetValue<string>();
     }
 
     private static bool IsHexHash(string value)

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -547,8 +547,84 @@ public class GitHubIssueReporterTests : IDisposable
             Assert.Equal("/search/issues", handler.Requests[0].RequestUri!.AbsolutePath);
             Assert.Equal("/repos/widthdom/CodeIndex/issues", handler.Requests[1].RequestUri!.AbsolutePath);
             Assert.Contains("labels=enhancement", handler.Requests[1].RequestUri!.Query);
-            Assert.Contains("state=all", handler.Requests[1].RequestUri!.Query);
+            Assert.Contains("state=open", handler.Requests[1].RequestUri!.Query);
+            Assert.DoesNotContain("state=all", handler.Requests[1].RequestUri!.Query);
             Assert.DoesNotContain(handler.Requests, r => r.Method == HttpMethod.Post);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryCreateIssueAsync_DuplicateLookupIgnoresClosedIssuesAndPullRequests()
+    {
+        // Closed history and PRs can mention the same suggestion hash, but only
+        // open Issues should suppress a new actionable submission.
+        // closed 済み履歴や PR が同じ提案ハッシュを含んでも、新規送信を抑止するのは
+        // open Issue のみであること。
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var record = MakeRecordWithKnownHash();
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent($$"""
+                {
+                    "total_count": 2,
+                    "items": [
+                        {
+                            "html_url": "https://github.com/widthdom/CodeIndex/issues/1357",
+                            "state": "closed",
+                            "body": "Submitted by cdidx. Hash: `{{record.Hash}}`"
+                        },
+                        {
+                            "html_url": "https://github.com/widthdom/CodeIndex/pull/2468",
+                            "state": "open",
+                            "pull_request": {},
+                            "body": "Submitted by cdidx. Hash: `{{record.Hash}}`"
+                        }
+                    ]
+                }
+                """),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/repos/widthdom/CodeIndex/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent($$"""
+                [
+                    {
+                        "html_url": "https://github.com/widthdom/CodeIndex/pull/9753",
+                        "state": "open",
+                        "pull_request": {},
+                        "body": "Submitted by cdidx. Hash: `{{record.Hash}}`"
+                    }
+                ]
+                """),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = MakeJsonContent("""{ "html_url": "https://github.com/widthdom/CodeIndex/issues/12345" }"""),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/12345", url);
+            Assert.Equal(3, handler.RequestCount);
+
+            var searchQuery = Uri.UnescapeDataString(handler.Requests[0].RequestUri!.Query);
+            Assert.Contains("is:issue", searchQuery);
+            Assert.Contains("is:open", searchQuery);
+            Assert.Contains("in:body", searchQuery);
+            Assert.Contains("state=open", handler.Requests[1].RequestUri!.Query);
+            Assert.DoesNotContain("state=all", handler.Requests[1].RequestUri!.Query);
+            Assert.Equal(HttpMethod.Post, handler.Requests[2].Method);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Restrict suggestion duplicate Search API lookup to open issues and explicitly exclude pull-request records.
- Change the label-list fallback to open issues only, with PR records skipped before hash matching.
- Add regression coverage for closed issues / PRs and a bilingual changelog fragment.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~GitHubIssueReporterTests"`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/2833.fixed.md`.
- README / user guide updates were not needed because this changes GitHub duplicate suppression behavior without changing documented CLI flags or output contracts.

## Review

- Adversarial review: No blocking/actionable issues found.

Fixes #2833
