### PR TITLE
[codex] Fix regex and logical line denial vectors

### DIFF
--- a/changelog.d/unreleased/3053.security.md
+++ b/changelog.d/unreleased/3053.security.md
@@ -1,0 +1,26 @@
+---
+category: security
+issues:
+  - 3053
+affected:
+  - src/CodeIndex/Indexer/BoundedRegex.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+  - src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/PerlReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/TerraformReferenceExtractor.cs
+  - tests/CodeIndex.Tests/BoundedRegexTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorCssTests.cs
+---
+
+## English
+
+- **Built-in reference extractor regex enumeration is timeout-bounded (#3053)** — shared match enumeration now forces and catches regex timeouts before built-in extractors iterate matches from repository-controlled source text.
+
+## 日本語
+
+- **組み込み reference extractor の正規表現列挙をタイムアウト付きにしました (#3053)** — リポジトリ由来のソース文字列から組み込み extractor が match を列挙する前に、共有の列挙処理で正規表現タイムアウトを強制・捕捉するようにしました。

--- a/changelog.d/unreleased/3054.security.md
+++ b/changelog.d/unreleased/3054.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3054
+affected:
+  - src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **TypeScript namespace alias references no longer build per-line dynamic regexes (#3054)** — namespace alias qualified usages are now found with a bounded scanner that preserves identifier boundaries without compiling one regex per alias per line.
+
+## 日本語
+
+- **TypeScript namespace alias 参照で行ごとの動的正規表現を生成しないようにしました (#3054)** — namespace alias の qualified usage は、alias ごと・行ごとの regex を組み立てず、識別子境界を保つ bounded scanner で検出するようになりました。

--- a/changelog.d/unreleased/3101.security.md
+++ b/changelog.d/unreleased/3101.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3101
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+---
+
+## English
+
+- **C# import alias registration now uses timeout-bounded signature regexes (#3101)** — `DbWriter` no longer calls the BCL regex APIs directly when classifying C# `using` signatures from indexed content.
+
+## 日本語
+
+- **C# import alias 登録で timeout 付き signature regex を使うようにしました (#3101)** — `DbWriter` は indexed content 由来の C# `using` signature を分類するとき、BCL の regex API を直接呼び出さなくなりました。

--- a/changelog.d/unreleased/3141.security.md
+++ b/changelog.d/unreleased/3141.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3141
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorPythonTests.cs
+---
+
+## English
+
+- **Python logical reference remapping now caps header and statement maps (#3141)** — oversized multiline Python headers or continuation statements now skip logical remapping instead of growing unbounded text and line/column arrays.
+
+## 日本語
+
+- **Python logical reference remap の header / statement map に上限を設けました (#3141)** — 巨大な複数行 header や continuation statement では、text と line/column 配列を無制限に増やさず logical remap をスキップします。

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -3,6 +3,7 @@ using CodeIndex.Cli;
 using CodeIndex.Indexer;
 using CodeIndex.Models;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace CodeIndex.Database;
 
@@ -35,6 +36,18 @@ public class DbWriter
     private const int DeleteFilesBatchSize = 500;
     private const int MaxSqlVariables = 999;
     private const int SqliteConstraintErrorCode = 19;
+    private static readonly BoundedRegex CSharpExternAliasSignatureRegex = new(
+        @"^\s*extern\s+alias\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly BoundedRegex CSharpGlobalUsingSignatureRegex = new(
+        @"^\s*global\s+using\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly BoundedRegex CSharpUsingStaticSignatureRegex = new(
+        @"^\s*(?:global\s+)?using\s+static\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly BoundedRegex CSharpUsingAliasSignatureRegex = new(
+        @"^\s*(?:global\s+)?using\s+(?<alias>@?\w+)\s*=\s*(?<target>[^;]+?)\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private int _rowSkipSavepointCounter;
     private long _batchRowsSkipped;
     private int _transactionDepth;
@@ -2361,14 +2374,14 @@ public class DbWriter
         // `extern alias X;` も import 行として現れるがアセンブリ別名でしかなく resolver 側の
         // qualified 索引には載らないので対象外。
         if (signature != null && signature.IndexOf("extern", StringComparison.Ordinal) >= 0
-            && System.Text.RegularExpressions.Regex.IsMatch(signature, @"^\s*extern\s+alias\b"))
+            && CSharpExternAliasSignatureRegex.IsMatch(signature))
         {
             return;
         }
         bool isGlobal = signature != null
-            && System.Text.RegularExpressions.Regex.IsMatch(signature, @"^\s*global\s+using\b");
+            && CSharpGlobalUsingSignatureRegex.IsMatch(signature);
         bool isStatic = signature != null
-            && System.Text.RegularExpressions.Regex.IsMatch(signature, @"^\s*(?:global\s+)?using\s+static\b");
+            && CSharpUsingStaticSignatureRegex.IsMatch(signature);
         // `using static Foo.Bar;` imports the static members of `Foo.Bar` into the file's
         // scope — NOT a namespace that a base clause `class X : Base` could pull from.
         // Drop it so we don't confuse the alias/namespace paths.
@@ -2384,9 +2397,7 @@ public class DbWriter
             // the alias enters the per-file map.
             // SymbolExtractor 側と同じく verbatim 識別子も `@?\w+` で受け、下の正規化で
             // 先頭 `@` を剥がしてから alias map に載せる。
-            var m = System.Text.RegularExpressions.Regex.Match(
-                signature,
-                @"^\s*(?:global\s+)?using\s+(?<alias>@?\w+)\s*=\s*(?<target>[^;]+?)\s*;");
+            var m = CSharpUsingAliasSignatureRegex.Match(signature);
             if (m.Success)
             {
                 aliasName = m.Groups["alias"].Value.Trim();

--- a/src/CodeIndex/Indexer/BoundedRegex.cs
+++ b/src/CodeIndex/Indexer/BoundedRegex.cs
@@ -43,6 +43,18 @@ internal sealed class BoundedRegex : BclRegex
         }
     }
 
+    public static BclMatch Match(BclRegex regex, string input)
+    {
+        try
+        {
+            return regex.Match(input);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return BclMatch.Empty;
+        }
+    }
+
     public static new MatchCollection Matches(string input, string pattern) =>
         Matches(input, pattern, RegexOptions.None);
 
@@ -58,6 +70,43 @@ internal sealed class BoundedRegex : BclRegex
         {
             return EmptyMatches();
         }
+    }
+
+    public static IEnumerable<BclMatch> EnumerateMatches(BclRegex regex, string input)
+    {
+        MatchCollection matches;
+        try
+        {
+            matches = regex.Matches(input);
+            _ = matches.Count;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            yield break;
+        }
+
+        foreach (BclMatch match in matches)
+            yield return match;
+    }
+
+    public static IEnumerable<BclMatch> EnumerateMatches(string input, string pattern) =>
+        EnumerateMatches(input, pattern, RegexOptions.None);
+
+    public static IEnumerable<BclMatch> EnumerateMatches(string input, string pattern, RegexOptions options)
+    {
+        MatchCollection matches;
+        try
+        {
+            matches = BclRegex.Matches(input, pattern, options, DefaultMatchTimeout);
+            _ = matches.Count;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            yield break;
+        }
+
+        foreach (BclMatch match in matches)
+            yield return match;
     }
 
     public static new bool IsMatch(string input, string pattern) =>

--- a/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CobolReferenceExtractor.cs
@@ -165,7 +165,7 @@ internal static class CobolReferenceExtractor
         foreach (var pattern in StatementPatterns)
             EmitMatches(pattern, rawLine, references, seen, fileId, context, lineNumber, container);
 
-        foreach (Match match in CobolPerformRegex.Matches(rawLine))
+        foreach (Match match in BoundedRegex.EnumerateMatches(CobolPerformRegex, rawLine))
         {
             var endName = match.Groups["end"].Value;
             if (!string.IsNullOrWhiteSpace(endName)
@@ -197,7 +197,7 @@ internal static class CobolReferenceExtractor
         int lineNumber,
         SymbolRecord? container)
     {
-        foreach (Match match in pattern.Regex.Matches(rawLine))
+        foreach (Match match in BoundedRegex.EnumerateMatches(pattern.Regex, rawLine))
             EmitNamedReference(references, seen, fileId, match, pattern.ReferenceKind, context, lineNumber, container);
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CssReferenceExtractor.cs
@@ -159,7 +159,7 @@ internal static class CssReferenceExtractor
         HashSet<string>? definitionNames,
         SymbolRecord? container)
     {
-        foreach (Match match in pattern.Regex.Matches(preparedLine))
+        foreach (Match match in BoundedRegex.EnumerateMatches(pattern.Regex, preparedLine))
         {
             var nameGroup = match.Groups["name"];
             if (definitionNames != null && definitionNames.Contains(nameGroup.Value))
@@ -443,7 +443,7 @@ internal static class CssReferenceExtractor
         HashSet<string>? definitionNames,
         SymbolRecord? container)
     {
-        foreach (Match match in regex.Matches(selectorPartBody))
+        foreach (Match match in BoundedRegex.EnumerateMatches(regex, selectorPartBody))
         {
             var nameGroup = match.Groups["name"];
             var prefixIndex = nameGroup.Index - 1;

--- a/src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/DartReferenceExtractor.cs
@@ -62,7 +62,7 @@ internal static class DartReferenceExtractor
 
         void EmitSingleMatch(Regex regex, string referenceKind)
         {
-            var match = regex.Match(preparedLine);
+            var match = BoundedRegex.Match(regex, preparedLine);
             if (!match.Success)
                 return;
 
@@ -76,13 +76,13 @@ internal static class DartReferenceExtractor
                 return;
 
             var names = match.Groups["names"];
-            foreach (Match name in Regex.Matches(names.Value, @"[A-Za-z_]\w*"))
+            foreach (Match name in BoundedRegex.EnumerateMatches(names.Value, @"[A-Za-z_]\w*"))
                 Add(name.Value, names.Index + name.Index, "mixin_in");
         }
 
         void EmitNamedConstructorCalls()
         {
-            foreach (Match match in NamedConstructorCallRegex.Matches(preparedLine))
+            foreach (Match match in BoundedRegex.EnumerateMatches(NamedConstructorCallRegex, preparedLine))
             {
                 var name = match.Groups["name"];
                 Add(name.Value, name.Index, "named_ctor_call");

--- a/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/JavaReferenceExtractor.cs
@@ -1137,7 +1137,7 @@ internal static class JavaReferenceExtractor
             lineNumber,
             resolveContainerForColumn);
 
-        foreach (Match match in ModuleProvidesDirectiveReferenceRegex.Matches(preparedLine))
+        foreach (Match match in BoundedRegex.EnumerateMatches(ModuleProvidesDirectiveReferenceRegex, preparedLine))
         {
             var serviceGroup = match.Groups["service"];
             ReferenceExtractor.AddTypeReferenceSegment(
@@ -1185,7 +1185,7 @@ internal static class JavaReferenceExtractor
         int lineNumber,
         Func<int, SymbolRecord?> resolveContainerForColumn)
     {
-        foreach (Match match in regex.Matches(preparedLine))
+        foreach (Match match in BoundedRegex.EnumerateMatches(regex, preparedLine))
         {
             var nameGroup = match.Groups["name"];
             ReferenceExtractor.AddTypeReferenceSegment(

--- a/src/CodeIndex/Indexer/References/Languages/PerlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/PerlReferenceExtractor.cs
@@ -191,7 +191,7 @@ internal static class PerlReferenceExtractor
     {
         var args = argsGroup.Value;
         var argsStart = argsGroup.Index;
-        foreach (Match moduleMatch in QuotedModuleRegex.Matches(args))
+        foreach (Match moduleMatch in BoundedRegex.EnumerateMatches(QuotedModuleRegex, args))
         {
             if (moduleMatch.Groups["name"].Success)
             {
@@ -204,7 +204,7 @@ internal static class PerlReferenceExtractor
 
             var names = namesGroup.Value;
             var namesStart = argsStart + namesGroup.Index;
-            foreach (Match nameMatch in Regex.Matches(names, @"[\p{L}_][\w:]*", RegexOptions.CultureInvariant))
+            foreach (Match nameMatch in BoundedRegex.EnumerateMatches(names, @"[\p{L}_][\w:]*", RegexOptions.CultureInvariant))
                 AddBaseModuleReference(nameMatch.Value, namesStart + nameMatch.Index, references, seen, fileId, context, lineNumber, resolveContainerForCall);
         }
     }

--- a/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SqlReferenceExtractor.cs
@@ -2104,7 +2104,7 @@ internal static partial class SqlReferenceExtractor
         Func<string, bool> shouldIgnoreName,
         string referenceKind)
     {
-        foreach (Match match in QualifiedColumnReferenceRegex.Matches(text))
+        foreach (Match match in BoundedRegex.EnumerateMatches(QualifiedColumnReferenceRegex, text))
         {
             if (IsInsideDoubleQuotedRegion(text, match.Index))
                 continue;
@@ -2159,7 +2159,7 @@ internal static partial class SqlReferenceExtractor
         rawIndex += leafIndex;
         rawName = rawName[leafIndex..].TrimStart();
 
-        var match = Regex.Match(
+        var match = BoundedRegex.Match(
             rawName,
             $"^(?<name>{QuotedIdentifierPattern}|{BareIdentifierPattern})",
             RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
@@ -3121,7 +3121,7 @@ internal static partial class SqlReferenceExtractor
                 pattern.Append(escaped);
         }
 
-        var match = Regex.Match(line, pattern.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        var match = BoundedRegex.Match(line, pattern.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         if (!match.Success)
             return false;
 

--- a/src/CodeIndex/Indexer/References/Languages/TerraformReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TerraformReferenceExtractor.cs
@@ -69,7 +69,7 @@ internal static class TerraformReferenceExtractor
         HashSet<string>? definitionNames,
         SymbolRecord? container)
     {
-        foreach (Match match in pattern.Regex.Matches(preparedLine))
+        foreach (Match match in BoundedRegex.EnumerateMatches(pattern.Regex, preparedLine))
         {
             var nameGroup = match.Groups["name"];
             if (definitionNames != null && definitionNames.Contains(nameGroup.Value))

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -1141,23 +1141,56 @@ internal static class TypeScriptReferenceExtractor
                 continue;
             }
 
-            foreach (Match match in Regex.Matches(
-                         preparedLine,
-                         $@"(?<![\w$]){Regex.Escape(binding.Alias)}\s*\.\s*[A-Za-z_$][\w$]*"))
+            foreach (var matchIndex in EnumerateNamespaceAliasQualifiedReferenceStarts(preparedLine, binding.Alias))
             {
                 ReferenceExtractor.AddReference(
                     references,
                     seen,
                     fileId,
                     binding.ModuleSpecifier,
-                    match.Index,
+                    matchIndex,
                     "reference",
                     context,
                     lineNumber,
-                    resolveContainerForColumn(match.Index));
+                    resolveContainerForColumn(matchIndex));
             }
         }
     }
+
+    private static IEnumerable<int> EnumerateNamespaceAliasQualifiedReferenceStarts(string text, string alias)
+    {
+        if (string.IsNullOrEmpty(alias))
+            yield break;
+
+        var searchIndex = 0;
+        while (searchIndex < text.Length)
+        {
+            var aliasIndex = text.IndexOf(alias, searchIndex, StringComparison.Ordinal);
+            if (aliasIndex < 0)
+                yield break;
+
+            searchIndex = aliasIndex + Math.Max(1, alias.Length);
+            if (aliasIndex > 0 && IsTypeScriptIdentifierPart(text[aliasIndex - 1]))
+                continue;
+
+            var afterAlias = aliasIndex + alias.Length;
+            if (afterAlias < text.Length && IsTypeScriptIdentifierPart(text[afterAlias]))
+                continue;
+
+            var dotIndex = SkipWhitespace(text, afterAlias);
+            if (dotIndex >= text.Length || text[dotIndex] != '.')
+                continue;
+
+            var memberIndex = SkipWhitespace(text, dotIndex + 1);
+            if (memberIndex >= text.Length || !IsTypeScriptNamespaceMemberStart(text[memberIndex]))
+                continue;
+
+            yield return aliasIndex;
+        }
+    }
+
+    private static bool IsTypeScriptNamespaceMemberStart(char ch) =>
+        ch == '_' || ch == '$' || ch is >= 'A' and <= 'Z' || ch is >= 'a' and <= 'z';
 
     private static int? FindShadowLine(IReadOnlyList<string> preparedLines, string alias, int bindingLine)
     {

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1276,7 +1276,7 @@ public static partial class ReferenceExtractor
             return;
         }
 
-        foreach (Match lambda in CSharpLambdaRegex.Matches(preparedLine))
+        foreach (Match lambda in BoundedRegex.EnumerateMatches(CSharpLambdaRegex, preparedLine))
         {
             var body = lambda.Groups["body"].Value;
             if (string.IsNullOrWhiteSpace(body))
@@ -1308,7 +1308,7 @@ public static partial class ReferenceExtractor
     private static HashSet<string> CollectCSharpLambdaParameterNames(string parameterText)
     {
         var names = new HashSet<string>(StringComparer.Ordinal);
-        foreach (Match match in Regex.Matches(parameterText, CSharpIdentifierPattern))
+        foreach (Match match in BoundedRegex.EnumerateMatches(parameterText, CSharpIdentifierPattern))
         {
             var name = NormalizeAtPrefixedIdentifier(match.Value);
             if (!IsIgnoredCallName("csharp", name))
@@ -1322,7 +1322,7 @@ public static partial class ReferenceExtractor
     {
         index = -1;
         var normalizedName = NormalizeAtPrefixedIdentifier(name);
-        foreach (Match match in Regex.Matches(text, CSharpIdentifierPattern))
+        foreach (Match match in BoundedRegex.EnumerateMatches(text, CSharpIdentifierPattern))
         {
             if (string.Equals(NormalizeAtPrefixedIdentifier(match.Value), normalizedName, StringComparison.Ordinal))
             {

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -1417,6 +1417,8 @@ public static partial class ReferenceExtractor
         return colon >= 0 && colon + 2 < trimmed.Length ? trimmed[(colon + 2)..] : trimmed;
     }
 
+    private const int MaxPythonLogicalReferenceLineLength = 32_768;
+
     private readonly record struct PythonLogicalHeaderReferenceLine(string Text, int[] PhysicalLines, int[] PhysicalColumns);
 
     private static bool TryBuildPythonLogicalHeaderReferenceLine(
@@ -1442,9 +1444,8 @@ public static partial class ReferenceExtractor
             {
                 if (builder.Length > 0)
                 {
-                    builder.Append(' ');
-                    physicalLines.Add(lineIndex);
-                    physicalColumns.Add(column);
+                    if (!TryAppendPythonLogicalReferenceChar(builder, physicalLines, physicalColumns, ' ', lineIndex, column, out header))
+                        return false;
                 }
 
                 for (var fragmentColumn = column; fragmentColumn < fragmentEndColumn; fragmentColumn++)
@@ -1453,9 +1454,8 @@ public static partial class ReferenceExtractor
                     if (fragmentChar == '\\' && fragmentColumn == fragmentEndColumn - 1)
                         break;
 
-                    builder.Append(fragmentChar);
-                    physicalLines.Add(lineIndex);
-                    physicalColumns.Add(fragmentColumn);
+                    if (!TryAppendPythonLogicalReferenceChar(builder, physicalLines, physicalColumns, fragmentChar, lineIndex, fragmentColumn, out header))
+                        return false;
                 }
             }
 
@@ -1530,9 +1530,8 @@ public static partial class ReferenceExtractor
             {
                 if (builder.Length > 0)
                 {
-                    builder.Append(' ');
-                    physicalLines.Add(lineIndex);
-                    physicalColumns.Add(column);
+                    if (!TryAppendPythonLogicalReferenceChar(builder, physicalLines, physicalColumns, ' ', lineIndex, column, out header))
+                        return false;
                 }
 
                 for (var fragmentColumn = column; fragmentColumn < fragmentEndColumn; fragmentColumn++)
@@ -1541,9 +1540,8 @@ public static partial class ReferenceExtractor
                     if (fragmentChar == '\\' && fragmentColumn == fragmentEndColumn - 1)
                         break;
 
-                    builder.Append(fragmentChar);
-                    physicalLines.Add(lineIndex);
-                    physicalColumns.Add(fragmentColumn);
+                    if (!TryAppendPythonLogicalReferenceChar(builder, physicalLines, physicalColumns, fragmentChar, lineIndex, fragmentColumn, out header))
+                        return false;
                 }
             }
 
@@ -1588,6 +1586,28 @@ public static partial class ReferenceExtractor
 
         header = new PythonLogicalHeaderReferenceLine(builder.ToString(), physicalLines.ToArray(), physicalColumns.ToArray());
         return header.Text.Length > 0;
+    }
+
+    private static bool TryAppendPythonLogicalReferenceChar(
+        StringBuilder builder,
+        List<int> physicalLines,
+        List<int> physicalColumns,
+        char value,
+        int physicalLine,
+        int physicalColumn,
+        out PythonLogicalHeaderReferenceLine header)
+    {
+        if (builder.Length >= MaxPythonLogicalReferenceLineLength)
+        {
+            header = default;
+            return false;
+        }
+
+        builder.Append(value);
+        physicalLines.Add(physicalLine);
+        physicalColumns.Add(physicalColumn);
+        header = default;
+        return true;
     }
 
     private static int FindPythonCommentColumn(string line, int startColumn)

--- a/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
+++ b/src/CodeIndex/Indexer/References/Support/LanguageReferenceExtractionSupport.cs
@@ -1994,7 +1994,7 @@ internal static class LanguageReferenceExtractionSupport
 
         foreach (var regex in new[] { GoVarTypeRegex, GoFieldTypeRegex, GoTypeAliasRegex })
         {
-            foreach (Match match in regex.Matches(preparedLine))
+            foreach (Match match in BoundedRegex.EnumerateMatches(regex, preparedLine))
             {
                 var group = match.Groups["type"];
                 EmitGoTypeExpression(group.Value, group.Index, references, seen, fileId, context, lineNumber, resolveContainerForColumn);
@@ -5355,7 +5355,7 @@ internal static class LanguageReferenceExtractionSupport
 
     private static IEnumerable<Match> EnumerateMatches(Regex regex, string input)
     {
-        foreach (Match match in regex.Matches(input))
+        foreach (Match match in BoundedRegex.EnumerateMatches(regex, input))
             yield return match;
     }
 

--- a/tests/CodeIndex.Tests/BoundedRegexTests.cs
+++ b/tests/CodeIndex.Tests/BoundedRegexTests.cs
@@ -32,4 +32,37 @@ public sealed class BoundedRegexTests
 
         Assert.Empty(matches);
     }
+
+    [Fact]
+    public void InstanceMatch_Timeout_ReturnsEmpty()
+    {
+        var regex = new BoundedRegex("(a+)+$", default, TimeSpan.FromMilliseconds(1));
+        var input = new string('a', 10_000) + "!";
+
+        var match = regex.Match(input);
+
+        Assert.False(match.Success);
+    }
+
+    [Fact]
+    public void InstanceMatches_Timeout_ReturnsEmpty()
+    {
+        var regex = new BoundedRegex("(a+)+$", default, TimeSpan.FromMilliseconds(1));
+        var input = new string('a', 10_000) + "!";
+
+        var matches = regex.Matches(input);
+
+        Assert.Empty(matches);
+    }
+
+    [Fact]
+    public void InstanceIsMatch_Timeout_ReturnsFalse()
+    {
+        var regex = new BoundedRegex("(a+)+$", default, TimeSpan.FromMilliseconds(1));
+        var input = new string('a', 10_000) + "!";
+
+        var isMatch = regex.IsMatch(input);
+
+        Assert.False(isMatch);
+    }
 }

--- a/tests/CodeIndex.Tests/BoundedRegexTests.cs
+++ b/tests/CodeIndex.Tests/BoundedRegexTests.cs
@@ -21,4 +21,15 @@ public sealed class BoundedRegexTests
     {
         Assert.Equal(RuntimeSafety.RegexMatchTimeout, BoundedRegex.DefaultMatchTimeout);
     }
+
+    [Fact]
+    public void EnumerateMatches_InstanceRegexTimeout_ReturnsEmpty()
+    {
+        var regex = new BoundedRegex("(a+)+$", default, TimeSpan.FromMilliseconds(1));
+        var input = new string('a', 10_000) + "!";
+
+        var matches = BoundedRegex.EnumerateMatches(regex, input);
+
+        Assert.Empty(matches);
+    }
 }

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -27,6 +27,28 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void InsertSymbols_CSharpLongMalformedUsingAliasSignature_DoesNotThrow()
+    {
+        var fileId = UpsertTestFile("src/Alias.cs", checksum: "alias");
+        var signature = "using Alias = " + new string('A', 50_000);
+
+        var exception = Record.Exception(() => _writer.InsertSymbols([
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "import",
+                Name = "Alias",
+                Line = 1,
+                StartLine = 1,
+                EndLine = 1,
+                Signature = signature,
+            },
+        ]));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
     public void Search_ExactSymbolBoostPrefersChunkContainingSymbol_Issue1977()
     {
         var fileId = InsertSearchFile(

--- a/tests/CodeIndex.Tests/ReferenceExtractorCssTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorCssTests.cs
@@ -147,6 +147,19 @@ public partial class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_Css_LongSelectorLine_UsesBoundedMatchEnumeration()
+    {
+        var className = new string('a', 20_000);
+        var content = $".{className} {{ color: red; }}";
+
+        var symbols = SymbolExtractor.Extract(1, "css", content);
+
+        var exception = Record.Exception(() => ReferenceExtractor.Extract(1, "css", content, symbols));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
     public void Extract_Css_DescendantSelectors_KeepClassReferencesVisible()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorPythonTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorPythonTests.cs
@@ -458,6 +458,30 @@ public partial class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_PythonOversizedLogicalHeaderAndStatement_DoesNotThrow()
+    {
+        var longTypeName = new string('A', 40_000);
+        var longValueName = new string('B', 40_000);
+        var content = $$"""
+            def build(
+                value: {{longTypeName}},
+            ):
+                result = (
+                    {{longValueName}}
+                )
+                return result
+            """;
+
+        var exception = Record.Exception(() =>
+        {
+            var symbols = SymbolExtractor.Extract(1, "python", content);
+            ReferenceExtractor.Extract(1, "python", content, symbols);
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
     public void Extract_PythonClassHook_AssignsReferencesToHookContainer()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -15339,6 +15339,44 @@ public partial class ReferenceExtractorTests
         Assert.Contains(references, r => r.SymbolName == "./public-api" && r.ReferenceKind == "reference" && r.Line == 16);
     }
 
+    [Fact]
+    public void Extract_TypeScriptNamespaceImportQualifiedUsage_ManyAliasesAcrossManyLines()
+    {
+        var imports = string.Join(
+            "\n",
+            Enumerable.Range(0, 12).Select(index => $"import * as Api{index} from \"./api{index}\";"));
+        var calls = string.Join(
+            "\n",
+            Enumerable.Range(0, 12).Select(index => $"    Api{index}.Client.connect();"));
+        var content = $$"""
+            {{imports}}
+
+            export function render() {
+            {{calls}}
+                Api1Extra.Client.connect();
+                OtherApi1.Client.connect();
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+
+        for (var index = 0; index < 12; index++)
+        {
+            var expectedLine = 15 + index;
+            Assert.Contains(references, r =>
+                r.SymbolName == $"./api{index}"
+                && r.ReferenceKind == "reference"
+                && r.Line == expectedLine
+                && r.ContainerName == "render");
+        }
+
+        Assert.DoesNotContain(references, r =>
+            r.SymbolName == "./api1"
+            && r.ReferenceKind == "reference"
+            && r.Line is 27 or 28);
+    }
+
 
 
 


### PR DESCRIPTION
## Summary
- Harden selected built-in reference extraction regex paths by routing match enumeration through bounded helpers and adding timeout-safe instance coverage.
- Replace TypeScript namespace alias qualified-reference regex fanout with a scanner.
- Bound C# import alias signature regexes and cap Python logical reference remap buffers.
- Add changelog fragments for #3053, #3054, #3101, and #3141.

## Validation
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~BoundedRegexTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: no blocking/actionable issues found.

## Notes
- No changes to AGENT.md, CLAUDE.md, AGENTS.md, or AGENT_GUIDE.md.

Fixes #3053
Fixes #3054
Fixes #3101
Fixes #3141
