### PR TITLE
Bound GitHub suggestion response handling

### DIFF
--- a/changelog.d/unreleased/3017.fixed.md
+++ b/changelog.d/unreleased/3017.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3017
+affected:
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+---
+
+## English
+
+- **GitHub suggestion success responses are now size-bounded (#3017)** — `GitHubIssueReporter` now reads successful GitHub API JSON responses through a fixed byte cap instead of materializing unbounded response bodies.
+
+## 日本語
+
+- **GitHub 提案送信の成功レスポンス本文にサイズ上限を設けました (#3017)** — `GitHubIssueReporter` は GitHub API の成功 JSON レスポンスを無制限に文字列化せず、固定バイト上限付きで読み取るようになりました。

--- a/changelog.d/unreleased/3018.fixed.md
+++ b/changelog.d/unreleased/3018.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3018
+affected:
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+---
+
+## English
+
+- **GitHub suggestion response JSON parsing now has an explicit depth cap (#3018)** — `GitHubIssueReporter` now parses GitHub API JSON responses with a fixed maximum depth so malformed responses cannot force excessive parser work.
+
+## 日本語
+
+- **GitHub 提案送信のレスポンスJSON解析に明示的な深度上限を設けました (#3018)** — `GitHubIssueReporter` は GitHub API JSON レスポンスを固定の最大深度で解析し、不正な深いレスポンスによる過剰な parser work を防ぐようになりました。

--- a/changelog.d/unreleased/3222.fixed.md
+++ b/changelog.d/unreleased/3222.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3222
+affected:
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+---
+
+## English
+
+- **GitHub suggestion search and create success responses now share bounded, depth-capped JSON handling (#3222)** — oversized or deeply nested GitHub success payloads no longer force unbounded reads or parser work during suggestion submission.
+
+## 日本語
+
+- **GitHub 提案送信の検索・作成成功レスポンスで、サイズ上限とJSON深度上限を共通適用しました (#3222)** — 過大または深すぎる GitHub 成功 payload が、提案送信中に無制限の読み取りや parser work を引き起こさないようになりました。

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -254,7 +254,10 @@ internal static class GitHubIssueReporter
         using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        var response = await HttpClient.SendAsync(requestMessage, cancellationToken);
+        using var response = await HttpClient.SendAsync(
+            requestMessage,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
         if (!response.IsSuccessStatusCode)
             return null;
 
@@ -298,7 +301,10 @@ internal static class GitHubIssueReporter
                 using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-                var response = await HttpClient.SendAsync(requestMessage, cancellationToken);
+                using var response = await HttpClient.SendAsync(
+                    requestMessage,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken);
                 if (!response.IsSuccessStatusCode)
                     return null;
 
@@ -462,7 +468,10 @@ internal static class GitHubIssueReporter
         };
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        var response = await HttpClient.SendAsync(requestMessage, cancellationToken);
+        using var response = await HttpClient.SendAsync(
+            requestMessage,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -53,6 +53,7 @@ internal static class GitHubIssueReporter
     internal const int MaxScrubInputLength = 16 * 1024;
     internal const int MaxGitHubApiErrorBodyBytes = 4 * 1024;
     internal const int MaxGitHubApiResponseBodyBytes = 256 * 1024;
+    internal const int MaxGitHubApiResponseJsonDepth = 16;
     private const int MaxGitHubApiErrorDetailLength = 500;
     private const string CodeExampleRemovedText = "[code example removed]";
     private const string ScrubInputTruncatedText = "\n[truncated]";
@@ -732,8 +733,13 @@ internal static class GitHubIssueReporter
             content,
             MaxGitHubApiResponseBodyBytes,
             cancellationToken).ConfigureAwait(false);
-        return JsonNode.Parse(Encoding.UTF8.GetString(payload));
+        return ParseGitHubApiResponseJson(Encoding.UTF8.GetString(payload));
     }
+
+    internal static JsonNode? ParseGitHubApiResponseJson(string json)
+        => JsonNode.Parse(
+            json,
+            documentOptions: new JsonDocumentOptions { MaxDepth = MaxGitHubApiResponseJsonDepth });
 
     private static bool IsRecoverableGitHubApiResponseException(Exception ex)
         => ex is JsonException or InvalidDataException;
@@ -763,7 +769,7 @@ internal static class GitHubIssueReporter
         redactedJson = errorBody;
         try
         {
-            var node = JsonNode.Parse(errorBody);
+            var node = ParseGitHubApiResponseJson(errorBody);
             if (node == null || !RedactSensitiveJsonFields(node))
                 return false;
 

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -52,6 +52,7 @@ internal static class GitHubIssueReporter
     internal const int MaxGitHubIssueTitleLength = 255;
     internal const int MaxScrubInputLength = 16 * 1024;
     internal const int MaxGitHubApiErrorBodyBytes = 4 * 1024;
+    internal const int MaxGitHubApiResponseBodyBytes = 256 * 1024;
     private const int MaxGitHubApiErrorDetailLength = 500;
     private const string CodeExampleRemovedText = "[code example removed]";
     private const string ScrubInputTruncatedText = "\n[truncated]";
@@ -256,8 +257,16 @@ internal static class GitHubIssueReporter
         if (!response.IsSuccessStatusCode)
             return null;
 
-        var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
-        var node = JsonNode.Parse(responseJson);
+        JsonNode? node;
+        try
+        {
+            node = await ReadGitHubApiResponseJsonAsync(response.Content, cancellationToken);
+        }
+        catch (Exception ex) when (IsRecoverableGitHubApiResponseException(ex))
+        {
+            return null;
+        }
+
         var items = node?["items"] as JsonArray;
         if (items == null || items.Count == 0)
             return null;
@@ -292,8 +301,17 @@ internal static class GitHubIssueReporter
                 if (!response.IsSuccessStatusCode)
                     return null;
 
-                var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
-                var items = JsonNode.Parse(responseJson) as JsonArray;
+                JsonNode? node;
+                try
+                {
+                    node = await ReadGitHubApiResponseJsonAsync(response.Content, cancellationToken);
+                }
+                catch (Exception ex) when (IsRecoverableGitHubApiResponseException(ex))
+                {
+                    return null;
+                }
+
+                var items = node as JsonArray;
                 if (items == null || items.Count == 0)
                     break;
 
@@ -462,8 +480,7 @@ internal static class GitHubIssueReporter
         }
 
         // Parse response to extract the issue URL / レスポンスを解析して Issue URL を抽出
-        var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
-        var responseNode = JsonNode.Parse(responseJson);
+        var responseNode = await ReadGitHubApiResponseJsonAsync(response.Content, cancellationToken);
         var issueUrl = responseNode?["html_url"]?.GetValue<string>();
         return issueUrl != null
             ? SuggestionStore.SubmitAttemptResult.Success(issueUrl)
@@ -708,6 +725,18 @@ internal static class GitHubIssueReporter
             ? body + ApiErrorBodyTruncatedText
             : body;
     }
+
+    internal static async Task<JsonNode?> ReadGitHubApiResponseJsonAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+        var payload = await BoundedHttpContentReader.ReadAsByteArrayAsync(
+            content,
+            MaxGitHubApiResponseBodyBytes,
+            cancellationToken).ConfigureAwait(false);
+        return JsonNode.Parse(Encoding.UTF8.GetString(payload));
+    }
+
+    private static bool IsRecoverableGitHubApiResponseException(Exception ex)
+        => ex is JsonException or InvalidDataException;
 
     private static string SanitizeApiErrorBody(string errorBody)
     {

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -734,6 +734,120 @@ public class GitHubIssueReporterTests : IDisposable
     }
 
     [Fact]
+    public async Task TryCreateIssueAsync_SearchSuccessBodyOverLimit_StillAttemptsCreate()
+    {
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[GitHubIssueReporter.MaxGitHubApiResponseBodyBytes + 1]),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/repos/widthdom/CodeIndex/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("[]"),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = MakeJsonContent("""{ "html_url": "https://github.com/widthdom/CodeIndex/issues/3333" }"""),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/3333", url);
+            Assert.Equal(3, handler.RequestCount);
+            Assert.Equal(HttpMethod.Post, handler.Requests[2].Method);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryCreateIssueAsync_LabelListJsonOverDepthLimit_StillAttemptsCreate()
+    {
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("""{ "total_count": 0, "items": [] }"""),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/repos/widthdom/CodeIndex/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent(MakeDeepObjectJson(GitHubIssueReporter.MaxGitHubApiResponseJsonDepth + 8)),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = MakeJsonContent("""{ "html_url": "https://github.com/widthdom/CodeIndex/issues/3334" }"""),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/3334", url);
+            Assert.Equal(3, handler.RequestCount);
+            Assert.Equal(HttpMethod.Post, handler.Requests[2].Method);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryCreateIssueDetailedAsync_CreateSuccessJsonOverDepthLimit_ReturnsDiagnosticError()
+    {
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("""{ "total_count": 0, "items": [] }"""),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/repos/widthdom/CodeIndex/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("[]"),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = MakeJsonContent(MakeDeepObjectJson(GitHubIssueReporter.MaxGitHubApiResponseJsonDepth + 8)),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var result = await GitHubIssueReporter.TryCreateIssueDetailedAsync(record, "1.0.0-test");
+
+            Assert.Null(result.IssueUrl);
+            Assert.Contains("Json", result.Error);
+            Assert.Contains("maximum configured depth", result.Error);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
     public async Task TryCreateIssueAsync_SearchApiFails_StillAttemptsCreate()
     {
         // Search-API failure (e.g. 5xx or rate limited) must not block a

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using CodeIndex.Cli;
 using CodeIndex.Models;
@@ -882,6 +883,28 @@ public class GitHubIssueReporterTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadGitHubApiResponseJsonAsync_RejectsJsonOverDepthLimit()
+    {
+        using var content = MakeJsonContent(MakeDeepObjectJson(GitHubIssueReporter.MaxGitHubApiResponseJsonDepth + 8));
+
+        await Assert.ThrowsAnyAsync<JsonException>(
+            () => GitHubIssueReporter.ReadGitHubApiResponseJsonAsync(content, CancellationToken.None));
+    }
+
+    [Fact]
+    public void BuildApiErrorDetail_DeepJsonUsesRegexFallbackWithoutLeakingSecret()
+    {
+        var errorBody = "{\"token\":\"value-that-must-not-leak\",\"nested\":"
+            + MakeDeepObjectJson(GitHubIssueReporter.MaxGitHubApiResponseJsonDepth + 8)
+            + "}";
+
+        var detail = GitHubIssueReporter.BuildApiErrorDetail(500, errorBody);
+
+        Assert.DoesNotContain("value-that-must-not-leak", detail);
+        Assert.Contains("[redacted]", detail);
+    }
+
+    [Fact]
     public async Task TryCreateIssueDetailedAsync_UserCancellation_Propagates()
     {
         _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
@@ -1061,6 +1084,17 @@ public class GitHubIssueReporterTests : IDisposable
 
     private static StringContent MakeJsonContent(string json) =>
         new(json, Encoding.UTF8, "application/json");
+
+    private static string MakeDeepObjectJson(int depth)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < depth; i++)
+            builder.Append("{\"x\":");
+        builder.Append('0');
+        for (var i = 0; i < depth; i++)
+            builder.Append('}');
+        return builder.ToString();
+    }
 
     public void Dispose()
     {

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -695,6 +695,44 @@ public class GitHubIssueReporterTests : IDisposable
     }
 
     [Fact]
+    public async Task TryCreateIssueDetailedAsync_CreateSuccessBodyOverLimit_ReturnsDiagnosticError()
+    {
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("""{ "total_count": 0, "items": [] }"""),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/repos/widthdom/CodeIndex/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("[]"),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new ByteArrayContent(new byte[GitHubIssueReporter.MaxGitHubApiResponseBodyBytes + 1]),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var result = await GitHubIssueReporter.TryCreateIssueDetailedAsync(record, "1.0.0-test");
+
+            Assert.Null(result.IssueUrl);
+            Assert.Contains("InvalidDataException", result.Error);
+            Assert.Contains("HTTP response body exceeded", result.Error);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
     public async Task TryCreateIssueAsync_SearchApiFails_StillAttemptsCreate()
     {
         // Search-API failure (e.g. 5xx or rate limited) must not block a
@@ -830,6 +868,17 @@ public class GitHubIssueReporterTests : IDisposable
 
         Assert.True(stream.BytesRead <= GitHubIssueReporter.MaxGitHubApiErrorBodyBytes + 1);
         Assert.EndsWith(" [response body truncated]", result);
+    }
+
+    [Fact]
+    public async Task ReadGitHubApiResponseJsonAsync_RejectsBodyOverLimit()
+    {
+        using var content = new ByteArrayContent(new byte[GitHubIssueReporter.MaxGitHubApiResponseBodyBytes + 1]);
+
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(
+            () => GitHubIssueReporter.ReadGitHubApiResponseJsonAsync(content, CancellationToken.None));
+
+        Assert.Contains("HTTP response body exceeded", ex.Message);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -772,6 +772,40 @@ public class GitHubIssueReporterTests : IDisposable
     }
 
     [Fact]
+    public async Task TryCreateIssueAsync_SearchSuccessDoesNotPrebufferResponseContent()
+    {
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new NonBufferingJsonContent("""
+                {
+                    "total_count": 1,
+                    "items": [
+                        { "html_url": "https://github.com/widthdom/CodeIndex/issues/3335" }
+                    ]
+                }
+                """),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/3335", url);
+            Assert.Equal(1, handler.RequestCount);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
     public async Task TryCreateIssueAsync_LabelListJsonOverDepthLimit_StillAttemptsCreate()
     {
         _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
@@ -810,6 +844,45 @@ public class GitHubIssueReporterTests : IDisposable
     }
 
     [Fact]
+    public async Task TryCreateIssueAsync_LabelListSuccessDoesNotPrebufferResponseContent()
+    {
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var record = MakeRecordWithKnownHash();
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("""{ "total_count": 0, "items": [] }"""),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/repos/widthdom/CodeIndex/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new NonBufferingJsonContent($$"""
+                [
+                    {
+                        "html_url": "https://github.com/widthdom/CodeIndex/issues/3336",
+                        "body": "Submitted by cdidx. Hash: `{{record.Hash}}`"
+                    }
+                ]
+                """),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/3336", url);
+            Assert.Equal(2, handler.RequestCount);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
     public async Task TryCreateIssueDetailedAsync_CreateSuccessJsonOverDepthLimit_ReturnsDiagnosticError()
     {
         _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
@@ -840,6 +913,43 @@ public class GitHubIssueReporterTests : IDisposable
             Assert.Null(result.IssueUrl);
             Assert.Contains("Json", result.Error);
             Assert.Contains("maximum configured depth", result.Error);
+        }
+        finally
+        {
+            GitHubIssueReporter.s_httpClientOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task TryCreateIssueAsync_CreateSuccessDoesNotPrebufferResponseContent()
+    {
+        _env.Set("CDIDX_GITHUB_TOKEN", "ghp_idempotency_test");
+
+        var handler = new RecordingHandler();
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/search/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("""{ "total_count": 0, "items": [] }"""),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/repos/widthdom/CodeIndex/issues",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = MakeJsonContent("[]"),
+            });
+        handler.AddResponse(req => req.Method == HttpMethod.Post && req.RequestUri!.AbsolutePath.Contains("/issues"),
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new NonBufferingJsonContent("""{ "html_url": "https://github.com/widthdom/CodeIndex/issues/3337" }"""),
+            });
+        using var mockClient = new HttpClient(handler);
+        GitHubIssueReporter.s_httpClientOverride = mockClient;
+        try
+        {
+            var record = MakeRecordWithKnownHash();
+            var url = await GitHubIssueReporter.TryCreateIssueAsync(record, "1.0.0-test");
+
+            Assert.Equal("https://github.com/widthdom/CodeIndex/issues/3337", url);
+            Assert.Equal(3, handler.RequestCount);
         }
         finally
         {
@@ -1255,6 +1365,37 @@ public class GitHubIssueReporterTests : IDisposable
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromException<HttpResponseMessage>(exception);
+        }
+    }
+
+    private sealed class NonBufferingJsonContent : HttpContent
+    {
+        private readonly byte[] _payload;
+
+        internal NonBufferingJsonContent(string json)
+        {
+            _payload = Encoding.UTF8.GetBytes(json);
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            Task.FromException(new InvalidOperationException("Response content was pre-buffered."));
+
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context,
+            CancellationToken cancellationToken) =>
+            Task.FromException(new InvalidOperationException("Response content was pre-buffered."));
+
+        protected override Task<Stream> CreateContentReadStreamAsync() =>
+            Task.FromResult<Stream>(new MemoryStream(_payload, writable: false));
+
+        protected override Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
+            Task.FromResult<Stream>(new MemoryStream(_payload, writable: false));
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _payload.Length;
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary

- Read GitHub suggestion search/list/create success responses with `ResponseHeadersRead` and the bounded HTTP content reader.
- Parse GitHub API response JSON with an explicit depth cap, including error-body redaction parsing.
- Add regression coverage for oversized responses, excessive JSON depth, and accidental HttpClient pre-buffering.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~GitHubIssueReporterTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Added changelog fragments:
  - `changelog.d/unreleased/3017.fixed.md`
  - `changelog.d/unreleased/3018.fixed.md`
  - `changelog.d/unreleased/3222.fixed.md`
- No AGENTS.md, CLAUDE.md, or AGENT_GUIDE.md changes.

## Follow-up Candidates

None.

Fixes #3017
Fixes #3018
Fixes #3222
