### PR TITLE
[codex] Harden workspace manifest validation

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -132,7 +132,7 @@ git status --short -- '**/packages.lock.json'
 
 ### Workspaces
 
-`cdidx.workspace.json` and `.cdidx-workspace.json` declare monorepo members without adding a YAML dependency. Workspace manifests are capped at 64 KiB, 16 JSON nesting levels, and 1024 members. The supported schema is additive: `members` is an array of member paths that must be relative to and resolve under the manifest directory, `index_strategy` is `per_member` or `single`, `default_db_name` overrides `codeindex.db`, and `shared_ignores` is reserved for shared ignore policy. `cdidx workspace list` and `cdidx workspace status` report member DB paths.
+`cdidx.workspace.json` and `.cdidx-workspace.json` declare monorepo members without adding a YAML dependency. Workspace manifests are capped at 64 KiB, 16 JSON nesting levels, and 1024 members. The supported schema is additive: `members` is an array of member paths that must be relative to and resolve under the manifest directory, `index_strategy` is `per_member` or `single`, `default_db_name` is a plain file name that overrides `codeindex.db`, and `shared_ignores` is reserved for shared ignore policy. `cdidx workspace list` and `cdidx workspace status` report member DB paths.
 
 `cdidx workspace use <name>` writes the active workspace to the per-user config directory. Query DB resolution keeps existing precedence: explicit `--db`, then explicit `--data-dir` / `CDIDX_DATA_DIR`, then active workspace state, then ancestor/CWD discovery.
 
@@ -2203,7 +2203,7 @@ member を宣言します。workspace manifest は 64 KiB、JSON nesting 16 leve
 schema は additive で、`members` は manifest directory からの相対 path かつ正規化後も
 manifest directory 配下に残る member path、
 `index_strategy` は `per_member` または `single`、`default_db_name` は
-`codeindex.db` の上書き、`shared_ignores` は共有 ignore policy 用の予約 field です。
+`codeindex.db` を上書きする plain file name、`shared_ignores` は共有 ignore policy 用の予約 field です。
 `cdidx workspace list` と `cdidx workspace status` は member DB path を報告します。
 
 `cdidx workspace use <name>` は active workspace を per-user config directory に保存します。

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -132,7 +132,7 @@ git status --short -- '**/packages.lock.json'
 
 ### Workspaces
 
-`cdidx.workspace.json` and `.cdidx-workspace.json` declare monorepo members without adding a YAML dependency. Workspace manifests are capped at 64 KiB and 16 JSON nesting levels. The supported schema is additive: `members` is an array of member paths relative to the manifest directory, `index_strategy` is `per_member` or `single`, `default_db_name` overrides `codeindex.db`, and `shared_ignores` is reserved for shared ignore policy. `cdidx workspace list` and `cdidx workspace status` report member DB paths.
+`cdidx.workspace.json` and `.cdidx-workspace.json` declare monorepo members without adding a YAML dependency. Workspace manifests are capped at 64 KiB, 16 JSON nesting levels, and 1024 members. The supported schema is additive: `members` is an array of member paths relative to the manifest directory, `index_strategy` is `per_member` or `single`, `default_db_name` overrides `codeindex.db`, and `shared_ignores` is reserved for shared ignore policy. `cdidx workspace list` and `cdidx workspace status` report member DB paths.
 
 `cdidx workspace use <name>` writes the active workspace to the per-user config directory. Query DB resolution keeps existing precedence: explicit `--db`, then explicit `--data-dir` / `CDIDX_DATA_DIR`, then active workspace state, then ancestor/CWD discovery.
 
@@ -2199,7 +2199,7 @@ git status --short -- '**/packages.lock.json'
 ### ワークスペース
 
 `cdidx.workspace.json` と `.cdidx-workspace.json` は YAML dependency を増やさずに monorepo
-member を宣言します。workspace manifest は 64 KiB と JSON nesting 16 level に制限されます。
+member を宣言します。workspace manifest は 64 KiB、JSON nesting 16 level、1024 members に制限されます。
 schema は additive で、`members` は manifest directory からの相対 member path、
 `index_strategy` は `per_member` または `single`、`default_db_name` は
 `codeindex.db` の上書き、`shared_ignores` は共有 ignore policy 用の予約 field です。

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -132,7 +132,7 @@ git status --short -- '**/packages.lock.json'
 
 ### Workspaces
 
-`cdidx.workspace.json` and `.cdidx-workspace.json` declare monorepo members without adding a YAML dependency. The supported schema is additive: `members` is an array of member paths relative to the manifest directory, `index_strategy` is `per_member` or `single`, `default_db_name` overrides `codeindex.db`, and `shared_ignores` is reserved for shared ignore policy. `cdidx workspace list` and `cdidx workspace status` report member DB paths.
+`cdidx.workspace.json` and `.cdidx-workspace.json` declare monorepo members without adding a YAML dependency. Workspace manifests are capped at 64 KiB and 16 JSON nesting levels. The supported schema is additive: `members` is an array of member paths relative to the manifest directory, `index_strategy` is `per_member` or `single`, `default_db_name` overrides `codeindex.db`, and `shared_ignores` is reserved for shared ignore policy. `cdidx workspace list` and `cdidx workspace status` report member DB paths.
 
 `cdidx workspace use <name>` writes the active workspace to the per-user config directory. Query DB resolution keeps existing precedence: explicit `--db`, then explicit `--data-dir` / `CDIDX_DATA_DIR`, then active workspace state, then ancestor/CWD discovery.
 
@@ -2199,8 +2199,9 @@ git status --short -- '**/packages.lock.json'
 ### ワークスペース
 
 `cdidx.workspace.json` と `.cdidx-workspace.json` は YAML dependency を増やさずに monorepo
-member を宣言します。schema は additive で、`members` は manifest directory からの相対
-member path、`index_strategy` は `per_member` または `single`、`default_db_name` は
+member を宣言します。workspace manifest は 64 KiB と JSON nesting 16 level に制限されます。
+schema は additive で、`members` は manifest directory からの相対 member path、
+`index_strategy` は `per_member` または `single`、`default_db_name` は
 `codeindex.db` の上書き、`shared_ignores` は共有 ignore policy 用の予約 field です。
 `cdidx workspace list` と `cdidx workspace status` は member DB path を報告します。
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -132,7 +132,7 @@ git status --short -- '**/packages.lock.json'
 
 ### Workspaces
 
-`cdidx.workspace.json` and `.cdidx-workspace.json` declare monorepo members without adding a YAML dependency. Workspace manifests are capped at 64 KiB, 16 JSON nesting levels, and 1024 members. The supported schema is additive: `members` is an array of member paths relative to the manifest directory, `index_strategy` is `per_member` or `single`, `default_db_name` overrides `codeindex.db`, and `shared_ignores` is reserved for shared ignore policy. `cdidx workspace list` and `cdidx workspace status` report member DB paths.
+`cdidx.workspace.json` and `.cdidx-workspace.json` declare monorepo members without adding a YAML dependency. Workspace manifests are capped at 64 KiB, 16 JSON nesting levels, and 1024 members. The supported schema is additive: `members` is an array of member paths that must be relative to and resolve under the manifest directory, `index_strategy` is `per_member` or `single`, `default_db_name` overrides `codeindex.db`, and `shared_ignores` is reserved for shared ignore policy. `cdidx workspace list` and `cdidx workspace status` report member DB paths.
 
 `cdidx workspace use <name>` writes the active workspace to the per-user config directory. Query DB resolution keeps existing precedence: explicit `--db`, then explicit `--data-dir` / `CDIDX_DATA_DIR`, then active workspace state, then ancestor/CWD discovery.
 
@@ -2200,7 +2200,8 @@ git status --short -- '**/packages.lock.json'
 
 `cdidx.workspace.json` と `.cdidx-workspace.json` は YAML dependency を増やさずに monorepo
 member を宣言します。workspace manifest は 64 KiB、JSON nesting 16 level、1024 members に制限されます。
-schema は additive で、`members` は manifest directory からの相対 member path、
+schema は additive で、`members` は manifest directory からの相対 path かつ正規化後も
+manifest directory 配下に残る member path、
 `index_strategy` は `per_member` または `single`、`default_db_name` は
 `codeindex.db` の上書き、`shared_ignores` は共有 ignore policy 用の予約 field です。
 `cdidx workspace list` と `cdidx workspace status` は member DB path を報告します。

--- a/changelog.d/unreleased/3037.fixed.md
+++ b/changelog.d/unreleased/3037.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3037
+affected:
+  - src/CodeIndex/Cli/WorkspaceManifest.cs
+  - tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Workspace manifests now enforce a JSON depth limit (#3037)** - `WorkspaceManifestLoader` now caps manifest parsing at 16 JSON nesting levels, preventing deeply nested input from consuming unnecessary parser work before schema validation.
+
+## 日本語
+
+- **workspace manifest が JSON depth limit を強制するようになりました (#3037)** - `WorkspaceManifestLoader` は manifest parsing を JSON nesting 16 level で制限し、深くネストした入力が schema validation 前に不要な parser work を消費しないようにしました。

--- a/changelog.d/unreleased/3038.fixed.md
+++ b/changelog.d/unreleased/3038.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3038
+affected:
+  - src/CodeIndex/Cli/WorkspaceManifest.cs
+  - tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Workspace manifests now cap member counts before probing paths (#3038)** - `WorkspaceManifestLoader` rejects manifests with more than 1024 non-empty string members before resolving or probing member directories.
+
+## 日本語
+
+- **workspace manifest が path probe 前に member count を制限するようになりました (#3038)** - `WorkspaceManifestLoader` は non-empty string member が 1024 件を超える manifest を、member directory の解決や probe の前に拒否します。

--- a/changelog.d/unreleased/3039-3215.fixed.md
+++ b/changelog.d/unreleased/3039-3215.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3039
+  - 3215
+affected:
+  - src/CodeIndex/Cli/WorkspaceManifest.cs
+  - tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Workspace manifest members must stay under the manifest root (#3039, #3215)** - member paths are now rejected when they are rooted or normalize outside the manifest directory, keeping workspace entries and per-member DB paths inside the declared workspace boundary.
+
+## 日本語
+
+- **workspace manifest の member は manifest root 配下に制限されるようになりました (#3039, #3215)** - member path が rooted path の場合や正規化後に manifest directory の外へ出る場合は拒否し、workspace entry と per-member DB path を宣言された workspace boundary 内に保ちます。

--- a/changelog.d/unreleased/3040.fixed.md
+++ b/changelog.d/unreleased/3040.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3040
+affected:
+  - src/CodeIndex/Cli/WorkspaceManifest.cs
+  - tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Workspace manifest DB names must be plain file names (#3040)** - `default_db_name` now rejects rooted paths, traversal values, and directory separators before constructing workspace DB paths.
+
+## 日本語
+
+- **workspace manifest の DB 名は plain file name に制限されるようになりました (#3040)** - `default_db_name` は workspace DB path を構築する前に rooted path、traversal value、directory separator 入りの値を拒否します。

--- a/src/CodeIndex/Cli/WorkspaceManifest.cs
+++ b/src/CodeIndex/Cli/WorkspaceManifest.cs
@@ -28,6 +28,7 @@ internal static class WorkspaceManifestLoader
     internal const string DotFileName = ".cdidx-workspace.json";
     internal const int MaxManifestBytes = 64 * 1024;
     internal const int MaxManifestDepth = 16;
+    internal const int MaxManifestMembers = 1024;
 
     internal static WorkspaceManifest? Find(string startingDirectory)
     {
@@ -72,14 +73,7 @@ internal static class WorkspaceManifestLoader
         var element = document.RootElement;
         var strategy = ReadString(element, "index_strategy") ?? "per_member";
         var dbName = ReadString(element, "default_db_name") ?? "codeindex.db";
-        var rawMembers = element.TryGetProperty("members", out var membersElement) && membersElement.ValueKind == JsonValueKind.Array
-            ? membersElement.EnumerateArray()
-                .Where(m => m.ValueKind == JsonValueKind.String)
-                .Select(m => m.GetString())
-                .Where(m => !string.IsNullOrWhiteSpace(m))
-                .Select(m => m!)
-                .ToArray()
-            : Array.Empty<string>();
+        var rawMembers = ReadMembers(element);
 
         var members = rawMembers.Select(member =>
         {
@@ -97,4 +91,28 @@ internal static class WorkspaceManifestLoader
         => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
+
+    private static IReadOnlyList<string> ReadMembers(JsonElement element)
+    {
+        if (!element.TryGetProperty("members", out var membersElement) || membersElement.ValueKind != JsonValueKind.Array)
+            return Array.Empty<string>();
+
+        var members = new List<string>();
+        foreach (var member in membersElement.EnumerateArray())
+        {
+            if (member.ValueKind != JsonValueKind.String)
+                continue;
+
+            var value = member.GetString();
+            if (string.IsNullOrWhiteSpace(value))
+                continue;
+
+            if (members.Count >= MaxManifestMembers)
+                throw new InvalidDataException($"Workspace manifest members exceed the {MaxManifestMembers} member limit.");
+
+            members.Add(value);
+        }
+
+        return members;
+    }
 }

--- a/src/CodeIndex/Cli/WorkspaceManifest.cs
+++ b/src/CodeIndex/Cli/WorkspaceManifest.cs
@@ -77,7 +77,7 @@ internal static class WorkspaceManifestLoader
 
         var members = rawMembers.Select(member =>
         {
-            var fullMember = Path.GetFullPath(Path.Combine(root, member));
+            var fullMember = ResolveMemberPath(root, member);
             var dbPath = string.Equals(strategy, "single", StringComparison.OrdinalIgnoreCase)
                 ? Path.Combine(root, ".cdidx", dbName)
                 : Path.Combine(fullMember, ".cdidx", dbName);
@@ -114,5 +114,31 @@ internal static class WorkspaceManifestLoader
         }
 
         return members;
+    }
+
+    private static string ResolveMemberPath(string root, string member)
+    {
+        if (Path.IsPathRooted(member))
+            throw new InvalidDataException($"Workspace manifest member path must be relative: {member}");
+
+        var fullMember = Path.GetFullPath(Path.Combine(root, member));
+        if (!IsSameOrDescendant(root, fullMember))
+            throw new InvalidDataException($"Workspace manifest member path escapes the manifest root: {member}");
+
+        return fullMember;
+    }
+
+    private static bool IsSameOrDescendant(string root, string path)
+    {
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var normalizedRoot = Path.GetFullPath(root);
+        var normalizedPath = Path.GetFullPath(path);
+        if (string.Equals(normalizedRoot, normalizedPath, comparison))
+            return true;
+
+        var rootWithSeparator = Path.EndsInDirectorySeparator(normalizedRoot)
+            ? normalizedRoot
+            : normalizedRoot + Path.DirectorySeparatorChar;
+        return normalizedPath.StartsWith(rootWithSeparator, comparison);
     }
 }

--- a/src/CodeIndex/Cli/WorkspaceManifest.cs
+++ b/src/CodeIndex/Cli/WorkspaceManifest.cs
@@ -27,6 +27,7 @@ internal static class WorkspaceManifestLoader
     internal const string FileName = "cdidx.workspace.json";
     internal const string DotFileName = ".cdidx-workspace.json";
     internal const int MaxManifestBytes = 64 * 1024;
+    internal const int MaxManifestDepth = 16;
 
     internal static WorkspaceManifest? Find(string startingDirectory)
     {
@@ -65,6 +66,7 @@ internal static class WorkspaceManifestLoader
         {
             CommentHandling = JsonCommentHandling.Skip,
             AllowTrailingCommas = true,
+            MaxDepth = MaxManifestDepth,
         });
 
         var element = document.RootElement;

--- a/src/CodeIndex/Cli/WorkspaceManifest.cs
+++ b/src/CodeIndex/Cli/WorkspaceManifest.cs
@@ -72,7 +72,7 @@ internal static class WorkspaceManifestLoader
 
         var element = document.RootElement;
         var strategy = ReadString(element, "index_strategy") ?? "per_member";
-        var dbName = ReadString(element, "default_db_name") ?? "codeindex.db";
+        var dbName = ValidateDefaultDbName(ReadString(element, "default_db_name") ?? "codeindex.db");
         var rawMembers = ReadMembers(element);
 
         var members = rawMembers.Select(member =>
@@ -91,6 +91,22 @@ internal static class WorkspaceManifestLoader
         => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
+
+    private static string ValidateDefaultDbName(string dbName)
+    {
+        if (string.IsNullOrWhiteSpace(dbName)
+            || dbName is "." or ".."
+            || Path.IsPathRooted(dbName)
+            || dbName.Contains('/')
+            || dbName.Contains('\\')
+            || dbName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || !string.Equals(Path.GetFileName(dbName), dbName, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Workspace manifest default_db_name must be a plain file name: {dbName}");
+        }
+
+        return dbName;
+    }
 
     private static IReadOnlyList<string> ReadMembers(JsonElement element)
     {

--- a/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
@@ -83,6 +83,30 @@ public class WorkspaceCommandRunnerTests
     }
 
     [Fact]
+    public void WorkspaceManifestLoader_Load_RejectsTooManyMembers()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_members");
+        try
+        {
+            var manifestPath = Path.Combine(root, "cdidx.workspace.json");
+            var members = string.Join(",", Enumerable.Range(0, WorkspaceManifestLoader.MaxManifestMembers + 1).Select(i => $"\"src{i}\""));
+            File.WriteAllText(manifestPath, $$"""
+                {
+                  "members": [{{members}}]
+                }
+                """);
+
+            var ex = Assert.Throws<InvalidDataException>(() => WorkspaceManifestLoader.Load(manifestPath));
+
+            Assert.Contains($"{WorkspaceManifestLoader.MaxManifestMembers} member limit", ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void WorkspaceManifestLoader_Load_AcceptsUtf8BomManifest()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_bom");

--- a/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
@@ -154,6 +154,56 @@ public class WorkspaceCommandRunnerTests
     }
 
     [Fact]
+    public void WorkspaceManifestLoader_Load_RejectsAbsoluteDefaultDbName()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_absolute_db");
+        try
+        {
+            var manifestPath = Path.Combine(root, "cdidx.workspace.json");
+            var dbName = Path.Combine(root, "outside.db");
+            File.WriteAllText(manifestPath, $$"""
+                {
+                  "default_db_name": {{JsonSerializer.Serialize(dbName)}}
+                }
+                """);
+
+            var ex = Assert.Throws<InvalidDataException>(() => WorkspaceManifestLoader.Load(manifestPath));
+
+            Assert.Contains("default_db_name must be a plain file name", ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("..")]
+    [InlineData("../outside.db")]
+    [InlineData("nested/index.db")]
+    public void WorkspaceManifestLoader_Load_RejectsUnsafeDefaultDbName(string dbName)
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_unsafe_db");
+        try
+        {
+            var manifestPath = Path.Combine(root, "cdidx.workspace.json");
+            File.WriteAllText(manifestPath, $$"""
+                {
+                  "default_db_name": {{JsonSerializer.Serialize(dbName)}}
+                }
+                """);
+
+            var ex = Assert.Throws<InvalidDataException>(() => WorkspaceManifestLoader.Load(manifestPath));
+
+            Assert.Contains("default_db_name must be a plain file name", ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void WorkspaceManifestLoader_Load_AcceptsUtf8BomManifest()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_bom");

--- a/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
@@ -65,6 +65,24 @@ public class WorkspaceCommandRunnerTests
     }
 
     [Fact]
+    public void WorkspaceManifestLoader_Load_RejectsDeeplyNestedManifest()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_depth");
+        try
+        {
+            var manifestPath = Path.Combine(root, "cdidx.workspace.json");
+            var nestedPrefix = string.Concat(Enumerable.Repeat("{\"nested\":", WorkspaceManifestLoader.MaxManifestDepth + 1));
+            File.WriteAllText(manifestPath, nestedPrefix + "0" + new string('}', WorkspaceManifestLoader.MaxManifestDepth + 1));
+
+            Assert.ThrowsAny<JsonException>(() => WorkspaceManifestLoader.Load(manifestPath));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void WorkspaceManifestLoader_Load_AcceptsUtf8BomManifest()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_bom");

--- a/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
@@ -107,6 +107,53 @@ public class WorkspaceCommandRunnerTests
     }
 
     [Fact]
+    public void WorkspaceManifestLoader_Load_RejectsRootedMemberPath()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_rooted_member");
+        try
+        {
+            var manifestPath = Path.Combine(root, "cdidx.workspace.json");
+            var absoluteMember = Path.Combine(root, "src", "A");
+            File.WriteAllText(manifestPath, $$"""
+                {
+                  "members": [{{JsonSerializer.Serialize(absoluteMember)}}]
+                }
+                """);
+
+            var ex = Assert.Throws<InvalidDataException>(() => WorkspaceManifestLoader.Load(manifestPath));
+
+            Assert.Contains("member path must be relative", ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void WorkspaceManifestLoader_Load_RejectsEscapingMemberPath()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_escaping_member");
+        try
+        {
+            var manifestPath = Path.Combine(root, "cdidx.workspace.json");
+            File.WriteAllText(manifestPath, """
+                {
+                  "members": ["../outside"]
+                }
+                """);
+
+            var ex = Assert.Throws<InvalidDataException>(() => WorkspaceManifestLoader.Load(manifestPath));
+
+            Assert.Contains("member path escapes the manifest root", ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void WorkspaceManifestLoader_Load_AcceptsUtf8BomManifest()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_bom");


### PR DESCRIPTION
## Summary

- Enforce workspace manifest limits for JSON depth and member counts before member path probing.
- Reject rooted or escaping workspace members so manifest entries stay under the manifest root.
- Validate `default_db_name` as a plain file name before constructing workspace DB paths.

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md` workspace manifest schema notes in English and Japanese.
- Added changelog fragments:
  - `changelog.d/unreleased/3037.fixed.md`
  - `changelog.d/unreleased/3038.fixed.md`
  - `changelog.d/unreleased/3039-3215.fixed.md`
  - `changelog.d/unreleased/3040.fixed.md`

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~WorkspaceCommandRunnerTests -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes --include src/CodeIndex/Cli/WorkspaceManifest.cs tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs`
- `dotnet build src/CodeIndex/CodeIndex.csproj -p:UseSharedCompilation=false`
- Codex adversarial review: `No blocking/actionable issues found.`

Attempted `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`, but the local run did not produce a final success/failure summary after a long no-output period in a busy multi-worktree environment, so it was not counted as completed validation.

## Follow-up Candidates

None.

Fixes #3037
Fixes #3038
Fixes #3039
Fixes #3040
Fixes #3215
