### PR TITLE
[codex] Bound installer network diagnostics

### DIFF
--- a/changelog.d/unreleased/3187.security.md
+++ b/changelog.d/unreleased/3187.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3187
+affected:
+  - install.sh
+  - tests/CodeIndex.Tests/InstallScriptTests.cs
+---
+
+## English
+
+- **Installer curl stderr diagnostics are now bounded (#3187)** — `install.sh` now prints only a capped stderr sample from failed curl calls and reports when the diagnostic stream was truncated, preventing oversized proxy or endpoint errors from being loaded or emitted in full.
+
+## 日本語
+
+- **installer の curl stderr 診断を上限付きにしました (#3187)** — `install.sh` は失敗した curl 呼び出しの stderr を上限付きサンプルだけ表示し、診断ストリームを切り詰めた場合はその旨を出すため、巨大な proxy / endpoint エラーを丸ごと読み込んだり出力したりしなくなりました。

--- a/changelog.d/unreleased/3188.security.md
+++ b/changelog.d/unreleased/3188.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3188
+affected:
+  - install.sh
+  - tests/CodeIndex.Tests/InstallScriptTests.cs
+---
+
+## English
+
+- **Installer latest-release responses are now capped before parsing (#3188)** — `install.sh` now rejects oversized GitHub latest-release API bodies before loading them into shell variables, matching the bounded update-checker behavior and keeping diagnostics small.
+
+## 日本語
+
+- **installer の latest-release response を parse 前に上限検査するようにしました (#3188)** — `install.sh` は GitHub latest-release API body が大きすぎる場合に shell 変数へ読み込む前に拒否し、上限付き update checker と同じ方針で診断出力を小さく保ちます。

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,7 @@ MANIFEST_REQUIRED_VERSION="1.24.6"
 GITHUB_BASE_URL="${CDIDX_GITHUB_BASE_URL:-https://github.com}"
 GITHUB_API_BASE_URL="${CDIDX_GITHUB_API_BASE_URL:-https://api.github.com}"
 CURL_STDERR_SAMPLE_BYTES=8192
+LATEST_RELEASE_RESPONSE_MAX_BYTES=65536
 REQUIRE_ATTESTATION="${CDIDX_REQUIRE_ATTESTATION:-0}"
 STRICT_VERIFY="${CDIDX_STRICT_VERIFY:-0}"
 RELEASE_GPG_FINGERPRINT="${CDIDX_RELEASE_GPG_FINGERPRINT:-}"
@@ -691,11 +692,22 @@ fetch_latest_release_version() {
         rm -f "$response_file"
         return 1
     fi
+    local explicit_version_examples
+    explicit_version_examples="rerun the installer with an explicit version (for example: 'curl -fsSL https://raw.githubusercontent.com/${REPO}/vX.Y.Z/install.sh | bash -s -- vX.Y.Z', or 'bash ./install.sh vX.Y.Z' from a checkout)"
+    local api_response_bytes
+    if ! api_response_bytes="$(file_size_bytes "$response_file")"; then
+        rm -f "$response_file"
+        report_error "Failed to inspect ${api_label} response size while fetching ${api_url}."
+        return 1
+    fi
+    if [ "${api_response_bytes:-0}" -gt "$LATEST_RELEASE_RESPONSE_MAX_BYTES" ]; then
+        rm -f "$response_file"
+        report_error "${api_label} response exceeded the ${LATEST_RELEASE_RESPONSE_MAX_BYTES} byte limit before shell parsing while fetching ${api_url} (HTTP ${http_code}). ${explicit_version_examples} to skip the latest-release API call."
+        return 1
+    fi
     local api_response
     api_response="$(cat "$response_file")"
     rm -f "$response_file"
-    local explicit_version_examples
-    explicit_version_examples="rerun the installer with an explicit version (for example: 'curl -fsSL https://raw.githubusercontent.com/${REPO}/vX.Y.Z/install.sh | bash -s -- vX.Y.Z', or 'bash ./install.sh vX.Y.Z' from a checkout)"
 
     case "$http_code" in
         200) ;;

--- a/install.sh
+++ b/install.sh
@@ -79,6 +79,7 @@ BINARY_NAME="cdidx"
 MANIFEST_REQUIRED_VERSION="1.24.6"
 GITHUB_BASE_URL="${CDIDX_GITHUB_BASE_URL:-https://github.com}"
 GITHUB_API_BASE_URL="${CDIDX_GITHUB_API_BASE_URL:-https://api.github.com}"
+CURL_STDERR_SAMPLE_BYTES=8192
 REQUIRE_ATTESTATION="${CDIDX_REQUIRE_ATTESTATION:-0}"
 STRICT_VERIFY="${CDIDX_STRICT_VERIFY:-0}"
 RELEASE_GPG_FINGERPRINT="${CDIDX_RELEASE_GPG_FINGERPRINT:-}"
@@ -593,6 +594,29 @@ is_proxy_tunnel_403() {
     printf '%s' "$1" | grep -Eqi 'CONNECT tunnel failed, response 403|HTTP code 403 from proxy after CONNECT'
 }
 
+file_size_bytes() {
+    wc -c < "$1" | tr -d '[:space:]'
+}
+
+read_bounded_file_sample() {
+    local path="$1"
+    local max_bytes="$2"
+    local label="$3"
+    local byte_count
+
+    if ! byte_count="$(file_size_bytes "$path")"; then
+        return 1
+    fi
+
+    if [ "${byte_count:-0}" -le "$max_bytes" ]; then
+        cat "$path"
+        return 0
+    fi
+
+    head -c "$max_bytes" "$path"
+    printf '\n[cdidx installer truncated %s: showing first %s of %s bytes]\n' "$label" "$max_bytes" "$byte_count"
+}
+
 curl_http_get() {
     local url="$1"
     local output_path="$2"
@@ -615,7 +639,7 @@ curl_http_get() {
         local curl_status=$?
         local stderr_text=""
         if [ -f "$curl_stderr" ]; then
-            stderr_text="$(cat "$curl_stderr")"
+            stderr_text="$(read_bounded_file_sample "$curl_stderr" "$CURL_STDERR_SAMPLE_BYTES" "curl stderr for ${source_label}")"
             rm -f "$curl_stderr"
         fi
 
@@ -1950,7 +1974,7 @@ probe_doctor_url() {
 
     local stderr_text=""
     if [ -f "$curl_stderr" ]; then
-        stderr_text="$(cat "$curl_stderr")"
+        stderr_text="$(read_bounded_file_sample "$curl_stderr" "$CURL_STDERR_SAMPLE_BYTES" "curl stderr for ${label}")"
         rm -f "$curl_stderr"
     fi
 

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -431,6 +431,49 @@ public sealed class InstallScriptTests : IDisposable
     }
 
     [Fact]
+    public void ResolveVersion_LatestLookupResponseTooLarge_FailsBeforeShellParsing()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            """
+            curl() {
+                local output_path=""
+                while [ $# -gt 0 ]; do
+                    case "$1" in
+                        -o)
+                            output_path="$2"
+                            shift 2
+                            ;;
+                        -w)
+                            shift 2
+                            ;;
+                        *)
+                            shift
+                            ;;
+                    esac
+                done
+
+                printf '%65537s' '' > "$output_path"
+                printf '%s' '{"tag_name":"v9.9.9"}' >> "$output_path"
+                printf '200'
+                return 0
+            }
+
+            resolve_version ""
+            """);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Fetching latest release version", stdout);
+        Assert.Contains("GitHub API response exceeded the 65536 byte limit before shell parsing", stderr);
+        Assert.Contains("HTTP 200", stderr);
+        Assert.Contains("explicit version", stderr);
+        Assert.DoesNotContain("Could not determine latest version", stderr);
+        Assert.DoesNotContain("Version: v9.9.9", stdout);
+    }
+
+    [Fact]
     public void ResolveVersion_ForbiddenLatestLookup_PrintsProxyAndVersionPinHints()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -552,6 +552,31 @@ public sealed class InstallScriptTests : IDisposable
     }
 
     [Fact]
+    public void ResolveVersion_TunnelForbiddenLatestLookup_CapsCurlStderrBeforePrinting()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (exitCode, _, stderr) = RunInstallerSnippet(
+            """
+            curl() {
+                printf '%s' "curl: (56) CONNECT tunnel failed, response 403 " >&2
+                for _ in {1..9000}; do printf 'X' >&2; done
+                printf '%s\n' "TAIL_SHOULD_NOT_APPEAR" >&2
+                return 56
+            }
+
+            resolve_version ""
+            """);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("curl: (56) CONNECT tunnel failed, response 403", stderr);
+        Assert.Contains("[cdidx installer truncated curl stderr for GitHub API: showing first 8192", stderr);
+        Assert.Contains("CONNECT tunnel failed with HTTP 403 while reaching GitHub API", stderr);
+        Assert.DoesNotContain("TAIL_SHOULD_NOT_APPEAR", stderr);
+    }
+
+    [Fact]
     public void DownloadAndInstall_ForbiddenGitHubAssetDownload_PrintsGitHubAndAllowListHints()
     {
         if (OperatingSystem.IsWindows())
@@ -4882,6 +4907,34 @@ public sealed class InstallScriptTests : IDisposable
         Assert.Contains("API probe: FAILED", stdout);
         Assert.Contains("Release asset probe: FAILED", stdout);
         Assert.Contains("Checksums probe: FAILED", stdout);
+    }
+
+    [Fact]
+    public void Doctor_ConnectTunnel403_CapsCurlStderrBeforePrinting()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            """
+            need_cmd() { :; }
+            detect_platform() { OS_NAME="linux"; ARCH_NAME="x64"; RID="linux-x64"; }
+            curl() {
+                printf '%s' "curl: (56) CONNECT tunnel failed, response 403 " >&2
+                for _ in {1..9000}; do printf 'X' >&2; done
+                printf '%s\n' "TAIL_SHOULD_NOT_APPEAR" >&2
+                return 56
+            }
+
+            run_doctor v1.2.3
+            """);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("[cdidx installer truncated curl stderr for GitHub API: showing first 8192", stderr);
+        Assert.Contains("CONNECT tunnel failed with HTTP 403", stderr);
+        Assert.Contains("Doctor detected at least one unreachable endpoint", stderr);
+        Assert.Contains("API probe: FAILED", stdout);
+        Assert.DoesNotContain("TAIL_SHOULD_NOT_APPEAR", stderr);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Cap installer curl stderr diagnostics before loading or printing them, with an explicit truncation notice.
- Reject oversized latest-release API response bodies before shell parsing.
- Add installer regression tests and bilingual changelog fragments for both issues.

## Validation

- `bash -n install.sh`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter FullyQualifiedName~InstallScriptTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net9.0 --filter FullyQualifiedName~InstallScriptTests -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and Changelog

- Added `changelog.d/unreleased/3187.security.md`.
- Added `changelog.d/unreleased/3188.security.md`.
- No README/developer guide changes were required because this only bounds existing installer diagnostics and parsing behavior.

## Review

Adversarial review of `origin/main..HEAD`: No blocking/actionable issues found.

## Follow-up Candidates

None.

Fixes #3187
Fixes #3188
