### PR TITLE
[codex] Refactor large classes and methods

### DIFF
--- a/src/CodeIndex/Cli/CdidxConfigFile.cs
+++ b/src/CodeIndex/Cli/CdidxConfigFile.cs
@@ -120,200 +120,261 @@ internal static class CdidxConfigFile
 
             var pending = new List<(string EnvName, string Value)>();
 
-            if (root.TryGetProperty("debug", out var debug))
-            {
-                if (!TryReadString(debug, "debug", path, out var value, out var err))
-                    return new LoadResult(Path: path, Error: err);
-                pending.Add(("CDIDX_DEBUG", value!));
-            }
-
-            if (root.TryGetProperty("metrics_path", out var metrics))
-            {
-                if (!TryReadString(metrics, "metrics_path", path, out var value, out var err))
-                    return new LoadResult(Path: path, Error: err);
-                pending.Add(("CDIDX_METRICS", value!));
-            }
-
-            if (root.TryGetProperty("disable_persistent_log", out var disableLog))
-            {
-                if (disableLog.ValueKind != JsonValueKind.True && disableLog.ValueKind != JsonValueKind.False)
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `disable_persistent_log` must be a boolean.");
-                if (disableLog.GetBoolean())
-                    pending.Add(("CDIDX_DISABLE_PERSISTENT_LOG", "1"));
-            }
-
-            if (root.TryGetProperty("global_tool_log_dir", out var logDir))
-            {
-                if (!TryReadString(logDir, "global_tool_log_dir", path, out var value, out var err))
-                    return new LoadResult(Path: path, Error: err);
-                pending.Add(("CDIDX_GLOBAL_TOOL_LOG_DIR", value!));
-            }
-
-            if (root.TryGetProperty("stale_after", out var staleAfter))
-            {
-                if (!TryReadString(staleAfter, "stale_after", path, out var value, out var err))
-                    return new LoadResult(Path: path, Error: err);
-                pending.Add((QueryCommandRunner.StaleAfterEnvironmentVariable, value!));
-            }
-
-            if (root.TryGetProperty("suggestion_dedup_threshold", out var suggestionDedupThreshold))
-            {
-                if (!TryReadNumberAsString(suggestionDedupThreshold, "suggestion_dedup_threshold", path, out var value, out var err))
-                    return new LoadResult(Path: path, Error: err);
-                if (!double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var threshold)
-                    || threshold < 0
-                    || threshold > 1)
-                {
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `suggestion_dedup_threshold` must be between 0 and 1.");
-                }
-
-                pending.Add((SuggestionStore.DedupThresholdEnvironmentVariable, value!));
-            }
-
-            if (root.TryGetProperty("suggestion_max_age_days", out var suggestionMaxAgeDays))
-            {
-                if (!TryReadPositiveIntegerAsString(suggestionMaxAgeDays, "suggestion_max_age_days", path, out var value, out var err))
-                    return new LoadResult(Path: path, Error: err);
-                var parsedMaxAgeDays = int.Parse(value!, CultureInfo.InvariantCulture);
-                if (parsedMaxAgeDays > SuggestionStore.MaximumMaxAgeDays)
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `suggestion_max_age_days` must be <= {SuggestionStore.MaximumMaxAgeDays}.");
-                pending.Add((SuggestionStore.MaxAgeDaysEnvironmentVariable, value!));
-            }
-
-            if (root.TryGetProperty("suggestion_max_count", out var suggestionMaxCount))
-            {
-                if (!TryReadPositiveIntegerAsString(suggestionMaxCount, "suggestion_max_count", path, out var value, out var err))
-                    return new LoadResult(Path: path, Error: err);
-                var parsedMaxCount = int.Parse(value!, CultureInfo.InvariantCulture);
-                if (parsedMaxCount > SuggestionStore.MaximumMaxCount)
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `suggestion_max_count` must be <= {SuggestionStore.MaximumMaxCount}.");
-                pending.Add((SuggestionStore.MaxCountEnvironmentVariable, value!));
-            }
-
-            if (root.TryGetProperty("indexing", out var indexing))
-            {
-                if (indexing.ValueKind != JsonValueKind.Object)
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `indexing` must be a JSON object.");
-                if (TryFindUnknownKey(indexing, KnownIndexingKeys, out var unknownIndexingKey))
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `indexing.{unknownIndexingKey}`. Supported keys: {string.Join(", ", KnownIndexingKeys)}.");
-
-                if (indexing.TryGetProperty("includeKinds", out var includeKinds))
-                {
-                    if (!TryReadStringArray(includeKinds, "indexing.includeKinds", path, out var value, out var err))
-                        return new LoadResult(Path: path, Error: err);
-                    if (value!.Length > 0)
-                        pending.Add((IndexCommandRunner.IncludeSymbolKindsEnvironmentVariable, string.Join(",", value)));
-                }
-
-                if (indexing.TryGetProperty("excludeKinds", out var excludeKinds))
-                {
-                    if (!TryReadStringArray(excludeKinds, "indexing.excludeKinds", path, out var value, out var err))
-                        return new LoadResult(Path: path, Error: err);
-                    if (value!.Length > 0)
-                        pending.Add((IndexCommandRunner.ExcludeSymbolKindsEnvironmentVariable, string.Join(",", value)));
-                }
-            }
-
-            if (root.TryGetProperty("search", out var search))
-            {
-                if (search.ValueKind != JsonValueKind.Object)
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `search` must be a JSON object.");
-                if (TryFindUnknownKey(search, KnownSearchKeys, out var unknownSearchKey))
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `search.{unknownSearchKey}`. Supported keys: {string.Join(", ", KnownSearchKeys)}.");
-                if (search.TryGetProperty("limit", out var limit))
-                {
-                    if (!TryReadSearchInteger(limit, "search.limit", "--limit", allowZero: false, path, out var value, out var err))
-                        return new LoadResult(Path: path, Error: err);
-                    pending.Add((QueryCommandRunner.DefaultLimitEnvironmentVariable, value!));
-                }
-                if (search.TryGetProperty("snippet_lines", out var snippetLines))
-                {
-                    if (!TryReadSearchInteger(snippetLines, "search.snippet_lines", "--snippet-lines", allowZero: false, path, out var value, out var err))
-                        return new LoadResult(Path: path, Error: err);
-                    pending.Add((QueryCommandRunner.DefaultSnippetLinesEnvironmentVariable, value!));
-                }
-                if (search.TryGetProperty("max_line_width", out var maxLineWidth))
-                {
-                    if (!TryReadSearchInteger(maxLineWidth, "search.max_line_width", "--max-line-width", allowZero: true, path, out var value, out var err))
-                        return new LoadResult(Path: path, Error: err);
-                    pending.Add((QueryCommandRunner.DefaultMaxLineWidthEnvironmentVariable, value!));
-                }
-            }
+            if (AddTopLevelEnvironmentSettings(root, path, pending) is { } topLevelError)
+                return topLevelError;
+            if (AddSuggestionEnvironmentSettings(root, path, pending) is { } suggestionError)
+                return suggestionError;
+            if (AddIndexingEnvironmentSettings(root, path, pending) is { } indexingError)
+                return indexingError;
+            if (AddSearchEnvironmentSettings(root, path, pending) is { } searchError)
+                return searchError;
 
             if (!ValidateOptionalObject(root, "output", KnownOutputKeys, path, out var optionalObjectError)
                 || !ValidateOptionalObject(root, "graph", KnownGraphKeys, path, out optionalObjectError)
                 || !ValidateOptionalObject(root, "folding", KnownFoldingKeys, path, out optionalObjectError))
                 return new LoadResult(Path: path, Error: optionalObjectError);
 
-            if (root.TryGetProperty("mcp", out var mcp))
-            {
-                if (mcp.ValueKind != JsonValueKind.Object)
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp` must be a JSON object.");
-                if (TryFindUnknownKey(mcp, KnownMcpKeys, out var unknownMcpKey))
-                    return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.{unknownMcpKey}`. Supported keys: {string.Join(", ", KnownMcpKeys)}.");
-
-                if (mcp.TryGetProperty("tools", out var tools))
-                {
-                    if (tools.ValueKind != JsonValueKind.Object)
-                        return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp.tools` must be a JSON object.");
-                    if (TryFindUnknownKey(tools, KnownMcpToolsKeys, out var unknownToolsKey))
-                        return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.tools.{unknownToolsKey}`. Supported keys: {string.Join(", ", KnownMcpToolsKeys)}.");
-
-                    if (tools.TryGetProperty("allow", out var allow))
-                    {
-                        if (!TryReadStringArray(allow, "mcp.tools.allow", path, out var value, out var err))
-                            return new LoadResult(Path: path, Error: err);
-                        if (value!.Length > 0)
-                            pending.Add(("CDIDX_MCP_TOOLS_ALLOW", string.Join(",", value)));
-                    }
-
-                    if (tools.TryGetProperty("deny", out var deny))
-                    {
-                        if (!TryReadStringArray(deny, "mcp.tools.deny", path, out var value, out var err))
-                            return new LoadResult(Path: path, Error: err);
-                        if (value!.Length > 0)
-                            pending.Add(("CDIDX_MCP_TOOLS_DENY", string.Join(",", value)));
-                    }
-                }
-
-                if (mcp.TryGetProperty("rate_limit", out var rateLimit))
-                {
-                    if (rateLimit.ValueKind != JsonValueKind.Object)
-                        return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp.rate_limit` must be a JSON object.");
-                    if (TryFindUnknownKey(rateLimit, KnownMcpRateLimitKeys, out var unknownRlKey))
-                        return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.rate_limit.{unknownRlKey}`. Supported keys: {string.Join(", ", KnownMcpRateLimitKeys)}.");
-
-                    if (rateLimit.TryGetProperty("rps", out var rps))
-                    {
-                        if (!TryReadNumberAsString(rps, "mcp.rate_limit.rps", path, out var value, out var err))
-                            return new LoadResult(Path: path, Error: err);
-                        pending.Add(("CDIDX_MCP_RATE_LIMIT_RPS", value!));
-                    }
-
-                    if (rateLimit.TryGetProperty("burst", out var burst))
-                    {
-                        if (!TryReadNumberAsString(burst, "mcp.rate_limit.burst", path, out var value, out var err))
-                            return new LoadResult(Path: path, Error: err);
-                        pending.Add(("CDIDX_MCP_RATE_LIMIT_BURST", value!));
-                    }
-                }
-            }
+            if (AddMcpEnvironmentSettings(root, path, pending) is { } mcpError)
+                return mcpError;
 
             // Apply only when the matching env var is not present (null), preserving the
             // documented precedence (real env wins over config-file value). An explicit
             // empty string still counts as "set" because several existing consumers
             // (e.g. RateLimiterOptions.FromEnvironment) treat empty as "feature off",
             // so a user clearing a checked-in value must be able to override with `export FOO=`.
-            foreach (var (name, value) in pending)
-            {
-                if (envReader(name) is null)
-                {
-                    envWriter(name, value);
-                    envWriter(ConfigSourceEnvironmentVariablePrefix + name, path);
-                }
-            }
+            ApplyPendingEnvironmentSettings(pending, path, envReader, envWriter);
 
             return new LoadResult(Path: path, Error: null);
+        }
+    }
+
+    private static LoadResult? AddTopLevelEnvironmentSettings(JsonElement root, string path, List<(string EnvName, string Value)> pending)
+    {
+        if (root.TryGetProperty("debug", out var debug))
+        {
+            if (!TryReadString(debug, "debug", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add(("CDIDX_DEBUG", value!));
+        }
+
+        if (root.TryGetProperty("metrics_path", out var metrics))
+        {
+            if (!TryReadString(metrics, "metrics_path", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add(("CDIDX_METRICS", value!));
+        }
+
+        if (root.TryGetProperty("disable_persistent_log", out var disableLog))
+        {
+            if (disableLog.ValueKind != JsonValueKind.True && disableLog.ValueKind != JsonValueKind.False)
+                return new LoadResult(Path: path, Error: $"[cdidx] {path}: `disable_persistent_log` must be a boolean.");
+            if (disableLog.GetBoolean())
+                pending.Add(("CDIDX_DISABLE_PERSISTENT_LOG", "1"));
+        }
+
+        if (root.TryGetProperty("global_tool_log_dir", out var logDir))
+        {
+            if (!TryReadString(logDir, "global_tool_log_dir", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add(("CDIDX_GLOBAL_TOOL_LOG_DIR", value!));
+        }
+
+        if (root.TryGetProperty("stale_after", out var staleAfter))
+        {
+            if (!TryReadString(staleAfter, "stale_after", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add((QueryCommandRunner.StaleAfterEnvironmentVariable, value!));
+        }
+
+        return null;
+    }
+
+    private static LoadResult? AddSuggestionEnvironmentSettings(JsonElement root, string path, List<(string EnvName, string Value)> pending)
+    {
+        if (root.TryGetProperty("suggestion_dedup_threshold", out var suggestionDedupThreshold))
+        {
+            if (!TryReadNumberAsString(suggestionDedupThreshold, "suggestion_dedup_threshold", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var threshold)
+                || threshold < 0
+                || threshold > 1)
+            {
+                return new LoadResult(Path: path, Error: $"[cdidx] {path}: `suggestion_dedup_threshold` must be between 0 and 1.");
+            }
+
+            pending.Add((SuggestionStore.DedupThresholdEnvironmentVariable, value!));
+        }
+
+        if (root.TryGetProperty("suggestion_max_age_days", out var suggestionMaxAgeDays))
+        {
+            if (!TryReadPositiveIntegerAsString(suggestionMaxAgeDays, "suggestion_max_age_days", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            var parsedMaxAgeDays = int.Parse(value!, CultureInfo.InvariantCulture);
+            if (parsedMaxAgeDays > SuggestionStore.MaximumMaxAgeDays)
+                return new LoadResult(Path: path, Error: $"[cdidx] {path}: `suggestion_max_age_days` must be <= {SuggestionStore.MaximumMaxAgeDays}.");
+            pending.Add((SuggestionStore.MaxAgeDaysEnvironmentVariable, value!));
+        }
+
+        if (root.TryGetProperty("suggestion_max_count", out var suggestionMaxCount))
+        {
+            if (!TryReadPositiveIntegerAsString(suggestionMaxCount, "suggestion_max_count", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            var parsedMaxCount = int.Parse(value!, CultureInfo.InvariantCulture);
+            if (parsedMaxCount > SuggestionStore.MaximumMaxCount)
+                return new LoadResult(Path: path, Error: $"[cdidx] {path}: `suggestion_max_count` must be <= {SuggestionStore.MaximumMaxCount}.");
+            pending.Add((SuggestionStore.MaxCountEnvironmentVariable, value!));
+        }
+
+        return null;
+    }
+
+    private static LoadResult? AddIndexingEnvironmentSettings(JsonElement root, string path, List<(string EnvName, string Value)> pending)
+    {
+        if (!root.TryGetProperty("indexing", out var indexing))
+            return null;
+
+        if (indexing.ValueKind != JsonValueKind.Object)
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: `indexing` must be a JSON object.");
+        if (TryFindUnknownKey(indexing, KnownIndexingKeys, out var unknownIndexingKey))
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `indexing.{unknownIndexingKey}`. Supported keys: {string.Join(", ", KnownIndexingKeys)}.");
+
+        if (indexing.TryGetProperty("includeKinds", out var includeKinds))
+        {
+            if (!TryReadStringArray(includeKinds, "indexing.includeKinds", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            if (value!.Length > 0)
+                pending.Add((IndexCommandRunner.IncludeSymbolKindsEnvironmentVariable, string.Join(",", value)));
+        }
+
+        if (indexing.TryGetProperty("excludeKinds", out var excludeKinds))
+        {
+            if (!TryReadStringArray(excludeKinds, "indexing.excludeKinds", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            if (value!.Length > 0)
+                pending.Add((IndexCommandRunner.ExcludeSymbolKindsEnvironmentVariable, string.Join(",", value)));
+        }
+
+        return null;
+    }
+
+    private static LoadResult? AddSearchEnvironmentSettings(JsonElement root, string path, List<(string EnvName, string Value)> pending)
+    {
+        if (!root.TryGetProperty("search", out var search))
+            return null;
+
+        if (search.ValueKind != JsonValueKind.Object)
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: `search` must be a JSON object.");
+        if (TryFindUnknownKey(search, KnownSearchKeys, out var unknownSearchKey))
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `search.{unknownSearchKey}`. Supported keys: {string.Join(", ", KnownSearchKeys)}.");
+
+        if (search.TryGetProperty("limit", out var limit))
+        {
+            if (!TryReadSearchInteger(limit, "search.limit", "--limit", allowZero: false, path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add((QueryCommandRunner.DefaultLimitEnvironmentVariable, value!));
+        }
+
+        if (search.TryGetProperty("snippet_lines", out var snippetLines))
+        {
+            if (!TryReadSearchInteger(snippetLines, "search.snippet_lines", "--snippet-lines", allowZero: false, path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add((QueryCommandRunner.DefaultSnippetLinesEnvironmentVariable, value!));
+        }
+
+        if (search.TryGetProperty("max_line_width", out var maxLineWidth))
+        {
+            if (!TryReadSearchInteger(maxLineWidth, "search.max_line_width", "--max-line-width", allowZero: true, path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add((QueryCommandRunner.DefaultMaxLineWidthEnvironmentVariable, value!));
+        }
+
+        return null;
+    }
+
+    private static LoadResult? AddMcpEnvironmentSettings(JsonElement root, string path, List<(string EnvName, string Value)> pending)
+    {
+        if (!root.TryGetProperty("mcp", out var mcp))
+            return null;
+
+        if (mcp.ValueKind != JsonValueKind.Object)
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp` must be a JSON object.");
+        if (TryFindUnknownKey(mcp, KnownMcpKeys, out var unknownMcpKey))
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.{unknownMcpKey}`. Supported keys: {string.Join(", ", KnownMcpKeys)}.");
+
+        if (AddMcpToolEnvironmentSettings(mcp, path, pending) is { } toolsError)
+            return toolsError;
+        return AddMcpRateLimitEnvironmentSettings(mcp, path, pending);
+    }
+
+    private static LoadResult? AddMcpToolEnvironmentSettings(JsonElement mcp, string path, List<(string EnvName, string Value)> pending)
+    {
+        if (!mcp.TryGetProperty("tools", out var tools))
+            return null;
+
+        if (tools.ValueKind != JsonValueKind.Object)
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp.tools` must be a JSON object.");
+        if (TryFindUnknownKey(tools, KnownMcpToolsKeys, out var unknownToolsKey))
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.tools.{unknownToolsKey}`. Supported keys: {string.Join(", ", KnownMcpToolsKeys)}.");
+
+        if (tools.TryGetProperty("allow", out var allow))
+        {
+            if (!TryReadStringArray(allow, "mcp.tools.allow", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            if (value!.Length > 0)
+                pending.Add(("CDIDX_MCP_TOOLS_ALLOW", string.Join(",", value)));
+        }
+
+        if (tools.TryGetProperty("deny", out var deny))
+        {
+            if (!TryReadStringArray(deny, "mcp.tools.deny", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            if (value!.Length > 0)
+                pending.Add(("CDIDX_MCP_TOOLS_DENY", string.Join(",", value)));
+        }
+
+        return null;
+    }
+
+    private static LoadResult? AddMcpRateLimitEnvironmentSettings(JsonElement mcp, string path, List<(string EnvName, string Value)> pending)
+    {
+        if (!mcp.TryGetProperty("rate_limit", out var rateLimit))
+            return null;
+
+        if (rateLimit.ValueKind != JsonValueKind.Object)
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: `mcp.rate_limit` must be a JSON object.");
+        if (TryFindUnknownKey(rateLimit, KnownMcpRateLimitKeys, out var unknownRlKey))
+            return new LoadResult(Path: path, Error: $"[cdidx] {path}: unknown key `mcp.rate_limit.{unknownRlKey}`. Supported keys: {string.Join(", ", KnownMcpRateLimitKeys)}.");
+
+        if (rateLimit.TryGetProperty("rps", out var rps))
+        {
+            if (!TryReadNumberAsString(rps, "mcp.rate_limit.rps", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add(("CDIDX_MCP_RATE_LIMIT_RPS", value!));
+        }
+
+        if (rateLimit.TryGetProperty("burst", out var burst))
+        {
+            if (!TryReadNumberAsString(burst, "mcp.rate_limit.burst", path, out var value, out var err))
+                return new LoadResult(Path: path, Error: err);
+            pending.Add(("CDIDX_MCP_RATE_LIMIT_BURST", value!));
+        }
+
+        return null;
+    }
+
+    private static void ApplyPendingEnvironmentSettings(
+        List<(string EnvName, string Value)> pending,
+        string path,
+        Func<string, string?> envReader,
+        Action<string, string?> envWriter)
+    {
+        foreach (var (name, value) in pending)
+        {
+            if (envReader(name) is not null)
+                continue;
+
+            envWriter(name, value);
+            envWriter(ConfigSourceEnvironmentVariablePrefix + name, path);
         }
     }
 

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -364,6 +364,146 @@ public static partial class IndexCommandRunner
         }
     }
 
+    private sealed record FullScanDiscoveryResult(
+        FileIndexer.ScanFilesResult ScanResult,
+        IReadOnlyList<string> Files,
+        List<CliJsonMessage> ErrorList,
+        List<CliJsonMessage> WarningList,
+        string? CurrentHeadForCheckpoint,
+        string ScanCheckpointPath,
+        IReadOnlySet<string> CheckpointedDirectories);
+
+    private static FullScanDiscoveryResult DiscoverFullScanFiles(
+        FileIndexer indexer,
+        string projectRoot,
+        IndexCommandOptions options,
+        string[] spinnerFrames,
+        CancellationToken cancellationToken)
+    {
+        CancellationTokenSource? spinnerCts = null;
+        if (!options.Json && !options.Quiet)
+            spinnerCts = ConsoleUi.StartSpinner("Scanning...", spinnerFrames);
+
+        void ThrowIfDiscoveryCancelled()
+        {
+            if (!cancellationToken.IsCancellationRequested)
+                return;
+
+            ConsoleUi.StopSpinner(spinnerCts);
+            throw new IndexInterruptedException(0, null);
+        }
+
+        var currentHeadForCheckpoint = GitHelper.TryGetHeadCommit(projectRoot);
+        var scanCheckpointPath = Path.Combine(projectRoot, ".cdidx", ScanCheckpointFileName);
+        var checkpointedDirectories = LoadScanCheckpoint(scanCheckpointPath, currentHeadForCheckpoint);
+        WriteFullScanJsonLiveness(options, "scanning files...");
+        var scanHeartbeat = StartFullScanJsonPhaseHeartbeat(options, "scanning files");
+        FileIndexer.ScanFilesResult scanResult;
+        try
+        {
+            ThrowIfDiscoveryCancelled();
+            scanResult = indexer.ScanFilesDetailed(checkpointedDirectories, continueOnError: true, cancellationToken: cancellationToken);
+            ThrowIfDiscoveryCancelled();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new IndexInterruptedException(0, null);
+        }
+        finally
+        {
+            StopFullScanJsonPhaseHeartbeat(scanHeartbeat);
+        }
+        var files = scanResult.Files;
+        ConsoleUi.StopSpinner(spinnerCts);
+        WriteFullScanJsonLiveness(options, $"found {ConsoleUi.Counted(files.Count, "file", format: "N0")}; preparing database...");
+        var fatalScanErrors = scanResult.Errors
+            .Where(error => error.IsFatal)
+            .ToList();
+        var warningScanErrors = scanResult.Errors
+            .Where(error => !error.IsFatal)
+            .ToList();
+        var errorList = fatalScanErrors
+            .Select(error => new CliJsonMessage(error.Path, error.Message))
+            .ToList();
+        var warningList = warningScanErrors
+            .Select(error => new CliJsonMessage(error.Path, error.Message))
+            .ToList();
+        if (!options.Json && !options.Quiet)
+        {
+            Console.WriteLine($"  Found {ConsoleUi.Counted(files.Count, "file", format: "N0")}");
+            foreach (var error in scanResult.Errors)
+                ConsoleUi.PrintWarning($"{error.Path}: {error.Message}");
+            Console.WriteLine();
+        }
+
+        return new FullScanDiscoveryResult(
+            scanResult,
+            files,
+            errorList,
+            warningList,
+            currentHeadForCheckpoint,
+            scanCheckpointPath,
+            checkpointedDirectories);
+    }
+
+    private static void WriteFullScanJsonLiveness(IndexCommandOptions options, string message)
+    {
+        if (!options.Json || options.Quiet)
+            return;
+
+        ConsoleUi.TryWriteErrorLine($"cdidx: {message}");
+    }
+
+    private static (CancellationTokenSource Cts, Task Task)? StartFullScanJsonPhaseHeartbeat(
+        IndexCommandOptions options,
+        string phase,
+        Func<string?>? detailProvider = null)
+    {
+        if (!options.Json || options.Quiet)
+            return null;
+
+        var cts = new CancellationTokenSource();
+        var token = cts.Token;
+        var task = Task.Run(async () =>
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                if (token.IsCancellationRequested)
+                    break;
+
+                var detail = detailProvider?.Invoke();
+                var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : $": {detail}";
+                ConsoleUi.TryWriteErrorLine($"cdidx: still {phase}{suffix}...");
+            }
+        }, token);
+        return (cts, task);
+    }
+
+    private static void StopFullScanJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
+    {
+        if (heartbeat == null)
+            return;
+
+        heartbeat.Value.Cts.Cancel();
+        try
+        {
+            heartbeat.Value.Task.Wait(TimeSpan.FromSeconds(1));
+        }
+        catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is OperationCanceledException or TaskCanceledException))
+        {
+        }
+        heartbeat.Value.Cts.Dispose();
+    }
+
     private static int RunFullScan(
         DbWriter writer,
         FileIndexer indexer,
@@ -446,118 +586,24 @@ public static partial class IndexCommandRunner
             }
         }
 
-        void WriteJsonLiveness(string message)
-        {
-            if (!options.Json || options.Quiet)
-                return;
-
-            ConsoleUi.TryWriteErrorLine($"cdidx: {message}");
-        }
-
-        (CancellationTokenSource Cts, Task Task)? StartJsonPhaseHeartbeat(string phase, Func<string?>? detailProvider = null)
-        {
-            if (!options.Json || options.Quiet)
-                return null;
-
-            var cts = new CancellationTokenSource();
-            var token = cts.Token;
-            var task = Task.Run(async () =>
-            {
-                while (!token.IsCancellationRequested)
-                {
-                    try
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(5), token).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        break;
-                    }
-
-                    if (token.IsCancellationRequested)
-                        break;
-
-                    var detail = detailProvider?.Invoke();
-                    var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : $": {detail}";
-                    ConsoleUi.TryWriteErrorLine($"cdidx: still {phase}{suffix}...");
-                }
-            }, token);
-            return (cts, task);
-        }
-
-        void StopJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
-        {
-            if (heartbeat == null)
-                return;
-
-            heartbeat.Value.Cts.Cancel();
-            try
-            {
-                heartbeat.Value.Task.Wait(TimeSpan.FromSeconds(1));
-            }
-            catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is OperationCanceledException or TaskCanceledException))
-            {
-            }
-            heartbeat.Value.Cts.Dispose();
-        }
-
-        CancellationTokenSource? spinnerCts = null;
-        if (!options.Json && !options.Quiet)
-            spinnerCts = ConsoleUi.StartSpinner("Scanning...", spinnerFrames);
-
         void ThrowIfFullScanCancelled(int filesProcessed, int? filesTotal)
         {
             if (!cancellationToken.IsCancellationRequested)
                 return;
 
-            ConsoleUi.StopSpinner(spinnerCts);
             throw new IndexInterruptedException(filesProcessed, filesTotal);
         }
 
-        var currentHeadForCheckpoint = GitHelper.TryGetHeadCommit(projectRoot);
-        var scanCheckpointPath = Path.Combine(projectRoot, ".cdidx", ScanCheckpointFileName);
-        var checkpointedDirectories = LoadScanCheckpoint(scanCheckpointPath, currentHeadForCheckpoint);
-        WriteJsonLiveness("scanning files...");
-        var scanHeartbeat = StartJsonPhaseHeartbeat("scanning files");
-        FileIndexer.ScanFilesResult scanResult;
-        try
-        {
-            ThrowIfFullScanCancelled(0, null);
-            scanResult = indexer.ScanFilesDetailed(checkpointedDirectories, continueOnError: true, cancellationToken: cancellationToken);
-            ThrowIfFullScanCancelled(0, null);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw new IndexInterruptedException(0, null);
-        }
-        finally
-        {
-            StopJsonPhaseHeartbeat(scanHeartbeat);
-        }
-        var files = scanResult.Files;
+        var discovery = DiscoverFullScanFiles(indexer, projectRoot, options, spinnerFrames, cancellationToken);
+        var scanResult = discovery.ScanResult;
+        var files = discovery.Files;
+        var errorList = discovery.ErrorList;
+        var warningList = discovery.WarningList;
+        var currentHeadForCheckpoint = discovery.CurrentHeadForCheckpoint;
+        var scanCheckpointPath = discovery.ScanCheckpointPath;
+        var checkpointedDirectories = discovery.CheckpointedDirectories;
         if (options.MemoryTrace)
             memorySamples.Add(CaptureMemorySample("scan", stopwatch));
-        ConsoleUi.StopSpinner(spinnerCts);
-        WriteJsonLiveness($"found {ConsoleUi.Counted(files.Count, "file", format: "N0")}; preparing database...");
-        var fatalScanErrors = scanResult.Errors
-            .Where(error => error.IsFatal)
-            .ToList();
-        var warningScanErrors = scanResult.Errors
-            .Where(error => !error.IsFatal)
-            .ToList();
-        var errorList = fatalScanErrors
-            .Select(error => new CliJsonMessage(error.Path, error.Message))
-            .ToList();
-        var warningList = warningScanErrors
-            .Select(error => new CliJsonMessage(error.Path, error.Message))
-            .ToList();
-        if (!options.Json && !options.Quiet)
-        {
-            Console.WriteLine($"  Found {ConsoleUi.Counted(files.Count, "file", format: "N0")}");
-            foreach (var error in scanResult.Errors)
-                ConsoleUi.PrintWarning($"{error.Path}: {error.Message}");
-            Console.WriteLine();
-        }
 
         // Full-scan commits to mutating the DB from here on. Keep the whole write phase in
         // one outer transaction so Ctrl-C/SIGTERM can roll back the batch marker,
@@ -629,7 +675,7 @@ public static partial class IndexCommandRunner
         if (options.MemoryTrace)
             memorySamples.Add(CaptureMemorySample("purge", stopwatch));
         ConsoleUi.StopSpinner(purgeCts);
-        WriteJsonLiveness(purged > 0
+        WriteFullScanJsonLiveness(options, purged > 0
             ? $"purged {purged:N0} stale file(s); preparing index writes..."
             : "preparing index writes...");
         if (!options.Json && !options.Quiet)
@@ -804,9 +850,10 @@ public static partial class IndexCommandRunner
             jsonHeartbeatTask = null;
         }
 
-        WriteJsonLiveness("preparing C# workspace symbols...");
+        WriteFullScanJsonLiveness(options, "preparing C# workspace symbols...");
         string? currentCSharpWorkspaceFile = null;
-        var csharpWorkspaceHeartbeat = StartJsonPhaseHeartbeat(
+        var csharpWorkspaceHeartbeat = StartFullScanJsonPhaseHeartbeat(
+            options,
             "preparing C# workspace symbols",
             () => currentCSharpWorkspaceFile);
         CSharpStaticInterfaceWorkspaceSymbols csharpWorkspace;
@@ -827,7 +874,7 @@ public static partial class IndexCommandRunner
         finally
         {
             currentCSharpWorkspaceFile = null;
-            StopJsonPhaseHeartbeat(csharpWorkspaceHeartbeat);
+            StopFullScanJsonPhaseHeartbeat(csharpWorkspaceHeartbeat);
         }
 
         EnsureIndexingActivityVisible();
@@ -1213,15 +1260,15 @@ public static partial class IndexCommandRunner
         PauseIndexSpinnerForConsoleWrite();
 
         ThrowIfFullScanCancelled(processed, files.Count);
-        WriteJsonLiveness("optimizing index...");
-        var optimizeHeartbeat = StartJsonPhaseHeartbeat("optimizing index");
+        WriteFullScanJsonLiveness(options, "optimizing index...");
+        var optimizeHeartbeat = StartFullScanJsonPhaseHeartbeat(options, "optimizing index");
         try
         {
             writer.OptimizeFts();
         }
         finally
         {
-            StopJsonPhaseHeartbeat(optimizeHeartbeat);
+            StopFullScanJsonPhaseHeartbeat(optimizeHeartbeat);
         }
         ThrowIfFullScanCancelled(processed, files.Count);
         // Only stamp readiness on a fully successful run (errors == 0). A partial / error

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -60,90 +60,15 @@ public static partial class IndexCommandRunner
                 CommandErrorCodes.UsageError);
         }
 
-        var targetPaths = new HashSet<string>(StringComparer.Ordinal);
-        var relevantIgnoreFileChanged = false;
-
-        if (options.Commits.Count > 0)
-        {
-            CancellationTokenSource? spinnerCts = null;
-            try
-            {
-                if (!options.Json)
-                    spinnerCts = ConsoleUi.StartSpinner("Resolving changed files...", spinnerFrames);
-                var repoRoot = GitHelper.TryGetRepositoryRoot(projectRoot) ?? Path.GetFullPath(projectRoot);
-                foreach (var commit in options.Commits)
-                {
-                    var changedFiles = GitHelper.GetChangedFilesFromCommit(projectRoot, commit);
-                    var normalized = NormalizeCommitFileTargets(projectRoot, repoRoot, changedFiles, out var commitTouchedRelevantIgnoreFile);
-                    relevantIgnoreFileChanged |= commitTouchedRelevantIgnoreFile;
-                    foreach (var f in normalized)
-                        targetPaths.Add(f);
-                }
-            }
-            catch (Exception ex)
-            {
-                return WriteCommandError(
-                    options.Json,
-                    jsonOptions,
-                    $"failed to resolve changed files from git commits: {ex.Message}",
-                    CommandExitCodes.UsageError,
-                    "Check the commit refs and rerun `cdidx index <projectPath> --commits <commit-ref> [commit-ref ...]`.",
-                    CommandErrorCodes.UsageError);
-            }
-            finally
-            {
-                ConsoleUi.StopSpinner(spinnerCts);
-            }
-            if (!options.Json && !options.Quiet)
-            {
-                Console.WriteLine($"  Found {ConsoleUi.Counted(targetPaths.Count, "changed file")} from git");
-                Console.WriteLine("  Note    : After reset/rebase/amend/switch/merge, prefer `cdidx .` over `--commits` for a full sync / 履歴改変やcheckout変更後は `--commits` より `cdidx .` を推奨");
-            }
-        }
-
-        if (options.ChangedBetweenSpecified)
-        {
-            CancellationTokenSource? spinnerCts = null;
-            WriteJsonLiveness("resolving changed files between git refs...");
-            var resolveHeartbeat = StartJsonPhaseHeartbeat("resolving changed files between git refs");
-            try
-            {
-                if (!options.Json)
-                    spinnerCts = ConsoleUi.StartSpinner("Resolving changed files between refs...", spinnerFrames);
-                var repoRoot = GitHelper.TryGetRepositoryRoot(projectRoot) ?? Path.GetFullPath(projectRoot);
-                var changedFiles = GitHelper.GetChangedFilesBetweenRefs(projectRoot, options.ChangedBetweenRefs[0], options.ChangedBetweenRefs[1]);
-                var normalized = NormalizeCommitFileTargets(projectRoot, repoRoot, changedFiles, out var rangeTouchedRelevantIgnoreFile);
-                relevantIgnoreFileChanged |= rangeTouchedRelevantIgnoreFile;
-                foreach (var f in normalized)
-                    targetPaths.Add(f);
-            }
-            catch (Exception ex)
-            {
-                return WriteCommandError(
-                    options.Json,
-                    jsonOptions,
-                    $"failed to resolve changed files between git refs: {ex.Message}",
-                    CommandExitCodes.UsageError,
-                    "Check the refs and rerun `cdidx index <projectPath> --changed-between <old-ref> <new-ref>`.",
-                    CommandErrorCodes.UsageError);
-            }
-            finally
-            {
-                StopJsonPhaseHeartbeat(resolveHeartbeat);
-                ConsoleUi.StopSpinner(spinnerCts);
-            }
-
-            WriteJsonLiveness($"found {ConsoleUi.Counted(targetPaths.Count, "changed file")}; preparing update...");
-            if (!options.Json)
-                Console.WriteLine($"  Found {targetPaths.Count} changed file(s) between git refs");
-        }
-
-        if (options.UpdateFiles.Count > 0)
-        {
-            relevantIgnoreFileChanged |= ContainsRelevantIgnoreFileUpdate(projectRoot, options.UpdateFiles);
-            foreach (var relPath in NormalizeUpdateFileTargets(projectRoot, options.UpdateFiles, options.Json))
-                targetPaths.Add(relPath);
-        }
+        var resolveTargetsExitCode = TryResolveUpdateTargets(
+            projectRoot,
+            options,
+            spinnerFrames,
+            jsonOptions,
+            out var targetPaths,
+            out var relevantIgnoreFileChanged);
+        if (resolveTargetsExitCode != null)
+            return resolveTargetsExitCode.Value;
 
         var typeScriptJavaScriptConfigChanged = ContainsJavaScriptTypeScriptConfigPath(targetPaths);
         if (relevantIgnoreFileChanged || ContainsIgnoreFilePath(targetPaths) || typeScriptJavaScriptConfigChanged)
@@ -211,61 +136,6 @@ public static partial class IndexCommandRunner
         var currentMetadataTargetVersion = DbContext.MetadataTargetVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var priorMetadataTargetCsharpMatchesCurrent = priorMetadataTargetCsharp == currentMetadataTargetVersion;
         var symbolsDroppedByKindFilter = 0;
-
-        void WriteJsonLiveness(string message)
-        {
-            if (!options.Json || options.Quiet)
-                return;
-
-            Console.Error.WriteLine($"cdidx: {message}");
-        }
-
-        (CancellationTokenSource Cts, Task Task)? StartJsonPhaseHeartbeat(string phase, Func<string?>? detailProvider = null)
-        {
-            if (!options.Json || options.Quiet)
-                return null;
-
-            var cts = new CancellationTokenSource();
-            var token = cts.Token;
-            var task = Task.Run(async () =>
-            {
-                while (!token.IsCancellationRequested)
-                {
-                    try
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(5), token).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        break;
-                    }
-
-                    if (token.IsCancellationRequested)
-                        break;
-
-                    var detail = detailProvider?.Invoke();
-                    var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : $": {detail}";
-                    Console.Error.WriteLine($"cdidx: still {phase}{suffix}...");
-                }
-            }, token);
-            return (cts, task);
-        }
-
-        void StopJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
-        {
-            if (heartbeat == null)
-                return;
-
-            heartbeat.Value.Cts.Cancel();
-            try
-            {
-                heartbeat.Value.Task.Wait(TimeSpan.FromSeconds(1));
-            }
-            catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is OperationCanceledException or TaskCanceledException))
-            {
-            }
-            heartbeat.Value.Cts.Dispose();
-        }
 
         void DemoteReadinessOnce()
         {
@@ -374,8 +244,8 @@ public static partial class IndexCommandRunner
         }
 
         ThrowIfUpdateCancelled();
-        WriteJsonLiveness("checking C# workspace contracts...");
-        var csharpWorkspaceHeartbeat = StartJsonPhaseHeartbeat("checking C# workspace contracts");
+        WriteIndexJsonLiveness(options, "checking C# workspace contracts...");
+        var csharpWorkspaceHeartbeat = StartIndexJsonPhaseHeartbeat(options, "checking C# workspace contracts");
         CSharpStaticInterfaceWorkspaceSymbols csharpWorkspace;
         try
         {
@@ -392,12 +262,12 @@ public static partial class IndexCommandRunner
         }
         finally
         {
-            StopJsonPhaseHeartbeat(csharpWorkspaceHeartbeat);
+            StopIndexJsonPhaseHeartbeat(csharpWorkspaceHeartbeat);
         }
         if (csharpWorkspace.HasStaticInterfaceContracts)
         {
-            WriteJsonLiveness("expanding C# update set for static interface contracts...");
-            var expandHeartbeat = StartJsonPhaseHeartbeat("expanding C# update set for static interface contracts");
+            WriteIndexJsonLiveness(options, "expanding C# update set for static interface contracts...");
+            var expandHeartbeat = StartIndexJsonPhaseHeartbeat(options, "expanding C# update set for static interface contracts");
             try
             {
                 foreach (var filePath in indexer.ScanFilesDetailed(cancellationToken: cancellationToken).Files)
@@ -423,7 +293,7 @@ public static partial class IndexCommandRunner
             }
             finally
             {
-                StopJsonPhaseHeartbeat(expandHeartbeat);
+                StopIndexJsonPhaseHeartbeat(expandHeartbeat);
             }
         }
 
@@ -439,9 +309,10 @@ public static partial class IndexCommandRunner
 
         StartUpdateSpinnerIfNeeded();
 
-        WriteJsonLiveness($"updating {ConsoleUi.Counted(targetPaths.Count, "file")}...");
+        WriteIndexJsonLiveness(options, $"updating {ConsoleUi.Counted(targetPaths.Count, "file")}...");
         string? currentUpdatePath = null;
-        var updateHeartbeat = StartJsonPhaseHeartbeat(
+        var updateHeartbeat = StartIndexJsonPhaseHeartbeat(
+            options,
             "updating index",
             () => currentUpdatePath == null
                 ? $"{updated + removed + skipped:N0}/{targetPaths.Count:N0} files processed"
@@ -980,7 +851,7 @@ public static partial class IndexCommandRunner
         }
         finally
         {
-            StopJsonPhaseHeartbeat(updateHeartbeat);
+            StopIndexJsonPhaseHeartbeat(updateHeartbeat);
         }
 
         ThrowIfUpdateCancelled();

--- a/src/CodeIndex/Cli/IndexCommandRunner.UpdateTargets.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.UpdateTargets.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+
+namespace CodeIndex.Cli;
+
+public static partial class IndexCommandRunner
+{
+    private static int? TryResolveUpdateTargets(
+        string projectRoot,
+        IndexCommandOptions options,
+        string[] spinnerFrames,
+        JsonSerializerOptions jsonOptions,
+        out HashSet<string> targetPaths,
+        out bool relevantIgnoreFileChanged)
+    {
+        targetPaths = new HashSet<string>(StringComparer.Ordinal);
+        relevantIgnoreFileChanged = false;
+
+        if (options.Commits.Count > 0)
+        {
+            CancellationTokenSource? spinnerCts = null;
+            try
+            {
+                if (!options.Json)
+                    spinnerCts = ConsoleUi.StartSpinner("Resolving changed files...", spinnerFrames);
+                var repoRoot = GitHelper.TryGetRepositoryRoot(projectRoot) ?? Path.GetFullPath(projectRoot);
+                foreach (var commit in options.Commits)
+                {
+                    var changedFiles = GitHelper.GetChangedFilesFromCommit(projectRoot, commit);
+                    var normalized = NormalizeCommitFileTargets(projectRoot, repoRoot, changedFiles, out var commitTouchedRelevantIgnoreFile);
+                    relevantIgnoreFileChanged |= commitTouchedRelevantIgnoreFile;
+                    foreach (var f in normalized)
+                        targetPaths.Add(f);
+                }
+            }
+            catch (Exception ex)
+            {
+                return WriteCommandError(
+                    options.Json,
+                    jsonOptions,
+                    $"failed to resolve changed files from git commits: {ex.Message}",
+                    CommandExitCodes.UsageError,
+                    "Check the commit refs and rerun `cdidx index <projectPath> --commits <commit-ref> [commit-ref ...]`.",
+                    CommandErrorCodes.UsageError);
+            }
+            finally
+            {
+                ConsoleUi.StopSpinner(spinnerCts);
+            }
+            if (!options.Json && !options.Quiet)
+            {
+                Console.WriteLine($"  Found {ConsoleUi.Counted(targetPaths.Count, "changed file")} from git");
+                Console.WriteLine("  Note    : After reset/rebase/amend/switch/merge, prefer `cdidx .` over `--commits` for a full sync / 履歴改変やcheckout変更後は `--commits` より `cdidx .` を推奨");
+            }
+        }
+
+        if (options.ChangedBetweenSpecified)
+        {
+            CancellationTokenSource? spinnerCts = null;
+            WriteIndexJsonLiveness(options, "resolving changed files between git refs...");
+            var resolveHeartbeat = StartIndexJsonPhaseHeartbeat(options, "resolving changed files between git refs");
+            try
+            {
+                if (!options.Json)
+                    spinnerCts = ConsoleUi.StartSpinner("Resolving changed files between refs...", spinnerFrames);
+                var repoRoot = GitHelper.TryGetRepositoryRoot(projectRoot) ?? Path.GetFullPath(projectRoot);
+                var changedFiles = GitHelper.GetChangedFilesBetweenRefs(projectRoot, options.ChangedBetweenRefs[0], options.ChangedBetweenRefs[1]);
+                var normalized = NormalizeCommitFileTargets(projectRoot, repoRoot, changedFiles, out var rangeTouchedRelevantIgnoreFile);
+                relevantIgnoreFileChanged |= rangeTouchedRelevantIgnoreFile;
+                foreach (var f in normalized)
+                    targetPaths.Add(f);
+            }
+            catch (Exception ex)
+            {
+                return WriteCommandError(
+                    options.Json,
+                    jsonOptions,
+                    $"failed to resolve changed files between git refs: {ex.Message}",
+                    CommandExitCodes.UsageError,
+                    "Check the refs and rerun `cdidx index <projectPath> --changed-between <old-ref> <new-ref>`.",
+                    CommandErrorCodes.UsageError);
+            }
+            finally
+            {
+                StopIndexJsonPhaseHeartbeat(resolveHeartbeat);
+                ConsoleUi.StopSpinner(spinnerCts);
+            }
+
+            WriteIndexJsonLiveness(options, $"found {ConsoleUi.Counted(targetPaths.Count, "changed file")}; preparing update...");
+            if (!options.Json)
+                Console.WriteLine($"  Found {targetPaths.Count} changed file(s) between git refs");
+        }
+
+        if (options.UpdateFiles.Count > 0)
+        {
+            relevantIgnoreFileChanged |= ContainsRelevantIgnoreFileUpdate(projectRoot, options.UpdateFiles);
+            foreach (var relPath in NormalizeUpdateFileTargets(projectRoot, options.UpdateFiles, options.Json))
+                targetPaths.Add(relPath);
+        }
+
+        return null;
+    }
+
+    private static void WriteIndexJsonLiveness(IndexCommandOptions options, string message)
+    {
+        if (!options.Json || options.Quiet)
+            return;
+
+        Console.Error.WriteLine($"cdidx: {message}");
+    }
+
+    private static (CancellationTokenSource Cts, Task Task)? StartIndexJsonPhaseHeartbeat(
+        IndexCommandOptions options,
+        string phase,
+        Func<string?>? detailProvider = null)
+    {
+        if (!options.Json || options.Quiet)
+            return null;
+
+        var cts = new CancellationTokenSource();
+        var token = cts.Token;
+        var task = Task.Run(async () =>
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                if (token.IsCancellationRequested)
+                    break;
+
+                var detail = detailProvider?.Invoke();
+                var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : $": {detail}";
+                Console.Error.WriteLine($"cdidx: still {phase}{suffix}...");
+            }
+        }, token);
+        return (cts, task);
+    }
+
+    private static void StopIndexJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
+    {
+        if (heartbeat == null)
+            return;
+
+        heartbeat.Value.Cts.Cancel();
+        try
+        {
+            heartbeat.Value.Task.Wait(TimeSpan.FromSeconds(1));
+        }
+        catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is OperationCanceledException or TaskCanceledException))
+        {
+        }
+        heartbeat.Value.Cts.Dispose();
+    }
+}

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -2581,108 +2581,155 @@ internal static class ProgramRunner
         if (args.Length == 0)
             return true;
 
-        var kept = new List<string>(args.Length);
-        string? path = null;
-        long maxBytes = AuditLogSink.DefaultMaxBytes;
-        var includeValues = false;
-        var passthrough = false;
+        var state = new AuditLogFlagParseState(args.Length);
         for (var i = 0; i < args.Length; i++)
         {
-            var arg = args[i];
-            if (passthrough)
-            {
-                kept.Add(arg);
-                continue;
-            }
-            if (arg == "--")
-            {
-                passthrough = true;
-                kept.Add(arg);
-                continue;
-            }
-
-            // Pass `--db` and its value through together so a dash-prefixed DB path
-            // (e.g. `cdidx mcp --db --some-uri`) is not mis-consumed as the start of
-            // an audit-log flag. The strict mcp parser downstream supports both
-            // `--db <value>` and `--db=value`; here we only need to guard the spaced form.
-            // `--db` とその値はまとめて通過させ、ダッシュ始まりの DB パス
-            // (例: `cdidx mcp --db --some-uri`) を audit-log フラグの先頭と
-            // 誤認しないようにする。`--db=value` 形式は値が同じトークンに含まれるため
-            // 既存ループでそのまま `kept` に流れる。
-            if (arg == "--db")
-            {
-                kept.Add(arg);
-                if (i + 1 < args.Length)
-                    kept.Add(args[++i]);
-                continue;
-            }
-
-            if (arg == "--audit-log")
-            {
-                if (i + 1 >= args.Length)
-                {
-                    error = "Error: --audit-log requires a path value (use `--audit-log <path>` or `--audit-log=<path>`).";
-                    return false;
-                }
-                path = args[++i];
-                if (string.IsNullOrWhiteSpace(path))
-                {
-                    error = "Error: --audit-log requires a non-empty path value.";
-                    return false;
-                }
-                continue;
-            }
-            if (arg.StartsWith("--audit-log=", StringComparison.Ordinal))
-            {
-                path = arg.Substring("--audit-log=".Length);
-                if (string.IsNullOrWhiteSpace(path))
-                {
-                    error = "Error: --audit-log requires a non-empty path value.";
-                    return false;
-                }
-                continue;
-            }
-            if (arg == "--audit-log-include-values")
-            {
-                includeValues = true;
-                continue;
-            }
-            if (arg == "--audit-log-max-bytes" || arg.StartsWith("--audit-log-max-bytes=", StringComparison.Ordinal))
-            {
-                string raw;
-                if (arg == "--audit-log-max-bytes")
-                {
-                    if (i + 1 >= args.Length)
-                    {
-                        error = "Error: --audit-log-max-bytes requires a byte count.";
-                        return false;
-                    }
-                    raw = args[++i];
-                }
-                else
-                {
-                    raw = arg.Substring("--audit-log-max-bytes=".Length);
-                }
-                if (!long.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
-                    || parsed < AuditLogSink.MinMaxBytes)
-                {
-                    error = $"Error: --audit-log-max-bytes must be an integer >= {AuditLogSink.MinMaxBytes}.";
-                    return false;
-                }
-                maxBytes = parsed;
-                continue;
-            }
-            kept.Add(arg);
+            if (!TryConsumeAuditLogArgument(args, ref i, state, out error))
+                return false;
         }
 
-        if (includeValues && path == null)
+        if (state.IncludeValues && state.Path == null)
         {
             error = "Error: --audit-log-include-values requires --audit-log <path>.";
             return false;
         }
 
-        options = new AuditLogOptions(path, maxBytes, includeValues);
-        args = kept.ToArray();
+        options = state.ToOptions();
+        args = state.Kept.ToArray();
+        return true;
+    }
+
+    private sealed class AuditLogFlagParseState
+    {
+        internal AuditLogFlagParseState(int capacity)
+        {
+            Kept = new List<string>(capacity);
+        }
+
+        internal List<string> Kept { get; }
+        internal string? Path { get; set; }
+        internal long MaxBytes { get; set; } = AuditLogSink.DefaultMaxBytes;
+        internal bool IncludeValues { get; set; }
+        internal bool Passthrough { get; set; }
+
+        internal AuditLogOptions ToOptions() => new(Path, MaxBytes, IncludeValues);
+    }
+
+    private static bool TryConsumeAuditLogArgument(
+        string[] args,
+        ref int index,
+        AuditLogFlagParseState state,
+        out string error)
+    {
+        error = string.Empty;
+        var arg = args[index];
+        if (state.Passthrough)
+        {
+            state.Kept.Add(arg);
+            return true;
+        }
+
+        if (arg == "--")
+        {
+            state.Passthrough = true;
+            state.Kept.Add(arg);
+            return true;
+        }
+
+        // Pass `--db` and its value through together so a dash-prefixed DB path
+        // (e.g. `cdidx mcp --db --some-uri`) is not mis-consumed as the start of
+        // an audit-log flag. The strict mcp parser downstream supports both
+        // `--db <value>` and `--db=value`; here we only need to guard the spaced form.
+        // `--db` とその値はまとめて通過させ、ダッシュ始まりの DB パス
+        // (例: `cdidx mcp --db --some-uri`) を audit-log フラグの先頭と
+        // 誤認しないようにする。`--db=value` 形式は値が同じトークンに含まれるため
+        // 既存ループでそのまま `kept` に流れる。
+        if (arg == "--db")
+        {
+            state.Kept.Add(arg);
+            if (index + 1 < args.Length)
+                state.Kept.Add(args[++index]);
+            return true;
+        }
+
+        if (arg == "--audit-log")
+            return TryConsumeAuditLogPathValue(args, ref index, state, out error);
+
+        if (arg.StartsWith("--audit-log=", StringComparison.Ordinal))
+            return TrySetAuditLogPath(arg.Substring("--audit-log=".Length), state, out error);
+
+        if (arg == "--audit-log-include-values")
+        {
+            state.IncludeValues = true;
+            return true;
+        }
+
+        if (arg == "--audit-log-max-bytes" || arg.StartsWith("--audit-log-max-bytes=", StringComparison.Ordinal))
+            return TryConsumeAuditLogMaxBytes(args, ref index, state, out error);
+
+        state.Kept.Add(arg);
+        return true;
+    }
+
+    private static bool TryConsumeAuditLogPathValue(
+        string[] args,
+        ref int index,
+        AuditLogFlagParseState state,
+        out string error)
+    {
+        if (index + 1 >= args.Length)
+        {
+            error = "Error: --audit-log requires a path value (use `--audit-log <path>` or `--audit-log=<path>`).";
+            return false;
+        }
+
+        return TrySetAuditLogPath(args[++index], state, out error);
+    }
+
+    private static bool TrySetAuditLogPath(string path, AuditLogFlagParseState state, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            error = "Error: --audit-log requires a non-empty path value.";
+            return false;
+        }
+
+        state.Path = path;
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryConsumeAuditLogMaxBytes(
+        string[] args,
+        ref int index,
+        AuditLogFlagParseState state,
+        out string error)
+    {
+        var arg = args[index];
+        string raw;
+        if (arg == "--audit-log-max-bytes")
+        {
+            if (index + 1 >= args.Length)
+            {
+                error = "Error: --audit-log-max-bytes requires a byte count.";
+                return false;
+            }
+            raw = args[++index];
+        }
+        else
+        {
+            raw = arg.Substring("--audit-log-max-bytes=".Length);
+        }
+
+        if (!long.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+            || parsed < AuditLogSink.MinMaxBytes)
+        {
+            error = $"Error: --audit-log-max-bytes must be an integer >= {AuditLogSink.MinMaxBytes}.";
+            return false;
+        }
+
+        state.MaxBytes = parsed;
+        error = string.Empty;
         return true;
     }
 

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -47,6 +47,13 @@ internal static class ProgramRunner
     };
     internal static TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
+    private sealed record CommandRunContext(
+        JsonSerializerOptions JsonOptions,
+        string AppVersion,
+        DateTimeOffset StartTimestamp,
+        Stopwatch Stopwatch,
+        CancellationToken CancellationToken);
+
     internal static int Run(
         string[] args,
         JsonSerializerOptions? jsonOptions = null,
@@ -126,207 +133,13 @@ internal static class ProgramRunner
         if (versionPinExit != CommandExitCodes.Success)
             return versionPinExit;
 
-        if (args.Length == 0 || args[0] is "--help" or "-h")
-        {
-            ConsoleUi.PrintUsageBrief(showBanner: args.Length > 0);
-            var helpExit = args.Length == 0 ? CommandExitCodes.UsageError : CommandExitCodes.Success;
-            GlobalToolLog.Info($"command_complete exit_code={helpExit} help_or_usage=true");
-            EmitCommandMetric("help", args, commandStartTimestamp, commandStopwatch, helpExit);
-            return helpExit;
-        }
-
-        if (args[0] is "--help-all" or "--help-extended")
-        {
-            ConsoleUi.PrintUsageFull(showBanner: true);
-            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} help_all=true");
-            EmitCommandMetric("help-all", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
-            return CommandExitCodes.Success;
-        }
-
-        if (args[0] == "--help-flags")
-        {
-            ConsoleUi.PrintFlagUsage(showBanner: true);
-            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} help_flags=true");
-            EmitCommandMetric("help-flags", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
-            return CommandExitCodes.Success;
-        }
-
-        if (args[0] is "--version" or "-V")
-        {
-            var versionExitCode = RunVersion(args[1..], jsonOptions, appVersion, cancellationToken);
-            GlobalToolLog.Info($"command_complete exit_code={versionExitCode} version_only=true");
-            EmitCommandMetric("version", args, commandStartTimestamp, commandStopwatch, versionExitCode);
-            return versionExitCode;
-        }
-
-        if (args[0] == "--check-updates")
-        {
-            var updateExitCode = RunCheckUpdates(args[1..], jsonOptions, appVersion, cancellationToken);
-            GlobalToolLog.Info($"command_complete exit_code={updateExitCode} check_updates=true");
-            EmitCommandMetric("check-updates", args, commandStartTimestamp, commandStopwatch, updateExitCode);
-            return updateExitCode;
-        }
-
-        if (args[0] is "--license" or "license")
-        {
-            if (args[0] == "license" && args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
-            {
-                ConsoleUi.PrintCommandUsage("license");
-                GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} subcommand_help=true");
-                EmitCommandMetric("license", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
-                return CommandExitCodes.Success;
-            }
-
-            ConsoleUi.PrintLicenseSummary();
-            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} license_only=true");
-            EmitCommandMetric("license", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
-            return CommandExitCodes.Success;
-        }
-
-        if (args[0] is "--completions" or "completions")
-        {
-            if (args[0] == "completions" && args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
-            {
-                ConsoleUi.PrintCommandUsage("completions");
-                GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} subcommand_help=true");
-                EmitCommandMetric("completions", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
-                return CommandExitCodes.Success;
-            }
-
-            var exitCode = RunCompletions(args[1..], args[0] == "completions" ? "completions" : "--completions");
-            GlobalToolLog.Info($"command_complete exit_code={exitCode} command=completions");
-            EmitCommandMetric("completions", args, commandStartTimestamp, commandStopwatch, exitCode);
-            return exitCode;
-        }
-
-        if (args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
-        {
-            if (!ConsoleUi.PrintCommandUsage(args[0]))
-                ConsoleUi.PrintUsage(showBanner: true);
-            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} subcommand_help=true");
-            EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
-            return CommandExitCodes.Success;
-        }
-
-        if (args[0] == "doctor")
-        {
-            var doctorExitCode = RunDoctor(args[1..], appVersion);
-            GlobalToolLog.Info($"command_complete exit_code={doctorExitCode} command=doctor");
-            EmitCommandMetric("doctor", args, commandStartTimestamp, commandStopwatch, doctorExitCode);
-            return doctorExitCode;
-        }
-
-        var easterEgg = args.FirstOrDefault(a => a is "--sushi" or "--coffee" or "--ramen" or "--wine" or "--beer" or "--matcha" or "--whisky");
-        if (easterEgg != null && !args.Any(a => !a.StartsWith('-')))
-        {
-            ConsoleUi.PrintEasterEggMessage(easterEgg);
-            GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.Success} easter_egg={easterEgg}");
-            EmitCommandMetric("easter_egg", args, commandStartTimestamp, commandStopwatch, CommandExitCodes.Success);
-            return CommandExitCodes.Success;
-        }
+        var context = new CommandRunContext(jsonOptions, appVersion, commandStartTimestamp, commandStopwatch, cancellationToken);
+        if (TryRunImmediateCommand(args, context, out var immediateExitCode))
+            return immediateExitCode;
 
         try
         {
-            beforeDispatchForTesting?.Invoke();
-
-            if (args[0] is "mcp" or "mcp-server")
-            {
-                var mcpExitCode = RunMcp(args[1..], appVersion);
-                GlobalToolLog.Info($"command_complete exit_code={mcpExitCode} command=mcp");
-                EmitCommandMetric("mcp", args, commandStartTimestamp, commandStopwatch, mcpExitCode);
-                return mcpExitCode;
-            }
-
-            if (args[0] is "lsp" or "--lsp")
-            {
-                var lspExitCode = RunLsp(args[1..], appVersion, jsonOptions);
-                GlobalToolLog.Info($"command_complete exit_code={lspExitCode} command=lsp");
-                EmitCommandMetric("lsp", args, commandStartTimestamp, commandStopwatch, lspExitCode);
-                return lspExitCode;
-            }
-
-            var commandName = args[0];
-            var subArgs = args[1..];
-            Func<string[], int>? queryRunner = commandName switch
-            {
-                "search" => a => QueryCommandRunner.RunSearch(a, jsonOptions),
-                "definition" => a => QueryCommandRunner.RunDefinition(a, jsonOptions),
-                "goto" => a => QueryCommandRunner.RunGoto(a, jsonOptions),
-                "references" => a => QueryCommandRunner.RunReferences(a, jsonOptions),
-                "callers" => a => QueryCommandRunner.RunCallers(a, jsonOptions),
-                "callees" => a => QueryCommandRunner.RunCallees(a, jsonOptions),
-                "symbols" => a => QueryCommandRunner.RunSymbols(a, jsonOptions),
-                "files" => a => QueryCommandRunner.RunFiles(a, jsonOptions),
-                "find" => a => QueryCommandRunner.RunFind(a, jsonOptions),
-                "excerpt" => a => QueryCommandRunner.RunExcerpt(a, jsonOptions),
-                "map" => a => QueryCommandRunner.RunMap(a, jsonOptions),
-                "inspect" => a => QueryCommandRunner.RunInspect(a, jsonOptions),
-                "outline" => a => QueryCommandRunner.RunOutline(a, jsonOptions),
-                "status" => a => QueryCommandRunner.RunStatus(a, jsonOptions, appVersion, cancellationToken),
-                "validate" => a => QueryCommandRunner.RunValidate(a, jsonOptions),
-                "languages" => a => QueryCommandRunner.RunLanguages(a, jsonOptions),
-                "impact" => a => QueryCommandRunner.RunImpact(a, jsonOptions),
-                "deps" => a => QueryCommandRunner.RunDeps(a, jsonOptions),
-                "unused" => a => QueryCommandRunner.RunUnused(a, jsonOptions),
-                "hotspots" => a => QueryCommandRunner.RunHotspots(a, jsonOptions),
-                "batch" => a => QueryCommandRunner.RunBatch(a, jsonOptions),
-                "suggestions" => a => SuggestionsCommandRunner.Run(a, jsonOptions),
-                _ => null,
-            };
-
-            int exitCode;
-            if (queryRunner is not null)
-            {
-                subArgs = InsertQueryLiteralSentinelForNonLogGlobalOption(commandName, subArgs);
-
-                if (!TryConsumeQueryTraceFlag(ref subArgs, out var traceMode, out var traceError))
-                {
-                    CommandErrorWriter.Write(StripErrorPrefix(traceError), "use one of `none`, `stderr`, or `file`.");
-                    GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.InvalidArgument} command={commandName} trace_flag_invalid=true");
-                    EmitCommandMetric(commandName, args, commandStartTimestamp, commandStopwatch, CommandExitCodes.InvalidArgument);
-                    return CommandExitCodes.InvalidArgument;
-                }
-
-                using var traceCapture = QueryTraceOutputCapture.TryStart(traceMode, subArgs);
-                exitCode = JsonEnvelopeWrapper.ShouldWrap(commandName, subArgs)
-                    ? JsonEnvelopeWrapper.RunWrapped(commandName, subArgs, appVersion, jsonOptions, queryRunner)
-                    : queryRunner(subArgs);
-                EmitQueryTrace(traceMode, commandName, subArgs, commandStartTimestamp, commandStopwatch, exitCode, traceCapture?.ResultCount);
-            }
-            else
-            {
-                exitCode = commandName switch
-                {
-                    "upgrade" => RunUpgrade(subArgs, jsonOptions, appVersion, cancellationToken),
-                    "index" => IndexCommandRunner.Run(subArgs, jsonOptions),
-                    "export" => ExportImportCommandRunner.RunExport(subArgs, jsonOptions, appVersion),
-                    "import" => ExportImportCommandRunner.RunImport(subArgs, jsonOptions),
-                    "diff" => DiffCommandRunner.Run(subArgs, jsonOptions),
-                    "hooks" => HookCommandRunner.Run(subArgs, jsonOptions),
-                    "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, jsonOptions),
-                    "optimize" => IndexCommandRunner.RunOptimizeFts(subArgs, jsonOptions),
-                    "vacuum" => QueryCommandRunner.RunVacuum(subArgs, jsonOptions),
-                    "validate-config" => CdidxConfigFile.RunValidate(subArgs, jsonOptions),
-                    "config" => subArgs.Length > 0 && subArgs[0] == "show"
-                        ? CdidxConfigFile.RunShow(subArgs[1..], jsonOptions)
-                        : CommandErrorWriter.WriteJsonOrHuman(
-                            ContainsJsonOutputFlag(subArgs),
-                            jsonOptions,
-                            "Unknown config command: use `cdidx config show`.",
-                            CommandExitCodes.UsageError,
-                            "use `cdidx config show`."),
-                    "workspace" => WorkspaceCommandRunner.Run(subArgs, jsonOptions),
-                    "db" => DbCommandRunner.Run(subArgs, jsonOptions),
-                    "report" => ReportCommandRunner.Run(subArgs, jsonOptions, appVersion),
-                    "test-extractor" => RunTestExtractor(subArgs, jsonOptions),
-                    _ when IsProjectPathArg(commandName)
-                        => IndexCommandRunner.Run(args, jsonOptions),
-                    _ => ShowError(args, $"Unknown command: {commandName}")
-                };
-            }
-            GlobalToolLog.Info($"command_complete exit_code={exitCode} command={commandName}");
-            EmitCommandMetric(commandName, args, commandStartTimestamp, commandStopwatch, exitCode);
-            return exitCode;
+            return RunDispatchedCommand(args, context, beforeDispatchForTesting);
         }
         catch (CodeIndexException ex)
         {
@@ -335,16 +148,16 @@ internal static class ProgramRunner
             // signal to branch on instead of parsing free-form messages.
             // #1580: 失敗ファイル / 構造化フィールドを CLI で一律に表示する。
             var exitCode = MapCodeIndexExceptionExitCode(ex.Code);
-            CodeIndexExceptionFormatter.Write(ex, args, jsonOptions);
+            CodeIndexExceptionFormatter.Write(ex, args, context.JsonOptions);
             GlobalToolLog.Error($"command_complete exit_code={exitCode} code_index_exception code={ex.Code} category={ex.Category} path={ex.Path}", ex, includeStacks: false);
-            EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, exitCode, ex.Code);
+            EmitCommandMetric(args[0], args, context.StartTimestamp, context.Stopwatch, exitCode, ex.Code);
             return exitCode;
         }
         catch (OperationCanceledException ex)
         {
             GlobalToolLog.Error($"command_complete exit_code={CommandExitCodes.CancelledBySignal} operation_cancelled", ex, includeStacks: false);
             Console.Error.WriteLine("Error: command cancelled before it could complete.");
-            EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, CommandExitCodes.CancelledBySignal, ex.GetType().Name);
+            EmitCommandMetric(args[0], args, context.StartTimestamp, context.Stopwatch, CommandExitCodes.CancelledBySignal, ex.GetType().Name);
             return CommandExitCodes.CancelledBySignal;
         }
         catch (Exception ex)
@@ -352,17 +165,288 @@ internal static class ProgramRunner
             if (JsonOutputFailure.TryHandle(ex, out var exitCode))
             {
                 GlobalToolLog.Error($"command_complete exit_code={exitCode} handled_exception", ex, includeStacks: false);
-                EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, exitCode, ex.GetType().Name);
+                EmitCommandMetric(args[0], args, context.StartTimestamp, context.Stopwatch, exitCode, ex.GetType().Name);
                 return exitCode;
             }
 
             var unhandledExitCode = MapUnhandledExceptionExitCode(ex);
             GlobalToolLog.Error($"command_complete exit_code={unhandledExitCode} unhandled_exception", ex);
             Console.Error.WriteLine("Error: command failed before it could complete. Run `cdidx report` for details.");
-            EmitCommandMetric(args[0], args, commandStartTimestamp, commandStopwatch, unhandledExitCode, ex.GetType().Name);
+            EmitCommandMetric(args[0], args, context.StartTimestamp, context.Stopwatch, unhandledExitCode, ex.GetType().Name);
             return unhandledExitCode;
         }
     }
+
+    private static bool TryRunImmediateCommand(string[] args, CommandRunContext context, out int exitCode)
+    {
+        if (TryRunHelpVersionOrUpdateCommand(args, context, out exitCode))
+            return true;
+        if (TryRunStandaloneUtilityCommand(args, context, out exitCode))
+            return true;
+        if (TryRunSubcommandHelp(args, context, out exitCode))
+            return true;
+        if (TryRunDoctorCommand(args, context, out exitCode))
+            return true;
+        if (TryRunEasterEggCommand(args, context, out exitCode))
+            return true;
+
+        exitCode = CommandExitCodes.Success;
+        return false;
+    }
+
+    private static bool TryRunHelpVersionOrUpdateCommand(string[] args, CommandRunContext context, out int exitCode)
+    {
+        if (args.Length == 0 || args[0] is "--help" or "-h")
+        {
+            ConsoleUi.PrintUsageBrief(showBanner: args.Length > 0);
+            exitCode = args.Length == 0 ? CommandExitCodes.UsageError : CommandExitCodes.Success;
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} help_or_usage=true");
+            EmitCommandMetric("help", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        if (args[0] is "--help-all" or "--help-extended")
+        {
+            ConsoleUi.PrintUsageFull(showBanner: true);
+            exitCode = CommandExitCodes.Success;
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} help_all=true");
+            EmitCommandMetric("help-all", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        if (args[0] == "--help-flags")
+        {
+            ConsoleUi.PrintFlagUsage(showBanner: true);
+            exitCode = CommandExitCodes.Success;
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} help_flags=true");
+            EmitCommandMetric("help-flags", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        if (args[0] is "--version" or "-V")
+        {
+            exitCode = RunVersion(args[1..], context.JsonOptions, context.AppVersion, context.CancellationToken);
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} version_only=true");
+            EmitCommandMetric("version", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        if (args[0] == "--check-updates")
+        {
+            exitCode = RunCheckUpdates(args[1..], context.JsonOptions, context.AppVersion, context.CancellationToken);
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} check_updates=true");
+            EmitCommandMetric("check-updates", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        exitCode = CommandExitCodes.Success;
+        return false;
+    }
+
+    private static bool TryRunStandaloneUtilityCommand(string[] args, CommandRunContext context, out int exitCode)
+    {
+        if (args[0] is "--license" or "license")
+        {
+            if (args[0] == "license" && args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
+            {
+                ConsoleUi.PrintCommandUsage("license");
+                exitCode = CommandExitCodes.Success;
+                GlobalToolLog.Info($"command_complete exit_code={exitCode} subcommand_help=true");
+                EmitCommandMetric("license", args, context.StartTimestamp, context.Stopwatch, exitCode);
+                return true;
+            }
+
+            ConsoleUi.PrintLicenseSummary();
+            exitCode = CommandExitCodes.Success;
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} license_only=true");
+            EmitCommandMetric("license", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        if (args[0] is "--completions" or "completions")
+        {
+            if (args[0] == "completions" && args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
+            {
+                ConsoleUi.PrintCommandUsage("completions");
+                exitCode = CommandExitCodes.Success;
+                GlobalToolLog.Info($"command_complete exit_code={exitCode} subcommand_help=true");
+                EmitCommandMetric("completions", args, context.StartTimestamp, context.Stopwatch, exitCode);
+                return true;
+            }
+
+            exitCode = RunCompletions(args[1..], args[0] == "completions" ? "completions" : "--completions");
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} command=completions");
+            EmitCommandMetric("completions", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        exitCode = CommandExitCodes.Success;
+        return false;
+    }
+
+    private static bool TryRunSubcommandHelp(string[] args, CommandRunContext context, out int exitCode)
+    {
+        if (args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
+        {
+            if (!ConsoleUi.PrintCommandUsage(args[0]))
+                ConsoleUi.PrintUsage(showBanner: true);
+            exitCode = CommandExitCodes.Success;
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} subcommand_help=true");
+            EmitCommandMetric(args[0], args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        exitCode = CommandExitCodes.Success;
+        return false;
+    }
+
+    private static bool TryRunDoctorCommand(string[] args, CommandRunContext context, out int exitCode)
+    {
+        if (args[0] == "doctor")
+        {
+            exitCode = RunDoctor(args[1..], context.AppVersion);
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} command=doctor");
+            EmitCommandMetric("doctor", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        exitCode = CommandExitCodes.Success;
+        return false;
+    }
+
+    private static bool TryRunEasterEggCommand(string[] args, CommandRunContext context, out int exitCode)
+    {
+        var easterEgg = args.FirstOrDefault(a => a is "--sushi" or "--coffee" or "--ramen" or "--wine" or "--beer" or "--matcha" or "--whisky");
+        if (easterEgg != null && !args.Any(a => !a.StartsWith('-')))
+        {
+            ConsoleUi.PrintEasterEggMessage(easterEgg);
+            exitCode = CommandExitCodes.Success;
+            GlobalToolLog.Info($"command_complete exit_code={exitCode} easter_egg={easterEgg}");
+            EmitCommandMetric("easter_egg", args, context.StartTimestamp, context.Stopwatch, exitCode);
+            return true;
+        }
+
+        exitCode = CommandExitCodes.Success;
+        return false;
+    }
+
+    private static int RunDispatchedCommand(
+        string[] args,
+        CommandRunContext context,
+        Action? beforeDispatchForTesting)
+    {
+        beforeDispatchForTesting?.Invoke();
+
+        if (args[0] is "mcp" or "mcp-server")
+        {
+            var mcpExitCode = RunMcp(args[1..], context.AppVersion);
+            GlobalToolLog.Info($"command_complete exit_code={mcpExitCode} command=mcp");
+            EmitCommandMetric("mcp", args, context.StartTimestamp, context.Stopwatch, mcpExitCode);
+            return mcpExitCode;
+        }
+
+        if (args[0] is "lsp" or "--lsp")
+        {
+            var lspExitCode = RunLsp(args[1..], context.AppVersion, context.JsonOptions);
+            GlobalToolLog.Info($"command_complete exit_code={lspExitCode} command=lsp");
+            EmitCommandMetric("lsp", args, context.StartTimestamp, context.Stopwatch, lspExitCode);
+            return lspExitCode;
+        }
+
+        var commandName = args[0];
+        var subArgs = args[1..];
+        var queryRunner = ResolveQueryRunner(commandName, context);
+
+        int exitCode;
+        if (queryRunner is not null)
+        {
+            subArgs = InsertQueryLiteralSentinelForNonLogGlobalOption(commandName, subArgs);
+
+            if (!TryConsumeQueryTraceFlag(ref subArgs, out var traceMode, out var traceError))
+            {
+                CommandErrorWriter.Write(StripErrorPrefix(traceError), "use one of `none`, `stderr`, or `file`.");
+                GlobalToolLog.Info($"command_complete exit_code={CommandExitCodes.InvalidArgument} command={commandName} trace_flag_invalid=true");
+                EmitCommandMetric(commandName, args, context.StartTimestamp, context.Stopwatch, CommandExitCodes.InvalidArgument);
+                return CommandExitCodes.InvalidArgument;
+            }
+
+            using var traceCapture = QueryTraceOutputCapture.TryStart(traceMode, subArgs);
+            exitCode = JsonEnvelopeWrapper.ShouldWrap(commandName, subArgs)
+                ? JsonEnvelopeWrapper.RunWrapped(commandName, subArgs, context.AppVersion, context.JsonOptions, queryRunner)
+                : queryRunner(subArgs);
+            EmitQueryTrace(traceMode, commandName, subArgs, context.StartTimestamp, context.Stopwatch, exitCode, traceCapture?.ResultCount);
+        }
+        else
+        {
+            exitCode = RunNonQueryCommand(commandName, subArgs, args, context);
+        }
+
+        GlobalToolLog.Info($"command_complete exit_code={exitCode} command={commandName}");
+        EmitCommandMetric(commandName, args, context.StartTimestamp, context.Stopwatch, exitCode);
+        return exitCode;
+    }
+
+    private static Func<string[], int>? ResolveQueryRunner(string commandName, CommandRunContext context) =>
+        commandName switch
+        {
+            "search" => a => QueryCommandRunner.RunSearch(a, context.JsonOptions),
+            "definition" => a => QueryCommandRunner.RunDefinition(a, context.JsonOptions),
+            "goto" => a => QueryCommandRunner.RunGoto(a, context.JsonOptions),
+            "references" => a => QueryCommandRunner.RunReferences(a, context.JsonOptions),
+            "callers" => a => QueryCommandRunner.RunCallers(a, context.JsonOptions),
+            "callees" => a => QueryCommandRunner.RunCallees(a, context.JsonOptions),
+            "symbols" => a => QueryCommandRunner.RunSymbols(a, context.JsonOptions),
+            "files" => a => QueryCommandRunner.RunFiles(a, context.JsonOptions),
+            "find" => a => QueryCommandRunner.RunFind(a, context.JsonOptions),
+            "excerpt" => a => QueryCommandRunner.RunExcerpt(a, context.JsonOptions),
+            "map" => a => QueryCommandRunner.RunMap(a, context.JsonOptions),
+            "inspect" => a => QueryCommandRunner.RunInspect(a, context.JsonOptions),
+            "outline" => a => QueryCommandRunner.RunOutline(a, context.JsonOptions),
+            "status" => a => QueryCommandRunner.RunStatus(a, context.JsonOptions, context.AppVersion, context.CancellationToken),
+            "validate" => a => QueryCommandRunner.RunValidate(a, context.JsonOptions),
+            "languages" => a => QueryCommandRunner.RunLanguages(a, context.JsonOptions),
+            "impact" => a => QueryCommandRunner.RunImpact(a, context.JsonOptions),
+            "deps" => a => QueryCommandRunner.RunDeps(a, context.JsonOptions),
+            "unused" => a => QueryCommandRunner.RunUnused(a, context.JsonOptions),
+            "hotspots" => a => QueryCommandRunner.RunHotspots(a, context.JsonOptions),
+            "batch" => a => QueryCommandRunner.RunBatch(a, context.JsonOptions),
+            "suggestions" => a => SuggestionsCommandRunner.Run(a, context.JsonOptions),
+            _ => null,
+        };
+
+    private static int RunNonQueryCommand(
+        string commandName,
+        string[] subArgs,
+        string[] originalArgs,
+        CommandRunContext context) =>
+        commandName switch
+        {
+            "upgrade" => RunUpgrade(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
+            "index" => IndexCommandRunner.Run(subArgs, context.JsonOptions),
+            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion),
+            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions),
+            "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions),
+            "hooks" => HookCommandRunner.Run(subArgs, context.JsonOptions),
+            "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),
+            "optimize" => IndexCommandRunner.RunOptimizeFts(subArgs, context.JsonOptions),
+            "vacuum" => QueryCommandRunner.RunVacuum(subArgs, context.JsonOptions),
+            "validate-config" => CdidxConfigFile.RunValidate(subArgs, context.JsonOptions),
+            "config" => subArgs.Length > 0 && subArgs[0] == "show"
+                ? CdidxConfigFile.RunShow(subArgs[1..], context.JsonOptions)
+                : CommandErrorWriter.WriteJsonOrHuman(
+                    ContainsJsonOutputFlag(subArgs),
+                    context.JsonOptions,
+                    "Unknown config command: use `cdidx config show`.",
+                    CommandExitCodes.UsageError,
+                    "use `cdidx config show`."),
+            "workspace" => WorkspaceCommandRunner.Run(subArgs, context.JsonOptions),
+            "db" => DbCommandRunner.Run(subArgs, context.JsonOptions),
+            "report" => ReportCommandRunner.Run(subArgs, context.JsonOptions, context.AppVersion),
+            "test-extractor" => RunTestExtractor(subArgs, context.JsonOptions),
+            _ when IsProjectPathArg(commandName)
+                => IndexCommandRunner.Run(originalArgs, context.JsonOptions),
+            _ => ShowError(originalArgs, $"Unknown command: {commandName}")
+        };
 
     internal static bool IsProjectPathArg(string arg)
     {
@@ -2054,30 +2138,71 @@ internal static class ProgramRunner
         Console.Error.WriteLine("Runs a read-only Language Server Protocol server over stdio using an existing CodeIndex database.");
     }
 
+    private sealed record McpRunOptions(
+        QueryCommandOptions QueryOptions,
+        string Transport,
+        string? ListenSpec,
+        AuditLogOptions AuditOptions);
+
     private static int RunMcp(string[] cmdArgs, string appVersion)
+    {
+        if (!TryPrepareMcpRun(cmdArgs, out var runOptions, out var exitCode))
+            return exitCode;
+
+        AuditLogSink? auditLog = null;
+        try
+        {
+            if (!TryOpenMcpAuditLog(runOptions.AuditOptions, out auditLog, out exitCode))
+                return exitCode;
+
+            // Pick the authenticator based on `CDIDX_MCP_AUTH_TOKEN` (#1559). When unset the
+            // permissive local-stdio default keeps the historical behaviour; when set every
+            // JSON-RPC request must include a matching `params.auth.token`. The tool-enablement
+            // gate (#1561) is wired automatically by the McpServer ctor via
+            // `McpToolFilter.FromEnvironment()`.
+            // `CDIDX_MCP_AUTH_TOKEN` の有無で authenticator を切り替える (#1559)。未設定なら
+            // permissive な stdio 既定で従来動作を維持し、設定済みなら全 JSON-RPC リクエストに
+            // `params.auth.token` の一致を要求する。ツール有効化ゲート (#1561) は McpServer の
+            // コンストラクタ内部で `McpToolFilter.FromEnvironment()` から自動取得される。
+            var authenticator = Mcp.McpAuthenticatorFactory.FromEnvironment();
+            using var server = new McpServer(runOptions.QueryOptions.DbPath, appVersion, runOptions.QueryOptions.DbPathExplicit, authenticator, auditLog);
+            return RunMcpServer(server, runOptions.Transport, runOptions.ListenSpec);
+        }
+        finally
+        {
+            auditLog?.Dispose();
+        }
+    }
+
+    private static bool TryPrepareMcpRun(string[] cmdArgs, out McpRunOptions runOptions, out int exitCode)
     {
         // Strip audit-log opt-in flags first so the strict mcp parser below does not see them
         // and raise an unknown-flag error. Keeps `--db` and `--` passthrough intact (#1562).
         // audit-log オプションフラグは厳格パーサに渡る前に除去し、未知フラグ扱いされるのを防ぐ (#1562)。
+        runOptions = null!;
+        exitCode = CommandExitCodes.Success;
         if (!TryConsumeAuditLogFlags(ref cmdArgs, out var auditOptions, out var auditError))
         {
             Console.Error.WriteLine(auditError);
             PrintMcpUsage();
-            return CommandExitCodes.UsageError;
+            exitCode = CommandExitCodes.UsageError;
+            return false;
         }
 
         if (!TryConsumeSuggestionDedupThresholdFlag(ref cmdArgs, out var thresholdError))
         {
             Console.Error.WriteLine(thresholdError);
             PrintMcpUsage();
-            return CommandExitCodes.UsageError;
+            exitCode = CommandExitCodes.UsageError;
+            return false;
         }
 
         if (!TryExtractMcpTransportFlags(cmdArgs, out var transportSpec, out var listenSpec, out var transportError))
         {
             Console.Error.WriteLine(transportError);
             PrintMcpUsage();
-            return CommandExitCodes.UsageError;
+            exitCode = CommandExitCodes.UsageError;
+            return false;
         }
 
         // Strip the transport flags from the args before delegating to QueryCommandRunner.ParseArgs
@@ -2090,9 +2215,22 @@ internal static class ProgramRunner
         {
             Console.Error.WriteLine(options.ParseError);
             PrintMcpUsage();
-            return CommandExitCodes.UsageError;
+            exitCode = CommandExitCodes.UsageError;
+            return false;
         }
 
+        if (!TryValidateMcpResidualArgs(residualArgs, out exitCode))
+            return false;
+
+        if (!TryResolveMcpTransport(transportSpec, listenSpec, out var transport, out exitCode))
+            return false;
+
+        runOptions = new McpRunOptions(options, transport, listenSpec, auditOptions);
+        return true;
+    }
+
+    private static bool TryValidateMcpResidualArgs(string[] residualArgs, out int exitCode)
+    {
         for (var i = 0; i < residualArgs.Length; i++)
         {
             if (residualArgs[i].StartsWith("--db=", StringComparison.Ordinal))
@@ -2110,81 +2248,85 @@ internal static class ProgramRunner
                 Console.Error.WriteLine($"Error: {residualArgs[i]} is not supported for mcp.");
             Console.Error.WriteLine("Hint: use `--db <path>` to point at a specific index, `--transport stdio|http` to pick a transport, `--http-listen host:port` for HTTP, or `--audit-log <path>` to enable per-call auditing.");
             PrintMcpUsage();
-            return CommandExitCodes.UsageError;
+            exitCode = CommandExitCodes.UsageError;
+            return false;
         }
 
-        var transport = transportSpec ?? "stdio";
+        exitCode = CommandExitCodes.Success;
+        return true;
+    }
+
+    private static bool TryResolveMcpTransport(string? transportSpec, string? listenSpec, out string transport, out int exitCode)
+    {
+        transport = transportSpec ?? "stdio";
         if (!string.Equals(transport, "stdio", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(transport, "http", StringComparison.OrdinalIgnoreCase))
         {
             Console.Error.WriteLine($"Error: --transport '{transport}' is not supported. Use `stdio` (default) or `http`.");
             PrintMcpUsage();
-            return CommandExitCodes.UsageError;
+            exitCode = CommandExitCodes.UsageError;
+            return false;
         }
 
         if (listenSpec != null && !string.Equals(transport, "http", StringComparison.OrdinalIgnoreCase))
         {
             Console.Error.WriteLine("Error: --http-listen requires `--transport http`.");
             PrintMcpUsage();
-            return CommandExitCodes.UsageError;
+            exitCode = CommandExitCodes.UsageError;
+            return false;
         }
 
-        AuditLogSink? auditLog = null;
-        if (auditOptions.Path != null)
+        exitCode = CommandExitCodes.Success;
+        return true;
+    }
+
+    private static bool TryOpenMcpAuditLog(AuditLogOptions auditOptions, out AuditLogSink? auditLog, out int exitCode)
+    {
+        auditLog = null;
+        if (auditOptions.Path == null)
         {
-            try
-            {
-                auditLog = new AuditLogSink(auditOptions.Path, auditOptions.MaxBytes, auditOptions.IncludeValues);
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"Error: failed to open audit log '{auditOptions.Path}' ({ex.GetType().Name}: {ex.Message}).");
-                Console.Error.WriteLine("Hint: pick a writable path or omit --audit-log to disable per-call auditing.");
-                return CommandExitCodes.UsageError;
-            }
+            exitCode = CommandExitCodes.Success;
+            return true;
         }
-
-        // Pick the authenticator based on `CDIDX_MCP_AUTH_TOKEN` (#1559). When unset the
-        // permissive local-stdio default keeps the historical behaviour; when set every
-        // JSON-RPC request must include a matching `params.auth.token`. The tool-enablement
-        // gate (#1561) is wired automatically by the McpServer ctor via
-        // `McpToolFilter.FromEnvironment()`.
-        // `CDIDX_MCP_AUTH_TOKEN` の有無で authenticator を切り替える (#1559)。未設定なら
-        // permissive な stdio 既定で従来動作を維持し、設定済みなら全 JSON-RPC リクエストに
-        // `params.auth.token` の一致を要求する。ツール有効化ゲート (#1561) は McpServer の
-        // コンストラクタ内部で `McpToolFilter.FromEnvironment()` から自動取得される。
-        var authenticator = Mcp.McpAuthenticatorFactory.FromEnvironment();
 
         try
         {
-            using var server = new McpServer(options.DbPath, appVersion, options.DbPathExplicit, authenticator, auditLog);
-
-            if (string.Equals(transport, "http", StringComparison.OrdinalIgnoreCase))
-                return RunMcpHttp(server, listenSpec ?? DefaultMcpHttpListen);
-
-            try
-            {
-                server.RunAsync().GetAwaiter().GetResult();
-                return CommandExitCodes.Success;
-            }
-            catch (OperationCanceledException)
-            {
-                Console.Out.Flush();
-                Console.Error.Flush();
-                return CommandExitCodes.CancelledBySignal;
-            }
-            catch (Exception ex)
-            {
-                GlobalToolLog.Error("mcp_server_failed " + GlobalToolLog.FormatExceptionChain(ex));
-                Console.Error.WriteLine($"Error: MCP server failed ({ex.GetType().Name}: {ex.Message}).");
-                Console.Out.Flush();
-                Console.Error.Flush();
-                return CommandExitCodes.DatabaseError;
-            }
+            auditLog = new AuditLogSink(auditOptions.Path, auditOptions.MaxBytes, auditOptions.IncludeValues);
+            exitCode = CommandExitCodes.Success;
+            return true;
         }
-        finally
+        catch (Exception ex)
         {
-            auditLog?.Dispose();
+            Console.Error.WriteLine($"Error: failed to open audit log '{auditOptions.Path}' ({ex.GetType().Name}: {ex.Message}).");
+            Console.Error.WriteLine("Hint: pick a writable path or omit --audit-log to disable per-call auditing.");
+            exitCode = CommandExitCodes.UsageError;
+            return false;
+        }
+    }
+
+    private static int RunMcpServer(McpServer server, string transport, string? listenSpec)
+    {
+        if (string.Equals(transport, "http", StringComparison.OrdinalIgnoreCase))
+            return RunMcpHttp(server, listenSpec ?? DefaultMcpHttpListen);
+
+        try
+        {
+            server.RunAsync().GetAwaiter().GetResult();
+            return CommandExitCodes.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            Console.Out.Flush();
+            Console.Error.Flush();
+            return CommandExitCodes.CancelledBySignal;
+        }
+        catch (Exception ex)
+        {
+            GlobalToolLog.Error("mcp_server_failed " + GlobalToolLog.FormatExceptionChain(ex));
+            Console.Error.WriteLine($"Error: MCP server failed ({ex.GetType().Name}: {ex.Message}).");
+            Console.Out.Flush();
+            Console.Error.Flush();
+            return CommandExitCodes.DatabaseError;
         }
     }
 

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1895,6 +1895,40 @@ public class FileIndexer
     internal PathFilterResult EvaluatePathFilter(string absolutePath, bool isDirectory = false)
     {
         var errors = new List<ScanError>();
+        if (TryEvaluatePathFilterPrefix(absolutePath, errors, out var fullPath, out var relativePath) is { } prefixResult)
+            return prefixResult;
+        if (TryLoadRootPathFilterRules(errors, isDirectory, out var activeIgnoreRules) is { } rootResult)
+            return rootResult;
+
+        if (relativePath.Length == 0 || relativePath == ".")
+            return new PathFilterResult(PathFilterKind.None, errors);
+
+        var segments = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var directorySegmentCount = isDirectory ? segments.Length : Math.Max(segments.Length - 1, 0);
+        var directoryResult = EvaluatePathFilterDirectorySegments(
+            segments,
+            directorySegmentCount,
+            errors,
+            activeIgnoreRules,
+            out var leafIgnoreRules,
+            out var inSubmodulePassthrough);
+        if (directoryResult != null)
+            return directoryResult.Value;
+
+        if (isDirectory)
+            return new PathFilterResult(PathFilterKind.None, errors);
+
+        return EvaluatePathFilterLeafFile(fullPath, errors, leafIgnoreRules, inSubmodulePassthrough);
+    }
+
+    private PathFilterResult? TryEvaluatePathFilterPrefix(
+        string absolutePath,
+        List<ScanError> errors,
+        out string fullPath,
+        out string relativePath)
+    {
+        fullPath = string.Empty;
+        relativePath = string.Empty;
         if (!IsFilePathSyntaxIndexable(absolutePath))
         {
             errors.Add(new ScanError(
@@ -1904,35 +1938,50 @@ public class FileIndexer
             return new PathFilterResult(PathFilterKind.ExcludedByDefaultFile, errors);
         }
 
-        var fullPath = Path.GetFullPath(absolutePath);
+        fullPath = Path.GetFullPath(absolutePath);
         if (!IsPathEqualOrParent(_projectRoot, fullPath))
             return new PathFilterResult(PathFilterKind.OutsideProjectRoot, errors);
 
-        var relativePath = NormalizeIgnorePath(Path.GetRelativePath(_projectRoot, fullPath));
+        relativePath = NormalizeIgnorePath(Path.GetRelativePath(_projectRoot, fullPath));
         if (relativePath.StartsWith("../", StringComparison.Ordinal))
             return new PathFilterResult(PathFilterKind.None, errors);
 
+        return null;
+    }
+
+    private PathFilterResult? TryLoadRootPathFilterRules(
+        List<ScanError> errors,
+        bool isDirectory,
+        out IgnoreRuleSet activeIgnoreRules)
+    {
         var fullyScanned = true;
         var preloadResult = LoadAncestorIgnoreRules(errors, ref fullyScanned);
-        var activeIgnoreRules = preloadResult.Rules;
+        activeIgnoreRules = preloadResult.Rules;
         if (!preloadResult.IgnoreRulesAvailable)
             return new PathFilterResult(PathFilterKind.IgnoreRulesUnavailable, errors);
 
         var projectRootFilterKind = GetDirectoryFilterKind(_projectRoot, activeIgnoreRules, isProjectRoot: true);
-        if (projectRootFilterKind != PathFilterKind.None)
-            return new PathFilterResult(projectRootFilterKind, errors);
+        return projectRootFilterKind != PathFilterKind.None
+            ? new PathFilterResult(projectRootFilterKind, errors)
+            : null;
+    }
 
-        if (relativePath.Length == 0 || relativePath == ".")
-            return new PathFilterResult(PathFilterKind.None, errors);
-
-        var segments = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+    private PathFilterResult? EvaluatePathFilterDirectorySegments(
+        string[] segments,
+        int directorySegmentCount,
+        List<ScanError> errors,
+        IgnoreRuleSet activeIgnoreRules,
+        out IgnoreRuleSet leafIgnoreRules,
+        out bool inSubmodulePassthrough)
+    {
         var currentDirectory = _projectRoot;
+        var fullyScanned = true;
         var loadResult = LoadIgnoreRulesForDirectory(currentDirectory, activeIgnoreRules, errors, ref fullyScanned);
-        activeIgnoreRules = loadResult.Rules;
+        leafIgnoreRules = loadResult.Rules;
+        inSubmodulePassthrough = false;
         if (!loadResult.IgnoreRulesAvailable)
             return new PathFilterResult(PathFilterKind.IgnoreRulesUnavailable, errors);
 
-        var directorySegmentCount = isDirectory ? segments.Length : Math.Max(segments.Length - 1, 0);
         // Mirror EnumerateDirectory's passthrough behavior so update-mode filters (--files /
         // --commits) match a fresh full scan: when SkipDirs is overridden because we're
         // routing toward a declared submodule, files/subdirs that do not themselves lead
@@ -1941,7 +1990,6 @@ public class FileIndexer
         // 更新モードのフィルタがフルスキャンと食い違わないようにする。submodule への通過のため
         // SkipDirs を上書きした場合でも、submodule に到達しないファイル・サブディレクトリは
         // 引き続き除外する。
-        var inSubmodulePassthrough = false;
         for (var i = 0; i < directorySegmentCount; i++)
         {
             var directoryName = segments[i];
@@ -1968,20 +2016,26 @@ public class FileIndexer
             else if (isSubmoduleAncestor)
                 inSubmodulePassthrough = true;
 
-            if (activeIgnoreRules.IsIgnored(childDirectory, isDirectory: true))
+            if (leafIgnoreRules.IsIgnored(childDirectory, isDirectory: true))
                 return new PathFilterResult(PathFilterKind.IgnoredByRules, errors);
 
             currentDirectory = childDirectory;
             fullyScanned = true;
-            loadResult = LoadIgnoreRulesForDirectory(currentDirectory, activeIgnoreRules, errors, ref fullyScanned);
-            activeIgnoreRules = loadResult.Rules;
+            loadResult = LoadIgnoreRulesForDirectory(currentDirectory, leafIgnoreRules, errors, ref fullyScanned);
+            leafIgnoreRules = loadResult.Rules;
             if (!loadResult.IgnoreRulesAvailable)
                 return new PathFilterResult(PathFilterKind.IgnoreRulesUnavailable, errors);
         }
 
-        if (isDirectory)
-            return new PathFilterResult(PathFilterKind.None, errors);
+        return null;
+    }
 
+    private PathFilterResult EvaluatePathFilterLeafFile(
+        string fullPath,
+        List<ScanError> errors,
+        IgnoreRuleSet activeIgnoreRules,
+        bool inSubmodulePassthrough)
+    {
         // File directly inside a submodule-ancestor passthrough directory: walker would not
         // index it, so neither should this filter.
         // submodule 祖先（passthrough）に直接置かれているファイルは walker も索引しないため

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -3034,6 +3034,58 @@ public class FileIndexer
         var relativePath = Path.GetRelativePath(_projectRoot, absolutePath);
         var normalizedRelativePath = NormalizeIndexPath(relativePath);
 
+        var (bytes, sizeBytes, modifiedUtc) = ReadRawBytesWithSizeLimit(
+            absolutePath,
+            normalizedRelativePath,
+            cancellationToken);
+        var (content, warning) = DecodeIndexableContent(bytes, relativePath);
+        // Normalize line endings to LF in one pass / 改行を1パスでLFに正規化
+        content = NormalizeLineEndings(content);
+        // Strip every line-leading UTF-8 BOM (U+FEFF): the leading BOM at offset 0
+        // and any BOM that immediately follows a `\n` (e.g. from accidental file
+        // concatenation or tool insertion). Leading BOM alone would make `^\s*`-
+        // anchored regexes silently miss line-1 declarations in BOM-prefixed
+        // Windows-authored sources; a BOM at the start of a mid-file line would
+        // additionally leak a phantom glyph through `search` / `excerpt` chunk
+        // output. Non-line-leading U+FEFF (Unicode 3.2+ ZWNBSP inside a string
+        // literal, identifier, or comment — e.g. `const s = "A\uFEFFB"`) is kept
+        // verbatim: stripping it would corrupt content fidelity for intentional
+        // mid-line ZWNBSP use. The checksum is computed after this canonicalization
+        // so freshness decisions match stored chunk/symbol line metadata. Closes #183/#1467.
+        // 行頭の UTF-8 BOM (U+FEFF) だけを剥がす — オフセット 0 の先頭 BOM と、
+        // `\n` の直後にある BOM (ファイル連結やツール挿入で発生) が対象。先頭 BOM
+        // だけでも行指向の `^\s*` 固定正規表現で BOM 付き Windows 作成ソースの
+        // 1 行目宣言を黙って取りこぼし、mid-file 行頭 BOM は `search` / `excerpt`
+        // のチャンク出力にそのまま幽霊グリフを漏らす。行頭以外の U+FEFF
+        // (Unicode 3.2+ の ZWNBSP を文字列リテラル・識別子・コメントで意図的に
+        // 使用しているケース、例: `const s = "A\uFEFFB"`) はそのまま保持する:
+        // これを剥がすと mid-line ZWNBSP の意図的利用に対して内容が壊れる。
+        // checksum はこの canonicalization 後に算出し、freshness 判定と保存される
+        // chunk / symbol 行メタデータを一致させる。Closes #183/#1467。
+        content = StripLineLeadingInvisibles(content);
+        if (IsGitLfsPointer(bytes))
+            content = string.Empty;
+        var lineCount = CountPhysicalLines(content);
+        var checksum = ComputeChecksum(Encoding.UTF8.GetBytes(content));
+        var record = new FileRecord
+        {
+            Path = normalizedRelativePath,
+            Lang = TryDetectLanguage(absolutePath, content).Language,
+            Size = sizeBytes,
+            Lines = lineCount,
+            Checksum = checksum,
+            Modified = modifiedUtc,
+            Generated = IsGeneratedCodeFile(normalizedRelativePath, content),
+        };
+
+        return (record, content, bytes, warning);
+    }
+
+    private (byte[] Bytes, long SizeBytes, DateTime ModifiedUtc) ReadRawBytesWithSizeLimit(
+        string absolutePath,
+        string normalizedRelativePath,
+        CancellationToken cancellationToken)
+    {
         // Read raw bytes through a single FileStream and cap the accumulated payload at
         // the configured max-file limit so a file that grew between the size probe and the read can no
         // longer bypass the cap. Splitting `FileInfo.Length` from `File.ReadAllBytes`
@@ -3103,13 +3155,16 @@ public class FileIndexer
                 break;
         }
 
+        return (bytes, sizeBytes, modifiedUtc);
+    }
+
+    private static (string Content, string? Warning) DecodeIndexableContent(byte[] bytes, string relativePath)
+    {
         var isUtf16Encoded = TryDetectUtf16Encoding(bytes, allowHeuristic: true, out var utf16BigEndian, out var hasUtf16Bom);
 
         if (!isUtf16Encoded && ContainsIndexBlockingNullByte(bytes))
             throw new BinaryFileSkippedException($"{relativePath}: binary file skipped because it contains NULL bytes");
 
-        string content;
-        string? warning = null;
         // BOM-based encoding detection: UTF-16 LE/BE source files are otherwise mangled
         // by the UTF-8 decoder (every other byte is U+FFFD or NUL), silently dropping
         // every symbol they declare. UTF-32 LE shares the first two bytes with UTF-16 LE
@@ -3121,62 +3176,21 @@ public class FileIndexer
         // ため、UTF-16 LE 経路から除外し UTF-8 fallback に流す。Closes #1540.
         if (isUtf16Encoded)
         {
-            content = new UnicodeEncoding(utf16BigEndian, byteOrderMark: hasUtf16Bom, throwOnInvalidBytes: false)
+            var content = new UnicodeEncoding(utf16BigEndian, byteOrderMark: hasUtf16Bom, throwOnInvalidBytes: false)
                 .GetString(bytes);
+            return (content, null);
         }
-        else
-        {
-            try
-            {
-                content = new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(bytes);
-            }
-            catch (DecoderFallbackException)
-            {
-                // Fall back to replacement mode but warn / 置換モードにフォールバックし警告
-                content = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(bytes);
-                warning = $"{relativePath}: contains invalid UTF-8 bytes (replaced with U+FFFD)";
-            }
-        }
-        // Normalize line endings to LF in one pass / 改行を1パスでLFに正規化
-        content = NormalizeLineEndings(content);
-        // Strip every line-leading UTF-8 BOM (U+FEFF): the leading BOM at offset 0
-        // and any BOM that immediately follows a `\n` (e.g. from accidental file
-        // concatenation or tool insertion). Leading BOM alone would make `^\s*`-
-        // anchored regexes silently miss line-1 declarations in BOM-prefixed
-        // Windows-authored sources; a BOM at the start of a mid-file line would
-        // additionally leak a phantom glyph through `search` / `excerpt` chunk
-        // output. Non-line-leading U+FEFF (Unicode 3.2+ ZWNBSP inside a string
-        // literal, identifier, or comment — e.g. `const s = "A\uFEFFB"`) is kept
-        // verbatim: stripping it would corrupt content fidelity for intentional
-        // mid-line ZWNBSP use. The checksum is computed after this canonicalization
-        // so freshness decisions match stored chunk/symbol line metadata. Closes #183/#1467.
-        // 行頭の UTF-8 BOM (U+FEFF) だけを剥がす — オフセット 0 の先頭 BOM と、
-        // `\n` の直後にある BOM (ファイル連結やツール挿入で発生) が対象。先頭 BOM
-        // だけでも行指向の `^\s*` 固定正規表現で BOM 付き Windows 作成ソースの
-        // 1 行目宣言を黙って取りこぼし、mid-file 行頭 BOM は `search` / `excerpt`
-        // のチャンク出力にそのまま幽霊グリフを漏らす。行頭以外の U+FEFF
-        // (Unicode 3.2+ の ZWNBSP を文字列リテラル・識別子・コメントで意図的に
-        // 使用しているケース、例: `const s = "A\uFEFFB"`) はそのまま保持する:
-        // これを剥がすと mid-line ZWNBSP の意図的利用に対して内容が壊れる。
-        // checksum はこの canonicalization 後に算出し、freshness 判定と保存される
-        // chunk / symbol 行メタデータを一致させる。Closes #183/#1467。
-        content = StripLineLeadingInvisibles(content);
-        if (IsGitLfsPointer(bytes))
-            content = string.Empty;
-        var lineCount = CountPhysicalLines(content);
-        var checksum = ComputeChecksum(Encoding.UTF8.GetBytes(content));
-        var record = new FileRecord
-        {
-            Path = normalizedRelativePath,
-            Lang = TryDetectLanguage(absolutePath, content).Language,
-            Size = sizeBytes,
-            Lines = lineCount,
-            Checksum = checksum,
-            Modified = modifiedUtc,
-            Generated = IsGeneratedCodeFile(normalizedRelativePath, content),
-        };
 
-        return (record, content, bytes, warning);
+        try
+        {
+            return (new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(bytes), null);
+        }
+        catch (DecoderFallbackException)
+        {
+            // Fall back to replacement mode but warn / 置換モードにフォールバックし警告
+            var content = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(bytes);
+            return (content, $"{relativePath}: contains invalid UTF-8 bytes (replaced with U+FFFD)");
+        }
     }
 
     public FileRecord BuildSkippedFileRecord(string absolutePath)

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -3569,17 +3569,7 @@ public class FileIndexer
         var isUtf16 = TryDetectUtf16Encoding(rawBytes, allowHeuristic: true, out var utf16BigEndian, out var hasUtf16Bom);
 
         if (isUtf16 && hasUtf16Bom)
-        {
-            issues.Add(new FileIssue
-            {
-                Path = relativePath,
-                Kind = "utf16_bom",
-                Line = 1,
-                Message = utf16BigEndian
-                    ? "UTF-16 BE BOM detected (decoded as UTF-16)"
-                    : "UTF-16 LE BOM detected (decoded as UTF-16)",
-            });
-        }
+            AddUtf16BomIssue(issues, relativePath, utf16BigEndian);
 
         if (TryGetConflictMarkerLine(content, out var conflictMarkerLine))
         {
@@ -3592,6 +3582,44 @@ public class FileIndexer
             });
         }
 
+        AddReplacementCharacterIssues(issues, relativePath, rawBytes, content, isUtf16, utf16BigEndian, hasUtf16Bom);
+
+        // Raw-byte heuristics: skip for UTF-16-decoded files because every UTF-16 LE ASCII
+        // codepoint looks like a NUL byte and CRLF appears as 0D 00 0A 00, so `bom` /
+        // `null_byte` / `mixed_line_endings` / `cr_only_line_endings` would all misfire.
+        // UTF-16 デコード経路では生バイト列が NUL バイトと 0D 00 0A 00 で埋まり、`bom` /
+        // `null_byte` / `mixed_line_endings` / `cr_only_line_endings` がすべて誤検出する
+        // ためスキップする。
+        if (!isUtf16)
+            AddRawByteContentIssues(issues, relativePath, rawBytes);
+
+        AddOversizeContentIssues(issues, relativePath, content);
+
+        return issues;
+    }
+
+    private static void AddUtf16BomIssue(List<FileIssue> issues, string relativePath, bool utf16BigEndian)
+    {
+        issues.Add(new FileIssue
+        {
+            Path = relativePath,
+            Kind = "utf16_bom",
+            Line = 1,
+            Message = utf16BigEndian
+                ? "UTF-16 BE BOM detected (decoded as UTF-16)"
+                : "UTF-16 LE BOM detected (decoded as UTF-16)",
+        });
+    }
+
+    private static void AddReplacementCharacterIssues(
+        List<FileIssue> issues,
+        string relativePath,
+        byte[] rawBytes,
+        string content,
+        bool isUtf16,
+        bool utf16BigEndian,
+        bool hasUtf16Bom)
+    {
         // Aggregate signal: when a large fraction of the decoded content is U+FFFD, the file
         // most likely uses a non-UTF8 encoding without a BOM (SHIFT_JIS / GBK / ISO-8859-1).
         // Emit one `non_utf8_likely` issue and suppress the per-line `replacement_char`
@@ -3632,134 +3660,136 @@ public class FileIndexer
         // Skip the per-line emission when `non_utf8_likely` already fired so a mojibake file
         // does not produce hundreds of near-duplicate `replacement_char` issues.
         // `non_utf8_likely` が出た場合は重複を抑え 1 件のアグリゲートに集約する。
-        if (!nonUtf8Likely)
+        if (nonUtf8Likely)
+            return;
+
+        for (int i = 0; i < content.Length; i++)
         {
-            for (int i = 0; i < content.Length; i++)
+            if (content[i] != '\uFFFD')
+                continue;
+
+            // Find line number / 行番号を特定
+            var lineNum = content[..i].Count(c => c == '\n') + 1;
+            var isSourceLiteral = replacementCharOrigin == FileIssue.OriginSourceLiteral;
+            issues.Add(new FileIssue
             {
-                if (content[i] == '\uFFFD')
-                {
-                    // Find line number / 行番号を特定
-                    var lineNum = content[..i].Count(c => c == '\n') + 1;
-                    var isSourceLiteral = replacementCharOrigin == FileIssue.OriginSourceLiteral;
-                    issues.Add(new FileIssue
-                    {
-                        Path = relativePath,
-                        Kind = "replacement_char",
-                        Line = lineNum,
-                        Message = isSourceLiteral
-                            ? $"U+FFFD source literal at line {lineNum}"
-                            : $"U+FFFD decoder replacement character at line {lineNum}",
-                        Origin = replacementCharOrigin,
-                        Severity = isSourceLiteral ? FileIssue.SeverityInfo : FileIssue.SeverityWarning,
-                    });
-                    // Skip to next line to avoid reporting every char on the same line
-                    // 同じ行の連続報告を避けるため次の行までスキップ
-                    var nextNewline = content.IndexOf('\n', i);
-                    if (nextNewline >= 0) i = nextNewline;
-                }
-            }
+                Path = relativePath,
+                Kind = "replacement_char",
+                Line = lineNum,
+                Message = isSourceLiteral
+                    ? $"U+FFFD source literal at line {lineNum}"
+                    : $"U+FFFD decoder replacement character at line {lineNum}",
+                Origin = replacementCharOrigin,
+                Severity = isSourceLiteral ? FileIssue.SeverityInfo : FileIssue.SeverityWarning,
+            });
+            // Skip to next line to avoid reporting every char on the same line
+            // 同じ行の連続報告を避けるため次の行までスキップ
+            var nextNewline = content.IndexOf('\n', i);
+            if (nextNewline >= 0) i = nextNewline;
+        }
+    }
+
+    private static void AddRawByteContentIssues(List<FileIssue> issues, string relativePath, byte[] rawBytes)
+    {
+        // BOM marker / BOMマーカー
+        if (rawBytes.Length >= 3 && rawBytes[0] == 0xEF && rawBytes[1] == 0xBB && rawBytes[2] == 0xBF)
+        {
+            issues.Add(new FileIssue
+            {
+                Path = relativePath,
+                Kind = "bom",
+                Line = 1,
+                Message = "UTF-8 BOM marker detected",
+            });
         }
 
-        // Raw-byte heuristics: skip for UTF-16-decoded files because every UTF-16 LE ASCII
-        // codepoint looks like a NUL byte and CRLF appears as 0D 00 0A 00, so `bom` /
-        // `null_byte` / `mixed_line_endings` / `cr_only_line_endings` would all misfire.
-        // UTF-16 デコード経路では生バイト列が NUL バイトと 0D 00 0A 00 で埋まり、`bom` /
-        // `null_byte` / `mixed_line_endings` / `cr_only_line_endings` がすべて誤検出する
-        // ためスキップする。
-        if (!isUtf16)
+        // NULL bytes (likely binary content) / NULLバイト（バイナリ混入の可能性）
+        if (rawBytes.Any(b => b == 0))
         {
-            // BOM marker / BOMマーカー
-            if (rawBytes.Length >= 3 && rawBytes[0] == 0xEF && rawBytes[1] == 0xBB && rawBytes[2] == 0xBF)
+            issues.Add(new FileIssue
             {
-                issues.Add(new FileIssue
-                {
-                    Path = relativePath,
-                    Kind = "bom",
-                    Line = 1,
-                    Message = "UTF-8 BOM marker detected",
-                });
-            }
+                Path = relativePath,
+                Kind = "null_byte",
+                Line = 0,
+                Message = "File contains NULL bytes (possible binary content)",
+            });
+        }
 
-            // NULL bytes (likely binary content) / NULLバイト（バイナリ混入の可能性）
-            if (rawBytes.Any(b => b == 0))
-            {
-                issues.Add(new FileIssue
-                {
-                    Path = relativePath,
-                    Kind = "null_byte",
-                    Line = 0,
-                    Message = "File contains NULL bytes (possible binary content)",
-                });
-            }
+        AddLineEndingIssues(issues, relativePath, rawBytes);
+    }
 
-            // Line-ending classification — check raw bytes before LF normalization so
-            // bare CR (legacy Mac) and three-way mixes are not silently flattened by
-            // the `\r\n` → `\n` then `\r` → `\n` pass in BuildRecordWithRawBytes.
-            // 改行コードの判定 — LF 正規化前の rawBytes で確認。BuildRecordWithRawBytes が
-            // `\r\n`→`\n`、`\r`→`\n` の順で潰してしまうため、生バイトで CR-only (旧 Mac)
-            // と 3 種混在を見分ける。
-            var hasCrlf = false;
-            var hasLfOnly = false;
-            var hasCrOnly = false;
-            for (int i = 0; i < rawBytes.Length; i++)
+    private static void AddLineEndingIssues(List<FileIssue> issues, string relativePath, byte[] rawBytes)
+    {
+        // Line-ending classification — check raw bytes before LF normalization so
+        // bare CR (legacy Mac) and three-way mixes are not silently flattened by
+        // the `\r\n` → `\n` then `\r` → `\n` pass in BuildRecordWithRawBytes.
+        // 改行コードの判定 — LF 正規化前の rawBytes で確認。BuildRecordWithRawBytes が
+        // `\r\n`→`\n`、`\r`→`\n` の順で潰してしまうため、生バイトで CR-only (旧 Mac)
+        // と 3 種混在を見分ける。
+        var hasCrlf = false;
+        var hasLfOnly = false;
+        var hasCrOnly = false;
+        for (int i = 0; i < rawBytes.Length; i++)
+        {
+            if (rawBytes[i] == 0x0D)
             {
-                if (rawBytes[i] == 0x0D)
+                if (i + 1 < rawBytes.Length && rawBytes[i + 1] == 0x0A)
                 {
-                    if (i + 1 < rawBytes.Length && rawBytes[i + 1] == 0x0A)
-                    {
-                        hasCrlf = true;
-                        i++; // skip the LF after CR
-                    }
-                    else
-                    {
-                        hasCrOnly = true;
-                    }
+                    hasCrlf = true;
+                    i++; // skip the LF after CR
                 }
-                else if (rawBytes[i] == 0x0A)
-                {
-                    hasLfOnly = true;
-                }
-            }
-            var distinctEndingTypes = (hasCrlf ? 1 : 0) + (hasLfOnly ? 1 : 0) + (hasCrOnly ? 1 : 0);
-            if (distinctEndingTypes >= 3)
-            {
-                issues.Add(new FileIssue
-                {
-                    Path = relativePath,
-                    Kind = "mixed_line_endings_three_way",
-                    Line = 0,
-                    Message = "Mixed line endings (CRLF, LF, and CR)",
-                });
-            }
-            else if (distinctEndingTypes == 2)
-            {
-                string description;
-                if (hasCrlf && hasLfOnly)
-                    description = "CRLF and LF";
-                else if (hasCrlf && hasCrOnly)
-                    description = "CRLF and CR";
                 else
-                    description = "LF and CR";
-                issues.Add(new FileIssue
                 {
-                    Path = relativePath,
-                    Kind = "mixed_line_endings",
-                    Line = 0,
-                    Message = $"Mixed line endings ({description})",
-                });
+                    hasCrOnly = true;
+                }
             }
-            else if (hasCrOnly)
+            else if (rawBytes[i] == 0x0A)
             {
-                issues.Add(new FileIssue
-                {
-                    Path = relativePath,
-                    Kind = "cr_only_line_endings",
-                    Line = 0,
-                    Message = "CR-only line endings (legacy Mac)",
-                });
+                hasLfOnly = true;
             }
         }
+        var distinctEndingTypes = (hasCrlf ? 1 : 0) + (hasLfOnly ? 1 : 0) + (hasCrOnly ? 1 : 0);
+        if (distinctEndingTypes >= 3)
+        {
+            issues.Add(new FileIssue
+            {
+                Path = relativePath,
+                Kind = "mixed_line_endings_three_way",
+                Line = 0,
+                Message = "Mixed line endings (CRLF, LF, and CR)",
+            });
+        }
+        else if (distinctEndingTypes == 2)
+        {
+            string description;
+            if (hasCrlf && hasLfOnly)
+                description = "CRLF and LF";
+            else if (hasCrlf && hasCrOnly)
+                description = "CRLF and CR";
+            else
+                description = "LF and CR";
+            issues.Add(new FileIssue
+            {
+                Path = relativePath,
+                Kind = "mixed_line_endings",
+                Line = 0,
+                Message = $"Mixed line endings ({description})",
+            });
+        }
+        else if (hasCrOnly)
+        {
+            issues.Add(new FileIssue
+            {
+                Path = relativePath,
+                Kind = "cr_only_line_endings",
+                Line = 0,
+                Message = "CR-only line endings (legacy Mac)",
+            });
+        }
+    }
 
+    private static void AddOversizeContentIssues(List<FileIssue> issues, string relativePath, string content)
+    {
         // line_too_long — surface the chunk/symbol/reference skip path that
         // triggers when a single physical line exceeds ChunkSplitter.MaxLineLength
         // (e.g. 1 MB minified `.min.js`, base64-encoded asset). The matching
@@ -3795,8 +3825,6 @@ public class FileIndexer
                 Message = $"Line {longFtsTokenLine} contains an FTS5 unicode61 token longer than {CodeIndex.Database.DbReader.FtsUnicode61MaxTokenLength} characters; that token is not searchable through FTS",
             });
         }
-
-        return issues;
     }
 
     internal static bool ContainsIndexBlockingNullByte(byte[] rawBytes)

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -493,6 +493,21 @@ public class FileIndexer
         IgnoreRuleSet Rules,
         bool IgnoreRulesAvailable);
 
+    private sealed record DirectoryScanState(
+        List<string> Results,
+        List<ScanError> Errors,
+        HashSet<string> NonIndexablePaths,
+        HashSet<string> UnknownExtensionFiles,
+        HashSet<string> ProbeFailedFilePaths,
+        HashSet<string> ListedDirectories,
+        HashSet<string> FullyScannedDirectories,
+        HashSet<string> CheckpointedDirectories,
+        HashSet<string> AttributePrunedDirectories,
+        HashSet<string> NestedRepositories,
+        HashSet<string> DanglingSymlinks,
+        HashSet<FileIdentity> VisitedFileIdentities,
+        HashSet<string> VisitedDirectories);
+
     private sealed class IgnoreRule
     {
         private readonly record struct PatternToken(char Value, bool Escaped);
@@ -2004,43 +2019,45 @@ public class FileIndexer
         var danglingSymlinks = new HashSet<string>(StringComparer.Ordinal);
         var visitedFileIdentities = new HashSet<FileIdentity>();
         var visitedDirectories = new HashSet<string>(StringComparer.Ordinal) { NormalizePathForComparison(_projectRoot) };
+        var scanState = new DirectoryScanState(
+            files,
+            errors,
+            nonIndexablePaths,
+            unknownExtensionFiles,
+            probeFailedFilePaths,
+            listedDirectories,
+            fullyScannedDirectories,
+            activeCheckpointedDirectories,
+            attributePrunedDirectories,
+            nestedRepositories,
+            danglingSymlinks,
+            visitedFileIdentities,
+            visitedDirectories);
         errors.AddRange(_submoduleLoadWarnings);
         var fullyScanned = true;
         var preloadResult = LoadAncestorIgnoreRules(errors, ref fullyScanned);
         if (preloadResult.IgnoreRulesAvailable)
         {
-            ScanDirectory(_projectRoot, files, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, activeCheckpointedDirectories, attributePrunedDirectories, nestedRepositories, danglingSymlinks, visitedFileIdentities, visitedDirectories, preloadResult.Rules, isProjectRoot: true, continueOnError, cancellationToken, depth: 0);
+            ScanDirectory(_projectRoot, scanState, preloadResult.Rules, isProjectRoot: true, continueOnError, cancellationToken, depth: 0);
         }
         return new ScanFilesResult(
-            files,
-            errors,
-            nonIndexablePaths.ToList(),
-            unknownExtensionFiles.OrderBy(path => path, StringComparer.Ordinal).ToList(),
-            probeFailedFilePaths.ToList(),
-            listedDirectories.ToList(),
-            fullyScannedDirectories.ToList(),
-            activeCheckpointedDirectories.Concat(fullyScannedDirectories).ToHashSet(StringComparer.Ordinal),
+            scanState.Results,
+            scanState.Errors,
+            scanState.NonIndexablePaths.ToList(),
+            scanState.UnknownExtensionFiles.OrderBy(path => path, StringComparer.Ordinal).ToList(),
+            scanState.ProbeFailedFilePaths.ToList(),
+            scanState.ListedDirectories.ToList(),
+            scanState.FullyScannedDirectories.ToList(),
+            scanState.CheckpointedDirectories.Concat(scanState.FullyScannedDirectories).ToHashSet(StringComparer.Ordinal),
             _ancestorIgnoreDirectories.ToList(),
-            attributePrunedDirectories.ToList(),
-            nestedRepositories.OrderBy(path => path, StringComparer.Ordinal).ToList(),
-            danglingSymlinks.OrderBy(path => path, StringComparer.Ordinal).ToList());
+            scanState.AttributePrunedDirectories.ToList(),
+            scanState.NestedRepositories.OrderBy(path => path, StringComparer.Ordinal).ToList(),
+            scanState.DanglingSymlinks.OrderBy(path => path, StringComparer.Ordinal).ToList());
     }
 
     private bool ScanDirectory(
         string dir,
-        List<string> results,
-        List<ScanError> errors,
-        HashSet<string> nonIndexablePaths,
-        HashSet<string> unknownExtensionFiles,
-        HashSet<string> probeFailedFilePaths,
-        HashSet<string> listedDirectories,
-        HashSet<string> fullyScannedDirectories,
-        HashSet<string> checkpointedDirectories,
-        HashSet<string> attributePrunedDirectories,
-        HashSet<string> nestedRepositories,
-        HashSet<string> danglingSymlinks,
-        HashSet<FileIdentity> visitedFileIdentities,
-        HashSet<string> visitedDirectories,
+        DirectoryScanState scanState,
         IgnoreRuleSet activeIgnoreRules,
         bool isProjectRoot = false,
         bool continueOnError = true,
@@ -2052,25 +2069,25 @@ public class FileIndexer
 
         if (depth > MaxDirectoryTraversalDepth)
         {
-            errors.Add(new ScanError(
+            scanState.Errors.Add(new ScanError(
                 relativeDir,
                 $"Skipped directory because traversal depth exceeded {MaxDirectoryTraversalDepth}. Check for symlink loops or unexpectedly deep generated trees.",
                 ScanIssueSeverity.Warning));
             return true;
         }
 
-        if (checkpointedDirectories.Contains(relativeDir))
+        if (scanState.CheckpointedDirectories.Contains(relativeDir))
             return true;
 
         var filterKind = GetDirectoryFilterKind(dir, activeIgnoreRules, isProjectRoot);
         if (filterKind != PathFilterKind.None)
         {
-            listedDirectories.Add(relativeDir);
-            fullyScannedDirectories.Add(relativeDir);
+            scanState.ListedDirectories.Add(relativeDir);
+            scanState.FullyScannedDirectories.Add(relativeDir);
             return true;
         }
 
-        return EnumerateDirectory(dir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, checkpointedDirectories, attributePrunedDirectories, nestedRepositories, danglingSymlinks, visitedFileIdentities, visitedDirectories, activeIgnoreRules, continueOnError, cancellationToken, depth);
+        return EnumerateDirectory(dir, scanState, activeIgnoreRules, continueOnError, cancellationToken, depth);
     }
 
     private bool IsNestedGitRepository(string dir)
@@ -2084,19 +2101,7 @@ public class FileIndexer
 
     private bool EnumerateDirectory(
         string dir,
-        List<string> results,
-        List<ScanError> errors,
-        HashSet<string> nonIndexablePaths,
-        HashSet<string> unknownExtensionFiles,
-        HashSet<string> probeFailedFilePaths,
-        HashSet<string> listedDirectories,
-        HashSet<string> fullyScannedDirectories,
-        HashSet<string> checkpointedDirectories,
-        HashSet<string> attributePrunedDirectories,
-        HashSet<string> nestedRepositories,
-        HashSet<string> danglingSymlinks,
-        HashSet<FileIdentity> visitedFileIdentities,
-        HashSet<string> visitedDirectories,
+        DirectoryScanState scanState,
         IgnoreRuleSet inheritedIgnoreRules,
         bool continueOnError,
         CancellationToken cancellationToken = default,
@@ -2106,7 +2111,7 @@ public class FileIndexer
         var fullyScanned = true;
         try
         {
-            var loadResult = LoadIgnoreRulesForDirectory(dir, inheritedIgnoreRules, errors, ref fullyScanned);
+            var loadResult = LoadIgnoreRulesForDirectory(dir, inheritedIgnoreRules, scanState.Errors, ref fullyScanned);
             var activeIgnoreRules = loadResult.Rules;
             if (!loadResult.IgnoreRulesAvailable)
                 return false;
@@ -2121,230 +2126,288 @@ public class FileIndexer
             var directoryIgnoreCase = DirectoryUsesIgnoreCase(dir);
             if (directoryIgnoreCase != _ignoreCase)
             {
-                errors.Add(new ScanError(
+                scanState.Errors.Add(new ScanError(
                     ToRelativePath(dir),
                     "Filesystem case-sensitivity differs from the project root; deduplicating file paths for this directory.",
                     ScanIssueSeverity.Warning));
             }
 
             if (!passthrough)
-            {
-                var seenFilePaths = directoryIgnoreCase
-                    ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-                    : null;
-                foreach (var enumeratedFile in _enumerateFiles(dir))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    // Strip any \\?\ prefix returned by EnumerateFiles when we passed a long-path
-                    // directory, so downstream relative-path math (which compares against the
-                    // un-prefixed _projectRoot) still produces the canonical project-relative key.
-                    // \\?\ 接頭辞付きの long-path ディレクトリを渡したとき EnumerateFiles も接頭辞付きで
-                    // 返すため、_projectRoot（接頭辞なし）と突き合わせる相対パス計算が崩れないよう剥がす。
-                    var file = LongPath.RemoveWindowsPrefix(enumeratedFile);
-                    if (!IsFilePathSyntaxIndexable(file))
-                    {
-                        errors.Add(new ScanError(
-                            FormatPathForScanIssue(file),
-                            "Skipped file because its path contains NUL or control characters.",
-                            ScanIssueSeverity.Warning));
-                        nonIndexablePaths.Add(FormatPathForScanIssue(file));
-                        continue;
-                    }
-
-                    if (seenFilePaths is not null && !seenFilePaths.Add(Path.GetFullPath(file)))
-                    {
-                        var relativePath = ToRelativePath(file);
-                        errors.Add(new ScanError(
-                            relativePath,
-                            "Skipped duplicate file path that differs only by case on a case-insensitive directory.",
-                            ScanIssueSeverity.Warning));
-                        nonIndexablePaths.Add(relativePath);
-                        continue;
-                    }
-
-                    var fileName = Path.GetFileName(file);
-
-                    // Skip excluded file names / 除外ファイル名をスキップ
-                    if (IsDefaultExcludedFileName(fileName))
-                        continue;
-
-                    if (activeIgnoreRules.IsIgnored(file, isDirectory: false))
-                        continue;
-
-                    // GetFileIndexability also rejects file symlinks/reparse points so the update-mode
-                    // (--files / --commits) path gets the same skip behavior without a second probe here.
-                    // GetFileIndexability もファイル symlink / reparse point を拒否するため、
-                    // update モード (--files / --commits) でも同じ skip 挙動が二重プローブ無しで効く。
-                    var indexability = GetFileIndexability(file);
-                    if (indexability == FileProbeStatus.Missing)
-                    {
-                        var relativePath = ToRelativePath(file);
-                        errors.Add(new ScanError(
-                            relativePath,
-                            "Skipped file because it was deleted during scanning.",
-                            ScanIssueSeverity.Warning));
-                        nonIndexablePaths.Add(relativePath);
-                        continue;
-                    }
-
-                    if (indexability == FileProbeStatus.ProbeFailed)
-                    {
-                        var relativePath = ToRelativePath(file);
-                        errors.Add(new ScanError(relativePath, "Could not probe file for indexability/language."));
-                        probeFailedFilePaths.Add(relativePath);
-                        continue;
-                    }
-
-                    if (indexability != FileProbeStatus.Supported)
-                    {
-                        nonIndexablePaths.Add(ToRelativePath(file));
-                        continue;
-                    }
-
-                    var relativeFile = ToRelativePath(file);
-                    // Include files with a known extension/filename or an extensionless recognized shebang
-                    // 既知の拡張子・既知ファイル名、または拡張子なしで shebang を認識できるファイルを含める
-                    var language = TryDetectLanguage(file);
-                    if (language.Status == FileProbeStatus.Missing)
-                    {
-                        errors.Add(new ScanError(
-                            relativeFile,
-                            "Skipped file because it was deleted during scanning.",
-                            ScanIssueSeverity.Warning));
-                        nonIndexablePaths.Add(relativeFile);
-                        continue;
-                    }
-
-                    if (language.Status == FileProbeStatus.ProbeFailed)
-                    {
-                        errors.Add(new ScanError(relativeFile, "Could not probe file for indexability/language."));
-                        probeFailedFilePaths.Add(relativeFile);
-                        continue;
-                    }
-
-                    if (language.Status != FileProbeStatus.Supported)
-                    {
-                        nonIndexablePaths.Add(relativeFile);
-                        if (HasUnknownExtension(file) && !IsInternalIndexArtifactPath(relativeFile))
-                            unknownExtensionFiles.Add(relativeFile);
-                        continue;
-                    }
-
-                    if (TryGetFileIdentity(file, out var identity) && !visitedFileIdentities.Add(identity))
-                    {
-                        errors.Add(new ScanError(
-                            relativeFile,
-                            "Skipped hardlinked file because the same file content was already indexed from another path.",
-                            ScanIssueSeverity.Warning));
-                        nonIndexablePaths.Add(relativeFile);
-                        continue;
-                    }
-
-                    results.Add(file);
-                }
-            }
+                EnumerateIndexableFilesInDirectory(dir, scanState, activeIgnoreRules, directoryIgnoreCase, cancellationToken);
 
             // A successful file listing proves the direct children of this directory.
             // Child subtree failures must not revoke that authority for sibling-file purge.
             // ファイル列挙が成功した時点で、このディレクトリ直下の子要素については authoritative とみなせる。
             // 子サブツリー失敗が sibling file purge の authority を奪ってはいけない。
-            listedDirectories.Add(ToRelativePath(dir));
-
-            foreach (var enumeratedEntry in Directory.EnumerateFileSystemEntries(LongPath.EnsureWindowsPrefix(dir)))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                var entry = LongPath.RemoveWindowsPrefix(enumeratedEntry);
-                if (!IsReparsePoint(entry) || Directory.Exists(LongPath.EnsureWindowsPrefix(entry)))
-                    continue;
-
-                var relativeEntry = ToRelativePath(entry);
-                danglingSymlinks.Add(relativeEntry);
-                errors.Add(new ScanError(relativeEntry, "Skipped dangling symlink because its target could not be resolved.", ScanIssueSeverity.Warning));
-                listedDirectories.Add(relativeEntry);
-                fullyScannedDirectories.Add(relativeEntry);
-                attributePrunedDirectories.Add(relativeEntry);
-            }
-
-            foreach (var enumeratedSubDir in Directory.EnumerateDirectories(LongPath.EnsureWindowsPrefix(dir)))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                var subDir = LongPath.RemoveWindowsPrefix(enumeratedSubDir);
-                if (IsNestedGitRepository(subDir) && !IsSubmoduleOrAncestor(subDir))
-                {
-                    var subRelative = ToRelativePath(subDir);
-                    listedDirectories.Add(subRelative);
-                    fullyScannedDirectories.Add(subRelative);
-                    nestedRepositories.Add(subRelative);
-                    continue;
-                }
-
-                // In passthrough mode, only descend into subdirectories that are themselves
-                // submodules or submodule ancestors. Treat siblings the same way SkipDirs
-                // would have treated them at this point.
-                // passthrough 中は、submodule 自体または submodule の祖先に該当する
-                // サブディレクトリのみ降りる。その他は本来 SkipDirs で止まっていた扱いに戻す。
-                if (passthrough && !IsSubmoduleOrAncestor(subDir))
-                {
-                    var subRelative = ToRelativePath(subDir);
-                    listedDirectories.Add(subRelative);
-                    fullyScannedDirectories.Add(subRelative);
-                    continue;
-                }
-
-                // Skip directory symlinks/reparse points to prevent infinite recursion on ancestor loops
-                // and duplicate indexing when a symlink points inside the same tree. On Windows, also
-                // skip Hidden/System directories so drive-root scans do not descend into OS-owned caches.
-                // Record the skipped directory itself as listed (for the immediate-parent purge path) AND
-                // as a prune prefix so the purge walker can authoritatively drop deep descendants that
-                // earlier runs left behind.
-                // ディレクトリ symlink / reparse point は親方向ループでの無限再帰や、
-                // ツリー内を指す symlink での二重 index を防ぐためスキップする。Windows では
-                // drive root 走査で OS 管理 cache に降りないよう Hidden/System ディレクトリもスキップする。
-                // skip したディレクトリ自身を listed 扱い（immediate parent purge 用）かつ prune prefix として
-                // 記録することで、以前の実行でできた深い子孫エントリも purge walker が確実に削除できる。
-                if (ShouldSkipDirectoryLink(subDir, errors, danglingSymlinks))
-                {
-                    var subRelative = ToRelativePath(subDir);
-                    listedDirectories.Add(subRelative);
-                    fullyScannedDirectories.Add(subRelative);
-                    attributePrunedDirectories.Add(subRelative);
-                    continue;
-                }
-
-                var resolvedSubDir = NormalizePathForComparison(GetDirectoryTraversalIdentity(subDir));
-                if (!visitedDirectories.Add(resolvedSubDir))
-                {
-                    var subRelative = ToRelativePath(subDir);
-                    errors.Add(new ScanError(subRelative, "Skipped symlinked directory because its resolved target was already scanned.", ScanIssueSeverity.Warning));
-                    listedDirectories.Add(subRelative);
-                    fullyScannedDirectories.Add(subRelative);
-                    attributePrunedDirectories.Add(subRelative);
-                    continue;
-                }
-
-                var childFullyScanned = ScanDirectory(subDir, results, errors, nonIndexablePaths, unknownExtensionFiles, probeFailedFilePaths, listedDirectories, fullyScannedDirectories, checkpointedDirectories, attributePrunedDirectories, nestedRepositories, danglingSymlinks, visitedFileIdentities, visitedDirectories, activeIgnoreRules, continueOnError: continueOnError, cancellationToken: cancellationToken, depth: depth + 1);
-                fullyScanned &= childFullyScanned;
-                if (!continueOnError && !childFullyScanned)
-                    break;
-            }
+            scanState.ListedDirectories.Add(ToRelativePath(dir));
+            RecordDanglingFileSystemEntries(dir, scanState, cancellationToken);
+            fullyScanned &= EnumerateSubdirectories(dir, scanState, activeIgnoreRules, passthrough, continueOnError, cancellationToken, depth);
         }
         catch (UnauthorizedAccessException)
         {
             // Skip inaccessible directories / アクセス不可ディレクトリはスキップ
-            errors.Add(new ScanError(ToRelativePath(dir), "Could not scan directory due to permissions."));
+            scanState.Errors.Add(new ScanError(ToRelativePath(dir), "Could not scan directory due to permissions."));
             fullyScanned = false;
         }
         catch (IOException)
         {
             // Skip on I/O errors / I/Oエラー時はスキップ
-            errors.Add(new ScanError(ToRelativePath(dir), "Could not scan directory due to an I/O error."));
+            scanState.Errors.Add(new ScanError(ToRelativePath(dir), "Could not scan directory due to an I/O error."));
             fullyScanned = false;
         }
 
         if (fullyScanned)
-            fullyScannedDirectories.Add(ToRelativePath(dir));
+            scanState.FullyScannedDirectories.Add(ToRelativePath(dir));
 
         return fullyScanned;
+    }
+
+    private void EnumerateIndexableFilesInDirectory(
+        string dir,
+        DirectoryScanState scanState,
+        IgnoreRuleSet activeIgnoreRules,
+        bool directoryIgnoreCase,
+        CancellationToken cancellationToken)
+    {
+        var seenFilePaths = directoryIgnoreCase
+            ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            : null;
+        foreach (var enumeratedFile in _enumerateFiles(dir))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            // Strip any \\?\ prefix returned by EnumerateFiles when we passed a long-path
+            // directory, so downstream relative-path math (which compares against the
+            // un-prefixed _projectRoot) still produces the canonical project-relative key.
+            // \\?\ 接頭辞付きの long-path ディレクトリを渡したとき EnumerateFiles も接頭辞付きで
+            // 返すため、_projectRoot（接頭辞なし）と突き合わせる相対パス計算が崩れないよう剥がす。
+            var file = LongPath.RemoveWindowsPrefix(enumeratedFile);
+            if (!TryAcceptScannedFile(file, scanState, activeIgnoreRules, seenFilePaths))
+                continue;
+
+            scanState.Results.Add(file);
+        }
+    }
+
+    private bool TryAcceptScannedFile(
+        string file,
+        DirectoryScanState scanState,
+        IgnoreRuleSet activeIgnoreRules,
+        HashSet<string>? seenFilePaths)
+    {
+        if (!IsFilePathSyntaxIndexable(file))
+        {
+            var issuePath = FormatPathForScanIssue(file);
+            scanState.Errors.Add(new ScanError(
+                issuePath,
+                "Skipped file because its path contains NUL or control characters.",
+                ScanIssueSeverity.Warning));
+            scanState.NonIndexablePaths.Add(issuePath);
+            return false;
+        }
+
+        if (seenFilePaths is not null && !seenFilePaths.Add(Path.GetFullPath(file)))
+        {
+            var relativePath = ToRelativePath(file);
+            scanState.Errors.Add(new ScanError(
+                relativePath,
+                "Skipped duplicate file path that differs only by case on a case-insensitive directory.",
+                ScanIssueSeverity.Warning));
+            scanState.NonIndexablePaths.Add(relativePath);
+            return false;
+        }
+
+        var fileName = Path.GetFileName(file);
+
+        // Skip excluded file names / 除外ファイル名をスキップ
+        if (IsDefaultExcludedFileName(fileName))
+            return false;
+
+        if (activeIgnoreRules.IsIgnored(file, isDirectory: false))
+            return false;
+
+        return TryAcceptSupportedScannedFile(file, scanState);
+    }
+
+    private bool TryAcceptSupportedScannedFile(string file, DirectoryScanState scanState)
+    {
+        // GetFileIndexability also rejects file symlinks/reparse points so the update-mode
+        // (--files / --commits) path gets the same skip behavior without a second probe here.
+        // GetFileIndexability もファイル symlink / reparse point を拒否するため、
+        // update モード (--files / --commits) でも同じ skip 挙動が二重プローブ無しで効く。
+        var indexability = GetFileIndexability(file);
+        if (indexability == FileProbeStatus.Missing)
+        {
+            var relativePath = ToRelativePath(file);
+            scanState.Errors.Add(new ScanError(
+                relativePath,
+                "Skipped file because it was deleted during scanning.",
+                ScanIssueSeverity.Warning));
+            scanState.NonIndexablePaths.Add(relativePath);
+            return false;
+        }
+
+        if (indexability == FileProbeStatus.ProbeFailed)
+        {
+            var relativePath = ToRelativePath(file);
+            scanState.Errors.Add(new ScanError(relativePath, "Could not probe file for indexability/language."));
+            scanState.ProbeFailedFilePaths.Add(relativePath);
+            return false;
+        }
+
+        if (indexability != FileProbeStatus.Supported)
+        {
+            scanState.NonIndexablePaths.Add(ToRelativePath(file));
+            return false;
+        }
+
+        var relativeFile = ToRelativePath(file);
+        // Include files with a known extension/filename or an extensionless recognized shebang
+        // 既知の拡張子・既知ファイル名、または拡張子なしで shebang を認識できるファイルを含める
+        var language = TryDetectLanguage(file);
+        if (language.Status == FileProbeStatus.Missing)
+        {
+            scanState.Errors.Add(new ScanError(
+                relativeFile,
+                "Skipped file because it was deleted during scanning.",
+                ScanIssueSeverity.Warning));
+            scanState.NonIndexablePaths.Add(relativeFile);
+            return false;
+        }
+
+        if (language.Status == FileProbeStatus.ProbeFailed)
+        {
+            scanState.Errors.Add(new ScanError(relativeFile, "Could not probe file for indexability/language."));
+            scanState.ProbeFailedFilePaths.Add(relativeFile);
+            return false;
+        }
+
+        if (language.Status != FileProbeStatus.Supported)
+        {
+            scanState.NonIndexablePaths.Add(relativeFile);
+            if (HasUnknownExtension(file) && !IsInternalIndexArtifactPath(relativeFile))
+                scanState.UnknownExtensionFiles.Add(relativeFile);
+            return false;
+        }
+
+        if (TryGetFileIdentity(file, out var identity) && !scanState.VisitedFileIdentities.Add(identity))
+        {
+            scanState.Errors.Add(new ScanError(
+                relativeFile,
+                "Skipped hardlinked file because the same file content was already indexed from another path.",
+                ScanIssueSeverity.Warning));
+            scanState.NonIndexablePaths.Add(relativeFile);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void RecordDanglingFileSystemEntries(
+        string dir,
+        DirectoryScanState scanState,
+        CancellationToken cancellationToken)
+    {
+        foreach (var enumeratedEntry in Directory.EnumerateFileSystemEntries(LongPath.EnsureWindowsPrefix(dir)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var entry = LongPath.RemoveWindowsPrefix(enumeratedEntry);
+            if (!IsReparsePoint(entry) || Directory.Exists(LongPath.EnsureWindowsPrefix(entry)))
+                continue;
+
+            var relativeEntry = ToRelativePath(entry);
+            scanState.DanglingSymlinks.Add(relativeEntry);
+            scanState.Errors.Add(new ScanError(relativeEntry, "Skipped dangling symlink because its target could not be resolved.", ScanIssueSeverity.Warning));
+            scanState.ListedDirectories.Add(relativeEntry);
+            scanState.FullyScannedDirectories.Add(relativeEntry);
+            scanState.AttributePrunedDirectories.Add(relativeEntry);
+        }
+    }
+
+    private bool EnumerateSubdirectories(
+        string dir,
+        DirectoryScanState scanState,
+        IgnoreRuleSet activeIgnoreRules,
+        bool passthrough,
+        bool continueOnError,
+        CancellationToken cancellationToken,
+        int depth)
+    {
+        var fullyScanned = true;
+        foreach (var enumeratedSubDir in Directory.EnumerateDirectories(LongPath.EnsureWindowsPrefix(dir)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var subDir = LongPath.RemoveWindowsPrefix(enumeratedSubDir);
+            if (TryRecordNonRecursiveSubdirectory(subDir, scanState, passthrough))
+                continue;
+
+            // Skip directory symlinks/reparse points to prevent infinite recursion on ancestor loops
+            // and duplicate indexing when a symlink points inside the same tree. On Windows, also
+            // skip Hidden/System directories so drive-root scans do not descend into OS-owned caches.
+            // Record the skipped directory itself as listed (for the immediate-parent purge path) AND
+            // as a prune prefix so the purge walker can authoritatively drop deep descendants that
+            // earlier runs left behind.
+            // ディレクトリ symlink / reparse point は親方向ループでの無限再帰や、
+            // ツリー内を指す symlink での二重 index を防ぐためスキップする。Windows では
+            // drive root 走査で OS 管理 cache に降りないよう Hidden/System ディレクトリもスキップする。
+            // skip したディレクトリ自身を listed 扱い（immediate parent purge 用）かつ prune prefix として
+            // 記録することで、以前の実行でできた深い子孫エントリも purge walker が確実に削除できる。
+            if (ShouldSkipDirectoryLink(subDir, scanState.Errors, scanState.DanglingSymlinks))
+            {
+                RecordPrunedDirectory(subDir, scanState);
+                continue;
+            }
+
+            var resolvedSubDir = NormalizePathForComparison(GetDirectoryTraversalIdentity(subDir));
+            if (!scanState.VisitedDirectories.Add(resolvedSubDir))
+            {
+                var subRelative = ToRelativePath(subDir);
+                scanState.Errors.Add(new ScanError(subRelative, "Skipped symlinked directory because its resolved target was already scanned.", ScanIssueSeverity.Warning));
+                RecordPrunedDirectory(subDir, scanState);
+                continue;
+            }
+
+            var childFullyScanned = ScanDirectory(subDir, scanState, activeIgnoreRules, continueOnError: continueOnError, cancellationToken: cancellationToken, depth: depth + 1);
+            fullyScanned &= childFullyScanned;
+            if (!continueOnError && !childFullyScanned)
+                break;
+        }
+
+        return fullyScanned;
+    }
+
+    private bool TryRecordNonRecursiveSubdirectory(string subDir, DirectoryScanState scanState, bool passthrough)
+    {
+        if (IsNestedGitRepository(subDir) && !IsSubmoduleOrAncestor(subDir))
+        {
+            var subRelative = ToRelativePath(subDir);
+            scanState.ListedDirectories.Add(subRelative);
+            scanState.FullyScannedDirectories.Add(subRelative);
+            scanState.NestedRepositories.Add(subRelative);
+            return true;
+        }
+
+        // In passthrough mode, only descend into subdirectories that are themselves
+        // submodules or submodule ancestors. Treat siblings the same way SkipDirs
+        // would have treated them at this point.
+        // passthrough 中は、submodule 自体または submodule の祖先に該当する
+        // サブディレクトリのみ降りる。その他は本来 SkipDirs で止まっていた扱いに戻す。
+        if (passthrough && !IsSubmoduleOrAncestor(subDir))
+        {
+            var subRelative = ToRelativePath(subDir);
+            scanState.ListedDirectories.Add(subRelative);
+            scanState.FullyScannedDirectories.Add(subRelative);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void RecordPrunedDirectory(string dir, DirectoryScanState scanState)
+    {
+        var relativeDir = ToRelativePath(dir);
+        scanState.ListedDirectories.Add(relativeDir);
+        scanState.FullyScannedDirectories.Add(relativeDir);
+        scanState.AttributePrunedDirectories.Add(relativeDir);
     }
 
     internal static bool TryGetFileIdentity(string path, out FileIdentity identity)


### PR DESCRIPTION
## Summary

- Split several large CLI/indexing methods into smaller focused helpers without changing behavior.
- Extracted update-target resolution, full-scan discovery, validation, config loading, MCP setup, audit-log flag parsing, path filtering, and file traversal logic.
- Kept changes scoped to existing CLI/indexer classes and preserved existing diagnostics and parsing behavior.

## Validation

- `dotnet build`
- `dotnet test`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
