### PR TITLE
Fix C# parameter extraction and cap signatures

### DIFF
--- a/changelog.d/unreleased/2988.fixed.md
+++ b/changelog.d/unreleased/2988.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 2988
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
+---
+
+## English
+
+- **C# multiline callable parameters no longer appear as properties (#2988)** — method, constructor, delegate, and primary-constructor parameter continuations are now excluded from field-style property extraction, while real fields and record primary component properties remain indexed.
+
+## 日本語
+
+- **C# の複数行 callable 引数が property として出なくなりました (#2988)** — メソッド、コンストラクタ、delegate、primary constructor の引数継続行を field 形式の property 抽出から除外し、本物のフィールドと record primary component の property は引き続きインデックスします。

--- a/changelog.d/unreleased/2989.fixed.md
+++ b/changelog.d/unreleased/2989.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2989
+affected:
+  - src/CodeIndex/Models/QueryResults.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerInspectTests.cs
+---
+
+## English
+
+- **Runaway inspect/outline signatures are capped (#2989)** — JSON output now limits oversized symbol signatures, reports `signature_truncated` plus `signature_original_length` metadata, and falls back to concise outline labels for truncated callable signatures.
+
+## 日本語
+
+- **inspect/outline の runaway signature を上限制御しました (#2989)** — JSON 出力で過大な symbol signature を切り詰め、`signature_truncated` と `signature_original_length` のメタデータを出し、切り詰めた callable signature の outline label は簡潔な形式へフォールバックするようにしました。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -70,6 +70,8 @@ public partial class DbReader
     private const int UnusedPublicOverfetchMaximum = 1024;
     private const int UnusedPublicCandidateBudget = 2048;
     private const string SymbolLanguageFileIdFilter = " AND s.file_id IN (SELECT id FROM files WHERE lang = @lang)";
+    private const int QueryOutputSignatureMaxChars = 512;
+    private const string QueryOutputSignatureTruncationSuffix = "...";
 
     private sealed class UnusedCandidateSymbol
     {
@@ -1388,6 +1390,8 @@ public partial class DbReader
         var nearbySymbols = primaryDefinition != null
             ? GetNearbySymbols(primaryDefinition.Path, primaryDefinition.StartLine, Math.Min(limit, 10), primaryDefinition.Name, primaryDefinition.StartLine)
             : [];
+        ApplyQueryOutputSignatureLimits(definitions);
+        ApplyQueryOutputSignatureLimits(nearbySymbols);
 
         var result = new SymbolAnalysisResult
         {
@@ -1614,6 +1618,51 @@ public partial class DbReader
             && string.Equals(left.Kind, right.Kind, StringComparison.Ordinal);
     }
 
+    private static void ApplyQueryOutputSignatureLimits(IEnumerable<SymbolResult> symbols)
+    {
+        foreach (var symbol in symbols)
+            ApplyQueryOutputSignatureLimit(symbol);
+    }
+
+    private static void ApplyQueryOutputSignatureLimit(SymbolResult symbol)
+    {
+        if (!TryTruncateQueryOutputSignature(symbol.Signature, out var signature, out var originalLength))
+            return;
+
+        symbol.Signature = signature;
+        symbol.SignatureTruncated = true;
+        symbol.SignatureOriginalLength = originalLength;
+    }
+
+    private static void ApplyQueryOutputSignatureLimits(IEnumerable<OutlineSymbol> symbols)
+    {
+        foreach (var symbol in symbols)
+            ApplyQueryOutputSignatureLimit(symbol);
+    }
+
+    private static void ApplyQueryOutputSignatureLimit(OutlineSymbol symbol)
+    {
+        if (!TryTruncateQueryOutputSignature(symbol.Signature, out var signature, out var originalLength))
+            return;
+
+        symbol.Signature = signature;
+        symbol.SignatureTruncated = true;
+        symbol.SignatureOriginalLength = originalLength;
+    }
+
+    private static bool TryTruncateQueryOutputSignature(string? signature, out string? truncatedSignature, out int? originalLength)
+    {
+        truncatedSignature = signature;
+        originalLength = null;
+        if (signature == null || signature.Length <= QueryOutputSignatureMaxChars)
+            return false;
+
+        originalLength = signature.Length;
+        truncatedSignature = signature[..(QueryOutputSignatureMaxChars - QueryOutputSignatureTruncationSuffix.Length)]
+            + QueryOutputSignatureTruncationSuffix;
+        return true;
+    }
+
     /// <summary>
     /// Return a structured outline of symbols in a single file, ordered deterministically.
     /// 1ファイルのシンボルを決定的な順序の構造化アウトラインとして返す。
@@ -1687,6 +1736,7 @@ public partial class DbReader
         }
 
         PopulateOutlineDepths(symbols);
+        ApplyQueryOutputSignatureLimits(symbols);
         PopulateOutlineDisplayNames(symbols, lang);
 
         return new OutlineResult
@@ -1711,6 +1761,9 @@ public partial class DbReader
     {
         if (IsCallableOutlineSymbol(symbol.Kind))
         {
+            if (symbol.SignatureTruncated)
+                return $"{symbol.Name}@{symbol.Line}";
+
             var compactSignature = TryBuildCompactCallableSignature(symbol.Name, symbol.Signature, lang);
             if (!string.IsNullOrWhiteSpace(compactSignature))
                 return compactSignature!;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2335,11 +2335,14 @@ public static partial class SymbolExtractor
         var privateScopeColumns = lang is "javascript" or "typescript"
             ? BuildJavaScriptTypeScriptPrivateScopeColumns(lines, lang)
             : null;
-        var csharpSwitchExpressionLines = lang == "csharp"
-            ? FindCSharpSwitchExpressionLines(structuralLines)
-            : null;
         var csharpInsideTypeBody = lang == "csharp"
             ? BuildCSharpTypeBodyScope(structuralLines)
+            : null;
+        var csharpCallableParameterScope = lang == "csharp"
+            ? BuildCSharpCallableParameterScope(structuralLines, csharpInsideTypeBody!)
+            : null;
+        var csharpSwitchExpressionLines = lang == "csharp"
+            ? FindCSharpSwitchExpressionLines(structuralLines)
             : null;
         var cssQualifiedRuleAncestors = lang == "css"
             ? FindCssQualifiedRuleAncestors(cssScannerLines!)
@@ -2749,6 +2752,15 @@ public static partial class SymbolExtractor
                             && HasCSharpTokenBeforeIndex(matchLine, "when", absoluteStartColumn + match.Groups["name"].Index))
                         {
                             lineOffset = absoluteStartColumn + Math.Max(1, match.Length);
+                            continue;
+                        }
+                        if (lang == "csharp"
+                            && pattern.BodyStyle == BodyStyle.None
+                          && (pattern.Kind == "property" || IsCSharpFieldLikeFunctionPattern(pattern))
+                          && csharpCallableParameterScope != null
+                          && csharpCallableParameterScope.IsInsideParameterListAt(i, csharpGateRawStartColumn))
+                        {
+                            lineOffset = FindNextSameLineBraceStatementStart(matchLine, absoluteStartColumn + Math.Max(1, match.Length), lang);
                             continue;
                         }
                         if (lang == "csharp"
@@ -3678,17 +3690,6 @@ public static partial class SymbolExtractor
                             name,
                             pendingRecordPrimaryComponents,
                             symbols);
-
-                        if (lang == "csharp" && pattern.Kind == "function")
-                        {
-                            CollectCSharpCallableParameterSymbols(
-                                fileId,
-                                signature,
-                                startLine,
-                                kind,
-                                name,
-                                symbols);
-                        }
 
                         // C# plain-field (kind `property`, BodyStyle.None) matches need their own
                         // advance path. The generic `sameLineEndColumn`-based advance below resolves
@@ -6912,6 +6913,236 @@ public static partial class SymbolExtractor
         return new CSharpTypeBodyScope(lineStartInsideTypeBody, transitions);
     }
 
+    private sealed class CSharpCallableParameterScope
+    {
+        private readonly bool[] _lineStartInsideParameterList;
+        private readonly List<(int Column, bool IsInsideParameterList)>?[] _transitions;
+
+        public CSharpCallableParameterScope(bool[] lineStartInsideParameterList, List<(int Column, bool IsInsideParameterList)>?[] transitions)
+        {
+            _lineStartInsideParameterList = lineStartInsideParameterList;
+            _transitions = transitions;
+        }
+
+        public bool IsInsideParameterListAt(int lineIndex, int column)
+        {
+            var state = _lineStartInsideParameterList[lineIndex];
+            var transitions = _transitions[lineIndex];
+            if (transitions == null)
+                return state;
+
+            foreach (var (col, isInsideParameterList) in transitions)
+            {
+                if (col >= column)
+                    break;
+                state = isInsideParameterList;
+            }
+
+            return state;
+        }
+    }
+
+    private static CSharpCallableParameterScope BuildCSharpCallableParameterScope(
+        string[] structuralLines,
+        CSharpTypeBodyScope typeBodyScope)
+    {
+        var lineStartInsideParameterList = new bool[structuralLines.Length];
+        var transitions = new List<(int Column, bool IsInsideParameterList)>?[structuralLines.Length];
+        var declarationBuffer = new StringBuilder();
+        var parameterParenDepth = 0;
+
+        for (int lineIndex = 0; lineIndex < structuralLines.Length; lineIndex++)
+        {
+            lineStartInsideParameterList[lineIndex] = parameterParenDepth > 0;
+            var line = structuralLines[lineIndex];
+
+            for (int cursor = 0; cursor < line.Length; cursor++)
+            {
+                var ch = line[cursor];
+                if (parameterParenDepth > 0)
+                {
+                    if (ch == '(')
+                    {
+                        parameterParenDepth++;
+                    }
+                    else if (ch == ')')
+                    {
+                        parameterParenDepth--;
+                        if (parameterParenDepth == 0)
+                            (transitions[lineIndex] ??= new List<(int, bool)>()).Add((cursor, false));
+                    }
+
+                    declarationBuffer.Append(ch);
+                    continue;
+                }
+
+                if (ch == '('
+                    && typeBodyScope.IsInsideTypeBodyAt(lineIndex, cursor)
+                    && IsCSharpCallableHeaderBeforeParameterList(declarationBuffer.ToString()))
+                {
+                    parameterParenDepth = 1;
+                    (transitions[lineIndex] ??= new List<(int, bool)>()).Add((cursor, true));
+                    declarationBuffer.Append(ch);
+                    continue;
+                }
+
+                if (ch is '{' or '}' or ';')
+                {
+                    declarationBuffer.Clear();
+                    continue;
+                }
+
+                declarationBuffer.Append(ch);
+            }
+        }
+
+        return new CSharpCallableParameterScope(lineStartInsideParameterList, transitions);
+    }
+
+    private static bool IsCSharpCallableHeaderBeforeParameterList(string header)
+    {
+        var text = header.Trim();
+        if (text.Length == 0 || ContainsCSharpTopLevelAssignment(text))
+            return false;
+
+        var end = SkipCSharpTrailingGenericParameterList(text, text.Length);
+        while (end > 0 && char.IsWhiteSpace(text[end - 1]))
+            end--;
+        if (end <= 0)
+            return false;
+
+        var tokenEnd = end;
+        var tokenStart = tokenEnd;
+        while (tokenStart > 0 && IsCSharpIdentifierPart(text[tokenStart - 1]))
+            tokenStart--;
+        if (tokenStart == tokenEnd)
+            return false;
+
+        var token = text[tokenStart..tokenEnd];
+        if (token.StartsWith('@') && token.Length > 1)
+            return true;
+
+        return token.Length > 0 && !IsCSharpNonCallableHeaderTailToken(token);
+    }
+
+    private static int SkipCSharpTrailingGenericParameterList(string text, int end)
+    {
+        while (end > 0 && char.IsWhiteSpace(text[end - 1]))
+            end--;
+        if (end <= 0 || text[end - 1] != '>')
+            return end;
+
+        var depth = 0;
+        for (var index = end - 1; index >= 0; index--)
+        {
+            if (text[index] == '>')
+            {
+                depth++;
+                continue;
+            }
+
+            if (text[index] == '<')
+            {
+                depth--;
+                if (depth == 0)
+                    return index;
+            }
+        }
+
+        return end;
+    }
+
+    private static bool ContainsCSharpTopLevelAssignment(string text)
+    {
+        var angleDepth = 0;
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        for (var index = 0; index < text.Length; index++)
+        {
+            var ch = text[index];
+            switch (ch)
+            {
+                case '<':
+                    angleDepth++;
+                    continue;
+                case '>' when angleDepth > 0:
+                    angleDepth--;
+                    continue;
+                case '(':
+                    parenDepth++;
+                    continue;
+                case ')' when parenDepth > 0:
+                    parenDepth--;
+                    continue;
+                case '[':
+                    bracketDepth++;
+                    continue;
+                case ']' when bracketDepth > 0:
+                    bracketDepth--;
+                    continue;
+                case '=' when angleDepth == 0 && parenDepth == 0 && bracketDepth == 0:
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCSharpIdentifierPart(char ch) =>
+        char.IsLetterOrDigit(ch) || ch is '_' or '$' or '@';
+
+    private static bool IsCSharpNonCallableHeaderTailToken(string token) =>
+        token is
+            "abstract" or
+            "async" or
+            "await" or
+            "base" or
+            "case" or
+            "catch" or
+            "const" or
+            "continue" or
+            "default" or
+            "delegate" or
+            "else" or
+            "event" or
+            "extern" or
+            "false" or
+            "file" or
+            "for" or
+            "foreach" or
+            "goto" or
+            "if" or
+            "internal" or
+            "lock" or
+            "nameof" or
+            "new" or
+            "null" or
+            "override" or
+            "private" or
+            "protected" or
+            "public" or
+            "readonly" or
+            "ref" or
+            "required" or
+            "return" or
+            "sealed" or
+            "sizeof" or
+            "stackalloc" or
+            "static" or
+            "switch" or
+            "this" or
+            "throw" or
+            "true" or
+            "typeof" or
+            "unsafe" or
+            "using" or
+            "var" or
+            "virtual" or
+            "volatile" or
+            "when" or
+            "while" or
+            "yield";
+
     private sealed class DartClassBodyScope
     {
         private readonly bool[] _lineStartInsideClassBody;
@@ -7722,157 +7953,6 @@ public static partial class SymbolExtractor
                 });
             }
         }
-    }
-
-    private static void CollectCSharpCallableParameterSymbols(
-        long fileId,
-        string signature,
-        int callableStartLine,
-        string callableKind,
-        string callableName,
-        List<SymbolRecord> symbols)
-    {
-        if (!TryGetCSharpCallableParameterList(signature, callableName, out var parameterList, out var parameterListStartLine))
-            return;
-
-        foreach (var rawParameter in SplitTopLevelRecordPrimaryComponents(parameterList, callableStartLine + parameterListStartLine))
-        {
-            if (!TryParseCSharpCallableParameter(rawParameter, out var parameter))
-                continue;
-
-            if (symbols.Any(symbol =>
-                symbol.FileId == fileId
-                && symbol.Kind == "property"
-                && symbol.Name == parameter.Name
-                && symbol.ContainerKind == callableKind
-                && symbol.ContainerName == callableName
-                && symbol.StartLine == parameter.Line))
-            {
-                continue;
-            }
-
-            symbols.Add(new SymbolRecord
-            {
-                FileId = fileId,
-                Kind = "property",
-                Name = parameter.Name,
-                Line = parameter.Line,
-                StartLine = parameter.Line,
-                EndLine = parameter.Line,
-                Signature = parameter.Signature,
-                ContainerKind = callableKind,
-                ContainerName = callableName,
-                ReturnType = parameter.Type,
-            });
-        }
-    }
-
-    private static bool TryGetCSharpCallableParameterList(
-        string signature,
-        string callableName,
-        out string parameterList,
-        out int parameterListStartLine)
-    {
-        parameterList = string.Empty;
-        parameterListStartLine = 0;
-
-        var parameterOpenIndex = FindCSharpCallableParameterListStart(signature, callableName);
-        if (parameterOpenIndex < 0)
-            return false;
-
-        var closeBracket = signature[parameterOpenIndex] == '[' ? ']' : ')';
-        var parameterCloseIndex = FindMatchingBracket(signature, parameterOpenIndex, signature[parameterOpenIndex], closeBracket);
-        if (parameterCloseIndex <= parameterOpenIndex)
-            return false;
-
-        parameterList = StripRecordComponentComments(signature[(parameterOpenIndex + 1)..parameterCloseIndex]);
-        parameterListStartLine = signature[..(parameterOpenIndex + 1)].Count(ch => ch == '\n');
-        return true;
-    }
-
-    private static int FindCSharpCallableParameterListStart(string signature, string callableName)
-    {
-        var searchIndex = 0;
-        while (searchIndex < signature.Length)
-        {
-            var nameIndex = signature.IndexOf(callableName, searchIndex, StringComparison.Ordinal);
-            if (nameIndex < 0)
-                return -1;
-
-            searchIndex = nameIndex + Math.Max(callableName.Length, 1);
-            if (!IsCSharpIdentifierBoundary(signature, nameIndex - 1)
-                || !IsCSharpIdentifierBoundary(signature, nameIndex + callableName.Length))
-            {
-                continue;
-            }
-
-            var index = nameIndex + callableName.Length;
-            while (index < signature.Length && char.IsWhiteSpace(signature[index]))
-                index++;
-
-            if (index < signature.Length && signature[index] == '<')
-            {
-                var genericCloseIndex = FindMatchingBracket(signature, index, '<', '>');
-                if (genericCloseIndex < 0)
-                    continue;
-
-                index = genericCloseIndex + 1;
-                while (index < signature.Length && char.IsWhiteSpace(signature[index]))
-                    index++;
-            }
-
-            if (index < signature.Length
-                && (signature[index] == '(' || (signature[index] == '[' && callableName == "this")))
-            {
-                return index;
-            }
-        }
-
-        return -1;
-    }
-
-    private static bool IsCSharpIdentifierBoundary(string text, int index) =>
-        index < 0
-        || index >= text.Length
-        || !(char.IsLetterOrDigit(text[index]) || text[index] is '_' or '@');
-
-    private static bool TryParseCSharpCallableParameter(RecordPrimaryComponentSlice rawParameter, out RecordPrimaryComponent parameter)
-    {
-        parameter = default;
-        if (string.IsNullOrWhiteSpace(rawParameter.Text))
-            return false;
-
-        var normalized = TrimAfterTopLevelEquals(rawParameter.Text).Trim();
-        if (normalized.Length == 0)
-            return false;
-
-        var parameterLine = rawParameter.Line;
-        var stripped = StripLeadingCSharpRecordComponentAttributes(normalized);
-        normalized = stripped.Text;
-        parameterLine += stripped.ConsumedNewlines;
-
-        var signature = normalized;
-        stripped = StripLeadingRecordComponentModifiers("csharp", normalized);
-        if (stripped.Text == normalized)
-            return false;
-
-        normalized = stripped.Text;
-        parameterLine += stripped.ConsumedNewlines;
-
-        if (normalized.Length == 0)
-            return false;
-
-        var nameMatch = Regex.Match(normalized, @"(?<name>@?[\p{L}_$][\p{L}\p{Nd}_$]*)\s*$", RegexOptions.CultureInvariant);
-        if (!nameMatch.Success)
-            return false;
-
-        var parameterName = nameMatch.Groups["name"].Value.TrimStart('@');
-        var parameterType = normalized[..nameMatch.Index].Trim();
-        if (parameterName.Length == 0 || parameterType.Length == 0)
-            return false;
-
-        parameter = new RecordPrimaryComponent(parameterName, parameterType, signature, parameterLine);
-        return true;
     }
 
     private static bool TryGetRecordPrimaryComponents(

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -95,6 +95,10 @@ public class SymbolResult
     public int? BodyStartLine { get; set; }
     public int? BodyEndLine { get; set; }
     public string? Signature { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool SignatureTruncated { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? SignatureOriginalLength { get; set; }
     public string? ContainerKind { get; set; }
     public string? ContainerName { get; set; }
     public string? Visibility { get; set; }
@@ -1098,6 +1102,10 @@ public class OutlineSymbol
     public int? BodyStartLine { get; set; }
     public int? BodyEndLine { get; set; }
     public string? Signature { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool SignatureTruncated { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? SignatureOriginalLength { get; set; }
     public string? ContainerKind { get; set; }
     public string? ContainerName { get; set; }
     public string? Visibility { get; set; }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerInspectTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerInspectTests.cs
@@ -110,6 +110,50 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunInspect_Json_TruncatesRunawayDefinitionSignatures_Issue2989()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_inspect_signature_limit");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var parameters = string.Join(", ", Enumerable.Range(0, 90).Select(index => $"string parameter{index:D2}"));
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/HugeSignatures.cs",
+                "csharp",
+                $$"""
+                public class HugeSignatures
+                {
+                    public void Run({{parameters}}) { }
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunInspect(
+                ["Run", "--db", dbPath, "--json", "--exact"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var definition = document.RootElement
+                .GetProperty("definitions")
+                .EnumerateArray()
+                .Single(item => item.GetProperty("name").GetString() == "Run");
+            var signature = definition.GetProperty("signature").GetString();
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.NotNull(signature);
+            Assert.True(signature!.Length <= 512);
+            Assert.EndsWith("...", signature, StringComparison.Ordinal);
+            Assert.True(definition.GetProperty("signature_truncated").GetBoolean());
+            Assert.True(definition.GetProperty("signature_original_length").GetInt32() > signature.Length);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunInspect_ParseFields_ImplyJsonAndCanonicalizeAliases_Issue3056()
     {
         var options = QueryCommandRunner.ParseArgs(
@@ -315,6 +359,52 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(QueryCommandRunner.DefaultCompactSectionLimit, symbolTruncation.GetProperty("returned").GetInt32());
             Assert.Equal(QueryCommandRunner.DefaultCompactSectionLimit + 3, symbolTruncation.GetProperty("source_count").GetInt32());
             Assert.True(symbolTruncation.GetProperty("truncated").GetBoolean());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunOutline_Json_TruncatesRunawaySignatures_Issue2989()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_outline_signature_limit");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var parameters = string.Join(", ", Enumerable.Range(0, 90).Select(index => $"string parameter{index:D2}"));
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/HugeSignatures.cs",
+                "csharp",
+                $$"""
+                public class HugeSignatures
+                {
+                    public void Run({{parameters}}) { }
+                }
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunOutline(
+                ["src/HugeSignatures.cs", "--db", dbPath, "--json"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var symbol = document.RootElement
+                .GetProperty("symbols")
+                .EnumerateArray()
+                .Single(item => item.GetProperty("name").GetString() == "Run");
+            var signature = symbol.GetProperty("signature").GetString();
+            var displayName = symbol.GetProperty("display_name").GetString();
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.NotNull(signature);
+            Assert.True(signature!.Length <= 512);
+            Assert.EndsWith("...", signature, StringComparison.Ordinal);
+            Assert.True(symbol.GetProperty("signature_truncated").GetBoolean());
+            Assert.True(symbol.GetProperty("signature_original_length").GetInt32() > signature.Length);
+            Assert.Equal($"Run@{symbol.GetProperty("line").GetInt32()}", displayName);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
@@ -109,7 +109,7 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
-    public void Extract_CSharp_DetectsScopedMethodParametersAsProperties()
+    public void Extract_CSharp_DoesNotClassifyScopedMethodParametersAsProperties()
     {
         var content = """
             public class RefService
@@ -126,27 +126,13 @@ public partial class SymbolExtractorTests
             """;
         var symbols = SymbolExtractor.Extract(1, "csharp", content);
 
-        Assert.Contains(symbols, s =>
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Update");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Buffer");
+        Assert.DoesNotContain(symbols, s =>
             s.Kind == "property"
-            && s.Name == "value"
             && s.ContainerKind == "function"
-            && s.ContainerName == "Update"
-            && s.ReturnType == "T"
-            && s.Signature == "scoped ref T value");
-        Assert.Contains(symbols, s =>
-            s.Kind == "property"
-            && s.Name == "data"
-            && s.ContainerKind == "function"
-            && s.ContainerName == "Update"
-            && s.ReturnType == "Span<int>"
-            && s.Signature == "scoped Span<int> data");
-        Assert.Contains(symbols, s =>
-            s.Kind == "property"
-            && s.Name == "value"
-            && s.ContainerKind == "function"
-            && s.ContainerName == "Buffer"
-            && s.ReturnType == "int"
-            && s.Signature == "scoped ref int value");
+            && s.ContainerName is "Update" or "Buffer"
+            && s.Name is "value" or "data");
     }
 
     [Fact]
@@ -2376,6 +2362,45 @@ public partial class SymbolExtractorTests
         Assert.Equal("public void M<T>( T value) {", overloads[0].Signature);
         Assert.Equal("public void M<T, U>( T first, U second) {", overloads[1].Signature);
         Assert.NotEqual(overloads[0].Signature, overloads[1].Signature);
+    }
+
+    [Fact]
+    public void Extract_CSharp_MultilineCallableParameters_DoNotBecomeProperties()
+    {
+        var content = """
+            using System.Text.Json;
+            using System.Threading;
+
+            public sealed class Runner
+            {
+                private readonly string _name;
+
+                public Runner(
+                    string appVersion,
+                    JsonSerializerOptions jsonOptions,
+                    CancellationToken cancellationToken)
+                {
+                }
+
+                public void Run(
+                    IActiveWorkspaceLoader activeWorkspaceLoader,
+                    CancellationToken cancellationToken)
+                {
+                }
+            }
+
+            public interface IActiveWorkspaceLoader
+            {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Runner");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Run");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "_name");
+        foreach (var parameterName in new[] { "appVersion", "jsonOptions", "cancellationToken", "activeWorkspaceLoader" })
+            Assert.DoesNotContain(symbols, s => s.Kind == "property" && s.Name == parameterName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Stop C# multiline callable parameters from being indexed as `property` symbols while preserving real fields and record primary component properties.
- Cap oversized `inspect` and `outline` JSON signatures with truncation metadata, and use concise outline labels when callable signatures are truncated.

## Validation
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests.Extract_CSharp" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunInspect_|FullyQualifiedName~QueryCommandRunnerTests.RunOutline_" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: No blocking/actionable issues found.

Fixes #2988
Fixes #2989