### PR TITLE
Sanitize MCP failure responses for backfill and index

### DIFF
--- a/changelog.d/unreleased/3201.fixed.md
+++ b/changelog.d/unreleased/3201.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3201
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP `backfill_fold` errors now use the central sanitizer (#3201)** — `backfill_fold` no longer returns raw exception messages in tool-result errors and instead emits the standard sanitized MCP error envelope while keeping detailed exception data on the server diagnostic path.
+
+## 日本語
+
+- **MCP `backfill_fold` のエラーが中央 sanitizer を使うようになりました (#3201)** — `backfill_fold` は tool-result error に生の例外メッセージを返さず、標準の sanitized MCP error envelope を返しつつ、詳細な例外情報はサーバー診断経路に残すようになりました。

--- a/changelog.d/unreleased/3202.fixed.md
+++ b/changelog.d/unreleased/3202.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3202
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP index per-file failures now use sanitized bounded messages (#3202)** — MCP `index` file failure entries no longer forward raw exception messages to tool responses or the persistent first-error log field, and failure messages now include truncation metadata.
+
+## 日本語
+
+- **MCP index のファイル単位 failure が sanitized かつ bounded な message を使うようになりました (#3202)** — MCP `index` のファイル単位 failure entry は、tool response や永続ログの first-error 欄へ生の例外メッセージを転送せず、failure message に truncation metadata を含めるようになりました。

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -4066,7 +4066,21 @@ public partial class McpServer
         }
         catch (Exception ex)
         {
-            return CreateToolErrorResponse(id, $"Failed to backfill folded-name columns: {ex.Message}");
+            DeferFrameLog(() =>
+            {
+                WriteMcpLogLine(BuildToolErrorLog("backfill_fold", ex.Message));
+                Database.DbDebug.DumpToStderr(ex);
+            });
+            var classification = McpErrorEnvelope.ClassifyException(ex);
+            return CreateToolErrorResponse(id, BuildSanitizedToolErrorMessage("backfill_fold", ex),
+                category: classification.Category,
+                suggestion: classification.Suggestion,
+                retrySafe: classification.RetrySafe,
+                extraData: new JsonObject
+                {
+                    ["tool"] = "backfill_fold",
+                    ["exception_type"] = ex.GetType().Name,
+                });
         }
     }
 

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -25,6 +25,7 @@ public partial class McpServer
     private const string BatchQueryResponseByteLimitEnvVar = "CDIDX_MCP_BATCH_RESPONSE_MAX_BYTES";
     internal const int MaxMcpArrayFilterCount = 100;
     internal const int MaxMcpArrayFilterStringLength = 4096;
+    internal const int MaxMcpIndexFailureMessageLength = 512;
 
     // --- Tool implementations / ツール実装 ---
 
@@ -3923,13 +3924,15 @@ public partial class McpServer
                     ["stage"] = failure.Stage,
                     ["exception_type"] = failure.ExceptionType,
                     ["message"] = failure.Message,
+                    ["message_truncated"] = failure.MessageTruncated,
                 });
             }
             structured["failed_count"] = failures.Count;
             structured["failures"] = failureArray;
             if (failures.Count > 50)
                 structured["failures_truncated"] = failures.Count - 50;
-            GlobalToolLog.Error($"mcp_index_file_failures count={failures.Count} first_path='{failures[0].Path}' first_error='{failures[0].ExceptionType}: {failures[0].Message}'");
+            GlobalToolLog.Error(
+                $"mcp_index_file_failures count={failures.Count} first_path={QuoteMcpIndexFailureLogValue(failures[0].Path)} first_error={QuoteMcpIndexFailureLogValue($"{failures[0].ExceptionType}: {failures[0].Message}")}");
         }
         if (!sqlGraphContractReadyAfter)
         {
@@ -3952,17 +3955,97 @@ public partial class McpServer
     private static IndexFileFailure BuildIndexFileFailure(string projectPath, string filePath, Exception ex, string stage)
     {
         var relativePath = FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectPath, filePath));
-        return new IndexFileFailure(relativePath, stage, ex.GetType().Name, ex.Message);
+        var message = BuildSanitizedIndexFileFailureMessage(stage, ex.GetType().Name, out var messageTruncated);
+        return new IndexFileFailure(relativePath, stage, ex.GetType().Name, message, messageTruncated);
     }
 
-    private static IndexFileFailure BuildScanFailure(FileIndexer.ScanError error) =>
-        new(
+    private static IndexFileFailure BuildScanFailure(FileIndexer.ScanError error)
+    {
+        var message = SanitizeAndCapMcpIndexFailureMessage(error.Message, out var messageTruncated);
+        return new IndexFileFailure(
             FileIndexer.NormalizePathSeparators(error.Path),
             "scan",
             nameof(FileIndexer.ScanError),
-            error.Message);
+            message,
+            messageTruncated);
+    }
 
-    private sealed record IndexFileFailure(string Path, string Stage, string ExceptionType, string Message);
+    internal static string BuildSanitizedIndexFileFailureMessageForTesting(string stage, string exceptionType, out bool messageTruncated) =>
+        BuildSanitizedIndexFileFailureMessage(stage, exceptionType, out messageTruncated);
+
+    internal static string SanitizeMcpIndexFailureMessageForTesting(string message, out bool messageTruncated) =>
+        SanitizeAndCapMcpIndexFailureMessage(message, out messageTruncated);
+
+    private static string BuildSanitizedIndexFileFailureMessage(string stage, string exceptionType, out bool messageTruncated)
+    {
+        var safeStage = SanitizeMcpIndexFailureToken(stage, "unknown_stage");
+        var safeExceptionType = SanitizeMcpIndexFailureToken(exceptionType, "Exception");
+        return SanitizeAndCapMcpIndexFailureMessage(
+            $"File indexing failed during {safeStage} ({safeExceptionType}). See cdidx server stderr for details.",
+            out messageTruncated);
+    }
+
+    private static string SanitizeMcpIndexFailureToken(string? value, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            if (char.IsAsciiLetterOrDigit(ch) || ch is '_' or '-' or '.')
+                builder.Append(ch);
+        }
+
+        return builder.Length == 0 ? fallback : builder.ToString();
+    }
+
+    private static string SanitizeAndCapMcpIndexFailureMessage(string? message, out bool messageTruncated)
+    {
+        var collapsed = CollapseMcpIndexFailureWhitespace(string.IsNullOrWhiteSpace(message)
+            ? "File indexing failed. See cdidx server stderr for details."
+            : message);
+        const string suffix = "...(truncated)";
+        if (collapsed.Length <= MaxMcpIndexFailureMessageLength)
+        {
+            messageTruncated = false;
+            return collapsed;
+        }
+
+        messageTruncated = true;
+        return collapsed[..(MaxMcpIndexFailureMessageLength - suffix.Length)] + suffix;
+    }
+
+    private static string CollapseMcpIndexFailureWhitespace(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        var lastWasSpace = false;
+        foreach (var ch in value)
+        {
+            if (ch is '\r' or '\n' or '\t' || char.IsControl(ch))
+            {
+                if (!lastWasSpace)
+                {
+                    builder.Append(' ');
+                    lastWasSpace = true;
+                }
+                continue;
+            }
+
+            builder.Append(ch);
+            lastWasSpace = ch == ' ';
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static string QuoteMcpIndexFailureLogValue(string value)
+    {
+        var message = SanitizeAndCapMcpIndexFailureMessage(value, out _);
+        return JsonSerializer.Serialize(message);
+    }
+
+    private sealed record IndexFileFailure(string Path, string Stage, string ExceptionType, string Message, bool MessageTruncated);
 
     private JsonNode ExecuteBackfillFold(JsonNode? id, JsonNode? args, JsonNode? progressToken = null)
     {

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -7676,6 +7676,37 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void ToolsCall_BackfillFold_ExceptionUsesSanitizedToolError_Issue3201()
+    {
+        var previousDebug = Environment.GetEnvironmentVariable(McpServer.DebugEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(McpServer.DebugEnvironmentVariable, null);
+            DbWriter.FoldBackfillRowUpdatedForTesting = () =>
+                throw new InvalidOperationException("SECRET_BACKFILL_LITERAL from /private/path");
+
+            var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"backfill_fold","arguments":{}}}""")!;
+            var response = _server.HandleMessage(request)!;
+
+            Assert.True(response["result"]!["isError"]!.GetValue<bool>(), response.ToJsonString());
+            var text = response["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
+            Assert.Equal("Tool 'backfill_fold' failed. See cdidx server stderr for details.", text);
+            Assert.DoesNotContain("SECRET_BACKFILL_LITERAL", response.ToJsonString());
+            Assert.DoesNotContain("/private/path", response.ToJsonString());
+
+            var structured = response["result"]!["structuredContent"]!;
+            Assert.Equal("internal_error", structured["category"]!.GetValue<string>());
+            Assert.Equal("backfill_fold", structured["tool"]!.GetValue<string>());
+            Assert.Equal(nameof(InvalidOperationException), structured["exception_type"]!.GetValue<string>());
+        }
+        finally
+        {
+            DbWriter.FoldBackfillRowUpdatedForTesting = null;
+            Environment.SetEnvironmentVariable(McpServer.DebugEnvironmentVariable, previousDebug);
+        }
+    }
+
+    [Fact]
     public void ToolsCall_BackfillFold_DryRunDoesNotWrite()
     {
         var writer = new DbWriter(_db.Connection);

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -1866,6 +1866,34 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void BuildSanitizedIndexFileFailureMessage_OmitsRawExceptionMessage_Issue3202()
+    {
+        var message = McpServer.BuildSanitizedIndexFileFailureMessageForTesting(
+            "index_file",
+            nameof(InvalidOperationException),
+            out var truncated);
+
+        Assert.Equal("File indexing failed during index_file (InvalidOperationException). See cdidx server stderr for details.", message);
+        Assert.False(truncated);
+        Assert.DoesNotContain("SECRET_LITERAL", message);
+        Assert.DoesNotContain("/private/path", message);
+    }
+
+    [Fact]
+    public void SanitizeMcpIndexFailureMessage_CapsAndCollapsesText_Issue3202()
+    {
+        var raw = "first line\nsecond\tline " + new string('x', McpServer.MaxMcpIndexFailureMessageLength + 100);
+
+        var message = McpServer.SanitizeMcpIndexFailureMessageForTesting(raw, out var truncated);
+
+        Assert.True(truncated);
+        Assert.True(message.Length <= McpServer.MaxMcpIndexFailureMessageLength);
+        Assert.EndsWith("...(truncated)", message);
+        Assert.DoesNotContain("\n", message);
+        Assert.DoesNotContain("\t", message);
+    }
+
+    [Fact]
     public void ToolsCall_ReusesDbContextAcrossInvocations()
     {
         // #1494: every MCP tool call used to construct a fresh DbContext (and reopen the
@@ -7491,6 +7519,9 @@ public class McpServerTests : IDisposable
             Assert.Equal(".gitignore", failure!["path"]!.GetValue<string>());
             Assert.Equal("scan", failure["stage"]!.GetValue<string>());
             Assert.Equal(nameof(FileIndexer.ScanError), failure["exception_type"]!.GetValue<string>());
+            Assert.False(failure["message_truncated"]!.GetValue<bool>());
+            Assert.DoesNotContain(fixtureDir, failure["message"]!.GetValue<string>());
+            Assert.DoesNotContain("\n", failure["message"]!.GetValue<string>());
 
             using var failedDb = new DbContext(dbPath);
             var failedUserVersion = failedDb.GetUserVersion();


### PR DESCRIPTION
## Summary
- Route `backfill_fold` exceptions through the central MCP sanitizer and keep raw diagnostics in stderr only.
- Sanitize and cap MCP `index` per-file failure messages while preserving structured failure metadata.
- Add changelog fragments for #3201 and #3202.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests.ToolsCall_BackfillFold_ExceptionUsesSanitizedToolError_Issue3201" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Issue3202|FullyQualifiedName~ToolsCall_Index_FatalScanErrorDoesNotRestampReadiness_Issue2874" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~BuildSanitizedIndexFileFailureMessage_OmitsRawExceptionMessage_Issue3202|FullyQualifiedName~SanitizeMcpIndexFailureMessage_CapsAndCollapsesText_Issue3202|FullyQualifiedName~ToolsCall_Index_FatalScanErrorDoesNotRestampReadiness_Issue2874|FullyQualifiedName~ToolsCall_BackfillFold_ExceptionUsesSanitizedToolError_Issue3201|FullyQualifiedName~ToolsCall_BackfillFold_StampsFoldReady"`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `codex exec` adversarial review: `No blocking/actionable issues found.`

Fixes #3201
Fixes #3202