### PR TITLE
Harden suggestion archive and backup permissions

### DIFF
--- a/changelog.d/unreleased/3235.security.md
+++ b/changelog.d/unreleased/3235.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3235
+affected:
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+---
+
+## English
+
+- **Suggestion archive JSONL files are forced owner-only on POSIX systems (#3235)** — pruned suggestion archives now use private file creation and hardening so archived local suggestion records do not inherit permissive default modes.
+
+## 日本語
+
+- **suggestion archive JSONL ファイルを POSIX で owner-only に強制するようになりました (#3235)** — prune された suggestion archive は private file creation と hardening を使うため、保存されたローカル suggestion record が permissive な既定 mode を継承しなくなりました。

--- a/changelog.d/unreleased/3236.security.md
+++ b/changelog.d/unreleased/3236.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3236
+affected:
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+---
+
+## English
+
+- **Corrupt suggestion backups are re-hardened after preservation (#3236)** — `.bak` files created from corrupt suggestion stores now have owner-only POSIX permissions reapplied after the move.
+
+## 日本語
+
+- **破損 suggestion backup の保存後に permission を再 harden するようになりました (#3236)** — 破損した suggestion store から作られる `.bak` ファイルは、move 後に POSIX の owner-only permission を再適用します。

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -1054,7 +1054,10 @@ public class SuggestionStore
         {
             var backupPath = _filePath + ".bak";
             if (File.Exists(LongPath.EnsureWindowsPrefix(_filePath)))
+            {
                 File.Move(LongPath.EnsureWindowsPrefix(_filePath), LongPath.EnsureWindowsPrefix(backupPath), overwrite: true);
+                DataDirectorySecurity.ApplyPrivateFileMode(backupPath);
+            }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -819,9 +819,19 @@ public class SuggestionStore
     {
         var dir = Path.GetDirectoryName(_archivePath);
         if (!string.IsNullOrEmpty(dir))
-            Directory.CreateDirectory(dir);
+            DataDirectorySecurity.CreatePrivateDirectory(dir);
 
-        using var stream = new FileStream(_archivePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.Append,
+            Access = FileAccess.Write,
+            Share = FileShare.Read,
+        };
+        if (!OperatingSystem.IsWindows())
+            options.UnixCreateMode = DataDirectorySecurity.PrivateFileMode;
+
+        using var stream = new FileStream(_archivePath, options);
+        DataDirectorySecurity.ApplyPrivateFileMode(_archivePath);
         using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         foreach (var record in records)
             writer.WriteLine(JsonSerializer.Serialize(record, s_jsonOptions));

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -766,6 +766,28 @@ public class SuggestionStoreTests : IDisposable
     }
 
     [Fact]
+    public void CorruptFile_OnPosixHardensBackupFileMode()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var filePath = Path.Combine(_tempDir, "suggestions-codeindex.json");
+        var backupPath = filePath + ".bak";
+        File.WriteAllText(filePath, "{corrupt json[[[");
+#pragma warning disable CA1416
+        File.SetUnixFileMode(
+            filePath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+#pragma warning restore CA1416
+
+        var all = _store.LoadAll();
+
+        Assert.Empty(all);
+        Assert.True(File.Exists(backupPath), "Corrupt file should be preserved as .bak");
+        AssertPrivateFileMode(backupPath);
+    }
+
+    [Fact]
     public void ZeroByteFile_IsPreservedAsBackup()
     {
         var filePath = Path.Combine(_tempDir, "suggestions-codeindex.json");

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -832,6 +832,24 @@ public class SuggestionStoreTests : IDisposable
     }
 
     [Fact]
+    public void TryAdd_OnPosixCreatesPrivateArchiveFile()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var clock = new ManualTimeProvider(new DateTimeOffset(2031, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var store = new SuggestionStore(_tempDir, null, clock);
+        var old = MakeRecord("other", null, "Old suggestion");
+        Assert.True(store.TryAdd(old));
+
+        clock.SetUtcNow(new DateTimeOffset(2032, 2, 5, 0, 0, 0, TimeSpan.Zero));
+        var fresh = MakeRecord("other", null, "Fresh suggestion");
+        Assert.True(store.TryAdd(fresh));
+
+        AssertPrivateFileMode(Path.Combine(_tempDir, "suggestions-codeindex.archive.jsonl"));
+    }
+
+    [Fact]
     public void TryAdd_PrunesOldestRecordsOverConfiguredMaxCount()
     {
         using var env = EnvironmentVariableScope.Capture(SuggestionStore.MaxCountEnvironmentVariable);
@@ -943,6 +961,15 @@ public class SuggestionStoreTests : IDisposable
             Hash = SuggestionStore.ComputeHash(category, language, description),
             CreatedAt = DateTime.UtcNow,
         };
+    }
+
+    private static void AssertPrivateFileMode(string path)
+    {
+#pragma warning disable CA1416
+        Assert.Equal(
+            DataDirectorySecurity.PrivateFileMode,
+            File.GetUnixFileMode(path) & DataDirectorySecurity.PermissionBits);
+#pragma warning restore CA1416
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary

- Force pruned suggestion archive JSONL files to owner-only POSIX permissions when they are created or appended.
- Reapply owner-only POSIX permissions to corrupt suggestion `.bak` backups after preservation.
- Add POSIX regression coverage for both paths.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SuggestionStoreTests -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/3235.security.md`.
- Added `changelog.d/unreleased/3236.security.md`.

## Follow-up Candidates

- #3267

Fixes #3235
Fixes #3236