### PR TITLE
Bound solution project discovery

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -207,7 +207,7 @@ Interactive terminal controls are allowed only when stdout is not redirected or 
 
 ### C# / .NET integration
 
-`SolutionProjectResolver` parses the plain-text `.sln` `Project(...) = "...", "...csproj"` entries and resolves C# / F# / VB project files. Project entries that normalize outside the active workspace root are ignored before filesystem probing or path-filter evaluation. When exactly one `.sln` exists at the workspace root, `--project <name|path>` uses it automatically; otherwise callers can pass `--solution <path>`.
+`SolutionProjectResolver` parses the plain-text `.sln` `Project(...) = "...", "...csproj"` entries with a non-regex parser and resolves C# / F# / VB project files. Project entries that normalize outside the active workspace root are ignored before filesystem probing or path-filter evaluation. Solution parsing rejects `.sln` files above 8 MiB, lines above 16,384 characters, and more than 4096 .NET project references with clear diagnostics. When exactly one `.sln` exists at the workspace root, `--project <name|path>` uses it automatically; otherwise callers can pass `--solution <path>`.
 
 Query commands that accept path filters (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `deps`, `impact`, `unused`, `hotspots`, and `validate`) expand `--project` into the matching project directory glob before hitting `DbReader`, so all existing SQL path predicates keep working. `index --project` expands to the files under the selected project directory and reuses the existing `--files` update path.
 
@@ -2302,7 +2302,7 @@ override が文書化されていない限り ANSI/progress control を抑止す
 
 ### C# / .NET 連携
 
-`SolutionProjectResolver` は plain-text の `.sln` に含まれる `Project(...) = "...", "...csproj"` 行を読み、C# / F# / VB の project file を解決する。active workspace root の外側へ正規化される project entry は、filesystem probe や path-filter 評価の前に無視する。workspace root に `.sln` が 1 つだけある場合、`--project <name|path>` は自動でそれを使う。複数ある場合は caller が `--solution <path>` を渡せる。
+`SolutionProjectResolver` は plain-text の `.sln` に含まれる `Project(...) = "...", "...csproj"` 行を non-regex parser で読み、C# / F# / VB の project file を解決する。active workspace root の外側へ正規化される project entry は、filesystem probe や path-filter 評価の前に無視する。solution parsing は 8 MiB を超える `.sln`、16,384 文字を超える行、4096 件を超える .NET project reference を明確な diagnostic とともに拒否する。workspace root に `.sln` が 1 つだけある場合、`--project <name|path>` は自動でそれを使う。複数ある場合は caller が `--solution <path>` を渡せる。
 
 path filter を受け付ける query コマンド（`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `deps`, `impact`, `unused`, `hotspots`, `validate`）は、`--project` を対応する project directory glob に展開してから `DbReader` に渡す。これにより既存の SQL path predicate をそのまま利用できる。`index --project` は選択された project directory 配下のファイルに展開し、既存の `--files` 更新経路を再利用する。
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -207,7 +207,7 @@ Interactive terminal controls are allowed only when stdout is not redirected or 
 
 ### C# / .NET integration
 
-`SolutionProjectResolver` parses the plain-text `.sln` `Project(...) = "...", "...csproj"` entries and resolves C# / F# / VB project files. When exactly one `.sln` exists at the workspace root, `--project <name|path>` uses it automatically; otherwise callers can pass `--solution <path>`.
+`SolutionProjectResolver` parses the plain-text `.sln` `Project(...) = "...", "...csproj"` entries and resolves C# / F# / VB project files. Project entries that normalize outside the active workspace root are ignored before filesystem probing or path-filter evaluation. When exactly one `.sln` exists at the workspace root, `--project <name|path>` uses it automatically; otherwise callers can pass `--solution <path>`.
 
 Query commands that accept path filters (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `deps`, `impact`, `unused`, `hotspots`, and `validate`) expand `--project` into the matching project directory glob before hitting `DbReader`, so all existing SQL path predicates keep working. `index --project` expands to the files under the selected project directory and reuses the existing `--files` update path.
 
@@ -2302,7 +2302,7 @@ override が文書化されていない限り ANSI/progress control を抑止す
 
 ### C# / .NET 連携
 
-`SolutionProjectResolver` は plain-text の `.sln` に含まれる `Project(...) = "...", "...csproj"` 行を読み、C# / F# / VB の project file を解決する。workspace root に `.sln` が 1 つだけある場合、`--project <name|path>` は自動でそれを使う。複数ある場合は caller が `--solution <path>` を渡せる。
+`SolutionProjectResolver` は plain-text の `.sln` に含まれる `Project(...) = "...", "...csproj"` 行を読み、C# / F# / VB の project file を解決する。active workspace root の外側へ正規化される project entry は、filesystem probe や path-filter 評価の前に無視する。workspace root に `.sln` が 1 つだけある場合、`--project <name|path>` は自動でそれを使う。複数ある場合は caller が `--solution <path>` を渡せる。
 
 path filter を受け付ける query コマンド（`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `deps`, `impact`, `unused`, `hotspots`, `validate`）は、`--project` を対応する project directory glob に展開してから `DbReader` に渡す。これにより既存の SQL path predicate をそのまま利用できる。`index --project` は選択された project directory 配下のファイルに展開し、既存の `--files` 更新経路を再利用する。
 

--- a/changelog.d/unreleased/3063.fixed.md
+++ b/changelog.d/unreleased/3063.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3063
+affected:
+  - src/CodeIndex/Cli/SolutionProjectResolver.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Solution project discovery now rejects project references outside the workspace root (#3063)** — `.sln` project entries that normalize outside the active workspace are ignored before filesystem probing or path-filter evaluation, so `--solution` / `--project` discovery stays within the intended workspace boundary.
+
+## 日本語
+
+- **solution project discovery が workspace root 外の project reference を拒否するようになりました (#3063)** — `.sln` の project entry が active workspace の外側へ正規化される場合、filesystem probe や path-filter 評価の前に無視するため、`--solution` / `--project` discovery が意図した workspace 境界内に留まります。

--- a/changelog.d/unreleased/3064.fixed.md
+++ b/changelog.d/unreleased/3064.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3064
+affected:
+  - src/CodeIndex/Cli/SolutionProjectResolver.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Solution parsing now has bounded work limits (#3064)** — `.sln` project discovery now rejects solution files above 8 MiB, lines above 16,384 characters, and more than 4096 .NET project references, and parses `Project(...)` entries without regex matching so malformed solutions cannot force unbounded regex runtime.
+
+## 日本語
+
+- **solution parsing に作業量上限を追加しました (#3064)** — `.sln` project discovery は 8 MiB を超える solution file、16,384 文字を超える行、4096 件を超える .NET project reference を拒否し、`Project(...)` entry を regex matching なしで parse するため、壊れた solution が無制限の regex runtime を強制できなくなりました。

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -115,6 +115,7 @@ internal static partial class SolutionProjectResolver
         string workspaceRoot,
         FileIndexer indexer)
     {
+        var root = Path.GetFullPath(workspaceRoot);
         var solutionDir = Path.GetDirectoryName(solutionPath) ?? workspaceRoot;
         var projects = new List<DotNetProjectInfo>();
         foreach (var line in File.ReadLines(solutionPath))
@@ -128,8 +129,11 @@ internal static partial class SolutionProjectResolver
                 continue;
 
             var fullPath = Path.GetFullPath(Path.Combine(solutionDir, projectPath));
+            if (!IsPathEqualOrParent(root, fullPath))
+                continue;
+
             if (File.Exists(fullPath) && !indexer.EvaluatePathFilter(fullPath).ShouldSkip)
-                projects.Add(BuildProjectInfo(fullPath, workspaceRoot, match.Groups["name"].Value));
+                projects.Add(BuildProjectInfo(fullPath, root, match.Groups["name"].Value));
         }
 
         return projects

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -1,12 +1,15 @@
-using System.Text.RegularExpressions;
 using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
 
 internal sealed record DotNetProjectInfo(string Name, string ProjectPath, string DirectoryPath);
 
-internal static partial class SolutionProjectResolver
+internal static class SolutionProjectResolver
 {
+    internal const long MaxSolutionFileBytes = 8L * 1024 * 1024;
+    internal const int MaxSolutionLineChars = 16 * 1024;
+    internal const int MaxSolutionProjectReferences = 4096;
+
     public static IReadOnlyList<DotNetProjectInfo> ResolveProjects(string workspaceRoot, string? solutionPath = null)
     {
         var root = Path.GetFullPath(workspaceRoot);
@@ -115,25 +118,41 @@ internal static partial class SolutionProjectResolver
         string workspaceRoot,
         FileIndexer indexer)
     {
+        RejectOversizedSolutionFile(solutionPath);
         var root = Path.GetFullPath(workspaceRoot);
         var solutionDir = Path.GetDirectoryName(solutionPath) ?? workspaceRoot;
         var projects = new List<DotNetProjectInfo>();
+        var lineNumber = 0;
+        var projectReferenceCount = 0;
         foreach (var line in File.ReadLines(solutionPath))
         {
-            var match = SolutionProjectLineRegex().Match(line);
-            if (!match.Success)
+            lineNumber++;
+            if (line.Length > MaxSolutionLineChars)
+            {
+                throw new InvalidOperationException(
+                    $"solution line is too long at {solutionPath}:{lineNumber}: {line.Length} characters exceeds limit {MaxSolutionLineChars}.");
+            }
+
+            if (!TryParseSolutionProjectLine(line, out var name, out var projectPath))
                 continue;
 
-            var projectPath = match.Groups["path"].Value.Replace('\\', Path.DirectorySeparatorChar);
             if (!IsDotNetProjectFile(projectPath))
                 continue;
 
+            projectReferenceCount++;
+            if (projectReferenceCount > MaxSolutionProjectReferences)
+            {
+                throw new InvalidOperationException(
+                    $"solution contains too many .NET project references: limit {MaxSolutionProjectReferences} exceeded in {solutionPath}.");
+            }
+
+            projectPath = projectPath.Replace('\\', Path.DirectorySeparatorChar);
             var fullPath = Path.GetFullPath(Path.Combine(solutionDir, projectPath));
             if (!IsPathEqualOrParent(root, fullPath))
                 continue;
 
             if (File.Exists(fullPath) && !indexer.EvaluatePathFilter(fullPath).ShouldSkip)
-                projects.Add(BuildProjectInfo(fullPath, root, match.Groups["name"].Value));
+                projects.Add(BuildProjectInfo(fullPath, root, name));
         }
 
         return projects
@@ -213,6 +232,60 @@ internal static partial class SolutionProjectResolver
             || extension.Equals(".vbproj", StringComparison.OrdinalIgnoreCase);
     }
 
-    [GeneratedRegex("^Project\\([^)]*\\)\\s*=\\s*\"(?<name>[^\"]+)\",\\s*\"(?<path>[^\"]+\\.(?:csproj|fsproj|vbproj))\"", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
-    private static partial Regex SolutionProjectLineRegex();
+    private static void RejectOversizedSolutionFile(string solutionPath)
+    {
+        var length = new FileInfo(solutionPath).Length;
+        if (length > MaxSolutionFileBytes)
+        {
+            throw new InvalidOperationException(
+                $"solution file is too large: {solutionPath} is {length} bytes; limit is {MaxSolutionFileBytes} bytes.");
+        }
+    }
+
+    private static bool TryParseSolutionProjectLine(string line, out string name, out string projectPath)
+    {
+        name = string.Empty;
+        projectPath = string.Empty;
+        if (!line.StartsWith("Project(", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var equalsIndex = line.IndexOf('=');
+        if (equalsIndex < 0)
+            return false;
+
+        var cursor = equalsIndex + 1;
+        if (!TryReadQuotedValue(line, ref cursor, out name))
+            return false;
+
+        cursor = SkipWhitespace(line, cursor);
+        if (cursor >= line.Length || line[cursor] != ',')
+            return false;
+
+        cursor++;
+        return TryReadQuotedValue(line, ref cursor, out projectPath);
+    }
+
+    private static bool TryReadQuotedValue(string line, ref int cursor, out string value)
+    {
+        value = string.Empty;
+        cursor = SkipWhitespace(line, cursor);
+        if (cursor >= line.Length || line[cursor] != '"')
+            return false;
+
+        var start = cursor + 1;
+        var end = line.IndexOf('"', start);
+        if (end < 0)
+            return false;
+
+        value = line[start..end];
+        cursor = end + 1;
+        return true;
+    }
+
+    private static int SkipWhitespace(string line, int cursor)
+    {
+        while (cursor < line.Length && char.IsWhiteSpace(line[cursor]))
+            cursor++;
+        return cursor;
+    }
 }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -1073,6 +1073,40 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void ResolveProjects_SkipsSolutionProjectsOutsideWorkspaceRoot_Issue3063()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_outside_root");
+        var externalRoot = Path.Combine(Path.GetDirectoryName(projectRoot)!, Path.GetFileName(projectRoot) + "_external");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src", "App"));
+            Directory.CreateDirectory(externalRoot);
+            var externalProject = Path.Combine(externalRoot, "External.csproj");
+            var externalProjectReference = Path.GetRelativePath(projectRoot, externalProject).Replace('/', '\\');
+            File.WriteAllText(Path.Combine(projectRoot, "Repo.sln"), $$"""
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "src\App\App.csproj", "{11111111-1111-1111-1111-111111111111}"
+            EndProject
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "External", "{{externalProjectReference}}", "{22222222-2222-2222-2222-222222222222}"
+            EndProject
+            """);
+            File.WriteAllText(Path.Combine(projectRoot, "src", "App", "App.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+            File.WriteAllText(externalProject, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+            var projects = SolutionProjectResolver.ResolveProjects(projectRoot, "Repo.sln");
+
+            Assert.Contains(projects, project => project.ProjectPath == "src/App/App.csproj");
+            Assert.DoesNotContain(projects, project => project.Name == "External");
+            Assert.DoesNotContain(projects, project => project.ProjectPath.Contains("..", StringComparison.Ordinal));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+            TestProjectHelper.DeleteDirectory(externalRoot);
+        }
+    }
+
+    [Fact]
     public void ResolveProjectFiles_HonorsGitRootIgnoreRulesForNestedWorkspace_Issue2862()
     {
         var repoRoot = TestProjectHelper.CreateTempProject("cdidx_index_project_filter_git_root");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -1107,6 +1107,73 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void ResolveProjects_RejectsOversizedSolutionFile_Issue3064()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_size_limit");
+        try
+        {
+            var solutionPath = Path.Combine(projectRoot, "Repo.sln");
+            using (var stream = new FileStream(solutionPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                stream.SetLength(SolutionProjectResolver.MaxSolutionFileBytes + 1);
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => SolutionProjectResolver.ResolveProjects(projectRoot, "Repo.sln"));
+
+            Assert.Contains("solution file is too large", ex.Message);
+            Assert.Contains(SolutionProjectResolver.MaxSolutionFileBytes.ToString(), ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void ResolveProjects_RejectsOverlongSolutionLine_Issue3064()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_line_limit");
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projectRoot, "Repo.sln"),
+                new string('x', SolutionProjectResolver.MaxSolutionLineChars + 1));
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => SolutionProjectResolver.ResolveProjects(projectRoot, "Repo.sln"));
+
+            Assert.Contains("solution line is too long", ex.Message);
+            Assert.Contains(":1", ex.Message);
+            Assert.Contains(SolutionProjectResolver.MaxSolutionLineChars.ToString(), ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void ResolveProjects_RejectsTooManySolutionProjectReferences_Issue3064()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_project_limit");
+        try
+        {
+            var lines = Enumerable.Range(0, SolutionProjectResolver.MaxSolutionProjectReferences + 1)
+                .Select(i => $"Project(\"{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}\") = \"P{i}\", \"src\\P{i}\\P{i}.csproj\", \"{{11111111-1111-1111-1111-111111111111}}\"");
+            File.WriteAllLines(Path.Combine(projectRoot, "Repo.sln"), lines);
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => SolutionProjectResolver.ResolveProjects(projectRoot, "Repo.sln"));
+
+            Assert.Contains("solution contains too many .NET project references", ex.Message);
+            Assert.Contains(SolutionProjectResolver.MaxSolutionProjectReferences.ToString(), ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ResolveProjectFiles_HonorsGitRootIgnoreRulesForNestedWorkspace_Issue2862()
     {
         var repoRoot = TestProjectHelper.CreateTempProject("cdidx_index_project_filter_git_root");


### PR DESCRIPTION
## Summary

- Keep `.sln` project discovery inside the active workspace root by ignoring project entries that normalize outside it.
- Replace solution project-line regex parsing with a bounded non-regex parser.
- Reject oversized `.sln` files, overlong solution lines, and excessive .NET project references with clear diagnostics.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ResolveProjects_ -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Updated `DEVELOPER_GUIDE.md`.
- Added `changelog.d/unreleased/3063.fixed.md`.
- Added `changelog.d/unreleased/3064.fixed.md`.

## Follow-up candidates

None.

Fixes #3063
Fixes #3064
