### PR TITLE
Fix referenced C# private const unused detection

### DIFF
--- a/changelog.d/unreleased/2990.fixed.md
+++ b/changelog.d/unreleased/2990.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 2990
+affected:
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **`unused` no longer reports referenced C# private constants as likely unused (#2990)** — C# same-file validation now reconstructs file text across chunk boundaries before masking comments and strings, so private constants used after multiline raw strings are not mistaken for dead code.
+
+## 日本語
+
+- **参照されている C# private 定数を `unused` が likely unused として報告しないようにしました (#2990)** — C# の同一ファイル内検証は chunk 境界をまたいでファイル本文を復元してからコメントと文字列をマスクするため、複数行 raw string の後で使われる private 定数を dead code と誤判定しなくなりました。

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -976,6 +976,68 @@ public class DbContext : IDisposable
         return count;
     }
 
+    internal static bool HasCSharpIdentifierOccurrenceOutsideLineRange(string? text, string? identifier, int startLine, int endLine)
+    {
+        if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(identifier))
+            return false;
+
+        var normalizedStartLine = Math.Max(1, startLine);
+        var normalizedEndLine = Math.Max(normalizedStartLine, endLine);
+        text = MaskCSharpCommentsAndStrings(text);
+
+        var inRangeOccurrences = 0;
+        var lineNumber = 1;
+        var lineStart = 0;
+        while (lineStart <= text.Length)
+        {
+            var lineEnd = text.IndexOf('\n', lineStart);
+            if (lineEnd < 0)
+                lineEnd = text.Length;
+
+            var lineOccurrences = CountCSharpIdentifierOccurrencesInRange(text, identifier, lineStart, lineEnd);
+            if (lineOccurrences > 0)
+            {
+                if (lineNumber < normalizedStartLine || lineNumber > normalizedEndLine)
+                    return true;
+
+                inRangeOccurrences += lineOccurrences;
+                if (inRangeOccurrences > 1)
+                    return true;
+            }
+
+            if (lineEnd == text.Length)
+                break;
+
+            lineStart = lineEnd + 1;
+            lineNumber++;
+        }
+
+        return false;
+    }
+
+    private static int CountCSharpIdentifierOccurrencesInRange(string text, string identifier, int start, int end)
+    {
+        var count = 0;
+        var searchIndex = start;
+        while (searchIndex < end)
+        {
+            var index = text.IndexOf(identifier, searchIndex, end - searchIndex, StringComparison.Ordinal);
+            if (index < 0)
+                break;
+
+            var beforeIndex = index - 1;
+            var afterIndex = index + identifier.Length;
+            var hasIdentifierBefore = beforeIndex >= start && IsCSharpIdentifierPart(text[beforeIndex]);
+            var hasIdentifierAfter = afterIndex < end && IsCSharpIdentifierPart(text[afterIndex]);
+            if (!hasIdentifierBefore && !hasIdentifierAfter)
+                count++;
+
+            searchIndex = index + identifier.Length;
+        }
+
+        return count;
+    }
+
     private static bool IsCSharpIdentifierPart(char ch)
     {
         return ch == '_' || char.IsLetterOrDigit(ch);

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
@@ -2904,14 +2905,14 @@ public partial class DbReader
             Math.Max(targetCount * UnusedPublicOverfetchMultiplier, UnusedPublicOverfetchMinimum),
             UnusedPublicOverfetchMaximum);
         var publicOrExported = new List<UnusedSymbolResult>(targetCount);
-        var chunksByFileId = new Dictionary<long, List<UnusedCandidateChunk>>();
-        var privateLike = CollectUnusedCandidateBucket(targetCount, batchSize, 0, chunksByFileId,
+        var fileContentByFileId = new Dictionary<long, string>();
+        var privateLike = CollectUnusedCandidateBucket(targetCount, batchSize, 0, fileContentByFileId,
             kind, lang, pathPatterns, excludePathPatterns, excludeTests, visibilityFilters, excludeVisibilityFilters);
-        var maybeNonPublic = CollectUnusedCandidateBucket(targetCount, batchSize, 1, chunksByFileId,
+        var maybeNonPublic = CollectUnusedCandidateBucket(targetCount, batchSize, 1, fileContentByFileId,
             kind, lang, pathPatterns, excludePathPatterns, excludeTests, visibilityFilters, excludeVisibilityFilters);
-        var reflectionOrConfig = CollectUnusedCandidateBucket(targetCount, batchSize, 3, chunksByFileId,
+        var reflectionOrConfig = CollectUnusedCandidateBucket(targetCount, batchSize, 3, fileContentByFileId,
             kind, lang, pathPatterns, excludePathPatterns, excludeTests, visibilityFilters, excludeVisibilityFilters);
-        CollectPublicUnusedCandidateBucket(targetCount, batchSize, publicFetchBudget, chunksByFileId,
+        CollectPublicUnusedCandidateBucket(targetCount, batchSize, publicFetchBudget, fileContentByFileId,
             publicOrExported, reflectionOrConfig, kind, lang, pathPatterns, excludePathPatterns, excludeTests, visibilityFilters, excludeVisibilityFilters);
 
         var merged = new List<UnusedSymbolResult>(privateLike.Count + maybeNonPublic.Count + publicOrExported.Count + reflectionOrConfig.Count);
@@ -2932,7 +2933,7 @@ public partial class DbReader
         if (targetBuckets.Count == 0)
             return [];
 
-        var chunksByFileId = new Dictionary<long, List<UnusedCandidateChunk>>();
+        var fileContentByFileId = new Dictionary<long, string>();
         var resultsByBucket = CreateUnusedBucketResultLists();
         const int batchSize = UnusedPublicOverfetchMaximum;
         foreach (var provisionalBucket in GetRelevantUnusedProvisionalBuckets(targetBuckets))
@@ -2948,7 +2949,7 @@ public partial class DbReader
                 offset += batch.Count;
                 foreach (var candidate in batch)
                 {
-                    if (HasSameFilePrivateUse(candidate, chunksByFileId))
+                    if (HasSameFilePrivateUse(candidate, fileContentByFileId))
                         continue;
 
                     var result = CreateUnusedSymbolResult(candidate);
@@ -2967,7 +2968,7 @@ public partial class DbReader
     }
 
     private List<UnusedSymbolResult> CollectUnusedCandidateBucket(int targetCount, int batchSize, int provisionalBucketOrder,
-        Dictionary<long, List<UnusedCandidateChunk>> chunksByFileId, string? kind, string? lang,
+        Dictionary<long, string> fileContentByFileId, string? kind, string? lang,
         IReadOnlyList<string>? pathPatterns, IReadOnlyList<string>? excludePathPatterns, bool excludeTests,
         IReadOnlyList<string>? visibilityFilters, IReadOnlyList<string>? excludeVisibilityFilters)
     {
@@ -2983,7 +2984,7 @@ public partial class DbReader
             offset += batch.Count;
             foreach (var candidate in batch)
             {
-                if (HasSameFilePrivateUse(candidate, chunksByFileId))
+                if (HasSameFilePrivateUse(candidate, fileContentByFileId))
                     continue;
 
                 results.Add(CreateUnusedSymbolResult(candidate));
@@ -2999,7 +3000,7 @@ public partial class DbReader
     }
 
     private void CollectPublicUnusedCandidateBucket(int targetCount, int batchSize, int candidateBudget,
-        Dictionary<long, List<UnusedCandidateChunk>> chunksByFileId,
+        Dictionary<long, string> fileContentByFileId,
         List<UnusedSymbolResult> publicOrExported, List<UnusedSymbolResult> reflectionOrConfig, string? kind, string? lang,
         IReadOnlyList<string>? pathPatterns, IReadOnlyList<string>? excludePathPatterns, bool excludeTests,
         IReadOnlyList<string>? visibilityFilters, IReadOnlyList<string>? excludeVisibilityFilters)
@@ -3017,7 +3018,7 @@ public partial class DbReader
             offset += batch.Count;
             foreach (var candidate in batch)
             {
-                if (HasSameFilePrivateUse(candidate, chunksByFileId))
+                if (HasSameFilePrivateUse(candidate, fileContentByFileId))
                     continue;
 
                 candidatesFetched++;
@@ -3042,7 +3043,7 @@ public partial class DbReader
         }
     }
 
-    private bool HasSameFilePrivateUse(UnusedCandidateSymbol candidate, Dictionary<long, List<UnusedCandidateChunk>> chunksByFileId)
+    private bool HasSameFilePrivateUse(UnusedCandidateSymbol candidate, Dictionary<long, string> fileContentByFileId)
     {
         if (!string.Equals(candidate.Lang, "csharp", StringComparison.Ordinal)
             || !IsPrivateLikeVisibility(candidate.Visibility)
@@ -3051,24 +3052,17 @@ public partial class DbReader
             || !HasTable("chunks"))
             return false;
 
-        foreach (var chunk in GetUnusedCandidateChunks(candidate.FileId, chunksByFileId))
-        {
-            var occurrenceCount = DbContext.CountCSharpIdentifierOccurrences(chunk.Content, candidate.Name);
-            if (occurrenceCount <= 0)
-                continue;
-
-            if (chunk.EndLine < candidate.StartLine
-                || chunk.StartLine > candidate.EndLine
-                || occurrenceCount > 1)
-                return true;
-        }
-
-        return false;
+        var fileContent = GetUnusedCandidateFileContent(candidate.FileId, fileContentByFileId);
+        return DbContext.HasCSharpIdentifierOccurrenceOutsideLineRange(
+            fileContent,
+            candidate.Name,
+            candidate.StartLine,
+            candidate.EndLine);
     }
 
-    private List<UnusedCandidateChunk> GetUnusedCandidateChunks(long fileId, Dictionary<long, List<UnusedCandidateChunk>> chunksByFileId)
+    private string GetUnusedCandidateFileContent(long fileId, Dictionary<long, string> fileContentByFileId)
     {
-        if (chunksByFileId.TryGetValue(fileId, out var cached))
+        if (fileContentByFileId.TryGetValue(fileId, out var cached))
             return cached;
 
         using var cmd = _conn.CreateCommand();
@@ -3090,8 +3084,47 @@ public partial class DbReader
                 GetNullableString(reader, 2) ?? string.Empty));
         }
 
-        chunksByFileId[fileId] = chunks;
-        return chunks;
+        var linesByNumber = new SortedDictionary<int, string>();
+        foreach (var chunk in chunks)
+            AddUnusedCandidateChunkLines(linesByNumber, chunk);
+
+        var builder = new StringBuilder();
+        var nextLine = 1;
+        foreach (var line in linesByNumber)
+        {
+            while (nextLine < line.Key)
+            {
+                builder.Append('\n');
+                nextLine++;
+            }
+
+            builder.Append(line.Value);
+            builder.Append('\n');
+            nextLine = line.Key + 1;
+        }
+
+        var content = builder.ToString();
+        fileContentByFileId[fileId] = content;
+        return content;
+    }
+
+    private static void AddUnusedCandidateChunkLines(SortedDictionary<int, string> linesByNumber, UnusedCandidateChunk chunk)
+    {
+        if (chunk.StartLine <= 0 || chunk.Content.Length == 0)
+            return;
+
+        var normalized = chunk.Content.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var lines = normalized.Split('\n');
+        var lineCount = normalized.Length > 0 && normalized[^1] == '\n' ? lines.Length - 1 : lines.Length;
+        if (chunk.EndLine >= chunk.StartLine)
+            lineCount = Math.Min(lineCount, chunk.EndLine - chunk.StartLine + 1);
+
+        for (var i = 0; i < lineCount; i++)
+        {
+            var lineNumber = chunk.StartLine + i;
+            if (!linesByNumber.ContainsKey(lineNumber))
+                linesByNumber.Add(lineNumber, lines[i]);
+        }
     }
 
     private IEnumerable<UnusedCandidateSymbol> FetchUnusedCandidateSymbols(int fetchLimit, int offset, int provisionalBucketOrder, string? kind, string? lang,
@@ -3649,7 +3682,7 @@ public partial class DbReader
     {
         var count = 0;
         var paths = new HashSet<string>(StringComparer.Ordinal);
-        var chunksByFileId = new Dictionary<long, List<UnusedCandidateChunk>>();
+        var fileContentByFileId = new Dictionary<long, string>();
         const int batchSize = UnusedPublicOverfetchMaximum;
         for (var bucket = 0; bucket <= 3; bucket++)
         {
@@ -3664,7 +3697,7 @@ public partial class DbReader
                 offset += batch.Count;
                 foreach (var candidate in batch)
                 {
-                    if (HasSameFilePrivateUse(candidate, chunksByFileId))
+                    if (HasSameFilePrivateUse(candidate, fileContentByFileId))
                         continue;
 
                     var result = CreateUnusedSymbolResult(candidate);
@@ -3688,7 +3721,7 @@ public partial class DbReader
     {
         var count = 0;
         var paths = new HashSet<string>(StringComparer.Ordinal);
-        var chunksByFileId = new Dictionary<long, List<UnusedCandidateChunk>>();
+        var fileContentByFileId = new Dictionary<long, string>();
         const int batchSize = UnusedPublicOverfetchMaximum;
         for (var bucket = 0; bucket <= 3; bucket++)
         {
@@ -3703,7 +3736,7 @@ public partial class DbReader
                 offset += batch.Count;
                 foreach (var candidate in batch)
                 {
-                    if (HasSameFilePrivateUse(candidate, chunksByFileId))
+                    if (HasSameFilePrivateUse(candidate, fileContentByFileId))
                         continue;
 
                     count++;

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -14461,9 +14461,9 @@ public class DbReaderTests : IDisposable
                 FileId = fileId,
                 Kind = "function",
                 Name = "HiddenInterpolated",
-                Line = 6,
-                StartLine = 6,
-                EndLine = 6,
+                Line = 7,
+                StartLine = 7,
+                EndLine = 7,
                 Signature = "private void HiddenInterpolated() { }",
                 Visibility = "private",
                 ContainerKind = "class",
@@ -14474,9 +14474,9 @@ public class DbReaderTests : IDisposable
                 FileId = fileId,
                 Kind = "function",
                 Name = "RawInterpolated",
-                Line = 7,
-                StartLine = 7,
-                EndLine = 7,
+                Line = 8,
+                StartLine = 8,
+                EndLine = 8,
                 Signature = "private void RawInterpolated() { }",
                 Visibility = "private",
                 ContainerKind = "class",
@@ -14487,9 +14487,9 @@ public class DbReaderTests : IDisposable
                 FileId = fileId,
                 Kind = "function",
                 Name = "CommentOnly",
-                Line = 9,
-                StartLine = 9,
-                EndLine = 9,
+                Line = 10,
+                StartLine = 10,
+                EndLine = 10,
                 Signature = "private void CommentOnly() { }",
                 Visibility = "private",
                 ContainerKind = "class",
@@ -14500,9 +14500,9 @@ public class DbReaderTests : IDisposable
                 FileId = fileId,
                 Kind = "function",
                 Name = "StringOnly",
-                Line = 10,
-                StartLine = 10,
-                EndLine = 10,
+                Line = 11,
+                StartLine = 11,
+                EndLine = 11,
                 Signature = "private void StringOnly() { _ = \"StringOnly\"; }",
                 Visibility = "private",
                 ContainerKind = "class",
@@ -14513,9 +14513,9 @@ public class DbReaderTests : IDisposable
                 FileId = fileId,
                 Kind = "function",
                 Name = "RawStringOnly",
-                Line = 11,
-                StartLine = 11,
-                EndLine = 11,
+                Line = 12,
+                StartLine = 12,
+                EndLine = 12,
                 Signature = "private void RawStringOnly() { _ = \"\"\"RawStringOnly\"\"\"; }",
                 Visibility = "private",
                 ContainerKind = "class",
@@ -14526,9 +14526,9 @@ public class DbReaderTests : IDisposable
                 FileId = fileId,
                 Kind = "function",
                 Name = "Hidden",
-                Line = 4,
-                StartLine = 4,
-                EndLine = 4,
+                Line = 6,
+                StartLine = 6,
+                EndLine = 6,
                 Signature = "private void Hidden() { }",
                 Visibility = "private",
                 ContainerKind = "class",
@@ -14545,6 +14545,92 @@ public class DbReaderTests : IDisposable
         Assert.Contains(unused, symbol => symbol.Name == "CommentOnly");
         Assert.Contains(unused, symbol => symbol.Name == "StringOnly");
         Assert.Contains(unused, symbol => symbol.Name == "RawStringOnly");
+    }
+
+    [Fact]
+    public void GetUnusedSymbols_PrivateConstUseAfterRawStringChunkBoundary_IsNotReported()
+    {
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/chunked_raw_string_fixture.cs",
+            Lang = "csharp",
+            Size = 512,
+            Lines = 10,
+            Modified = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        _writer.InsertChunks(
+        [
+            new ChunkRecord
+            {
+                FileId = fileId,
+                ChunkIndex = 0,
+                StartLine = 1,
+                EndLine = 5,
+                Content = """"
+                public class ChunkedRawStringFixture
+                {
+                    private const string UsedRowsSql = "SELECT 1";
+                    private const string FillerSql = """
+                        SELECT
+                """",
+            },
+            new ChunkRecord
+            {
+                FileId = fileId,
+                ChunkIndex = 1,
+                StartLine = 5,
+                EndLine = 10,
+                Content = """"
+                        SELECT
+                            value
+                        """;
+                    public void Compare() { _ = UsedRowsSql; }
+                    private const string ActuallyUnused = "unused";
+                }
+                """",
+            },
+        ]);
+        _writer.InsertSymbols(
+        [
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = "UsedRowsSql",
+                Line = 3,
+                StartLine = 3,
+                EndLine = 3,
+                Signature = "private const string UsedRowsSql = \"SELECT 1\";",
+                Visibility = "private",
+                ReturnType = "string",
+                ContainerKind = "class",
+                ContainerName = "ChunkedRawStringFixture",
+            },
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "function",
+                Name = "ActuallyUnused",
+                Line = 9,
+                StartLine = 9,
+                EndLine = 9,
+                Signature = "private const string ActuallyUnused = \"unused\";",
+                Visibility = "private",
+                ReturnType = "string",
+                ContainerKind = "class",
+                ContainerName = "ChunkedRawStringFixture",
+            },
+        ]);
+
+        var unused = _reader.GetUnusedSymbols(limit: 10, kind: null, lang: "csharp",
+            pathPatterns: ["chunked_raw_string_fixture.cs"], excludePathPatterns: null, excludeTests: false);
+        var count = _reader.CountUnusedSymbols(kind: null, lang: "csharp",
+            pathPatterns: ["chunked_raw_string_fixture.cs"], excludePathPatterns: null, excludeTests: false);
+
+        Assert.DoesNotContain(unused, symbol => symbol.Name == "UsedRowsSql");
+        Assert.Contains(unused, symbol => symbol.Name == "ActuallyUnused");
+        Assert.Equal(1, count.Count);
+        Assert.Equal(1, count.FileCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Reconstruct C# file text across chunk boundaries before same-file private-use validation in `unused`.
- Add a regression fixture for private constants referenced after multiline raw string chunks.
- Add an unreleased changelog fragment for #2990.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests.GetUnusedSymbols_Private"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DbReaderTests"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll unused --lang csharp --path src/CodeIndex/Cli/DiffCommandRunner.cs --json --limit 40`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog

- Added `changelog.d/unreleased/2990.fixed.md`.
- No documentation changes were needed; this fixes existing `unused` behavior without changing the command contract.

## Follow-up candidates

- None.

Fixes #2990