### PR TITLE
Bound query input sizes

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -779,6 +779,11 @@ WHERE fts_chunks MATCH 'content:authenticate'
 
 ### How the search works
 
+Literal-safe `search` queries are bounded in the reader before FTS5
+sanitization: maximum 1000 characters and 128 whitespace terms. Keep this guard
+in `DbReader` so CLI, MCP, and direct reader callers share the same failure mode;
+raw `--fts` queries continue to use the raw FTS complexity limits instead.
+
 When you run:
 ```sql
 SELECT f.path, c.start_line, c.content
@@ -3010,6 +3015,8 @@ MCPツール呼び出しは `structuredContent` に構造化JSON、`content` に
 exact-match flag の互換性は [USER_GUIDE.md](USER_GUIDE.md#フラグ互換性と移行) に記載しています。MCP schema はこの表と同期してください。`search.exact` は `exactSubstring` の legacy alias、name-based tools の `exact` は `exactName` の legacy alias です。新しい exact-match alias を追加する場合は、compatibility table、CLI help、MCP description、changelog fragment を同じ変更で更新してください。
 
 `search`、`definition`、`references`、`callers`、`callees`、`symbols`、`files` は `--path`、繰り返し指定できる `--exclude-path`、`--exclude-tests` による絞り込みを共有します。読み取り層は tests や docs より source を優先し、`search` はシンボル名やパスがクエリと正確に一致する候補をさらに上位に出して、AIクライアントが実装ファイルへ早く到達できるようにします。
+
+literal-safe な `search` query は reader 層で FTS5 sanitization 前に 1000 文字、128 whitespace term へ制限します。CLI、MCP、直接 reader caller の failure mode を揃えるため、この guard は `DbReader` に置きます。raw `--fts` query は別途 raw FTS complexity limit を使います。
 
 `search --json` と MCP の `search` は、フルチャンクを `chunk_start_line`、`chunk_end_line`、`snippet_start_line`、`snippet_end_line`、`snippet`、`match_lines`、`highlights`、`context_before`、`context_after`、`truncated_line_count`、`dropped_match_line_count`、`truncation_context` を持つ軽量スニペットへ投影します。`--snippet-lines` で抜粋長を先に制限でき（デフォルト: 8、最大: 20）、`--max-line-width`（CLI）/ `maxLineWidth`（MCP）は `find` / `references` / `excerpt` / `inspect` と同じ共有 `LineWidthFormatter.ClampLine` 契約（デフォルト: 512、最大: 4096、`0` で切り詰め解除）で各スニペット行を最初のマッチトークン周辺にクランプするため、minified / transpiled / 生成された 1 行ファイル内の 1 ヒットで数百 KB を返さなくなります。クランプされた行はスニペットに `...(+N)...` マーカーが入り、`truncation_context.char_counts`、`truncation_context.total_chars`、`highlights[].truncated`、`highlights[].original_line_length`、`highlights[].truncated_char_counts` で AI クライアントがクランプの有無と省略文字数を検出できます。`highlights[].terms` は互換性のため distinct な term list のまま残し、`highlights[].term_occurrences` は一致ごとの `term`、1-based の `line` / `column`、`length` を記録します。exact substring search では `highlights[].literal_terms` と `highlights[].literal_term_occurrences`（MCP では camelCase）も追加され、広めの診断 token list を残したまま、要求された literal phrase だけを render できます。exact ではない記号の多い code phrase 検索では、FTS tokenization が記号を失いやすい場合に exact substring semantics で再検索できるよう、CLI JSON compact result に `exact_substring_hint`、MCP `search` に `recovery_hint` を追加します。`dropped_match_line_count` は選択された snippet window 外に落ちた一致行数を示します。
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -217,7 +217,7 @@ Interactive terminal controls are allowed only when stdout is not redirected or 
 
 Query commands that accept path filters (`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `deps`, `impact`, `unused`, `hotspots`, and `validate`) expand `--project` into the matching project directory glob before hitting `DbReader`, so all existing SQL path predicates keep working. `index --project` expands to the files under the selected project directory and reuses the existing `--files` update path, but rejects expansions above 65,536 files for one project or 131,072 unique files across all requested projects with an explicit-files recovery hint.
 
-`cdidx batch` is a CLI-side query loop for editor integrations and scripts that need several query commands against the same DB without spawning `cdidx` repeatedly. It opens one `DbContext` / `DbReader`, reads newline-delimited JSON string arrays from stdin, and dispatches only query commands through the existing `QueryCommandRunner` paths so output and validation stay identical to the standalone command shape.
+`cdidx batch` is a CLI-side query loop for editor integrations and scripts that need several query commands against the same DB without spawning `cdidx` repeatedly. It opens one `DbContext` / `DbReader`, reads newline-delimited JSON string arrays from stdin, caps each decoded string argument at 8,192 characters, and dispatches only query commands through the existing `QueryCommandRunner` paths so output and validation stay identical to the standalone command shape.
 
 Editor integrations can request standard location shapes directly. `definition`, `references`, `search`, `find`, and `validate` accept `--format <text|json|lsp|qf|sarif>`; `lsp` emits LSP `Location` arrays, `qf` emits Vim quickfix lines, and `sarif` emits SARIF 2.1.0. `goto <symbol>` returns the single unambiguous definition as one LSP `Location`, while `goto --all <symbol>` returns all matching locations.
 
@@ -2355,7 +2355,7 @@ override が文書化されていない限り ANSI/progress control を抑止す
 
 path filter を受け付ける query コマンド（`search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `deps`, `impact`, `unused`, `hotspots`, `validate`）は、`--project` を対応する project directory glob に展開してから `DbReader` に渡す。これにより既存の SQL path predicate をそのまま利用できる。`index --project` は選択された project directory 配下のファイルに展開し、既存の `--files` 更新経路を再利用する。ただし 1 project で 65,536 files、requested projects 全体で 131,072 unique files を超える展開は拒否し、明示的な `--files` を使う recovery hint を返す。
 
-`cdidx batch` は、同じ DB に複数の query command を投げる editor integration や script 向けの CLI 側 query loop である。1 つの `DbContext` / `DbReader` を開き、stdin から newline-delimited JSON 文字列配列を読み、query command だけを既存の `QueryCommandRunner` 経路へ dispatch するため、出力と validation は単発コマンドと同じ形を保つ。
+`cdidx batch` は、同じ DB に複数の query command を投げる editor integration や script 向けの CLI 側 query loop である。1 つの `DbContext` / `DbReader` を開き、stdin から newline-delimited JSON 文字列配列を読み、デコード後の各文字列引数を 8,192 文字に制限し、query command だけを既存の `QueryCommandRunner` 経路へ dispatch するため、出力と validation は単発コマンドと同じ形を保つ。
 
 editor integration は標準的な location 形状を直接要求できる。`definition`、`references`、`search`、`find`、`validate` は `--format <text|json|lsp|qf|sarif>` を受け付け、`lsp` は LSP `Location` 配列、`qf` は Vim quickfix 行、`sarif` は SARIF 2.1.0 を出力する。`goto <symbol>` は曖昧でない単一定義を 1 つの LSP `Location` として返し、`goto --all <symbol>` は一致する全 location を返す。
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -876,6 +876,9 @@ Search normalizes literal FTS queries to Unicode NFC before matching. If every
 literal token exceeds SQLite FTS5 unicode61's 1000-character token cap,
 zero-result JSON includes `query_degraded_reason` and `tokens_dropped`. Index
 validation reports long unbroken FTS tokens as `fts_token_too_long`.
+Literal-safe `search` queries are capped at 1000 characters and 128 whitespace
+terms. Oversized generated input is rejected before FTS5 sanitization; split it
+into smaller searches or use narrower text.
 Guard-aware search filters primary `search` matches by nearby literal guards:
 `--require-before` / `--require-after` keep matches only when the guard query
 appears in the selected line window, while `--reject-before` / `--reject-after`
@@ -3175,6 +3178,9 @@ literal FTS クエリは照合前に Unicode NFC へ正規化されます。す�
 token が SQLite FTS5 unicode61 の 1000 文字 token 上限を超える場合、0 件
 JSON には `query_degraded_reason` と `tokens_dropped` が含まれます。index
 validation は長い連続 FTS token を `fts_token_too_long` として報告します。
+literal-safe な `search` query は 1000 文字、128 whitespace term までです。
+生成された大きすぎる入力は FTS5 sanitization 前に拒否されるため、小さな検索へ分割するか、
+より狭い text にしてください。
 guard-aware search は primary の `search` 一致を近傍の literal guard で絞り込みます:
 `--require-before` / `--require-after` は指定行窓内に guard query がある場合だけ残し、
 `--reject-before` / `--reject-after` は guard query がある一致を落とします。JSON の検索結果には

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -927,8 +927,9 @@ For scripts or editor integrations that need several queries against the same
 index, `cdidx batch --db <path>` keeps one SQLite connection open and reads one
 JSON string array per stdin line. Each array starts with a query command name,
 followed by that command's normal arguments. Each stdin line is capped at
-1,048,576 characters, and each command can carry at most 256 arguments after
-the command name:
+1,048,576 characters, each decoded string argument is capped at 8,192
+characters, and each command can carry at most 256 arguments after the command
+name:
 
 ```bash
 printf '%s\n' \
@@ -3221,7 +3222,8 @@ cdidx search "authenticate" --json --verbose
 同じインデックスに対して複数の query を投げる script や editor integration では、
 `cdidx batch --db <path>` を使うと 1 つの SQLite connection を開いたまま処理できます。
 stdin の各行は JSON 文字列配列で、先頭に query command 名、その後ろに通常の引数を並べます。
-各 stdin 行は 1,048,576 文字まで、各 command は command 名の後ろに最大 256 引数までです:
+各 stdin 行は 1,048,576 文字まで、デコード後の各文字列引数は 8,192 文字まで、
+各 command は command 名の後ろに最大 256 引数までです:
 
 ```bash
 printf '%s\n' \

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1068,7 +1068,7 @@ cdidx find "graph table" --path src/CodeIndex/Cli/QueryCommandRunner.cs
 cdidx find "Graph Table" --path src/CodeIndex/Cli/QueryCommandRunner.cs --exact --before 1 --after 1 --json
 ```
 
-`find` fills the gap between repo-wide `search` and line-number-based `excerpt`: when you already know the target file, it returns matching line numbers, columns, and short surrounding context from the indexed file without falling back to raw-text tools.
+`find` fills the gap between repo-wide `search` and line-number-based `excerpt`: when you already know the target file, it returns matching line numbers, columns, and short surrounding context from the indexed file without falling back to raw-text tools. The query text is capped at 1,000 characters, matching `search`.
 
 ### List files
 
@@ -3360,7 +3360,7 @@ cdidx find "graph table" --path src/CodeIndex/Cli/QueryCommandRunner.cs
 cdidx find "Graph Table" --path src/CodeIndex/Cli/QueryCommandRunner.cs --exact --before 1 --after 1 --json
 ```
 
-`find` は、リポジトリ全体を対象にする `search` と、行番号が必要な `excerpt` の間を埋めるコマンドです。対象ファイルが既に分かっているときに、raw text ツールへ戻らずに、インデックス済みファイルから一致行番号・列番号・短い前後文脈を返します。
+`find` は、リポジトリ全体を対象にする `search` と、行番号が必要な `excerpt` の間を埋めるコマンドです。対象ファイルが既に分かっているときに、raw text ツールへ戻らずに、インデックス済みファイルから一致行番号・列番号・短い前後文脈を返します。query text は `search` と同じく 1,000 文字までです。
 
 ### ファイル一覧
 

--- a/changelog.d/unreleased/3081.fixed.md
+++ b/changelog.d/unreleased/3081.fixed.md
@@ -1,0 +1,22 @@
+---
+category: fixed
+issues:
+  - 3081
+affected:
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - src/CodeIndex/Database/SearchQueryLimitException.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/DbSearchReaderIssueTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+  - USER_GUIDE.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Literal search sanitization now rejects oversized generated input (#3081)** — literal-safe `search` queries are capped at 1,000 characters and 128 whitespace terms in the database reader before FTS5 sanitization, with CLI and MCP returning usage errors instead of falling through to database failures.
+
+## 日本語
+
+- **literal search sanitization が大きすぎる生成入力を拒否するようになりました (#3081)** — literal-safe な `search` query は FTS5 sanitization 前の database reader 層で 1,000 文字、128 whitespace term に制限され、CLI/MCP は database failure へ落とさず usage error を返します。

--- a/changelog.d/unreleased/3100.fixed.md
+++ b/changelog.d/unreleased/3100.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3100
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`find` now enforces the shared query length limit (#3100)** — `cdidx find` and `cdidx find --count` reject query text above 1,000 characters before opening the database reader.
+
+## 日本語
+
+- **`find` が共通の query 長上限を適用するようになりました (#3100)** — `cdidx find` と `cdidx find --count` は、query text が 1,000 文字を超える場合、database reader を開く前に拒否します。

--- a/changelog.d/unreleased/3231.fixed.md
+++ b/changelog.d/unreleased/3231.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3231
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Batch query arguments are now individually capped (#3231)** — `cdidx batch` rejects any decoded JSON string argument longer than 8,192 characters before dispatching the query command.
+
+## 日本語
+
+- **batch query の各引数に個別上限を追加しました (#3231)** — `cdidx batch` は、デコード後の JSON 文字列引数が 8,192 文字を超える場合、query command へ dispatch する前に拒否します。

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -1031,7 +1031,7 @@ public static class ConsoleUi
         Console.WriteLine("  --limit <n>, --top <n>     Max results to return (default: 20)");
         Console.WriteLine("  --lang <lang>              Filter by language (aliases: bat, cmd, cshtml, razor, ts, tsx, cts, mts)");
         Console.WriteLine("  --path <glob>              Restrict matches to glob-style path patterns (* and ?)");
-        WriteHelpLine($"  --query <query>            Pass a query literal, useful when the query starts with '-' (`search` max {QueryLimits.MaxQueryLength} chars)");
+        WriteHelpLine($"  --query <query>            Pass a query literal, useful when the query starts with '-' (`search`/`find` max {QueryLimits.MaxQueryLength} chars)");
         Console.WriteLine("  --exclude-path <glob>      Exclude glob-style path patterns (* and ?) (repeatable)");
         Console.WriteLine("  --exclude-tests            Exclude likely test files");
         Console.WriteLine("  --include-generated        Include generated files in query results");

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -7586,6 +7586,12 @@ public static class QueryCommandRunner
             Console.Error.WriteLine("Hint: narrow the search with more specific query text, --lang, --path, or --exclude-tests, or reduce pagination offset before retrying guarded search.");
             return CommandExitCodes.UsageError;
         }
+        catch (SearchQueryLimitException ex)
+        {
+            Console.Error.WriteLine($"Error [{CommandErrorCodes.UsageError}]: {ex.Message}");
+            Console.Error.WriteLine("Hint: shorten the search text or split generated input into smaller literal queries.");
+            return CommandExitCodes.UsageError;
+        }
         catch (Exception ex)
         {
             if (JsonOutputFailure.TryHandle(ex, out var exitCode))

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -28,6 +28,7 @@ public static class QueryCommandRunner
     internal const int MaxWorkspaceDependencyDatabasePairCount = MaxWorkspaceDependencyDatabaseCount * (MaxWorkspaceDependencyDatabaseCount - 1);
     internal const int BatchMaxLineChars = 1024 * 1024;
     internal const int BatchMaxArgumentCount = 256;
+    internal const int BatchMaxArgumentChars = 8192;
     internal const int BatchMaxJsonDepth = 32;
     internal const string DefaultLimitEnvironmentVariable = "CDIDX_DEFAULT_LIMIT";
     internal const string DefaultSnippetLinesEnvironmentVariable = "CDIDX_DEFAULT_SNIPPET_LINES";
@@ -429,7 +430,13 @@ public static class QueryCommandRunner
                     Console.Error.WriteLine($"Error: batch line {lineNumber} must contain only strings.");
                     return false;
                 }
-                values.Add(element.GetString() ?? string.Empty);
+                var value = element.GetString() ?? string.Empty;
+                if (value.Length > BatchMaxArgumentChars)
+                {
+                    Console.Error.WriteLine($"Error: batch line {lineNumber} argument {values.Count + 1} exceeds the {BatchMaxArgumentChars} character limit.");
+                    return false;
+                }
+                values.Add(value);
             }
 
             commandName = values[0];

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -2727,6 +2727,13 @@ public static class QueryCommandRunner
             Console.Error.WriteLine(FindUsage);
             return CommandExitCodes.UsageError;
         }
+        if (options.Query.Length > QueryLimits.MaxQueryLength)
+        {
+            Console.Error.WriteLine($"Error: {QueryLimits.FormatQueryTooLongError()}");
+            Console.Error.WriteLine("Hint: Shorten the find text or split generated input into smaller queries before running `cdidx find`.");
+            Console.Error.WriteLine(FindUsage);
+            return CommandExitCodes.UsageError;
+        }
 
         if (options.PathPatterns.Count == 0)
         {

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -11,6 +11,8 @@ public partial class DbReader
 {
     internal const int FtsUnicode61MaxTokenLength = 1000;
     internal const string AllTokensFilteredByLengthReason = "all_tokens_filtered_by_length";
+    internal const int MaxLiteralSearchQueryLength = 1000;
+    internal const int MaxLiteralSearchTokenCount = 128;
     internal const int MaxRawFtsQueryLength = 2000;
     internal const int MaxRawFtsBooleanOperators = 64;
     internal const int MaxRawFtsNearOperators = 16;
@@ -44,7 +46,7 @@ public partial class DbReader
         // クエリ内のダブルクォートをエスケープし、各トークンをダブルクォートで囲む。
         // ユーザー入力末尾の `*` は prefix 検索の shorthand として保持し、`auth*` で
         // `authenticate` を raw FTS5 構文なしに検索できるようにする。
-        var tokens = query.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        var tokens = SplitLiteralSearchTokens(query);
         if (tokens.Length == 0)
             return "\"\"";
         return string.Join(" ", tokens.Select(token => FormatFtsToken(token, prefix)));
@@ -56,7 +58,7 @@ public partial class DbReader
             return FtsQueryDiagnostics.None;
 
         var normalizedQuery = NormalizeLiteralSearchQuery(query, NormalizeQueryLanguage(lang));
-        var tokens = normalizedQuery.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+        var tokens = SplitLiteralSearchTokens(normalizedQuery)
             .Select(token => token.Length > 1 && token.EndsWith('*') ? token[..^1] : token)
             .Where(token => token.Length > 0)
             .ToArray();
@@ -114,6 +116,8 @@ public partial class DbReader
             return [];
 
         lang = NormalizeQueryLanguage(lang);
+        if (!rawQuery)
+            ValidateLiteralSearchQueryLength(query);
         var normalizedQuery = rawQuery ? query : NormalizeLiteralSearchQuery(query, lang);
         var coverageTokens = exact ? new List<string>() : GetSearchCoverageTokens(normalizedQuery, rawQuery);
         var hasGuardFilters = guardFilters is { Count: > 0 };
@@ -408,6 +412,9 @@ public partial class DbReader
         if (string.IsNullOrWhiteSpace(query))
             return new QueryCountResult(0, 0);
 
+        if (!rawQuery)
+            ValidateLiteralSearchQueryLength(query);
+
         if (guardFilters is { Count: > 0 })
         {
             var guardedResults = Search(query, int.MaxValue, lang, rawQuery, pathPatterns, excludePathPatterns, excludeTests, deduplicate, since, exact, prefix, visibilityRank, guardFilters: guardFilters, guardWindow: guardWindow);
@@ -614,7 +621,7 @@ public partial class DbReader
     private static string[] BuildPrimarySearchMatchTerms(string query, string normalizedQuery, bool rawQuery, bool exact)
     {
         IEnumerable<string> rawTerms = !exact && !rawQuery
-            ? normalizedQuery.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+            ? SplitLiteralSearchTokens(normalizedQuery)
             : [rawQuery ? query.Trim() : normalizedQuery.Trim()];
         var terms = rawTerms.Select(NormalizeGuardSearchTerm).ToList();
         if (!exact && rawQuery)
@@ -791,6 +798,25 @@ public partial class DbReader
         return string.Equals(lang, "csharp", StringComparison.OrdinalIgnoreCase)
             ? CSharpVerbatimNameNormalizer.Normalize(normalized)
             : normalized;
+    }
+
+    private static void ValidateLiteralSearchQueryLength(string query)
+    {
+        if (query.Length <= MaxLiteralSearchQueryLength)
+            return;
+
+        throw new SearchQueryLimitException(
+            $"literal search query is too long ({query.Length} characters); maximum is {MaxLiteralSearchQueryLength}. Split generated input into smaller queries.");
+    }
+
+    private static string[] SplitLiteralSearchTokens(string query)
+    {
+        var tokens = query.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length <= MaxLiteralSearchTokenCount)
+            return tokens;
+
+        throw new SearchQueryLimitException(
+            $"literal search query has too many terms ({tokens.Length}); maximum is {MaxLiteralSearchTokenCount}. Split generated input into smaller queries.");
     }
 
     internal static string ValidateRawFtsQuery(string query)
@@ -1230,7 +1256,7 @@ public partial class DbReader
 
     private static List<string> GetSearchCoverageTokens(string query, bool rawQuery)
     {
-        var tokens = rawQuery ? ExtractRawFtsCoverageTokens(query) : query.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        var tokens = rawQuery ? ExtractRawFtsCoverageTokens(query) : SplitLiteralSearchTokens(query);
         if (tokens.Length <= 1)
             return [];
 

--- a/src/CodeIndex/Database/SearchQueryLimitException.cs
+++ b/src/CodeIndex/Database/SearchQueryLimitException.cs
@@ -1,0 +1,9 @@
+namespace CodeIndex.Database;
+
+internal sealed class SearchQueryLimitException : Exception
+{
+    public SearchQueryLimitException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1272,6 +1272,10 @@ public partial class McpServer
                 {
                     countResults = reader.Search(query, MaxLimit, lang, rawQuery, pathPatterns, excludePaths, excludeTests, deduplicate, since, exact, prefix, guardFilters: guardFilters, guardWindow: guardWindow);
                 }
+                catch (SearchQueryLimitException ex)
+                {
+                    return CreateToolErrorResponse(id, ex.Message);
+                }
                 catch (SearchGuardCandidateLimitException ex)
                 {
                     return CreateToolErrorResponse(id, $"guarded search is too broad: {ex.Message} Narrow the search with more specific query text, lang/path filters, or a smaller cursor offset.");
@@ -1294,6 +1298,10 @@ public partial class McpServer
             try
             {
                 results = reader.Search(query, FetchLimitForEnvelope(limit), lang, rawQuery, pathPatterns, excludePaths, excludeTests, deduplicate, since, exact, prefix, cursor: cursor, guardFilters: guardFilters, guardWindow: guardWindow);
+            }
+            catch (SearchQueryLimitException ex)
+            {
+                return CreateToolErrorResponse(id, ex.Message);
             }
             catch (SearchGuardCandidateLimitException ex)
             {

--- a/tests/CodeIndex.Tests/DbSearchReaderIssueTests.cs
+++ b/tests/CodeIndex.Tests/DbSearchReaderIssueTests.cs
@@ -172,6 +172,52 @@ public sealed class DbSearchReaderIssueTests : IDisposable
         Assert.Equal([1, 2], result.GuardEvidence!.Select(evidence => evidence.Line).ToArray());
     }
 
+    [Fact]
+    public void Search_LiteralQueryAtLengthLimitRuns_Issue3081()
+    {
+        var query = new string('a', DbReader.MaxLiteralSearchQueryLength);
+        InsertIndexedFile("src/literal-length-limit.cs", "csharp", query);
+
+        var results = _reader.Search(query, pathPatterns: ["src/literal-length-limit.cs"], limit: 1);
+
+        var result = Assert.Single(results);
+        Assert.Equal("src/literal-length-limit.cs", result.Path);
+    }
+
+    [Fact]
+    public void Search_LiteralQueryOverLengthLimitThrows_Issue3081()
+    {
+        var query = new string('a', DbReader.MaxLiteralSearchQueryLength + 1);
+
+        var ex = Assert.Throws<SearchQueryLimitException>(() => _reader.Search(query, pathPatterns: ["src/*.cs"], limit: 1));
+
+        Assert.Contains("literal search query is too long", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbReader.MaxLiteralSearchQueryLength.ToString(), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Search_LiteralTokenCountAtLimitRuns_Issue3081()
+    {
+        var query = BuildLiteralTermQuery(DbReader.MaxLiteralSearchTokenCount);
+        InsertIndexedFile("src/literal-token-limit.cs", "csharp", query);
+
+        var results = _reader.Search(query, pathPatterns: ["src/literal-token-limit.cs"], limit: 1);
+
+        var result = Assert.Single(results);
+        Assert.Equal("src/literal-token-limit.cs", result.Path);
+    }
+
+    [Fact]
+    public void Search_LiteralTokenCountOverLimitThrows_Issue3081()
+    {
+        var query = BuildLiteralTermQuery(DbReader.MaxLiteralSearchTokenCount + 1);
+
+        var ex = Assert.Throws<SearchQueryLimitException>(() => _reader.Search(query, pathPatterns: ["src/*.cs"], limit: 1));
+
+        Assert.Contains("literal search query has too many terms", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbReader.MaxLiteralSearchTokenCount.ToString(), ex.Message, StringComparison.Ordinal);
+    }
+
     private void InsertIndexedFile(string path, string lang, string content, DateTime? modified = null)
     {
         var normalized = content.Replace("\r\n", "\n");
@@ -194,6 +240,9 @@ public sealed class DbSearchReaderIssueTests : IDisposable
             Content = normalized,
         }]);
     }
+
+    private static string BuildLiteralTermQuery(int termCount)
+        => string.Join(' ', Enumerable.Range(0, termCount).Select(i => $"t{i:D3}"));
 
     public void Dispose()
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -3781,6 +3781,30 @@ jobs:
         Assert.DoesNotContain("query cannot be empty or whitespace-only", stderr);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RunFind_QueryTooLongReturnsUsageError_Issue3100(bool countOnly)
+    {
+        var args = new List<string>
+        {
+            new('x', QueryLimits.MaxQueryLength + 1),
+            "--path",
+            "src/**/*.cs",
+        };
+        if (countOnly)
+            args.Add("--count");
+
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+            [.. args],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains($"Error: {QueryLimits.FormatQueryTooLongError()}", stderr);
+        Assert.Contains("Hint: Shorten the find text", stderr);
+        Assert.Contains("Usage: cdidx find", stderr);
+    }
+
     [Fact]
     public void RunSearch_ZeroResultsHonorsStaleAfterEnvironment()
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1078,6 +1078,30 @@ jobs:
     }
 
     [Fact]
+    public void RunSearch_LiteralTokenCountTooHighReturnsUsageError_Issue3081()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_literal_terms_too_many");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var query = string.Join(' ', Enumerable.Range(0, DbReader.MaxLiteralSearchTokenCount + 1).Select(i => $"t{i:D3}"));
+
+            var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                [query, "--db", dbPath],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Contains("literal search query has too many terms", stderr);
+            Assert.Contains("smaller literal queries", stderr);
+            Assert.DoesNotContain("database error:", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSearch_RawFtsTooManyNearOperatorsReturnsUsageError()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_raw_fts_too_many_near");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -779,6 +779,56 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunBatch_ArgumentAtLimitParsesBeforeDispatch_Issue3231()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_batch_arg_at_limit");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var commandName = new string('x', QueryCommandRunner.BatchMaxArgumentChars);
+            var input = JsonSerializer.Serialize(new[] { commandName }) + "\n";
+
+            var (exitCode, stdout, stderr) = CaptureConsoleWithInput(
+                input,
+                () => QueryCommandRunner.RunBatch(["--db", dbPath], _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains("batch only supports query commands", stderr);
+            Assert.DoesNotContain("character limit", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunBatch_ArgumentExceedsLimitReturnsUsageError_Issue3231()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_batch_arg_too_long");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var commandName = new string('x', QueryCommandRunner.BatchMaxArgumentChars + 1);
+            var input = JsonSerializer.Serialize(new[] { commandName }) + "\n";
+
+            var (exitCode, stdout, stderr) = CaptureConsoleWithInput(
+                input,
+                () => QueryCommandRunner.RunBatch(["--db", dbPath], _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stdout);
+            Assert.Contains($"argument 1 exceeds the {QueryCommandRunner.BatchMaxArgumentChars} character limit", stderr);
+            Assert.DoesNotContain("batch only supports query commands", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunBatch_TooDeepJsonLine_ReturnsUsageError_Issue3022()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_batch_json_depth");


### PR DESCRIPTION
## Summary
- Add per-decoded-argument length validation for `cdidx batch`.
- Enforce the shared query length limit for `cdidx find` and `find --count`.
- Bound literal-safe search queries in `DbReader` before FTS5 sanitization and return CLI/MCP usage errors for oversized generated input.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunBatch_Argument|FullyQualifiedName~RunFind_QueryTooLongReturnsUsageError_Issue3100|FullyQualifiedName~Issue3081"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `cdidx status --check --json`
- Codex adversarial review of `origin/main..HEAD`: No blocking/actionable issues found.

Fixes #3231
Fixes #3100
Fixes #3081