### PR TITLE
Bound diagnostic logging payloads

### DIFF
--- a/changelog.d/unreleased/3078.fixed.md
+++ b/changelog.d/unreleased/3078.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3078
+affected:
+  - src/CodeIndex/Database/DbDebug.cs
+  - tests/CodeIndex.Tests/DbDebugTests.cs
+---
+
+## English
+
+- **DbDebug redaction now hashes large strings through a bounded path (#3078)** — redacted diagnostic string hashes use fixed-size string segments plus length metadata, avoiding full UTF-8 materialization for oversized values.
+
+## 日本語
+
+- **DbDebug redaction が巨大文字列を bounded path でハッシュするようになりました (#3078)** — redacted diagnostic string hash は固定長の文字列セグメントと長さ metadata を使い、巨大な値の UTF-8 全体 materialization を避けます。

--- a/changelog.d/unreleased/3079.fixed.md
+++ b/changelog.d/unreleased/3079.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3079
+affected:
+  - src/CodeIndex/Database/DbDebug.cs
+  - tests/CodeIndex.Tests/DbDebugTests.cs
+---
+
+## English
+
+- **Query profiling now caps captured query-plan diagnostics (#3079)** — `--profile` limits captured `EXPLAIN QUERY PLAN` rows, truncates oversized detail strings, and emits a truncation marker when additional plan rows are omitted.
+
+## 日本語
+
+- **query profiling の query-plan diagnostics を制限するようになりました (#3079)** — `--profile` は取得する `EXPLAIN QUERY PLAN` 行数を制限し、巨大な detail 文字列を切り詰め、追加の plan 行を省略した場合は truncation marker を出します。

--- a/changelog.d/unreleased/3080.fixed.md
+++ b/changelog.d/unreleased/3080.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3080
+affected:
+  - src/CodeIndex/Database/DbDebug.cs
+  - tests/CodeIndex.Tests/DbDebugTests.cs
+---
+
+## English
+
+- **Slow-query GlobalToolLog SQL text is now consistently truncated (#3080)** — slow-query diagnostics share the bounded SQL formatter before writing to stderr or the persistent global tool log.
+
+## 日本語
+
+- **slow-query の GlobalToolLog SQL text を一貫して切り詰めるようになりました (#3080)** — slow-query diagnostics は stderr と永続 global tool log に書き込む前に、共通の bounded SQL formatter を使います。

--- a/changelog.d/unreleased/3224.fixed.md
+++ b/changelog.d/unreleased/3224.fixed.md
@@ -1,6 +1,7 @@
 ---
 category: fixed
 issues:
+  - 3108
   - 3224
 affected:
   - USER_GUIDE.md
@@ -10,8 +11,8 @@ affected:
 
 ## English
 
-- **Metrics JSONL events now bound string fields (#3224)** — `--metrics` and `CDIDX_METRICS` records now clamp oversized string fields, emit `*_length` / `*_truncated` metadata, and keep each serialized event within a fixed byte budget.
+- **Metrics JSONL events now bound string fields (#3108, #3224)** — `--metrics` and `CDIDX_METRICS` records now clamp oversized string fields, emit `*_length` / `*_truncated` metadata, and keep each serialized event within a fixed byte budget.
 
 ## 日本語
 
-- **Metrics JSONL event の文字列フィールドを制限するようになりました (#3224)** — `--metrics` と `CDIDX_METRICS` のレコードは巨大な文字列フィールドを切り詰め、`*_length` / `*_truncated` metadata を出力し、各 serialized event を固定 byte budget 内に収めます。
+- **Metrics JSONL event の文字列フィールドを制限するようになりました (#3108, #3224)** — `--metrics` と `CDIDX_METRICS` のレコードは巨大な文字列フィールドを切り詰め、`*_length` / `*_truncated` metadata を出力し、各 serialized event を固定 byte budget 内に収めます。

--- a/src/CodeIndex/Database/DbDebug.cs
+++ b/src/CodeIndex/Database/DbDebug.cs
@@ -34,6 +34,7 @@ public static class DbDebug
     private const int MaxHashSegmentChars = 2048;
     internal const int MaxQueryPlanRows = 64;
     internal const int MaxQueryPlanDetailChars = 512;
+    internal const int MaxSlowQuerySqlChars = 200;
     private const string DiagnosticTruncationMarker = "...<truncated>";
     private static readonly byte[] s_hashSalt = RandomNumberGenerator.GetBytes(16);
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<SqliteDataReader, ActiveProfile> s_activeProfiles = new();
@@ -272,12 +273,13 @@ public static class DbDebug
 
     private static void WriteSlowQueryToStderr(SqliteCommand cmd, double elapsedMs, int? rowsRead)
     {
-        var sql = (cmd.CommandText ?? string.Empty).ReplaceLineEndings(" ");
-        if (sql.Length > 200)
-            sql = sql[..200] + "...";
+        var sql = FormatSqlForSlowQueryLog(cmd.CommandText ?? string.Empty);
         var rowText = rowsRead.HasValue ? $" rows={rowsRead.Value}" : string.Empty;
         Console.Error.WriteLine($"[cdidx] slow_query elapsed_ms={elapsedMs:0.###}{rowText} sql={sql}");
     }
+
+    internal static string FormatSqlForSlowQueryLog(string sql) =>
+        TruncateDiagnosticText(sql.ReplaceLineEndings(" "), MaxSlowQuerySqlChars);
 
     private static List<QueryPlanRow> CaptureQueryPlan(SqliteCommand source)
     {
@@ -314,7 +316,7 @@ public static class DbDebug
         return rows;
     }
 
-    private static string TruncateDiagnosticText(string value, int maxChars)
+    internal static string TruncateDiagnosticText(string value, int maxChars)
     {
         if (value.Length <= maxChars)
             return value;
@@ -560,7 +562,7 @@ public sealed class QueryProfileEntry
         _slowLogged = true;
         try
         {
-            CodeIndex.Cli.GlobalToolLog.Info($"slow_query elapsed_ms={elapsedMs:0.###} rows_scanned={RowsScanned} sql={Sql.Replace("\n", " ", StringComparison.Ordinal)}");
+            CodeIndex.Cli.GlobalToolLog.Info($"slow_query elapsed_ms={elapsedMs:0.###} rows_scanned={RowsScanned} sql={DbDebug.FormatSqlForSlowQueryLog(Sql)}");
         }
         catch
         {

--- a/src/CodeIndex/Database/DbDebug.cs
+++ b/src/CodeIndex/Database/DbDebug.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Security.Cryptography;
 using System.Text;
 using System.Diagnostics;
@@ -30,6 +31,7 @@ namespace CodeIndex.Database;
 public static class DbDebug
 {
     private const int MaxNumericChars = 64;
+    private const int MaxHashSegmentChars = 2048;
     private static readonly byte[] s_hashSalt = RandomNumberGenerator.GetBytes(16);
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<SqliteDataReader, ActiveProfile> s_activeProfiles = new();
 
@@ -431,15 +433,34 @@ public static class DbDebug
 
     private static string ShortHash(string s)
     {
-        var valueBytes = Encoding.UTF8.GetBytes(s);
-        var input = new byte[s_hashSalt.Length + valueBytes.Length];
-        Buffer.BlockCopy(s_hashSalt, 0, input, 0, s_hashSalt.Length);
-        Buffer.BlockCopy(valueBytes, 0, input, s_hashSalt.Length, valueBytes.Length);
-        var bytes = SHA256.HashData(input);
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        hash.AppendData(s_hashSalt);
+        AppendHashInt32(hash, s.Length);
+        var prefixLength = Math.Min(s.Length, MaxHashSegmentChars);
+        AppendHashUtf8(hash, s.AsSpan(0, prefixLength));
+        var suffixStart = Math.Max(prefixLength, s.Length - MaxHashSegmentChars);
+        AppendHashInt32(hash, suffixStart);
+        if (suffixStart < s.Length)
+            AppendHashUtf8(hash, s.AsSpan(suffixStart));
+
+        var bytes = hash.GetHashAndReset();
         var sb = new StringBuilder(16);
         for (int i = 0; i < 8; i++)
             sb.Append(bytes[i].ToString("x2"));
         return sb.ToString();
+    }
+
+    private static void AppendHashInt32(IncrementalHash hash, int value)
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
+        hash.AppendData(buffer);
+    }
+
+    private static void AppendHashUtf8(IncrementalHash hash, ReadOnlySpan<char> value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value.ToString());
+        hash.AppendData(bytes);
     }
 
     private static bool LooksLikePathName(string? valueName) =>

--- a/src/CodeIndex/Database/DbDebug.cs
+++ b/src/CodeIndex/Database/DbDebug.cs
@@ -32,6 +32,9 @@ public static class DbDebug
 {
     private const int MaxNumericChars = 64;
     private const int MaxHashSegmentChars = 2048;
+    internal const int MaxQueryPlanRows = 64;
+    internal const int MaxQueryPlanDetailChars = 512;
+    private const string DiagnosticTruncationMarker = "...<truncated>";
     private static readonly byte[] s_hashSalt = RandomNumberGenerator.GetBytes(16);
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<SqliteDataReader, ActiveProfile> s_activeProfiles = new();
 
@@ -290,19 +293,36 @@ public static class DbDebug
             using var reader = explain.ExecuteReader();
             while (reader.Read())
             {
+                if (rows.Count >= MaxQueryPlanRows)
+                {
+                    rows.Add(new QueryPlanRow(-1, -1, -1, $"EXPLAIN QUERY PLAN rows truncated after {MaxQueryPlanRows} rows."));
+                    break;
+                }
+
                 rows.Add(new QueryPlanRow(
                     reader.GetInt32(0),
                     reader.GetInt32(1),
                     reader.GetInt32(2),
-                    reader.GetString(3)));
+                    TruncateDiagnosticText(reader.GetString(3), MaxQueryPlanDetailChars)));
             }
         }
         catch (Exception ex)
         {
-            rows.Add(new QueryPlanRow(-1, -1, -1, "EXPLAIN QUERY PLAN failed: " + ex.Message));
+            rows.Add(new QueryPlanRow(-1, -1, -1, TruncateDiagnosticText("EXPLAIN QUERY PLAN failed: " + ex.Message, MaxQueryPlanDetailChars)));
         }
 
         return rows;
+    }
+
+    private static string TruncateDiagnosticText(string value, int maxChars)
+    {
+        if (value.Length <= maxChars)
+            return value;
+        if (maxChars <= 0)
+            return string.Empty;
+        if (maxChars <= DiagnosticTruncationMarker.Length)
+            return DiagnosticTruncationMarker[..maxChars];
+        return value[..(maxChars - DiagnosticTruncationMarker.Length)] + DiagnosticTruncationMarker;
     }
 
     internal static void SnapshotRow(SqliteDataReader reader)

--- a/tests/CodeIndex.Tests/DbDebugTests.cs
+++ b/tests/CodeIndex.Tests/DbDebugTests.cs
@@ -10,6 +10,12 @@ public class DbDebugTests
     private static string CaptureStderr(Action action)
         => ConsoleCapture.CaptureError(action);
 
+    private static string BuildUnionAllQuery(int count)
+        => string.Join(" UNION ALL ", Enumerable.Range(0, count).Select(i => $"SELECT {i} AS value"));
+
+    private static string QuoteSqlIdentifier(string identifier)
+        => "\"" + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+
     [Fact]
     public void ExecuteTrackedReader_EmitsActivityAndSlowQueryLog()
     {
@@ -40,6 +46,69 @@ public class DbDebugTests
         var activity = Assert.Single(stopped.Where(activity => activity.OperationName == "db.query"));
         Assert.Equal("sqlite", activity.GetTagItem("db.system"));
         Assert.Equal("SELECT", activity.GetTagItem("db.operation"));
+    }
+
+    [Fact]
+    public void ExecuteTrackedReader_ProfileCapsQueryPlanRows()
+    {
+        DbDebug.ResetForTesting();
+        try
+        {
+            using var conn = new SqliteConnection("Data Source=:memory:");
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = BuildUnionAllQuery(120);
+
+            DbDebug.BeginProfile();
+            using (var reader = cmd.ExecuteTrackedReader())
+            {
+                while (reader.TrackedRead()) { }
+            }
+
+            var entry = Assert.Single(DbDebug.EndProfile());
+            Assert.True(entry.QueryPlan.Count <= DbDebug.MaxQueryPlanRows + 1);
+            Assert.Contains(entry.QueryPlan, row => row.Detail.Contains("truncated after", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DbDebug.EndProfile();
+        }
+    }
+
+    [Fact]
+    public void ExecuteTrackedReader_ProfileTruncatesLongQueryPlanDetails()
+    {
+        DbDebug.ResetForTesting();
+        try
+        {
+            using var conn = new SqliteConnection("Data Source=:memory:");
+            conn.Open();
+            var tableName = "t_" + new string('a', DbDebug.MaxQueryPlanDetailChars * 2);
+            var quotedTableName = QuoteSqlIdentifier(tableName);
+            using (var create = conn.CreateCommand())
+            {
+                create.CommandText = $"CREATE TABLE {quotedTableName} (id INTEGER)";
+                create.ExecuteNonQuery();
+            }
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT id FROM {quotedTableName}";
+
+            DbDebug.BeginProfile();
+            using (var reader = cmd.ExecuteTrackedReader())
+            {
+                while (reader.TrackedRead()) { }
+            }
+
+            var entry = Assert.Single(DbDebug.EndProfile());
+            var detail = Assert.Single(entry.QueryPlan).Detail;
+            Assert.True(detail.Length <= DbDebug.MaxQueryPlanDetailChars, $"Detail was {detail.Length} chars.");
+            Assert.EndsWith("...<truncated>", detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DbDebug.EndProfile();
+        }
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/DbDebugTests.cs
+++ b/tests/CodeIndex.Tests/DbDebugTests.cs
@@ -1,3 +1,4 @@
+using CodeIndex.Cli;
 using CodeIndex.Database;
 using Microsoft.Data.Sqlite;
 using System.Diagnostics;
@@ -108,6 +109,47 @@ public class DbDebugTests
         finally
         {
             DbDebug.EndProfile();
+        }
+    }
+
+    [Fact]
+    public void QueryProfileEntry_SlowQueryGlobalToolLogTruncatesSql()
+    {
+        var logDir = Path.Combine(Path.GetTempPath(), $"cdidx_slow_query_log_{Guid.NewGuid():N}");
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_FORCE_GLOBAL_TOOL_LOG",
+            "CDIDX_DISABLE_PERSISTENT_LOG",
+            "CDIDX_GLOBAL_TOOL_LOG_DIR",
+            GlobalToolLog.LogFormatEnvironmentVariable);
+        try
+        {
+            env.Set("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
+            env.Set("CDIDX_DISABLE_PERSISTENT_LOG", null);
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+            env.Set(GlobalToolLog.LogFormatEnvironmentVariable, "text");
+
+            using var session = GlobalToolLog.TryStartForTesting(["status"], "1.10.0");
+            Assert.NotNull(session);
+            var sql = "SELECT " + new string('x', 5000) + Environment.NewLine + "FROM very_large_query";
+            var entry = new QueryProfileEntry(sql, []);
+            entry.AddElapsed(TimeSpan.FromMilliseconds(10));
+            entry.MarkCompletedIfSlow(0);
+            session!.Dispose();
+
+            var logPath = Assert.Single(Directory.GetFiles(logDir, "stderr-*.log"));
+            var content = File.ReadAllText(logPath);
+            var slowLine = Assert.Single(content.Split('\n').Where(line => line.Contains("slow_query", StringComparison.Ordinal)));
+            Assert.Contains("sql=SELECT ", slowLine);
+            Assert.Contains("...<truncated>", slowLine);
+            Assert.DoesNotContain(new string('x', 1000), content);
+            var sqlText = slowLine[(slowLine.IndexOf(" sql=", StringComparison.Ordinal) + " sql=".Length)..].TrimEnd('\r');
+            Assert.True(sqlText.Length <= DbDebug.MaxSlowQuerySqlChars, $"SQL text was {sqlText.Length} chars.");
+            Assert.DoesNotContain('\r', sqlText);
+            Assert.DoesNotContain('\n', sqlText);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(logDir);
         }
     }
 

--- a/tests/CodeIndex.Tests/DbDebugTests.cs
+++ b/tests/CodeIndex.Tests/DbDebugTests.cs
@@ -200,6 +200,38 @@ public class DbDebugTests
     }
 
     [Fact]
+    public void DumpToStderr_RedactedMode_HashesLargeStringsWithBoundedShape()
+    {
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        env.Set("CDIDX_DEBUG", "1");
+        try
+        {
+            DbDebug.ResetContext();
+            var largeValue = new string('x', 100_000) + "tail";
+            using var conn = new SqliteConnection("Data Source=:memory:");
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT @value AS content";
+            cmd.Parameters.AddWithValue("@value", largeValue);
+            using (var reader = cmd.ExecuteTrackedReader())
+            {
+                Assert.True(reader.TrackedRead());
+                _ = reader.GetString(0);
+            }
+
+            var output = CaptureStderr(() => DbDebug.DumpToStderr(new InvalidOperationException("boom")));
+            Assert.Contains($"@value = <str len={largeValue.Length} sha256=", output);
+            Assert.Contains($"[content] = <str len={largeValue.Length} sha256=", output);
+            Assert.DoesNotContain(new string('x', 1000), output);
+            Assert.DoesNotContain("tail", output);
+        }
+        finally
+        {
+            DbDebug.ResetContext();
+        }
+    }
+
+    [Fact]
     public void DumpToStderr_UnsafeMode_IncludesRawContent()
     {
         using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");


### PR DESCRIPTION
## Summary

- Bound DbDebug redacted string hashing so oversized values use fixed-size string segments plus length metadata instead of materializing the full UTF-8 payload.
- Cap query profiling `EXPLAIN QUERY PLAN` capture by row count and detail length, with an omitted-row marker.
- Reuse one bounded SQL formatter for slow-query stderr and GlobalToolLog entries.
- Link the existing MetricsSink string/record bounds fragment to #3108; the implementation and tests were already present on `origin/main` via #3224.

## Validation

- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DbDebugTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~MetricsSinkTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~DbDebugTests|FullyQualifiedName~MetricsSinkTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Full-suite note: attempted `dotnet test CodeIndex.sln -c Release --no-build -p:UseSharedCompilation=false`, but stopped it after several minutes with no additional output; the targeted Release tests above passed.

## Documentation And Changelog

- Added `changelog.d/unreleased/3078.fixed.md`
- Added `changelog.d/unreleased/3079.fixed.md`
- Added `changelog.d/unreleased/3080.fixed.md`
- Updated `changelog.d/unreleased/3224.fixed.md` to reference #3108
- No changes to `AGENTS.md`, `CLAUDE.md`, or `AGENT_GUIDE.md`

## Review

- Adversarial review of `origin/main..HEAD`: No blocking/actionable issues found.
- External `codex exec` review was attempted but could not run because the Codex CLI reported a usage-limit error.

## Follow-up Candidates

None.

Fixes #3078
Fixes #3079
Fixes #3080
Fixes #3108