### PR TITLE
[codex] Bound db maintenance output

### DIFF
--- a/changelog.d/unreleased/2880.fixed.md
+++ b/changelog.d/unreleased/2880.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2880
+affected:
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+---
+
+## English
+
+- **`db checkpoints --list` now bounds checkpoint enumeration (#2880)** — checkpoint listing now caps checkpoint directories and files inspected per checkpoint, and reports truncation in text and JSON output when those caps are hit.
+
+## 日本語
+
+- **`db checkpoints --list` が checkpoint 列挙を上限付きにしました (#2880)** — checkpoint 一覧は checkpoint ディレクトリ数と checkpoint ごとの検査ファイル数を制限し、上限に達した場合は text / JSON 出力で truncation を報告します。

--- a/changelog.d/unreleased/2881.fixed.md
+++ b/changelog.d/unreleased/2881.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2881
+affected:
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+---
+
+## English
+
+- **`db --integrity-check` and `db schema` now cap diagnostic output (#2881)** — integrity rows, schema entries, and long schema SQL text are now bounded, with truncation metadata exposed in text and JSON output.
+
+## 日本語
+
+- **`db --integrity-check` と `db schema` が診断出力を上限付きにしました (#2881)** — integrity 行、schema entry、長い schema SQL text を制限し、truncation metadata を text / JSON 出力で公開します。

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -13,6 +13,8 @@ public static class DbCommandRunner
 {
     private const string CheckpointsDirectorySuffix = ".checkpoints";
     private const string AutoCheckpointPrefix = "auto-";
+    internal const int CheckpointListEntryLimit = 100;
+    internal const int CheckpointFileInspectLimit = 32;
     private static readonly char[] InvalidCheckpointNameChars = Path.GetInvalidFileNameChars();
     internal static Action? RestoreFailureAfterBackupForTesting { get; set; }
 
@@ -274,7 +276,14 @@ public static class DbCommandRunner
             if (options.Json)
             {
                 Console.WriteLine(JsonSerializer.Serialize(
-                    new DbCheckpointJsonResult("success", fullDbPath, result.Name, result.CheckpointPath, result.Files),
+                    new DbCheckpointJsonResult(
+                        "success",
+                        fullDbPath,
+                        result.Name,
+                        result.CheckpointPath,
+                        result.Files,
+                        result.FilesTruncated,
+                        CheckpointFileInspectLimit),
                     CliJsonSerializerContextFactory.Create(jsonOptions).DbCheckpointJsonResult));
             }
             else
@@ -283,7 +292,7 @@ public static class DbCommandRunner
                 Console.WriteLine($"  database  : {fullDbPath}");
                 Console.WriteLine($"  name      : {result.Name}");
                 Console.WriteLine($"  checkpoint: {result.CheckpointPath}");
-                Console.WriteLine($"  files     : {ConsoleUi.Counted(result.Files.Count, "file")}");
+                Console.WriteLine($"  files     : {ConsoleUi.Counted(result.Files.Count, "file")}{(result.FilesTruncated ? " (truncated)" : string.Empty)}");
             }
 
             return CommandExitCodes.Success;
@@ -305,25 +314,32 @@ public static class DbCommandRunner
         if (!TryResolveFileDb(options.DbPath, out var fullDbPath, out var error))
             return WriteCommandError(options.Json, jsonOptions, error, CommandExitCodes.DatabaseError, "Use a filesystem database path, not a SQLite URI.", CommandErrorCodes.DbError);
 
-        var entries = ListCheckpoints(fullDbPath);
+        var result = ListCheckpoints(fullDbPath);
         if (options.Json)
         {
             Console.WriteLine(JsonSerializer.Serialize(
-                new DbCheckpointListJsonResult(fullDbPath, entries),
+                new DbCheckpointListJsonResult(
+                    fullDbPath,
+                    result.Entries,
+                    result.Truncated,
+                    CheckpointListEntryLimit,
+                    CheckpointFileInspectLimit),
                 CliJsonSerializerContextFactory.Create(jsonOptions).DbCheckpointListJsonResult));
         }
         else
         {
             Console.WriteLine("Database checkpoints");
             Console.WriteLine($"  database: {fullDbPath}");
-            if (entries.Count == 0)
+            if (result.Truncated)
+                Console.WriteLine($"  truncated: yes (checkpoint directory limit {CheckpointListEntryLimit:N0}, file limit {CheckpointFileInspectLimit:N0} per checkpoint)");
+            if (result.Entries.Count == 0)
             {
                 Console.WriteLine("  checkpoints: none");
             }
             else
             {
-                foreach (var entry in entries)
-                    Console.WriteLine($"  {entry.Name}  {entry.CreatedAtUtc}  {entry.Bytes:N0} bytes");
+                foreach (var entry in result.Entries)
+                    Console.WriteLine($"  {entry.Name}  {entry.CreatedAtUtc}  {entry.Bytes:N0} bytes{(entry.FilesTruncated ? " (files truncated)" : string.Empty)}");
             }
         }
 
@@ -599,28 +615,83 @@ public static class DbCommandRunner
             throw;
         }
 
-        var files = Directory.GetFiles(checkpointPath).Select(Path.GetFileName).Where(f => f is not null).Select(f => f!).OrderBy(f => f, StringComparer.Ordinal).ToList();
-        return new DbCheckpointOperationResult(name, checkpointPath, files);
+        var files = EnumerateCheckpointFileNames(checkpointPath);
+        return new DbCheckpointOperationResult(name, checkpointPath, files.Items, files.Truncated);
     }
 
-    private static List<DbCheckpointListEntryJsonResult> ListCheckpoints(string fullDbPath)
+    private static DbCheckpointListReadResult ListCheckpoints(string fullDbPath)
     {
         var root = GetCheckpointRoot(fullDbPath);
         if (!Directory.Exists(root))
-            return [];
+            return new DbCheckpointListReadResult([], Truncated: false);
 
         var dbFileName = Path.GetFileName(fullDbPath);
-        return Directory.GetDirectories(root)
-            .Where(path => !Path.GetFileName(path).StartsWith(".tmp-", StringComparison.Ordinal))
-            .Where(path => File.Exists(LongPath.EnsureWindowsPrefix(Path.Combine(path, dbFileName))))
-            .Select(path =>
+        var entries = new List<DbCheckpointListEntryJsonResult>();
+        var checkpointsTruncated = false;
+        var directoriesInspected = 0;
+        foreach (var path in Directory.EnumerateDirectories(root))
+        {
+            if (directoriesInspected >= CheckpointListEntryLimit)
             {
-                var info = new DirectoryInfo(path);
-                var bytes = Directory.GetFiles(path).Sum(file => new FileInfo(file).Length);
-                return new DbCheckpointListEntryJsonResult(info.Name, path, info.CreationTimeUtc.ToString("O", System.Globalization.CultureInfo.InvariantCulture), bytes);
-            })
-            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
-            .ToList();
+                checkpointsTruncated = true;
+                break;
+            }
+
+            directoriesInspected++;
+            if (Path.GetFileName(path).StartsWith(".tmp-", StringComparison.Ordinal))
+                continue;
+            if (!File.Exists(LongPath.EnsureWindowsPrefix(Path.Combine(path, dbFileName))))
+                continue;
+
+            var info = new DirectoryInfo(path);
+            var bytes = SumCheckpointBytes(path);
+            entries.Add(new DbCheckpointListEntryJsonResult(
+                info.Name,
+                path,
+                info.CreationTimeUtc.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+                bytes.Bytes,
+                bytes.Truncated));
+        }
+
+        entries.Sort((left, right) => string.Compare(left.Name, right.Name, StringComparison.Ordinal));
+        return new DbCheckpointListReadResult(entries, checkpointsTruncated || entries.Any(entry => entry.FilesTruncated));
+    }
+
+    private static (List<string> Items, bool Truncated) EnumerateCheckpointFileNames(string checkpointPath)
+    {
+        var files = new List<string>();
+        var truncated = false;
+        foreach (var file in Directory.EnumerateFiles(checkpointPath))
+        {
+            if (files.Count >= CheckpointFileInspectLimit)
+            {
+                truncated = true;
+                break;
+            }
+
+            var name = Path.GetFileName(file);
+            if (name is not null)
+                files.Add(name);
+        }
+
+        files.Sort(StringComparer.Ordinal);
+        return (files, truncated);
+    }
+
+    private static (long Bytes, bool Truncated) SumCheckpointBytes(string checkpointPath)
+    {
+        long bytes = 0;
+        var filesSeen = 0;
+        foreach (var file in Directory.EnumerateFiles(checkpointPath))
+        {
+            if (filesSeen >= CheckpointFileInspectLimit)
+                return (bytes, Truncated: true);
+
+            bytes += new FileInfo(file).Length;
+            filesSeen++;
+        }
+
+        return (bytes, Truncated: false);
     }
 
     private static string RestoreCheckpoint(string fullDbPath, string name, string checkpointPath)
@@ -856,4 +927,6 @@ internal sealed class DbCommandOptions
     public string? ParseError { get; init; }
 }
 
-internal sealed record DbCheckpointOperationResult(string Name, string CheckpointPath, List<string> Files);
+internal sealed record DbCheckpointOperationResult(string Name, string CheckpointPath, List<string> Files, bool FilesTruncated);
+
+internal sealed record DbCheckpointListReadResult(List<DbCheckpointListEntryJsonResult> Entries, bool Truncated);

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -15,8 +15,13 @@ public static class DbCommandRunner
     private const string AutoCheckpointPrefix = "auto-";
     internal const int CheckpointListEntryLimit = 100;
     internal const int CheckpointFileInspectLimit = 32;
+    internal const int IntegrityCheckRowLimit = 100;
+    internal const int IntegrityCheckTextLimit = 4096;
+    internal const int SchemaEntryLimit = 200;
+    internal const int SchemaSqlTextLimit = 8192;
     private static readonly char[] InvalidCheckpointNameChars = Path.GetInvalidFileNameChars();
     internal static Action? RestoreFailureAfterBackupForTesting { get; set; }
+    internal static Func<IEnumerable<string>>? IntegrityCheckRowsForTesting { get; set; }
 
     public static int Run(string[] cmdArgs, JsonSerializerOptions jsonOptions)
     {
@@ -101,7 +106,8 @@ public static class DbCommandRunner
     {
         try
         {
-            var issues = RunIntegrityCheckPragma(dbPath);
+            var result = RunIntegrityCheckPragma(dbPath);
+            var issues = result.Rows;
             var ok = issues.Count == 1 && string.Equals(issues[0], "ok", StringComparison.Ordinal);
             var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
 
@@ -111,7 +117,12 @@ public static class DbCommandRunner
                     new DbIntegrityCheckJsonResult(
                         Path.GetFullPath(isUri ? dbPath : dbPath),
                         ok,
-                        ok ? new List<string>() : issues),
+                        ok ? new List<string>() : issues,
+                        result.Truncated,
+                        result.RowsTruncated,
+                        result.TextTruncated,
+                        IntegrityCheckRowLimit,
+                        IntegrityCheckTextLimit),
                     jsonContext.DbIntegrityCheckJsonResult));
             }
             else
@@ -121,7 +132,9 @@ public static class DbCommandRunner
                 Console.WriteLine($"  result  : {(ok ? "ok" : "corrupted")}");
                 if (!ok)
                 {
-                    Console.WriteLine($"  issues  : {ConsoleUi.Counted(issues.Count, "row")}");
+                    Console.WriteLine($"  issues  : {ConsoleUi.Counted(issues.Count, "row")}{(result.RowsTruncated ? " (truncated)" : string.Empty)}");
+                    if (result.Truncated)
+                        Console.WriteLine($"  truncated: yes (row limit {IntegrityCheckRowLimit:N0}, text limit {IntegrityCheckTextLimit:N0} chars)");
                     foreach (var line in issues)
                         Console.WriteLine($"    - {line}");
                     Console.WriteLine();
@@ -157,7 +170,15 @@ public static class DbCommandRunner
             {
                 var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
                 Console.WriteLine(JsonSerializer.Serialize(
-                    new DbSchemaJsonResult(fullPath, schema.UserVersion, schema.Entries),
+                    new DbSchemaJsonResult(
+                        fullPath,
+                        schema.UserVersion,
+                        schema.Entries,
+                        schema.Truncated,
+                        schema.EntriesTruncated,
+                        schema.SqlTruncated,
+                        SchemaEntryLimit,
+                        SchemaSqlTextLimit),
                     jsonContext.DbSchemaJsonResult));
             }
             else
@@ -165,6 +186,8 @@ public static class DbCommandRunner
                 Console.WriteLine("Database schema");
                 Console.WriteLine($"  database    : {fullPath}");
                 Console.WriteLine($"  user_version: {schema.UserVersion}");
+                if (schema.Truncated)
+                    Console.WriteLine($"  truncated   : yes (entry limit {SchemaEntryLimit:N0}, SQL text limit {SchemaSqlTextLimit:N0} chars)");
                 foreach (var entry in schema.Entries)
                 {
                     Console.WriteLine();
@@ -394,8 +417,11 @@ public static class DbCommandRunner
     // pragma side effects of the normal DbContext open path.
     // PRAGMA integrity_check は問題が無ければ 1 行の `"ok"` を、破損があれば最大 N 行の検出結果を返す。
     // 読み取りのみのため read-only 接続で十分で、DbContext の WAL モード設定副作用を避けられる。
-    private static List<string> RunIntegrityCheckPragma(string dbPath)
+    private static DbIntegrityCheckReadResult RunIntegrityCheckPragma(string dbPath)
     {
+        if (IntegrityCheckRowsForTesting != null)
+            return BoundIntegrityRows(IntegrityCheckRowsForTesting());
+
         var connectionString = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
             ? $"Data Source={dbPath}"
             : new SqliteConnectionStringBuilder
@@ -407,18 +433,28 @@ public static class DbCommandRunner
         using var connection = new SqliteConnection(connectionString);
         connection.Open();
         using var cmd = connection.CreateCommand();
-        cmd.CommandText = "PRAGMA integrity_check";
+        cmd.CommandText = $"PRAGMA integrity_check({IntegrityCheckRowLimit + 1})";
         using var reader = cmd.ExecuteReader();
         var rows = new List<string>();
+        var rowsTruncated = false;
+        var textTruncated = false;
         while (reader.Read())
         {
+            if (rows.Count >= IntegrityCheckRowLimit)
+            {
+                rowsTruncated = true;
+                break;
+            }
+
             var raw = reader.IsDBNull(0) ? string.Empty : reader.GetString(0);
-            rows.Add(raw);
+            var bounded = TruncateDiagnosticText(raw, IntegrityCheckTextLimit);
+            textTruncated |= bounded.Truncated;
+            rows.Add(bounded.Text);
         }
-        return rows.Count > 0 ? rows : new List<string> { "ok" };
+        return new DbIntegrityCheckReadResult(rows.Count > 0 ? rows : new List<string> { "ok" }, rowsTruncated, textTruncated);
     }
 
-    private static (int UserVersion, List<DbSchemaEntryJsonResult> Entries) ReadSchema(string dbPath)
+    private static DbSchemaReadResult ReadSchema(string dbPath)
     {
         using var connection = OpenConnection(dbPath, writable: false);
         using var versionCmd = connection.CreateCommand();
@@ -428,22 +464,64 @@ public static class DbCommandRunner
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
-            SELECT type, name, tbl_name, sql
+            SELECT type, name, tbl_name, substr(sql, 1, @sql_limit)
             FROM sqlite_master
             WHERE type IN ('table', 'index', 'trigger', 'view')
-            ORDER BY type, name";
+            ORDER BY type, name
+            LIMIT @entry_limit";
+        cmd.Parameters.AddWithValue("@sql_limit", SchemaSqlTextLimit + 1);
+        cmd.Parameters.AddWithValue("@entry_limit", SchemaEntryLimit + 1);
         using var reader = cmd.ExecuteReader();
         var entries = new List<DbSchemaEntryJsonResult>();
+        var entriesTruncated = false;
+        var sqlTruncated = false;
         while (reader.Read())
         {
+            if (entries.Count >= SchemaEntryLimit)
+            {
+                entriesTruncated = true;
+                break;
+            }
+
+            var rawSql = reader.IsDBNull(3) ? null : reader.GetString(3);
+            var boundedSql = rawSql is null ? (Text: (string?)null, Truncated: false) : TruncateDiagnosticText(rawSql, SchemaSqlTextLimit);
+            sqlTruncated |= boundedSql.Truncated;
             entries.Add(new DbSchemaEntryJsonResult(
                 reader.GetString(0),
                 reader.GetString(1),
                 reader.IsDBNull(2) ? null : reader.GetString(2),
-                reader.IsDBNull(3) ? null : reader.GetString(3)));
+                boundedSql.Text));
         }
 
-        return (userVersion, entries);
+        return new DbSchemaReadResult(userVersion, entries, entriesTruncated, sqlTruncated);
+    }
+
+    private static DbIntegrityCheckReadResult BoundIntegrityRows(IEnumerable<string> rawRows)
+    {
+        var rows = new List<string>();
+        var rowsTruncated = false;
+        var textTruncated = false;
+        foreach (var raw in rawRows)
+        {
+            if (rows.Count >= IntegrityCheckRowLimit)
+            {
+                rowsTruncated = true;
+                break;
+            }
+
+            var bounded = TruncateDiagnosticText(raw, IntegrityCheckTextLimit);
+            textTruncated |= bounded.Truncated;
+            rows.Add(bounded.Text);
+        }
+
+        return new DbIntegrityCheckReadResult(rows.Count > 0 ? rows : new List<string> { "ok" }, rowsTruncated, textTruncated);
+    }
+
+    private static (string Text, bool Truncated) TruncateDiagnosticText(string text, int limit)
+    {
+        if (text.Length <= limit)
+            return (text, false);
+        return (text[..limit] + " [truncated]", true);
     }
 
     private static (int OrphanSymbolReferences, int OrphanReferenceLines, int OrphanSymbols, int Total) PruneOrphans(string dbPath, bool apply)
@@ -930,3 +1008,17 @@ internal sealed class DbCommandOptions
 internal sealed record DbCheckpointOperationResult(string Name, string CheckpointPath, List<string> Files, bool FilesTruncated);
 
 internal sealed record DbCheckpointListReadResult(List<DbCheckpointListEntryJsonResult> Entries, bool Truncated);
+
+internal sealed record DbIntegrityCheckReadResult(List<string> Rows, bool RowsTruncated, bool TextTruncated)
+{
+    public bool Truncated => RowsTruncated || TextTruncated;
+}
+
+internal sealed record DbSchemaReadResult(
+    int UserVersion,
+    List<DbSchemaEntryJsonResult> Entries,
+    bool EntriesTruncated,
+    bool SqlTruncated)
+{
+    public bool Truncated => EntriesTruncated || SqlTruncated;
+}

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -49,17 +49,23 @@ internal sealed record DbCheckpointJsonResult(
     [property: JsonPropertyName("db_path")] string DbPath,
     [property: JsonPropertyName("name")] string Name,
     [property: JsonPropertyName("checkpoint_path")] string CheckpointPath,
-    [property: JsonPropertyName("files")] List<string> Files);
+    [property: JsonPropertyName("files")] List<string> Files,
+    [property: JsonPropertyName("files_truncated")] bool FilesTruncated = false,
+    [property: JsonPropertyName("file_limit")] int FileLimit = 0);
 
 internal sealed record DbCheckpointListJsonResult(
     [property: JsonPropertyName("db_path")] string DbPath,
-    [property: JsonPropertyName("checkpoints")] List<DbCheckpointListEntryJsonResult> Checkpoints);
+    [property: JsonPropertyName("checkpoints")] List<DbCheckpointListEntryJsonResult> Checkpoints,
+    [property: JsonPropertyName("truncated")] bool Truncated = false,
+    [property: JsonPropertyName("checkpoint_limit")] int CheckpointLimit = 0,
+    [property: JsonPropertyName("file_limit")] int FileLimit = 0);
 
 internal sealed record DbCheckpointListEntryJsonResult(
     [property: JsonPropertyName("name")] string Name,
     [property: JsonPropertyName("checkpoint_path")] string CheckpointPath,
     [property: JsonPropertyName("created_at_utc")] string CreatedAtUtc,
-    [property: JsonPropertyName("bytes")] long Bytes);
+    [property: JsonPropertyName("bytes")] long Bytes,
+    [property: JsonPropertyName("files_truncated")] bool FilesTruncated = false);
 
 internal sealed record DbRestoreJsonResult(
     [property: JsonPropertyName("status")] string Status,

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -42,7 +42,12 @@ internal sealed record CommandErrorJsonResult(
 internal sealed record DbIntegrityCheckJsonResult(
     [property: JsonPropertyName("db_path")] string DbPath,
     [property: JsonPropertyName("ok")] bool Ok,
-    [property: JsonPropertyName("issues")] List<string> Issues);
+    [property: JsonPropertyName("issues")] List<string> Issues,
+    [property: JsonPropertyName("truncated")] bool Truncated = false,
+    [property: JsonPropertyName("rows_truncated")] bool RowsTruncated = false,
+    [property: JsonPropertyName("text_truncated")] bool TextTruncated = false,
+    [property: JsonPropertyName("row_limit")] int RowLimit = 0,
+    [property: JsonPropertyName("text_limit")] int TextLimit = 0);
 
 internal sealed record DbCheckpointJsonResult(
     [property: JsonPropertyName("status")] string Status,
@@ -83,7 +88,12 @@ internal sealed record DbSchemaEntryJsonResult(
 internal sealed record DbSchemaJsonResult(
     [property: JsonPropertyName("db_path")] string DbPath,
     [property: JsonPropertyName("user_version")] int UserVersion,
-    [property: JsonPropertyName("entries")] List<DbSchemaEntryJsonResult> Entries);
+    [property: JsonPropertyName("entries")] List<DbSchemaEntryJsonResult> Entries,
+    [property: JsonPropertyName("truncated")] bool Truncated = false,
+    [property: JsonPropertyName("entries_truncated")] bool EntriesTruncated = false,
+    [property: JsonPropertyName("sql_truncated")] bool SqlTruncated = false,
+    [property: JsonPropertyName("entry_limit")] int EntryLimit = 0,
+    [property: JsonPropertyName("sql_text_limit")] int SqlTextLimit = 0);
 
 internal sealed record DbPruneJsonResult(
     [property: JsonPropertyName("status")] string Status,

--- a/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
@@ -347,6 +347,47 @@ public class DbCommandRunnerTests
     }
 
     [Fact]
+    public void Run_CheckpointsList_CapsCheckpointAndFileEnumeration_Issue2880()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_db_checkpoint_list_cap_{Guid.NewGuid():N}");
+        var dbPath = Path.Combine(root, "codeindex.db");
+        var checkpointRoot = dbPath + ".checkpoints";
+        Directory.CreateDirectory(checkpointRoot);
+        try
+        {
+            File.WriteAllText(dbPath, "db");
+            for (var i = 0; i < DbCommandRunner.CheckpointListEntryLimit + 1; i++)
+            {
+                var checkpointPath = Path.Combine(checkpointRoot, $"checkpoint-{i:D4}");
+                Directory.CreateDirectory(checkpointPath);
+                File.WriteAllText(Path.Combine(checkpointPath, "codeindex.db"), "db");
+                for (var file = 0; file < DbCommandRunner.CheckpointFileInspectLimit + 1; file++)
+                    File.WriteAllText(Path.Combine(checkpointPath, $"extra-{file:D4}.txt"), "x");
+            }
+
+            var (listExit, json) = RunAndCaptureJson(["checkpoints", "--list", "--db", dbPath, "--json"]);
+            var (textExit, stdout, _) = RunAndCaptureStreams(["checkpoints", "--list", "--db", dbPath]);
+
+            Assert.Equal(CommandExitCodes.Success, listExit);
+            Assert.Equal(CommandExitCodes.Success, textExit);
+            Assert.True(json.GetProperty("truncated").GetBoolean());
+            Assert.Equal(DbCommandRunner.CheckpointListEntryLimit, json.GetProperty("checkpoint_limit").GetInt32());
+            Assert.Equal(DbCommandRunner.CheckpointFileInspectLimit, json.GetProperty("file_limit").GetInt32());
+            var checkpoints = json.GetProperty("checkpoints");
+            Assert.Equal(DbCommandRunner.CheckpointListEntryLimit, checkpoints.GetArrayLength());
+            Assert.Contains(checkpoints.EnumerateArray(), entry => entry.GetProperty("files_truncated").GetBoolean());
+            Assert.Contains("truncated: yes", stdout);
+            Assert.Contains("files truncated", stdout);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Run_RestoreIncompleteCheckpoint_ReturnsErrorAndKeepsDatabase()
     {
         var root = Path.Combine(Path.GetTempPath(), $"cdidx_db_checkpoint_bad_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
@@ -533,6 +533,81 @@ public class DbCommandRunnerTests
         }
     }
 
+    [Fact]
+    public void Run_IntegrityCheck_JsonCapsRowsAndText_Issue2881()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_integrity_cap_{Guid.NewGuid():N}.db");
+        try
+        {
+            File.WriteAllText(dbPath, "placeholder");
+            DbCommandRunner.IntegrityCheckRowsForTesting = () =>
+                Enumerable.Range(0, DbCommandRunner.IntegrityCheckRowLimit + 1)
+                    .Select(i => i == 0
+                        ? new string('x', DbCommandRunner.IntegrityCheckTextLimit + 10)
+                        : $"issue {i}");
+
+            var (exitCode, json) = RunAndCaptureJson(["--integrity-check", "--db", dbPath, "--json"]);
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            Assert.True(json.GetProperty("truncated").GetBoolean());
+            Assert.True(json.GetProperty("rows_truncated").GetBoolean());
+            Assert.True(json.GetProperty("text_truncated").GetBoolean());
+            Assert.Equal(DbCommandRunner.IntegrityCheckRowLimit, json.GetProperty("row_limit").GetInt32());
+            Assert.Equal(DbCommandRunner.IntegrityCheckTextLimit, json.GetProperty("text_limit").GetInt32());
+            var issues = json.GetProperty("issues");
+            Assert.Equal(DbCommandRunner.IntegrityCheckRowLimit, issues.GetArrayLength());
+            Assert.EndsWith(" [truncated]", issues[0].GetString());
+        }
+        finally
+        {
+            DbCommandRunner.IntegrityCheckRowsForTesting = null;
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void Run_Schema_JsonCapsEntriesAndSqlText_Issue2881()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_schema_cap_{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+            {
+                DataSource = dbPath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+            }.ConnectionString))
+            {
+                connection.Open();
+                var columns = string.Join(", ", Enumerable.Range(0, 900).Select(i => $"col{i:D4} TEXT"));
+                Execute(connection, $"CREATE TABLE aaaa_long({columns})");
+                for (var i = 0; i < DbCommandRunner.SchemaEntryLimit + 1; i++)
+                    Execute(connection, $"CREATE TABLE t{i:D4}(value TEXT)");
+            }
+            SqliteConnection.ClearAllPools();
+
+            var (exitCode, json) = RunAndCaptureJson(["schema", "--db", dbPath, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.True(json.GetProperty("truncated").GetBoolean());
+            Assert.True(json.GetProperty("entries_truncated").GetBoolean());
+            Assert.True(json.GetProperty("sql_truncated").GetBoolean());
+            Assert.Equal(DbCommandRunner.SchemaEntryLimit, json.GetProperty("entry_limit").GetInt32());
+            Assert.Equal(DbCommandRunner.SchemaSqlTextLimit, json.GetProperty("sql_text_limit").GetInt32());
+            var entries = json.GetProperty("entries");
+            Assert.Equal(DbCommandRunner.SchemaEntryLimit, entries.GetArrayLength());
+            var longEntry = entries.EnumerateArray().Single(entry => entry.GetProperty("name").GetString() == "aaaa_long");
+            Assert.EndsWith(" [truncated]", longEntry.GetProperty("sql").GetString());
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
     private (int ExitCode, string StdOut, string StdErr) RunAndCaptureStreams(string[] args)
     {
         using var capture = ConsoleCapture.Start(captureOut: true, captureError: true);


### PR DESCRIPTION
## Summary
- Bound `db checkpoints --list` and checkpoint file inspection so untrusted checkpoint directories cannot force unbounded directory/file enumeration.
- Bound `db integrity-check` and `db schema` diagnostic/schema output, with explicit truncation metadata in JSON/text results.
- Added focused regression coverage and changelog fragments for #2880 and #2881.

## Validation
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Cli/DbCommandRunner.cs src/CodeIndex/Cli/JsonOutputContracts.cs tests/CodeIndex.Tests/DbCommandRunnerTests.cs changelog.d/unreleased/2880.fixed.md changelog.d/unreleased/2881.fixed.md --json`
- `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug -p:UseSharedCompilation=false --no-restore`
- `dotnet build tools/CodeIndex.Changelog/CodeIndex.Changelog.csproj -c Debug -p:UseSharedCompilation=false --no-restore`
- `dotnet tools/CodeIndex.Changelog/bin/Debug/net8.0/CodeIndex.Changelog.dll check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -f net8.0 --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1 -nr:false --filter FullyQualifiedName~DbCommandRunnerTests` blocked locally: VSTest aborted while starting its TCP listener with `System.Net.Sockets.SocketException (13): Permission denied`.
- Codex adversarial review: `codex exec` was attempted, but this environment could not resolve `api.openai.com`; manual adversarial pass over `origin/main..HEAD` found no blocking/actionable issues.

Fixes #2880
Fixes #2881