### PR TITLE
[codex] Bound JSON and culture-sensitive parsing paths

### DIFF
--- a/changelog.d/unreleased/3404.fixed.md
+++ b/changelog.d/unreleased/3404.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 3404
+affected:
+  - src/CodeIndex/Database/DbDebug.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - tests/CodeIndex.Tests/CultureScope.cs
+  - tests/CodeIndex.Tests/DbDebugTests.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+---
+
+## English
+
+- **Environment numeric settings now parse with invariant culture (#3404)** — `CDIDX_SLOW_QUERY_MS`, suggestion max-age/max-count settings, and GitHub submit timeout now ignore current-culture-specific numeric signs.
+
+## 日本語
+
+- **環境変数の数値設定が invariant culture で parse されるようになりました (#3404)** — `CDIDX_SLOW_QUERY_MS`、suggestion の max-age/max-count 設定、GitHub submit timeout は、現在カルチャ固有の数値記号に左右されなくなりました。

--- a/changelog.d/unreleased/3444.fixed.md
+++ b/changelog.d/unreleased/3444.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3444
+affected:
+  - tools/CodeIndex.Changelog/Program.cs
+  - tests/CodeIndex.Tests/ChangelogToolTests.cs
+---
+
+## English
+
+- **Changelog parsing now uses invariant, friendly validation (#3444)** — changelog release dates, versions, previous versions, and fragment issue numbers now use invariant parsing and report `ChangelogException` messages for invalid inputs.
+
+## 日本語
+
+- **changelog parsing が invariant で friendly な検証を使うようになりました (#3444)** — changelog の release date、version、previous version、fragment issue number は invariant parsing を使い、不正な入力には `ChangelogException` のメッセージを返します。

--- a/changelog.d/unreleased/3454.fixed.md
+++ b/changelog.d/unreleased/3454.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3454
+affected:
+  - src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+  - tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
+---
+
+## English
+
+- **`--json-envelope` now rejects oversized raw JSON item lines before parsing (#3454)** — envelope wrapping now caps each captured NDJSON item line before `JsonNode.Parse` and returns a structured envelope error instead of doing unbounded parser work.
+
+## 日本語
+
+- **`--json-envelope` が過大な raw JSON item 行を parse 前に拒否するようになりました (#3454)** — envelope wrapping は捕捉した NDJSON item の各行に上限を設け、`JsonNode.Parse` に渡す前に構造化 envelope error を返すため、無制限な parser 処理を避けます。

--- a/changelog.d/unreleased/3466.fixed.md
+++ b/changelog.d/unreleased/3466.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3466
+affected:
+  - src/CodeIndex/Cli/IssueDuplicatePreflight.cs
+  - tests/CodeIndex.Tests/IssueDuplicatePreflightTests.cs
+---
+
+## English
+
+- **Open-issues duplicate preflight now bounds issue-number scalars (#3466)** — malformed `--open-issues` JSON with an oversized issue number now returns an `invalid-preflight-file` diagnostic instead of parsing an unbounded scalar.
+
+## 日本語
+
+- **open-issues duplicate preflight が issue number scalar に上限を設けるようになりました (#3466)** — 過大な issue number を含む不正な `--open-issues` JSON は、無制限の scalar parse を行わず `invalid-preflight-file` 診断を返します。

--- a/changelog.d/unreleased/3470.fixed.md
+++ b/changelog.d/unreleased/3470.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3470
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **`test-extractor` JSON comparison now uses bounded parser options (#3470)** — expected-symbols comparison now parses expected and actual JSON with an explicit depth cap and reports a usage error when the fixture is too deep.
+
+## 日本語
+
+- **`test-extractor` の JSON 比較が上限付き parser options を使うようになりました (#3470)** — expected-symbols 比較は expected / actual JSON を明示的な深度上限付きで parse し、fixture が深すぎる場合は usage error を返します。

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
@@ -176,7 +177,7 @@ internal static class GitHubIssueReporter
         if (string.IsNullOrWhiteSpace(raw))
             return DefaultTimeout;
 
-        return int.TryParse(raw, out var seconds) && seconds is > 0 and <= MaxSubmitTimeoutSeconds
+        return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds) && seconds is > 0 and <= MaxSubmitTimeoutSeconds
             ? TimeSpan.FromSeconds(seconds)
             : DefaultTimeout;
     }

--- a/src/CodeIndex/Cli/IssueDuplicatePreflight.cs
+++ b/src/CodeIndex/Cli/IssueDuplicatePreflight.cs
@@ -15,6 +15,7 @@ internal sealed class IssueDuplicatePreflight
     internal const int MaxOpenIssueTitleLength = GitHubIssueReporter.MaxGitHubIssueTitleLength;
     internal const int MaxOpenIssueUrlLength = 2048;
     internal const int MaxOpenIssueLabelLength = 128;
+    internal const int MaxOpenIssueNumberLength = 32;
     internal const int MaxTitleTokenizationInputLength = MaxOpenIssueTitleLength;
     internal const int MaxGitHubRepositoryLength = 200;
     private const int GitHubOpenIssuesPerPage = 100;
@@ -23,6 +24,7 @@ internal sealed class IssueDuplicatePreflight
     private const string GitHubSourcePrefix = "github:";
     private const string GitHubTokenEnvironmentVariable = "CDIDX_GITHUB_TOKEN";
     private const string GitHubApiBase = "https://api.github.com";
+    private const string InvalidPreflightFileErrorCode = "invalid-preflight-file";
 
     private static readonly HashSet<string> StopTitleTokens = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -87,6 +89,12 @@ internal sealed class IssueDuplicatePreflight
                 documentOptions: new JsonDocumentOptions { MaxDepth = MaxOpenIssuesJsonDepth });
             preflight = new IssueDuplicatePreflight(true, fullPath, ParseOpenIssues(root));
             return true;
+        }
+        catch (InvalidOpenIssuesFileException ex)
+        {
+            preflight = new IssueDuplicatePreflight(false, null, []);
+            error = $"invalid --open-issues file '{path}' ({InvalidPreflightFileErrorCode}): {ex.Message}";
+            return false;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
         {
@@ -255,7 +263,7 @@ internal sealed class IssueDuplicatePreflight
             error = null;
             return true;
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or IOException or InvalidOperationException)
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or IOException or InvalidOperationException or InvalidOpenIssuesFileException)
         {
             preflight = new IssueDuplicatePreflight(false, null, []);
             error = $"could not fetch --open-issues github for repository '{repository}': {ex.Message}";
@@ -358,13 +366,21 @@ internal sealed class IssueDuplicatePreflight
         => GitHubHttpClientFactory.CreateDefaultHttpClient(TimeSpan.FromSeconds(10));
 
     private static string? TryReadString(JsonNode? node, int maxLength)
+        => TryReadString(node, maxLength, truncate: true, fieldName: null);
+
+    private static string? TryReadString(JsonNode? node, int maxLength, bool truncate, string? fieldName)
     {
         if (node == null)
             return null;
         try
         {
             var value = node.GetValue<string>();
-            return value.Length <= maxLength ? value : value[..maxLength];
+            if (value.Length <= maxLength)
+                return value;
+            if (truncate)
+                return value[..maxLength];
+            throw new InvalidOpenIssuesFileException(
+                $"{fieldName ?? "string scalar"} exceeds maximum supported length of {maxLength.ToString(CultureInfo.InvariantCulture)} characters.");
         }
         catch (InvalidOperationException)
         {
@@ -380,9 +396,9 @@ internal sealed class IssueDuplicatePreflight
         {
             return node.GetValue<int>();
         }
-        catch (InvalidOperationException)
+        catch (Exception ex) when (ex is InvalidOperationException or FormatException or OverflowException)
         {
-            var value = TryReadString(node, int.MaxValue);
+            var value = TryReadString(node, MaxOpenIssueNumberLength, truncate: false, fieldName: "issue number");
             return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
                 ? parsed
                 : null;
@@ -458,4 +474,6 @@ internal sealed class IssueDuplicatePreflight
     }
 
     private sealed record OpenIssue(int? Number, string Title, string? Url, List<string> Labels);
+
+    private sealed class InvalidOpenIssuesFileException(string message) : Exception(message);
 }

--- a/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+++ b/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
@@ -18,6 +18,7 @@ internal static class JsonEnvelopeWrapper
 {
     internal const string EnvelopeFlag = "--json-envelope";
     internal const int MaxCapturedOutputChars = 10 * 1024 * 1024;
+    internal const int MaxRawJsonItemChars = 1024 * 1024;
     internal const int MaxRawJsonItemDepth = 32;
 
     private static readonly HashSet<string> WrappableCommands = new(StringComparer.Ordinal)
@@ -128,7 +129,28 @@ internal static class JsonEnvelopeWrapper
         }
 
         var raw = captured.ToString();
-        var results = ParseRawJsonItems(raw);
+        JsonArray results;
+        JsonObject? parseError = null;
+        try
+        {
+            results = ParseRawJsonItems(raw);
+        }
+        catch (JsonEnvelopeRawJsonItemLimitExceededException ex)
+        {
+            exitCode = CommandExitCodes.InvalidArgument;
+            var message = $"--json-envelope raw JSON item line exceeded {ex.MaxChars} characters.";
+            var hint = "Run the command with --json for streaming NDJSON output or reduce the raw item size.";
+            Console.Error.WriteLine($"Error [{CommandErrorCodes.UsageError}]: {message}");
+            Console.Error.WriteLine($"Hint: {hint}");
+            parseError = new JsonObject
+            {
+                ["message"] = message,
+                ["hint"] = hint,
+                ["error_code"] = CommandErrorCodes.UsageError,
+                ["max_chars"] = ex.MaxChars,
+            };
+            results = [];
+        }
         var envelope = BuildEnvelope(
             command,
             queryNormalized,
@@ -137,7 +159,8 @@ internal static class JsonEnvelopeWrapper
             appVersion,
             stopwatch.Elapsed.TotalMilliseconds,
             results,
-            exitCode);
+            exitCode,
+            parseError);
 
         Console.WriteLine(envelope.ToJsonString(jsonOptions));
         return exitCode;
@@ -206,6 +229,8 @@ internal static class JsonEnvelopeWrapper
         {
             if (string.IsNullOrWhiteSpace(line))
                 continue;
+            if (line.Length > MaxRawJsonItemChars)
+                throw new JsonEnvelopeRawJsonItemLimitExceededException(MaxRawJsonItemChars);
 
             JsonNode? node;
             try
@@ -355,6 +380,11 @@ internal static class JsonEnvelopeWrapper
     }
 
     private sealed class JsonEnvelopeCaptureLimitExceededException(int maxChars) : Exception
+    {
+        public int MaxChars { get; } = maxChars;
+    }
+
+    private sealed class JsonEnvelopeRawJsonItemLimitExceededException(int maxChars) : Exception
     {
         public int MaxChars { get; } = maxChars;
     }

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -33,7 +33,12 @@ internal static class ProgramRunner
     internal const int WorkspaceVersionPinMaxSkippedBlankLines = 16;
     internal const int WorkspaceVersionPinMaxLineChars = 256;
     internal const long TestExtractorMaxInputBytes = 4 * 1024 * 1024;
+    internal const int TestExtractorJsonComparisonMaxDepth = 32;
     private const int TestExtractorReadBufferBytes = 81920;
+    private static readonly JsonDocumentOptions s_testExtractorJsonComparisonOptions = new()
+    {
+        MaxDepth = TestExtractorJsonComparisonMaxDepth,
+    };
     private static readonly TimeSpan InstallerRunTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan InstallerKillWaitTimeout = TimeSpan.FromSeconds(5);
     private static readonly HashSet<string> NonLogGlobalOptionNames =
@@ -517,8 +522,16 @@ internal static class ProgramRunner
             if (!TryReadTestExtractorFile(expect, "expected symbols", out var expected, out readExitCode))
                 return readExitCode;
             var actual = JsonSerializer.Serialize(symbols);
-            if (!JsonEquivalent(expected, actual))
+            if (!TryJsonEquivalent(expected, actual, out var jsonError))
             {
+                if (jsonError is not null)
+                {
+                    return CommandErrorWriter.Write(
+                        $"test-extractor expected or actual symbols JSON could not be parsed within the {TestExtractorJsonComparisonMaxDepth} depth limit: {jsonError.Message}",
+                        CommandExitCodes.InvalidArgument,
+                        "Use a shallower expected-symbols JSON fixture.");
+                }
+
                 Console.Error.WriteLine("Expected symbols did not match extracted symbols.");
                 Console.Error.WriteLine(actual);
                 return CommandExitCodes.InvalidArgument;
@@ -626,11 +639,23 @@ internal static class ProgramRunner
         return true;
     }
 
-    private static bool JsonEquivalent(string expected, string actual)
+    private static bool TryJsonEquivalent(string expected, string actual, out JsonException? error)
     {
-        using var expectedDoc = JsonDocument.Parse(expected);
-        using var actualDoc = JsonDocument.Parse(actual);
-        return JsonSerializer.Serialize(expectedDoc.RootElement) == JsonSerializer.Serialize(actualDoc.RootElement);
+        error = null;
+        try
+        {
+            // Both inputs are already bounded: expected JSON is read through
+            // TryReadTestExtractorFile and actual JSON comes from the in-memory
+            // extractor result. Keep parser depth explicit for the comparison.
+            using var expectedDoc = JsonDocument.Parse(expected, s_testExtractorJsonComparisonOptions);
+            using var actualDoc = JsonDocument.Parse(actual, s_testExtractorJsonComparisonOptions);
+            return JsonSerializer.Serialize(expectedDoc.RootElement) == JsonSerializer.Serialize(actualDoc.RootElement);
+        }
+        catch (JsonException ex)
+        {
+            error = ex;
+            return false;
+        }
     }
 
     private static int RunDoctor(string[] args, string appVersion)

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -928,7 +928,7 @@ public class SuggestionStore
     internal static TimeSpan ResolveMaxAge()
     {
         var raw = Environment.GetEnvironmentVariable(MaxAgeDaysEnvironmentVariable);
-        return int.TryParse(raw, out var days) && days is > 0 and <= MaximumMaxAgeDays
+        return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var days) && days is > 0 and <= MaximumMaxAgeDays
             ? TimeSpan.FromDays(days)
             : TimeSpan.FromDays(DefaultMaxAgeDays);
     }
@@ -936,7 +936,7 @@ public class SuggestionStore
     internal static int ResolveMaxCount()
     {
         var raw = Environment.GetEnvironmentVariable(MaxCountEnvironmentVariable);
-        return int.TryParse(raw, out var count) && count is > 0 and <= MaximumMaxCount
+        return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var count) && count is > 0 and <= MaximumMaxCount
             ? count
             : DefaultMaxCount;
     }

--- a/src/CodeIndex/Database/DbDebug.cs
+++ b/src/CodeIndex/Database/DbDebug.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Diagnostics;
@@ -259,7 +260,7 @@ public static class DbDebug
         var raw = Environment.GetEnvironmentVariable("CDIDX_SLOW_QUERY_MS");
         if (string.IsNullOrWhiteSpace(raw))
             return null;
-        return long.TryParse(raw, out var value) && value >= 0 ? value : null;
+        return long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) && value >= 0 ? value : null;
     }
 
     private static string GetStatementOperation(string? sql)

--- a/tests/CodeIndex.Tests/ChangelogToolTests.cs
+++ b/tests/CodeIndex.Tests/ChangelogToolTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using CodeIndex.Changelog;
 
 namespace CodeIndex.Tests;
@@ -33,6 +34,71 @@ public sealed class ChangelogToolTests
                 Directory.SetCurrentDirectory(previousDirectory);
                 Directory.Delete(unrelatedDirectory, recursive: true);
             }
+        }
+    }
+
+    [Fact]
+    public void ProgramMainPrepareBadVersionReturnsFriendlyError_Issue3444()
+    {
+        var (exitCode, stdout, stderr) = CaptureChangelogMain(
+            ["prepare", "--version", "not-a-version", "--date", "2026-05-01"]);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("--version must be a version like X.Y.Z.", stderr);
+    }
+
+    [Fact]
+    public void ProgramMainPrepareBadDateReturnsFriendlyError_Issue3444()
+    {
+        var (exitCode, stdout, stderr) = CaptureChangelogMain(
+            ["prepare", "--version", "1.17.0", "--date", "05/01/2026"]);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("--date must use yyyy-MM-dd.", stderr);
+    }
+
+    [Fact]
+    public void ProgramMainReleaseNotesBadPreviousVersionReturnsFriendlyError_Issue3444()
+    {
+        var (exitCode, stdout, stderr) = CaptureChangelogMain(
+            ["release-notes", "--version", "1.17.0", "--previous-version", "bad"]);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("--previous-version must be a version like X.Y.Z.", stderr);
+    }
+
+    [Fact]
+    public void ProgramMainRenderUsesInvariantInputsUnderNonInvariantCulture_Issue3444()
+    {
+        using var scope = new TestRepositoryScope();
+        scope.WriteFile("CodeIndex.sln", string.Empty);
+        scope.WriteFile("CHANGELOG.md", SampleChangelog);
+        scope.WriteFile("version.json", """
+            {
+              "version": "1.16.0"
+            }
+            """);
+        scope.WriteFile("changelog.d/unreleased/195.fixed.md", SampleFragment);
+
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var (exitCode, stdout, stderr) = CaptureChangelogMain(
+                ["render", "--version", "1.17.0", "--date", "2026-05-01"]);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Contains("### [1.17.0] - 2026-05-01", stdout);
+            Assert.Contains("English release note", stdout);
+            Assert.Contains("Japanese release note", stdout);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
         }
     }
 
@@ -566,6 +632,29 @@ public sealed class ChangelogToolTests
         }
 
         return count;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) CaptureChangelogMain(string[] args)
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            using var outWriter = new StringWriter();
+            using var errorWriter = new StringWriter();
+            Console.SetOut(outWriter);
+            Console.SetError(errorWriter);
+            try
+            {
+                var exitCode = CodeIndex.Changelog.Program.Main(args);
+                return (exitCode, outWriter.ToString(), errorWriter.ToString());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+        }
     }
 
     private static string OversizedContent(long maxBytes) => new('x', checked((int)maxBytes + 1));

--- a/tests/CodeIndex.Tests/CultureScope.cs
+++ b/tests/CodeIndex.Tests/CultureScope.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+
+namespace CodeIndex.Tests;
+
+internal sealed class CultureScope : IDisposable
+{
+    private readonly CultureInfo _originalCulture;
+    private readonly CultureInfo _originalUiCulture;
+
+    public CultureScope(CultureInfo culture)
+    {
+        _originalCulture = CultureInfo.CurrentCulture;
+        _originalUiCulture = CultureInfo.CurrentUICulture;
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+    }
+
+    public void Dispose()
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+        CultureInfo.CurrentUICulture = _originalUiCulture;
+    }
+}
+
+internal static class TestCultures
+{
+    public static CultureInfo BuildCaretPositiveSignCulture()
+    {
+        var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        culture.NumberFormat.PositiveSign = "^";
+        return culture;
+    }
+}

--- a/tests/CodeIndex.Tests/DbDebugTests.cs
+++ b/tests/CodeIndex.Tests/DbDebugTests.cs
@@ -50,6 +50,28 @@ public class DbDebugTests
     }
 
     [Fact]
+    public void ExecuteTrackedReader_SlowQueryThresholdIgnoresCurrentCulturePositiveSign_Issue3404()
+    {
+        using var env = EnvironmentVariableScope.Capture("CDIDX_SLOW_QUERY_MS");
+        using var _ = new CultureScope(TestCultures.BuildCaretPositiveSignCulture());
+        env.Set("CDIDX_SLOW_QUERY_MS", "^0");
+
+        using var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT 1";
+
+        var stderr = CaptureStderr(() =>
+        {
+            using var reader = cmd.ExecuteTrackedReader();
+            Assert.True(reader.TrackedRead());
+            Assert.Equal(1, reader.GetInt32(0));
+        });
+
+        Assert.DoesNotContain("slow_query", stderr);
+    }
+
+    [Fact]
     public void ExecuteTrackedReader_ProfileCapsQueryPlanRows()
     {
         DbDebug.ResetForTesting();

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -110,6 +110,15 @@ public class GitHubIssueReporterTests : IDisposable
         Assert.Equal(GitHubIssueReporter.DefaultTimeout, GitHubIssueReporter.ResolveSubmitTimeout());
     }
 
+    [Fact]
+    public void ResolveSubmitTimeout_IgnoresCurrentCulturePositiveSign_Issue3404()
+    {
+        using var _ = new CultureScope(TestCultures.BuildCaretPositiveSignCulture());
+        _env.Set("CDIDX_GITHUB_SUBMIT_TIMEOUT_SECONDS", "^3");
+
+        Assert.Equal(GitHubIssueReporter.DefaultTimeout, GitHubIssueReporter.ResolveSubmitTimeout());
+    }
+
     [Theory]
     [InlineData(null, false)]
     [InlineData("", false)]

--- a/tests/CodeIndex.Tests/IssueDuplicatePreflightTests.cs
+++ b/tests/CodeIndex.Tests/IssueDuplicatePreflightTests.cs
@@ -94,6 +94,30 @@ public sealed class IssueDuplicatePreflightTests : IDisposable
     }
 
     [Fact]
+    public void TryLoad_OversizedIssueNumberScalar_ReturnsInvalidPreflightFile_Issue3466()
+    {
+        var issueNumber = new string('9', IssueDuplicatePreflight.MaxOpenIssueNumberLength + 1);
+        var path = WriteOpenIssuesJson(
+            $$"""
+            [
+              {
+                "number": "{{issueNumber}}",
+                "title": "Oversized number should fail",
+                "labels": [{"name": "bug"}],
+                "url": "https://example.com/issues/1"
+              }
+            ]
+            """);
+
+        var loaded = IssueDuplicatePreflight.TryLoad(path, out var preflight, out var error);
+
+        Assert.False(loaded);
+        Assert.False(preflight.Checked);
+        Assert.Contains("invalid-preflight-file", error);
+        Assert.Contains(IssueDuplicatePreflight.MaxOpenIssueNumberLength.ToString(System.Globalization.CultureInfo.InvariantCulture), error);
+    }
+
+    [Fact]
     public void TryLoad_GitHubSourceFetchesOpenIssuesWithExplicitToken_Issue3449()
     {
         _env.Set("CDIDX_GITHUB_TOKEN", "explicit-token");

--- a/tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
+++ b/tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
@@ -293,6 +293,33 @@ public class JsonEnvelopeWrapperTests
     }
 
     [Fact]
+    public void RunWrapped_OversizedRawJsonItem_ReturnsStructuredEnvelopeError_Issue3454()
+    {
+        var rawLine = new string('x', JsonEnvelopeWrapper.MaxRawJsonItemChars + 1);
+        var (exitCode, stdout, stderr) = CaptureConsole(() => JsonEnvelopeWrapper.RunWrapped(
+            "search",
+            ["Needle", "--json-envelope"],
+            "1.0.0",
+            _jsonOptions,
+            _ =>
+            {
+                Console.WriteLine(rawLine);
+                return CommandExitCodes.Success;
+            }));
+
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+        Assert.Contains("--json-envelope raw JSON item line exceeded", stderr);
+        using var document = JsonDocument.Parse(stdout);
+        var metadata = document.RootElement.GetProperty("metadata");
+        Assert.Equal(CommandExitCodes.InvalidArgument, metadata.GetProperty("exit_code").GetInt32());
+        Assert.Equal(0, metadata.GetProperty("result_count").GetInt32());
+        var error = metadata.GetProperty("error");
+        Assert.Equal(CommandErrorCodes.UsageError, error.GetProperty("error_code").GetString());
+        Assert.Equal(JsonEnvelopeWrapper.MaxRawJsonItemChars, error.GetProperty("max_chars").GetInt32());
+        Assert.Equal(0, document.RootElement.GetProperty("results").GetArrayLength());
+    }
+
+    [Fact]
     public void RunWrapped_MixedRawLines_ParsesWithoutMaterializingSplitArray_Issue3015()
     {
         var (exitCode, stdout, stderr) = CaptureConsole(() => JsonEnvelopeWrapper.RunWrapped(

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -344,6 +344,36 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void Run_TestExtractor_ExpectedSymbolsTooDeep_ReturnsInvalidArgument_Issue3470()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_test_extractor_deep_expect_{Guid.NewGuid():N}");
+            try
+            {
+                Directory.CreateDirectory(tempDir);
+                var file = Path.Combine(tempDir, "app.py");
+                var expect = Path.Combine(tempDir, "expected.json");
+                File.WriteAllText(file, "def hello():\n    pass\n");
+                File.WriteAllText(expect, BuildNestedJsonArray(ProgramRunner.TestExtractorJsonComparisonMaxDepth + 1));
+
+                var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                    ["test-extractor", "--language", "python", "--file", file, "--expect-symbols", expect],
+                    appVersion: "1.10.0"));
+
+                Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+                Assert.Empty(stdout);
+                Assert.Contains("test-extractor expected or actual symbols JSON could not be parsed", stderr);
+                Assert.Contains($"{ProgramRunner.TestExtractorJsonComparisonMaxDepth} depth limit", stderr);
+            }
+            finally
+            {
+                TestProjectHelper.DeleteDirectory(tempDir);
+            }
+        }
+    }
+
+    [Fact]
     public void TryConsumeQueryTraceFlag_StripsTraceAndPreservesEscapedQuery()
     {
         string[] args = ["needle", "--trace=stderr", "--lang", "csharp", "--", "--trace=file"];
@@ -2809,6 +2839,17 @@ exit 0
         Assert.StartsWith("Hint: ", lines[1]);
         if (lines.Length == 3)
             Assert.StartsWith("Usage: ", lines[2]);
+    }
+
+    private static string BuildNestedJsonArray(int depth)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < depth; i++)
+            builder.Append('[');
+        builder.Append('0');
+        for (var i = 0; i < depth; i++)
+            builder.Append(']');
+        return builder.ToString();
     }
 
     private sealed class ThrowingResolver : IJsonTypeInfoResolver

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -1054,6 +1054,16 @@ public class SuggestionStoreTests : IDisposable
     }
 
     [Fact]
+    public void ResolveMaxAge_IgnoresCurrentCulturePositiveSign_Issue3404()
+    {
+        using var env = EnvironmentVariableScope.Capture(SuggestionStore.MaxAgeDaysEnvironmentVariable);
+        using var _ = new CultureScope(TestCultures.BuildCaretPositiveSignCulture());
+        env.Set(SuggestionStore.MaxAgeDaysEnvironmentVariable, "^30");
+
+        Assert.Equal(TimeSpan.FromDays(SuggestionStore.DefaultMaxAgeDays), SuggestionStore.ResolveMaxAge());
+    }
+
+    [Fact]
     public void ResolveMaxCount_AcceptsMaximumConfiguredValue()
     {
         using var env = EnvironmentVariableScope.Capture(SuggestionStore.MaxCountEnvironmentVariable);
@@ -1068,6 +1078,16 @@ public class SuggestionStoreTests : IDisposable
         using var env = EnvironmentVariableScope.Capture(SuggestionStore.MaxCountEnvironmentVariable);
         var tooLarge = SuggestionStore.MaximumMaxCount + 1;
         env.Set(SuggestionStore.MaxCountEnvironmentVariable, tooLarge.ToString(CultureInfo.InvariantCulture));
+
+        Assert.Equal(SuggestionStore.DefaultMaxCount, SuggestionStore.ResolveMaxCount());
+    }
+
+    [Fact]
+    public void ResolveMaxCount_IgnoresCurrentCulturePositiveSign_Issue3404()
+    {
+        using var env = EnvironmentVariableScope.Capture(SuggestionStore.MaxCountEnvironmentVariable);
+        using var _ = new CultureScope(TestCultures.BuildCaretPositiveSignCulture());
+        env.Set(SuggestionStore.MaxCountEnvironmentVariable, "^42");
 
         Assert.Equal(SuggestionStore.DefaultMaxCount, SuggestionStore.ResolveMaxCount());
     }

--- a/tools/CodeIndex.Changelog/Program.cs
+++ b/tools/CodeIndex.Changelog/Program.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -91,7 +92,7 @@ public static class Program
                 if (i + 1 >= args.Length)
                     throw new ChangelogException("Missing value for --version.");
 
-                version = Version.Parse(args[++i]);
+                version = ChangelogValueParser.ParseVersion(args[++i], "--version");
                 continue;
             }
 
@@ -100,7 +101,7 @@ public static class Program
                 if (i + 1 >= args.Length)
                     throw new ChangelogException("Missing value for --date.");
 
-                releaseDate = DateOnly.Parse(args[++i]);
+                releaseDate = ChangelogValueParser.ParseDate(args[++i], "--date");
                 continue;
             }
 
@@ -109,7 +110,7 @@ public static class Program
                 if (i + 1 >= args.Length)
                     throw new ChangelogException("Missing value for --previous-version.");
 
-                previousVersion = Version.Parse(args[++i]);
+                previousVersion = ChangelogValueParser.ParseVersion(args[++i], "--previous-version");
                 continue;
             }
 
@@ -161,6 +162,62 @@ public static class Program
     }
 
     private sealed record ParsedOptions(Version Version, DateOnly ReleaseDate, Version? PreviousVersion);
+}
+
+internal static class ChangelogValueParser
+{
+    private const string DateFormat = "yyyy-MM-dd";
+
+    internal static Version ParseVersion(string value, string optionName)
+    {
+        if (!TryParseVersion(value, out var version))
+            throw new ChangelogException($"{optionName} must be a version like X.Y.Z.");
+
+        return version;
+    }
+
+    internal static DateOnly ParseDate(string value, string optionName)
+    {
+        if (!DateOnly.TryParseExact(value, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+            throw new ChangelogException($"{optionName} must use {DateFormat}.");
+
+        return date;
+    }
+
+    internal static int ParseIssueNumber(string value, string relativePath)
+    {
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var issueNumber) || issueNumber <= 0)
+            throw new ChangelogException($"{relativePath}: invalid issue number '{value}'.");
+
+        return issueNumber;
+    }
+
+    private static bool TryParseVersion(string value, out Version version)
+    {
+        version = new Version(0, 0);
+        var trimmed = value.Trim();
+        var parts = trimmed.Split('.');
+        if (parts.Length is < 2 or > 4)
+            return false;
+
+        Span<int> parsed = stackalloc int[4] { -1, -1, -1, -1 };
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var part = parts[i];
+            if (part.Length == 0 || part.Any(ch => ch is < '0' or > '9'))
+                return false;
+            if (!int.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out parsed[i]))
+                return false;
+        }
+
+        version = parts.Length switch
+        {
+            2 => new Version(parsed[0], parsed[1]),
+            3 => new Version(parsed[0], parsed[1], parsed[2]),
+            _ => new Version(parsed[0], parsed[1], parsed[2], parsed[3]),
+        };
+        return true;
+    }
 }
 
 public sealed class ChangelogTool
@@ -433,10 +490,7 @@ public sealed class ChangelogTool
                 var item = line[4..].Trim();
                 if (currentKey == "issues")
                 {
-                    if (!int.TryParse(item, out var issueNumber))
-                        throw new ChangelogException($"{relativePath}: invalid issue number '{item}'.");
-
-                    frontMatterIssues.Add(issueNumber);
+                    frontMatterIssues.Add(ChangelogValueParser.ParseIssueNumber(item, relativePath));
                 }
                 else if (currentKey == "affected")
                 {
@@ -465,10 +519,7 @@ public sealed class ChangelogTool
                     {
                         if (currentKey == "issues")
                         {
-                            if (!int.TryParse(value, out var issueNumber))
-                                throw new ChangelogException($"{relativePath}: invalid issue number '{value}'.");
-
-                            frontMatterIssues.Add(issueNumber);
+                            frontMatterIssues.Add(ChangelogValueParser.ParseIssueNumber(value, relativePath));
                         }
                         else
                         {
@@ -576,7 +627,9 @@ public sealed class ChangelogTool
         if (!document.RootElement.TryGetProperty("version", out var versionElement))
             throw new ChangelogException("version.json is missing the version property.");
 
-        return Version.Parse(versionElement.GetString() ?? throw new ChangelogException("version.json contains an empty version."));
+        return ChangelogValueParser.ParseVersion(
+            versionElement.GetString() ?? throw new ChangelogException("version.json contains an empty version."),
+            "version.json version");
     }
 
     private static string ReadAllTextBounded(string absolutePath, string repositoryRoot, long maxBytes)


### PR DESCRIPTION
## Summary

- Added bounded handling for raw JSON envelope item lines, `test-extractor` JSON comparison depth, and open-issues issue-number scalars.
- Switched changelog release inputs and selected environment numeric settings to invariant parsing with friendly diagnostics/default behavior.
- Added bilingual changelog fragments and focused regression tests for each fixed issue.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~JsonEnvelopeWrapperTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~ProgramRunnerTests.Run_TestExtractor`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~IssueDuplicatePreflightTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~ChangelogToolTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~DbDebugTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~SuggestionStoreTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~GitHubIssueReporterTests`
- Adversarial review: No blocking/actionable issues found.

## Notes

- Full unfiltered `CodeIndex.Tests` was attempted after the merge from latest `origin/main` and interrupted after prolonged no output; the issue-focused net8/net9 test set above passed.
- `AGENTS.md`, `CLAUDE.md`, and `AGENT_GUIDE.md` were not changed.

Fixes #3454
Fixes #3470
Fixes #3466
Fixes #3444
Fixes #3404
