### PR TITLE
[codex] Pin ReferenceExtractor full-suite headroom

### DIFF
--- a/changelog.d/unreleased/2947.fixed.md
+++ b/changelog.d/unreleased/2947.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 2947
+affected:
+  - tests/CodeIndex.Tests/BoundedRegexTests.cs
+---
+
+## English
+
+- **Release full-suite ReferenceExtractor stability is pinned (#2947)** — regression coverage now keeps bounded regex timeout headroom at least two seconds so ReferenceExtractor fixtures do not lose expected matches under full-suite scheduler contention.
+
+## 日本語
+
+- **Release full suite での ReferenceExtractor の安定性を固定しました (#2947)** — bounded regex の timeout headroom を 2 秒以上に保つ回帰テストを追加し、full suite の scheduler contention 下で ReferenceExtractor fixture が期待する match を失わないようにしました。

--- a/tests/CodeIndex.Tests/BoundedRegexTests.cs
+++ b/tests/CodeIndex.Tests/BoundedRegexTests.cs
@@ -6,11 +6,13 @@ namespace CodeIndex.Tests;
 public sealed class BoundedRegexTests
 {
     [Fact]
-    public void DefaultMatchTimeout_KeepsBoundedMatchesFromTimingOutUnderNormalSchedulerContention()
+    public void DefaultMatchTimeout_KeepsReferenceExtractorFullSuiteHeadroom()
     {
+        // Regression coverage for #2947: Release full-suite scheduler contention can make
+        // ReferenceExtractor fixtures lose expected regex matches if this budget is too small.
         Assert.InRange(
             BoundedRegex.DefaultMatchTimeout,
-            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2),
             TimeSpan.FromSeconds(5));
     }
 


### PR DESCRIPTION
## Summary

- Pin BoundedRegex regression coverage so Release full-suite ReferenceExtractor tests require at least two seconds of regex timeout headroom.
- Add the bilingual changelog fragment for #2947.

## Root Cause

#2947 was a full-suite/order-dependent symptom where bounded regex headroom could be too small under scheduler contention, causing ReferenceExtractor fixtures to lose expected matches. Latest `origin/main` already passes the reported Release full-suite command; this PR locks the minimum timeout coverage so that stability does not regress.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~BoundedRegexTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review against `origin/main..HEAD`: no blocking/actionable findings.

## Documentation / Changelog

- Added `changelog.d/unreleased/2947.fixed.md`.
- No `AGENTS.md`, `CLAUDE.md`, or `AGENT_GUIDE.md` changes.

## Follow-Up Candidates

None.

Fixes #2947
