### PR TITLE
Harden suggestion store JSON permissions

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -57,6 +57,7 @@ Development contracts:
 |---|---|
 | `.cdidx/` | Created with mode `0700`. |
 | `codeindex.db` plus WAL/SHM sidecars | Mode `0600` is applied when the files exist. |
+| `suggestions-*.json` suggestion stores | Written atomically with owner-only mode `0600` on POSIX. |
 | Index lock metadata sidecars and active workspace `active.json` | Written as owner-only files and read through small bounded buffers so stale or corrupted diagnostics cannot expose local paths more broadly or force unbounded allocation. |
 | Checkpoint roots, snapshot directories, manifest files, copied DB/WAL/SHM snapshots, and restore staging/backup directories | Forced owner-only on POSIX. |
 | `status --json` | Reports `data_dir_mode` and `db_file_mode` when the platform exposes Unix file modes. |
@@ -2164,6 +2165,7 @@ net9 CI lane に合わせる場合は `FRAMEWORK=net9.0 make test` を使いま�
 |---|---|
 | `.cdidx/` | mode `0700` で作成。 |
 | `codeindex.db` と WAL/SHM sidecar | ファイルが存在する場合は mode `0600` を適用。 |
+| `suggestions-*.json` suggestion store | POSIX では owner-only の mode `0600` で atomic write します。 |
 | index lock metadata sidecar と active workspace の `active.json` | owner-only file として書き、stale / corrupt diagnostic が local path を広く漏らしたり unbounded allocation を強制したりしないよう小さな bounded buffer で読みます。 |
 | database checkpoint root、snapshot directory、manifest file、copy された DB/WAL/SHM snapshot、restore staging/backup directory | POSIX では owner-only に固定。 |
 | `status --json` | platform が Unix file mode を公開する場合、`data_dir_mode` と `db_file_mode` を報告。 |

--- a/changelog.d/unreleased/3267.security.md
+++ b/changelog.d/unreleased/3267.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 3267
+affected:
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Suggestion store JSON files now use private POSIX permissions (#3267)** — primary `suggestions-*.json` stores are written through the atomic private-file mode path so persisted triage context stays owner-only on POSIX systems.
+
+## 日本語
+
+- **suggestion store JSON file が POSIX の private permission を使うようになりました (#3267)** — primary `suggestions-*.json` store は atomic な private-file mode 経路で書き込まれ、永続化された triage context が POSIX で owner-only のままになります。

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -764,7 +764,7 @@ public class SuggestionStore
             Directory.CreateDirectory(dir);
 
         NormalizeRecordDefaults(records);
-        AtomicFileWriter.WriteJson(_filePath, records, s_jsonOptions);
+        AtomicFileWriter.WriteJson(_filePath, records, s_jsonOptions, DataDirectorySecurity.ApplyPrivateFileMode);
     }
 
     private static bool HasUpstreamSubmission(SuggestionRecord record) =>

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -304,6 +304,19 @@ public class SuggestionStoreTests : IDisposable
         Assert.True(File.Exists(filePath));
     }
 
+    [Fact]
+    public void TryAdd_OnPosixCreatesPrivateStoreFile()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var filePath = Path.Combine(_tempDir, "suggestions-codeindex.json");
+
+        Assert.True(_store.TryAdd(MakeRecord("other", null, "Private suggestion store")));
+
+        AssertPrivateFileMode(filePath);
+    }
+
     // --- LoadAll tests / LoadAll テスト ---
 
     [Fact]


### PR DESCRIPTION
## Summary

- Write primary `suggestions-*.json` stores through the existing atomic private-file mode callback path.
- Add POSIX regression coverage for owner-only suggestion store files.
- Document the suggestion store permission contract.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SuggestionStoreTests" -c Debug -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -c Debug -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review against `origin/main..HEAD`: no actionable correctness or regression issues found.

## Documentation / Changelog

- Updated `DEVELOPER_GUIDE.md` filesystem permissions contract in English and Japanese.
- Added changelog fragment: `changelog.d/unreleased/3267.security.md`.

## Scope

- Related issue check for `SuggestionStore` private permissions found only #3267.
- No follow-up candidates.

Fixes #3267