### PR TITLE
Bound oversized diagnostics across CLI and MCP

### DIFF
--- a/changelog.d/unreleased/3090.fixed.md
+++ b/changelog.d/unreleased/3090.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3090
+affected:
+  - src/CodeIndex/Mcp/RateLimiter.cs
+  - tests/CodeIndex.Tests/RateLimiterTests.cs
+---
+
+## English
+
+- **MCP rate-limiter environment warnings now truncate oversized values (#3090)** — invalid or clamped `CDIDX_MCP_RATE_LIMIT_*` diagnostics bound the echoed environment value before writing warnings.
+
+## 日本語
+
+- **MCP rate limiter の環境変数 warning は過大な値を切り詰めるようになりました (#3090)** — invalid / clamp される `CDIDX_MCP_RATE_LIMIT_*` 診断は、warning に出す環境変数値を上限付き表示にします。

--- a/changelog.d/unreleased/3091.fixed.md
+++ b/changelog.d/unreleased/3091.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3091
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP keep-alive interval warnings now truncate oversized environment values (#3091)** — invalid `CDIDX_MCP_KEEP_ALIVE_INTERVAL_S` diagnostics bound the echoed raw value before writing stderr.
+
+## 日本語
+
+- **MCP keep-alive interval warning は過大な環境変数値を切り詰めるようになりました (#3091)** — invalid な `CDIDX_MCP_KEEP_ALIVE_INTERVAL_S` 診断は、stderr に出す raw 値を上限付き表示にします。

--- a/changelog.d/unreleased/3092.fixed.md
+++ b/changelog.d/unreleased/3092.fixed.md
@@ -1,0 +1,25 @@
+---
+category: fixed
+issues:
+  - 3092
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Parse.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/HookCommandRunner.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerGraphTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerMapTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+---
+
+## English
+
+- **CLI option diagnostics now bound user-supplied values (#3092)** — index, query, and hooks warnings/errors now use the shared bounded display formatter before echoing option tokens or values, truncating oversized input and flattening control characters.
+
+## 日本語
+
+- **CLI option 診断はユーザー指定値を上限付き表示にするようになりました (#3092)** — index / query / hooks の warning / error は option token や値を表示する前に共有の bounded display formatter を通し、過大入力を切り詰めて制御文字を空白化します。

--- a/changelog.d/unreleased/3093.security.md
+++ b/changelog.d/unreleased/3093.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3093
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+---
+
+## English
+
+- **Database path diagnostics now truncate oversized `--db` values (#3093)** — query and batch database errors keep the URI/path kind visible while bounding echoed database paths before writing stderr.
+
+## 日本語
+
+- **database path 診断は過大な `--db` 値を切り詰めるようになりました (#3093)** — query / batch の database error は URI/path の種別を残しつつ、stderr に出す database path を上限付き表示にしました。

--- a/changelog.d/unreleased/3094.fixed.md
+++ b/changelog.d/unreleased/3094.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3094
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+---
+
+## English
+
+- **Batch-row skip warnings now truncate oversized row details (#3094)** — `DbWriter` bounds row identifiers and batch/row exception messages before emitting skipped-row diagnostics.
+
+## 日本語
+
+- **batch-row skip warning は過大な row 詳細を切り詰めるようになりました (#3094)** — `DbWriter` は skipped-row 診断を出す前に row identifier と batch / row exception message を上限付き表示にします。

--- a/changelog.d/unreleased/3095.fixed.md
+++ b/changelog.d/unreleased/3095.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3095
+affected:
+  - src/CodeIndex/Cli/MacProfileDetector.cs
+  - tests/CodeIndex.Tests/MacProfileDetectorTests.cs
+---
+
+## English
+
+- **MAC profile detection now bounds proc-attr reads and hint output (#3095)** — `/proc/self/attr/*` reads are capped, and oversized AppArmor/SELinux profile strings are truncated before appearing in database-access hints.
+
+## 日本語
+
+- **MAC profile 検出は proc-attr 読み取りと hint 出力を上限付きにしました (#3095)** — `/proc/self/attr/*` の読み取りを制限し、過大な AppArmor / SELinux profile 文字列は database-access hint に出す前に切り詰めます。

--- a/changelog.d/unreleased/3135.fixed.md
+++ b/changelog.d/unreleased/3135.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3135
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.Parse.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Invalid `CDIDX_NOTIFY` values now warn before falling back (#3135)** — index argument parsing reports bounded stderr warnings for unsupported notification modes instead of silently ignoring the environment value.
+
+## 日本語
+
+- **無効な `CDIDX_NOTIFY` 値は fallback 前に warning を出すようになりました (#3135)** — index の引数解析は未対応の notification mode を黙って無視せず、上限付きの stderr warning として報告します。

--- a/changelog.d/unreleased/3181.fixed.md
+++ b/changelog.d/unreleased/3181.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3181
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+---
+
+## English
+
+- **Did-you-mean suggestions now reject oversized inputs before distance matching (#3181)** — command, flag, language, and kind suggestions skip values beyond the diagnostic display limit so typo matching does not allocate large edit-distance matrices for malformed input.
+
+## 日本語
+
+- **Did-you-mean 候補は距離計算前に過大入力を拒否するようになりました (#3181)** — command / flag / language / kind の候補提示は診断表示上限を超える値をスキップし、不正な入力で巨大な編集距離行列を割り当てないようになりました。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -128,6 +128,7 @@ public static class ConsoleUi
         => $"{indent}{label.PadRight(labelWidth)}: {value}";
 
     internal const int DefaultDiagnosticValueCharLimit = 120;
+    internal const int MaxSuggestionInputCharLength = DefaultDiagnosticValueCharLimit;
 
     internal readonly record struct BoundedDisplayText(string Text, bool Truncated, int OriginalLength);
 
@@ -1231,15 +1232,17 @@ public static class ConsoleUi
     /// </summary>
     public static string? FindClosestMatch(string? input, IEnumerable<string> candidates)
     {
-        if (string.IsNullOrWhiteSpace(input))
+        var normalized = NormalizeSuggestionInput(input);
+        if (normalized == null)
             return null;
 
-        var normalized = input.ToLowerInvariant();
         string? best = null;
         var bestDist = int.MaxValue;
         foreach (var candidate in candidates)
         {
             if (string.IsNullOrEmpty(candidate))
+                continue;
+            if (candidate.Length > MaxSuggestionInputCharLength)
                 continue;
             var candidateNormalized = candidate.ToLowerInvariant();
             if (string.Equals(normalized, candidateNormalized, StringComparison.Ordinal))
@@ -1265,14 +1268,16 @@ public static class ConsoleUi
     /// </summary>
     public static IReadOnlyList<string> FindClosestMatches(string? input, IEnumerable<string> candidates, int maxResults = 3)
     {
-        if (string.IsNullOrWhiteSpace(input) || maxResults <= 0)
+        var normalized = NormalizeSuggestionInput(input);
+        if (normalized == null || maxResults <= 0)
             return Array.Empty<string>();
 
-        var normalized = input.ToLowerInvariant();
         var matches = new List<(string Candidate, int Distance)>();
         foreach (var candidate in candidates)
         {
             if (string.IsNullOrEmpty(candidate))
+                continue;
+            if (candidate.Length > MaxSuggestionInputCharLength)
                 continue;
             var candidateNormalized = candidate.ToLowerInvariant();
             if (string.Equals(normalized, candidateNormalized, StringComparison.Ordinal))
@@ -1288,6 +1293,14 @@ public static class ConsoleUi
             .Select(m => m.Candidate)
             .Take(maxResults)
             .ToList();
+    }
+
+    private static string? NormalizeSuggestionInput(string? input)
+    {
+        if (input == null || input.Length > MaxSuggestionInputCharLength || string.IsNullOrWhiteSpace(input))
+            return null;
+
+        return input.ToLowerInvariant();
     }
 
     private static int GetSuggestionDistanceThreshold(int inputLength, int commandLength)

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -140,18 +140,39 @@ public static class ConsoleUi
         if (value == null)
             return new BoundedDisplayText("<null>", Truncated: false, OriginalLength: 0);
 
-        if (value.Length <= maxChars)
-            return new BoundedDisplayText(value, Truncated: false, value.Length);
+        var displayValue = FlattenDiagnosticControlChars(value);
+        if (displayValue.Length <= maxChars)
+            return new BoundedDisplayText(displayValue, Truncated: false, value.Length);
 
         var marker = string.Create(CultureInfo.InvariantCulture, $"... <truncated; original length {value.Length} chars>");
         var text = maxChars == 0
             ? marker.TrimStart('.', ' ')
-            : value[..maxChars] + marker;
+            : displayValue[..maxChars] + marker;
         return new BoundedDisplayText(text, Truncated: true, value.Length);
     }
 
     internal static string FormatBoundedValue(string? value, int maxChars = DefaultDiagnosticValueCharLimit)
         => BoundDisplayText(value, maxChars).Text;
+
+    private static string FlattenDiagnosticControlChars(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (char.IsControl(value[i]))
+            {
+                var chars = value.ToCharArray();
+                for (var j = i; j < chars.Length; j++)
+                {
+                    if (char.IsControl(chars[j]))
+                        chars[j] = ' ';
+                }
+
+                return new string(chars);
+            }
+        }
+
+        return value;
+    }
 
     private const int SpinnerFrameDelayMs = 100;
     private const int SpinnerStopDelayMs = 20;

--- a/src/CodeIndex/Cli/HookCommandRunner.cs
+++ b/src/CodeIndex/Cli/HookCommandRunner.cs
@@ -65,7 +65,10 @@ public static class HookCommandRunner
                     break;
                 default:
                     if (args[i].StartsWith("-", StringComparison.Ordinal))
-                        Console.Error.WriteLine($"Warning: unknown option '{args[i]}' (ignored) / 不明なオプション '{args[i]}'（無視されます）");
+                    {
+                        var displayValue = ConsoleUi.FormatBoundedValue(args[i]);
+                        Console.Error.WriteLine($"Warning: unknown option '{displayValue}' (ignored) / 不明なオプション '{displayValue}'（無視されます）");
+                    }
                     else if (command == null)
                         command = args[i];
                     else
@@ -137,7 +140,7 @@ public static class HookCommandRunner
     {
         if (!options.Json)
             PrintUsage();
-        return WriteResult(options.Json, jsonOptions, "error", $"unknown hooks command: {options.Command}", projectPath, null, null, CommandExitCodes.UsageError);
+        return WriteResult(options.Json, jsonOptions, "error", $"unknown hooks command: {ConsoleUi.FormatBoundedValue(options.Command)}", projectPath, null, null, CommandExitCodes.UsageError);
     }
 
     private static bool IsManagedHook(string content)

--- a/src/CodeIndex/Cli/IndexCommandRunner.Parse.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Parse.cs
@@ -21,6 +21,7 @@ public static partial class IndexCommandRunner
         "--read-only", "--immutable",
     ];
 
+    internal const string CompletionNotificationEnvironmentVariable = "CDIDX_NOTIFY";
     internal const string IndexParallelismEnvironmentVariable = "CDIDX_INDEX_PARALLELISM";
     internal const int MaxIndexParallelism = 16;
     internal const int MaxSymbolKindFilterCsvLength = 2048;
@@ -524,12 +525,16 @@ public static partial class IndexCommandRunner
 
     private static CompletionNotificationMode ReadCompletionNotificationModeFromEnvironment()
     {
-        var value = Environment.GetEnvironmentVariable("CDIDX_NOTIFY");
+        var value = Environment.GetEnvironmentVariable(CompletionNotificationEnvironmentVariable);
         if (string.IsNullOrWhiteSpace(value))
             return CompletionNotificationMode.Auto;
 
-        string? ignored = null;
-        return ParseCompletionNotificationMode(value, CompletionNotificationMode.Auto, ref ignored);
+        string? parseError = null;
+        var mode = ParseCompletionNotificationMode(value, CompletionNotificationMode.Auto, ref parseError);
+        if (parseError != null)
+            WarnInvalidCompletionNotificationEnvironmentValue(value);
+
+        return mode;
     }
 
     private static CompletionNotificationMode ParseCompletionNotificationMode(string value, CompletionNotificationMode fallback, ref string? parseError)
@@ -549,6 +554,12 @@ public static partial class IndexCommandRunner
     {
         parseError ??= $"invalid --notify value '{ConsoleUi.FormatBoundedValue(value)}': expected auto, bell, osc9, desktop, or none";
         return fallback;
+    }
+
+    private static void WarnInvalidCompletionNotificationEnvironmentValue(string value)
+    {
+        var displayValue = ConsoleUi.FormatBoundedValue(value);
+        Console.Error.WriteLine($"Warning: invalid {CompletionNotificationEnvironmentVariable} value '{displayValue}' (ignored; use auto, bell, osc9, desktop, or none) / 不正な {CompletionNotificationEnvironmentVariable} 値 '{displayValue}'（無視。auto, bell, osc9, desktop, none のいずれかを指定）");
     }
 
     private static string? AbsolutizePathOption(string? value)

--- a/src/CodeIndex/Cli/IndexCommandRunner.Parse.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Parse.cs
@@ -136,7 +136,8 @@ public static partial class IndexCommandRunner
                     }
                     else
                     {
-                        Console.Error.WriteLine($"Warning: invalid --debounce value '{args[i + 1]}' (ignored; must be a non-negative integer in milliseconds) / 不正な --debounce 値 '{args[i + 1]}'（無視。ミリ秒の0以上の整数を指定）");
+                        var displayValue = ConsoleUi.FormatBoundedValue(args[i + 1]);
+                        Console.Error.WriteLine($"Warning: invalid --debounce value '{displayValue}' (ignored; must be a non-negative integer in milliseconds) / 不正な --debounce 値 '{displayValue}'（無視。ミリ秒の0以上の整数を指定）");
                         i++;
                     }
                     break;
@@ -338,7 +339,7 @@ public static partial class IndexCommandRunner
             case "all":
                 return FileIndexer.SymlinkPolicy.All;
             default:
-                parseError ??= $"invalid --follow-symlinks value '{value}': expected none, internal, or all";
+                parseError ??= $"invalid --follow-symlinks value '{ConsoleUi.FormatBoundedValue(value)}': expected none, internal, or all";
                 return fallback;
         }
     }
@@ -347,9 +348,10 @@ public static partial class IndexCommandRunner
     {
         var name = TrimInlineValue(token);
         var suggestion = ConsoleUi.FindClosestMatch(name, AcceptedIndexFlags);
+        var displayToken = ConsoleUi.FormatBoundedValue(token);
         return suggestion == null
-            ? $"unknown option '{token}'"
-            : $"unknown option '{token}'\nDid you mean: {suggestion}?";
+            ? $"unknown option '{displayToken}'"
+            : $"unknown option '{displayToken}'\nDid you mean: {suggestion}?";
     }
 
     private static string TrimInlineValue(string token)
@@ -452,11 +454,13 @@ public static partial class IndexCommandRunner
             if (parsed <= MaxIndexParallelism)
                 return parsed;
 
-            Console.Error.WriteLine($"Warning: {source} value '{value}' exceeds the maximum {MaxIndexParallelism}; using {MaxIndexParallelism} / {source} 値 '{value}' は最大 {MaxIndexParallelism} を超えています。{MaxIndexParallelism} を使用します");
+            var displayValue = ConsoleUi.FormatBoundedValue(value);
+            Console.Error.WriteLine($"Warning: {source} value '{displayValue}' exceeds the maximum {MaxIndexParallelism}; using {MaxIndexParallelism} / {source} 値 '{displayValue}' は最大 {MaxIndexParallelism} を超えています。{MaxIndexParallelism} を使用します");
             return MaxIndexParallelism;
         }
 
-        Console.Error.WriteLine($"Warning: invalid {source} value '{value}' (ignored; use a positive integer) / 不正な {source} 値 '{value}'（無視。正の整数を指定）");
+        var invalidDisplayValue = ConsoleUi.FormatBoundedValue(value);
+        Console.Error.WriteLine($"Warning: invalid {source} value '{invalidDisplayValue}' (ignored; use a positive integer) / 不正な {source} 値 '{invalidDisplayValue}'（無視。正の整数を指定）");
         return fallback;
     }
 
@@ -469,7 +473,8 @@ public static partial class IndexCommandRunner
         if (FileIndexer.TryParseMaxFileSizeBytes(value, out var parsed))
             return parsed;
 
-        Console.Error.WriteLine($"Warning: invalid {FileIndexer.MaxFileSizeEnvironmentVariable} value '{value}' (ignored; use positive bytes or K/M/G suffixes) / 不正な {FileIndexer.MaxFileSizeEnvironmentVariable} 値 '{value}'（無視。正の byte 数または K/M/G 接尾辞を指定）");
+        var displayValue = ConsoleUi.FormatBoundedValue(value);
+        Console.Error.WriteLine($"Warning: invalid {FileIndexer.MaxFileSizeEnvironmentVariable} value '{displayValue}' (ignored; use positive bytes or K/M/G suffixes) / 不正な {FileIndexer.MaxFileSizeEnvironmentVariable} 値 '{displayValue}'（無視。正の byte 数または K/M/G 接尾辞を指定）");
         return null;
     }
 
@@ -478,7 +483,8 @@ public static partial class IndexCommandRunner
         if (FileIndexer.TryParseMaxFileSizeBytes(value, out var parsed))
             return parsed;
 
-        Console.Error.WriteLine($"Warning: invalid --max-file-bytes value '{value}' (ignored; use positive bytes or K/M/G suffixes) / 不正な --max-file-bytes 値 '{value}'（無視。正の byte 数または K/M/G 接尾辞を指定）");
+        var displayValue = ConsoleUi.FormatBoundedValue(value);
+        Console.Error.WriteLine($"Warning: invalid --max-file-bytes value '{displayValue}' (ignored; use positive bytes or K/M/G suffixes) / 不正な --max-file-bytes 値 '{displayValue}'（無視。正の byte 数または K/M/G 接尾辞を指定）");
         return fallback;
     }
 
@@ -493,7 +499,8 @@ public static partial class IndexCommandRunner
             return fallback;
         }
 
-        Console.Error.WriteLine($"Warning: invalid {source} value '{value}' (ignored; use a positive integer) / 不正な {source} 値 '{value}'（無視。正の整数を指定）");
+        var displayValue = ConsoleUi.FormatBoundedValue(value);
+        Console.Error.WriteLine($"Warning: invalid {source} value '{displayValue}' (ignored; use a positive integer) / 不正な {source} 値 '{displayValue}'（無視。正の整数を指定）");
         return fallback;
     }
 
@@ -510,7 +517,8 @@ public static partial class IndexCommandRunner
 
     private static DurationOutputFormat WarnInvalidDurationFormat(string value, DurationOutputFormat fallback)
     {
-        Console.Error.WriteLine($"Warning: invalid --duration-format value '{value}' (ignored; use auto, seconds, or hms) / 不正な --duration-format 値 '{value}'（無視。auto, seconds, hms のいずれかを指定）");
+        var displayValue = ConsoleUi.FormatBoundedValue(value);
+        Console.Error.WriteLine($"Warning: invalid --duration-format value '{displayValue}' (ignored; use auto, seconds, or hms) / 不正な --duration-format 値 '{displayValue}'（無視。auto, seconds, hms のいずれかを指定）");
         return fallback;
     }
 
@@ -539,7 +547,7 @@ public static partial class IndexCommandRunner
 
     private static CompletionNotificationMode WarnInvalidCompletionNotificationMode(string value, CompletionNotificationMode fallback, ref string? parseError)
     {
-        parseError ??= $"invalid --notify value '{value}': expected auto, bell, osc9, desktop, or none";
+        parseError ??= $"invalid --notify value '{ConsoleUi.FormatBoundedValue(value)}': expected auto, bell, osc9, desktop, or none";
         return fallback;
     }
 

--- a/src/CodeIndex/Cli/MacProfileDetector.cs
+++ b/src/CodeIndex/Cli/MacProfileDetector.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Text;
 using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Cli;
@@ -7,9 +8,10 @@ internal static class MacProfileDetector
 {
     internal const string CurrentAttrPath = "/proc/self/attr/current";
     internal const string ExecAttrPath = "/proc/self/attr/exec";
+    internal const int MaxProcAttrReadChars = 4096;
 
     public static string? DetectCurrent()
-        => DetectCurrent(File.ReadAllText);
+        => DetectCurrent(ReadProcAttrFile);
 
     internal static string? DetectCurrent(Func<string, string> readAllText)
     {
@@ -24,6 +26,9 @@ internal static class MacProfileDetector
 
     internal static string? DetectFromProcAttrs(string? current, string? exec)
     {
+        current = BoundProcAttrValue(current);
+        exec = BoundProcAttrValue(exec);
+
         var appArmor = TryExtractAppArmorProfile(current) ?? TryExtractAppArmorProfile(exec);
         if (appArmor != null)
             return $"apparmor:{appArmor}";
@@ -37,29 +42,57 @@ internal static class MacProfileDetector
         if (string.IsNullOrWhiteSpace(profile))
             return "Hint: check that `--db` points to a readable SQLite file, verify parent directory permissions, move the index to a writable location, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.";
 
+        var displayProfile = FormatProfileForHint(profile);
         if (profile.StartsWith("apparmor:", StringComparison.OrdinalIgnoreCase))
-            return $"Hint: this looks like an AppArmor confinement restriction ({profile}); check `aa-status`, snap/flatpak permissions, and audit logs, move the index to a writable location, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.";
+            return $"Hint: this looks like an AppArmor confinement restriction ({displayProfile}); check `aa-status`, snap/flatpak permissions, and audit logs, move the index to a writable location, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.";
 
         if (profile.StartsWith("selinux:", StringComparison.OrdinalIgnoreCase))
-            return $"Hint: this looks like an SELinux confinement restriction ({profile}); check `getenforce`, `ausearch`, and `audit2why`, move the index to a writable location, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.";
+            return $"Hint: this looks like an SELinux confinement restriction ({displayProfile}); check `getenforce`, `ausearch`, and `audit2why`, move the index to a writable location, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.";
 
-        return $"Hint: this looks like a Linux MAC confinement restriction ({profile}); check AppArmor/SELinux audit logs, move the index to a writable location, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.";
+        return $"Hint: this looks like a Linux MAC confinement restriction ({displayProfile}); check AppArmor/SELinux audit logs, move the index to a writable location, or use a SQLite `file:` URI with `immutable=1` for read-only mounts.";
     }
 
     internal static bool IsPermissionStyleSqliteError(SqliteException ex)
         => ex.SqliteErrorCode is 3 or 10 or 14 or 23;
 
+    internal static string ReadProcAttrFileForTesting(string path) => ReadProcAttrFile(path);
+
     private static string? ReadProcAttr(Func<string, string> readAllText, string path)
     {
         try
         {
-            var value = readAllText(path).Trim();
+            var value = BoundProcAttrValue(readAllText(path))?.Trim();
             return string.IsNullOrWhiteSpace(value) ? null : value;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {
             return null;
         }
+    }
+
+    private static string ReadProcAttrFile(string path)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: false);
+        var buffer = new char[MaxProcAttrReadChars];
+        var read = reader.ReadBlock(buffer, 0, buffer.Length);
+        return new string(buffer, 0, read);
+    }
+
+    private static string? BoundProcAttrValue(string? value)
+    {
+        if (value == null)
+            return null;
+
+        return value.Length <= MaxProcAttrReadChars ? value : value[..MaxProcAttrReadChars];
+    }
+
+    private static string FormatProfileForHint(string profile)
+    {
+        return ConsoleUi.FormatBoundedValue(profile)
+            .Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
     }
 
     private static string? TryExtractAppArmorProfile(string? value)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -301,7 +301,7 @@ public static class QueryCommandRunner
         var isUri = dbPath.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
         if (!isUri && !File.Exists(dbPath))
         {
-            Console.Error.WriteLine($"Error [{CommandErrorCodes.DbNotFound}]: database not found at {Path.GetFullPath(dbPath)}");
+            Console.Error.WriteLine($"Error [{CommandErrorCodes.DbNotFound}]: database not found at {FormatDbDiagnosticValue(Path.GetFullPath(dbPath))}");
             Console.Error.WriteLine("Hint: create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command.");
             return CommandExitCodes.DatabaseError;
         }
@@ -7373,7 +7373,7 @@ public static class QueryCommandRunner
             {
                 if (!DbPathResolver.TryNormalizeDbPath(dbPath, out fileExistsPath, out var parseError))
                 {
-                    var boundedDbPath = SqliteFileUri.TruncateDiagnosticValue(dbPath);
+                    var boundedDbPath = FormatDbDiagnosticValue(dbPath);
                     Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: invalid --db file URI: {SqliteFileUri.FormatParseError(parseError)}");
                     Console.Error.WriteLine($"Hint: pass a valid SQLite file URI such as `file:///absolute/path/to/codeindex.db?immutable=1`; the --db value resolved to: {boundedDbPath}");
                     GlobalToolLog.Error($"invalid_db_file_uri db={FormatLogValue(dbPath)} exception={FormatLogValue(parseError?.ToString() ?? "<unknown>")}");
@@ -7385,9 +7385,10 @@ public static class QueryCommandRunner
                 && !File.Exists(LongPath.EnsureWindowsPrefix(fileExistsPath)))
             {
                 var resolvedPath = Path.GetFullPath(fileExistsPath);
-                Console.Error.WriteLine($"Error [{CommandErrorCodes.DbNotFound}]: database not found at {resolvedPath}");
+                var displayPath = FormatDbDiagnosticValue(resolvedPath);
+                Console.Error.WriteLine($"Error [{CommandErrorCodes.DbNotFound}]: database not found at {displayPath}");
                 if (isUri)
-                    Console.Error.WriteLine($"Hint: the --db path resolved to: {resolvedPath}");
+                    Console.Error.WriteLine($"Hint: the --db path resolved to: {displayPath}");
                 Console.Error.WriteLine("Hint: create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command.");
                 return CommandExitCodes.DatabaseError;
             }
@@ -7487,7 +7488,7 @@ public static class QueryCommandRunner
 
     private static int WriteInvalidCodeIndexDbError(string dbPath, string? validationReason)
     {
-        Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: {dbPath} does not appear to be a valid CodeIndex database ({validationReason}).");
+        Console.Error.WriteLine($"Error [{CommandErrorCodes.DbError}]: {FormatDbDiagnosticValue(dbPath)} does not appear to be a valid CodeIndex database ({validationReason}).");
         Console.Error.WriteLine("Hint: rebuild with `cdidx index <projectPath> --db <path>` to create a fresh database.");
         return CommandExitCodes.DatabaseError;
     }
@@ -7570,6 +7571,17 @@ public static class QueryCommandRunner
 
         return SqliteFileUri.TruncateDiagnosticValue(value)
             .Replace("\\", "/", StringComparison.Ordinal)
+            .Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
+    }
+
+    private static string FormatDbDiagnosticValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return "<empty>";
+
+        return SqliteFileUri.TruncateDiagnosticValue(value)
             .Replace("\r", " ", StringComparison.Ordinal)
             .Replace("\n", " ", StringComparison.Ordinal)
             .Replace("\t", " ", StringComparison.Ordinal);
@@ -7703,7 +7715,7 @@ public static class QueryCommandRunner
         if (File.Exists(LongPath.EnsureWindowsPrefix(options.DbPath)))
             return null;
 
-        return $"Error [{CommandErrorCodes.DbNotFound}]: --db '{options.DbPath}' does not point to an existing database file.";
+        return $"Error [{CommandErrorCodes.DbNotFound}]: --db '{FormatDbDiagnosticValue(options.DbPath)}' does not point to an existing database file.";
     }
 
     private static readonly HashSet<string> KnownSymbolKindFilters = new(StringComparer.Ordinal)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -293,7 +293,7 @@ public static class QueryCommandRunner
                 continue;
             }
 
-            Console.Error.WriteLine($"Error: {arg} is not supported for batch.");
+            Console.Error.WriteLine($"Error: {ConsoleUi.FormatBoundedValue(arg)} is not supported for batch.");
             Console.Error.WriteLine($"Usage: {ConsoleUi.GetUsageLine("batch")}");
             return CommandExitCodes.UsageError;
         }
@@ -2882,32 +2882,32 @@ public static class QueryCommandRunner
                     i++;
                 }
                 if ((arg == "--limit" || arg == "--top") && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var limit) || limit <= 0))
-                    return BuildPositiveIntegerError("--limit", value, arg);
+                    return BuildPositiveIntegerError("--limit", ConsoleUi.FormatBoundedValue(value), arg);
                 if ((arg == "--limit" || arg == "--top")
                     && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var limitCeil)
                     && NumericFlagUpperBounds.TryGetValue("--limit", out var limitMax)
                     && limitCeil > limitMax)
-                    return BuildPositiveIntegerUpperBoundError("--limit", value, limitMax);
+                    return BuildPositiveIntegerUpperBoundError("--limit", ConsoleUi.FormatBoundedValue(value), limitMax);
                 if (arg == "--max-line-width" && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var widthValue) || widthValue < 0))
-                    return BuildNonNegativeIntegerError(arg, value);
+                    return BuildNonNegativeIntegerError(arg, ConsoleUi.FormatBoundedValue(value));
                 if (arg == "--max-line-width" && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var widthCeil) && widthCeil > LineWidthFormatter.MaxAllowedLineWidth)
-                    return BuildNonNegativeIntegerUpperBoundError("--max-line-width", value, LineWidthFormatter.MaxAllowedLineWidth);
+                    return BuildNonNegativeIntegerUpperBoundError("--max-line-width", ConsoleUi.FormatBoundedValue(value), LineWidthFormatter.MaxAllowedLineWidth);
                 if ((arg == "--before" || arg == "--after") && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var context) || context < 0))
-                    return BuildNonNegativeIntegerError(arg, value);
+                    return BuildNonNegativeIntegerError(arg, ConsoleUi.FormatBoundedValue(value));
                 if ((arg == "--before" || arg == "--after")
                     && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var contextCeil)
                     && NumericFlagUpperBounds.TryGetValue(arg, out var contextMax)
                     && contextCeil > contextMax)
-                    return BuildNonNegativeIntegerUpperBoundError(arg, value, contextMax);
+                    return BuildNonNegativeIntegerUpperBoundError(arg, ConsoleUi.FormatBoundedValue(value), contextMax);
                 if (arg == "--snippet-lines" && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var snippetLines) || snippetLines <= 0))
-                    return BuildPositiveIntegerError(arg, value, arg);
+                    return BuildPositiveIntegerError(arg, ConsoleUi.FormatBoundedValue(value), arg);
                 if (arg == "--snippet-lines"
                     && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var snippetLinesCeil)
                     && NumericFlagUpperBounds.TryGetValue(arg, out var snippetLinesMax)
                     && snippetLinesCeil > snippetLinesMax)
-                    return BuildPositiveIntegerUpperBoundError(arg, value, snippetLinesMax);
+                    return BuildPositiveIntegerUpperBoundError(arg, ConsoleUi.FormatBoundedValue(value), snippetLinesMax);
                 if ((arg == "--focus-line" || arg == "--focus-column") && (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var focus) || focus <= 0))
-                    return BuildPositiveIntegerError(arg, value, arg);
+                    return BuildPositiveIntegerError(arg, ConsoleUi.FormatBoundedValue(value), arg);
                 if (arg == "--query")
                 {
                     queryCount++;
@@ -2922,7 +2922,7 @@ public static class QueryCommandRunner
 
             if (rawArg.StartsWith('-'))
             {
-                var error = $"Error: unsupported option for find: {rawArg}";
+                var error = $"Error: unsupported option for find: {ConsoleUi.FormatBoundedValue(rawArg)}";
                 // Suggest the closest accepted find flag for typos like `--paht` → `--path`
                 // (#1582). Strip any inline `=value` portion before matching, since the prefix
                 // might not have been a recognized value-taking option (TrySplitInlineOptionValue
@@ -4579,7 +4579,7 @@ public static class QueryCommandRunner
             case OutputFormatJsonGraph:
                 return true;
             default:
-                error = $"Error: deps --format must be one of edgelist, dot, graphml, or json-graph; got '{rawFormat}'.";
+                error = $"Error: deps --format must be one of edgelist, dot, graphml, or json-graph; got '{ConsoleUi.FormatBoundedValue(rawFormat)}'.";
                 return false;
         }
     }
@@ -5990,7 +5990,7 @@ public static class QueryCommandRunner
                         statusCheckScopes.Add(scope);
                         break;
                     default:
-                        AddParseError($"Error: unsupported --check scope '{rawScope}'. Use one or more of workspace, fold, graph, issues, hotspot, csharp, sql, newer.");
+                        AddParseError($"Error: unsupported --check scope '{ConsoleUi.FormatBoundedValue(rawScope)}'. Use one or more of workspace, fold, graph, issues, hotspot, csharp, sql, newer.");
                         break;
                 }
             }
@@ -6010,7 +6010,8 @@ public static class QueryCommandRunner
         {
             if (seenSingleValueOptions.Add(canonicalName))
                 return;
-            Console.Error.WriteLine($"Warning: {canonicalName} specified more than once; the rightmost CLI value '{newValue}' takes precedence over earlier CLI values and any environment/config default.");
+            var displayValue = ConsoleUi.FormatBoundedValue(newValue);
+            Console.Error.WriteLine($"Warning: {canonicalName} specified more than once; the rightmost CLI value '{displayValue}' takes precedence over earlier CLI values and any environment/config default.");
         }
 
         for (int i = 0; i < args.Length; i++)
@@ -6100,7 +6101,7 @@ public static class QueryCommandRunner
                     }
                     else
                     {
-                        AddParseError($"Error: --json format must be one of ndjson or array, got '{inlineValue}'. Hint: use `--json` or `--json=ndjson` for newline-delimited JSON, or `--json=array` for a single JSON array.");
+                        AddParseError($"Error: --json format must be one of ndjson or array, got '{ConsoleUi.FormatBoundedValue(inlineValue)}'. Hint: use `--json` or `--json=ndjson` for newline-delimited JSON, or `--json=array` for a single JSON array.");
                     }
                     break;
                 case "--indexed-only":
@@ -6117,7 +6118,7 @@ public static class QueryCommandRunner
                     }
                     else
                     {
-                        AddParseError($"Error: unsupported --capability value '{capabilityValue}'. Use graph, symbols, or references.");
+                        AddParseError($"Error: unsupported --capability value '{ConsoleUi.FormatBoundedValue(capabilityValue)}'. Use graph, symbols, or references.");
                     }
                     break;
                 case "--format":
@@ -6142,7 +6143,7 @@ public static class QueryCommandRunner
                             var allowedFormats = allowIssueDraftsFormat
                                 ? "text, json, count, compact, csv, tsv, lsp, qf, sarif, or issue-drafts"
                                 : "text, json, count, compact, csv, tsv, lsp, qf, or sarif";
-                            AddParseError($"Error: --format must be one of {allowedFormats}; got '{formatValue}'.");
+                            AddParseError($"Error: --format must be one of {allowedFormats}; got '{ConsoleUi.FormatBoundedValue(formatValue)}'.");
                         }
                     }
                     else
@@ -6454,7 +6455,7 @@ public static class QueryCommandRunner
                         minEntrypointConfidence = parsedMinEntrypointConfidence;
                     }
                     else
-                        AddParseError($"Error: --min-entrypoint-confidence must be a number from 0.0 through 1.0; got '{minEntrypointConfidenceValue}'.");
+                        AddParseError($"Error: --min-entrypoint-confidence must be a number from 0.0 through 1.0; got '{ConsoleUi.FormatBoundedValue(minEntrypointConfidenceValue)}'.");
                     break;
                 case "--check":
                     if (allowStatusCheck)
@@ -6540,7 +6541,7 @@ public static class QueryCommandRunner
                     }
                     else
                     {
-                        AddParseError($"Error: unsupported option: {currentArg}. Use `--` before a query literal that starts with `-`.");
+                        AddParseError($"Error: unsupported option: {ConsoleUi.FormatBoundedValue(currentArg)}. Use `--` before a query literal that starts with `-`.");
                     }
                     break;
                 case "--path":
@@ -6588,7 +6589,7 @@ public static class QueryCommandRunner
                         since = parsedSince;
                     }
                     else
-                        AddParseError($"Error: could not parse --since value '{sinceValue}' as a date/time. Use ISO 8601 format (e.g. 2024-01-01 or 2024-01-01T00:00:00Z).");
+                        AddParseError($"Error: could not parse --since value '{ConsoleUi.FormatBoundedValue(sinceValue)}' as a date/time. Use ISO 8601 format (e.g. 2024-01-01 or 2024-01-01T00:00:00Z).");
                     break;
                 case "--start":
                 case "--start-line":
@@ -6701,7 +6702,7 @@ public static class QueryCommandRunner
                     }
                     else
                     {
-                        AddParseError($"Error: invalid --snippet-focus value '{snippetFocusValue}'. Use leftmost, quality, or proximity.");
+                        AddParseError($"Error: invalid --snippet-focus value '{ConsoleUi.FormatBoundedValue(snippetFocusValue)}'. Use leftmost, quality, or proximity.");
                     }
                     break;
                 case "--max-line-width":
@@ -6719,7 +6720,7 @@ public static class QueryCommandRunner
                 default:
                     if (args[i].StartsWith('-'))
                     {
-                        AddParseError($"Error: unsupported option: {args[i]}. Use `--` before a query literal that starts with `-`.");
+                        AddParseError($"Error: unsupported option: {ConsoleUi.FormatBoundedValue(args[i])}. Use `--` before a query literal that starts with `-`.");
                         break;
                     }
                     else if (query == null)
@@ -6873,7 +6874,7 @@ public static class QueryCommandRunner
                     sections.Add(section);
                     break;
                 default:
-                    addParseError($"Error: --sections contains unsupported section '{rawSection}'. Use one or more of tree, languages, hotspots, metrics.");
+                    addParseError($"Error: --sections contains unsupported section '{ConsoleUi.FormatBoundedValue(rawSection)}'. Use one or more of tree, languages, hotspots, metrics.");
                     break;
             }
         }
@@ -6941,7 +6942,7 @@ public static class QueryCommandRunner
                     canonical = "callees";
                     break;
                 default:
-                    addParseError($"Error: unsupported --fields value '{rawField}'. Use one or more of all, file, workspace, graph, definitions, body, nearby_symbols, references, callers, callees.");
+                    addParseError($"Error: unsupported --fields value '{ConsoleUi.FormatBoundedValue(rawField)}'. Use one or more of all, file, workspace, graph, definitions, body, nearby_symbols, references, callers, callees.");
                     continue;
             }
 
@@ -7066,7 +7067,7 @@ public static class QueryCommandRunner
     {
         if (TryFindUnsupportedBracketGlob(pattern, out var reason))
         {
-            addParseError($"Error: {optionName} '{pattern}' is not a valid glob: {reason}. Hint: escape '[' or ']' with a backslash when matching literal path characters, or use only '*' and '?' wildcards.");
+            addParseError($"Error: {optionName} '{ConsoleUi.FormatBoundedValue(pattern)}' is not a valid glob: {reason}. Hint: escape '[' or ']' with a backslash when matching literal path characters, or use only '*' and '?' wildcards.");
         }
     }
 
@@ -7174,7 +7175,7 @@ public static class QueryCommandRunner
                 groupBy = HotspotsGroupedByNameKind;
                 return true;
             default:
-                error = $"Error: unsupported hotspots --group-by value '{requestedGroupBy}'. Use symbol, file, or statement.";
+                error = $"Error: unsupported hotspots --group-by value '{ConsoleUi.FormatBoundedValue(requestedGroupBy)}'. Use symbol, file, or statement.";
                 return false;
         }
     }
@@ -7237,7 +7238,7 @@ public static class QueryCommandRunner
                 unit = TimeSpan.FromDays(1);
                 break;
             default:
-                error = $"Error: could not parse stale-after value '{value}'. Use a positive duration with m, h, or d suffix (e.g. 30m, 2h, 7d).";
+                error = $"Error: could not parse stale-after value '{ConsoleUi.FormatBoundedValue(value)}'. Use a positive duration with m, h, or d suffix (e.g. 30m, 2h, 7d).";
                 return false;
         }
 
@@ -7245,20 +7246,20 @@ public static class QueryCommandRunner
             !double.IsFinite(number) ||
             number <= 0)
         {
-            error = $"Error: could not parse stale-after value '{value}'. Use a positive duration with m, h, or d suffix (e.g. 30m, 2h, 7d).";
+            error = $"Error: could not parse stale-after value '{ConsoleUi.FormatBoundedValue(value)}'. Use a positive duration with m, h, or d suffix (e.g. 30m, 2h, 7d).";
             return false;
         }
 
         var ticks = number * unit.Ticks;
         if (ticks > TimeSpan.MaxValue.Ticks)
         {
-            error = $"Error: stale-after value '{value}' is too large.";
+            error = $"Error: stale-after value '{ConsoleUi.FormatBoundedValue(value)}' is too large.";
             return false;
         }
 
         if (ticks > MaxStaleAfter.Ticks)
         {
-            error = $"Error: stale-after value '{value}' exceeds the maximum {MaxStaleAfterDisplay}.";
+            error = $"Error: stale-after value '{ConsoleUi.FormatBoundedValue(value)}' exceeds the maximum {MaxStaleAfterDisplay}.";
             return false;
         }
 
@@ -7777,7 +7778,7 @@ public static class QueryCommandRunner
         {
             if (!KnownVisibilityFilters.Contains(value))
             {
-                addParseError($"Error: unsupported {optionName} value '{value}'. Use one or more of public, protected, internal, private.");
+                addParseError($"Error: unsupported {optionName} value '{ConsoleUi.FormatBoundedValue(value)}'. Use one or more of public, protected, internal, private.");
                 continue;
             }
 
@@ -7793,7 +7794,7 @@ public static class QueryCommandRunner
             && !alternateAcceptedKinds.Any(kinds => kinds.Contains(options.Kind)))
         {
             CommandErrorWriter.Write(
-                $"invalid --kind value `{options.Kind}`.",
+                $"invalid --kind value `{ConsoleUi.FormatBoundedValue(options.Kind)}`.",
                 $"use one of: {string.Join(", ", acceptedKinds)}.",
                 GetUsageLineOrThrow(commandName));
             return true;
@@ -7813,7 +7814,7 @@ public static class QueryCommandRunner
         if (options.UnusedBucket != null && !IsKnownUnusedBucket(options.UnusedBucket))
         {
             CommandErrorWriter.Write(
-                $"invalid --bucket value `{options.UnusedBucket}`.",
+                $"invalid --bucket value `{ConsoleUi.FormatBoundedValue(options.UnusedBucket)}`.",
                 $"use one of: {string.Join(", ", OrderedUnusedBuckets)}.",
                 GetUsageLineOrThrow("unused"));
             return true;
@@ -7822,7 +7823,7 @@ public static class QueryCommandRunner
         if (options.MinUnusedConfidence != null && !IsKnownUnusedConfidence(options.MinUnusedConfidence))
         {
             CommandErrorWriter.Write(
-                $"invalid --min-confidence value `{options.MinUnusedConfidence}`.",
+                $"invalid --min-confidence value `{ConsoleUi.FormatBoundedValue(options.MinUnusedConfidence)}`.",
                 "use one of: medium, low.",
                 GetUsageLineOrThrow("unused"));
             return true;
@@ -7932,11 +7933,12 @@ public static class QueryCommandRunner
             if (eq > 0)
                 nameForSuggestion = nameForSuggestion[..eq];
             var suggestion = ConsoleUi.FindClosestMatch(nameForSuggestion, supported.Where(o => o != "--"));
+            var displayArg = ConsoleUi.FormatBoundedValue(arg);
             var hint = suggestion == null
-                ? $"remove `{arg}` and rerun, or use only the options shown in `{commandName} --help`."
-                : $"Did you mean: {suggestion}? Remove `{arg}` and rerun, or use `{suggestion}` if that is what you meant.";
+                ? $"remove `{displayArg}` and rerun, or use only the options shown in `{commandName} --help`."
+                : $"Did you mean: {suggestion}? Remove `{displayArg}` and rerun, or use `{suggestion}` if that is what you meant.";
             CommandErrorWriter.Write(
-                $"{arg} is not supported for {commandName}.",
+                $"{displayArg} is not supported for {commandName}.",
                 hint,
                 GetUsageLineOrThrow(commandName));
             return true;
@@ -8952,11 +8954,11 @@ public static class QueryCommandRunner
 
         if (AllValidKinds.Contains(kind))
         {
-            Console.Error.WriteLine($"WARN: '{kind}' is a symbol kind, but --kind on '{command}' filters by reference kind ({string.Join(", ", acceptedKinds)}). Use symbols/definition/hotspots/unused to filter by symbol kind.");
+            Console.Error.WriteLine($"WARN: '{ConsoleUi.FormatBoundedValue(kind)}' is a symbol kind, but --kind on '{command}' filters by reference kind ({string.Join(", ", acceptedKinds)}). Use symbols/definition/hotspots/unused to filter by symbol kind.");
             return;
         }
 
-        Console.Error.WriteLine($"Hint: '{kind}' is not a known reference kind for '{command}'. Available reference kinds: {string.Join(", ", acceptedKinds)}");
+        Console.Error.WriteLine($"Hint: '{ConsoleUi.FormatBoundedValue(kind)}' is not a known reference kind for '{command}'. Available reference kinds: {string.Join(", ", acceptedKinds)}");
         var suggestion = ConsoleUi.FindClosestMatch(kind, acceptedKinds);
         if (suggestion != null)
             Console.Error.WriteLine($"Did you mean: --kind {suggestion}?");
@@ -9452,7 +9454,7 @@ public static class QueryCommandRunner
         if (string.Equals(optionName, "--max-line-width", StringComparison.Ordinal))
             return TryParseNonNegativeInt(rawValue, optionName, out value, out error, displayRawValue);
 
-        displayRawValue ??= rawValue;
+        displayRawValue ??= ConsoleUi.FormatBoundedValue(rawValue);
         if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out value) || value <= 0)
         {
             value = 0;
@@ -9473,7 +9475,7 @@ public static class QueryCommandRunner
 
     private static bool TryParseNonNegativeInt(string rawValue, string optionName, out int value, out string? error, string? displayRawValue = null)
     {
-        displayRawValue ??= rawValue;
+        displayRawValue ??= ConsoleUi.FormatBoundedValue(rawValue);
         if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out value) || value < 0)
         {
             value = 0;

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1038,12 +1038,26 @@ public class DbWriter
     private void WarnSkippedBatchRow(string rowIdentifier, Exception batchException, Exception rowException)
     {
         Interlocked.Increment(ref _batchRowsSkipped);
-        var message = $"Warning: skipped failed batch row ({rowIdentifier}); batch_error={batchException.Message}; row_error={rowException.Message}";
+        var message = BuildBatchRowSkipWarning(rowIdentifier, batchException, rowException);
         var testSink = BatchRowSkipWarningForTesting;
         if (testSink != null)
             testSink(message);
         else
             Console.Error.WriteLine(message);
+    }
+
+    internal static string BuildBatchRowSkipWarningForTesting(string rowIdentifier, Exception batchException, Exception rowException)
+        => BuildBatchRowSkipWarning(rowIdentifier, batchException, rowException);
+
+    private static string BuildBatchRowSkipWarning(string rowIdentifier, Exception batchException, Exception rowException)
+        => $"Warning: skipped failed batch row ({FormatBatchRowSkipDiagnosticValue(rowIdentifier)}); batch_error={FormatBatchRowSkipDiagnosticValue(batchException.Message)}; row_error={FormatBatchRowSkipDiagnosticValue(rowException.Message)}";
+
+    private static string FormatBatchRowSkipDiagnosticValue(string? value)
+    {
+        return ConsoleUi.FormatBoundedValue(value)
+            .Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
     }
 
     private void InsertChunkBatch(IReadOnlyList<ChunkRecord> chunks, int start, int end)

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -1365,7 +1365,7 @@ public partial class McpServer : IDisposable
             || seconds > MaxKeepAliveIntervalSeconds)
         {
             Console.Error.WriteLine(
-                $"[cdidx-mcp] Ignoring invalid {KeepAliveIntervalEnvironmentVariable}='{raw}'. Expected a finite value between {MinKeepAliveIntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)} and {MaxKeepAliveIntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)} seconds. Keep-alive notifications stay disabled.");
+                $"[cdidx-mcp] Ignoring invalid {KeepAliveIntervalEnvironmentVariable}='{ConsoleUi.FormatBoundedValue(raw)}'. Expected a finite value between {MinKeepAliveIntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)} and {MaxKeepAliveIntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)} seconds. Keep-alive notifications stay disabled.");
             return null;
         }
         return TimeSpan.FromSeconds(seconds);

--- a/src/CodeIndex/Mcp/RateLimiter.cs
+++ b/src/CodeIndex/Mcp/RateLimiter.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using CodeIndex.Cli;
 
 namespace CodeIndex.Mcp;
 
@@ -222,12 +223,12 @@ internal sealed class RateLimiterOptions
 
         if (!TryParsePositiveDouble(rpsRaw, out var rps))
         {
-            warningSink($"[cdidx-mcp] Ignoring invalid {RpsEnvVar}='{rpsRaw}'. Expected a positive number (tokens per second). Rate limiting stays disabled.");
+            warningSink($"[cdidx-mcp] Ignoring invalid {RpsEnvVar}='{FormatEnvironmentValue(rpsRaw)}'. Expected a positive number (tokens per second). Rate limiting stays disabled.");
             return Disabled;
         }
         if (rps > MaxRefillTokensPerSecond)
         {
-            warningSink($"[cdidx-mcp] Clamping {RpsEnvVar}='{rpsRaw}' to maximum {MaxRefillTokensPerSecond.ToString(CultureInfo.InvariantCulture)} tokens per second.");
+            warningSink($"[cdidx-mcp] Clamping {RpsEnvVar}='{FormatEnvironmentValue(rpsRaw)}' to maximum {MaxRefillTokensPerSecond.ToString(CultureInfo.InvariantCulture)} tokens per second.");
             rps = MaxRefillTokensPerSecond;
         }
 
@@ -243,22 +244,24 @@ internal sealed class RateLimiterOptions
         }
         else if (!TryParsePositiveDouble(burstRaw, out burst))
         {
-            warningSink($"[cdidx-mcp] Ignoring invalid {BurstEnvVar}='{burstRaw}'. Expected a positive number (bucket capacity). Falling back to default burst.");
+            warningSink($"[cdidx-mcp] Ignoring invalid {BurstEnvVar}='{FormatEnvironmentValue(burstRaw)}'. Expected a positive number (bucket capacity). Falling back to default burst.");
             burst = Math.Max(rps, 1.0);
         }
         else if (burst > MaxBurstCapacity)
         {
-            warningSink($"[cdidx-mcp] Clamping {BurstEnvVar}='{burstRaw}' to maximum {MaxBurstCapacity.ToString(CultureInfo.InvariantCulture)} tokens.");
+            warningSink($"[cdidx-mcp] Clamping {BurstEnvVar}='{FormatEnvironmentValue(burstRaw)}' to maximum {MaxBurstCapacity.ToString(CultureInfo.InvariantCulture)} tokens.");
             burst = MaxBurstCapacity;
         }
 
         var bucketIdleTtl = DefaultBucketIdleTtl;
         var bucketIdleRaw = envReader(BucketIdleSecondsEnvVar);
         if (!string.IsNullOrWhiteSpace(bucketIdleRaw) && !TryParsePositiveTimeSpanSeconds(bucketIdleRaw, out bucketIdleTtl))
-            warningSink($"[cdidx-mcp] Ignoring invalid {BucketIdleSecondsEnvVar}='{bucketIdleRaw}'. Expected a positive finite number of seconds. Falling back to the default bucket idle TTL.");
+            warningSink($"[cdidx-mcp] Ignoring invalid {BucketIdleSecondsEnvVar}='{FormatEnvironmentValue(bucketIdleRaw)}'. Expected a positive finite number of seconds. Falling back to the default bucket idle TTL.");
 
         return new RateLimiterOptions { RefillTokensPerSecond = rps, BurstCapacity = burst, BucketIdleTtl = bucketIdleTtl };
     }
+
+    private static string FormatEnvironmentValue(string value) => ConsoleUi.FormatBoundedValue(value);
 
     private static bool TryParsePositiveDouble(string raw, out double value)
     {

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -1445,6 +1445,14 @@ public class ConsoleUiTests
     }
 
     [Fact]
+    public void FindClosestMatch_OversizedInput_ReturnsNull()
+    {
+        var input = new string('x', ConsoleUi.MaxSuggestionInputCharLength + 1);
+
+        Assert.Null(ConsoleUi.FindClosestMatch(input, new[] { "search" }));
+    }
+
+    [Fact]
     public void FindClosestMatches_ReturnsRankedSuggestions()
     {
         var candidates = new[] { "added", "changed", "fixed", "removed", "security", "docs" };
@@ -1461,6 +1469,16 @@ public class ConsoleUiTests
         var candidates = new[] { "added", "changed" };
 
         var matches = ConsoleUi.FindClosestMatches("absolutelynotrelated", candidates);
+
+        Assert.Empty(matches);
+    }
+
+    [Fact]
+    public void FindClosestMatches_OversizedInput_ReturnsEmpty()
+    {
+        var input = new string('x', ConsoleUi.MaxSuggestionInputCharLength + 1);
+
+        var matches = ConsoleUi.FindClosestMatches(input, new[] { "added", "changed" });
 
         Assert.Empty(matches);
     }

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -1484,6 +1484,25 @@ public class ConsoleUiTests
     }
 
     [Fact]
+    public void FormatBoundedValue_FlattensControlCharacters()
+    {
+        var formatted = ConsoleUi.FormatBoundedValue("bad\r\nline\t\u001b[31m");
+
+        Assert.Equal("bad  line  [31m", formatted);
+    }
+
+    [Fact]
+    public void FormatBoundedValue_TruncatedValueFlattensControlCharacters()
+    {
+        var value = new string('a', ConsoleUi.DefaultDiagnosticValueCharLimit - 1) + "\nzzz";
+
+        var formatted = ConsoleUi.FormatBoundedValue(value);
+
+        Assert.DoesNotContain("\n", formatted);
+        Assert.Contains("<truncated; original length", formatted);
+    }
+
+    [Fact]
     public void FindClosestMatches_ZeroMaxResults_ReturnsEmpty()
     {
         var candidates = new[] { "added", "changed" };

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -1803,6 +1803,27 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void BatchRowSkipWarning_TruncatesOversizedDiagnostics_Issue3094()
+    {
+        var rowValue = new string('r', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+        var batchValue = new string('b', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+        var rowErrorValue = new string('e', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+
+        var warning = DbWriter.BuildBatchRowSkipWarningForTesting(
+            $"symbol file_id=1 name={rowValue} line=42",
+            new InvalidOperationException(batchValue),
+            new InvalidOperationException(rowErrorValue));
+
+        Assert.Contains("Warning: skipped failed batch row", warning, StringComparison.Ordinal);
+        Assert.Contains("batch_error=", warning, StringComparison.Ordinal);
+        Assert.Contains("row_error=", warning, StringComparison.Ordinal);
+        Assert.Contains("<truncated; original length", warning, StringComparison.Ordinal);
+        Assert.DoesNotContain(rowValue, warning, StringComparison.Ordinal);
+        Assert.DoesNotContain(batchValue, warning, StringComparison.Ordinal);
+        Assert.DoesNotContain(rowErrorValue, warning, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DeleteFileData_RemovesChunksAndSymbols()
     {
         var fileId = _writer.UpsertFile(new FileRecord

--- a/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
@@ -66,6 +66,19 @@ public class HookCommandRunnerTests
     }
 
     [Fact]
+    public void Hooks_UnknownOption_TruncatesOversizedToken()
+    {
+        var token = "--" + new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 20);
+
+        var (exitCode, _, stderr) = RunHooksAndCaptureStreams([token]);
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("unknown option", stderr);
+        Assert.Contains("<truncated; original length", stderr);
+        Assert.DoesNotContain(token, stderr);
+    }
+
+    [Fact]
     public void Hooks_Install_ChainsExistingPreCommitHook()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("hook_chain");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -525,6 +525,18 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void ParseArgs_UnknownIndexOption_TruncatesOversizedToken()
+    {
+        var token = "--" + new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 20);
+
+        var options = IndexCommandRunner.ParseArgs([".", token]);
+
+        Assert.Contains("unknown option", options.ParseError);
+        Assert.Contains("<truncated; original length", options.ParseError);
+        Assert.DoesNotContain(token, options.ParseError);
+    }
+
+    [Fact]
     public void ParseArgs_ForceFlag_SetsForce()
     {
         var options = IndexCommandRunner.ParseArgs([".", "--force"]);
@@ -1520,6 +1532,32 @@ public class IndexCommandRunnerTests
 
                 Assert.True(options.MaxFileSizeBytes is null or > 0);
                 Assert.Contains("invalid --max-file-bytes value", stderr.ToString());
+            }
+            finally
+            {
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    [Fact]
+    public void ParseArgs_MaxFileBytesInvalidValue_TruncatesOversizedValue()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalErr = Console.Error;
+            using var stderr = new StringWriter();
+            var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+            try
+            {
+                Console.SetError(stderr);
+
+                _ = IndexCommandRunner.ParseArgs([".", "--max-file-bytes", value]);
+
+                var warning = stderr.ToString();
+                Assert.Contains("invalid --max-file-bytes value", warning);
+                Assert.Contains("<truncated; original length", warning);
+                Assert.DoesNotContain(value, warning);
             }
             finally
             {

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -881,6 +881,37 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void ParseArgs_InvalidNotifyEnvironmentWarnsAndFallsBack_Issue3135()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            using var env = EnvironmentVariableScope.Capture(IndexCommandRunner.CompletionNotificationEnvironmentVariable);
+            var originalErr = Console.Error;
+            using var stderr = new StringWriter();
+            var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+            try
+            {
+                env.Set(IndexCommandRunner.CompletionNotificationEnvironmentVariable, value);
+                Console.SetError(stderr);
+
+                var options = IndexCommandRunner.ParseArgs(["."]);
+
+                Assert.Equal(CompletionNotificationMode.Auto, options.NotifyMode);
+                Assert.Null(options.ParseError);
+                var warning = stderr.ToString();
+                Assert.Contains($"invalid {IndexCommandRunner.CompletionNotificationEnvironmentVariable} value", warning);
+                Assert.Contains("ignored; use auto, bell, osc9, desktop, or none", warning);
+                Assert.Contains("<truncated; original length", warning);
+                Assert.DoesNotContain(value, warning);
+            }
+            finally
+            {
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    [Fact]
     public void Run_FullScanAfterHeadChange_WithPostExtractionHooksKeepsSequentialReferences()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_head_changed_hooks_sequential");

--- a/tests/CodeIndex.Tests/MacProfileDetectorTests.cs
+++ b/tests/CodeIndex.Tests/MacProfileDetectorTests.cs
@@ -19,6 +19,20 @@ public class MacProfileDetectorTests
     }
 
     [Fact]
+    public void BuildDatabaseHint_AppArmor_TruncatesOversizedProfile_Issue3095()
+    {
+        var profileTail = new string('a', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+        var profile = "apparmor:" + profileTail;
+
+        var hint = MacProfileDetector.BuildDatabaseHint(profile);
+
+        Assert.Contains("AppArmor", hint);
+        Assert.Contains("<truncated; original length", hint);
+        Assert.DoesNotContain(profile, hint);
+        Assert.DoesNotContain(profileTail, hint);
+    }
+
+    [Fact]
     public void BuildDatabaseHint_SELinux_NamesAuditTools()
     {
         var hint = MacProfileDetector.BuildDatabaseHint("selinux:user_u:user_r:user_t:s0");
@@ -37,11 +51,41 @@ public class MacProfileDetectorTests
     }
 
     [Fact]
+    public void DetectFromProcAttrs_OverlongAppArmorValueIsCappedBeforeParsing_Issue3095()
+    {
+        var current = new string('a', MacProfileDetector.MaxProcAttrReadChars + 1) + " (enforce)";
+
+        var profile = MacProfileDetector.DetectFromProcAttrs(current, null);
+
+        Assert.Null(profile);
+    }
+
+    [Fact]
     public void DetectFromProcAttrs_SELinuxCurrent_ReturnsContext()
     {
         var profile = MacProfileDetector.DetectFromProcAttrs("user_u:user_r:user_t:s0", null);
 
         Assert.Equal("selinux:user_u:user_r:user_t:s0", profile);
+    }
+
+    [Fact]
+    public void ReadProcAttrFile_CapsReadLength_Issue3095()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cdidx_proc_attr_{Guid.NewGuid():N}.txt");
+        var content = new string('p', MacProfileDetector.MaxProcAttrReadChars + 100);
+        try
+        {
+            File.WriteAllText(path, content);
+
+            var value = MacProfileDetector.ReadProcAttrFileForTesting(path);
+
+            Assert.Equal(MacProfileDetector.MaxProcAttrReadChars, value.Length);
+            Assert.Equal(new string('p', MacProfileDetector.MaxProcAttrReadChars), value);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     [Theory]

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -6361,6 +6361,34 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void Constructor_InvalidKeepAliveEnvironment_TruncatesWarning_Issue3091()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            using var env = EnvironmentVariableScope.Capture("CDIDX_MCP_KEEP_ALIVE_INTERVAL_S");
+            var originalErr = Console.Error;
+            using var stderr = new StringWriter();
+            var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+            try
+            {
+                env.Set("CDIDX_MCP_KEEP_ALIVE_INTERVAL_S", value);
+                Console.SetError(stderr);
+
+                using var server = new McpServer(_dbPath, "1.0", dbPathExplicit: true);
+
+                var warning = stderr.ToString();
+                Assert.Contains("Ignoring invalid CDIDX_MCP_KEEP_ALIVE_INTERVAL_S", warning);
+                Assert.Contains("<truncated; original length", warning);
+                Assert.DoesNotContain(value, warning);
+            }
+            finally
+            {
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    [Fact]
     public void ToolsCall_Status_ReportsKeepAliveIntervalBounds()
     {
         var response = _server.HandleMessage(JsonNode.Parse(

--- a/tests/CodeIndex.Tests/QueryCommandRunnerGraphTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerGraphTests.cs
@@ -9,6 +9,21 @@ namespace CodeIndex.Tests;
 public partial class QueryCommandRunnerTests
 {
     [Fact]
+    public void RunDeps_InvalidFormat_FlattensControlCharacters_Issue3092()
+    {
+        var value = "bad\nforged\tvalue";
+
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
+            ["--format", value],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("deps --format must be one of", stderr);
+        Assert.Contains("bad forged value", stderr);
+        Assert.DoesNotContain(value, stderr);
+    }
+
+    [Fact]
     public void RunReferences_AllowsExcludePathValueThatLooksLikePreviewOption()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_references_preview_like_exclude_path_value");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerMapTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerMapTests.cs
@@ -41,6 +41,37 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunMap_ParseInvalidMinEntrypointConfidence_TruncatesOversizedValue()
+    {
+        var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+
+        var options = QueryCommandRunner.ParseArgs(
+            ["--min-entrypoint-confidence", value],
+            jsonDefault: false,
+            validateDefaultSnippetLines: false,
+            validateDefaultMaxLineWidth: false);
+
+        Assert.Contains("--min-entrypoint-confidence must be a number", options.ParseError);
+        Assert.Contains("<truncated; original length", options.ParseError);
+        Assert.DoesNotContain(value, options.ParseError);
+    }
+
+    [Fact]
+    public void RunMap_ParseInvalidSections_FlattensControlCharacters_Issue3092()
+    {
+        var value = "tree,bad\nforged\tvalue";
+
+        var options = QueryCommandRunner.ParseArgs(
+            ["--sections", value],
+            jsonDefault: false,
+            validateDefaultSnippetLines: false,
+            validateDefaultMaxLineWidth: false);
+
+        Assert.Contains("--sections contains unsupported section 'bad forged value'", options.ParseError);
+        Assert.DoesNotContain("bad\nforged\tvalue", options.ParseError);
+    }
+
+    [Fact]
     public void RunMap_CompactJson_CapsSectionsAndReportsTruncation_Issue3009()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_map_compact");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1546,6 +1546,70 @@ jobs:
         Assert.Contains("Did you mean: --path?", stderr);
     }
 
+    [Fact]
+    public void RunSearch_InvalidSnippetFocus_TruncatesOversizedValue()
+    {
+        var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["foo", "--snippet-focus", value],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("invalid --snippet-focus value", stderr);
+        Assert.Contains("<truncated; original length", stderr);
+        Assert.DoesNotContain(value, stderr);
+    }
+
+    [Fact]
+    public void RunSearch_InvalidLimit_TruncatesOversizedValue()
+    {
+        var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["foo", "--limit", value],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("--limit requires an integer", stderr);
+        Assert.Contains("<truncated; original length", stderr);
+        Assert.DoesNotContain(value, stderr);
+    }
+
+    [Fact]
+    public void RunSearch_InvalidJsonFormat_TruncatesOversizedInlineValue()
+    {
+        var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["foo", "--json=" + value],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("--json format must be one of ndjson or array", stderr);
+        Assert.Contains("<truncated; original length", stderr);
+        Assert.DoesNotContain(value, stderr);
+    }
+
+    [Fact]
+    public void RunSearch_InvalidFormat_TruncatesOversizedValue()
+    {
+        var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["foo", "--format", value],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("--format must be one of", stderr);
+        Assert.Contains("<truncated; original length", stderr);
+        Assert.DoesNotContain(value, stderr);
+    }
+
     // `find` previously emitted only the raw `Error: unsupported option for find: --paht`
     // line — round-2 fix routes the unknown token through the same suggester so users see
     // `Did you mean: --path?`. Covers both the separated and inline `=value` forms.

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -1642,6 +1642,63 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void WithDb_MissingOversizedPathReturnsBoundedDiagnostics_Issue3093()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue3093_missing_db");
+        try
+        {
+            var missingDbPath = Path.Combine(
+                projectRoot,
+                Path.Combine(Enumerable.Repeat("segment", 40).ToArray()),
+                "codeindex.db");
+            var resolvedPath = Path.GetFullPath(missingDbPath);
+            Assert.True(resolvedPath.Length > SqliteFileUri.MaxDiagnosticValueLength);
+
+            var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+                ["--db", missingDbPath],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Contains($"Error [{CommandErrorCodes.DbNotFound}]: --db '", stderr);
+            Assert.Contains("does not point to an existing database file", stderr);
+            Assert.Contains("...(truncated,", stderr);
+            Assert.DoesNotContain(resolvedPath, stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunBatch_MissingOversizedDbPathReturnsBoundedDiagnostics_Issue3093()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue3093_batch_db");
+        try
+        {
+            var missingDbPath = Path.Combine(
+                projectRoot,
+                Path.Combine(Enumerable.Repeat("segment", 40).ToArray()),
+                "codeindex.db");
+            var resolvedPath = Path.GetFullPath(missingDbPath);
+            Assert.True(resolvedPath.Length > SqliteFileUri.MaxDiagnosticValueLength);
+
+            var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunBatch(
+                ["--db", missingDbPath],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            Assert.Contains($"Error [{CommandErrorCodes.DbNotFound}]: database not found at ", stderr);
+            Assert.Contains("...(truncated,", stderr);
+            Assert.DoesNotContain(resolvedPath, stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void WithDb_SqliteCantOpenSurfacesAccessOpenCategory_Issue2072()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_issue2072_cantopen");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -100,6 +100,22 @@ public partial class QueryCommandRunnerTests
         Assert.Equal(0, options.MaxLineWidth);
     }
 
+    [Fact]
+    public void ParseArgs_InvalidPathGlob_FlattensControlCharacters_Issue3092()
+    {
+        var value = "src/[bad\nforged\tvalue";
+
+        var options = QueryCommandRunner.ParseArgs(
+            ["RunSearch", "--path", value],
+            jsonDefault: false,
+            allowNamedQuery: true,
+            validateDefaultSnippetLines: false,
+            validateDefaultMaxLineWidth: false);
+
+        Assert.Contains("--path 'src/[bad forged value' is not a valid glob", options.ParseError);
+        Assert.DoesNotContain(value, options.ParseError);
+    }
+
     [Theory]
     [InlineData("count")]
     [InlineData("compact")]
@@ -314,6 +330,16 @@ public partial class QueryCommandRunnerTests
     {
         Assert.False(QueryCommandRunner.TryParseStaleAfter(value, out _, out var error));
         Assert.Contains(QueryCommandRunner.MaxStaleAfterDisplay, error);
+    }
+
+    [Fact]
+    public void TryParseStaleAfter_MaxDuration_FlattensControlCharacters_Issue3092()
+    {
+        var value = "31d\n\t";
+
+        Assert.False(QueryCommandRunner.TryParseStaleAfter(value, out _, out var error));
+        Assert.Contains("stale-after value '31d  '", error);
+        Assert.DoesNotContain(value, error);
     }
 
     [Fact]
@@ -1584,6 +1610,35 @@ public partial class QueryCommandRunnerTests
         Assert.Contains($"SQLite file URI query length exceeds {SqliteFileUri.MaxQueryLength}", stderr);
         Assert.Contains("...(truncated,", stderr);
         Assert.DoesNotContain(new string('a', SqliteFileUri.MaxDiagnosticValueLength + 1), stderr);
+    }
+
+    [Fact]
+    public void RunBatch_UnsupportedOptionTruncatesOversizedToken()
+    {
+        var token = "--" + new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunBatch(
+            [token],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("is not supported for batch", stderr);
+        Assert.Contains("<truncated; original length", stderr);
+        Assert.DoesNotContain(token, stderr);
+    }
+
+    [Fact]
+    public void RunBatch_UnsupportedOptionFlattensMultilineToken()
+    {
+        var token = "--bad\nforged\tvalue";
+
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunBatch(
+            [token],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("--bad forged value is not supported for batch", stderr);
+        Assert.DoesNotContain(token, stderr);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/RateLimiterTests.cs
+++ b/tests/CodeIndex.Tests/RateLimiterTests.cs
@@ -1,3 +1,4 @@
+using CodeIndex.Cli;
 using CodeIndex.Mcp;
 
 namespace CodeIndex.Tests;
@@ -308,6 +309,90 @@ public class RateLimiterTests
         Assert.Equal(RateLimiterOptions.MaxRefillTokensPerSecond, opts.BurstCapacity);
         Assert.Single(warnings);
         Assert.Contains("Clamping CDIDX_MCP_RATE_LIMIT_RPS", warnings[0]);
+    }
+
+    [Fact]
+    public void FromEnvironment_OversizedInvalidRps_TruncatesWarning_Issue3090()
+    {
+        var value = new string('x', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+        var warnings = new List<string>();
+
+        var opts = RateLimiterOptions.FromEnvironment(
+            key => key == RateLimiterOptions.RpsEnvVar ? value : null,
+            warnings.Add);
+
+        Assert.False(opts.IsEnabled);
+        var warning = Assert.Single(warnings);
+        Assert.Contains("Ignoring invalid CDIDX_MCP_RATE_LIMIT_RPS", warning);
+        Assert.Contains("<truncated; original length", warning);
+        Assert.DoesNotContain(value, warning);
+    }
+
+    [Fact]
+    public void FromEnvironment_MultilineInvalidRps_FlattensWarning_Issue3090()
+    {
+        var value = "bad\nforged\tvalue";
+        var warnings = new List<string>();
+
+        var opts = RateLimiterOptions.FromEnvironment(
+            key => key == RateLimiterOptions.RpsEnvVar ? value : null,
+            warnings.Add);
+
+        Assert.False(opts.IsEnabled);
+        var warning = Assert.Single(warnings);
+        Assert.Contains("bad forged value", warning);
+        Assert.DoesNotContain("\n", warning);
+        Assert.DoesNotContain("\r", warning);
+        Assert.DoesNotContain("\t", warning);
+    }
+
+    [Fact]
+    public void FromEnvironment_OversizedTooLargeRps_TruncatesWarning_Issue3090()
+    {
+        var value = new string('9', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+        var warnings = new List<string>();
+
+        var opts = RateLimiterOptions.FromEnvironment(
+            key => key == RateLimiterOptions.RpsEnvVar ? value : null,
+            warnings.Add);
+
+        Assert.True(opts.IsEnabled);
+        Assert.Equal(RateLimiterOptions.MaxRefillTokensPerSecond, opts.RefillTokensPerSecond);
+        var warning = Assert.Single(warnings);
+        Assert.Contains("Clamping CDIDX_MCP_RATE_LIMIT_RPS", warning);
+        Assert.Contains("<truncated; original length", warning);
+        Assert.DoesNotContain(value, warning);
+    }
+
+    [Fact]
+    public void FromEnvironment_OversizedBurstAndBucketIdleValues_TruncateWarnings_Issue3090()
+    {
+        var burstValue = new string('b', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+        var bucketIdleValue = new string('i', ConsoleUi.DefaultDiagnosticValueCharLimit + 1);
+        var warnings = new List<string>();
+
+        var opts = RateLimiterOptions.FromEnvironment(
+            key => key switch
+            {
+                RateLimiterOptions.RpsEnvVar => "2",
+                RateLimiterOptions.BurstEnvVar => burstValue,
+                RateLimiterOptions.BucketIdleSecondsEnvVar => bucketIdleValue,
+                _ => null,
+            },
+            warnings.Add);
+
+        Assert.True(opts.IsEnabled);
+        Assert.Equal(2.0, opts.BurstCapacity);
+        Assert.Equal(RateLimiterOptions.DefaultBucketIdleTtl, opts.BucketIdleTtl);
+        Assert.Equal(2, warnings.Count);
+        Assert.Contains(warnings, warning =>
+            warning.Contains("Ignoring invalid CDIDX_MCP_RATE_LIMIT_BURST", StringComparison.Ordinal)
+            && warning.Contains("<truncated; original length", StringComparison.Ordinal)
+            && !warning.Contains(burstValue, StringComparison.Ordinal));
+        Assert.Contains(warnings, warning =>
+            warning.Contains("Ignoring invalid CDIDX_MCP_RATE_LIMIT_BUCKET_IDLE_SECONDS", StringComparison.Ordinal)
+            && warning.Contains("<truncated; original length", StringComparison.Ordinal)
+            && !warning.Contains(bucketIdleValue, StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Bound and flatten user-controlled diagnostic values across CLI option parsing, database path errors, MCP rate-limit and keep-alive warnings, batch-row skip warnings, and MAC profile hints.
- Cap did-you-mean matching input before edit-distance work, and warn on invalid `CDIDX_NOTIFY` before falling back.
- Added issue-scoped bilingual changelog fragments, including `3093.security.md`.

No requested issue had an existing work-start comment, so none were skipped. `AGENT.md`, `CLAUDE.md`, and `AGENT_GUIDE.md` were not modified.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false --filter "RunDeps_InvalidFormat_FlattensControlCharacters_Issue3092|RunMap_ParseInvalidSections_FlattensControlCharacters_Issue3092|ParseArgs_InvalidPathGlob_FlattensControlCharacters_Issue3092|TryParseStaleAfter_MaxDuration_FlattensControlCharacters_Issue3092"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: initial findings were fixed; final follow-up reported `No blocking/actionable issues found.`

Fixes #3090
Fixes #3091
Fixes #3092
Fixes #3093
Fixes #3094
Fixes #3095
Fixes #3135
Fixes #3181