### PR TITLE
Limit HTTP MCP out-of-band JSON probe depth

### DIFF
--- a/changelog.d/unreleased/3013.security.md
+++ b/changelog.d/unreleased/3013.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3013
+affected:
+  - src/CodeIndex/Mcp/HttpMcpTransport.cs
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **HTTP MCP cancellation probes now enforce the shared JSON depth limit (#3013)** — cancellation notifications inspected before normal HTTP MCP request handling now parse with the same bounded JSON depth used by stdio MCP frames.
+
+## 日本語
+
+- **HTTP MCP の cancellation probe が共有 JSON 深さ制限を適用するようになりました (#3013)** — 通常の HTTP MCP リクエスト処理前に検査される cancellation notification は、stdio MCP frame と同じ bounded JSON depth で parse されるようになりました。

--- a/changelog.d/unreleased/3228.security.md
+++ b/changelog.d/unreleased/3228.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3228
+affected:
+  - src/CodeIndex/Mcp/HttpMcpTransport.cs
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **HTTP MCP response probes now enforce the shared JSON depth limit (#3228)** — JSON-RPC responses inspected out of band by the HTTP MCP transport now parse with the same bounded JSON depth used by stdio MCP frames.
+
+## 日本語
+
+- **HTTP MCP の response probe が共有 JSON 深さ制限を適用するようになりました (#3228)** — HTTP MCP transport が out-of-band で検査する JSON-RPC response は、stdio MCP frame と同じ bounded JSON depth で parse されるようになりました。

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -439,7 +439,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     {
         try
         {
-            var node = JsonNode.Parse(body);
+            var node = JsonNode.Parse(body, documentOptions: HttpProbeJsonDocumentOptions);
             return node is JsonObject obj
                 && obj.ContainsKey("id")
                 && obj["method"] is null

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -31,6 +31,11 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     internal const string MaxRequestBodyBytesEnvVar = "CDIDX_MCP_HTTP_MAX_REQUEST_BYTES";
     internal const string MaxQueueDepthEnvVar = "CDIDX_MCP_HTTP_MAX_QUEUE_DEPTH";
 
+    private static readonly JsonDocumentOptions HttpProbeJsonDocumentOptions = new()
+    {
+        MaxDepth = McpServer.MaxJsonDepth,
+    };
+
     private readonly HttpListener _listener;
     private readonly string _endpoint;
     private readonly Action<HttpRequestLogRecord>? _requestLogger;
@@ -417,7 +422,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     {
         try
         {
-            var node = JsonNode.Parse(body);
+            var node = JsonNode.Parse(body, documentOptions: HttpProbeJsonDocumentOptions);
             if (node is not JsonObject obj)
                 return false;
             var method = obj["method"]?.GetValue<string>();
@@ -775,7 +780,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     {
         try
         {
-            using var doc = JsonDocument.Parse(body);
+            using var doc = JsonDocument.Parse(body, HttpProbeJsonDocumentOptions);
             if (!doc.RootElement.TryGetProperty("id", out var id))
                 return null;
 

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -282,6 +282,41 @@ public class HttpMcpTransportTests : IDisposable
     }
 
     [Fact]
+    public async Task HttpTransport_JsonRpcResponseBeyondJsonDepth_IsQueuedForNormalHandling()
+    {
+        var listen = HttpMcpTransport.ResolveListenSpec("127.0.0.1:0");
+        var outOfBandHandlerCalls = 0;
+        await using var transport = new HttpMcpTransport(
+            listen.Prefix,
+            listen.Host,
+            listen.Port,
+            bearerToken: null);
+        transport.OutOfBandFrameHandler = _ =>
+        {
+            Interlocked.Increment(ref outOfBandHandlerCalls);
+            return null;
+        };
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var body = BuildNestedJsonRpcResponse(McpServer.MaxJsonDepth + 1);
+        var post = client.PostAsync(
+            listen.Prefix,
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        await WaitUntilAsync(
+            () => transport.QueuedRequestCount == 1,
+            "deep JSON-RPC response to stay in the normal HTTP MCP queue");
+
+        Assert.Equal(0, Volatile.Read(ref outOfBandHandlerCalls));
+        var frame = await transport.ReadFrameAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(body, frame);
+
+        await transport.WriteFrameAsync("""{"jsonrpc":"2.0","id":null,"result":{}}""", CancellationToken.None);
+        using var response = await post.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public async Task HttpTransport_RequestBodyOverLimit_Returns413AndDoesNotKillServer()
     {
         await using var harness = await McpHttpHarness.StartAsync(_dbPath, maxRequestBodyBytes: 64);
@@ -633,6 +668,14 @@ public class HttpMcpTransportTests : IDisposable
     private static string BuildNestedCancellationNotification(int nestedObjectCount)
     {
         var builder = new StringBuilder("""{"jsonrpc":"2.0","method":"$/cancelRequest","params":""");
+        AppendNestedObject(builder, nestedObjectCount);
+        builder.Append('}');
+        return builder.ToString();
+    }
+
+    private static string BuildNestedJsonRpcResponse(int nestedObjectCount)
+    {
+        var builder = new StringBuilder("""{"jsonrpc":"2.0","id":1,"result":""");
         AppendNestedObject(builder, nestedObjectCount);
         builder.Append('}');
         return builder.ToString();

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -247,6 +247,41 @@ public class HttpMcpTransportTests : IDisposable
     }
 
     [Fact]
+    public async Task HttpTransport_CancellationNotificationBeyondJsonDepth_IsQueuedForNormalHandling()
+    {
+        var listen = HttpMcpTransport.ResolveListenSpec("127.0.0.1:0");
+        var outOfBandHandlerCalls = 0;
+        await using var transport = new HttpMcpTransport(
+            listen.Prefix,
+            listen.Host,
+            listen.Port,
+            bearerToken: null);
+        transport.OutOfBandFrameHandler = _ =>
+        {
+            Interlocked.Increment(ref outOfBandHandlerCalls);
+            return null;
+        };
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var body = BuildNestedCancellationNotification(McpServer.MaxJsonDepth + 1);
+        var post = client.PostAsync(
+            listen.Prefix,
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        await WaitUntilAsync(
+            () => transport.QueuedRequestCount == 1,
+            "deep cancellation notification to stay in the normal HTTP MCP queue");
+
+        Assert.Equal(0, Volatile.Read(ref outOfBandHandlerCalls));
+        var frame = await transport.ReadFrameAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(body, frame);
+
+        await transport.WriteFrameAsync("""{"jsonrpc":"2.0","id":null,"result":{}}""", CancellationToken.None);
+        using var response = await post.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public async Task HttpTransport_RequestBodyOverLimit_Returns413AndDoesNotKillServer()
     {
         await using var harness = await McpHttpHarness.StartAsync(_dbPath, maxRequestBodyBytes: 64);
@@ -593,6 +628,25 @@ public class HttpMcpTransportTests : IDisposable
         }
 
         Assert.Fail($"Timed out waiting for {description}.");
+    }
+
+    private static string BuildNestedCancellationNotification(int nestedObjectCount)
+    {
+        var builder = new StringBuilder("""{"jsonrpc":"2.0","method":"$/cancelRequest","params":""");
+        AppendNestedObject(builder, nestedObjectCount);
+        builder.Append('}');
+        return builder.ToString();
+    }
+
+    private static void AppendNestedObject(StringBuilder builder, int nestedObjectCount)
+    {
+        for (var i = 0; i < nestedObjectCount; i++)
+            builder.Append("""{"next":""");
+
+        builder.Append('0');
+
+        for (var i = 0; i < nestedObjectCount; i++)
+            builder.Append('}');
     }
 
     private sealed class McpHttpHarness : IAsyncDisposable


### PR DESCRIPTION
## Summary

- Apply the shared MCP JSON depth limit to HTTP MCP request-id probing and out-of-band cancellation/response classification.
- Add deep JSON regression coverage for cancellation notifications and JSON-RPC responses that should fall back to normal HTTP MCP handling instead of invoking the out-of-band handler.
- Add bilingual security changelog fragments for both issues.

## Validation

- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~HttpTransport_CancellationNotificationBeyondJsonDepth" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~HttpTransport_JsonRpcResponseBeyondJsonDepth" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~HttpMcpTransportTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `codex exec` adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- `changelog.d/unreleased/3013.security.md`
- `changelog.d/unreleased/3228.security.md`
- No README or guide update was needed; this is HTTP MCP parser hardening under the existing max JSON depth contract.

## Follow-up candidates

None.

Fixes #3013
Fixes #3228
