### PR TITLE
[codex] Document external pull request policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,24 @@
-## Summary
+## Pull Request Policy
 
-- Describe the change.
+This repository currently does not accept external pull requests.
 
-## Validation
+Issue reports, feature requests, and improvement suggestions are welcome. Please
+open an Issue first if you want to report a bug or suggest an improvement.
 
-- [ ] Tests added or updated for changed behavior, or not needed because:
-- [ ] Relevant validation command(s) run:
+Pull request creation is restricted to collaborators only.
 
-## Documentation and changelog
+## Pull Request 方針
 
-- [ ] Documentation updated, or not needed because:
-- [ ] Changelog fragment added under `changelog.d/unreleased/`, or not needed because:
-- [ ] Fragment follows `.codex/workflows/changelog-fragment.md` for category, issue front matter, and bilingual sections.
+このリポジトリでは、現在外部からの Pull Request は受け付けていません。
 
-## Issues
+不具合報告、機能要望、改善提案の Issue は歓迎します。バグ報告や改善提案が
+ある場合は、まず Issue を作成してください。
 
-Fixes #
+Pull Request の作成は collaborator のみに制限しています。
 
-## Follow-up issues
+## Collaborator checklist
 
-- None
+- [ ] The change follows the existing code style.
+- [ ] The change includes tests when behavior changes.
+- [ ] The change includes a changelog fragment when user-visible behavior changes.
+- [ ] Documentation has been updated when needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,31 @@
 
 Thanks for improving CodeIndex.
 
+## Contribution Policy
+
+Issue reports, feature requests, and improvement suggestions are welcome.
+Please open an Issue first if you want to report a bug, request a feature, or
+propose an improvement.
+
+This repository currently does not accept external pull requests. Pull request
+creation is restricted to collaborators only, and implementation work is handled
+by the maintainer or trusted collaborators.
+
+This policy keeps code style, changelog format, review quality, and maintenance
+cost consistent. It may be revisited in the future.
+
+## コントリビューション方針
+
+不具合報告、機能要望、改善提案の Issue は歓迎します。バグ報告、機能要望、
+改善提案がある場合は、まず Issue を作成してください。
+
+このリポジトリでは、現在外部からの Pull Request は受け付けていません。
+Pull Request の作成は collaborator のみに制限しており、実装作業は maintainer
+または信頼済み collaborator が行います。
+
+この方針は、コードスタイル、changelog 形式、レビュー品質、保守コストを
+一定に保つためのものです。将来的に見直す可能性があります。
+
 ## Licensing of Contributions
 
 By submitting a pull request, patch, issue attachment, or other contribution,
@@ -42,8 +67,8 @@ Start from the shared project guidance:
   platform alternatives.
 - `AGENT_GUIDE.md` for repository workflow rules used by coding agents.
 
-For a normal change, create a topic branch from the latest `origin/main`.
-Use a short, descriptive branch name. For issue fixes, use
+For a normal collaborator change, create a topic branch from the latest
+`origin/main`. Use a short, descriptive branch name. For issue fixes, use
 `fix-issue<issue-number>` unless the issue or maintainer asks for a different
 name.
 
@@ -76,8 +101,8 @@ When adding a new file that can affect release artifact contents, signing,
 publishing, installer behavior, or package restore trust, add it to
 `.github/CODEOWNERS` in the same change.
 
-Before opening a pull request, run the checks that match the change. For code
-changes, the default full validation is:
+Before a collaborator opens a pull request, run the checks that match the
+change. For code changes, the default full validation is:
 
 ```bash
 make lint
@@ -103,7 +128,7 @@ Issue-based changes should use a filename like `<issue>.docs.md` or
 
 ## Pull Request Checklist
 
-Before requesting review, confirm:
+Before collaborators request review, confirm:
 
 - the branch is based on the latest practical `origin/main`;
 - commits are focused and use English messages;

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ CodeIndex is not an AI editor, coding agent, or chat application. Conversation, 
 
 Embeddings, vector search, and LLM-based semantic ranking are not assumptions of CodeIndex core. If supported in the future, they should be positioned as optional extensions or separate layers built on top of the local index, rather than as part of the core retrieval model.
 
+## Contribution Policy
+
+Issue reports, feature requests, and improvement suggestions are welcome.
+
+This repository currently does not accept external pull requests. Pull request
+creation is restricted to collaborators only, and implementation changes are
+handled by the maintainer or trusted collaborators.
+
+This policy helps keep the repository's code style, changelog format, review
+quality, and maintenance cost consistent. It may be revisited in the future.
+
 ## Quick Start
 
 ```bash
@@ -362,6 +373,17 @@ CodeIndex は、人間のユーザーと AI エージェント向けの local-fi
 CodeIndex は AI editor、coding agent、chat application ではありません。会話、編集、コミット、pull request、自律的な変更判断は、cdidx を呼び出す外部 agent または editor の責務です。Symbol extraction / reference extraction は、速度、ローカル完結、説明可能性、retrieval の有用性に集中するための lightweight indexing hints です。compiler-accurate semantic analysis、full type resolution、exact call graph を目的とするものではありません。
 
 Embedding、vector search、LLM-based semantic ranking は CodeIndex core の前提機能ではありません。将来的に扱う場合も、core に組み込むのではなく、local index の上に置く optional extension または separate layer として位置づけます。
+
+## コントリビューション方針
+
+不具合報告、機能要望、改善提案の Issue は歓迎します。
+
+このリポジトリでは、現在外部からの Pull Request は受け付けていません。
+Pull Request の作成は collaborator のみに制限しており、実装変更は maintainer
+または信頼済み collaborator が行います。
+
+この方針は、コードスタイル、changelog 形式、レビュー品質、保守コストを
+一定に保つためのものです。将来的に見直す可能性があります。
 
 ## すぐに試す
 

--- a/changelog.d/unreleased/+external-pr-policy.docs.md
+++ b/changelog.d/unreleased/+external-pr-policy.docs.md
@@ -1,0 +1,15 @@
+---
+category: docs
+affected:
+  - README.md
+  - CONTRIBUTING.md
+  - .github/pull_request_template.md
+---
+
+## English
+
+- **External pull request policy is now documented** — the repository now states that issue reports and feature requests are welcome, while external pull requests are currently not accepted and pull request creation is restricted to collaborators only.
+
+## 日本語
+
+- **外部 Pull Request の受け付け方針を文書化しました** — 不具合報告や機能要望の Issue は歓迎しつつ、現在は外部 Pull Request を受け付けず、Pull Request の作成を collaborator のみに制限していることを明記しました。


### PR DESCRIPTION
## Summary

- Document that issues, feature requests, and improvement suggestions are welcome while external pull requests are not currently accepted.
- Clarify that pull request creation is restricted to collaborators, with implementation changes handled by the maintainer or trusted collaborators.
- Replace the pull request template with a short policy notice plus a collaborator checklist.

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `git diff --cached --check`

## Documentation and changelog

- Updated `README.md` and `CONTRIBUTING.md` with English/Japanese policy text.
- Updated `.github/pull_request_template.md` with English/Japanese PR policy text.
- Added changelog fragment `changelog.d/unreleased/+external-pr-policy.docs.md`.

## Issues

- Not issue-based.

## Follow-up candidates

- None.