### PR TITLE
Harden export and import security paths

### DIFF
--- a/changelog.d/unreleased/3057-3207.fixed.md
+++ b/changelog.d/unreleased/3057-3207.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3057
+  - 3207
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Import manifests now enforce size and JSON depth limits (#3057, #3207)** — `cdidx import` rejects oversized or deeply nested `manifest.json` entries before deserialization can consume disproportionate memory or parser work.
+
+## 日本語
+
+- **import manifest にサイズ上限と JSON depth 上限を適用しました (#3057, #3207)** — `cdidx import` は過大または深くネストされた `manifest.json` を deserialization 前に拒否し、過剰なメモリ消費や parser 作業を防ぎます。

--- a/changelog.d/unreleased/3208.fixed.md
+++ b/changelog.d/unreleased/3208.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3208
+affected:
+  - src/CodeIndex/Cli/CommandErrorWriter.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Export/import catch-all errors no longer echo raw exception messages (#3208)** — `cdidx export`, `cdidx import`, and `cdidx export ctags` now report sanitized exception types instead of messages that can include absolute paths or provider-specific details.
+
+## 日本語
+
+- **export/import の catch-all error が生の例外メッセージを出さないようになりました (#3208)** — `cdidx export`、`cdidx import`、`cdidx export ctags` は絶対パスや provider 固有情報を含みうるメッセージではなく、sanitize された例外型を表示します。

--- a/changelog.d/unreleased/3209.fixed.md
+++ b/changelog.d/unreleased/3209.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3209
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Export snapshot temp databases are now private on POSIX (#3209)** — `cdidx export` reapplies owner-only file permissions to the temporary SQLite snapshot before it is archived.
+
+## 日本語
+
+- **export snapshot の一時 DB を POSIX で private にしました (#3209)** — `cdidx export` は archive 化前の一時 SQLite snapshot に owner-only の file permission を再適用します。

--- a/changelog.d/unreleased/3210.fixed.md
+++ b/changelog.d/unreleased/3210.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3210
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Imported database replacements now reapply private permissions (#3210)** — `cdidx import` hardens the moved `codeindex.db` file after replacement so broad temporary-file modes are not inherited.
+
+## 日本語
+
+- **import で置き換えた DB に private permission を再適用しました (#3210)** — `cdidx import` は移動後の `codeindex.db` を harden し、一時ファイルの広い permission を引き継がないようにします。

--- a/src/CodeIndex/Cli/CommandErrorWriter.cs
+++ b/src/CodeIndex/Cli/CommandErrorWriter.cs
@@ -5,6 +5,7 @@ namespace CodeIndex.Cli;
 internal static class CommandErrorWriter
 {
     internal const string DefaultHint = "Run '<cmd> --help' for usage information.";
+    private const int SanitizedExceptionTypeNameLimit = 120;
 
     internal static void Write(string message, string? hint = null, string? usage = null, string? errorCode = null)
     {
@@ -45,5 +46,18 @@ internal static class CommandErrorWriter
 
         Write(message, exitCode, hint, usage, errorCode);
         return exitCode;
+    }
+
+    internal static string FormatSanitizedException(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        var typeName = ex.GetType().Name;
+        if (string.IsNullOrWhiteSpace(typeName))
+            return nameof(Exception);
+
+        return typeName.Length <= SanitizedExceptionTypeNameLimit
+            ? typeName
+            : typeName[..SanitizedExceptionTypeNameLimit] + "...";
     }
 }

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -558,13 +558,15 @@ internal static class ExportImportCommandRunner
         cmd.ExecuteNonQuery();
     }
 
-    private static void CreateDatabaseSnapshot(string sourceDbPath, string snapshotPath)
+    internal static void CreateDatabaseSnapshot(string sourceDbPath, string snapshotPath)
     {
         using var source = new SqliteConnection(CreateUnpooledConnectionString(sourceDbPath));
         using var destination = new SqliteConnection(CreateUnpooledConnectionString(snapshotPath));
         source.Open();
         destination.Open();
+        DataDirectorySecurity.ApplyPrivateFileMode(snapshotPath);
         source.BackupDatabase(destination);
+        DataDirectorySecurity.ApplyPrivateFileMode(snapshotPath);
     }
 
     private static string CreateUnpooledConnectionString(string dbPath)

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -12,6 +12,8 @@ internal static class ExportImportCommandRunner
 {
     private const string ManifestEntryName = "manifest.json";
     private const string DatabaseEntryName = "codeindex.db";
+    internal const int MaxImportManifestBytes = 64 * 1024;
+    internal const int MaxImportManifestJsonDepth = 16;
     internal const long MaxImportDatabaseBytes = 8L * 1024 * 1024 * 1024;
     private const int ImportCopyBufferSize = 81920;
     private static readonly DateTimeOffset DeterministicZipTimestamp = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
@@ -349,21 +351,81 @@ internal static class ExportImportCommandRunner
 
     private static bool TryReadManifest(ZipArchiveEntry manifestEntry, JsonSerializerOptions jsonOptions, out ExportManifest manifest, out string message)
     {
+        if (!TryValidateManifestEntrySize(manifestEntry, out message))
+        {
+            manifest = null!;
+            return false;
+        }
+
         try
         {
             using var stream = manifestEntry.Open();
-            manifest = JsonSerializer.Deserialize<ExportManifest>(stream, jsonOptions)
-                ?? throw new JsonException("manifest.json did not contain an object");
+            using var manifestBytes = new MemoryStream((int)Math.Min(Math.Max(manifestEntry.Length, 0), MaxImportManifestBytes));
+            CopyToWithLimit(stream, manifestBytes, MaxImportManifestBytes, ManifestEntryName);
+            manifestBytes.Position = 0;
+            var parsedManifest = JsonSerializer.Deserialize<ExportManifest>(manifestBytes, CreateImportManifestJsonOptions(jsonOptions));
+            if (parsedManifest == null)
+            {
+                manifest = null!;
+                message = "manifest.json did not contain an object";
+                return false;
+            }
+
+            manifest = parsedManifest;
             message = string.Empty;
             return true;
         }
-        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        catch (InvalidDataException ex)
         {
             manifest = null!;
             message = ex.Message;
             return false;
         }
+        catch (JsonException ex)
+        {
+            manifest = null!;
+            message = IsJsonDepthLimitException(ex)
+                ? $"manifest.json exceeds the JSON depth limit of {MaxImportManifestJsonDepth}"
+                : "manifest.json is not valid export manifest JSON";
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            manifest = null!;
+            message = "manifest.json contains unsupported export manifest JSON";
+            return false;
+        }
     }
+
+    private static bool TryValidateManifestEntrySize(ZipArchiveEntry manifestEntry, out string message)
+    {
+        if (manifestEntry.Length < 0 || manifestEntry.CompressedLength < 0)
+        {
+            message = "archive manifest.json size metadata is invalid";
+            return false;
+        }
+
+        if (manifestEntry.Length > MaxImportManifestBytes)
+        {
+            message = $"archive manifest.json is too large: {ConsoleUi.FormatBytes(manifestEntry.Length)} uncompressed exceeds the import limit of {ConsoleUi.FormatBytes(MaxImportManifestBytes)}";
+            return false;
+        }
+
+        if (manifestEntry.CompressedLength > MaxImportManifestBytes)
+        {
+            message = $"archive manifest.json is too large: {ConsoleUi.FormatBytes(manifestEntry.CompressedLength)} compressed exceeds the import limit of {ConsoleUi.FormatBytes(MaxImportManifestBytes)}";
+            return false;
+        }
+
+        message = string.Empty;
+        return true;
+    }
+
+    private static JsonSerializerOptions CreateImportManifestJsonOptions(JsonSerializerOptions jsonOptions)
+        => new(jsonOptions) { MaxDepth = MaxImportManifestJsonDepth };
+
+    private static bool IsJsonDepthLimitException(JsonException ex)
+        => ex.Message.Contains("depth", StringComparison.OrdinalIgnoreCase);
 
     private static bool TryValidateManifestHeader(ExportManifest manifest, out string message)
     {
@@ -464,6 +526,9 @@ internal static class ExportImportCommandRunner
     }
 
     internal static long CopyToWithLimit(Stream source, Stream target, long maxBytes)
+        => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName);
+
+    private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName)
     {
         var buffer = new byte[ImportCopyBufferSize];
         long totalBytes = 0;
@@ -471,7 +536,7 @@ internal static class ExportImportCommandRunner
         while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
         {
             if (totalBytes > maxBytes - bytesRead)
-                throw new InvalidDataException($"archive codeindex.db exceeds the import limit of {ConsoleUi.FormatBytes(maxBytes)}.");
+                throw new InvalidDataException($"archive {entryName} exceeds the import limit of {ConsoleUi.FormatBytes(maxBytes)}.");
 
             target.Write(buffer, 0, bytesRead);
             totalBytes += bytesRead;

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -121,7 +121,7 @@ internal static class ExportImportCommandRunner
         }
         catch (Exception ex) when (ex is IOException or InvalidDataException or UnauthorizedAccessException or SqliteException)
         {
-            return WriteError($"import failed: {ex.Message}", "check the archive path and destination database permissions.", "cdidx import <archive> [--db <path>] [--prune-paths] [--json]");
+            return WriteError($"import failed ({CommandErrorWriter.FormatSanitizedException(ex)}).", "check the archive path and destination database permissions.", "cdidx import <archive> [--db <path>] [--prune-paths] [--json]");
         }
         finally
         {
@@ -202,7 +202,7 @@ internal static class ExportImportCommandRunner
         }
         catch (Exception ex)
         {
-            return WriteError($"export failed: {ex.Message}", "check the database and output archive paths.", "cdidx export <archive> [--db <path>] [--json]");
+            return WriteError($"export failed ({CommandErrorWriter.FormatSanitizedException(ex)}).", "check the database and output archive paths.", "cdidx export <archive> [--db <path>] [--json]");
         }
         finally
         {
@@ -286,7 +286,7 @@ internal static class ExportImportCommandRunner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SqliteException)
         {
-            return WriteError($"ctags export failed: {ex.Message}", "check the database and output paths.", "cdidx export ctags [--output <path>] [--db <path>]");
+            return WriteError($"ctags export failed ({CommandErrorWriter.FormatSanitizedException(ex)}).", "check the database and output paths.", "cdidx export ctags [--output <path>] [--db <path>]");
         }
     }
 

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -575,6 +575,7 @@ internal static class ExportImportCommandRunner
     internal static void ReplaceImportedDatabase(string tempPath, string fullDbPath)
     {
         File.Move(tempPath, fullDbPath, overwrite: true);
+        DataDirectorySecurity.ApplyPrivateFileMode(fullDbPath);
         DeleteSqliteSidecars(fullDbPath);
     }
 

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -319,6 +319,33 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void ReplaceImportedDatabase_AppliesPrivateFileMode()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_mode_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var tempPath = Path.Combine(workDir, "staged.db");
+            File.WriteAllText(dbPath, "existing db");
+            File.WriteAllText(tempPath, "imported db");
+            File.SetUnixFileMode(tempPath, DataDirectorySecurity.PermissionBits);
+
+            ExportImportCommandRunner.ReplaceImportedDatabase(tempPath, dbPath);
+
+            var mode = File.GetUnixFileMode(dbPath) & DataDirectorySecurity.PermissionBits;
+            Assert.Equal(DataDirectorySecurity.PrivateFileMode, mode);
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void TryValidateDatabaseEntrySize_RejectsOversizedUncompressedLength()
     {
         var ok = ExportImportCommandRunner.TryValidateDatabaseEntrySize(

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -106,6 +106,81 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void RunImport_FailureOmitsRawExceptionMessage()
+    {
+        var workDir = TestProjectHelper.CreateTempProject("import_error_sanitize");
+        try
+        {
+            var archiveDirectory = Path.Combine(workDir, "archive-directory");
+            Directory.CreateDirectory(archiveDirectory);
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archiveDirectory, "--db", dbPath], new JsonSerializerOptions()));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains("import failed (", stderr);
+            Assert.DoesNotContain(archiveDirectory, stderr);
+            Assert.DoesNotContain(Path.GetFileName(archiveDirectory), stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void RunExportArchive_FailureOmitsRawExceptionMessage()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("export_error_sanitize");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var outputDirectory = Path.Combine(projectRoot, "archive-output");
+            Directory.CreateDirectory(outputDirectory);
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunExport([outputDirectory, "--db", dbPath], new JsonSerializerOptions(), "test"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains("export failed (", stderr);
+            Assert.DoesNotContain(outputDirectory, stderr);
+            Assert.DoesNotContain(Path.GetFileName(outputDirectory), stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunExportCtags_FailureOmitsRawExceptionMessage()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("ctags_error_sanitize");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var outputDirectory = Path.Combine(projectRoot, "tags-output");
+            Directory.CreateDirectory(outputDirectory);
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunExport(["ctags", "--db", dbPath, "--output", outputDirectory], new JsonSerializerOptions(), "test"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains("ctags export failed (", stderr);
+            Assert.DoesNotContain(outputDirectory, stderr);
+            Assert.DoesNotContain(Path.GetFileName(outputDirectory), stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void WriteExportArchiveFile_FailurePreservesExistingArchive()
     {
         var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_export_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -156,6 +156,29 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void CreateDatabaseSnapshot_AppliesPrivateFileMode()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = TestProjectHelper.CreateTempProject("export_snapshot_mode");
+        try
+        {
+            var sourceDbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var snapshotPath = Path.Combine(projectRoot, "snapshot.db");
+
+            ExportImportCommandRunner.CreateDatabaseSnapshot(sourceDbPath, snapshotPath);
+
+            var mode = File.GetUnixFileMode(snapshotPath) & DataDirectorySecurity.PermissionBits;
+            Assert.Equal(DataDirectorySecurity.PrivateFileMode, mode);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunExportCtags_FailureOmitsRawExceptionMessage()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("ctags_error_sanitize");

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using System.Text.Json;
 using CodeIndex.Cli;
 
@@ -5,6 +6,66 @@ namespace CodeIndex.Tests;
 
 public class ExportImportCommandRunnerTests
 {
+    [Fact]
+    public void RunImport_RejectsOversizedManifestBeforeDatabaseEntry()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_manifest_size_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var manifest = new string(' ', ExportImportCommandRunner.MaxImportManifestBytes + 1);
+            var archivePath = CreateArchiveWithManifest(workDir, manifest);
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath], new JsonSerializerOptions()));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains("archive manifest is invalid: archive manifest.json is too large", stderr);
+            Assert.DoesNotContain("archive is missing codeindex.db", stderr);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_RejectsDeepManifestBeforeDatabaseEntry()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_manifest_depth_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var depth = ExportImportCommandRunner.MaxImportManifestJsonDepth + 4;
+            var manifest =
+                "{\"format_version\":\"1\",\"cdidx_version\":\"test\",\"user_version\":0,\"database_sha256\":\"" +
+                new string('0', 64) +
+                "\",\"nested\":" +
+                string.Concat(Enumerable.Repeat("{\"x\":", depth)) +
+                "0" +
+                new string('}', depth) +
+                "}";
+            var archivePath = CreateArchiveWithManifest(workDir, manifest);
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath], new JsonSerializerOptions()));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains($"manifest.json exceeds the JSON depth limit of {ExportImportCommandRunner.MaxImportManifestJsonDepth}", stderr);
+            Assert.DoesNotContain("archive is missing codeindex.db", stderr);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("-wal")]
@@ -205,5 +266,15 @@ public class ExportImportCommandRunnerTests
 
         Assert.Equal(4, copied);
         Assert.Equal([1, 2, 3, 4], target.ToArray());
+    }
+
+    private static string CreateArchiveWithManifest(string workDir, string manifest)
+    {
+        var archivePath = Path.Combine(workDir, "codeindex.cdidx.zip");
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+        var entry = archive.CreateEntry("manifest.json");
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(manifest);
+        return archivePath;
     }
 }


### PR DESCRIPTION
## Summary

- Cap `cdidx import` manifest bytes and JSON depth before deserializing manifests.
- Sanitize export/import catch-all errors so raw exception messages are not echoed.
- Reapply private POSIX file permissions to export snapshot temp DBs and imported DB replacements.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug --filter "FullyQualifiedName~ExportImportCommandRunnerTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~ExportImportCommandRunnerTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet build src/CodeIndex/CodeIndex.csproj -c Debug -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false` was attempted; it observed `PostExtractionHookTests.CallbackBudgetExceeded_AddsDiagnosticAndSkipsTimedOutMutation` once during the full suite and did not reach a clean final summary. The same test passed when rerun directly for net8.0 and net9.0. Filed follow-up #3252.

## Documentation And Changelog

- Added `changelog.d/unreleased/3057-3207.fixed.md`.
- Added `changelog.d/unreleased/3208.fixed.md`.
- Added `changelog.d/unreleased/3209.fixed.md`.
- Added `changelog.d/unreleased/3210.fixed.md`.
- No direct `CHANGELOG.md` update; ordinary issue-fix fragments were used.

## Follow-Up Candidates

- #3252

Fixes #3057
Fixes #3207
Fixes #3208
Fixes #3209
Fixes #3210