### PR TITLE
Fix MCP audit request id truncation coverage

### DIFF
--- a/changelog.d/unreleased/3306-3308.fixed.md
+++ b/changelog.d/unreleased/3306-3308.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3306
+  - 3307
+  - 3308
+affected:
+  - tests/CodeIndex.Tests/McpAuditLogTests.cs
+---
+
+## English
+
+- **MCP audit request-id truncation coverage now uses a protocol-valid escaped id (#3306, #3307, #3308)**: the regression test now keeps the JSON-RPC id within request validation limits while still making the serialized audit request id exceed the audit display cap.
+
+## 日本語
+
+- **MCP audit request-id truncation のカバレッジが protocol-valid な escaped id を使うようになりました (#3306, #3307, #3308)**: 回帰テストは JSON-RPC id を request validation の上限内に保ちつつ、serialized audit request id が audit 表示上限を超える入力で検証するようになりました。

--- a/tests/CodeIndex.Tests/McpAuditLogTests.cs
+++ b/tests/CodeIndex.Tests/McpAuditLogTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using CodeIndex.Cli;
@@ -490,6 +491,39 @@ public class McpAuditLogTests : IDisposable
         Assert.Equal(serializedId, record.GetProperty("request_id").GetString());
         Assert.False(record.TryGetProperty("request_id_length", out _));
         Assert.False(record.TryGetProperty("request_id_truncated", out _));
+    }
+
+    [Fact]
+    public void ToolsCall_EscapedRequestId_TruncatesAuditRequestId_Issue3306()
+    {
+        using var sink = new AuditLogSink(_auditPath, AuditLogSink.DefaultMaxBytes, includeValues: false);
+        using var server = CreateServer(sink);
+        var id = new string('\u3042', 43);
+        Assert.True(id.Length <= McpServer.MaxRequestIdCharacterCount);
+        Assert.True(Encoding.UTF8.GetByteCount(id) <= McpServer.MaxRequestIdByteLength);
+        var serializedId = JsonSerializer.Serialize(id);
+        Assert.True(serializedId.Length > AuditLogSink.MaxRequestIdChars);
+        var requestIdDisplay = McpBoundedText.ForDisplay(serializedId, AuditLogSink.MaxRequestIdChars);
+        var request = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = id,
+            ["method"] = "tools/call",
+            ["params"] = new JsonObject
+            {
+                ["name"] = "ping",
+                ["arguments"] = new JsonObject(),
+            },
+        };
+
+        var response = server.HandleMessage(request)!;
+
+        Assert.False(response.AsObject().ContainsKey("error"));
+        Assert.NotNull(response["result"]);
+        var record = ReadOnlyRecord();
+        Assert.Equal(requestIdDisplay.Text, record.GetProperty("request_id").GetString());
+        Assert.Equal(serializedId.Length, record.GetProperty("request_id_length").GetInt32());
+        Assert.True(record.GetProperty("request_id_truncated").GetBoolean());
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/McpAuditLogTests.cs
+++ b/tests/CodeIndex.Tests/McpAuditLogTests.cs
@@ -463,12 +463,13 @@ public class McpAuditLogTests : IDisposable
     }
 
     [Fact]
-    public void ToolsCall_MaxLengthRequestId_PreservesAuditRequestId_Issue3237()
+    public void ToolsCall_MaxLengthRequestId_PreservesAuditRequestId_Issue3237_3307()
     {
         using var sink = new AuditLogSink(_auditPath, AuditLogSink.DefaultMaxBytes, includeValues: false);
         using var server = CreateServer(sink);
         var id = new string('r', McpServer.MaxRequestIdCharacterCount);
         var serializedId = JsonSerializer.Serialize(id);
+        Assert.True(serializedId.Length <= AuditLogSink.MaxRequestIdChars);
         var request = new JsonObject
         {
             ["jsonrpc"] = "2.0",

--- a/tests/CodeIndex.Tests/McpAuditLogTests.cs
+++ b/tests/CodeIndex.Tests/McpAuditLogTests.cs
@@ -127,7 +127,7 @@ public class McpAuditLogTests : IDisposable
     }
 
     [Fact]
-    public void ToolsCall_OversizedRequestId_IsRejectedBeforeAuditRecord_Issue3104()
+    public void ToolsCall_OversizedRequestId_IsRejectedBeforeAuditRecord_Issue3104_3308()
     {
         using var sink = new AuditLogSink(_auditPath, AuditLogSink.DefaultMaxBytes, includeValues: false);
         using var server = CreateServer(sink);


### PR DESCRIPTION
## Summary

- Added MCP audit regression coverage for a JSON-RPC request id that passes validation but exceeds the audit display cap after JSON escaping.
- Clarified the max-valid request-id boundary and the oversized-id rejection audit boundary.
- Added a bilingual changelog fragment for the three duplicate audit test issues.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpAuditLogTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false --no-restore`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false --no-restore`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/3306-3308.fixed.md`.
- No README or developer-guide updates were required because this changes regression coverage only, not runtime behavior or user-facing output.

## Issues

Fixes #3306
Fixes #3307
Fixes #3308

## Follow-up Candidates

None.