### PR TITLE
Sanitize diagnostic and report redaction paths

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -164,7 +164,7 @@ ownership boundaries so behavior changes remain reviewable and testable.
 
 CodeIndex exposes an opt-in `ActivitySource` named `CodeIndex`. MCP JSON-RPC frames create `mcp.request` server spans and SQLite commands routed through tracked database helpers create `db.query` spans. MCP callers can pass W3C trace context as `params._meta.traceparent`; when present, the MCP span uses that trace as its parent. No exporter dependency is bundled, so spans are emitted only when the host process installs an OpenTelemetry/Diagnostics listener.
 
-Set `CDIDX_SLOW_QUERY_MS=<milliseconds>` to write slow SQLite command diagnostics to stderr. Query commands also accept `--profile` for a JSON profile block and `--slow-query-ms <milliseconds>` for command-scoped profiling.
+Set `CDIDX_SLOW_QUERY_MS=<milliseconds>` to write slow SQLite command diagnostics to stderr. Query commands also accept `--profile` for a JSON profile block and `--slow-query-ms <milliseconds>` for command-scoped profiling. Slow-query SQL diagnostics are single-line, length-bounded, and redact SQL string/blob/numeric literals before they reach stderr or the global tool log; the logged SQL is intended for operation/shape debugging, not value recovery.
 
 ### Indexing pipeline
 

--- a/changelog.d/unreleased/3371.security.md
+++ b/changelog.d/unreleased/3371.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 3371
+affected:
+  - src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+  - src/CodeIndex/Cli/GlobalToolLog.cs
+  - tests/CodeIndex.Tests/GlobalToolLogTests.cs
+---
+
+## English
+
+- **Global tool logs now classify exception messages before persistence (#3371)** — persistent exception chains store stable message categories and redact stack-line diagnostics instead of writing raw exception messages that can contain paths, SQL, queries, or secret-looking values.
+
+## 日本語
+
+- **Global tool log が例外メッセージを永続化前に分類するようになりました (#3371)** — 永続化される例外チェーンは、パス、SQL、クエリ、機密値らしき文字列を含み得る raw exception message ではなく、安定した message category と redacted stack-line diagnostics を記録します。

--- a/changelog.d/unreleased/3403.security.md
+++ b/changelog.d/unreleased/3403.security.md
@@ -1,0 +1,19 @@
+---
+category: security
+issues:
+  - 3403
+affected:
+  - src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+  - src/CodeIndex/Database/DbDebug.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/DbDebugTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **Environment-variable diagnostics now redact secret-looking invalid values (#3403)** — invalid `CDIDX_DEBUG` and MCP response/keep-alive environment warnings bound and redact displayed values before writing to stderr.
+
+## 日本語
+
+- **環境変数診断が機密値らしき不正値を redaction するようになりました (#3403)** — 不正な `CDIDX_DEBUG` と MCP response / keep-alive 環境変数の警告は、stderr へ出力する前に表示値を bounded かつ redacted にします。

--- a/changelog.d/unreleased/3416.security.md
+++ b/changelog.d/unreleased/3416.security.md
@@ -1,0 +1,15 @@
+---
+category: security
+issues:
+  - 3416
+affected:
+  - src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+  - src/CodeIndex/Database/DbDebug.cs
+  - tests/CodeIndex.Tests/DbDebugTests.cs
+  - DEVELOPER_GUIDE.md
+---
+## English
+- **Slow-query SQL diagnostics now redact literals (#3416)** — slow-query stderr and global tool log entries redact SQL string, blob, and numeric literals before applying the existing length bound.
+
+## 日本語
+- **slow-query SQL 診断がリテラルを redaction するようになりました (#3416)** — slow-query の stderr / global tool log 出力は、既存の長さ制限を適用する前に SQL 文字列・blob・数値リテラルを redaction します。

--- a/changelog.d/unreleased/3471.security.md
+++ b/changelog.d/unreleased/3471.security.md
@@ -1,0 +1,15 @@
+---
+category: security
+issues:
+  - 3471
+affected:
+  - src/CodeIndex/Cli/IndexFreshnessChecker.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
+---
+## English
+- **Index freshness and scanner probe diagnostics now use stable IO categories (#3471)** — status freshness scan errors and ancestor ignore directory probes no longer include raw filesystem exception messages.
+
+## 日本語
+- **index freshness と scanner probe の診断が安定した IO カテゴリを使うようになりました (#3471)** — status freshness の scan error と ancestor ignore directory probe は、生の filesystem 例外メッセージを含めなくなりました。

--- a/changelog.d/unreleased/3554.security.md
+++ b/changelog.d/unreleased/3554.security.md
@@ -1,0 +1,14 @@
+---
+category: security
+issues:
+  - 3554
+affected:
+  - src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+  - src/CodeIndex/Cli/ReportCommandRunner.cs
+  - tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+---
+## English
+- **Report bundle redaction is now consistent across JSON and log tails (#3554)** — report JSON redacts local path fields, log tail redaction preserves unrelated key-value fields after sensitive values, and `--include-args` keeps safe arguments while redacting secret-looking values and local paths.
+
+## 日本語
+- **report bundle の redaction が JSON と log tail で一貫するようになりました (#3554)** — report JSON はローカル path field を redaction し、log tail redaction は機密値の後続 key-value field を保持し、`--include-args` は安全な引数を残しつつ secret らしき値とローカル path を redaction します。

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
+using CodeIndex.Diagnostics;
 
 namespace CodeIndex.Cli;
 
@@ -123,7 +124,7 @@ internal static class GlobalToolLog
         sb.Append("] type=");
         sb.Append(ex.GetType().FullName);
         sb.Append(" message=");
-        sb.Append(QuoteLogValue(ex.Message));
+        sb.Append(QuoteLogValue(DiagnosticRedactor.ClassifyException(ex)));
         sb.AppendLine();
 
         if (includeStacks && !string.IsNullOrWhiteSpace(ex.StackTrace))
@@ -132,7 +133,7 @@ internal static class GlobalToolLog
             {
                 sb.Append(indent);
                 sb.Append("  stack: ");
-                sb.AppendLine(line.TrimEnd('\r'));
+                sb.AppendLine(DiagnosticRedactor.FormatExceptionStackLine(line.TrimEnd('\r')));
             }
         }
 

--- a/src/CodeIndex/Cli/IndexFreshnessChecker.cs
+++ b/src/CodeIndex/Cli/IndexFreshnessChecker.cs
@@ -1,4 +1,5 @@
 using CodeIndex.Database;
+using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
@@ -6,6 +7,8 @@ namespace CodeIndex.Cli;
 internal static class IndexFreshnessChecker
 {
     private const int SampleLimit = 20;
+    private const int MaxScanErrorPathChars = 180;
+    internal const int MaxScanErrorSampleChars = 240;
 
     internal static IndexFreshnessCheckResult Check(DbReader reader, string? projectRoot)
     {
@@ -55,7 +58,7 @@ internal static class IndexFreshnessChecker
                 continue;
 
             result.ScanErrorCount++;
-            AddSample(result.ScanErrors, $"{error.Path}: {error.Message}");
+            AddSample(result.ScanErrors, FormatScanSample(error.Path, error.Message));
         }
 
         using var indexedEnumerator = reader.EnumerateIndexedFileSnapshots().GetEnumerator();
@@ -107,7 +110,7 @@ internal static class IndexFreshnessChecker
             {
                 var relativePath = FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectRoot, absolutePath));
                 result.ScanErrorCount++;
-                AddSample(result.ScanErrors, $"{relativePath}: {ex.Message}");
+                AddSample(result.ScanErrors, FormatScanFailureSample(relativePath, ex));
             }
         }
 
@@ -191,4 +194,24 @@ internal static class IndexFreshnessChecker
         if (samples.Count < SampleLimit)
             samples.Add(value);
     }
+
+    internal static string FormatScanFailureSample(string relativePath, Exception ex) =>
+        FormatScanSample(relativePath, ClassifyScanFailure(ex));
+
+    private static string FormatScanSample(string relativePath, string message)
+    {
+        var path = DiagnosticRedactor.BoundDiagnosticText(
+            FileIndexer.NormalizePathSeparators(relativePath),
+            MaxScanErrorPathChars);
+        return DiagnosticRedactor.BoundDiagnosticText($"{path}: {message}", MaxScanErrorSampleChars);
+    }
+
+    private static string ClassifyScanFailure(Exception ex) =>
+        ex switch
+        {
+            UnauthorizedAccessException => "access-denied",
+            IOException => "io-error",
+            InvalidOperationException => "probe-failed",
+            _ => "probe-failed",
+        };
 }

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 
@@ -66,14 +67,14 @@ public static class ReportCommandRunner
             WriteBundle(fullOutputPath, bundle);
 
             var summary = new ReportBundleSummary(
-                fullOutputPath,
+                options.Json ? RedactedPlaceholder : fullOutputPath,
                 resolvedVersion,
                 bundle.Files.Count,
                 bundle.SchemaTables.Count,
                 bundle.LogLinesIncluded,
                 bundle.LogIncluded,
                 bundle.DbIncluded,
-                bundle.DbPath);
+                options.Json ? RedactLocalJsonPath(bundle.DbPath) : bundle.DbPath);
 
             if (options.Json)
             {
@@ -83,12 +84,12 @@ public static class ReportCommandRunner
             else
             {
                 Console.WriteLine("Bug report bundle");
-                Console.WriteLine($"  output       : {summary.OutputPath}");
+                Console.WriteLine($"  output       : {fullOutputPath}");
                 Console.WriteLine($"  cdidx        : v{summary.Version}");
                 Console.WriteLine($"  files        : {summary.Files}");
                 Console.WriteLine($"  schema rows  : {summary.SchemaTables}");
                 Console.WriteLine($"  log lines    : {(summary.LogIncluded ? summary.LogLinesIncluded.ToString() : "skipped")}");
-                Console.WriteLine($"  schema source: {(summary.DbIncluded ? summary.DbPath : "(no DB found)")}");
+                Console.WriteLine($"  schema source: {(summary.DbIncluded ? bundle.DbPath : "(no DB found)")}");
                 Console.WriteLine();
                 Console.WriteLine("Attach the tarball to the GitHub issue. Path lists, query strings, and");
                 Console.WriteLine("`args=` log lines are redacted by default; rerun with `--include-args` to");
@@ -104,12 +105,20 @@ public static class ReportCommandRunner
             return WriteCommandError(
                 options.Json,
                 jsonOptions,
-                $"failed to build report: {ex.Message}",
+                $"failed to build report: {FormatReportExceptionMessage(ex)}",
                 CommandExitCodes.DatabaseError,
                 "Retry `cdidx report --output <path>`. If this persists, check that the output directory is writable.",
                 CommandErrorCodes.DbError);
         }
     }
+
+    private static string FormatReportExceptionMessage(Exception ex) =>
+        DiagnosticRedactor.BoundDiagnosticText(
+            DiagnosticRedactor.RedactSensitiveText(ex.Message, RedactedPlaceholder, redactPaths: true),
+            maxChars: 512);
+
+    private static string? RedactLocalJsonPath(string? path) =>
+        string.IsNullOrWhiteSpace(path) ? path : RedactedPlaceholder;
 
     internal static ReportBundle BuildBundle(ReportCommandOptions options, string version)
     {
@@ -314,7 +323,7 @@ public static class ReportCommandRunner
         sb.AppendLine();
         foreach (var line in collected)
         {
-            sb.AppendLine(includeArgs ? RedactPathFields(line) : RedactSensitiveFields(line));
+            sb.AppendLine(RedactLogLine(line, includeArgs));
         }
         linesIncluded = collected.Count;
         return sb.ToString();
@@ -393,27 +402,11 @@ public static class ReportCommandRunner
 
     internal static string RedactSensitiveFields(string line)
     {
-        var redacted = RedactKeyValue(line, "args=");
-        return RedactPathFields(redacted);
+        return RedactLogLine(line, includeArgs: false);
     }
 
-    private static string RedactPathFields(string line)
-    {
-        var redacted = RedactKeyValue(line, "cwd=");
-        redacted = RedactKeyValue(redacted, "process_path=");
-        redacted = RedactKeyValue(redacted, "base_dir=");
-        redacted = RedactKeyValue(redacted, "db=");
-        redacted = RedactKeyValue(redacted, "path=");
-        return redacted;
-    }
-
-    private static string RedactKeyValue(string line, string key)
-    {
-        var idx = line.IndexOf(key, StringComparison.Ordinal);
-        if (idx < 0)
-            return line;
-        return line[..(idx + key.Length)] + RedactedPlaceholder;
-    }
+    internal static string RedactLogLine(string line, bool includeArgs) =>
+        DiagnosticRedactor.RedactReportLogLine(line, includeArgs, RedactedPlaceholder);
 
     internal static void WriteBundle(string outputPath, ReportBundle bundle, Action? beforeWriteEntries = null)
     {

--- a/src/CodeIndex/Database/DbDebug.cs
+++ b/src/CodeIndex/Database/DbDebug.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Diagnostics;
 using CodeIndex;
 using CodeIndex.Cli;
+using CodeIndex.Diagnostics;
 using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Database;
@@ -155,8 +156,9 @@ public static class DbDebug
     {
         if (Interlocked.Exchange(ref _invalidDebugValueWarned, 1) != 0)
             return;
+        var displayValue = DiagnosticRedactor.FormatEnvironmentValue("CDIDX_DEBUG", value);
         Console.Error.WriteLine(
-            $"[cdidx] CDIDX_DEBUG value '{value}' is not recognized. Expected one of: 1, 0, true, false, yes, no, on, off, unsafe, full. Falling back to off.");
+            $"[cdidx] CDIDX_DEBUG value '{displayValue}' is not recognized. Expected one of: 1, 0, true, false, yes, no, on, off, unsafe, full. Falling back to off.");
     }
 
     private static void WarnUnsafeDowngradedOnce()

--- a/src/CodeIndex/Database/DbDebug.cs
+++ b/src/CodeIndex/Database/DbDebug.cs
@@ -280,8 +280,14 @@ public static class DbDebug
         Console.Error.WriteLine($"[cdidx] slow_query elapsed_ms={elapsedMs:0.###}{rowText} sql={sql}");
     }
 
-    internal static string FormatSqlForSlowQueryLog(string sql) =>
-        TruncateDiagnosticText(sql.ReplaceLineEndings(" "), MaxSlowQuerySqlChars);
+    internal static string FormatSqlForSlowQueryLog(string sql)
+    {
+        var singleLine = sql.ReplaceLineEndings(" ");
+        var redacted = DiagnosticRedactor.RedactSensitiveText(
+            DiagnosticRedactor.RedactSqlLiterals(singleLine),
+            redactPaths: true);
+        return TruncateDiagnosticText(redacted, MaxSlowQuerySqlChars);
+    }
 
     private static List<QueryPlanRow> CaptureQueryPlan(SqliteCommand source)
     {

--- a/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+++ b/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
@@ -95,6 +95,44 @@ internal static class DiagnosticRedactor
         return BoundDiagnosticText(RedactSensitiveText(raw, AngleRedacted, redactPaths: true), maxChars);
     }
 
+    internal static string RedactSqlLiterals(string sql)
+    {
+        if (string.IsNullOrEmpty(sql))
+            return sql;
+
+        var builder = new StringBuilder(sql.Length);
+        var i = 0;
+        while (i < sql.Length)
+        {
+            var ch = sql[i];
+            if ((ch == 'x' || ch == 'X') && i + 1 < sql.Length && sql[i + 1] == '\'')
+            {
+                builder.Append(ch).Append('\'').Append(AngleRedacted).Append('\'');
+                i = ConsumeSqlSingleQuotedLiteral(sql, i + 1);
+                continue;
+            }
+
+            if (ch == '\'')
+            {
+                builder.Append('\'').Append(AngleRedacted).Append('\'');
+                i = ConsumeSqlSingleQuotedLiteral(sql, i);
+                continue;
+            }
+
+            if (IsSqlNumericLiteralStart(sql, i))
+            {
+                builder.Append("<number>");
+                i = ConsumeSqlNumericLiteral(sql, i);
+                continue;
+            }
+
+            builder.Append(ch);
+            i++;
+        }
+
+        return builder.ToString();
+    }
+
     internal static string RedactSensitiveText(string value, string placeholder = AngleRedacted, bool redactPaths = false)
     {
         if (string.IsNullOrEmpty(value))
@@ -162,6 +200,75 @@ internal static class DiagnosticRedactor
 
         return false;
     }
+
+    private static int ConsumeSqlSingleQuotedLiteral(string value, int quoteIndex)
+    {
+        var i = quoteIndex + 1;
+        while (i < value.Length)
+        {
+            if (value[i] != '\'')
+            {
+                i++;
+                continue;
+            }
+
+            if (i + 1 < value.Length && value[i + 1] == '\'')
+            {
+                i += 2;
+                continue;
+            }
+
+            return i + 1;
+        }
+
+        return value.Length;
+    }
+
+    private static bool IsSqlNumericLiteralStart(string value, int index)
+    {
+        var ch = value[index];
+        if (!char.IsDigit(ch) && (ch != '.' || index + 1 >= value.Length || !char.IsDigit(value[index + 1])))
+            return false;
+
+        return index == 0 || !IsSqlIdentifierPart(value[index - 1]);
+    }
+
+    private static int ConsumeSqlNumericLiteral(string value, int index)
+    {
+        var i = index;
+        if (i + 1 < value.Length && value[i] == '0' && (value[i + 1] == 'x' || value[i + 1] == 'X'))
+        {
+            i += 2;
+            while (i < value.Length && Uri.IsHexDigit(value[i]))
+                i++;
+            return i;
+        }
+
+        while (i < value.Length && char.IsDigit(value[i]))
+            i++;
+        if (i < value.Length && value[i] == '.')
+        {
+            i++;
+            while (i < value.Length && char.IsDigit(value[i]))
+                i++;
+        }
+        if (i < value.Length && (value[i] == 'e' || value[i] == 'E'))
+        {
+            var exponent = i + 1;
+            if (exponent < value.Length && (value[exponent] == '+' || value[exponent] == '-'))
+                exponent++;
+            var digitStart = exponent;
+            while (exponent < value.Length && char.IsDigit(value[exponent]))
+                exponent++;
+            if (exponent > digitStart)
+                i = exponent;
+        }
+
+        return i;
+    }
+
+    private static bool IsSqlIdentifierPart(char ch) =>
+        char.IsLetterOrDigit(ch) || ch == '_' || ch == '$';
 
     private static string FlattenDiagnosticControlChars(string value)
     {

--- a/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+++ b/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
@@ -1,0 +1,142 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Diagnostics;
+
+internal static class DiagnosticRedactor
+{
+    internal const int DefaultDiagnosticValueCharLimit = 120;
+    internal const string AngleRedacted = "<redacted>";
+    internal const string TruncationMarker = "... <truncated>";
+
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    private static readonly Regex UriUserInfoPattern = new(
+        @"(?<scheme>[a-z][a-z0-9+\-.]*://)(?<user>[^:@/\s]+):(?<password>[^@/\s]+)@",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex BearerTokenPattern = new(
+        @"\bBearer\s+[A-Za-z0-9._~+\-/]+=*",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex SensitiveAssignmentPattern = new(
+        @"(?<![\w.-])(?<name>--?[\w.-]*(?:token|password|passwd|pwd|secret|auth|apikey|api-key|api_key|access-key|access_key|credential)[\w.-]*)(?<sep>=|:)(?<value>[^\s,;]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex GitHubTokenPattern = new(
+        @"\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex LongHexPattern = new(
+        @"\b[0-9a-f]{32,}\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex LongBase64Pattern = new(
+        @"\b[A-Za-z0-9+/]{40,}={0,2}\b",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex WindowsAbsolutePathPattern = new(
+        @"\b[A-Za-z]:[\\/][^\s""'<>|]+",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex UnixAbsolutePathPattern = new(
+        @"(?<![A-Za-z0-9+\-.]:)/[^\s""'<>]+(?:/[^\s""'<>]+)*",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    internal static string ClassifyException(Exception ex)
+    {
+        return ex switch
+        {
+            UnauthorizedAccessException => "access_denied",
+            PathTooLongException => "path_too_long",
+            DirectoryNotFoundException => "directory_not_found",
+            FileNotFoundException => "file_not_found",
+            IOException => "io_error",
+            DecoderFallbackException => "decoder_error",
+            OperationCanceledException => "operation_canceled",
+            TimeoutException => "timeout",
+            SqliteException => "sqlite_error",
+            ArgumentException => "argument_error",
+            InvalidOperationException => "invalid_operation",
+            NotSupportedException => "not_supported",
+            _ => "exception_message_redacted",
+        };
+    }
+
+    internal static string FormatExceptionStackLine(string line, int maxChars = 512) =>
+        BoundDiagnosticText(RedactSensitiveText(line, AngleRedacted, redactPaths: true), maxChars);
+
+    internal static string RedactSensitiveText(string value, string placeholder = AngleRedacted, bool redactPaths = false)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        var redacted = UriUserInfoPattern.Replace(value, match =>
+            match.Groups["scheme"].Value + match.Groups["user"].Value + ":" + placeholder + "@");
+        redacted = BearerTokenPattern.Replace(redacted, "Bearer " + placeholder);
+        redacted = SensitiveAssignmentPattern.Replace(redacted, match =>
+            match.Groups["name"].Value + match.Groups["sep"].Value + placeholder);
+        redacted = GitHubTokenPattern.Replace(redacted, placeholder);
+        redacted = LongHexPattern.Replace(redacted, placeholder);
+        redacted = LongBase64Pattern.Replace(redacted, placeholder);
+        if (redactPaths)
+        {
+            redacted = WindowsAbsolutePathPattern.Replace(redacted, placeholder);
+            redacted = UnixAbsolutePathPattern.Replace(redacted, placeholder);
+        }
+
+        return redacted;
+    }
+
+    internal static string BoundDiagnosticText(string? value, int maxChars = DefaultDiagnosticValueCharLimit)
+    {
+        if (maxChars < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxChars), maxChars, "Diagnostic limit must be non-negative.");
+
+        if (value is null)
+            return "<null>";
+
+        var flattened = FlattenDiagnosticControlChars(value);
+        if (flattened.Length <= maxChars)
+            return flattened;
+
+        if (maxChars == 0)
+            return TruncationMarker.TrimStart('.', ' ');
+        if (maxChars <= TruncationMarker.Length)
+            return TruncationMarker[..maxChars];
+
+        return flattened[..(maxChars - TruncationMarker.Length)] + TruncationMarker;
+    }
+
+    private static string FlattenDiagnosticControlChars(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            if (ch == '\r' || ch == '\n' || ch == '\t')
+            {
+                builder.Append(' ');
+            }
+            else if (char.IsControl(ch))
+            {
+                builder.Append(string.Create(CultureInfo.InvariantCulture, $"\\u{(int)ch:x4}"));
+            }
+            else
+            {
+                builder.Append(ch);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+++ b/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Data.Sqlite;
 
@@ -24,6 +25,11 @@ internal static class DiagnosticRedactor
 
     private static readonly Regex SensitiveAssignmentPattern = new(
         @"(?<![\w.-])(?<name>--?[\w.-]*(?:token|password|passwd|pwd|secret|auth|apikey|api-key|api_key|access-key|access_key|credential)[\w.-]*)(?<sep>=|:)(?<value>[^\s,;]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex SensitiveSeparatedArgumentPattern = new(
+        @"(?<![\w.-])(?<name>--?[\w.-]*(?:token|password|passwd|pwd|secret|auth|apikey|api-key|api_key|access-key|access_key|credential)[\w.-]*)\s+(?<value>""[^""]*""|'[^']*'|[^\s,;]+)",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
         RegexTimeout);
 
@@ -133,6 +139,35 @@ internal static class DiagnosticRedactor
         return builder.ToString();
     }
 
+    internal static string RedactReportLogLine(string line, bool includeArgs, string placeholder = AngleRedacted)
+    {
+        if (string.IsNullOrEmpty(line))
+            return line;
+
+        if (TryRedactReportJsonLogLine(line, includeArgs, placeholder, out var redactedJsonLine))
+            return redactedJsonLine;
+
+        return RedactReportKeyValueLogLine(line, includeArgs, placeholder);
+    }
+
+    private static string RedactReportKeyValueLogLine(string line, bool includeArgs, string placeholder)
+    {
+        var builder = new StringBuilder(line.Length);
+        var position = 0;
+        while (TryFindReportKey(line, position, out var keyStart, out var keyEnd, out var valueStart))
+        {
+            builder.Append(RedactSensitiveText(line[position..valueStart], placeholder, redactPaths: true));
+            var valueEnd = FindReportValueEnd(line, valueStart);
+            var key = line[keyStart..keyEnd];
+            var value = line[valueStart..valueEnd];
+            builder.Append(RedactReportLogValue(key, value, includeArgs, placeholder));
+            position = valueEnd;
+        }
+
+        builder.Append(RedactSensitiveText(line[position..], placeholder, redactPaths: true));
+        return builder.ToString();
+    }
+
     internal static string RedactSensitiveText(string value, string placeholder = AngleRedacted, bool redactPaths = false)
     {
         if (string.IsNullOrEmpty(value))
@@ -143,6 +178,8 @@ internal static class DiagnosticRedactor
         redacted = BearerTokenPattern.Replace(redacted, "Bearer " + placeholder);
         redacted = SensitiveAssignmentPattern.Replace(redacted, match =>
             match.Groups["name"].Value + match.Groups["sep"].Value + placeholder);
+        redacted = SensitiveSeparatedArgumentPattern.Replace(redacted, match =>
+            match.Groups["name"].Value + " " + placeholder);
         redacted = GitHubTokenPattern.Replace(redacted, placeholder);
         redacted = LongHexPattern.Replace(redacted, placeholder);
         redacted = LongBase64Pattern.Replace(redacted, match =>
@@ -189,6 +226,177 @@ internal static class DiagnosticRedactor
             || name.Contains("access-key", StringComparison.OrdinalIgnoreCase)
             || name.Contains("access_key", StringComparison.OrdinalIgnoreCase)
             || name.Contains("credential", StringComparison.OrdinalIgnoreCase));
+
+    private static bool TryRedactReportJsonLogLine(
+        string line,
+        bool includeArgs,
+        string placeholder,
+        out string redacted)
+    {
+        redacted = line;
+        if (!LooksLikeJsonObject(line))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(line);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+                return false;
+
+            using var stream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream))
+            {
+                writer.WriteStartObject();
+                foreach (var property in document.RootElement.EnumerateObject())
+                {
+                    writer.WritePropertyName(property.Name);
+                    if (property.Value.ValueKind == JsonValueKind.String)
+                    {
+                        writer.WriteStringValue(RedactReportJsonStringProperty(
+                            property.Name,
+                            property.Value.GetString() ?? string.Empty,
+                            includeArgs,
+                            placeholder));
+                    }
+                    else
+                    {
+                        property.Value.WriteTo(writer);
+                    }
+                }
+
+                writer.WriteEndObject();
+            }
+
+            redacted = Encoding.UTF8.GetString(stream.ToArray());
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static bool LooksLikeJsonObject(string line)
+    {
+        var start = 0;
+        while (start < line.Length && char.IsWhiteSpace(line[start]))
+            start++;
+        if (start >= line.Length || line[start] != '{')
+            return false;
+
+        var end = line.Length - 1;
+        while (end >= start && char.IsWhiteSpace(line[end]))
+            end--;
+
+        return end > start && line[end] == '}';
+    }
+
+    private static string RedactReportJsonStringProperty(string key, string value, bool includeArgs, string placeholder)
+    {
+        if (key.Equals("msg", StringComparison.Ordinal))
+        {
+            var redactedMessage = RedactReportKeyValueLogLine(value, includeArgs, placeholder);
+            return RedactSensitiveText(redactedMessage, placeholder, redactPaths: true);
+        }
+
+        return RedactReportLogValue(key, value, includeArgs, placeholder);
+    }
+
+    private static string RedactReportLogValue(string key, string value, bool includeArgs, string placeholder)
+    {
+        if (key.Equals("args", StringComparison.Ordinal))
+        {
+            return includeArgs
+                ? RedactSensitiveText(value, placeholder, redactPaths: true)
+                : placeholder;
+        }
+
+        if (IsReportPathKey(key) || IsSensitiveName(key))
+            return placeholder;
+
+        return RedactSensitiveText(value, placeholder, redactPaths: true);
+    }
+
+    private static bool IsReportPathKey(string key) =>
+        key is "cwd" or "process_path" or "base_dir" or "db" or "path";
+
+    private static bool TryFindReportKey(
+        string line,
+        int start,
+        out int keyStart,
+        out int keyEnd,
+        out int valueStart)
+    {
+        for (var i = start; i < line.Length; i++)
+        {
+            if (i > 0 && !char.IsWhiteSpace(line[i - 1]))
+                continue;
+            if (TryReadReportKeyAt(line, i, out keyEnd, out valueStart))
+            {
+                keyStart = i;
+                return true;
+            }
+        }
+
+        keyStart = -1;
+        keyEnd = -1;
+        valueStart = -1;
+        return false;
+    }
+
+    private static bool TryReadReportKeyAt(string line, int index, out int keyEnd, out int valueStart)
+    {
+        keyEnd = -1;
+        valueStart = -1;
+        if (index >= line.Length || !IsReportKeyStart(line[index]))
+            return false;
+
+        var i = index + 1;
+        while (i < line.Length && IsReportKeyChar(line[i]))
+            i++;
+        if (i >= line.Length || line[i] != '=')
+            return false;
+
+        keyEnd = i;
+        valueStart = i + 1;
+        return true;
+    }
+
+    private static int FindReportValueEnd(string line, int valueStart)
+    {
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+        for (var i = valueStart; i < line.Length; i++)
+        {
+            var ch = line[i];
+            if (ch == '\'' && !inDoubleQuote)
+            {
+                inSingleQuote = !inSingleQuote;
+            }
+            else if (ch == '"' && !inSingleQuote)
+            {
+                inDoubleQuote = !inDoubleQuote;
+            }
+            else if (!inSingleQuote && !inDoubleQuote && char.IsWhiteSpace(ch))
+            {
+                var next = i + 1;
+                if (next < line.Length && TryReadReportKeyAt(line, next, out _, out _))
+                    return i;
+            }
+        }
+
+        return line.Length;
+    }
+
+    private static bool IsReportKeyStart(char ch) =>
+        char.IsLetter(ch) || ch == '_';
+
+    private static bool IsReportKeyChar(char ch) =>
+        char.IsLetterOrDigit(ch) || ch is '_' or '-' or '.';
 
     private static bool LooksLikeOpaqueToken(string value)
     {

--- a/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+++ b/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
@@ -9,7 +9,6 @@ internal static class DiagnosticRedactor
 {
     internal const int DefaultDiagnosticValueCharLimit = 120;
     internal const string AngleRedacted = "<redacted>";
-    internal const string TruncationMarker = "... <truncated>";
 
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
 
@@ -48,8 +47,13 @@ internal static class DiagnosticRedactor
         RegexOptions.CultureInvariant | RegexOptions.Compiled,
         RegexTimeout);
 
+    private static readonly Regex UriPathPattern = new(
+        @"\b(?<prefix>[a-z][a-z0-9+\-.]*://[^/\s""'<>?#]*)(?<tail>[/?#][^\s""'<>]*)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
     private static readonly Regex UnixAbsolutePathPattern = new(
-        @"(?<![A-Za-z0-9+\-.]:)/[^\s""'<>]+(?:/[^\s""'<>]+)*",
+        @"(?<![A-Za-z0-9+\-.]:)(?<!/)/[^\s""'<>]+(?:/[^\s""'<>]+)*",
         RegexOptions.CultureInvariant | RegexOptions.Compiled,
         RegexTimeout);
 
@@ -76,6 +80,21 @@ internal static class DiagnosticRedactor
     internal static string FormatExceptionStackLine(string line, int maxChars = 512) =>
         BoundDiagnosticText(RedactSensitiveText(line, AngleRedacted, redactPaths: true), maxChars);
 
+    internal static string FormatEnvironmentValue(string? raw, int maxChars = DefaultDiagnosticValueCharLimit) =>
+        FormatEnvironmentValue(envVarName: null, raw, maxChars);
+
+    internal static string FormatEnvironmentValue(string? envVarName, string? raw, int maxChars = DefaultDiagnosticValueCharLimit)
+    {
+        if (raw is null)
+            return "<null>";
+        if (raw.Length == 0)
+            return "<empty>";
+        if (IsSensitiveName(envVarName))
+            return AngleRedacted;
+
+        return BoundDiagnosticText(RedactSensitiveText(raw, AngleRedacted, redactPaths: true), maxChars);
+    }
+
     internal static string RedactSensitiveText(string value, string placeholder = AngleRedacted, bool redactPaths = false)
     {
         if (string.IsNullOrEmpty(value))
@@ -88,9 +107,11 @@ internal static class DiagnosticRedactor
             match.Groups["name"].Value + match.Groups["sep"].Value + placeholder);
         redacted = GitHubTokenPattern.Replace(redacted, placeholder);
         redacted = LongHexPattern.Replace(redacted, placeholder);
-        redacted = LongBase64Pattern.Replace(redacted, placeholder);
+        redacted = LongBase64Pattern.Replace(redacted, match =>
+            LooksLikeOpaqueToken(match.Value) ? placeholder : match.Value);
         if (redactPaths)
         {
+            redacted = UriPathPattern.Replace(redacted, match => match.Groups["prefix"].Value + placeholder);
             redacted = WindowsAbsolutePathPattern.Replace(redacted, placeholder);
             redacted = UnixAbsolutePathPattern.Replace(redacted, placeholder);
         }
@@ -110,12 +131,36 @@ internal static class DiagnosticRedactor
         if (flattened.Length <= maxChars)
             return flattened;
 
-        if (maxChars == 0)
-            return TruncationMarker.TrimStart('.', ' ');
-        if (maxChars <= TruncationMarker.Length)
-            return TruncationMarker[..maxChars];
+        var marker = string.Create(CultureInfo.InvariantCulture, $"... <truncated; original length {flattened.Length} chars>");
+        return maxChars == 0
+            ? marker.TrimStart('.', ' ')
+            : flattened[..maxChars] + marker;
+    }
 
-        return flattened[..(maxChars - TruncationMarker.Length)] + TruncationMarker;
+    private static bool IsSensitiveName(string? name) =>
+        !string.IsNullOrWhiteSpace(name)
+        && (name.Contains("token", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("password", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("passwd", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("pwd", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("secret", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("auth", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("apikey", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("api-key", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("api_key", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("access-key", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("access_key", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("credential", StringComparison.OrdinalIgnoreCase));
+
+    private static bool LooksLikeOpaqueToken(string value)
+    {
+        foreach (var ch in value)
+        {
+            if (char.IsDigit(ch) || ch is '+' or '/' or '=')
+                return true;
+        }
+
+        return false;
     }
 
     private static string FlattenDiagnosticControlChars(string value)

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -2913,7 +2913,7 @@ public class FileIndexer
     {
         if (!Directory.Exists(LongPath.EnsureWindowsPrefix(dir)))
         {
-            reason = "directory does not exist";
+            reason = "directory-missing";
             return false;
         }
 
@@ -2926,12 +2926,12 @@ public class FileIndexer
         }
         catch (UnauthorizedAccessException)
         {
-            reason = "access denied";
+            reason = "access-denied";
             return false;
         }
-        catch (IOException ex)
+        catch (IOException)
         {
-            reason = ex.Message;
+            reason = "io-error";
             return false;
         }
     }

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
 using CodeIndex.Cli;
 using CodeIndex.Database;
+using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
 
 namespace CodeIndex.Mcp;
@@ -1453,8 +1454,9 @@ public partial class McpServer : IDisposable
             || seconds < MinKeepAliveIntervalSeconds
             || seconds > MaxKeepAliveIntervalSeconds)
         {
+            var displayValue = DiagnosticRedactor.FormatEnvironmentValue(KeepAliveIntervalEnvironmentVariable, raw);
             Console.Error.WriteLine(
-                $"[cdidx-mcp] Ignoring invalid {KeepAliveIntervalEnvironmentVariable}='{ConsoleUi.FormatBoundedValue(raw)}'. Expected a finite value between {MinKeepAliveIntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)} and {MaxKeepAliveIntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)} seconds. Keep-alive notifications stay disabled.");
+                $"[cdidx-mcp] Ignoring invalid {KeepAliveIntervalEnvironmentVariable}='{displayValue}'. Expected a finite value between {MinKeepAliveIntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)} and {MaxKeepAliveIntervalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)} seconds. Keep-alive notifications stay disabled.");
             return null;
         }
         return TimeSpan.FromSeconds(seconds);
@@ -3943,13 +3945,15 @@ public partial class McpServer : IDisposable
         if (!int.TryParse(raw, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var limit)
             || limit <= 0)
         {
-            Console.Error.WriteLine($"[cdidx-mcp] Ignoring invalid {envVar}='{raw}'. Expected a positive integer for {description}. Using default {defaultValue.ToString(System.Globalization.CultureInfo.InvariantCulture)}.");
+            var displayValue = DiagnosticRedactor.FormatEnvironmentValue(envVar, raw);
+            Console.Error.WriteLine($"[cdidx-mcp] Ignoring invalid {envVar}='{displayValue}'. Expected a positive integer for {description}. Using default {defaultValue.ToString(System.Globalization.CultureInfo.InvariantCulture)}.");
             return defaultValue;
         }
 
         if (limit > maximumValue)
         {
-            Console.Error.WriteLine($"[cdidx-mcp] Clamping {envVar}='{raw}' to maximum {maximumValue.ToString(System.Globalization.CultureInfo.InvariantCulture)} for {description}.");
+            var displayValue = DiagnosticRedactor.FormatEnvironmentValue(envVar, raw);
+            Console.Error.WriteLine($"[cdidx-mcp] Clamping {envVar}='{displayValue}' to maximum {maximumValue.ToString(System.Globalization.CultureInfo.InvariantCulture)} for {description}.");
             return maximumValue;
         }
 

--- a/tests/CodeIndex.Tests/DbDebugTests.cs
+++ b/tests/CodeIndex.Tests/DbDebugTests.cs
@@ -229,6 +229,50 @@ public class DbDebugTests
     }
 
     [Fact]
+    public void IsEnabled_InvalidDebugValue_RedactsSecretLookingValue_Issue3403()
+    {
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        const string secret = "0123456789abcdef0123456789abcdef";
+        env.Set("CDIDX_DEBUG", $"token={secret}");
+        try
+        {
+            DbDebug.ResetForTesting();
+            var output = CaptureStderr(() => Assert.False(DbDebug.IsEnabled));
+
+            Assert.Contains("CDIDX_DEBUG value 'token=<redacted>' is not recognized", output);
+            Assert.DoesNotContain(secret, output);
+        }
+        finally
+        {
+            DbDebug.ResetForTesting();
+        }
+    }
+
+    [Fact]
+    public void IsEnabled_InvalidDebugValue_RedactsPathAndUrlValue_Issue3403()
+    {
+        using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");
+        const string path = "/Users/example/private/project";
+        const string url = "https://example.test/private/project/config.json";
+        const string queryUrl = "https://example.test?query=user-content";
+        env.Set("CDIDX_DEBUG", $"path={path} url={url} query={queryUrl}");
+        try
+        {
+            DbDebug.ResetForTesting();
+            var output = CaptureStderr(() => Assert.False(DbDebug.IsEnabled));
+
+            Assert.Contains("CDIDX_DEBUG value 'path=<redacted> url=https://example.test<redacted> query=https://example.test<redacted>' is not recognized", output);
+            Assert.DoesNotContain(path, output);
+            Assert.DoesNotContain("/private/project/config.json", output);
+            Assert.DoesNotContain("query=user-content", output);
+        }
+        finally
+        {
+            DbDebug.ResetForTesting();
+        }
+    }
+
+    [Fact]
     public void DumpToStderr_RedactsTextByDefault()
     {
         using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");

--- a/tests/CodeIndex.Tests/DbDebugTests.cs
+++ b/tests/CodeIndex.Tests/DbDebugTests.cs
@@ -154,6 +154,27 @@ public class DbDebugTests
     }
 
     [Fact]
+    public void FormatSqlForSlowQueryLog_RedactsLiteralsAndSensitiveText_Issue3416()
+    {
+        var path = "/Users/example/private/project/secret_module.cs";
+        var searchText = "literal user search text";
+        var secret = "0123456789abcdef0123456789abcdef";
+        var sql = $"SELECT * FROM chunks WHERE path = '{path}' AND content MATCH '{searchText}' AND api_token = '{secret}' AND rank > 42 AND payload = X'0123abcd'";
+
+        var formatted = DbDebug.FormatSqlForSlowQueryLog(sql);
+
+        Assert.Contains("path = '<redacted>'", formatted);
+        Assert.Contains("content MATCH '<redacted>'", formatted);
+        Assert.Contains("api_token = '<redacted>'", formatted);
+        Assert.Contains("rank > <number>", formatted);
+        Assert.Contains("payload = X'<redacted>'", formatted);
+        Assert.DoesNotContain(path, formatted);
+        Assert.DoesNotContain(searchText, formatted);
+        Assert.DoesNotContain(secret, formatted);
+        Assert.DoesNotContain("0123abcd", formatted);
+    }
+
+    [Fact]
     public void DumpToStderr_NoOp_WhenDisabled()
     {
         using var env = EnvironmentVariableScope.Capture("CDIDX_DEBUG");

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -2437,7 +2437,7 @@ public class FileIndexerTests
             Assert.Empty(result.Files);
             Assert.Contains(result.Errors, error =>
                 error.Path == ".."
-                && error.Message.StartsWith("Could not read ancestor ignore directory:", StringComparison.Ordinal));
+                && error.Message == "Could not read ancestor ignore directory: access-denied.");
             Assert.True(result.HadErrors);
         }
         finally

--- a/tests/CodeIndex.Tests/GlobalToolLogTests.cs
+++ b/tests/CodeIndex.Tests/GlobalToolLogTests.cs
@@ -206,6 +206,37 @@ public class GlobalToolLogTests
     }
 
     [Fact]
+    public void FormatExceptionChain_ClassifiesExceptionMessagesWithoutRawDetails_Issue3371()
+    {
+        var exception = new IOException(
+            "failed to read /Users/widthdom/private/project/token.txt token=0123456789abcdef0123456789abcdef query=SELECT * FROM secret");
+
+        var formatted = GlobalToolLog.FormatExceptionChain(exception);
+
+        Assert.Contains("type=System.IO.IOException", formatted);
+        Assert.Contains("message=\"io_error\"", formatted);
+        Assert.DoesNotContain("/Users/widthdom/private", formatted);
+        Assert.DoesNotContain("0123456789abcdef0123456789abcdef", formatted);
+        Assert.DoesNotContain("SELECT * FROM secret", formatted);
+    }
+
+    [Fact]
+    public void FormatExceptionChain_ClassifiesInnerExceptionMessages_Issue3371()
+    {
+        var exception = new InvalidOperationException(
+            "outer raw path /tmp/private",
+            new UnauthorizedAccessException("denied /home/user/secret.txt password=hunter2"));
+
+        var formatted = GlobalToolLog.FormatExceptionChain(exception);
+
+        Assert.Contains("message=\"invalid_operation\"", formatted);
+        Assert.Contains("message=\"access_denied\"", formatted);
+        Assert.DoesNotContain("/tmp/private", formatted);
+        Assert.DoesNotContain("/home/user/secret.txt", formatted);
+        Assert.DoesNotContain("hunter2", formatted);
+    }
+
+    [Fact]
     public void LogOptionsFromEnvironment_AcceptsMaximumMbValue()
     {
         using var env = EnvironmentVariableScope.Capture(

--- a/tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
+++ b/tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
@@ -1,0 +1,40 @@
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+public class IndexFreshnessCheckerTests
+{
+    [Fact]
+    public void FormatScanFailureSample_ClassifiesIoMessage_Issue3471()
+    {
+        const string secret = "0123456789abcdef0123456789abcdef";
+        var rawPath = "/Users/example/private/project/secret.cs";
+        var exception = new IOException($"Could not read {rawPath} token={secret}");
+
+        var sample = IndexFreshnessChecker.FormatScanFailureSample("src/App.cs", exception);
+
+        Assert.Equal("src/App.cs: io-error", sample);
+        Assert.DoesNotContain(rawPath, sample);
+        Assert.DoesNotContain(secret, sample);
+    }
+
+    [Fact]
+    public void FormatScanFailureSample_ClassifiesAccessDenied_Issue3471()
+    {
+        var exception = new UnauthorizedAccessException("/Users/example/private/project/secret.cs");
+
+        var sample = IndexFreshnessChecker.FormatScanFailureSample("src/Secret.cs", exception);
+
+        Assert.Equal("src/Secret.cs: access-denied", sample);
+    }
+
+    [Fact]
+    public void FormatScanFailureSample_ClassifiesProbeFailure_Issue3471()
+    {
+        var exception = new InvalidOperationException("probe failed for /Users/example/private/project/secret.cs");
+
+        var sample = IndexFreshnessChecker.FormatScanFailureSample("src/Broken.cs", exception);
+
+        Assert.Equal("src/Broken.cs: probe-failed", sample);
+    }
+}

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -6988,6 +6988,53 @@ public class McpServerTests : IDisposable
     }
 
     [Fact]
+    public void ToolsCall_InvalidResponseByteLimit_RedactsSecretLookingEnvValue_Issue3403()
+    {
+        using var env = EnvironmentVariableScope.Capture("CDIDX_MCP_RESPONSE_MAX_BYTES");
+        const string secret = "0123456789abcdef0123456789abcdef";
+        env.Set("CDIDX_MCP_RESPONSE_MAX_BYTES", $"token={secret}");
+
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status"}}""")!;
+
+        var stderr = ConsoleCapture.CaptureError(() => _server.HandleMessage(request));
+
+        Assert.Contains("CDIDX_MCP_RESPONSE_MAX_BYTES='token=<redacted>'", stderr);
+        Assert.DoesNotContain(secret, stderr);
+    }
+
+    [Fact]
+    public void ToolsCall_InvalidResponseByteLimit_RedactsPathAndUrlEnvValue_Issue3403()
+    {
+        using var env = EnvironmentVariableScope.Capture("CDIDX_MCP_RESPONSE_MAX_BYTES");
+        const string path = "/Users/example/private/project";
+        const string url = "https://example.test/private/project/config.json";
+        const string queryUrl = "https://example.test?query=user-content";
+        env.Set("CDIDX_MCP_RESPONSE_MAX_BYTES", $"path={path} url={url} query={queryUrl}");
+
+        var request = JsonNode.Parse("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status"}}""")!;
+
+        var stderr = ConsoleCapture.CaptureError(() => _server.HandleMessage(request));
+
+        Assert.Contains("CDIDX_MCP_RESPONSE_MAX_BYTES='path=<redacted> url=https://example.test<redacted> query=https://example.test<redacted>'", stderr);
+        Assert.DoesNotContain(path, stderr);
+        Assert.DoesNotContain("/private/project/config.json", stderr);
+        Assert.DoesNotContain("query=user-content", stderr);
+    }
+
+    [Fact]
+    public void Constructor_InvalidKeepAliveInterval_RedactsSecretLookingEnvValue_Issue3403()
+    {
+        using var env = EnvironmentVariableScope.Capture("CDIDX_MCP_KEEP_ALIVE_INTERVAL_S");
+        var secret = "github_pat_" + "a".PadLeft(82, 'a');
+        env.Set("CDIDX_MCP_KEEP_ALIVE_INTERVAL_S", $"Bearer {secret}");
+
+        var stderr = ConsoleCapture.CaptureError(() => _ = new McpServer(_dbPath, ConsoleUi.LoadVersion()));
+
+        Assert.Contains("CDIDX_MCP_KEEP_ALIVE_INTERVAL_S='Bearer <redacted>'", stderr);
+        Assert.DoesNotContain(secret, stderr);
+    }
+
+    [Fact]
     public void ResponseLimitSerializer_StopsBeforeFullStringMaterialization_Issue2860()
     {
         var payload = new JsonObject

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1892,8 +1892,10 @@ exit 0
             var logPath = Directory.GetFiles(logDir, "stderr-*.log", SearchOption.TopDirectoryOnly).Single();
             var log = File.ReadAllText(logPath);
             Assert.Contains("unhandled_exception", log);
-            Assert.Contains("exception[0] type=System.ApplicationException message=\"outer wrapper\"", log);
-            Assert.Contains("inner_exception[1] type=System.InvalidOperationException message=\"root cause\"", log);
+            Assert.Contains("exception[0] type=System.ApplicationException message=\"exception_message_redacted\"", log);
+            Assert.Contains("inner_exception[1] type=System.InvalidOperationException message=\"invalid_operation\"", log);
+            Assert.DoesNotContain("outer wrapper", log);
+            Assert.DoesNotContain("root cause", log);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
@@ -601,10 +601,70 @@ public class ReportCommandRunnerTests
             ]);
 
             Assert.Equal(CommandExitCodes.Success, exitCode);
-            Assert.Equal(Path.GetFullPath(output), json.GetProperty("output_path").GetString());
+            Assert.Equal(ReportCommandRunner.RedactedPlaceholder, json.GetProperty("output_path").GetString());
             Assert.True(json.GetProperty("files").GetInt32() >= 4);
             Assert.False(json.GetProperty("log_included").GetBoolean());
             Assert.False(json.GetProperty("db_included").GetBoolean());
+        }
+        finally
+        {
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void Run_JsonMode_RedactsLocalSummaryPaths_Issue3554()
+    {
+        var workDir = CreateWorkDir();
+        var dbPath = Path.Combine(workDir, "codeindex.db");
+        try
+        {
+            using (var db = new DbContext(dbPath))
+                db.InitializeSchema();
+            SqliteConnection.ClearAllPools();
+
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var (exitCode, json) = RunAndCaptureJson([
+                "--output", output,
+                "--db", dbPath,
+                "--no-log",
+                "--json",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(ReportCommandRunner.RedactedPlaceholder, json.GetProperty("output_path").GetString());
+            Assert.Equal(ReportCommandRunner.RedactedPlaceholder, json.GetProperty("db_path").GetString());
+            Assert.True(json.GetProperty("db_included").GetBoolean());
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void Run_JsonMode_RedactsFailureExceptionMessage_Issue3554()
+    {
+        var workDir = CreateWorkDir();
+        try
+        {
+            var fileParent = Path.Combine(workDir, "not-a-directory");
+            File.WriteAllText(fileParent, "blocking file");
+            var output = Path.Combine(fileParent, "bundle.tgz");
+
+            var (exitCode, json) = RunAndCaptureJson([
+                "--output", output,
+                "--db", Path.Combine(workDir, "missing.db"),
+                "--json",
+            ]);
+
+            Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+            var message = json.GetProperty("message").GetString();
+            Assert.Contains("failed to build report:", message);
+            Assert.Contains(ReportCommandRunner.RedactedPlaceholder, message);
+            Assert.DoesNotContain(workDir, message);
+            Assert.DoesNotContain(fileParent, message);
         }
         finally
         {
@@ -670,6 +730,96 @@ public class ReportCommandRunnerTests
 
         Assert.Contains("args=[redacted]", redacted);
         Assert.DoesNotContain("SELECT * FROM secret", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsJsonLifecycleMessage_Issue3554()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "{\"ts\":\"2026-05-16T03:00:00.000Z\",\"level\":\"INFO\",\"msg\":\"cwd=/Users/example/private db=/Users/example/private/.cdidx/codeindex.db path=/Users/example/private/.cdidx/config.json args=query \\\"SELECT * FROM secret\\\"\"}");
+
+        using var document = JsonDocument.Parse(redacted);
+        var message = document.RootElement.GetProperty("msg").GetString();
+        Assert.Contains("cwd=[redacted]", message);
+        Assert.Contains("db=[redacted]", message);
+        Assert.Contains("path=[redacted]", message);
+        Assert.Contains("args=[redacted]", message);
+        Assert.DoesNotContain("/Users/example/private", redacted);
+        Assert.DoesNotContain("SELECT * FROM secret", redacted);
+    }
+
+    [Fact]
+    public void RedactLogLine_JsonIncludeArgsPreservesSafeArgsAndRedactsSecrets_Issue3554()
+    {
+        const string secret = "0123456789abcdef0123456789abcdef";
+        var redacted = ReportCommandRunner.RedactLogLine(
+            $"{{\"ts\":\"2026-05-16T03:00:00.000Z\",\"level\":\"INFO\",\"msg\":\"args=query --literal safe --token={secret} /Users/example/private status=ok\"}}",
+            includeArgs: true);
+
+        using var document = JsonDocument.Parse(redacted);
+        var message = document.RootElement.GetProperty("msg").GetString();
+        Assert.Contains("args=query --literal safe --token=[redacted] [redacted]", message);
+        Assert.Contains("status=ok", message);
+        Assert.DoesNotContain(secret, redacted);
+        Assert.DoesNotContain("/Users/example/private", redacted);
+        Assert.DoesNotContain("args=[redacted]", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_PreservesFieldsAfterRedactedValues_Issue3554()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "2026-05-16T03:00:00Z [INFO] cwd=/private/foo status=ok token=0123456789abcdef0123456789abcdef elapsed_ms=4 path=/tmp/config.json");
+
+        Assert.Contains("cwd=[redacted]", redacted);
+        Assert.Contains("status=ok", redacted);
+        Assert.Contains("token=[redacted]", redacted);
+        Assert.Contains("elapsed_ms=4", redacted);
+        Assert.Contains("path=[redacted]", redacted);
+        Assert.DoesNotContain("/private/foo", redacted);
+        Assert.DoesNotContain("0123456789abcdef0123456789abcdef", redacted);
+        Assert.DoesNotContain("/tmp/config.json", redacted);
+    }
+
+    [Fact]
+    public void RedactLogLine_IncludeArgsPreservesSafeArgsAndRedactsSecrets_Issue3554()
+    {
+        const string secret = "0123456789abcdef0123456789abcdef";
+        var redacted = ReportCommandRunner.RedactLogLine(
+            $"2026-05-16T03:00:00Z [INFO] args=query --literal safe --token={secret} /Users/example/private status=ok",
+            includeArgs: true);
+
+        Assert.Contains("args=query --literal safe --token=[redacted] [redacted]", redacted);
+        Assert.Contains("status=ok", redacted);
+        Assert.DoesNotContain(secret, redacted);
+        Assert.DoesNotContain("/Users/example/private", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsNoKeyPathTokenAndUrlQuery_Issue3554()
+    {
+        const string secret = "0123456789abcdef0123456789abcdef";
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            $"2026-05-16T03:00:00Z [ERROR] sample /Users/example/private {secret} https://example.test?query=user-content");
+
+        Assert.Contains("[redacted]", redacted);
+        Assert.Contains("https://example.test[redacted]", redacted);
+        Assert.DoesNotContain("/Users/example/private", redacted);
+        Assert.DoesNotContain(secret, redacted);
+        Assert.DoesNotContain("query=user-content", redacted);
+    }
+
+    [Fact]
+    public void RedactSensitiveFields_RedactsPrefixAndSuffixOutsideKeyValues_Issue3554()
+    {
+        var redacted = ReportCommandRunner.RedactSensitiveFields(
+            "2026-05-16T03:00:00Z [ERROR] prefix /Users/example/before cwd=/Users/example/private status=ok suffix /Users/example/after");
+
+        Assert.Contains("cwd=[redacted]", redacted);
+        Assert.Contains("status=ok", redacted);
+        Assert.DoesNotContain("/Users/example/before", redacted);
+        Assert.DoesNotContain("/Users/example/private", redacted);
+        Assert.DoesNotContain("/Users/example/after", redacted);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Sanitize global exception logs, invalid environment diagnostics, slow-query SQL, freshness scan diagnostics, and report bundle output.
- Add shared diagnostic redaction for secrets, paths, URL paths/query strings, SQL literals, and report log tails.
- Add changelog fragments for each addressed issue.

## Issues
Fixes #3371
Fixes #3403
Fixes #3416
Fixes #3471
Fixes #3554

## Validation
Latest base: `origin/main` at `d7112c17597ef40adbfb227fb30e7d2509536462`.

- `dotnet build CodeIndex.sln`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~GlobalToolLogTests|FullyQualifiedName~Run_ForcedGlobalToolLogging_WritesUnhandledExceptionChain|FullyQualifiedName~DbDebugTests|FullyQualifiedName~McpServerTests|FullyQualifiedName~IndexFreshnessCheckerTests|FullyQualifiedName~ScanFilesDetailed_FailsClosedWhenAncestorIgnoreDirectoryIsUnreadable|FullyQualifiedName~ReportCommandRunnerTests"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`

Additional full-suite check before the final latest-main replay:
- `dotnet test CodeIndex.sln --filter "FullyQualifiedName!~RunPublishedTrimmedCli_SerializesQueryJsonAndErrorJson"` (net8 passed; net9 had one transient `PackageNormalizeCli_JsonContinueOnErrorReportsAggregateSummary` failure, and the exact test passed when rerun on both this branch and `origin/main`)

## Review
- Ran Codex adversarial review; addressed findings for JSON report log redaction, invalid-env path/URL redaction, report log non-key spans, authority-only URL query strings, and report JSON error messages.