### PR TITLE
Cap SQLite file URI parsing

### DIFF
--- a/changelog.d/unreleased/3140.security.md
+++ b/changelog.d/unreleased/3140.security.md
@@ -1,0 +1,18 @@
+---
+category: security
+issues:
+  - 3140
+affected:
+  - src/CodeIndex/Database/SqliteFileUri.cs
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - tests/CodeIndex.Tests/DbPathResolverTests.cs
+---
+
+## English
+
+- **SQLite file URI parsing now rejects oversized inputs before normalization (#3140)** — `file:` database URIs and query strings are capped before query slicing, percent unescaping, or `Uri` parsing, and rejected diagnostics are bounded.
+
+## 日本語
+
+- **SQLite file URI 解析が正規化前に過大入力を拒否するようになりました (#3140)** — `file:` DB URI と query 文字列を、query 切り出し、percent unescape、`Uri` 解析より前に上限チェックし、拒否時の診断も bounded にしました。

--- a/changelog.d/unreleased/3140.security.md
+++ b/changelog.d/unreleased/3140.security.md
@@ -3,10 +3,19 @@ category: security
 issues:
   - 3140
 affected:
+  - src/CodeIndex/Cli/DbCommandRunner.cs
   - src/CodeIndex/Database/SqliteFileUri.cs
   - src/CodeIndex/Cli/DbPathResolver.cs
+  - src/CodeIndex/Cli/DiffCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Validation.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
   - src/CodeIndex/Database/DbContext.cs
+  - tests/CodeIndex.Tests/DbCommandRunnerTests.cs
   - tests/CodeIndex.Tests/DbPathResolverTests.cs
+  - tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
 ---
 
 ## English

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -65,7 +65,16 @@ public static class DbCommandRunner
                 CommandErrorCodes.UsageError);
 
         var dbPath = options.DbPath;
-        var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
+        var isUri = SqliteFileUri.StartsWithFileScheme(dbPath);
+        if (!SqliteFileUri.TryValidateBounds(dbPath, out var parseError))
+            return WriteCommandError(
+                options.Json,
+                jsonOptions,
+                $"invalid --db file URI: {SqliteFileUri.FormatParseError(parseError)}",
+                CommandExitCodes.DatabaseError,
+                "Pass a valid SQLite file URI whose full value and query string fit within the supported limits.",
+                CommandErrorCodes.DbError);
+
         if (!isUri && !File.Exists(LongPath.EnsureWindowsPrefix(dbPath)))
             return WriteCommandError(
                 options.Json,

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -1,3 +1,4 @@
+using CodeIndex.Database;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 using System.Security.Cryptography;
@@ -239,8 +240,9 @@ public static class DbPathResolver
         try
         {
             // Strip query params (?immutable=1 etc.) before URI parsing so LocalPath is clean.
-            var qIdx = dbPath.IndexOf('?');
-            var trimmed = qIdx >= 0 ? dbPath[..qIdx] : dbPath;
+            if (!SqliteFileUri.TryGetPathBeforeQuery(dbPath, out var trimmed, out var boundsError))
+                throw boundsError ?? new FormatException("Invalid SQLite file URI.");
+
             if (ContainsInvalidPercentEscape(trimmed))
                 throw new FormatException("Invalid percent escape in SQLite file URI.");
 
@@ -424,27 +426,16 @@ public static class DbPathResolver
     }
 
     public static bool UriRequestsReadOnly(string uriText)
-    {
-        if (!uriText.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        var qIdx = uriText.IndexOf('?');
-        if (qIdx < 0) return false;
-        var query = uriText[(qIdx + 1)..];
-        foreach (var raw in query.Split('&'))
-        {
-            var seg = raw.Trim();
-            if (seg.Equals("immutable=1", StringComparison.OrdinalIgnoreCase)) return true;
-            if (seg.Equals("mode=ro", StringComparison.OrdinalIgnoreCase)) return true;
-        }
-        return false;
-    }
+        => SqliteFileUri.RequestsReadOnly(uriText);
 
     private static bool PathsEqual(string left, string right)
         => PathCasing.PathsEqual(left, right);
 
-    private static string QuoteLogValue(string value) =>
-        "\"" + value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal).Replace("\r", "\\r", StringComparison.Ordinal).Replace("\n", "\\n", StringComparison.Ordinal) + "\"";
+    private static string QuoteLogValue(string value)
+    {
+        var boundedValue = SqliteFileUri.TruncateDiagnosticValue(value);
+        return "\"" + boundedValue.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal).Replace("\r", "\\r", StringComparison.Ordinal).Replace("\n", "\\n", StringComparison.Ordinal) + "\"";
+    }
 
     private static bool IsUnderDirectory(string parentDirectory, string candidatePath)
         => PathCasing.IsPathEqualOrParent(parentDirectory, candidatePath);

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CodeIndex.Database;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 
@@ -29,6 +30,15 @@ public static class DiffCommandRunner
                 "Run `cdidx diff <db1> <db2> --help` to see the supported command shape.",
                 CommandErrorCodes.UsageError);
 
+        var json = options.Json || options.SummaryOnly;
+        var leftUriValidationExitCode = ValidateReadableDbFileUri(options.LeftDb!, json, jsonOptions);
+        if (leftUriValidationExitCode != null)
+            return leftUriValidationExitCode.Value;
+
+        var rightUriValidationExitCode = ValidateReadableDbFileUri(options.RightDb!, json, jsonOptions);
+        if (rightUriValidationExitCode != null)
+            return rightUriValidationExitCode.Value;
+
         try
         {
             var leftHeader = ReadHeader(options.LeftDb!);
@@ -56,6 +66,20 @@ public static class DiffCommandRunner
                 "Pass two readable CodeIndex SQLite database paths.",
                 CommandErrorCodes.DbError);
         }
+    }
+
+    private static int? ValidateReadableDbFileUri(string dbPath, bool json, JsonSerializerOptions jsonOptions)
+    {
+        if (SqliteFileUri.TryValidateBounds(dbPath, out var parseError))
+            return null;
+
+        return WriteCommandError(
+            json,
+            jsonOptions,
+            $"invalid database file URI: {SqliteFileUri.FormatParseError(parseError)}",
+            UnreadableExitCode,
+            "Pass two readable CodeIndex SQLite database paths or valid SQLite file URIs.",
+            CommandErrorCodes.DbError);
     }
 
     internal static DiffCommandOptions ParseArgs(string[] args)

--- a/src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
@@ -34,6 +34,10 @@ public static partial class IndexCommandRunner
                 "Run `cdidx optimize --help` to see the supported command shape.",
                 CommandErrorCodes.UsageError);
 
+        var dbUriValidationExitCode = ValidateDbPathFileUri(options.DbPath, "optimize", options.Json, jsonOptions);
+        if (dbUriValidationExitCode != null)
+            return dbUriValidationExitCode.Value;
+
         if (DbPathResolver.UriRequestsReadOnly(options.DbPath))
             return WriteCommandError(
                 options.Json,

--- a/src/CodeIndex/Cli/IndexCommandRunner.Validation.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Validation.cs
@@ -59,6 +59,10 @@ public static partial class IndexCommandRunner
                 CommandErrorCodes.UsageError);
         }
 
+        var dbUriValidationExitCode = ValidateDbPathFileUri(dbPath, "index", options.Json, jsonOptions);
+        if (dbUriValidationExitCode != null)
+            return dbUriValidationExitCode.Value;
+
         var rebuildConfirmationExitCode = ConfirmRebuildIfNeeded(options, dbPath, jsonOptions);
         if (rebuildConfirmationExitCode != null)
             return rebuildConfirmationExitCode.Value;
@@ -86,6 +90,24 @@ public static partial class IndexCommandRunner
         }
 
         return null;
+    }
+
+    private static int? ValidateDbPathFileUri(
+        string dbPath,
+        string command,
+        bool json,
+        JsonSerializerOptions jsonOptions)
+    {
+        if (DbPathResolver.TryNormalizeDbPath(dbPath, out _, out var parseError))
+            return null;
+
+        return WriteCommandError(
+            json,
+            jsonOptions,
+            $"invalid --db file URI for {command}: {SqliteFileUri.FormatParseError(parseError)}",
+            CommandExitCodes.DatabaseError,
+            "Pass a valid SQLite file URI whose full value and query string fit within the supported limits.",
+            CommandErrorCodes.DbError);
     }
 
     private static int? ValidateCommitRefsBeforeIndexSetup(IndexCommandOptions options, JsonSerializerOptions jsonOptions)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -6411,7 +6411,14 @@ public static class QueryCommandRunner
             AddParseError(defaultMaxLineWidthError);
 
         var dbResolution = DbPathResolver.ResolveForQuery(Environment.CurrentDirectory, dbPath, dataDir);
-        var resolvedDbPath = readOnly ? DbContext.ToReadOnlyUri(dbResolution.DbPath) : dbResolution.DbPath;
+        var resolvedDbPath = dbResolution.DbPath;
+        if (readOnly)
+        {
+            var canAppendReadOnlyFlags = !SqliteFileUri.StartsWithFileScheme(resolvedDbPath) ||
+                SqliteFileUri.TryValidateBounds(resolvedDbPath, out _);
+            if (canAppendReadOnlyFlags)
+                resolvedDbPath = DbContext.ToReadOnlyUri(resolvedDbPath);
+        }
 
         return new QueryCommandOptions
         {

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -6933,8 +6933,9 @@ public static class QueryCommandRunner
             {
                 if (!DbPathResolver.TryNormalizeDbPath(dbPath, out fileExistsPath, out var parseError))
                 {
-                    Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: invalid --db file URI: {parseError?.Message ?? dbPath}");
-                    Console.Error.WriteLine($"Hint: pass a valid SQLite file URI such as `file:///absolute/path/to/codeindex.db?immutable=1`; the --db value resolved to: {dbPath}");
+                    var boundedDbPath = SqliteFileUri.TruncateDiagnosticValue(dbPath);
+                    Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: invalid --db file URI: {SqliteFileUri.FormatParseError(parseError)}");
+                    Console.Error.WriteLine($"Hint: pass a valid SQLite file URI such as `file:///absolute/path/to/codeindex.db?immutable=1`; the --db value resolved to: {boundedDbPath}");
                     GlobalToolLog.Error($"invalid_db_file_uri db={FormatLogValue(dbPath)} exception={FormatLogValue(parseError?.ToString() ?? "<unknown>")}");
                     return CommandExitCodes.DatabaseError;
                 }
@@ -7127,7 +7128,7 @@ public static class QueryCommandRunner
         if (string.IsNullOrEmpty(value))
             return "<empty>";
 
-        return value
+        return SqliteFileUri.TruncateDiagnosticValue(value)
             .Replace("\\", "/", StringComparison.Ordinal)
             .Replace("\r", " ", StringComparison.Ordinal)
             .Replace("\n", " ", StringComparison.Ordinal)

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -453,8 +453,13 @@ public class DbContext : IDisposable
 
     public static string ToReadOnlyUri(string dbPath)
     {
-        if (dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+        if (SqliteFileUri.StartsWithFileScheme(dbPath))
+        {
+            if (!SqliteFileUri.TryValidateBounds(dbPath, out var boundsError))
+                throw boundsError ?? new FormatException("Invalid SQLite file URI.");
+
             return AppendReadOnlyQuery(dbPath);
+        }
 
         var fileUri = new Uri(Path.GetFullPath(dbPath)).AbsoluteUri;
         return $"{fileUri}?immutable=1&mode=ro";

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -159,14 +159,20 @@ public class DbContext : IDisposable
         message = string.Empty;
         isNotFound = false;
 
-        if (dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase) && UriRequestsReadOnly(dbPath))
+        if (SqliteFileUri.StartsWithFileScheme(dbPath) && !SqliteFileUri.TryValidateBounds(dbPath, out var boundsError))
+        {
+            message = boundsError?.Message ?? "Invalid SQLite file URI.";
+            return false;
+        }
+
+        if (SqliteFileUri.StartsWithFileScheme(dbPath) && SqliteFileUri.RequestsReadOnly(dbPath))
         {
             message = $"database must be writable: {dbPath}";
             return false;
         }
 
         var openTarget = dbPath;
-        if (dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+        if (SqliteFileUri.StartsWithFileScheme(dbPath))
         {
             var normalized = TryGetLocalPath(dbPath);
             if (normalized != null)
@@ -238,8 +244,11 @@ public class DbContext : IDisposable
         // and all write-oriented pragmas. This is the CLI escape hatch for sandboxes where
         // even SqliteOpenMode.ReadOnly cannot touch -shm/-wal side files.
         // URI 形式が渡された場合は writable open を省き、直接 read-only として扱う。
-        if (dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+        if (SqliteFileUri.StartsWithFileScheme(dbPath))
         {
+            if (!SqliteFileUri.TryValidateBounds(dbPath, out var boundsError))
+                throw boundsError ?? new FormatException("Invalid SQLite file URI.");
+
             // URI escape hatch — but ONLY when the caller explicitly requested read-only
             // semantics. A bare `file:///path.db` without `immutable=1` / `mode=ro` falls
             // through to the normal filesystem path, otherwise SQLite's default open mode
@@ -248,7 +257,7 @@ public class DbContext : IDisposable
             // and skip TryMigrateForRead / writable pragmas.
             // 明示的に read-only を要求した URI のみエスケープハッチ扱い。裸の file: URI は
             // 通常経路にフォールバックさせて read-write-CREATE の副作用を防ぐ。
-            if (UriRequestsReadOnly(dbPath))
+            if (SqliteFileUri.RequestsReadOnly(dbPath))
             {
                 try
                 {
@@ -716,25 +725,6 @@ public class DbContext : IDisposable
             innerException: lastBusyError);
     }
 
-    // Detect whether a SQLite URI explicitly requests read-only semantics. Only URIs that
-    // set `immutable=1` or `mode=ro` take the read-only escape hatch — plain `file:`
-    // URIs must not, or SQLite would open read-write-CREATE and a `status` call could
-    // silently mutate or create the target DB.
-    // `immutable=1` or `mode=ro` が明示されている場合のみ read-only として扱う。
-    private static bool UriRequestsReadOnly(string uriText)
-    {
-        var qIdx = uriText.IndexOf('?');
-        if (qIdx < 0) return false;
-        var query = uriText[(qIdx + 1)..];
-        foreach (var raw in query.Split('&'))
-        {
-            var seg = raw.Trim();
-            if (seg.Equals("immutable=1", StringComparison.OrdinalIgnoreCase)) return true;
-            if (seg.Equals("mode=ro", StringComparison.OrdinalIgnoreCase)) return true;
-        }
-        return false;
-    }
-
     // Best-effort: extract the filesystem path from a SQLite URI so -wal checks can run.
     // Returns null if parsing fails; the caller simply skips the gate in that case.
     // URI から filesystem path を取り出すベストエフォート。失敗したらゲートをスキップ。
@@ -743,8 +733,9 @@ public class DbContext : IDisposable
         try
         {
             // Trim the query string (?immutable=1 etc.) before parsing so LocalPath is clean.
-            var qIdx = uriText.IndexOf('?');
-            var trimmed = qIdx >= 0 ? uriText[..qIdx] : uriText;
+            if (!SqliteFileUri.TryGetPathBeforeQuery(uriText, out var trimmed, out _))
+                return null;
+
             var uri = new Uri(trimmed);
             return uri.IsFile ? uri.LocalPath : null;
         }

--- a/src/CodeIndex/Database/SqliteFileUri.cs
+++ b/src/CodeIndex/Database/SqliteFileUri.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+
+namespace CodeIndex.Database;
+
+internal static class SqliteFileUri
+{
+    internal const int MaxUriLength = 16 * 1024;
+    internal const int MaxQueryLength = 2048;
+    internal const int MaxDiagnosticValueLength = 256;
+
+    private const string FileSchemePrefix = "file:";
+
+    internal static bool StartsWithFileScheme(string uriText)
+        => uriText.StartsWith(FileSchemePrefix, StringComparison.OrdinalIgnoreCase);
+
+    internal static bool TryGetPathBeforeQuery(string uriText, out string pathText, out FormatException? parseError)
+    {
+        pathText = uriText;
+        if (!StartsWithFileScheme(uriText))
+        {
+            parseError = null;
+            return true;
+        }
+
+        if (!TryValidateBounds(uriText, out var queryIndex, out parseError))
+            return false;
+
+        pathText = queryIndex >= 0 ? uriText[..queryIndex] : uriText;
+        return true;
+    }
+
+    internal static bool TryValidateBounds(string uriText, out FormatException? parseError)
+    {
+        if (!StartsWithFileScheme(uriText))
+        {
+            parseError = null;
+            return true;
+        }
+
+        return TryValidateBounds(uriText, out _, out parseError);
+    }
+
+    internal static bool RequestsReadOnly(string uriText)
+    {
+        if (!StartsWithFileScheme(uriText))
+            return false;
+
+        if (!TryValidateBounds(uriText, out var queryIndex, out _))
+            return false;
+
+        if (queryIndex < 0)
+            return false;
+
+        var query = uriText.AsSpan(queryIndex + 1);
+        while (!query.IsEmpty)
+        {
+            var ampersandIndex = query.IndexOf('&');
+            var segment = ampersandIndex >= 0 ? query[..ampersandIndex] : query;
+            segment = segment.Trim();
+            if (segment.Equals("immutable=1".AsSpan(), StringComparison.OrdinalIgnoreCase) ||
+                segment.Equals("mode=ro".AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (ampersandIndex < 0)
+                break;
+
+            query = query[(ampersandIndex + 1)..];
+        }
+
+        return false;
+    }
+
+    internal static string TruncateDiagnosticValue(string value)
+    {
+        if (value.Length <= MaxDiagnosticValueLength)
+            return value;
+
+        return value[..MaxDiagnosticValueLength] +
+            "...(truncated, " +
+            value.Length.ToString(CultureInfo.InvariantCulture) +
+            " chars)";
+    }
+
+    private static bool TryValidateBounds(string uriText, out int queryIndex, out FormatException? parseError)
+    {
+        queryIndex = -1;
+        if (uriText.Length > MaxUriLength)
+        {
+            parseError = new FormatException(
+                $"SQLite file URI length exceeds {MaxUriLength.ToString(CultureInfo.InvariantCulture)} characters.");
+            return false;
+        }
+
+        queryIndex = uriText.IndexOf('?');
+        if (queryIndex >= 0)
+        {
+            var queryLength = uriText.Length - queryIndex - 1;
+            if (queryLength > MaxQueryLength)
+            {
+                parseError = new FormatException(
+                    $"SQLite file URI query length exceeds {MaxQueryLength.ToString(CultureInfo.InvariantCulture)} characters.");
+                return false;
+            }
+        }
+
+        parseError = null;
+        return true;
+    }
+}

--- a/src/CodeIndex/Database/SqliteFileUri.cs
+++ b/src/CodeIndex/Database/SqliteFileUri.cs
@@ -83,6 +83,9 @@ internal static class SqliteFileUri
             " chars)";
     }
 
+    internal static string FormatParseError(Exception? parseError)
+        => parseError?.Message ?? "Invalid SQLite file URI.";
+
     private static bool TryValidateBounds(string uriText, out int queryIndex, out FormatException? parseError)
     {
         queryIndex = -1;

--- a/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
@@ -17,6 +17,13 @@ public class DbCommandRunnerTests
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
     };
 
+    public static IEnumerable<object[]> DirectSqliteModeArgs()
+    {
+        yield return new object[] { new[] { "--integrity-check" } };
+        yield return new object[] { new[] { "schema" } };
+        yield return new object[] { new[] { "prune", "--dry-run" } };
+    }
+
     [Fact]
     public void ParseArgs_IntegrityCheckFlagSetsFlag()
     {
@@ -98,6 +105,23 @@ public class DbCommandRunnerTests
         Assert.Equal(CommandExitCodes.UsageError, exitCode);
         Assert.Contains("db requires a mode flag", stderr);
         Assert.Contains("--integrity-check", stderr);
+    }
+
+    [Theory]
+    [MemberData(nameof(DirectSqliteModeArgs))]
+    public void Run_DirectSqliteModesRejectOversizedFileUriQuery_Issue3140(string[] modeArgs)
+    {
+        var dbUri = "file:///tmp/codeindex.db?" + new string('a', SqliteFileUri.MaxQueryLength + 1);
+        var args = new List<string>(modeArgs) { "--db", dbUri }.ToArray();
+
+        var (exitCode, stdout, stderr) = RunAndCaptureStreams(args);
+
+        Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("invalid --db file URI", stderr);
+        Assert.Contains($"SQLite file URI query length exceeds {SqliteFileUri.MaxQueryLength}", stderr);
+        Assert.Contains("supported limits", stderr);
+        Assert.DoesNotContain(new string('a', SqliteFileUri.MaxDiagnosticValueLength + 1), stderr);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/DbPathResolverTests.cs
+++ b/tests/CodeIndex.Tests/DbPathResolverTests.cs
@@ -2,6 +2,7 @@ using CodeIndex.Cli;
 using CodeIndex.Database;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
+using System.Globalization;
 
 namespace CodeIndex.Tests;
 
@@ -239,6 +240,18 @@ public class DbPathResolverTests
     }
 
     [Fact]
+    public void UriRequestsReadOnly_OversizedFileUriQuery_ReturnsFalseWithoutScanningQuery()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_path_resolver_{Guid.NewGuid():N}.db");
+        var readOnlyUri = new Uri(dbPath).AbsoluteUri +
+            "?" +
+            new string('a', SqliteFileUri.MaxQueryLength + 1) +
+            "&immutable=1";
+
+        Assert.False(DbPathResolver.UriRequestsReadOnly(readOnlyUri));
+    }
+
+    [Fact]
     public void TryResolveWritableMutationDbPath_RelativeReadOnlyUri_ReturnsWorkingDirectoryPath()
     {
         var fileName = $"cdidx_db_path_resolver_{Guid.NewGuid():N}.db";
@@ -260,6 +273,83 @@ public class DbPathResolverTests
         Assert.False(resolved);
         Assert.Equal(malformedUri, normalized);
         Assert.NotNull(parseError);
+    }
+
+    [Fact]
+    public void TryNormalizeDbPath_OversizedFileUri_ReturnsParseErrorWithoutChangingValue()
+    {
+        var oversizedUri = "file:///" + new string('a', SqliteFileUri.MaxUriLength);
+
+        var resolved = DbPathResolver.TryNormalizeDbPath(oversizedUri, out var normalized, out var parseError);
+
+        Assert.False(resolved);
+        Assert.Equal(oversizedUri, normalized);
+        Assert.NotNull(parseError);
+        Assert.Contains(SqliteFileUri.MaxUriLength.ToString(CultureInfo.InvariantCulture), parseError.Message);
+        Assert.DoesNotContain(new string('a', 32), parseError.Message);
+    }
+
+    [Fact]
+    public void TryNormalizeDbPath_OversizedFileUriQuery_ReturnsParseErrorWithoutChangingValue()
+    {
+        var oversizedQueryUri = "file:///tmp/codeindex.db?" + new string('a', SqliteFileUri.MaxQueryLength + 1);
+
+        var resolved = DbPathResolver.TryNormalizeDbPath(oversizedQueryUri, out var normalized, out var parseError);
+
+        Assert.False(resolved);
+        Assert.Equal(oversizedQueryUri, normalized);
+        Assert.NotNull(parseError);
+        Assert.Contains(SqliteFileUri.MaxQueryLength.ToString(CultureInfo.InvariantCulture), parseError.Message);
+        Assert.DoesNotContain(new string('a', 32), parseError.Message);
+    }
+
+    [Fact]
+    public void TryValidateExistingCodeIndexDb_OversizedFileUriQuery_ReturnsBoundedErrorWithoutOpening()
+    {
+        var opened = false;
+        var oversizedQueryUri = "file:///tmp/codeindex.db?" + new string('a', SqliteFileUri.MaxQueryLength + 1);
+
+        var resolved = DbContext.TryValidateExistingCodeIndexDb(
+            oversizedQueryUri,
+            _ =>
+            {
+                opened = true;
+                throw new InvalidOperationException("Unexpected open.");
+            },
+            _ => throw new InvalidOperationException("Unexpected open."),
+            sleep: null,
+            out var message,
+            out var isNotFound);
+
+        Assert.False(resolved);
+        Assert.False(opened);
+        Assert.False(isNotFound);
+        Assert.Contains(SqliteFileUri.MaxQueryLength.ToString(CultureInfo.InvariantCulture), message);
+        Assert.DoesNotContain(new string('a', 32), message);
+    }
+
+    [Fact]
+    public void DbContext_OversizedFileUriQuery_ThrowsBeforeOpeningSqlite()
+    {
+        var oversizedQueryUri = "file:///tmp/codeindex.db?" + new string('a', SqliteFileUri.MaxQueryLength + 1);
+
+        var ex = Assert.Throws<FormatException>(() => new DbContext(oversizedQueryUri));
+
+        Assert.Contains(SqliteFileUri.MaxQueryLength.ToString(CultureInfo.InvariantCulture), ex.Message);
+        Assert.DoesNotContain(new string('a', 32), ex.Message);
+    }
+
+    [Fact]
+    public void TruncateDiagnosticValue_OversizedInput_ReturnsBoundedValueWithLength()
+    {
+        var oversizedUri = "file:" + new string('x', SqliteFileUri.MaxDiagnosticValueLength + 1);
+
+        var diagnostic = SqliteFileUri.TruncateDiagnosticValue(oversizedUri);
+
+        Assert.True(diagnostic.Length < SqliteFileUri.MaxDiagnosticValueLength + 64);
+        Assert.Contains("truncated", diagnostic, StringComparison.Ordinal);
+        Assert.Contains(oversizedUri.Length.ToString(CultureInfo.InvariantCulture), diagnostic, StringComparison.Ordinal);
+        Assert.DoesNotContain(new string('x', SqliteFileUri.MaxDiagnosticValueLength), diagnostic);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/DbPathResolverTests.cs
+++ b/tests/CodeIndex.Tests/DbPathResolverTests.cs
@@ -340,6 +340,18 @@ public class DbPathResolverTests
     }
 
     [Fact]
+    public void ToReadOnlyUri_OversizedFileUriQuery_ThrowsBeforeAppendingReadOnlyFlags()
+    {
+        var oversizedQueryUri = "file:///tmp/codeindex.db?" + new string('a', SqliteFileUri.MaxQueryLength + 1);
+
+        var ex = Assert.Throws<FormatException>(() => DbContext.ToReadOnlyUri(oversizedQueryUri));
+
+        Assert.Contains(SqliteFileUri.MaxQueryLength.ToString(CultureInfo.InvariantCulture), ex.Message);
+        Assert.DoesNotContain("immutable=1", ex.Message);
+        Assert.DoesNotContain(new string('a', 32), ex.Message);
+    }
+
+    [Fact]
     public void TruncateDiagnosticValue_OversizedInput_ReturnsBoundedValueWithLength()
     {
         var oversizedUri = "file:" + new string('x', SqliteFileUri.MaxDiagnosticValueLength + 1);

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using CodeIndex.Cli;
+using CodeIndex.Database;
 using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Tests;
@@ -41,6 +42,21 @@ public class DiffCommandRunnerTests
             TestProjectHelper.DeleteDirectory(leftRoot);
             TestProjectHelper.DeleteDirectory(rightRoot);
         }
+    }
+
+    [Fact]
+    public void Run_OversizedFileUriQueryReturnsBoundedErrorBeforeReadingHeaders_Issue3140()
+    {
+        var dbUri = "file:///tmp/codeindex.db?" + new string('a', SqliteFileUri.MaxQueryLength + 1);
+
+        var (exitCode, stdout, stderr) = RunWithCapturedStreams([dbUri, "/tmp/missing-codeindex.db"]);
+
+        Assert.Equal(3, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("invalid database file URI", stderr);
+        Assert.Contains($"SQLite file URI query length exceeds {SqliteFileUri.MaxQueryLength}", stderr);
+        Assert.Contains("valid SQLite file URIs", stderr);
+        Assert.DoesNotContain(new string('a', SqliteFileUri.MaxDiagnosticValueLength + 1), stderr);
     }
 
     [Fact]
@@ -598,6 +614,29 @@ public class DiffCommandRunnerTests
             finally
             {
                 Console.SetOut(originalOut);
+            }
+        }
+    }
+
+    private (int ExitCode, string StdOut, string StdErr) RunWithCapturedStreams(string[] args)
+    {
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        lock (TestConsoleLock.Gate)
+        {
+            try
+            {
+                Console.SetOut(stdout);
+                Console.SetError(stderr);
+                var exitCode = DiffCommandRunner.Run(args, _jsonOptions);
+                return (exitCode, stdout.ToString(), stderr.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
             }
         }
     }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -3198,6 +3198,37 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_OversizedFileUriQueryDbPath_ReturnsBoundedJsonError_Issue3140()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "class App {}\n");
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var dbUri = new Uri(dbPath).AbsoluteUri + "?" + new string('a', SqliteFileUri.MaxQueryLength + 1);
+
+            var (exitCode, stdout, stderr) = RunCliInSubprocess([projectRoot, "--db", dbUri, "--json"], projectRoot);
+
+            using var document = JsonDocument.Parse(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.DbError, json.GetProperty("error_code").GetString());
+            Assert.Contains("invalid --db file URI for index", json.GetProperty("message").GetString());
+            Assert.Contains($"SQLite file URI query length exceeds {SqliteFileUri.MaxQueryLength}", json.GetProperty("message").GetString());
+            Assert.Contains("supported limits", json.GetProperty("hint").GetString());
+            Assert.DoesNotContain(new string('a', SqliteFileUri.MaxDiagnosticValueLength + 1), stdout);
+            Assert.False(Directory.Exists(Path.Combine(projectRoot, ".cdidx")));
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_MissingCdidxDirectoryInReadOnlyProject_ReturnsDatabaseErrorWithoutStackTrace()
     {
         if (OperatingSystem.IsWindows())
@@ -3412,6 +3443,45 @@ public class IndexCommandRunnerTests
             if (File.Exists(dbPath))
                 File.Delete(dbPath);
         }
+    }
+
+    [Fact]
+    public void RunOptimizeFts_OversizedFileUriQuery_ReturnsBoundedJsonError_Issue3140()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_optimize_uri_cap_{Guid.NewGuid():N}.db");
+        var dbUri = new Uri(dbPath).AbsoluteUri + "?" + new string('a', SqliteFileUri.MaxQueryLength + 1);
+        int exitCode;
+        JsonElement json;
+        string stderr;
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            try
+            {
+                using var stdout = new StringWriter();
+                using var stderrWriter = new StringWriter();
+                Console.SetOut(stdout);
+                Console.SetError(stderrWriter);
+                exitCode = IndexCommandRunner.RunOptimizeFts(["--db", dbUri, "--json"], _jsonOptions);
+                stderr = stderrWriter.ToString();
+                using var document = JsonDocument.Parse(stdout.ToString());
+                json = document.RootElement.Clone();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+        }
+
+        Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        Assert.Equal("error", json.GetProperty("status").GetString());
+        Assert.Equal(CommandErrorCodes.DbError, json.GetProperty("error_code").GetString());
+        Assert.Contains("invalid --db file URI for optimize", json.GetProperty("message").GetString());
+        Assert.Contains($"SQLite file URI query length exceeds {SqliteFileUri.MaxQueryLength}", json.GetProperty("message").GetString());
+        Assert.Contains("supported limits", json.GetProperty("hint").GetString());
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -1545,6 +1545,22 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void WithDb_OversizedFileUriQueryReturnsBoundedDiagnostics_Issue3140()
+    {
+        var longQuery = new string('a', SqliteFileUri.MaxQueryLength + 1);
+        var dbUri = "file:///tmp/codeindex.db?" + longQuery;
+
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--db", dbUri],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+        Assert.Contains($"SQLite file URI query length exceeds {SqliteFileUri.MaxQueryLength}", stderr);
+        Assert.Contains("...(truncated,", stderr);
+        Assert.DoesNotContain(new string('a', SqliteFileUri.MaxDiagnosticValueLength + 1), stderr);
+    }
+
+    [Fact]
     public void WithDb_SqliteCantOpenSurfacesAccessOpenCategory_Issue2072()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue2072_cantopen");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -1561,6 +1561,22 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void WithDb_ReadOnlyOversizedFileUriQueryReturnsBoundedDiagnostics_Issue3140()
+    {
+        var longQuery = new string('a', SqliteFileUri.MaxQueryLength + 1);
+        var dbUri = "file:///tmp/codeindex.db?" + longQuery;
+
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--read-only", "--db", dbUri],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+        Assert.Contains($"SQLite file URI query length exceeds {SqliteFileUri.MaxQueryLength}", stderr);
+        Assert.Contains("...(truncated,", stderr);
+        Assert.DoesNotContain(new string('a', SqliteFileUri.MaxDiagnosticValueLength + 1), stderr);
+    }
+
+    [Fact]
     public void WithDb_SqliteCantOpenSurfacesAccessOpenCategory_Issue2072()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue2072_cantopen");


### PR DESCRIPTION
## Summary

- Added bounded SQLite `file:` URI validation before CLI/database URI parsing and read-only query detection.
- Replaced query-string splitting with a bounded scanner and truncated oversized diagnostics/log fields.
- Covered query, db, diff, index, optimize, and resolver paths with issue-focused regression tests.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbPathResolverTests|FullyQualifiedName~DbCommandRunnerTests|FullyQualifiedName~DiffCommandRunnerTests|FullyQualifiedName~IndexCommandRunnerTests|FullyQualifiedName~QueryCommandRunnerTests" -p:UseSharedCompilation=false` (passed)
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter Issue3140 -p:UseSharedCompilation=false` (passed)
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "Issue3140|FullyQualifiedName~RunStatus_Json_RelativeReadOnlyUriFoldRemediationUsesWorkingDirectoryDbPath|FullyQualifiedName~RunStatus_HumanOutput_RelativeReadOnlyUriUsesWorkingDirectoryDbPath|FullyQualifiedName~TryResolveWritableMutationDbPath_RelativeReadOnlyUri_ReturnsWorkingDirectoryPath" -p:UseSharedCompilation=false` (passed)
- `dotnet run --project tools/CodeIndex.Changelog -- check` (passed)
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore` (passed)
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false` (passed)
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false` (passed)
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check` (passed)
- `git diff --check origin/main...HEAD` (passed)
- Codex adversarial review: no blocking/actionable issues found.

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/3140.security.md`.
- No AGENTS.md, CLAUDE.md, or AGENT_GUIDE.md changes.

## Follow-up Candidates

- None.

Fixes #3140
