### PR TITLE
Fix hook and backfill option handling

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -216,7 +216,7 @@ local index automatically:
 
 | Hook behavior | Detail |
 |---|---|
-| Refresh command | The installed hook runs `cdidx index . --quiet` before the commit completes. |
+| Refresh command | The installed hook runs `cdidx index <selected-project-path> --quiet` before the commit completes. When `--project` is omitted, the selected path is the current directory at install time. |
 | Quiet mode | `--quiet` suppresses normal progress and success output for hook contexts while still printing indexing errors to stderr and returning a non-zero exit code. |
 | Existing hooks | If `.git/hooks/pre-commit` already exists, `cdidx hooks install` moves it to `.git/hooks/pre-commit.cdidx-chain` and calls it after the cdidx refresh, preserving tools such as Husky, pre-commit, and lefthook. |
 | Intentional skip | Use `git commit --no-verify` when you intentionally need to skip all pre-commit hooks. |
@@ -2514,7 +2514,7 @@ pre-commit hook をインストールします:
 
 | hook の動作 | 詳細 |
 |---|---|
-| 更新コマンド | インストールされた hook はコミット完了前に `cdidx index . --quiet` を実行します。 |
+| 更新コマンド | インストールされた hook はコミット完了前に `cdidx index <selected-project-path> --quiet` を実行します。`--project` を省略した場合、選択パスはインストール時のカレントディレクトリです。 |
 | quiet mode | `--quiet` は hook 環境向けに通常の進捗・成功出力を抑制しつつ、indexing エラーは引き続き stderr に出力し、非ゼロの終了コードを返します。 |
 | 既存 hook の扱い | リポジトリに `.git/hooks/pre-commit` がある場合、`cdidx hooks install` はそれを `.git/hooks/pre-commit.cdidx-chain` に移動し、cdidx の更新後に呼び出すため、Husky、pre-commit、lefthook などのツールも維持されます。 |
 | 意図的な skip | すべての pre-commit hook を意図的にスキップする必要があるときは `git commit --no-verify` を使ってください。 |
@@ -4141,7 +4141,8 @@ cdidx hooks status
 cdidx hooks uninstall
 ```
 
-インストールされた hook は commit 完了前に `cdidx index . --quiet` を実行します。
+インストールされた hook は commit 完了前に `cdidx index <selected-project-path> --quiet` を実行します。
+`--project` を省略した場合、選択パスはインストール時のカレントディレクトリです。
 `--quiet` は hook 向けに通常の進捗と成功出力を抑制しますが、indexing error は
 stderr に出し、失敗時は非ゼロ終了します。既存の `.git/hooks/pre-commit` がある
 場合、`cdidx hooks install` はそれを `.git/hooks/pre-commit.cdidx-chain` に退避し、

--- a/changelog.d/unreleased/3170.fixed.md
+++ b/changelog.d/unreleased/3170.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3170
+affected:
+  - src/CodeIndex/Cli/HookCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
+  - tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **hooks and backfill-fold now reject unknown options (#3170)** — `cdidx hooks ...` and `cdidx backfill-fold` now return a usage error for unsupported flags instead of warning and continuing.
+
+## 日本語
+
+- **hooks と backfill-fold が未知のオプションを拒否するようになりました (#3170)** — `cdidx hooks ...` と `cdidx backfill-fold` は、未対応フラグを warning のみで続行せず usage error として終了します。

--- a/changelog.d/unreleased/3171.fixed.md
+++ b/changelog.d/unreleased/3171.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3171
+affected:
+  - src/CodeIndex/Cli/HookCommandRunner.cs
+  - tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **hooks install now preserves the selected project path (#3171)** — generated pre-commit hooks now run `cdidx index` against the resolved install-time project path instead of always indexing `.`.
+
+## 日本語
+
+- **hooks install が選択された project path を保持するようになりました (#3171)** — 生成される pre-commit hook は常に `.` を index するのではなく、インストール時に解決した project path を対象に `cdidx index` を実行します。

--- a/src/CodeIndex/Cli/HookCommandRunner.cs
+++ b/src/CodeIndex/Cli/HookCommandRunner.cs
@@ -15,10 +15,18 @@ public static class HookCommandRunner
     public static int Run(string[] args, JsonSerializerOptions jsonOptions)
     {
         var options = ParseArgs(args);
-        if (options.ShowHelp || options.Command == null)
+        if (options.ShowHelp || (options.Command == null && options.ParseError == null))
         {
             PrintUsage();
             return options.ShowHelp ? CommandExitCodes.Success : CommandExitCodes.UsageError;
+        }
+
+        if (options.ParseError != null)
+        {
+            var errorProjectPath = Path.GetFullPath(options.ProjectPath ?? Environment.CurrentDirectory);
+            if (!options.Json)
+                PrintUsage();
+            return WriteResult(options.Json, jsonOptions, "error", options.ParseError, errorProjectPath, null, null, CommandExitCodes.UsageError);
         }
 
         var projectPath = Path.GetFullPath(options.ProjectPath ?? Environment.CurrentDirectory);
@@ -46,6 +54,7 @@ public static class HookCommandRunner
         var json = false;
         var force = false;
         var showHelp = false;
+        string? parseError = null;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -67,7 +76,7 @@ public static class HookCommandRunner
                     if (args[i].StartsWith("-", StringComparison.Ordinal))
                     {
                         var displayValue = ConsoleUi.FormatBoundedValue(args[i]);
-                        Console.Error.WriteLine($"Warning: unknown option '{displayValue}' (ignored) / 不明なオプション '{displayValue}'（無視されます）");
+                        parseError ??= $"unknown option '{displayValue}'";
                     }
                     else if (command == null)
                         command = args[i];
@@ -77,7 +86,7 @@ public static class HookCommandRunner
             }
         }
 
-        return new HookCommandOptions(command, projectPath, json, force, showHelp);
+        return new HookCommandOptions(command, projectPath, json, force, showHelp, parseError);
     }
 
     private static int Install(HookCommandOptions options, JsonSerializerOptions jsonOptions, string projectPath, string hooksDir, string hookPath, string chainedHookPath)
@@ -267,7 +276,7 @@ fi
         => Console.Error.WriteLine("Usage: cdidx hooks <install|uninstall|status> [--project <path>] [--force] [--json]");
 }
 
-public sealed record HookCommandOptions(string? Command, string? ProjectPath, bool Json, bool Force, bool ShowHelp);
+public sealed record HookCommandOptions(string? Command, string? ProjectPath, bool Json, bool Force, bool ShowHelp, string? ParseError);
 
 public sealed record HookCommandJsonResult(
     string Status,

--- a/src/CodeIndex/Cli/HookCommandRunner.cs
+++ b/src/CodeIndex/Cli/HookCommandRunner.cs
@@ -102,12 +102,12 @@ public static class HookCommandRunner
                 if (File.Exists(ioChainedHookPath) && !options.Force)
                     return WriteResult(options.Json, jsonOptions, "error", $"chained hook already exists: {chainedHookPath}", projectPath, hookPath, chainedHookPath, CommandExitCodes.UsageError);
 
-                ReplaceCustomHookWithManagedHook(hooksDir, hookPath, chainedHookPath);
+                ReplaceCustomHookWithManagedHook(hooksDir, hookPath, chainedHookPath, projectPath);
                 return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, chainedHookPath, CommandExitCodes.Success);
             }
         }
 
-        AtomicFileWriter.WriteText(hookPath, BuildHookScript(chainedHookPath), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), MakeExecutable);
+        AtomicFileWriter.WriteText(hookPath, BuildHookScript(chainedHookPath, projectPath), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), MakeExecutable);
 
         return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, File.Exists(ioChainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
     }
@@ -161,7 +161,7 @@ public static class HookCommandRunner
         return content is not null && IsManagedHook(content);
     }
 
-    private static void ReplaceCustomHookWithManagedHook(string hooksDir, string hookPath, string chainedHookPath)
+    private static void ReplaceCustomHookWithManagedHook(string hooksDir, string hookPath, string chainedHookPath, string projectPath)
     {
         var stagedHookPath = Path.Combine(hooksDir, $".{HookName}.{Guid.NewGuid():N}.tmp");
         var ioStagedHookPath = LongPath.EnsureWindowsPrefix(stagedHookPath);
@@ -171,7 +171,7 @@ public static class HookCommandRunner
 
         try
         {
-            WriteStagedHookScript(ioStagedHookPath, chainedHookPath);
+            WriteStagedHookScript(ioStagedHookPath, chainedHookPath, projectPath);
             File.Replace(ioStagedHookPath, ioHookPath, ioChainedHookPath, ignoreMetadataErrors: true);
             stagedHookMoved = true;
             MakeExecutable(ioHookPath);
@@ -183,7 +183,7 @@ public static class HookCommandRunner
         }
     }
 
-    private static void WriteStagedHookScript(string ioStagedHookPath, string chainedHookPath)
+    private static void WriteStagedHookScript(string ioStagedHookPath, string chainedHookPath, string projectPath)
     {
         using (var stream = new FileStream(ioStagedHookPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
         {
@@ -193,7 +193,7 @@ public static class HookCommandRunner
                 bufferSize: 1024,
                 leaveOpen: true))
             {
-                writer.Write(BuildHookScript(chainedHookPath));
+                writer.Write(BuildHookScript(chainedHookPath, projectPath));
                 writer.Flush();
             }
 
@@ -215,13 +215,14 @@ public static class HookCommandRunner
         }
     }
 
-    private static string BuildHookScript(string chainedHookPath)
+    private static string BuildHookScript(string chainedHookPath, string projectPath)
     {
         var quotedChainedHook = QuoteShell(chainedHookPath);
+        var quotedProjectPath = QuoteShell(projectPath);
         return $"""
 #!/bin/sh
 {BeginMarker}
-cdidx index . --quiet
+cdidx index {quotedProjectPath} --quiet
 cdidx_status=$?
 if [ "$cdidx_status" -ne 0 ]; then
   echo "cdidx pre-commit index failed; commit aborted. Use git commit --no-verify to bypass hooks." >&2

--- a/src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
@@ -350,11 +350,15 @@ public static partial class IndexCommandRunner
                 case "--help" or "-h":
                     return new BackfillFoldCommandOptions { ShowHelp = true, DbPath = dbPath, Json = json, DryRun = dryRun, NoCheckpoint = noCheckpoint };
                 default:
-                    if (args[i].StartsWith('-'))
-                    {
-                        Console.Error.WriteLine($"Warning: unknown option '{args[i]}' (ignored) / 不明なオプション '{args[i]}'（無視されます）");
-                        WriteUnknownBackfillFoldOptionSuggestion(args[i]);
-                    }
+                    if (args[i].StartsWith("-", StringComparison.Ordinal))
+                        return new BackfillFoldCommandOptions
+                        {
+                            DbPath = dbPath,
+                            Json = json,
+                            DryRun = dryRun,
+                            NoCheckpoint = noCheckpoint,
+                            ParseError = BuildUnknownBackfillFoldOptionError(args[i]),
+                        };
                     else
                         return new BackfillFoldCommandOptions
                         {
@@ -363,7 +367,6 @@ public static partial class IndexCommandRunner
                             DryRun = dryRun,
                             ParseError = $"backfill-fold does not accept positional arguments: '{args[i]}'"
                         };
-                    break;
             }
         }
 
@@ -376,11 +379,13 @@ public static partial class IndexCommandRunner
         };
     }
 
-    private static void WriteUnknownBackfillFoldOptionSuggestion(string token)
+    private static string BuildUnknownBackfillFoldOptionError(string token)
     {
         var name = TrimInlineValue(token);
         var suggestion = ConsoleUi.FindClosestMatch(name, AcceptedBackfillFoldFlags);
-        if (suggestion != null)
-            Console.Error.WriteLine($"Did you mean: {suggestion}?");
+        var displayToken = ConsoleUi.FormatBoundedValue(token);
+        return suggestion == null
+            ? $"unknown option '{displayToken}'"
+            : $"unknown option '{displayToken}'\nDid you mean: {suggestion}?";
     }
 }

--- a/src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
@@ -330,6 +330,7 @@ public static partial class IndexCommandRunner
         var json = false;
         var dryRun = false;
         var noCheckpoint = false;
+        string? parseError = null;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -351,22 +352,14 @@ public static partial class IndexCommandRunner
                     return new BackfillFoldCommandOptions { ShowHelp = true, DbPath = dbPath, Json = json, DryRun = dryRun, NoCheckpoint = noCheckpoint };
                 default:
                     if (args[i].StartsWith("-", StringComparison.Ordinal))
-                        return new BackfillFoldCommandOptions
-                        {
-                            DbPath = dbPath,
-                            Json = json,
-                            DryRun = dryRun,
-                            NoCheckpoint = noCheckpoint,
-                            ParseError = BuildUnknownBackfillFoldOptionError(args[i]),
-                        };
+                    {
+                        parseError ??= BuildUnknownBackfillFoldOptionError(args[i]);
+                    }
                     else
-                        return new BackfillFoldCommandOptions
-                        {
-                            DbPath = dbPath,
-                            Json = json,
-                            DryRun = dryRun,
-                            ParseError = $"backfill-fold does not accept positional arguments: '{args[i]}'"
-                        };
+                    {
+                        parseError ??= $"backfill-fold does not accept positional arguments: '{args[i]}'";
+                    }
+                    break;
             }
         }
 
@@ -376,6 +369,7 @@ public static partial class IndexCommandRunner
             Json = json,
             DryRun = dryRun,
             NoCheckpoint = noCheckpoint,
+            ParseError = parseError,
         };
     }
 

--- a/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
@@ -76,6 +76,19 @@ public class HookCommandRunnerTests
         Assert.Contains("unknown option", stderr);
         Assert.Contains("<truncated; original length", stderr);
         Assert.DoesNotContain(token, stderr);
+        Assert.DoesNotContain("Warning: unknown option", stderr);
+    }
+
+    [Fact]
+    public void Hooks_CommandUnknownOption_ReturnsUsageError()
+    {
+        var (exitCode, stdout, stderr) = RunHooksAndCaptureStreams(["status", "--bogus"]);
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("Usage: cdidx hooks", stderr);
+        Assert.Contains("unknown option '--bogus'", stderr);
+        Assert.DoesNotContain("Warning: unknown option", stderr);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
@@ -28,7 +28,7 @@ public class HookCommandRunnerTests
             Assert.True(File.Exists(hookPath));
             var hook = File.ReadAllText(hookPath);
             Assert.Contains("BEGIN CDIDX MANAGED PRE-COMMIT", hook);
-            Assert.Contains("cdidx index . --quiet", hook);
+            Assert.Contains($"cdidx index {QuoteShellForTest(projectRoot)} --quiet", hook);
 
             var statusExit = RunHooksAndCaptureStreams(["status", "--project", projectRoot]).ExitCode;
             Assert.Equal(CommandExitCodes.Success, statusExit);
@@ -40,6 +40,30 @@ public class HookCommandRunnerTests
         finally
         {
             TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Hooks_Install_QuotesSelectedProjectPathInGeneratedHook()
+    {
+        var parent = TestProjectHelper.CreateTempProject("hook_project_quote");
+        var projectRoot = Path.Combine(parent, "repo with ' quote");
+        try
+        {
+            Directory.CreateDirectory(projectRoot);
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+
+            var exitCode = RunHooksAndCaptureStreams(["install", "--project", projectRoot]).ExitCode;
+            var hookPath = Path.Combine(projectRoot, ".git", "hooks", "pre-commit");
+            var hook = File.ReadAllText(hookPath);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Contains($"cdidx index {QuoteShellForTest(projectRoot)} --quiet", hook);
+            Assert.DoesNotContain("cdidx index . --quiet", hook);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(parent);
         }
     }
 
@@ -279,4 +303,7 @@ public class HookCommandRunnerTests
 
     private static void AssertNoHookTempFiles(string hooksDir)
         => Assert.Empty(Directory.GetFiles(hooksDir, ".pre-commit.*.tmp"));
+
+    private static string QuoteShellForTest(string value)
+        => "'" + value.Replace("'", "'\"'\"'", StringComparison.Ordinal) + "'";
 }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -142,6 +142,40 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void RunBackfillFold_UnknownOptionBeforeJson_ReturnsJsonUsageError()
+    {
+        var missingDb = Path.Combine(Path.GetTempPath(), $"cdidx_backfill_unknown_json_{Guid.NewGuid():N}.db");
+
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            try
+            {
+                Console.SetOut(stdout);
+                Console.SetError(stderr);
+                var exitCode = IndexCommandRunner.RunBackfillFold(["--db", missingDb, "--dryrun", "--json"], _jsonOptions);
+
+                Assert.Equal(CommandExitCodes.UsageError, exitCode);
+                Assert.Equal(string.Empty, stderr.ToString());
+                using var document = JsonDocument.Parse(stdout.ToString());
+                var json = document.RootElement;
+                Assert.Equal("error", json.GetProperty("status").GetString());
+                Assert.Contains("unknown option '--dryrun'", json.GetProperty("message").GetString());
+                Assert.Contains("Run `cdidx backfill-fold --help`", json.GetProperty("hint").GetString());
+                Assert.Equal(CommandErrorCodes.UsageError, json.GetProperty("error_code").GetString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    [Fact]
     public void FormatIndexFileException_RegexTimeout_UsesBoundedExtractionMessage()
     {
         var ex = new RegexMatchTimeoutException("raw-sensitive-content", "raw-sensitive-pattern", TimeSpan.FromSeconds(2));

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -110,6 +110,38 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void RunBackfillFold_UnknownOption_ReturnsUsageError()
+    {
+        var missingDb = Path.Combine(Path.GetTempPath(), $"cdidx_backfill_unknown_{Guid.NewGuid():N}.db");
+
+        lock (TestConsoleLock.Gate)
+        {
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            try
+            {
+                Console.SetOut(stdout);
+                Console.SetError(stderr);
+                var exitCode = IndexCommandRunner.RunBackfillFold(["--db", missingDb, "--dryrun"], _jsonOptions);
+
+                Assert.Equal(CommandExitCodes.UsageError, exitCode);
+                Assert.Equal(string.Empty, stdout.ToString());
+                Assert.Contains("unknown option '--dryrun'", stderr.ToString());
+                Assert.Contains("Did you mean: --dry-run?", stderr.ToString());
+                Assert.DoesNotContain("Warning: unknown option", stderr.ToString());
+                Assert.DoesNotContain("database not found", stderr.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+            }
+        }
+    }
+
+    [Fact]
     public void FormatIndexFileException_RegexTimeout_UsesBoundedExtractionMessage()
     {
         var ex = new RegexMatchTimeoutException("raw-sensitive-content", "raw-sensitive-pattern", TimeSpan.FromSeconds(2));


### PR DESCRIPTION
## Summary

- Reject unknown `cdidx hooks` and `cdidx backfill-fold` options with usage errors instead of warning and continuing.
- Preserve the resolved `hooks install --project` path in generated pre-commit hooks, including shell quoting for selected project paths.
- Update hook documentation and add bilingual changelog fragments.

## Validation

- `dotnet build CodeIndex.sln -c Debug -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~HookCommandRunnerTests|FullyQualifiedName~RunBackfillFold_UnknownOption" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Updated `USER_GUIDE.md` for generated hook project-path behavior.
- Added `changelog.d/unreleased/3170.fixed.md`.
- Added `changelog.d/unreleased/3171.fixed.md`.

## Review

Adversarial review found one actionable parse-error JSON-mode issue for `backfill-fold`; it was fixed in `cfacd889d`. Final review result: No blocking/actionable issues found.

## Follow-up Candidates

None.

Fixes #3170
Fixes #3171