### PR TITLE
Bound workspace version pin reads

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -321,7 +321,7 @@ Do not add mutable static caches, shared `StringBuilder` instances, reused `Matc
 
 ### Workspace version pinning
 
-On startup, `cdidx` walks up from the current directory looking for `.cdidx-version`. The first non-empty line is treated as the required CLI version for that workspace. A mismatch prints a warning and continues by default; `--strict-version` or `CDIDX_STRICT_VERSION=1` turns the mismatch into exit code `64` (`EX_USAGE`). This check is advisory and does not rewrite the file. Use it to keep teams on the same binary when index contracts or query behavior differ between releases.
+On startup, `cdidx` walks up from the current directory looking for `.cdidx-version`. The first non-empty line is treated as the required CLI version for that workspace. The pin file is read with a 4096-byte cap; `cdidx` skips at most 16 leading blank lines, and each scanned line must be at most 256 characters. If those limits are exceeded, the pin is ignored with a warning. A mismatch prints a warning and continues by default; `--strict-version` or `CDIDX_STRICT_VERSION=1` turns the mismatch into exit code `64` (`EX_USAGE`). This check is advisory and does not rewrite the file. Use it to keep teams on the same binary when index contracts or query behavior differ between releases.
 
 ### Release freshness and upgrade checks
 
@@ -2335,7 +2335,9 @@ graph edge 意味を表します。端末表示、JSON 出力、MCP contract の
 ### ワークスペースのバージョン固定
 
 startup 時、`cdidx` は current directory から上へ `.cdidx-version` を探します。最初の non-empty
-line を workspace が要求する CLI version として扱い、mismatch は既定では warning のみです。
+line を workspace が要求する CLI version として扱います。pin file は 4096 byte 上限で読み、
+先頭の blank line は最大 16 行まで skip し、読み取る各 line は最大 256 文字です。これらの
+上限を超えた場合、pin は warning とともに無視されます。mismatch は既定では warning のみです。
 `--strict-version` または `CDIDX_STRICT_VERSION=1` では exit code `64` (`EX_USAGE`) になります。
 この check は advisory で、file は書き換えません。index contract や query behavior が
 release 間で異なる場合に、team の binary version を揃えるために使います。

--- a/changelog.d/unreleased/3072.fixed.md
+++ b/changelog.d/unreleased/3072.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3072
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Workspace version pins are now read with startup-safe bounds (#3072)** — `.cdidx-version` files now have small byte, leading blank-line, and per-line caps, and malformed pins are warned about and ignored instead of making every command scan excessive input.
+
+## 日本語
+
+- **ワークスペースのバージョン固定を起動時に安全な上限付きで読むようにしました (#3072)** — `.cdidx-version` は小さな byte 上限、先頭 blank line 上限、行長上限付きで読み、壊れた pin は警告して無視するため、各コマンドが過剰な入力を走査し続けることを防ぎます。

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -1628,7 +1628,7 @@ internal static class ProgramRunner
                 return false;
             }
 
-            return TryParseWorkspaceVersionPin(Encoding.UTF8.GetString(bytes), pinPath, out required, out warning);
+            return TryParseWorkspaceVersionPin(DecodeWorkspaceVersionPinBytes(bytes), pinPath, out required, out warning);
         }
         catch (Exception ex)
         {
@@ -1664,6 +1664,17 @@ internal static class ProgramRunner
         var result = new byte[totalRead];
         Array.Copy(buffer, result, totalRead);
         return result;
+    }
+
+    private static string DecodeWorkspaceVersionPinBytes(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var reader = new StreamReader(
+            stream,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: Math.Min(1024, Math.Max(1, bytes.Length)));
+        return reader.ReadToEnd();
     }
 
     private static bool TryParseWorkspaceVersionPin(string content, string pinPath, out string required, out string warning)

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -20,6 +20,9 @@ internal static class ProgramRunner
     internal const string QuietEnvironmentVariable = "CDIDX_QUIET";
     private const string InstallerScriptUrlTemplate = "https://raw.githubusercontent.com/Widthdom/CodeIndex/{0}/install.sh";
     private const long MaxInstallerScriptBytes = 1024 * 1024;
+    internal const int WorkspaceVersionPinMaxBytes = 4096;
+    internal const int WorkspaceVersionPinMaxSkippedBlankLines = 16;
+    internal const int WorkspaceVersionPinMaxLineChars = 256;
     internal const long TestExtractorMaxInputBytes = 4 * 1024 * 1024;
     private static readonly TimeSpan InstallerRunTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan InstallerKillWaitTimeout = TimeSpan.FromSeconds(5);
@@ -1590,13 +1593,9 @@ internal static class ProgramRunner
             return CommandExitCodes.Success;
 
         string required;
-        try
+        if (!TryReadWorkspaceVersionPin(pinPath, out required, out var warning))
         {
-            required = File.ReadLines(pinPath).FirstOrDefault(line => !string.IsNullOrWhiteSpace(line))?.Trim() ?? "";
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"Warning: could not read .cdidx-version at {pinPath}: {ex.Message}");
+            Console.Error.WriteLine(warning);
             return CommandExitCodes.Success;
         }
 
@@ -1613,6 +1612,95 @@ internal static class ProgramRunner
         Console.Error.WriteLine($"Error: {message}");
         Console.Error.WriteLine("Hint: rerun without --strict-version to warn only, or install the pinned cdidx version for this workspace.");
         return CommandExitCodes.ExUsage;
+    }
+
+    private static bool TryReadWorkspaceVersionPin(string pinPath, out string required, out string warning)
+    {
+        required = string.Empty;
+        warning = string.Empty;
+
+        try
+        {
+            var bytes = ReadWorkspaceVersionPinBytes(pinPath);
+            if (bytes.Length > WorkspaceVersionPinMaxBytes)
+            {
+                warning = $"Warning: ignoring .cdidx-version at {pinPath}: file exceeds {WorkspaceVersionPinMaxBytes} bytes.";
+                return false;
+            }
+
+            return TryParseWorkspaceVersionPin(Encoding.UTF8.GetString(bytes), pinPath, out required, out warning);
+        }
+        catch (Exception ex)
+        {
+            warning = $"Warning: could not read .cdidx-version at {pinPath}: {ex.Message}";
+            return false;
+        }
+    }
+
+    private static byte[] ReadWorkspaceVersionPinBytes(string pinPath)
+    {
+        var buffer = new byte[WorkspaceVersionPinMaxBytes + 1];
+        var totalRead = 0;
+
+        using var stream = new FileStream(
+            pinPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete,
+            bufferSize: Math.Min(1024, buffer.Length),
+            FileOptions.SequentialScan);
+
+        while (totalRead < buffer.Length)
+        {
+            var read = stream.Read(buffer, totalRead, buffer.Length - totalRead);
+            if (read == 0)
+                break;
+            totalRead += read;
+        }
+
+        if (totalRead == buffer.Length)
+            return buffer;
+
+        var result = new byte[totalRead];
+        Array.Copy(buffer, result, totalRead);
+        return result;
+    }
+
+    private static bool TryParseWorkspaceVersionPin(string content, string pinPath, out string required, out string warning)
+    {
+        required = string.Empty;
+        warning = string.Empty;
+
+        using var reader = new StringReader(content);
+        var skippedBlankLines = 0;
+        var lineNumber = 0;
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            lineNumber++;
+            if (line.Length > WorkspaceVersionPinMaxLineChars)
+            {
+                warning = $"Warning: ignoring .cdidx-version at {pinPath}: line {lineNumber} exceeds {WorkspaceVersionPinMaxLineChars} characters.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                skippedBlankLines++;
+                if (skippedBlankLines > WorkspaceVersionPinMaxSkippedBlankLines)
+                {
+                    warning = $"Warning: ignoring .cdidx-version at {pinPath}: more than {WorkspaceVersionPinMaxSkippedBlankLines} leading blank lines.";
+                    return false;
+                }
+
+                continue;
+            }
+
+            required = line.Trim();
+            return true;
+        }
+
+        return true;
     }
 
     internal static string? FindWorkspaceVersionPin(string startDirectory)

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -390,6 +390,83 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void Run_WorkspaceVersionPinTooLarge_WarnsAndIgnoresPin()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("version-pin-large");
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projectRoot, ".cdidx-version"),
+                "9.9.9\n" + new string('x', ProgramRunner.WorkspaceVersionPinMaxBytes));
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                ["--strict-version", "--version", "--json"],
+                appVersion: "1.10.0",
+                configStartDirectory: projectRoot));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Contains("\"version\":\"1.10.0\"", stdout);
+            Assert.Contains($"file exceeds {ProgramRunner.WorkspaceVersionPinMaxBytes} bytes", stderr);
+            Assert.DoesNotContain("workspace requires cdidx v9.9.9", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_WorkspaceVersionPinTooManyBlankLines_WarnsAndIgnoresPin()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("version-pin-blanks");
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projectRoot, ".cdidx-version"),
+                new string('\n', ProgramRunner.WorkspaceVersionPinMaxSkippedBlankLines + 1) + "9.9.9\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                ["--strict-version", "--version", "--json"],
+                appVersion: "1.10.0",
+                configStartDirectory: projectRoot));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Contains("\"version\":\"1.10.0\"", stdout);
+            Assert.Contains($"more than {ProgramRunner.WorkspaceVersionPinMaxSkippedBlankLines} leading blank lines", stderr);
+            Assert.DoesNotContain("workspace requires cdidx v9.9.9", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_WorkspaceVersionPinLineTooLong_WarnsAndIgnoresPin()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("version-pin-line");
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projectRoot, ".cdidx-version"),
+                new string('9', ProgramRunner.WorkspaceVersionPinMaxLineChars + 1) + "\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                ["--strict-version", "--version", "--json"],
+                appVersion: "1.10.0",
+                configStartDirectory: projectRoot));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Contains("\"version\":\"1.10.0\"", stdout);
+            Assert.Contains($"line 1 exceeds {ProgramRunner.WorkspaceVersionPinMaxLineChars} characters", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void UpdateChecker_Check_ReportsNewerRelease()
     {
         var cachePath = Path.Combine(Path.GetTempPath(), $"cdidx_update_check_{Guid.NewGuid():N}.json");

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -390,6 +390,32 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void Run_WorkspaceVersionPinUtf8Bom_MatchingStrictPinSucceeds()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("version-pin-bom");
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projectRoot, ".cdidx-version"),
+                "1.10.0\n",
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                ["--strict-version", "--version", "--json"],
+                appVersion: "1.10.0",
+                configStartDirectory: projectRoot));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Contains("\"version\":\"1.10.0\"", stdout);
+            Assert.DoesNotContain("workspace requires cdidx", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_WorkspaceVersionPinTooLarge_WarnsAndIgnoresPin()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("version-pin-large");


### PR DESCRIPTION
## Summary

- Bound `.cdidx-version` startup reads to a small byte cap, leading blank-line cap, and per-line cap.
- Warn and ignore malformed workspace version pins when those limits are exceeded.
- Preserve BOM-aware decoding so existing valid pinned workspaces keep matching under `--strict-version`.

## Documentation and changelog

- Updated `DEVELOPER_GUIDE.md` in English and Japanese.
- Added changelog fragment `changelog.d/unreleased/3072.fixed.md`.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProgramRunnerTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `codex exec review --base origin/main --ephemeral`

## Follow-up candidates

None.

Fixes #3072