### PR TITLE
[codex] Bound index JSON parsing samples

### DIFF
--- a/changelog.d/unreleased/3044.fixed.md
+++ b/changelog.d/unreleased/3044.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3044
+affected:
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+---
+
+## English
+
+- **Watch-mode human summaries now bound sub-run JSON parsing (#3044)** — oversized or deeply nested sub-run payloads fall back to an exit-code-only summary instead of being parsed for informational counts.
+
+## 日本語
+
+- **watch mode の human summary で sub-run JSON parsing を制限しました (#3044)** — 過大または深くネストした sub-run payload は情報用 counts を解析せず、exit code だけの要約にフォールバックします。

--- a/changelog.d/unreleased/3060.security.md
+++ b/changelog.d/unreleased/3060.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 3060
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Full-scan checkpoint loading now bounds JSON depth and directory payloads (#3060)** — malformed scan checkpoints are ignored before oversized completed-directory sets can be trusted.
+
+## 日本語
+
+- **full-scan checkpoint の読み込みで JSON 深さと directory payload を制限しました (#3060)** — 破損した scan checkpoint は、過大な完了済み directory set として信頼される前に無視されます。

--- a/changelog.d/unreleased/3133.fixed.md
+++ b/changelog.d/unreleased/3133.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3133
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.DryRun.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Index dry-run JSON now reports bounded file and error samples (#3133)** — dry-run output keeps total counts while capping file and error sample arrays so large repositories do not require unbounded result lists.
+
+## 日本語
+
+- **index dry-run JSON が file / error の bounded sample を返すようになりました (#3133)** — dry-run output は総数を保持しつつ file / error sample array を制限し、大規模リポジトリで無制限の結果リストを必要としないようにしました。

--- a/src/CodeIndex/Cli/IndexCommandRunner.DryRun.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.DryRun.cs
@@ -6,6 +6,10 @@ namespace CodeIndex.Cli;
 
 public static partial class IndexCommandRunner
 {
+    internal const int DryRunFileSampleLimit = 100;
+    internal const int DryRunErrorSampleLimit = 100;
+    private const int DryRunScanErrorKeyLimit = 2048;
+
     private static int RunDryRun(
         IndexCommandOptions options,
         bool ignoreCase,
@@ -17,18 +21,29 @@ public static partial class IndexCommandRunner
         var projectPath = options.ProjectPath!;
         var dryIndexer = new FileIndexer(projectPath, ignoreCase, ignoreRuleRoot, options.MaxFileSizeBytes, directoryIgnoreCaseProbe: null, symlinkPolicy: options.SymlinkPolicy);
         IReadOnlyList<string> dryCandidates;
-        var errorList = new List<CliJsonMessage>();
+        var errorSamples = new List<CliJsonMessage>();
+        var errorCount = 0;
         var dryScanErrorKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        void RecordDryRunError(string file, string message)
+        {
+            errorCount++;
+            if (errorSamples.Count < DryRunErrorSampleLimit)
+                errorSamples.Add(new CliJsonMessage(file, message));
+        }
 
         void RecordDryRunScanErrors(IEnumerable<FileIndexer.ScanError> scanErrors)
         {
             foreach (var scanError in scanErrors)
             {
                 var key = $"{scanError.Path}\n{scanError.Message}";
-                if (!dryScanErrorKeys.Add(key))
-                    continue;
+                if (dryScanErrorKeys.Count < DryRunScanErrorKeyLimit)
+                {
+                    if (!dryScanErrorKeys.Add(key))
+                        continue;
+                }
 
-                errorList.Add(new CliJsonMessage(scanError.Path, scanError.Message));
+                RecordDryRunError(scanError.Path, scanError.Message);
                 if (!options.Json)
                     ConsoleUi.PrintWarning($"{scanError.Path}: {scanError.Message}");
             }
@@ -47,7 +62,8 @@ public static partial class IndexCommandRunner
             return exitCode;
         }
 
-        var dryFiles = new List<string>();
+        var dryFileSamples = new List<string>();
+        var dryFileCount = 0;
         var langCounts = new Dictionary<string, int>();
         foreach (var f in dryCandidates)
         {
@@ -61,14 +77,16 @@ public static partial class IndexCommandRunner
                 if (message != null)
                 {
                     var displayPath = FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectPath, f));
-                    errorList.Add(new CliJsonMessage(displayPath, message));
+                    RecordDryRunError(displayPath, message);
                     if (!options.Json && !options.Quiet)
                         ConsoleUi.PrintWarning($"{displayPath}: {message}");
                 }
                 continue;
             }
 
-            dryFiles.Add(f);
+            dryFileCount++;
+            if (dryFileSamples.Count < DryRunFileSampleLimit)
+                dryFileSamples.Add(FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectPath, f)));
             langCounts[lang] = langCounts.GetValueOrDefault(lang) + 1;
         }
         if (options.Json)
@@ -76,14 +94,20 @@ public static partial class IndexCommandRunner
             Console.WriteLine(JsonSerializer.Serialize(new IndexDryRunJsonResult
             {
                 Status = "dry_run",
-                FilesTotal = dryFiles.Count,
+                FilesTotal = dryFileCount,
+                FileSamples = dryFileSamples.Count > 0 ? dryFileSamples : null,
+                FileSamplesTruncated = dryFileCount > dryFileSamples.Count,
+                FileSampleLimit = DryRunFileSampleLimit,
                 Languages = langCounts,
-                Errors = errorList.Count > 0 ? errorList : null,
+                ErrorsTotal = errorCount,
+                Errors = errorSamples.Count > 0 ? errorSamples : null,
+                ErrorsTruncated = errorCount > errorSamples.Count,
+                ErrorLimit = DryRunErrorSampleLimit,
             }, jsonContext.IndexDryRunJsonResult));
         }
         else
         {
-            Console.WriteLine($"Dry run: {dryFiles.Count} files would be indexed");
+            Console.WriteLine($"Dry run: {dryFileCount} files would be indexed");
             foreach (var (lang, count) in langCounts.OrderByDescending(kv => kv.Value))
                 Console.WriteLine($"  {lang,-12} {count,6}");
         }

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -286,43 +286,76 @@ public static partial class IndexCommandRunner
         || ex is SqliteException { SqliteErrorCode: 5 or 6 or 8 or 10 or 14 };
 
     internal const int MaxScanCheckpointBytes = 1024 * 1024;
+    internal const int MaxScanCheckpointJsonDepth = 16;
+    internal const int MaxScanCheckpointDirectories = 4096;
+    internal const int MaxScanCheckpointDirectoryLength = 4096;
 
-    private static IReadOnlySet<string> LoadScanCheckpoint(string path, string? currentHead)
+    internal static IReadOnlySet<string> LoadScanCheckpoint(string path, string? currentHead)
     {
         try
         {
             if (string.IsNullOrWhiteSpace(currentHead) || !File.Exists(path))
-                return new HashSet<string>(StringComparer.Ordinal);
+                return EmptyScanCheckpointDirectories();
 
             var text = DataDirectorySecurity.ReadTextWithinLimit(path, MaxScanCheckpointBytes, FileShare.ReadWrite);
             if (text is null)
-                return new HashSet<string>(StringComparer.Ordinal);
+                return EmptyScanCheckpointDirectories();
 
-            var checkpoint = JsonSerializer.Deserialize<ScanCheckpoint>(text);
+            var checkpoint = JsonSerializer.Deserialize<ScanCheckpoint>(
+                text,
+                new JsonSerializerOptions { MaxDepth = MaxScanCheckpointJsonDepth });
             if (checkpoint is not { Version: ScanCheckpointVersion }
                 || !string.Equals(checkpoint.GitHead, currentHead, StringComparison.Ordinal)
-                || checkpoint.Directories is not { Count: > 0 })
+                || !TryBuildScanCheckpointDirectories(checkpoint.Directories, out var directories))
             {
-                return new HashSet<string>(StringComparer.Ordinal);
+                return EmptyScanCheckpointDirectories();
             }
 
-            return checkpoint.Directories
-                .Where(directory => directory.Length > 0)
-                .ToHashSet(StringComparer.Ordinal);
+            return directories;
         }
         catch (JsonException)
         {
-            return new HashSet<string>(StringComparer.Ordinal);
+            return EmptyScanCheckpointDirectories();
         }
         catch (IOException)
         {
-            return new HashSet<string>(StringComparer.Ordinal);
+            return EmptyScanCheckpointDirectories();
         }
         catch (UnauthorizedAccessException)
         {
-            return new HashSet<string>(StringComparer.Ordinal);
+            return EmptyScanCheckpointDirectories();
         }
     }
+
+    private static bool TryBuildScanCheckpointDirectories(IReadOnlyList<string>? rawDirectories, out IReadOnlySet<string> directories)
+    {
+        directories = EmptyScanCheckpointDirectories();
+        if (rawDirectories is not { Count: > 0 })
+            return false;
+        if (rawDirectories.Count > MaxScanCheckpointDirectories)
+            return false;
+
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var directory in rawDirectories)
+        {
+            if (directory is null)
+                return false;
+            if (directory.Length == 0)
+                continue;
+            if (directory.Length > MaxScanCheckpointDirectoryLength)
+                return false;
+
+            result.Add(directory);
+        }
+
+        if (result.Count == 0)
+            return false;
+
+        directories = result;
+        return true;
+    }
+
+    private static HashSet<string> EmptyScanCheckpointDirectories() => new(StringComparer.Ordinal);
 
     private static void SaveScanCheckpoint(string path, string? currentHead, IReadOnlySet<string> directories)
     {

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -16,6 +16,8 @@ internal static class IndexWatchRunner
 {
     internal const int DefaultDebounceMs = 500;
     internal const int MaxDebounceMs = 60_000;
+    internal const int MaxHumanSummarySubRunJsonChars = 64 * 1024;
+    internal const int MaxHumanSummaryJsonDepth = 16;
     private const int InternalBufferSize = 64 * 1024;
     private const int PollIntervalMs = 50;
 
@@ -302,10 +304,12 @@ internal static class IndexWatchRunner
         };
         try
         {
-            var trimmed = subRunJson.TrimEnd('\r', '\n');
-            if (!string.IsNullOrEmpty(trimmed))
+            var trimmedLength = TrimTrailingLineBreaks(subRunJson);
+            if (trimmedLength > 0 && trimmedLength <= MaxHumanSummarySubRunJsonChars)
             {
-                using var doc = JsonDocument.Parse(trimmed);
+                using var doc = JsonDocument.Parse(
+                    subRunJson.AsMemory(0, trimmedLength),
+                    new JsonDocumentOptions { MaxDepth = MaxHumanSummaryJsonDepth });
                 var root = doc.RootElement;
                 if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("summary", out var summary)
                     && summary.ValueKind == JsonValueKind.Object)
@@ -325,6 +329,15 @@ internal static class IndexWatchRunner
 
         var detail = details.Count > 0 ? $" ({string.Join(", ", details)})" : string.Empty;
         return $"{prefix}{batchLabel}{detail} in {elapsedMs.ToString("N0", System.Globalization.CultureInfo.InvariantCulture)} ms";
+    }
+
+    private static int TrimTrailingLineBreaks(string value)
+    {
+        var length = value.Length;
+        while (length > 0 && (value[length - 1] == '\r' || value[length - 1] == '\n'))
+            length--;
+
+        return length;
     }
 
     private static void EmitWatchStarted(

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -195,8 +195,14 @@ internal sealed class IndexDryRunJsonResult
 {
     public string Status { get; init; } = string.Empty;
     public int FilesTotal { get; init; }
+    public List<string>? FileSamples { get; init; }
+    public bool FileSamplesTruncated { get; init; }
+    public int FileSampleLimit { get; init; }
     public Dictionary<string, int> Languages { get; init; } = new();
+    public int ErrorsTotal { get; init; }
     public List<CliJsonMessage>? Errors { get; init; }
+    public bool ErrorsTruncated { get; init; }
+    public int ErrorLimit { get; init; }
 }
 
 internal sealed class IndexWatchEventJsonResult

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -7905,6 +7905,62 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_DryRun_JsonCapsFileSamples()
+    {
+        var projectRoot = CreateTempProject();
+        var fileCount = IndexCommandRunner.DryRunFileSampleLimit + 3;
+        try
+        {
+            foreach (var i in Enumerable.Range(0, fileCount))
+                File.WriteAllText(Path.Combine(projectRoot, $"sample{i:D3}.cs"), $"public class Sample{i} {{ }}\n");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--dry-run", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("dry_run", json.GetProperty("status").GetString());
+            Assert.Equal(fileCount, json.GetProperty("files_total").GetInt32());
+            Assert.Equal(fileCount, json.GetProperty("languages").GetProperty("csharp").GetInt32());
+            Assert.Equal(IndexCommandRunner.DryRunFileSampleLimit, json.GetProperty("file_sample_limit").GetInt32());
+            Assert.True(json.GetProperty("file_samples_truncated").GetBoolean());
+            Assert.Equal(IndexCommandRunner.DryRunFileSampleLimit, json.GetProperty("file_samples").GetArrayLength());
+            Assert.Equal(0, json.GetProperty("errors_total").GetInt32());
+            Assert.False(json.GetProperty("errors_truncated").GetBoolean());
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_DryRun_JsonCapsErrorSamples()
+    {
+        var projectRoot = CreateTempProject();
+        var fileCount = IndexCommandRunner.DryRunErrorSampleLimit + 3;
+        try
+        {
+            foreach (var i in Enumerable.Range(0, fileCount))
+                File.WriteAllText(Path.Combine(projectRoot, $"large{i:D3}.cs"), $"public class Large{i} {{ }}\n");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--dry-run", "--max-file-bytes", "1", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("dry_run", json.GetProperty("status").GetString());
+            Assert.Equal(0, json.GetProperty("files_total").GetInt32());
+            Assert.Equal(fileCount, json.GetProperty("errors_total").GetInt32());
+            Assert.Equal(IndexCommandRunner.DryRunErrorSampleLimit, json.GetProperty("error_limit").GetInt32());
+            Assert.True(json.GetProperty("errors_truncated").GetBoolean());
+            Assert.Equal(IndexCommandRunner.DryRunErrorSampleLimit, json.GetProperty("errors").GetArrayLength());
+            Assert.Equal(IndexCommandRunner.DryRunFileSampleLimit, json.GetProperty("file_sample_limit").GetInt32());
+            Assert.False(json.GetProperty("file_samples_truncated").GetBoolean());
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_DryRun_FullScan_ReportsUnreadableDirectory()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -183,6 +183,88 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void LoadScanCheckpoint_ValidPayload_ReturnsBoundedDirectorySet()
+    {
+        var projectRoot = CreateTempProject();
+        var checkpointPath = Path.Combine(projectRoot, "scan-checkpoint.json");
+        try
+        {
+            File.WriteAllText(checkpointPath, JsonSerializer.Serialize(new
+            {
+                Version = 1,
+                GitHead = "abc123",
+                Directories = new[] { "src", string.Empty, "tests", "src" },
+            }));
+
+            var directories = IndexCommandRunner.LoadScanCheckpoint(checkpointPath, "abc123");
+
+            Assert.Equal(2, directories.Count);
+            Assert.Contains("src", directories);
+            Assert.Contains("tests", directories);
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void LoadScanCheckpoint_DirectoryPayloadOutsideBounds_ReturnsEmpty()
+    {
+        var projectRoot = CreateTempProject();
+        var checkpointPath = Path.Combine(projectRoot, "scan-checkpoint.json");
+        try
+        {
+            File.WriteAllText(checkpointPath, JsonSerializer.Serialize(new
+            {
+                Version = 1,
+                GitHead = "abc123",
+                Directories = Enumerable.Range(0, IndexCommandRunner.MaxScanCheckpointDirectories + 1)
+                    .Select(i => $"dir{i}")
+                    .ToArray(),
+            }));
+            Assert.Empty(IndexCommandRunner.LoadScanCheckpoint(checkpointPath, "abc123"));
+
+            File.WriteAllText(checkpointPath, JsonSerializer.Serialize(new
+            {
+                Version = 1,
+                GitHead = "abc123",
+                Directories = new[] { new string('x', IndexCommandRunner.MaxScanCheckpointDirectoryLength + 1) },
+            }));
+            Assert.Empty(IndexCommandRunner.LoadScanCheckpoint(checkpointPath, "abc123"));
+
+            File.WriteAllText(checkpointPath, """{"Version":1,"GitHead":"abc123","Directories":[null]}""");
+            Assert.Empty(IndexCommandRunner.LoadScanCheckpoint(checkpointPath, "abc123"));
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void LoadScanCheckpoint_JsonDepthOutsideBounds_ReturnsEmpty()
+    {
+        var projectRoot = CreateTempProject();
+        var checkpointPath = Path.Combine(projectRoot, "scan-checkpoint.json");
+        try
+        {
+            var depth = IndexCommandRunner.MaxScanCheckpointJsonDepth + 4;
+            var nestedStart = string.Concat(Enumerable.Repeat("[", depth));
+            var nestedEnd = string.Concat(Enumerable.Repeat("]", depth));
+            File.WriteAllText(
+                checkpointPath,
+                $$"""{"Version":1,"GitHead":"abc123","Directories":{{nestedStart}}"src"{{nestedEnd}}}""");
+
+            Assert.Empty(IndexCommandRunner.LoadScanCheckpoint(checkpointPath, "abc123"));
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_NullByteFile_SkipsWithoutPersistingPartialRows()
     {
         var projectRoot = CreateTempProject();

--- a/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
@@ -309,6 +309,62 @@ public class IndexWatchRunnerTests
     }
 
     [Fact]
+    public void FormatHumanSummary_BoundedSubRunJson_ExtractsCounts()
+    {
+        var summary = InvokeFormatHumanSummary(
+            "updated",
+            2,
+            123,
+            """{"summary":{"updated":1,"removed":2,"errors":3}}""" + Environment.NewLine,
+            CommandExitCodes.Success);
+
+        Assert.Contains("[watch] updated 2 paths", summary);
+        Assert.Contains("exit code 0", summary);
+        Assert.Contains("updated 1", summary);
+        Assert.Contains("removed 2", summary);
+        Assert.Contains("errors 3", summary);
+    }
+
+    [Fact]
+    public void FormatHumanSummary_OversizedSubRunJson_UsesTerseSummary()
+    {
+        var oversized = $$"""{"summary":{"updated":1,"removed":2,"errors":3},"padding":"{{new string('x', IndexWatchRunner.MaxHumanSummarySubRunJsonChars + 1)}}"}""";
+
+        var summary = InvokeFormatHumanSummary(
+            "updated",
+            2,
+            123,
+            oversized,
+            CommandExitCodes.Success);
+
+        Assert.Contains("exit code 0", summary);
+        Assert.DoesNotContain("updated 1", summary);
+        Assert.DoesNotContain("removed 2", summary);
+        Assert.DoesNotContain("errors 3", summary);
+    }
+
+    [Fact]
+    public void FormatHumanSummary_DeepSubRunJson_UsesTerseSummary()
+    {
+        var depth = IndexWatchRunner.MaxHumanSummaryJsonDepth + 4;
+        var nestedStart = string.Concat(Enumerable.Repeat("[", depth));
+        var nestedEnd = string.Concat(Enumerable.Repeat("]", depth));
+        var deepJson = $$"""{"summary":{"updated":1,"removed":2,"errors":3},"deep":{{nestedStart}}0{{nestedEnd}}}""";
+
+        var summary = InvokeFormatHumanSummary(
+            "updated",
+            2,
+            123,
+            deepJson,
+            CommandExitCodes.Success);
+
+        Assert.Contains("exit code 0", summary);
+        Assert.DoesNotContain("updated 1", summary);
+        Assert.DoesNotContain("removed 2", summary);
+        Assert.DoesNotContain("errors 3", summary);
+    }
+
+    [Fact]
     public void RunCore_CancellationToken_StopsImmediately()
     {
         var projectRoot = CreateTempProject();
@@ -477,6 +533,18 @@ public class IndexWatchRunnerTests
             CancellationToken.None,
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default);
+    }
+
+    private static string InvokeFormatHumanSummary(
+        string status,
+        int? batchSize,
+        long elapsedMs,
+        string subRunJson,
+        int exitCode)
+    {
+        var method = typeof(IndexWatchRunner).GetMethod("FormatHumanSummary", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return Assert.IsType<string>(method.Invoke(null, [status, batchSize, elapsedMs, subRunJson, exitCode]));
     }
 
     private string RunIndexAndCapture(string[] args, out int exitCode)


### PR DESCRIPTION
## Summary

- Bound `index --dry-run --json` file and error samples while preserving total counts. (#3133)
- Bound persisted full-scan checkpoint JSON depth and directory payload size. (#3060)
- Bound watch-mode sub-run JSON parsing used for human summaries. (#3044)

## Documentation and changelog

- [x] Documentation updated, or not needed because: no existing dry-run JSON schema reference was found in README/DEVELOPER_GUIDE; behavior is covered by changelog fragments.
- [x] Changelog fragment added under `changelog.d/unreleased/`:
  - `changelog.d/unreleased/3133.fixed.md`
  - `changelog.d/unreleased/3060.security.md`
  - `changelog.d/unreleased/3044.fixed.md`
- [x] Fragment follows `.codex/workflows/changelog-fragment.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter "FullyQualifiedName~LoadScanCheckpoint"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter "FullyQualifiedName~FormatHumanSummary"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter "FullyQualifiedName~Run_DryRun_JsonCaps"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter "FullyQualifiedName~Run_DryRun_"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~LoadScanCheckpoint|FullyQualifiedName~FormatHumanSummary|FullyQualifiedName~Run_DryRun_"`
- `dotnet build CodeIndex.sln -c Debug -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `git diff --check origin/main..HEAD`

## Review

- Codex adversarial review: No blocking/actionable issues found.

## Issues

Fixes #3133
Fixes #3060
Fixes #3044

## Follow-up candidates

None.
