### PR TITLE
[codex] Improve extractor hot path performance

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -240,6 +240,28 @@ Query commands that accept path filters (`search`, `definition`, `references`, `
 
 Editor integrations can request standard location shapes directly. `definition`, `references`, `search`, `find`, and `validate` accept `--format <text|json|lsp|qf|sarif>`; `lsp` emits LSP `Location` arrays, `qf` emits Vim quickfix lines, and `sarif` emits SARIF 2.1.0. `goto <symbol>` returns the single unambiguous definition as one LSP `Location`, while `goto --all <symbol>` returns all matching locations.
 
+### Extractor performance contract
+
+Symbol and reference extractors run during `cdidx index`, so language-specific
+helpers must assume they will see generated files, very large methods, and
+thousands of declarations or references in one syntactic scope. Avoid helper
+shapes that rescan the same body, line range, or accumulated result list once
+per candidate. If scope or delimiter information is needed for many candidates,
+precompute the ranges once per file, function, or block and reuse that structure
+for the per-candidate lookup.
+
+Duplicate detection in hot extraction loops should use a `HashSet` or another
+constant-time structure keyed by the full emitted record identity. Do not add
+`List.Any(...)`, `List.Contains(...)`, nested regex scans, or repeated string
+joins to loops that can run once per local variable, parameter, call site, type
+reference, or pattern match in a large generated file.
+
+The C# value-receiver path is the reference example: local receiver scopes are
+derived from precomputed block spans for the containing function, and duplicate
+receiver records are tracked with a hash set. Regressions in this area should
+have a focused correctness test for the scoping rule and a large-fixture runaway
+guard that would fail before users see multi-hour indexing stalls.
+
 ### Extractor concurrency contract
 
 `SymbolExtractor` and `ReferenceExtractor` must be safe to call concurrently for different files or repeated calls on the same file content. Shared `Regex` instances and static lookup tables are initialized once by the CLR and treated as immutable after type initialization. Per-extraction state belongs in local variables, method parameters, caller-owned collections, or language-specific state objects created for that extraction call.
@@ -2435,6 +2457,24 @@ path filter を受け付ける query コマンド（`search`, `definition`, `ref
 `cdidx batch` は、同じ DB に複数の query command を投げる editor integration や script 向けの CLI 側 query loop である。1 つの `DbContext` / `DbReader` を開き、stdin から newline-delimited JSON 文字列配列を読み、デコード後の各文字列引数を 8,192 文字に制限し、query command だけを既存の `QueryCommandRunner` 経路へ dispatch するため、出力と validation は単発コマンドと同じ形を保つ。
 
 editor integration は標準的な location 形状を直接要求できる。`definition`、`references`、`search`、`find`、`validate` は `--format <text|json|lsp|qf|sarif>` を受け付け、`lsp` は LSP `Location` 配列、`qf` は Vim quickfix 行、`sarif` は SARIF 2.1.0 を出力する。`goto <symbol>` は曖昧でない単一定義を 1 つの LSP `Location` として返し、`goto --all <symbol>` は一致する全 location を返す。
+
+### 抽出器の性能契約
+
+symbol / reference extractor は `cdidx index` 中に実行されるため、言語別 helper は
+生成ファイル、非常に大きなメソッド、1 つの構文スコープ内に数千個の宣言や参照がある入力を
+前提にする。候補ごとに同じ本文、行範囲、蓄積済み結果リストを再走査する helper 形状は避ける。
+多数の候補に対して scope や delimiter 情報が必要な場合は、file / function / block 単位で
+範囲情報を一度だけ事前計算し、候補ごとの lookup でその構造を再利用する。
+
+hot な抽出ループでの重複検出には、出力 record の完全な identity を key にした `HashSet` などの
+定数時間構造を使う。大きな生成ファイルで local variable、parameter、call site、type reference、
+pattern match ごとに実行され得るループへ、`List.Any(...)`、`List.Contains(...)`、nested regex scan、
+繰り返しの string join を追加してはならない。
+
+C# の value receiver 経路を参照例とする。local receiver の scope は containing function 用に
+事前計算した block span から導出し、重複 receiver record は hash set で追跡する。この領域の
+regression には、scope rule の focused correctness test と、ユーザーが multi-hour indexing stall を
+見る前に失敗する大規模 fixture の runaway guard を追加する。
 
 ### 抽出器の並行実行契約
 

--- a/changelog.d/unreleased/+csharp-reference-extraction-performance.fixed.md
+++ b/changelog.d/unreleased/+csharp-reference-extraction-performance.fixed.md
@@ -1,0 +1,24 @@
+---
+category: fixed
+affected:
+  - DEVELOPER_GUIDE.md
+  - src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.Support.cs
+  - src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.ValueReceivers.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorCSharpTests.cs
+---
+
+## English
+
+- **Fixed runaway C# reference extraction on very large methods.** Large C# repositories could spend an excessive amount of time in the `references` phase when a file contained a very large method, especially generated code or hand-written methods with thousands of local variables. In affected cases, indexing that previously finished in tens of minutes could continue for hours while making little progress through C# reference extraction.
+- The slowdown came from value receiver tracking. For every local value receiver, the extractor rescanned the method body to find the innermost block end and then performed a linear duplicate check against the receivers already collected for the function. Methods with many locals therefore paid the same body scan and growing duplicate check repeatedly, creating super-linear behavior.
+- C# reference extraction now builds block scope spans once per function body and reuses them when assigning local receiver scopes. It also uses a hash set for duplicate receiver detection. This keeps receiver collection practical for very large methods while preserving block-scoped behavior for locals that shadow enum or type names.
+- Added regression coverage for block-scoped local receiver behavior and a large-method runaway guard so future changes catch this class of performance regression earlier.
+- Documented the extractor performance contract in the developer guide so future language-specific extractor changes avoid per-candidate body rescans and linear duplicate checks in hot paths.
+
+## 日本語
+
+- **非常に大きなメソッドで C# 参照抽出が暴走する問題を修正しました。** 大型の C# リポジトリで、巨大な生成コードや数千個規模のローカル変数を持つ手書きメソッドが含まれている場合、インデックス作成が `references` フェーズで極端に長く止まることがありました。影響を受けるケースでは、以前は数十分で終わっていたインデックス作成が、C# の参照抽出中に何時間も進みにくくなることがありました。
+- 原因は value receiver 追跡でした。各ローカル value receiver ごとに、最内側ブロックの終端を求めるためメソッド本文を再走査し、その後で関数内に集め済みの receiver に対して線形の重複チェックを行っていました。ローカル変数が多いメソッドでは、同じ本文走査と増え続ける重複チェックを何度も支払うため、super-linear な挙動になっていました。
+- C# 参照抽出では、関数本文ごとのブロックスコープ範囲を一度だけ構築し、ローカル receiver のスコープ判定で再利用するようにしました。また、receiver の重複検出にはハッシュセットを使うようにしました。これにより、巨大なメソッドでも実用的な時間で receiver を収集しつつ、enum や type 名を隠すブロックスコープ付きローカルの扱いは維持されます。
+- ブロックスコープ付きローカル receiver の挙動と、大きなメソッドでの暴走を検出する回帰テストを追加しました。
+- 開発者ガイドに extractor の性能契約を記載し、今後の言語別 extractor 変更で hot path に候補ごとの本文再走査や線形重複チェックを入れないようにしました。

--- a/changelog.d/unreleased/+noncsharp-symbol-dedupe-performance.fixed.md
+++ b/changelog.d/unreleased/+noncsharp-symbol-dedupe-performance.fixed.md
@@ -1,0 +1,33 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
+  - src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cpp.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Java.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Rust.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Shell.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorRustSwiftTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Reduced symbol extraction overhead for large non-C# generated files.** Rust `use` expansion, Shell alias expansion, Go grouped declarations, Java/Kotlin primary-constructor or record components, C++ same-line class members, Dockerfile named stage chains, and JavaScript/TypeScript exported surfaces and object/class scan-target collection now avoid candidate-by-candidate scans over growing lists.
+- The shared symbol-line identity cache preserves the existing duplicate key of file, line, kind, and name for language paths such as Rust, Shell, Go, and JavaScript/TypeScript synthetic class emission. Java/Kotlin record component materialization now tracks existing component names per parent record, Java compact constructor synthesis reuses the already filtered same-line symbols, C++ same-line class-member backfill tracks member names per container, Dockerfile extraction tracks stage names as the file is scanned, and JavaScript/TypeScript export/object-literal supplement passes keep per-file or per-container name sets plus scan-target identity sets.
+- Swift and TypeScript reference extraction also now checks existing type-reference rows through the shared reference dedupe key instead of scanning the accumulated reference list while expanding typealias / type-alias targets.
+- These changes avoid theoretical super-linear hot paths in generated files with thousands of declarations, imports, aliases, constructor components, object-literal properties, export variables, object literal targets, or class expression targets while keeping emitted symbols and duplicate semantics unchanged.
+- Added large-fixture runaway guards for Rust, Shell, Go, Java, Kotlin, C++, Dockerfile, JavaScript, TypeScript, and Swift so future extractor changes catch this class of non-C# performance regression earlier.
+
+## 日本語
+
+- **大きな C# 以外の生成ファイルに対する symbol 抽出のオーバーヘッドを減らしました。** Rust の `use` 展開、Shell の alias 展開、Go の grouped declaration、Java/Kotlin の primary constructor / record component、C++ の same-line class member、Dockerfile の named stage chain、JavaScript/TypeScript の exported surface と object/class scan-target collection で、候補ごとに増え続ける list を走査しないようにしました。
+- 共通の symbol-line identity cache は、Rust、Shell、Go、JavaScript/TypeScript の synthetic class emission などの経路で従来どおり file、line、kind、name を重複キーとして使います。Java/Kotlin の record component materialization は親 record ごとの component name set を使い、Java compact constructor synthesis は同一行に絞り込んだ既存 symbol を再利用し、C++ の same-line class member 補完は container ごとの member name set を使い、Dockerfile 抽出はファイル走査中に stage name を追跡し、JavaScript/TypeScript の export / object literal 補完はファイル単位または container 単位の name set と scan-target identity set を使うようにしました。
+- Swift と TypeScript の reference 抽出でも、typealias / type alias target 展開時に accumulated reference list を走査するのではなく、共通の reference dedupe key で既存の type-reference 行を確認するようにしました。
+- これにより、数千個の declaration、import、alias、constructor component、object literal property、export variable、object literal target、class expression target を含む生成ファイルで理論上発生しうる super-linear な hot path を避けます。出力される symbol と重複判定の意味は変えていません。
+- Rust、Shell、Go、Java、Kotlin、C++、Dockerfile、JavaScript、TypeScript、Swift に対する大規模 fixture の runaway guard を追加し、今後の extractor 変更で同種の C# 以外の性能 regression を早く検出できるようにしました。

--- a/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.Support.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.Support.cs
@@ -465,13 +465,15 @@ public static partial class ReferenceExtractor
                 continue;
 
             var names = new List<CSharpFunctionValueReceiverNameRecord>();
+            var seenNames = new HashSet<CSharpFunctionValueReceiverNameRecord>();
             if (symbol.BodyStartLine != null && symbol.BodyEndLine != null)
             {
                 var start = Math.Max(symbol.BodyStartLine.Value - 1, 0);
                 var end = Math.Min(symbol.BodyEndLine.Value - 1, structuralLines.Count - 1);
+                var blockScopes = BuildCSharpBlockScopes(structuralLines, start, end);
                 var bodyText = string.Join("\n", structuralLines.Skip(start).Take(end - start + 1));
                 if (symbol.Kind == "function")
-                    AddCSharpParameterNames(names, symbol.Signature, symbol.BodyStartLine.Value, 0, symbol.BodyEndLine.Value, int.MaxValue);
+                    AddCSharpParameterNames(names, symbol.Signature, symbol.BodyStartLine.Value, 0, symbol.BodyEndLine.Value, int.MaxValue, seenNames);
                 for (var i = start; i <= end; i++)
                 {
                     foreach (Match match in CSharpLocalValueNameRegex.Matches(structuralLines[i]))
@@ -480,8 +482,9 @@ public static partial class ReferenceExtractor
                             NormalizeCSharpIdentifier(match.Groups["name"].Value),
                             i + 1,
                             match.Index,
-                            FindInnermostCSharpBlockEndLine(structuralLines, start, end, i, match.Index),
-                            int.MaxValue);
+                            FindInnermostCSharpBlockEndLine(blockScopes, end + 1, i, match.Index),
+                            int.MaxValue,
+                            seenNames);
                     foreach (Match match in CSharpForeachValueNameRegex.Matches(structuralLines[i]))
                     {
                         var scopeEnd = FindFollowingCSharpEmbeddedStatementEndPosition(structuralLines, end, i, match.Index);
@@ -491,7 +494,8 @@ public static partial class ReferenceExtractor
                             i + 1,
                             match.Index,
                             scopeEnd.Line,
-                            scopeEnd.Column);
+                            scopeEnd.Column,
+                            seenNames);
                     }
                     foreach (Match match in CSharpQueryRangeValueNameRegex.Matches(structuralLines[i]))
                     {
@@ -509,7 +513,8 @@ public static partial class ReferenceExtractor
                             i + 1,
                             match.Index,
                             scopeEnd.Line,
-                            scopeEnd.Column);
+                            scopeEnd.Column,
+                            seenNames);
                     }
                     foreach (Match match in CSharpDeclarationPatternValueNameRegex.Matches(structuralLines[i]))
                     {
@@ -522,7 +527,8 @@ public static partial class ReferenceExtractor
                             i + 1,
                             match.Index,
                             scopeEnd.Line,
-                            scopeEnd.Column);
+                            scopeEnd.Column,
+                            seenNames);
                     }
                     foreach (Match match in CSharpCaseDeclarationPatternValueNameRegex.Matches(structuralLines[i]))
                     {
@@ -535,10 +541,11 @@ public static partial class ReferenceExtractor
                             i + 1,
                             match.Index,
                             scopeEnd.Line,
-                            scopeEnd.Column);
+                            scopeEnd.Column,
+                            seenNames);
                     }
                     foreach (Match match in CSharpOutValueNameRegex.Matches(structuralLines[i]))
-                        AddCSharpFunctionValueReceiverName(names, NormalizeCSharpIdentifier(match.Groups["name"].Value), i + 1, match.Index, symbol.BodyEndLine.Value, int.MaxValue);
+                        AddCSharpFunctionValueReceiverName(names, NormalizeCSharpIdentifier(match.Groups["name"].Value), i + 1, match.Index, symbol.BodyEndLine.Value, int.MaxValue, seenNames);
                     foreach (Match match in CSharpCatchValueNameRegex.Matches(structuralLines[i]))
                     {
                         var scopeEnd = FindFollowingCSharpEmbeddedStatementEndPosition(structuralLines, end, i, match.Index);
@@ -548,7 +555,8 @@ public static partial class ReferenceExtractor
                             i + 1,
                             match.Index,
                             scopeEnd.Line,
-                            scopeEnd.Column);
+                            scopeEnd.Column,
+                            seenNames);
                     }
                     foreach (Match match in CSharpUsingStatementValueNameRegex.Matches(structuralLines[i]))
                     {
@@ -559,7 +567,8 @@ public static partial class ReferenceExtractor
                             i + 1,
                             match.Index,
                             scopeEnd.Line,
-                            scopeEnd.Column);
+                            scopeEnd.Column,
+                            seenNames);
                     }
                     foreach (Match match in CSharpFixedValueNameRegex.Matches(structuralLines[i]))
                     {
@@ -570,16 +579,18 @@ public static partial class ReferenceExtractor
                             i + 1,
                             match.Index,
                             scopeEnd.Line,
-                            scopeEnd.Column);
+                            scopeEnd.Column,
+                            seenNames);
                     }
                 }
 
-                AddCSharpRecursivePatternValueReceiverNames(names, bodyText, structuralLines, start, end);
+                AddCSharpRecursivePatternValueReceiverNames(names, bodyText, structuralLines, start, end, seenNames);
                 AddCSharpLambdaParameterNames(
                     names,
                     bodyText,
                     start + 1,
-                    symbol.BodyEndLine.Value);
+                    symbol.BodyEndLine.Value,
+                    seenNames);
             }
 
             if (names.Count > 0)
@@ -1746,7 +1757,14 @@ public static partial class ReferenceExtractor
             || (lineNumber == record.ScopeEndLine && column < record.ScopeEndColumn);
     }
 
-    private static void AddCSharpParameterNames(List<CSharpFunctionValueReceiverNameRecord> names, string? signature, int scopeStartLine, int scopeStartColumn, int scopeEndLine, int scopeEndColumn)
+    private static void AddCSharpParameterNames(
+        List<CSharpFunctionValueReceiverNameRecord> names,
+        string? signature,
+        int scopeStartLine,
+        int scopeStartColumn,
+        int scopeEndLine,
+        int scopeEndColumn,
+        HashSet<CSharpFunctionValueReceiverNameRecord>? seenNames = null)
     {
         if (string.IsNullOrWhiteSpace(signature))
             return;
@@ -1760,7 +1778,7 @@ public static partial class ReferenceExtractor
         foreach (var segment in SplitTopLevelCSharpParameterSegments(parameters))
         {
             if (TryExtractTrailingCSharpParameterName(segment, out var name))
-                AddCSharpFunctionValueReceiverName(names, name, scopeStartLine, scopeStartColumn, scopeEndLine, scopeEndColumn);
+                AddCSharpFunctionValueReceiverName(names, name, scopeStartLine, scopeStartColumn, scopeEndLine, scopeEndColumn, seenNames);
         }
     }
 
@@ -1844,7 +1862,12 @@ public static partial class ReferenceExtractor
         return !string.IsNullOrWhiteSpace(name);
     }
 
-    private static void AddCSharpLambdaParameterNames(List<CSharpFunctionValueReceiverNameRecord> names, string bodyText, int startLineNumber, int scopeEndLine)
+    private static void AddCSharpLambdaParameterNames(
+        List<CSharpFunctionValueReceiverNameRecord> names,
+        string bodyText,
+        int startLineNumber,
+        int scopeEndLine,
+        HashSet<CSharpFunctionValueReceiverNameRecord>? seenNames = null)
     {
         if (string.IsNullOrWhiteSpace(bodyText))
             return;
@@ -1857,7 +1880,7 @@ public static partial class ReferenceExtractor
                 break;
 
             var lambdaScopeEnd = FindCSharpArrowExpressionScopeEndPosition(bodyText, arrowIndex, startLineNumber, scopeEndLine);
-            AddCSharpLambdaParametersBeforeArrow(names, bodyText, arrowIndex, startLineNumber, lambdaScopeEnd);
+            AddCSharpLambdaParametersBeforeArrow(names, bodyText, arrowIndex, startLineNumber, lambdaScopeEnd, seenNames);
             searchIndex = arrowIndex + 2;
         }
     }
@@ -1867,7 +1890,8 @@ public static partial class ReferenceExtractor
         string bodyText,
         IReadOnlyList<string> structuralLines,
         int bodyStartIndex,
-        int bodyEndIndex)
+        int bodyEndIndex,
+        HashSet<CSharpFunctionValueReceiverNameRecord>? seenNames = null)
     {
         if (string.IsNullOrWhiteSpace(bodyText))
             return;
@@ -1880,7 +1904,7 @@ public static partial class ReferenceExtractor
             if (pattern.ArrowIndex >= 0)
             {
                 var scopeEnd = FindCSharpArrowExpressionScopeEndPosition(bodyText, pattern.ArrowIndex, startLineNumber, bodyEndIndex + 1);
-                AddCSharpFunctionValueReceiverName(names, pattern.Name, position.Line, position.Column, scopeEnd.Line, scopeEnd.Column);
+                AddCSharpFunctionValueReceiverName(names, pattern.Name, position.Line, position.Column, scopeEnd.Line, scopeEnd.Column, seenNames);
                 continue;
             }
 
@@ -1889,14 +1913,14 @@ public static partial class ReferenceExtractor
                 if (!TryFindCSharpSwitchCaseScopeEndPosition(structuralLines, bodyEndIndex, declarationLineIndex, position.Column, out var scopeEnd))
                     continue;
 
-                AddCSharpFunctionValueReceiverName(names, pattern.Name, position.Line, position.Column, scopeEnd.Line, scopeEnd.Column);
+                AddCSharpFunctionValueReceiverName(names, pattern.Name, position.Line, position.Column, scopeEnd.Line, scopeEnd.Column, seenNames);
                 continue;
             }
 
             if (!TryFindCSharpDeclarationPatternScopeEndPosition(structuralLines, bodyStartIndex, bodyEndIndex, declarationLineIndex, position.Column, out var declarationScopeEnd))
                 continue;
 
-            AddCSharpFunctionValueReceiverName(names, pattern.Name, position.Line, position.Column, declarationScopeEnd.Line, declarationScopeEnd.Column);
+            AddCSharpFunctionValueReceiverName(names, pattern.Name, position.Line, position.Column, declarationScopeEnd.Line, declarationScopeEnd.Column, seenNames);
         }
     }
 

--- a/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.ValueReceivers.cs
+++ b/src/CodeIndex/Indexer/References/Languages/CSharpReferenceExtractor.ValueReceivers.cs
@@ -7,12 +7,15 @@ namespace CodeIndex.Indexer;
 
 public static partial class ReferenceExtractor
 {
+    private readonly record struct CSharpBlockScope(int StartLineIndex, int StartColumn, int EndLineIndex, int EndColumn);
+
     private static void AddCSharpLambdaParametersBeforeArrow(
         List<CSharpFunctionValueReceiverNameRecord> names,
         string bodyText,
         int arrowIndex,
         int startLineNumber,
-        CSharpLineColumn scopeEnd)
+        CSharpLineColumn scopeEnd,
+        HashSet<CSharpFunctionValueReceiverNameRecord>? seenNames = null)
     {
         var leftIndex = SkipWhitespaceBackward(bodyText, arrowIndex - 1);
         if (leftIndex < 0)
@@ -29,7 +32,7 @@ public static partial class ReferenceExtractor
             foreach (var segment in SplitTopLevelCSharpParameterSegments(parameters))
             {
                 if (TryExtractTrailingCSharpParameterName(segment, out var parameterName))
-                    AddCSharpFunctionValueReceiverName(names, parameterName, scopeStart.Line, scopeStart.Column, scopeEnd.Line, scopeEnd.Column);
+                    AddCSharpFunctionValueReceiverName(names, parameterName, scopeStart.Line, scopeStart.Column, scopeEnd.Line, scopeEnd.Column, seenNames);
             }
 
             return;
@@ -53,23 +56,32 @@ public static partial class ReferenceExtractor
             || (TryReadPreviousIdentifierToken(bodyText, prefixIndex, out var previousToken)
                 && string.Equals(previousToken, "return", StringComparison.Ordinal)))
         {
-            AddCSharpFunctionValueReceiverName(names, parameter, declarationLine, identifierStart - GetLineStartOffset(bodyText, arrowIndex), scopeEnd.Line, scopeEnd.Column);
+            AddCSharpFunctionValueReceiverName(names, parameter, declarationLine, identifierStart - GetLineStartOffset(bodyText, arrowIndex), scopeEnd.Line, scopeEnd.Column, seenNames);
         }
     }
 
-    private static void AddCSharpFunctionValueReceiverName(List<CSharpFunctionValueReceiverNameRecord> names, string name, int scopeStartLine, int scopeStartColumn, int scopeEndLine, int scopeEndColumn)
+    private static void AddCSharpFunctionValueReceiverName(
+        List<CSharpFunctionValueReceiverNameRecord> names,
+        string name,
+        int scopeStartLine,
+        int scopeStartColumn,
+        int scopeEndLine,
+        int scopeEndColumn,
+        HashSet<CSharpFunctionValueReceiverNameRecord>? seenNames = null)
     {
         if (string.IsNullOrWhiteSpace(name))
             return;
-        if (names.Any(record =>
-            record.ScopeStartLine == scopeStartLine
-            && record.ScopeStartColumn == scopeStartColumn
-            && record.ScopeEndLine == scopeEndLine
-            && record.ScopeEndColumn == scopeEndColumn
-            && string.Equals(record.Name, name, StringComparison.Ordinal)))
-            return;
 
-        names.Add(new CSharpFunctionValueReceiverNameRecord(name, scopeStartLine, scopeStartColumn, scopeEndLine, scopeEndColumn));
+        var record = new CSharpFunctionValueReceiverNameRecord(name, scopeStartLine, scopeStartColumn, scopeEndLine, scopeEndColumn);
+        if (seenNames != null)
+        {
+            if (seenNames.Add(record))
+                names.Add(record);
+            return;
+        }
+
+        if (!names.Contains(record))
+            names.Add(record);
     }
 
     private static int GetLineNumberFromOffset(string text, int offset, int startLineNumber)
@@ -85,51 +97,75 @@ public static partial class ReferenceExtractor
         return lineNumber;
     }
 
-    private static int FindInnermostCSharpBlockEndLine(
+    private static List<CSharpBlockScope> BuildCSharpBlockScopes(
         IReadOnlyList<string> structuralLines,
         int bodyStartIndex,
-        int bodyEndIndex,
-        int declarationLineIndex,
-        int declarationColumn)
+        int bodyEndIndex)
     {
-        var depth = 0;
+        var blockScopes = new List<CSharpBlockScope>();
+        var stack = new Stack<(int LineIndex, int Column)>();
         for (var lineIndex = bodyStartIndex; lineIndex <= bodyEndIndex; lineIndex++)
         {
             var line = structuralLines[lineIndex];
-            var limit = lineIndex == declarationLineIndex ? Math.Min(declarationColumn, line.Length) : line.Length;
-            for (var column = 0; column < limit; column++)
+            for (var column = 0; column < line.Length; column++)
             {
                 if (line[column] == '{')
-                    depth++;
-                else if (line[column] == '}' && depth > 0)
-                    depth--;
-            }
-
-            if (lineIndex != declarationLineIndex)
-                continue;
-
-            var declarationDepth = depth;
-            for (var scanLine = declarationLineIndex; scanLine <= bodyEndIndex; scanLine++)
-            {
-                var scan = structuralLines[scanLine];
-                var scanStart = scanLine == declarationLineIndex ? declarationColumn : 0;
-                for (var column = scanStart; column < scan.Length; column++)
                 {
-                    if (scan[column] == '{')
-                        depth++;
-                    else if (scan[column] == '}' && depth > 0)
-                    {
-                        depth--;
-                        if (depth < declarationDepth)
-                            return scanLine + 1;
-                    }
+                    stack.Push((lineIndex, column));
+                }
+                else if (line[column] == '}' && stack.Count > 0)
+                {
+                    var start = stack.Pop();
+                    blockScopes.Add(new CSharpBlockScope(start.LineIndex, start.Column, lineIndex, column));
                 }
             }
-
-            break;
         }
 
-        return bodyEndIndex + 1;
+        return blockScopes;
+    }
+
+    private static int FindInnermostCSharpBlockEndLine(
+        IReadOnlyList<CSharpBlockScope> blockScopes,
+        int fallbackEndLine,
+        int declarationLineIndex,
+        int declarationColumn)
+    {
+        CSharpBlockScope? bestScope = null;
+        foreach (var scope in blockScopes)
+        {
+            if (!ContainsCSharpBlockScope(scope, declarationLineIndex, declarationColumn))
+                continue;
+
+            if (bestScope == null || IsNarrowerCSharpBlockScope(scope, bestScope.Value))
+            {
+                bestScope = scope;
+            }
+        }
+
+        return bestScope?.EndLineIndex + 1 ?? fallbackEndLine;
+    }
+
+    private static bool ContainsCSharpBlockScope(CSharpBlockScope scope, int lineIndex, int column)
+    {
+        var startsBefore = lineIndex > scope.StartLineIndex
+            || (lineIndex == scope.StartLineIndex && column > scope.StartColumn);
+        if (!startsBefore)
+            return false;
+
+        return lineIndex < scope.EndLineIndex
+            || (lineIndex == scope.EndLineIndex && column < scope.EndColumn);
+    }
+
+    private static bool IsNarrowerCSharpBlockScope(CSharpBlockScope candidate, CSharpBlockScope current)
+    {
+        var candidateLineSpan = candidate.EndLineIndex - candidate.StartLineIndex;
+        var currentLineSpan = current.EndLineIndex - current.StartLineIndex;
+        if (candidateLineSpan != currentLineSpan)
+            return candidateLineSpan < currentLineSpan;
+
+        var candidateColumnSpan = candidate.EndColumn - candidate.StartColumn;
+        var currentColumnSpan = current.EndColumn - current.StartColumn;
+        return candidateColumnSpan < currentColumnSpan;
     }
 
     private static CSharpLineColumn FindFollowingCSharpEmbeddedStatementEndPosition(

--- a/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/SwiftReferenceExtractor.cs
@@ -146,12 +146,15 @@ internal static class SwiftReferenceExtractor
                 if (!HasIdentifierBoundaries(preparedLine, index, alias.Length))
                     continue;
                 var column = index + 1;
-                if (!references.Any(reference =>
-                        reference.FileId == fileId
-                        && reference.Line == lineNumber
-                        && reference.Column == column
-                        && reference.ReferenceKind == "type_reference"
-                        && string.Equals(reference.SymbolName, alias, StringComparison.Ordinal)))
+                var container = resolveContainerForColumn(index);
+                if (!seen.Contains(ReferenceExtractor.BuildReferenceDedupeKey(
+                        fileId,
+                        "swift",
+                        lineNumber,
+                        column,
+                        "type_reference",
+                        alias,
+                        container)))
                 {
                     continue;
                 }
@@ -169,7 +172,7 @@ internal static class SwiftReferenceExtractor
                     fileId,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(index),
+                    container,
                     binding.Value.TypeParameters);
             }
         }

--- a/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/Languages/TypeScriptReferenceExtractor.cs
@@ -293,12 +293,15 @@ internal static class TypeScriptReferenceExtractor
                 if (!HasIdentifierBoundaries(preparedLine, index, alias.Length))
                     continue;
                 var column = index + 1;
-                if (!references.Any(reference =>
-                        reference.FileId == fileId
-                        && reference.Line == lineNumber
-                        && reference.Column == column
-                        && reference.ReferenceKind == "type_reference"
-                        && string.Equals(reference.SymbolName, alias, StringComparison.Ordinal)))
+                var container = resolveContainerForColumn(index);
+                if (!seen.Contains(ReferenceExtractor.BuildReferenceDedupeKey(
+                        fileId,
+                        "typescript",
+                        lineNumber,
+                        column,
+                        "type_reference",
+                        alias,
+                        container)))
                 {
                     continue;
                 }
@@ -316,7 +319,7 @@ internal static class TypeScriptReferenceExtractor
                     fileId,
                     context,
                     lineNumber,
-                    resolveContainerForColumn(index),
+                    container,
                     binding.Value.TypeParameters);
             }
         }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cpp.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cpp.cs
@@ -35,6 +35,14 @@ public static partial class SymbolExtractor
             if (body.Length == 0)
                 continue;
 
+            var existingMemberNames = symbols
+                .Where(symbol =>
+                    symbol.Kind == "function"
+                    && symbol.Line == classSymbol.StartLine
+                    && symbol.ContainerKind == classSymbol.Kind
+                    && symbol.ContainerName == classSymbol.Name)
+                .Select(symbol => symbol.Name)
+                .ToHashSet(StringComparer.Ordinal);
             var segments = body.Split(';');
             var searchStart = 0;
             foreach (var segment in segments)
@@ -53,7 +61,7 @@ public static partial class SymbolExtractor
                     continue;
                 }
 
-                if (TryAddCppSameLineClassMemberSymbol(fileId, classSymbol, trimmedSegment, lineIndex + 1, symbols))
+                if (TryAddCppSameLineClassMemberSymbol(fileId, classSymbol, trimmedSegment, lineIndex + 1, symbols, existingMemberNames))
                     searchStart = segmentStart + trimmedSegment.Length + 1;
                 else
                     searchStart = segmentStart + trimmedSegment.Length + 1;
@@ -66,7 +74,8 @@ public static partial class SymbolExtractor
         SymbolRecord classSymbol,
         string segment,
         int lineNumber,
-        List<SymbolRecord> symbols)
+        List<SymbolRecord> symbols,
+        HashSet<string> existingMemberNames)
     {
         foreach (var pattern in PatternCache["cpp"])
         {
@@ -83,15 +92,8 @@ public static partial class SymbolExtractor
             if (string.IsNullOrWhiteSpace(name))
                 continue;
 
-            if (symbols.Any(symbol =>
-                symbol.Kind == "function"
-                && symbol.Line == lineNumber
-                && symbol.Name == name
-                && symbol.ContainerKind == classSymbol.Kind
-                && symbol.ContainerName == classSymbol.Name))
-            {
+            if (!existingMemberNames.Add(name))
                 return true;
-            }
 
             symbols.Add(new SymbolRecord
             {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
@@ -368,14 +368,15 @@ public static partial class SymbolExtractor
         long fileId,
         string line,
         int lineNumber,
-        List<SymbolRecord> symbols)
+        List<SymbolRecord> symbols,
+        HashSet<string> stageNames)
     {
         var match = DockerfileNamedFromImageRegex.Match(line);
         if (!match.Success)
             return;
 
         var name = match.Groups["name"].Value;
-        if (symbols.Any(symbol => symbol.Kind == "stage" && symbol.Name == name))
+        if (stageNames.Contains(name))
             return;
 
         AddSymbolRecord(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Go.cs
@@ -728,13 +728,7 @@ public static partial class SymbolExtractor
     }
 
     private static bool HasGoSymbol(List<SymbolRecord> symbols, long fileId, int lineNumber, string kind, string name)
-    {
-        return symbols.Any(symbol =>
-            symbol.FileId == fileId
-            && symbol.Line == lineNumber
-            && symbol.Kind == kind
-            && symbol.Name == name);
-    }
+        => HasSymbolLineIdentity(symbols, fileId, lineNumber, kind, name);
 
     private static void AssignGoMethodReceiverContainers(List<SymbolRecord> symbols)
     {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Java.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Java.cs
@@ -346,16 +346,19 @@ public static partial class SymbolExtractor
                                     && (symbol.ContainerName == null || symbol.ContainerName == recordSymbol.Name)
                                     && (symbol.ContainerKind == null || symbol.ContainerKind == "class"))
                                 .ToList();
+                            var hasCompactConstructorSymbol = false;
                             foreach (var existingSymbol in existingSymbols)
                             {
                                 if (LooksLikeJavaCompactConstructorSymbol(existingSymbol, recordSymbol.Name))
+                                {
+                                    hasCompactConstructorSymbol = true;
                                     continue;
+                                }
+
                                 symbols.Remove(existingSymbol);
                             }
 
-                            if (!symbols.Any(symbol => LooksLikeJavaCompactConstructorSymbol(symbol, recordSymbol.Name)
-                                    && symbol.FileId == fileId
-                                    && symbol.StartLine == i + 1))
+                            if (!hasCompactConstructorSymbol)
                             {
                                 symbols.Add(new SymbolRecord
                                 {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
@@ -39,6 +39,7 @@ public static partial class SymbolExtractor
         JavaScriptScopePrivacyFlags[][] privateScopeColumns)
     {
         var targets = new List<JavaScriptClassScanTarget>();
+        var targetIdentities = new HashSet<(int StartIndex, int ScanStartIndex, int ScanEndExclusive, string ContainerName)>();
         var lexState = new JavaScriptLexState();
         for (int i = 0; i < lines.Length; i++)
         {
@@ -122,13 +123,9 @@ public static partial class SymbolExtractor
                 containerName: containerName,
                 isExported: isExported);
 
-            if (!targets.Any(t => t.StartIndex == candidate.StartIndex
-                && t.ScanStartIndex == candidate.ScanStartIndex
-                && t.ScanEndExclusive == candidate.ScanEndExclusive
-                && t.ContainerName == candidate.ContainerName))
-            {
+            var targetIdentity = (candidate.StartIndex, candidate.ScanStartIndex, candidate.ScanEndExclusive, candidate.ContainerName);
+            if (targetIdentities.Add(targetIdentity))
                 targets.Add(candidate);
-            }
         }
 
         return targets
@@ -1861,6 +1858,8 @@ public static partial class SymbolExtractor
     {
         var sanitizedLines = BuildJavaScriptTypeScriptSanitizedLines(lines);
         var syntheticClassTargets = new List<JavaScriptClassScanTarget>();
+        var symbolLineIdentities = BuildSymbolLineIdentities(symbols);
+        var targetIdentities = new HashSet<(int StartIndex, int StartColumn, int ScanStartIndex, int ScanEndExclusive, int FirstLineScanOffset, string ContainerKind, string ContainerName)>();
 
         for (int i = 0; i < lines.Length; i++)
         {
@@ -1952,6 +1951,8 @@ public static partial class SymbolExtractor
                         lines,
                         symbols,
                         syntheticClassTargets,
+                        symbolLineIdentities,
+                        targetIdentities,
                         i,
                         absoluteMatchIndex,
                         classTokenLineIndex,
@@ -2646,6 +2647,11 @@ public static partial class SymbolExtractor
         List<SymbolRecord> symbols,
         JavaScriptScopePrivacyFlags[][] privateScopeColumns)
     {
+        var exportedSymbolNames = symbols
+            .Where(symbol => symbol.Visibility == "export")
+            .Select(symbol => symbol.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
         for (int i = 0; i < sanitizedLines.Length; i++)
         {
             var sanitizedLine = sanitizedLines[i];
@@ -2688,7 +2694,7 @@ public static partial class SymbolExtractor
                     endColumn);
                 foreach (var variableName in variableNames)
                 {
-                    if (symbols.Any(s => s.Visibility == "export" && s.Name == variableName.Name))
+                    if (!exportedSymbolNames.Add(variableName.Name))
                         continue;
 
                     AddSymbolRecord(
@@ -4691,6 +4697,12 @@ public static partial class SymbolExtractor
             var parenDepth = 0;
             var bracketDepth = 0;
             var skippingPropertyValue = false;
+            var existingContainerSymbolNames = symbols
+                .Where(symbol =>
+                    symbol.ContainerKind == "object"
+                    && symbol.ContainerName == target.ContainerName)
+                .Select(symbol => symbol.Name)
+                .ToHashSet(StringComparer.Ordinal);
 
             for (int lineIndex = target.ScanStartIndex; lineIndex < target.ScanEndExclusive; lineIndex++)
             {
@@ -4772,32 +4784,15 @@ public static partial class SymbolExtractor
                         if (propertyMatch.Success)
                         {
                             var propertyName = propertyMatch.Groups["name"].Value;
-                            var hasExistingContainerSymbol = symbols.Any(s =>
-                                s.Name == propertyName
-                                && s.ContainerKind == "object"
-                                && s.ContainerName == target.ContainerName);
-                            if (!hasExistingContainerSymbol)
-                            {
-                                AddSymbolRecord(
-                                    symbols,
-                                    cssSeenSymbols: null,
-                                    lineIndex + 1,
-                                    new SymbolRecord
-                                    {
-                                        FileId = fileId,
-                                        Kind = "property",
-                                        Name = propertyName,
-                                        Line = lineIndex + 1,
-                                        StartLine = lineIndex + 1,
-                                        StartColumn = scanColumn + propertyMatch.Index,
-                                        EndLine = lineIndex + 1,
-                                        Signature = rawLines[lineIndex].Trim(),
-                                        ContainerKind = "object",
-                                        ContainerName = target.ContainerName,
-                                        Visibility = "export",
-                                    },
-                                    rawLines[lineIndex]);
-                            }
+                            AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
+                                fileId,
+                                rawLines,
+                                symbols,
+                                existingContainerSymbolNames,
+                                target.ContainerName,
+                                propertyName,
+                                lineIndex,
+                                scanColumn + propertyMatch.Index);
 
                             scanColumn += propertyMatch.Length;
                             skippingPropertyValue = true;
@@ -4811,32 +4806,15 @@ public static partial class SymbolExtractor
                                 out var literalPropertyName,
                                 out var literalValueStartColumn))
                         {
-                            var hasExistingContainerSymbol = symbols.Any(s =>
-                                s.Name == literalPropertyName
-                                && s.ContainerKind == "object"
-                                && s.ContainerName == target.ContainerName);
-                            if (!hasExistingContainerSymbol)
-                            {
-                                AddSymbolRecord(
-                                    symbols,
-                                    cssSeenSymbols: null,
-                                    lineIndex + 1,
-                                    new SymbolRecord
-                                    {
-                                        FileId = fileId,
-                                        Kind = "property",
-                                        Name = literalPropertyName,
-                                        Line = lineIndex + 1,
-                                        StartLine = lineIndex + 1,
-                                        StartColumn = scanColumn,
-                                        EndLine = lineIndex + 1,
-                                        Signature = rawLines[lineIndex].Trim(),
-                                        ContainerKind = "object",
-                                        ContainerName = target.ContainerName,
-                                        Visibility = "export",
-                                    },
-                                    rawLines[lineIndex]);
-                            }
+                            AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
+                                fileId,
+                                rawLines,
+                                symbols,
+                                existingContainerSymbolNames,
+                                target.ContainerName,
+                                literalPropertyName,
+                                lineIndex,
+                                scanColumn);
 
                             scanColumn = literalValueStartColumn;
                             skippingPropertyValue = true;
@@ -4850,32 +4828,15 @@ public static partial class SymbolExtractor
                                 out var computedLiteralPropertyName,
                                 out var computedLiteralValueStartColumn))
                         {
-                            var hasExistingContainerSymbol = symbols.Any(s =>
-                                s.Name == computedLiteralPropertyName
-                                && s.ContainerKind == "object"
-                                && s.ContainerName == target.ContainerName);
-                            if (!hasExistingContainerSymbol)
-                            {
-                                AddSymbolRecord(
-                                    symbols,
-                                    cssSeenSymbols: null,
-                                    lineIndex + 1,
-                                    new SymbolRecord
-                                    {
-                                        FileId = fileId,
-                                        Kind = "property",
-                                        Name = computedLiteralPropertyName,
-                                        Line = lineIndex + 1,
-                                        StartLine = lineIndex + 1,
-                                        StartColumn = scanColumn,
-                                        EndLine = lineIndex + 1,
-                                        Signature = rawLines[lineIndex].Trim(),
-                                        ContainerKind = "object",
-                                        ContainerName = target.ContainerName,
-                                        Visibility = "export",
-                                    },
-                                    rawLines[lineIndex]);
-                            }
+                            AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
+                                fileId,
+                                rawLines,
+                                symbols,
+                                existingContainerSymbolNames,
+                                target.ContainerName,
+                                computedLiteralPropertyName,
+                                lineIndex,
+                                scanColumn);
 
                             scanColumn = computedLiteralValueStartColumn;
                             skippingPropertyValue = true;
@@ -4892,32 +4853,15 @@ public static partial class SymbolExtractor
                         if (shorthandMatch.Success)
                         {
                             var propertyName = shorthandMatch.Groups["name"].Value;
-                            var hasExistingContainerSymbol = symbols.Any(s =>
-                                s.Name == propertyName
-                                && s.ContainerKind == "object"
-                                && s.ContainerName == target.ContainerName);
-                            if (!hasExistingContainerSymbol)
-                            {
-                                AddSymbolRecord(
-                                    symbols,
-                                    cssSeenSymbols: null,
-                                    lineIndex + 1,
-                                    new SymbolRecord
-                                    {
-                                        FileId = fileId,
-                                        Kind = "property",
-                                        Name = propertyName,
-                                        Line = lineIndex + 1,
-                                        StartLine = lineIndex + 1,
-                                        StartColumn = scanColumn + shorthandMatch.Index,
-                                        EndLine = lineIndex + 1,
-                                        Signature = rawLines[lineIndex].Trim(),
-                                        ContainerKind = "object",
-                                        ContainerName = target.ContainerName,
-                                        Visibility = "export",
-                                    },
-                                    rawLines[lineIndex]);
-                            }
+                            AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
+                                fileId,
+                                rawLines,
+                                symbols,
+                                existingContainerSymbolNames,
+                                target.ContainerName,
+                                propertyName,
+                                lineIndex,
+                                scanColumn + shorthandMatch.Index);
 
                             scanColumn += shorthandMatch.Length;
                             continue;
@@ -4953,6 +4897,40 @@ public static partial class SymbolExtractor
                 }
             }
         }
+    }
+
+    private static void AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
+        long fileId,
+        string[] rawLines,
+        List<SymbolRecord> symbols,
+        HashSet<string> existingContainerSymbolNames,
+        string containerName,
+        string propertyName,
+        int lineIndex,
+        int startColumn)
+    {
+        if (propertyName.Length == 0 || !existingContainerSymbolNames.Add(propertyName))
+            return;
+
+        AddSymbolRecord(
+            symbols,
+            cssSeenSymbols: null,
+            lineIndex + 1,
+            new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "property",
+                Name = propertyName,
+                Line = lineIndex + 1,
+                StartLine = lineIndex + 1,
+                StartColumn = startColumn,
+                EndLine = lineIndex + 1,
+                Signature = rawLines[lineIndex].Trim(),
+                ContainerKind = "object",
+                ContainerName = containerName,
+                Visibility = "export",
+            },
+            rawLines[lineIndex]);
     }
 
     private static bool TryReadJavaScriptTypeScriptLiteralObjectLiteralKeyName(
@@ -6327,6 +6305,8 @@ public static partial class SymbolExtractor
     private static List<JavaScriptClassScanTarget> CollectJavaScriptTypeScriptSyntheticClassScanTargets(long fileId, string lang, string[] lines, List<SymbolRecord> symbols, JavaScriptScopePrivacyFlags[][] privateScopeColumns)
     {
         var targets = new List<JavaScriptClassScanTarget>();
+        var symbolLineIdentities = BuildSymbolLineIdentities(symbols);
+        var targetIdentities = new HashSet<(int StartIndex, int StartColumn, int ScanStartIndex, int ScanEndExclusive, int FirstLineScanOffset, string ContainerKind, string ContainerName)>();
         var lexState = new JavaScriptLexState();
         for (int i = 0; i < lines.Length; i++)
         {
@@ -6336,7 +6316,7 @@ public static partial class SymbolExtractor
             var lineOffset = FindNextJavaScriptTypeScriptStatementStart(sanitizedLine, 0);
             while (lineOffset >= 0 && lineOffset < sanitizedLine.Length)
             {
-                TryAddJavaScriptTypeScriptSyntheticClassTarget(fileId, lang, lines, symbols, targets, i, lineOffset, sanitizedLine, privateScopeColumns);
+                TryAddJavaScriptTypeScriptSyntheticClassTarget(fileId, lang, lines, symbols, targets, symbolLineIdentities, targetIdentities, i, lineOffset, sanitizedLine, privateScopeColumns);
                 lineOffset = FindNextJavaScriptTypeScriptStatementStart(sanitizedLine, lineOffset + 1);
             }
         }
@@ -7484,6 +7464,8 @@ public static partial class SymbolExtractor
         string[] lines,
         List<SymbolRecord> symbols,
         List<JavaScriptClassScanTarget> targets,
+        HashSet<SymbolLineIdentity> symbolLineIdentities,
+        HashSet<(int StartIndex, int StartColumn, int ScanStartIndex, int ScanEndExclusive, int FirstLineScanOffset, string ContainerKind, string ContainerName)> targetIdentities,
         int startIndex,
         int startColumn,
         string sanitizedLine,
@@ -7517,6 +7499,8 @@ public static partial class SymbolExtractor
                 lines,
                 symbols,
                 targets,
+                symbolLineIdentities,
+                targetIdentities,
                 startIndex,
                 startColumn + anonymousDefaultMatch.Index,
                 classTokenLineIndex,
@@ -7558,6 +7542,8 @@ public static partial class SymbolExtractor
                     lines,
                     symbols,
                     targets,
+                    symbolLineIdentities,
+                    targetIdentities,
                     startIndex,
                     startColumn + exportEqualsMatch.Index,
                     exportEqualsClassTokenLineIndex,
@@ -7609,6 +7595,8 @@ public static partial class SymbolExtractor
             lines,
             symbols,
             targets,
+            symbolLineIdentities,
+            targetIdentities,
             startIndex,
             startColumn + classExpressionBindingMatch.Index,
             classExpressionTokenLineIndex,
@@ -7629,6 +7617,8 @@ public static partial class SymbolExtractor
         string[] lines,
         List<SymbolRecord> symbols,
         List<JavaScriptClassScanTarget> targets,
+        HashSet<SymbolLineIdentity> symbolLineIdentities,
+        HashSet<(int StartIndex, int StartColumn, int ScanStartIndex, int ScanEndExclusive, int FirstLineScanOffset, string ContainerKind, string ContainerName)> targetIdentities,
         int declarationStartIndex,
         int declarationStartColumn,
         int classTokenLineIndex,
@@ -7640,10 +7630,9 @@ public static partial class SymbolExtractor
         if (bodyStartLine == null || bodyEndLine == null)
             return;
 
-        var existingClass = symbols.FirstOrDefault(s => s.Kind == "class" && s.Line == declarationStartIndex + 1 && s.Name == containerName);
-        if (existingClass == null)
+        if (!HasSymbolLineIdentity(symbolLineIdentities, fileId, declarationStartIndex + 1, "class", containerName))
         {
-            symbols.Add(new SymbolRecord
+            var symbol = new SymbolRecord
             {
                 FileId = fileId,
                 Kind = "class",
@@ -7655,20 +7644,22 @@ public static partial class SymbolExtractor
                 BodyEndLine = bodyEndLine,
                 Signature = BuildJavaScriptTypeScriptSyntheticClassSignature(lines, declarationStartIndex, declarationStartColumn, classTokenLineIndex, classTokenStartColumn, bodyStartLine, bodyEndLine, lang),
                 Visibility = visibility,
-            });
+            };
+            symbols.Add(symbol);
+            RecordSymbolLineIdentity(symbolLineIdentities, symbol);
         }
 
         var candidate = CreateJavaScriptClassScanTarget(lines, lang, classTokenLineIndex, classTokenStartColumn, bodyStartLine, bodyEndLine, "class", containerName);
-        if (!targets.Any(t => t.StartIndex == candidate.StartIndex
-            && t.StartColumn == candidate.StartColumn
-            && t.ScanStartIndex == candidate.ScanStartIndex
-            && t.ScanEndExclusive == candidate.ScanEndExclusive
-            && t.FirstLineScanOffset == candidate.FirstLineScanOffset
-            && t.ContainerKind == candidate.ContainerKind
-            && t.ContainerName == candidate.ContainerName))
-        {
+        var targetIdentity = (
+            candidate.StartIndex,
+            candidate.StartColumn,
+            candidate.ScanStartIndex,
+            candidate.ScanEndExclusive,
+            candidate.FirstLineScanOffset,
+            candidate.ContainerKind,
+            candidate.ContainerName);
+        if (targetIdentities.Add(targetIdentity))
             targets.Add(candidate);
-        }
     }
 
     private static string BuildJavaScriptTypeScriptSyntheticClassSignature(
@@ -7938,6 +7929,9 @@ public static partial class SymbolExtractor
                                 }
                             }
                         }
+
+                        column = valueStartColumn;
+                        continue;
                     }
                 }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Rust.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Rust.cs
@@ -10,6 +10,7 @@ public static partial class SymbolExtractor
 {
     private static void ExtractRustUseSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
     {
+        var symbolLineIdentities = BuildSymbolLineIdentities(symbols);
         for (var i = 0; i < lines.Length; i++)
         {
             if (!TryReadRustUseStatement(lines, i, out var statement, out var lineStarts, out var endLineIndex))
@@ -44,25 +45,27 @@ public static partial class SymbolExtractor
                     continue;
 
                 var name = occurrence.Name;
-                if (HasRustSymbol(symbols, fileId, occurrence.Line, "import", name))
+                if (HasSymbolLineIdentity(symbolLineIdentities, fileId, occurrence.Line, "import", name))
                     continue;
 
+                var symbol = new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "import",
+                    Name = name,
+                    Line = occurrence.Line,
+                    StartLine = occurrence.Line,
+                    StartColumn = occurrence.Column,
+                    EndLine = occurrence.Line,
+                    Signature = statement.Trim(),
+                };
                 AddSymbolRecord(
                     symbols,
                     cssSeenSymbols: null,
                     occurrence.Line,
-                    new SymbolRecord
-                    {
-                        FileId = fileId,
-                        Kind = "import",
-                        Name = name,
-                        Line = occurrence.Line,
-                        StartLine = occurrence.Line,
-                        StartColumn = occurrence.Column,
-                        EndLine = occurrence.Line,
-                        Signature = statement.Trim(),
-                    },
+                    symbol,
                     lines[occurrence.Line - 1]);
+                RecordSymbolLineIdentity(symbolLineIdentities, symbol);
             }
 
             i = endLineIndex;
@@ -71,6 +74,7 @@ public static partial class SymbolExtractor
 
     private static void ExtractRustMultilineImplSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
     {
+        var symbolLineIdentities = BuildSymbolLineIdentities(symbols);
         for (var i = 0; i < lines.Length; i++)
         {
             if (!TryReadRustImplStatement(lines, i, out var statement, out var lineStarts, out var endLineIndex))
@@ -90,25 +94,27 @@ public static partial class SymbolExtractor
                 continue;
 
             var position = GetRustStatementPosition(match.Groups["name"].Index, lineStarts, i + 1);
-            if (HasRustSymbol(symbols, fileId, position.Line, "class", name))
+            if (HasSymbolLineIdentity(symbolLineIdentities, fileId, position.Line, "class", name))
                 continue;
 
+            var symbol = new SymbolRecord
+            {
+                FileId = fileId,
+                Kind = "class",
+                Name = name,
+                Line = position.Line,
+                StartLine = position.Line,
+                StartColumn = position.Column,
+                EndLine = position.Line,
+                Signature = statement.Trim(),
+            };
             AddSymbolRecord(
                 symbols,
                 cssSeenSymbols: null,
                 position.Line,
-                new SymbolRecord
-                {
-                    FileId = fileId,
-                    Kind = "class",
-                    Name = name,
-                    Line = position.Line,
-                    StartLine = position.Line,
-                    StartColumn = position.Column,
-                    EndLine = position.Line,
-                    Signature = statement.Trim(),
-                },
+                symbol,
                 lines[position.Line - 1]);
+            RecordSymbolLineIdentity(symbolLineIdentities, symbol);
         }
     }
 
@@ -446,15 +452,6 @@ public static partial class SymbolExtractor
         }
 
         return new RustAsKeywordSpan(-1, 0);
-    }
-
-    private static bool HasRustSymbol(List<SymbolRecord> symbols, long fileId, int lineNumber, string kind, string name)
-    {
-        return symbols.Any(symbol =>
-            symbol.FileId == fileId
-            && symbol.Line == lineNumber
-            && symbol.Kind == kind
-            && symbol.Name == name);
     }
 
 }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Shell.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Shell.cs
@@ -10,6 +10,7 @@ public static partial class SymbolExtractor
 {
     private static void ExpandShellAliasSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
     {
+        var symbolLineIdentities = BuildSymbolLineIdentities(symbols);
         for (var i = 0; i < lines.Length; i++)
         {
             var line = lines[i];
@@ -24,25 +25,27 @@ public static partial class SymbolExtractor
                 if (!IsShellAliasName(name))
                     continue;
 
-                if (HasShellAliasSymbol(symbols, fileId, i + 1, name))
+                if (HasSymbolLineIdentity(symbolLineIdentities, fileId, i + 1, "alias", name))
                     continue;
 
+                var symbol = new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "alias",
+                    Name = name,
+                    Line = i + 1,
+                    StartLine = i + 1,
+                    StartColumn = tokenStart,
+                    EndLine = i + 1,
+                    Signature = line.Trim(),
+                };
                 AddSymbolRecord(
                     symbols,
                     cssSeenSymbols: null,
                     i + 1,
-                    new SymbolRecord
-                    {
-                        FileId = fileId,
-                        Kind = "alias",
-                        Name = name,
-                        Line = i + 1,
-                        StartLine = i + 1,
-                        StartColumn = tokenStart,
-                        EndLine = i + 1,
-                        Signature = line.Trim(),
-                    },
+                    symbol,
                     line);
+                RecordSymbolLineIdentity(symbolLineIdentities, symbol);
             }
         }
     }
@@ -222,15 +225,6 @@ public static partial class SymbolExtractor
 
         tokenEnd = cursor;
         return tokenEnd > tokenStart;
-    }
-
-    private static bool HasShellAliasSymbol(List<SymbolRecord> symbols, long fileId, int lineNumber, string name)
-    {
-        return symbols.Any(symbol =>
-            symbol.FileId == fileId
-            && symbol.Line == lineNumber
-            && symbol.Kind == "alias"
-            && string.Equals(symbol.Name, name, StringComparison.Ordinal));
     }
 
     private static bool IsShellAliasName(string name) =>

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -2387,6 +2387,9 @@ public static partial class SymbolExtractor
         var cssSeenSymbols = lang == "css"
             ? new HashSet<string>(StringComparer.Ordinal)
             : null;
+        var dockerfileStageNames = lang == "dockerfile"
+            ? new HashSet<string>(StringComparer.Ordinal)
+            : null;
         var csharpSuppressedContinuationUntil = -1;
         var goImportBlock = false;
 
@@ -2418,7 +2421,7 @@ public static partial class SymbolExtractor
                 AddDockerfileAdditionalLabelSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileAdditionalExposeSymbols(fileId, line, i + 1, symbols);
                 AddDockerfileAdditionalVolumeSymbols(fileId, line, i + 1, symbols);
-                AddDockerfileNamedStageBaseImageSymbol(fileId, line, i + 1, symbols);
+                AddDockerfileNamedStageBaseImageSymbol(fileId, line, i + 1, symbols, dockerfileStageNames!);
                 AddDockerfileShellSymbol(fileId, line, i + 1, symbols);
                 AddDockerfileCopyDestinationSymbol(fileId, line, i + 1, symbols);
                 AddDockerfileAddDestinationSymbol(fileId, line, i + 1, symbols);
@@ -3615,6 +3618,9 @@ public static partial class SymbolExtractor
                                             ReturnType = NormalizeMetadata(rawReturnType),
                                         },
                                     line);
+
+                                if (dockerfileStageNames != null && kind == "stage")
+                                    dockerfileStageNames.Add(name);
 
                                 if (lang == "objc"
                                     && pattern.Kind == "class"
@@ -5492,6 +5498,65 @@ public static partial class SymbolExtractor
         {
         }
     }
+
+    private readonly record struct SymbolLineIdentity(long FileId, int Line, string Kind, string Name);
+
+    private static readonly ConditionalWeakTable<List<SymbolRecord>, SymbolLineIdentityState> SymbolLineIdentityStates = new();
+
+    private sealed class SymbolLineIdentityState
+    {
+        private readonly HashSet<SymbolLineIdentity> _identities = [];
+        private int _knownCount;
+
+        public bool Contains(List<SymbolRecord> symbols, SymbolLineIdentity identity)
+        {
+            Sync(symbols);
+            return _identities.Contains(identity);
+        }
+
+        private void Sync(List<SymbolRecord> symbols)
+        {
+            if (_knownCount > symbols.Count)
+            {
+                _identities.Clear();
+                _knownCount = 0;
+            }
+
+            for (; _knownCount < symbols.Count; _knownCount++)
+                _identities.Add(GetSymbolLineIdentity(symbols[_knownCount]));
+        }
+    }
+
+    private static HashSet<SymbolLineIdentity> BuildSymbolLineIdentities(IEnumerable<SymbolRecord> symbols)
+    {
+        var identities = new HashSet<SymbolLineIdentity>();
+        foreach (var symbol in symbols)
+            identities.Add(GetSymbolLineIdentity(symbol));
+        return identities;
+    }
+
+    private static SymbolLineIdentity GetSymbolLineIdentity(SymbolRecord symbol)
+        => new(symbol.FileId, symbol.Line, symbol.Kind, symbol.Name);
+
+    private static bool HasSymbolLineIdentity(
+        HashSet<SymbolLineIdentity> identities,
+        long fileId,
+        int lineNumber,
+        string kind,
+        string name)
+        => identities.Contains(new SymbolLineIdentity(fileId, lineNumber, kind, name));
+
+    private static bool HasSymbolLineIdentity(
+        List<SymbolRecord> symbols,
+        long fileId,
+        int lineNumber,
+        string kind,
+        string name)
+        => SymbolLineIdentityStates.GetValue(symbols, _ => new SymbolLineIdentityState())
+            .Contains(symbols, new SymbolLineIdentity(fileId, lineNumber, kind, name));
+
+    private static void RecordSymbolLineIdentity(HashSet<SymbolLineIdentity> identities, SymbolRecord symbol)
+        => identities.Add(GetSymbolLineIdentity(symbol));
 
     private readonly record struct SameLineSignatureKey(int Line, int StartLine, string Signature);
     private static bool TryAddRPacmanPackageLoaderSymbols(
@@ -7958,19 +8023,21 @@ public static partial class SymbolExtractor
             if (parentSymbol == null)
                 continue;
 
-            foreach (var component in pending.Components)
-            {
-                if (symbols.Any(symbol =>
+            var existingComponentNames = symbols
+                .Where(symbol =>
                     symbol.FileId == pending.FileId
                     && symbol.Kind == "property"
-                    && symbol.Name == component.Name
                     && symbol.ContainerKind == pending.Kind
                     && symbol.ContainerName == pending.RecordName
                     && symbol.StartLine >= parentSymbol.StartLine
-                    && symbol.EndLine <= parentSymbol.EndLine))
-                {
+                    && symbol.EndLine <= parentSymbol.EndLine)
+                .Select(symbol => symbol.Name)
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var component in pending.Components)
+            {
+                if (!existingComponentNames.Add(component.Name))
                     continue;
-                }
 
                 symbols.Add(new SymbolRecord
                 {

--- a/tests/CodeIndex.Tests/ReferenceExtractorCSharpTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorCSharpTests.cs
@@ -9664,4 +9664,77 @@ public partial class ReferenceExtractorTests
             r.SymbolName == "seed"
             && r.ReferenceKind == "capture");
     }
+
+    [Fact]
+    public void Extract_CsharpQualifiedEnumMemberAccess_WithBlockScopedLocalNamedLikeEnum_DoesNotLeakPastBlock()
+    {
+        const string content = """
+            namespace Demo;
+
+            public enum Status
+            {
+                Ready
+            }
+
+            public sealed class Holder
+            {
+                public int Ready { get; set; }
+            }
+
+            public sealed class Uses
+            {
+                public void Run()
+                {
+                    {
+                        var Status = new Holder();
+                        _ = Status.Ready;
+                    }
+
+                    _ = Status.Ready;
+                }
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+
+        var readyRefs = references
+            .Where(reference => reference.SymbolName == "Ready" && reference.ReferenceKind == "call")
+            .ToList();
+
+        var readyRef = Assert.Single(readyRefs);
+        Assert.Equal("Run", readyRef.ContainerName);
+    }
+
+    [Fact]
+    public void Extract_CSharpLargeMethodWithManyLocals_CompletesWithinPracticalBudget()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("class Demo");
+        builder.AppendLine("{");
+        builder.AppendLine("    int Run(int input)");
+        builder.AppendLine("    {");
+        builder.AppendLine("        var result = input;");
+        for (var i = 0; i < 10_000; i++)
+        {
+            builder.Append("        var value").Append(i).Append(" = result + ").Append(i).AppendLine(";");
+            builder.Append("        result += value").Append(i).AppendLine(";");
+        }
+        builder.AppendLine("        return Helper(result);");
+        builder.AppendLine("    }");
+        builder.AppendLine("    int Helper(int value) => value;");
+        builder.AppendLine("}");
+        var content = builder.ToString();
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        var stopwatch = Stopwatch.StartNew();
+        var references = ReferenceExtractor.Extract(1, "csharp", content, symbols);
+        stopwatch.Stop();
+
+        Assert.Contains(references, reference => reference.SymbolName == "Helper" && reference.ReferenceKind == "call");
+        var runawayBudget = TimeSpan.FromSeconds(15);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large C# method reference extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
 }

--- a/tests/CodeIndex.Tests/ReferenceExtractorRustSwiftTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorRustSwiftTests.cs
@@ -354,6 +354,36 @@ public partial class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_SwiftLargeTypealiasUseSet_CompletesWithinPracticalBudget()
+    {
+        var uses = string.Join('\n', Enumerable.Range(0, 5_000).Select(index => $"let v{index}: MyAlias = value"));
+        var content = $$"""
+            class SomeType {}
+            typealias MyAlias = SomeType
+            {{uses}}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "swift", content);
+
+        var stopwatch = Stopwatch.StartNew();
+        var references = ReferenceExtractor.Extract(1, "swift", content, symbols);
+        stopwatch.Stop();
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.Context == "let v0: MyAlias = value");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.Context == "let v4999: MyAlias = value");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large Swift typealias reference extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
     public void Extract_SwiftGenericTypealiasHeritage_DoesNotEmitTypeParameterAsTarget()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -2627,6 +2627,36 @@ public partial class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptLargeTypeAliasUseSet_CompletesWithinPracticalBudget()
+    {
+        var uses = string.Join('\n', Enumerable.Range(0, 5_000).Select(index => $"let v{index}: MyAlias = value;"));
+        var content = $$"""
+            class SomeType {}
+            type MyAlias = SomeType;
+            {{uses}}
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "typescript", content);
+
+        var stopwatch = Stopwatch.StartNew();
+        var references = ReferenceExtractor.Extract(1, "typescript", content, symbols);
+        stopwatch.Stop();
+
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.Context == "let v0: MyAlias = value;");
+        Assert.Contains(references, reference =>
+            reference.SymbolName == "SomeType"
+            && reference.ReferenceKind == "type_reference"
+            && reference.Context == "let v4999: MyAlias = value;");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large TypeScript type alias reference extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
     public void Extract_TypeScriptTypeAliasWithGenericDefault_EmitsUnderlyingTypeReference()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -2233,6 +2233,23 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScriptLargeExportedVariables_CompletesWithinPracticalBudget()
+    {
+        var lines = string.Join('\n', Enumerable.Range(0, 5_000).Select(i => $"export const value{i} = {i};"));
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "typescript", lines);
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "value0" && s.Visibility == "export");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "value4999" && s.Visibility == "export");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large TypeScript exported variable extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
     public void Extract_TypeScript_DetectsDeclareExportedVariableSurfaceSymbols()
     {
         var content = """
@@ -6677,6 +6694,25 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_ShellLargeAliasSet_CompletesWithinPracticalBudget()
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < 5_000; i++)
+            builder.Append("alias a").Append(i).Append("='echo ").Append(i).AppendLine("'");
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "shell", builder.ToString());
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "a0");
+        Assert.Contains(symbols, s => s.Kind == "alias" && s.Name == "a4999");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large shell alias extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
     public void Extract_SQL_DetectsCreateStatements()
     {
         var content = "CREATE TEMP TABLE users (\n  id INT PRIMARY KEY\n);\n\nCREATE OR REPLACE FUNCTION get_user(id INT) RETURNS void;\n\nCREATE MATERIALIZED VIEW active_users AS SELECT * FROM users;\n\nCREATE TYPE color AS ENUM ('red', 'green');\nCREATE TYPE inventory_item AS (name text);\nCREATE SCHEMA analytics;\nCREATE SCHEMA AUTHORIZATION analytics_owner;\nCREATE SEQUENCE order_seq;\nCREATE EXTENSION IF NOT EXISTS pgcrypto;\nCREATE DOMAIN positive_int AS integer CHECK (VALUE > 0);\nCREATE UNIQUE INDEX users_email_idx ON users (id);\n\nALTER TABLE users ADD COLUMN email TEXT;";
@@ -8689,6 +8725,25 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_RustLargeUseSet_CompletesWithinPracticalBudget()
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < 8_000; i++)
+            builder.Append("use crate::generated::Item").Append(i).AppendLine(";");
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "rust", builder.ToString());
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Item0");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Item7999");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large Rust use extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
     public void Extract_Rust_MapsImplBlocksToImplementingType()
     {
         var content = """
@@ -8806,6 +8861,43 @@ public partial class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "MaxRetries");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "DefaultTimeout");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "GlobalConfig");
+    }
+
+    [Fact]
+    public void Extract_GoLargeGroupedDeclarations_CompletesWithinPracticalBudget()
+    {
+        var typeLines = string.Join('\n', Enumerable.Range(0, 2_000).Select(i => $"    Type{i} struct {{ Embedded{i} }}"));
+        var constLines = string.Join('\n', Enumerable.Range(0, 2_000).Select(i => $"    Const{i} = {i}"));
+        var varLines = string.Join('\n', Enumerable.Range(0, 2_000).Select(i => $"    Var{i} Config"));
+        var content = $$"""
+            package generated
+
+            type (
+            {{typeLines}}
+            )
+
+            const (
+            {{constLines}}
+            )
+
+            var (
+            {{varLines}}
+            )
+            """;
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "go", content);
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Type0");
+        Assert.Contains(symbols, s => s.Kind == "struct" && s.Name == "Type1999");
+        Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "Embedded1999");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Const0");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "Var1999");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large Go grouped declaration extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
     }
 
     [Fact]
@@ -9201,6 +9293,32 @@ public partial class SymbolExtractorTests
 
         var pointY = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "y" && s.ContainerName == "Point"));
         Assert.Equal(40, pointY.Line);
+    }
+
+    [Fact]
+    public void Extract_JavaLargeRecordPrimaryComponents_CompletesWithinPracticalBudget()
+    {
+        var componentLines = string.Join('\n', Enumerable.Range(0, 2_000).Select(i => $"    int p{i},"));
+        var content = $$"""
+            package com.example;
+
+            public record Huge(
+            {{componentLines}}
+                int tail
+            ) {}
+            """;
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "java", content);
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "p0" && s.ContainerName == "Huge");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "p1999" && s.ContainerName == "Huge");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "tail" && s.ContainerName == "Huge");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large Java record component extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
     }
 
     [Fact]
@@ -9910,6 +10028,29 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_KotlinLargePrimaryConstructorComponents_CompletesWithinPracticalBudget()
+    {
+        var components = string.Join(", ", Enumerable.Range(0, 2_000).Select(i => $"val p{i}: String"));
+        var content = $"""
+            package generated
+
+            data class Huge({components}, val tail: String)
+            """;
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "kotlin", content);
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "p0" && s.ContainerName == "Huge");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "p1999" && s.ContainerName == "Huge");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "tail" && s.ContainerName == "Huge");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large Kotlin primary constructor extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
     public void Extract_Kotlin_DistinguishesValueClassesAndInlineReifiedFunctions()
     {
         var content = """
@@ -10576,6 +10717,24 @@ public partial class SymbolExtractorTests
         var value = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "value");
         Assert.Equal("MyApp", value.ContainerName);
         Assert.Contains("decltype(foo(42))", value.ReturnType);
+    }
+
+    [Fact]
+    public void Extract_CppLargeSameLineClassBody_CompletesWithinPracticalBudget()
+    {
+        var members = string.Join(' ', Enumerable.Range(0, 2_000).Select(i => $"int method{i}();"));
+        var content = $"class Big {{ {members} }};";
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "cpp", content);
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "method0" && s.ContainerName == "Big");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "method1999" && s.ContainerName == "Big");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large C++ same-line class body extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
     }
 
     [Fact]
@@ -15192,6 +15351,29 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_DockerfileLargeNamedStageChain_CompletesWithinPracticalBudget()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("FROM alpine AS stage0");
+        for (var i = 1; i < 2_000; i++)
+            builder.Append("FROM stage").Append(i - 1).Append(" AS stage").Append(i).AppendLine();
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", builder.ToString());
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "stage" && s.Name == "stage0");
+        Assert.Contains(symbols, s => s.Kind == "stage" && s.Name == "stage1999");
+        Assert.Contains(symbols, s => s.Kind == "base_image" && s.Name == "alpine");
+        Assert.DoesNotContain(symbols, s => s.Kind == "base_image" && s.Name == "stage0");
+        Assert.DoesNotContain(symbols, s => s.Kind == "base_image" && s.Name == "stage1998");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large Dockerfile named stage extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
     public void Extract_Dockerfile_DetectsLowercaseInstructionsAndEnvSymbols()
     {
         var content = """
@@ -16749,6 +16931,63 @@ public partial class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "run" && s.ContainerKind == "object");
         Assert.Contains(symbols, s => s.Kind == "generator" && s.Name == "gen" && s.ContainerKind == "object");
+    }
+
+    [Fact]
+    public void Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget()
+    {
+        var properties = string.Join(", ", Enumerable.Range(0, 3_000).Select(i => $"p{i}: {i}"));
+        var content = $"export default {{ {properties} }};";
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "javascript", content);
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "p0" && s.ContainerKind == "object" && s.ContainerName == "default");
+        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "p2999" && s.ContainerKind == "object" && s.ContainerName == "default");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large JavaScript exported object literal extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
+    public void Extract_JavaScriptLargeObjectLiteralTargets_CompletesWithinPracticalBudget()
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < 2_000; i++)
+            builder.Append("export const obj").Append(i).Append(" = { run").Append(i).AppendLine("() { return 1; } };");
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "javascript", builder.ToString());
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "run0" && s.ContainerKind == "object" && s.ContainerName == "obj0");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "run1999" && s.ContainerKind == "object" && s.ContainerName == "obj1999");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large JavaScript object literal target extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
+    }
+
+    [Fact]
+    public void Extract_TypeScriptLargeClassExpressionTargets_CompletesWithinPracticalBudget()
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < 2_000; i++)
+            builder.Append("export const C").Append(i).Append(" = class { method").Append(i).AppendLine("(): number { return 1; } };");
+
+        var stopwatch = Stopwatch.StartNew();
+        var symbols = SymbolExtractor.Extract(1, "typescript", builder.ToString());
+        stopwatch.Stop();
+
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "C0");
+        Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "C1999");
+        Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "method1999" && s.ContainerKind == "class" && s.ContainerName == "C1999");
+        var runawayBudget = TimeSpan.FromSeconds(10);
+        Assert.True(
+            stopwatch.Elapsed < runawayBudget,
+            $"Large TypeScript class expression target extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Fix the C# reference-extraction slowdown by avoiding repeated value-receiver body rescans and expensive duplicate checks.
- Reduce non-C# extractor hot-path overhead by replacing candidate-by-candidate scans over growing symbol/reference lists with keyed HashSet/cache lookups.
- Add large-fixture runaway guards for C#, Rust, Shell, Go, Java, Kotlin, C++, Dockerfile, JavaScript, TypeScript, and Swift paths.
- Document the performance issue and prevention guidance in changelog/developer documentation.

## Root Cause

Large generated files could trigger super-linear extraction work when supplemental extractors repeatedly scanned already accumulated references, symbols, or scan targets while processing each new candidate. The observed severe regression was in C# reference extraction; the follow-up audit found similar theoretical hot paths in several non-C# symbol/reference extractors.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj --no-restore -p:UseSharedCompilation=false -m:1 -v:minimal`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore -p:UseSharedCompilation=false -m:1 -v:minimal`
- Reflection harness for targeted extractor performance/correctness tests: 19 PASS
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `cdidx index ... --json`
- cdidx searches confirmed no remaining `symbols.Any`, `symbols.First`, `targets.Any`, `references.Any`, or `references.First` hot-path matches in extractor code.

Note: `dotnet test` could not run in this environment because VSTest/MSBuild socket or pipe creation failed with `Permission denied`; targeted tests were run through the reflection harness instead.