### PR TITLE
Fix MCP timeout cleanup and telemetry cap test

### DIFF
--- a/changelog.d/unreleased/3020.fixed.md
+++ b/changelog.d/unreleased/3020.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 3020
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+---
+
+## English
+
+- **MCP request timeout races now cancel unused delay timers (#3020)** — isolated MCP request dispatch now cancels and disposes the timeout delay when the request work finishes first, avoiding unnecessary timer churn after fast requests.
+
+## 日本語
+
+- **MCP request timeout の race が未使用 delay timer をキャンセルするようになりました (#3020)** — isolated MCP request dispatch は request work が先に完了した場合に timeout delay をキャンセルして破棄するため、高速な request 後の不要な timer churn を避けます。

--- a/changelog.d/unreleased/3325.fixed.md
+++ b/changelog.d/unreleased/3325.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 3325
+affected:
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP telemetry cap test now ignores unrelated invocation events (#3325)** — the argument-key cap regression test filters telemetry by a unique request id, so full-suite runs no longer fail when another invocation event appears in the captured error stream.
+
+## 日本語
+
+- **MCP telemetry cap test が無関係な invocation event を無視するようになりました (#3325)** — argument-key cap の regression test は一意な request id で telemetry を絞り込むため、full-suite 実行時に別の invocation event が捕捉されても失敗しなくなりました。

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -1578,7 +1578,9 @@ public partial class McpServer : IDisposable
                     _isolateDbForCurrentRequest.Value = previousIsolation;
                 }
             }, requestCts.Token);
-            var completed = await Task.WhenAny(actionTask, Task.Delay(_requestTimeout)).ConfigureAwait(false);
+            using var timeoutDelayCts = new CancellationTokenSource();
+            var timeoutTask = Task.Delay(_requestTimeout, timeoutDelayCts.Token);
+            var completed = await Task.WhenAny(actionTask, timeoutTask).ConfigureAwait(false);
             if (completed != actionTask)
             {
                 try { requestCts.Cancel(); }
@@ -1593,6 +1595,7 @@ public partial class McpServer : IDisposable
                 return CreateRequestTimeoutResponse(id, stopwatch.Elapsed);
             }
 
+            timeoutDelayCts.Cancel();
             return await actionTask.ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (requestCts.IsCancellationRequested)

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -679,13 +679,14 @@ public class McpServerTests : IDisposable
     {
         using var writer = new StringWriter();
         using var error = new StringWriter();
+        const int requestId = 3325;
         var arguments = new JsonObject();
         for (var i = 0; i < AuditLogSink.MaxAuditArgumentCount + 3; i++)
             arguments[$"arg{i}"] = i;
         var request = new JsonObject
         {
             ["jsonrpc"] = "2.0",
-            ["id"] = 123,
+            ["id"] = requestId,
             ["method"] = "tools/call",
             ["params"] = new JsonObject
             {
@@ -715,7 +716,8 @@ public class McpServerTests : IDisposable
 
         var line = error.ToString()
             .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-            .Single(l => l.Contains("\"event\":\"mcp.tool.invocation\"", StringComparison.Ordinal));
+            .Single(l => l.Contains("\"event\":\"mcp.tool.invocation\"", StringComparison.Ordinal)
+                && l.Contains($"\"request_id\":\"{requestId}\"", StringComparison.Ordinal));
         var jsonStart = line.IndexOf('{');
         using var document = JsonDocument.Parse(line[jsonStart..]);
         var root = document.RootElement;


### PR DESCRIPTION
## Summary

- Cancel and dispose the isolated MCP request timeout delay when request work completes before the timeout.
- Make the MCP telemetry argument-key cap test filter captured invocation logs by a unique request id so unrelated events do not make full-suite runs flaky.

## Root Cause

- Isolated MCP request dispatch raced work against an uncancellable `Task.Delay`, leaving the delay timer scheduled after fast requests.
- The telemetry cap regression test selected a `mcp.tool.invocation` line only by event type, so extra invocation events in the captured error stream could make `Single(...)` fail.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RequestTimeout_ReturnsStructuredTimeoutError" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests.ProcessLineAsync_CapsTelemetryArgumentKeyCount" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/3020.fixed.md`.
- Added `changelog.d/unreleased/3325.fixed.md`.
- No AGENTS.md, CLAUDE.md, or AGENT_GUIDE.md changes.

## Follow-up Candidates

None.

Fixes #3020
Fixes #3325