### PR TITLE
Stream indexed chunks for find matching

### DIFF
--- a/changelog.d/unreleased/3099.fixed.md
+++ b/changelog.d/unreleased/3099.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3099
+affected:
+  - src/CodeIndex/Database/DbReader.FilesStatus.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+---
+
+## English
+
+- **`find` and `find --count` now stream indexed chunks while matching (#3099)** — both paths share the same incremental line matcher, avoiding full per-file line-map reconstruction and keeping overlap handling consistent.
+
+## 日本語
+
+- **`find` と `find --count` が照合時にインデックス済みチャンクをストリーム処理するようになりました (#3099)** — 両経路が同じ増分行 matcher を共有し、ファイル全体の行マップ再構成を避けつつ重複チャンクの扱いを揃えます。

--- a/src/CodeIndex/Database/DbReader.FilesStatus.cs
+++ b/src/CodeIndex/Database/DbReader.FilesStatus.cs
@@ -22,7 +22,7 @@ public partial class DbReader
             : null;
 
         using var fileCmd = _conn.CreateCommand();
-        var sql = "SELECT f.path, f.lang, f.lines FROM files f WHERE 1=1";
+        var sql = "SELECT f.id, f.path, f.lang, f.lines FROM files f WHERE 1=1";
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
@@ -39,86 +39,72 @@ public partial class DbReader
             if (results.Count >= limit)
                 break;
 
-            var path = fileReader.GetString(0);
-            var fileLang = GetNullableString(fileReader, 1);
-            var totalLines = fileReader.GetInt32(2);
-            if (!TryLoadIndexedFileLines(path, out _, out _, out var lineMap) || lineMap.Count == 0)
+            var fileId = fileReader.GetInt64(0);
+            var path = fileReader.GetString(1);
+            var fileLang = GetNullableString(fileReader, 2);
+            var totalLines = fileReader.GetInt32(3);
+            if (totalLines <= 0)
                 continue;
 
             var searchQuery = exact && !regex ? ExactSourceSearchNormalizer.Normalize(query, fileLang) : query;
-            for (int lineNumber = 1; lineNumber <= totalLines && results.Count < limit; lineNumber++)
+            var pendingMatches = new Queue<PendingFileFindMatch>();
+            var snippetWindow = new Queue<IndexedLine>();
+            var snippetLinesByNumber = new Dictionary<int, string>();
+            var acceptedMatches = results.Count;
+
+            foreach (var indexedLine in EnumerateIndexedFileLines(fileId))
             {
-                if (focusLine.HasValue && lineNumber != focusLine.Value)
-                    continue;
-                if (!lineMap.TryGetValue(lineNumber, out var lineText))
-                    continue;
+                if (indexedLine.Number > totalLines)
+                    break;
 
-                int[]? rawIndexMap = null;
-                var searchLine = exact && !regex
-                    ? ExactSourceSearchNormalizer.Normalize(lineText, fileLang, out rawIndexMap)
-                    : lineText;
-                var snippetStart = Math.Max(1, lineNumber - before);
-                var snippetEnd = Math.Min(totalLines, lineNumber + after);
-                var snippetLineNumbers = Enumerable.Range(snippetStart, snippetEnd - snippetStart + 1)
-                    .Where(lineMap.ContainsKey)
-                    .ToList();
-                if (snippetLineNumbers.Count == 0)
-                    continue;
+                AddLineToFindWindow(indexedLine, snippetWindow, snippetLinesByNumber);
 
-                if (regexMatcher != null)
+                if (acceptedMatches < limit && (!focusLine.HasValue || indexedLine.Number == focusLine.Value))
                 {
-                    foreach (Match match in regexMatcher.Matches(searchLine))
+                    foreach (var lineMatch in EnumerateFindLineMatches(
+                        indexedLine.Text,
+                        fileLang,
+                        searchQuery,
+                        comparison,
+                        regexMatcher,
+                        exact && !regex,
+                        focusColumn))
                     {
-                        if (!match.Success || results.Count >= limit)
+                        if (acceptedMatches >= limit)
                             break;
-                        TryAddMatch(match.Index, Math.Max(1, match.Length));
+
+                        pendingMatches.Enqueue(new PendingFileFindMatch(
+                            indexedLine.Number,
+                            lineMatch.Column,
+                            lineMatch.Length,
+                            Math.Max(1, indexedLine.Number - before),
+                            Math.Min(totalLines, indexedLine.Number + after)));
+                        acceptedMatches++;
                     }
-                    continue;
                 }
 
-                for (int searchStart = 0; searchStart < searchLine.Length && results.Count < limit;)
-                {
-                    var matchColumn = searchLine.IndexOf(searchQuery, searchStart, comparison);
-                    if (matchColumn < 0)
-                        break;
-                    TryAddMatch(matchColumn, searchQuery.Length);
-                    searchStart = matchColumn + 1;
-                }
+                FlushReadyFindMatches(
+                    path,
+                    fileLang,
+                    pendingMatches,
+                    snippetLinesByNumber,
+                    results,
+                    maxLineWidth,
+                    indexedLine.Number);
+                PruneFindWindow(indexedLine.Number, before, pendingMatches, snippetWindow, snippetLinesByNumber);
 
-                bool TryAddMatch(int matchColumn, int matchLength)
-                {
-                    var rawMatchColumn = rawIndexMap == null ? matchColumn : rawIndexMap[matchColumn];
-                    var rawMatchLength = matchLength;
-                    if (rawIndexMap != null && matchLength > 0)
-                    {
-                        var rawMatchEndIndex = rawIndexMap[matchColumn + matchLength - 1];
-                        rawMatchLength = rawMatchEndIndex - rawMatchColumn + 1;
-                    }
-                    if (focusColumn.HasValue && (focusColumn.Value < rawMatchColumn + 1 || focusColumn.Value > rawMatchColumn + rawMatchLength))
-                        return false;
-
-                    var snippetLines = snippetLineNumbers.Select(line => lineMap[line]).ToList();
-                    var clampedSnippet = LineWidthFormatter.ClampLines(
-                        snippetLines,
-                        maxLineWidth,
-                        focusLineIndex: snippetLineNumbers.IndexOf(lineNumber),
-                        focusColumn: rawMatchColumn + 1,
-                        focusLength: rawMatchLength);
-
-                    results.Add(new FileFindResult
-                    {
-                        Path = path,
-                        Lang = fileLang,
-                        Line = lineNumber,
-                        Column = rawMatchColumn + 1,
-                        StartLine = snippetLineNumbers[0],
-                        EndLine = snippetLineNumbers[^1],
-                        Snippet = clampedSnippet.Text,
-                        SnippetTruncated = clampedSnippet.Truncated,
-                    });
-                    return true;
-                }
+                if (results.Count >= limit && pendingMatches.Count == 0)
+                    break;
             }
+
+            FlushReadyFindMatches(
+                path,
+                fileLang,
+                pendingMatches,
+                snippetLinesByNumber,
+                results,
+                maxLineWidth,
+                int.MaxValue);
         }
 
         return results;
@@ -152,7 +138,7 @@ public partial class DbReader
             ? new Regex(query, exact ? RegexOptions.None : RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500))
             : null;
         using var fileCmd = _conn.CreateCommand();
-        var sql = "SELECT f.path, f.lang, f.lines FROM files f WHERE 1=1";
+        var sql = "SELECT f.id, f.path, f.lang, f.lines FROM files f WHERE 1=1";
         if (lang != null)
             sql += " AND f.lang = @lang";
         AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
@@ -167,60 +153,32 @@ public partial class DbReader
         using var fileReader = fileCmd.ExecuteTrackedReader();
         while (fileReader.TrackedRead())
         {
-            var path = fileReader.GetString(0);
-            var fileLang = GetNullableString(fileReader, 1);
-            var totalLines = fileReader.GetInt32(2);
-            if (!TryLoadIndexedFileLines(path, out _, out _, out var lineMap) || lineMap.Count == 0)
+            var fileId = fileReader.GetInt64(0);
+            var fileLang = GetNullableString(fileReader, 2);
+            var totalLines = fileReader.GetInt32(3);
+            if (totalLines <= 0)
                 continue;
 
             var searchQuery = exact && !regex ? ExactSourceSearchNormalizer.Normalize(query, fileLang) : query;
             var fileMatches = 0;
-            for (int lineNumber = 1; lineNumber <= totalLines; lineNumber++)
+            foreach (var indexedLine in EnumerateIndexedFileLines(fileId))
             {
-                if (focusLine.HasValue && lineNumber != focusLine.Value)
+                if (indexedLine.Number > totalLines)
+                    break;
+
+                if (focusLine.HasValue && indexedLine.Number != focusLine.Value)
                     continue;
-                if (!lineMap.TryGetValue(lineNumber, out var lineText))
-                    continue;
 
-                int[]? rawIndexMap = null;
-                var searchLine = exact && !regex
-                    ? ExactSourceSearchNormalizer.Normalize(lineText, fileLang, out rawIndexMap)
-                    : lineText;
-                if (regexMatcher != null)
+                foreach (var _ in EnumerateFindLineMatches(
+                    indexedLine.Text,
+                    fileLang,
+                    searchQuery,
+                    comparison,
+                    regexMatcher,
+                    exact && !regex,
+                    focusColumn))
                 {
-                    foreach (Match match in regexMatcher.Matches(searchLine))
-                    {
-                        if (!match.Success)
-                            continue;
-                        if (IsFocusedMatch(match.Index, Math.Max(1, match.Length)))
-                            fileMatches++;
-                    }
-                    continue;
-                }
-
-                for (int searchStart = 0; searchStart < searchLine.Length;)
-                {
-                    var matchColumn = searchLine.IndexOf(searchQuery, searchStart, comparison);
-                    if (matchColumn < 0)
-                        break;
-
-                    if (IsFocusedMatch(matchColumn, searchQuery.Length))
-                        fileMatches++;
-                    searchStart = matchColumn + 1;
-                }
-
-                bool IsFocusedMatch(int matchColumn, int matchLength)
-                {
-                    if (!focusColumn.HasValue)
-                        return true;
-                    var rawMatchColumn = rawIndexMap == null ? matchColumn : rawIndexMap[matchColumn];
-                    var rawMatchLength = matchLength;
-                    if (rawIndexMap != null && matchLength > 0)
-                    {
-                        var rawMatchEndIndex = rawIndexMap[matchColumn + matchLength - 1];
-                        rawMatchLength = rawMatchEndIndex - rawMatchColumn + 1;
-                    }
-                    return focusColumn.Value >= rawMatchColumn + 1 && focusColumn.Value <= rawMatchColumn + rawMatchLength;
+                    fileMatches++;
                 }
             }
 
@@ -232,6 +190,160 @@ public partial class DbReader
         }
 
         return new QueryCountResult(count, fileCount);
+    }
+
+    private readonly record struct IndexedLine(int Number, string Text);
+
+    private readonly record struct FindLineMatch(int Column, int Length);
+
+    private readonly record struct PendingFileFindMatch(int LineNumber, int Column, int Length, int SnippetStart, int SnippetEnd);
+
+    private IEnumerable<IndexedLine> EnumerateIndexedFileLines(long fileId)
+    {
+        using var chunkCmd = _conn.CreateCommand();
+        chunkCmd.CommandText = @"
+            SELECT c.start_line, c.end_line, c.content
+            FROM chunks c
+            WHERE c.file_id = @fileId
+            ORDER BY c.start_line, c.chunk_index";
+        chunkCmd.Parameters.AddWithValue("@fileId", fileId);
+
+        var lastEmittedLine = 0;
+        using var chunkReader = chunkCmd.ExecuteTrackedReader();
+        while (chunkReader.TrackedRead())
+        {
+            var chunkStartLine = chunkReader.GetInt32(0);
+            var chunkEndLine = chunkReader.GetInt32(1);
+            var chunkLines = chunkReader.GetString(2).Split('\n');
+            var lineCount = chunkEndLine - chunkStartLine + 1;
+
+            for (int i = 0; i < chunkLines.Length && i < lineCount; i++)
+            {
+                var absoluteLine = chunkStartLine + i;
+                if (absoluteLine <= lastEmittedLine)
+                    continue;
+
+                lastEmittedLine = absoluteLine;
+                yield return new IndexedLine(absoluteLine, chunkLines[i]);
+            }
+        }
+    }
+
+    private static IEnumerable<FindLineMatch> EnumerateFindLineMatches(
+        string lineText,
+        string? fileLang,
+        string searchQuery,
+        StringComparison comparison,
+        Regex? regexMatcher,
+        bool normalizeExactSource,
+        int? focusColumn)
+    {
+        int[]? rawIndexMap = null;
+        var searchLine = normalizeExactSource
+            ? ExactSourceSearchNormalizer.Normalize(lineText, fileLang, out rawIndexMap)
+            : lineText;
+
+        if (regexMatcher != null)
+        {
+            foreach (Match match in regexMatcher.Matches(searchLine))
+            {
+                if (!match.Success)
+                    continue;
+                if (TryCreateFindLineMatch(match.Index, Math.Max(1, match.Length), rawIndexMap, focusColumn, out var lineMatch))
+                    yield return lineMatch;
+            }
+
+            yield break;
+        }
+
+        for (int searchStart = 0; searchStart < searchLine.Length;)
+        {
+            var matchColumn = searchLine.IndexOf(searchQuery, searchStart, comparison);
+            if (matchColumn < 0)
+                break;
+
+            if (TryCreateFindLineMatch(matchColumn, searchQuery.Length, rawIndexMap, focusColumn, out var lineMatch))
+                yield return lineMatch;
+            searchStart = matchColumn + 1;
+        }
+    }
+
+    private static bool TryCreateFindLineMatch(int matchColumn, int matchLength, int[]? rawIndexMap, int? focusColumn, out FindLineMatch lineMatch)
+    {
+        var rawMatchColumn = rawIndexMap == null ? matchColumn : rawIndexMap[matchColumn];
+        var rawMatchLength = matchLength;
+        if (rawIndexMap != null && matchLength > 0)
+        {
+            var rawMatchEndIndex = rawIndexMap[matchColumn + matchLength - 1];
+            rawMatchLength = rawMatchEndIndex - rawMatchColumn + 1;
+        }
+
+        lineMatch = new FindLineMatch(rawMatchColumn, rawMatchLength);
+        return !focusColumn.HasValue || (focusColumn.Value >= rawMatchColumn + 1 && focusColumn.Value <= rawMatchColumn + rawMatchLength);
+    }
+
+    private static void AddLineToFindWindow(IndexedLine indexedLine, Queue<IndexedLine> snippetWindow, Dictionary<int, string> snippetLinesByNumber)
+    {
+        snippetWindow.Enqueue(indexedLine);
+        snippetLinesByNumber[indexedLine.Number] = indexedLine.Text;
+    }
+
+    private static void FlushReadyFindMatches(
+        string path,
+        string? fileLang,
+        Queue<PendingFileFindMatch> pendingMatches,
+        Dictionary<int, string> snippetLinesByNumber,
+        List<FileFindResult> results,
+        int maxLineWidth,
+        int availableThroughLine)
+    {
+        while (pendingMatches.Count > 0 && pendingMatches.Peek().SnippetEnd <= availableThroughLine)
+        {
+            var pending = pendingMatches.Dequeue();
+            var snippetLineNumbers = Enumerable.Range(pending.SnippetStart, pending.SnippetEnd - pending.SnippetStart + 1)
+                .Where(snippetLinesByNumber.ContainsKey)
+                .ToList();
+            if (snippetLineNumbers.Count == 0)
+                continue;
+
+            var snippetLines = snippetLineNumbers.Select(line => snippetLinesByNumber[line]).ToList();
+            var clampedSnippet = LineWidthFormatter.ClampLines(
+                snippetLines,
+                maxLineWidth,
+                focusLineIndex: snippetLineNumbers.IndexOf(pending.LineNumber),
+                focusColumn: pending.Column + 1,
+                focusLength: pending.Length);
+
+            results.Add(new FileFindResult
+            {
+                Path = path,
+                Lang = fileLang,
+                Line = pending.LineNumber,
+                Column = pending.Column + 1,
+                StartLine = snippetLineNumbers[0],
+                EndLine = snippetLineNumbers[^1],
+                Snippet = clampedSnippet.Text,
+                SnippetTruncated = clampedSnippet.Truncated,
+            });
+        }
+    }
+
+    private static void PruneFindWindow(
+        int currentLine,
+        int before,
+        Queue<PendingFileFindMatch> pendingMatches,
+        Queue<IndexedLine> snippetWindow,
+        Dictionary<int, string> snippetLinesByNumber)
+    {
+        var minLineToKeep = currentLine - before;
+        if (pendingMatches.Count > 0)
+            minLineToKeep = Math.Min(minLineToKeep, pendingMatches.Peek().SnippetStart);
+
+        while (snippetWindow.Count > 0 && snippetWindow.Peek().Number < minLineToKeep)
+        {
+            var removed = snippetWindow.Dequeue();
+            snippetLinesByNumber.Remove(removed.Number);
+        }
     }
 
     /// <summary>

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -3582,6 +3582,78 @@ jobs:
     }
 
     [Fact]
+    public void RunFind_StreamsOverlappingChunksOnce_Issue3099()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_stream_chunks");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            using (var db = new DbContext(dbPath))
+            {
+                var writer = new DbWriter(db.Connection);
+                var fileId = writer.UpsertFile(new FileRecord
+                {
+                    Path = "src/overlap.txt",
+                    Lang = "text",
+                    Size = "first\nalpha one\nshared alpha\nalpha after\nlast".Length,
+                    Lines = 5,
+                    Modified = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    Checksum = "overlapping-chunks",
+                });
+                writer.InsertChunks([
+                    new ChunkRecord
+                    {
+                        FileId = fileId,
+                        ChunkIndex = 0,
+                        StartLine = 1,
+                        EndLine = 3,
+                        Content = "first\nalpha one\nshared alpha",
+                    },
+                    new ChunkRecord
+                    {
+                        FileId = fileId,
+                        ChunkIndex = 1,
+                        StartLine = 3,
+                        EndLine = 5,
+                        Content = "shared alpha\nalpha after\nlast",
+                    }
+                ]);
+            }
+
+            var (findExitCode, findStdout, findStderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["shared", "--db", dbPath, "--path", "src/overlap.txt", "--json", "--before", "1", "--after", "1"],
+                _jsonOptions));
+            using var findDocument = ParseJsonOutput(findStdout);
+            var findJson = findDocument.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, findExitCode);
+            Assert.Equal(string.Empty, findStderr);
+            Assert.Equal(3, findJson.GetProperty("line").GetInt32());
+            Assert.Equal(1, findJson.GetProperty("column").GetInt32());
+            Assert.Equal(2, findJson.GetProperty("start_line").GetInt32());
+            Assert.Equal(4, findJson.GetProperty("end_line").GetInt32());
+            Assert.Contains("alpha one", findJson.GetProperty("snippet").GetString());
+            Assert.Contains("alpha after", findJson.GetProperty("snippet").GetString());
+
+            var (countExitCode, countStdout, countStderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["alpha", "--db", dbPath, "--path", "src/overlap.txt", "--json", "--count"],
+                _jsonOptions));
+            using var countDocument = ParseJsonOutput(countStdout);
+            var countJson = countDocument.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, countExitCode);
+            Assert.Equal(string.Empty, countStderr);
+            Assert.Equal(3, countJson.GetProperty("count").GetInt32());
+            Assert.Equal(1, countJson.GetProperty("files").GetInt32());
+            Assert.Equal(1, countJson.GetProperty("file_count").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunFind_ExactTreatsCSharpGlobalQualifiedNamesAsCanonical()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_find_exact_csharp_global");


### PR DESCRIPTION
## Summary

- Stream indexed chunk lines for `find` and `find --count` instead of reconstructing a full per-file line map.
- Share the line matcher between result-producing and count-only paths so exact, regex, and focus filtering stay consistent.
- Add regression coverage for overlapping chunk rows with snippet context and count-only matching.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunFind_StreamsOverlappingChunksOnce_Issue3099" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunFind" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Full-suite note: `dotnet test CodeIndex.sln --no-build -p:UseSharedCompilation=false` was started but did not complete after 12+ minutes with no failure output; I terminated that run and relied on the targeted find coverage plus solution build.

## Documentation And Changelog

- Added `changelog.d/unreleased/3099.fixed.md`.
- No README/user guide changes: CLI output and command syntax are unchanged.

## Scope Notes

- #3100 was excluded because it already had a work-started comment on branch `fix-issue3231-3100-3081`.
- Follow-up candidates: none.

Fixes #3099