### PR TITLE
[codex] Split FileIndexer and DbContext responsibilities

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -139,7 +139,7 @@ git status --short -- '**/packages.lock.json'
 | CLI runners | `Cli/IndexCommandRunner.cs`, `Cli/QueryCommandRunner.cs` | Indexing commands, search/definition/reference/caller/callee/symbol/file/map/inspect/outline/status commands, and argument parsing. |
 | CLI support | `Cli/ConsoleUi.cs`, `Cli/CommandExitCodes.cs`, `Cli/SearchSnippetFormatter.cs`, `Cli/LineWidthFormatter.cs` | User-facing output, exit codes, focused snippet formatting, and line-width clamping. |
 | Workspace resolution | `Cli/DbPathResolver.cs`, `Cli/GitHelper.cs`, `Cli/IndexFreshnessChecker.cs`, `Cli/WorkspaceMetadataEnricher.cs`, `Cli/GlobalToolLog.cs` | DB path resolution, git-aware refresh inputs, DB/worktree freshness checks, workspace metadata, and persistent install logs. |
-| SQLite storage | `Database/DbContext.cs`, `Database/DbWriter.cs`, `Database/DbReader.cs` | WAL-backed SQLite schema, batch writes, stale-file cleanup, FTS5 search, symbol/reference lookups, excerpts, outlines, inspect bundles, status, and dependency queries. |
+| SQLite storage | `Database/DbContext.cs`, `Database/DbConnectionFactory.cs`, `Database/DbPragmaPolicy.cs`, `Database/DbWriter.cs`, `Database/DbReader.cs` | WAL-backed SQLite schema, connection/retry and pragma policy, batch writes, stale-file cleanup, FTS5 search, symbol/reference lookups, excerpts, outlines, inspect bundles, status, and dependency queries. |
 | Repository map | `Database/RepoMapBuilder.cs` | Repo-level overview for `map`: file stats, likely entrypoints, hotspots, and module grouping. |
 | File scanning | `Indexer/Scanning/FileIndexer.cs`, `Indexer/Scanning/ChunkSplitter.cs` | Shared full/update path filtering, ignore handling, language detection, file records, and 80-line chunks with 10-line overlap. |
 | Symbol extraction | `Indexer/Symbols/SymbolExtractor.cs`, `Indexer/Symbols/SymbolExtractor.Lisp.cs`, `Indexer/Symbols/CSharpSymbolNameNormalizer.cs` | Hybrid symbol extraction across supported languages plus C# persisted-name canonicalization. |
@@ -435,7 +435,7 @@ Current stable codes and triggers:
 
 | Area | Policy |
 |---|---|
-| Writable open pragmas | `DbContext` opens writable indexes in WAL mode, sets `PRAGMA auto_vacuum=INCREMENTAL` before schema creation for new empty databases, sets `PRAGMA application_id=0x43444958` (`CDIX`), sets `PRAGMA synchronous=NORMAL`, and pins `PRAGMA wal_autocheckpoint=1000`. |
+| Writable open pragmas | `DbContext` opens writable indexes in WAL mode, applies connection performance pragmas through `DbPragmaPolicy`, sets `PRAGMA auto_vacuum=INCREMENTAL` before schema creation for new empty databases, sets `PRAGMA application_id=0x43444958` (`CDIX`), sets `PRAGMA synchronous=NORMAL`, and pins `PRAGMA wal_autocheckpoint=1000`. |
 | Application id | The application id lets file-type detection tools distinguish cdidx databases from generic SQLite databases. |
 | Durable WAL file set | When WAL is active, the durable SQLite index is the `.db` file plus sibling `.db-wal` and `.db-shm` files. Backups, diagnostics bundles, and manual copies must include all three files when the siblings exist, or use SQLite's `.backup` command/API from a live connection. Copying only `codeindex.db` can produce a stale snapshot because committed pages may still live in `codeindex.db-wal`. |
 | `synchronous=NORMAL` | Under WAL, `NORMAL` avoids per-commit fsync pressure during 500-row indexing batches while preserving database consistency after crashes. |
@@ -2324,7 +2324,7 @@ git status --short -- '**/packages.lock.json'
 | CLI ランナー | `Cli/IndexCommandRunner.cs`, `Cli/QueryCommandRunner.cs` | index と search / definition / reference / caller / callee / symbol / file / map / inspect / outline / status 系コマンド、引数解析。 |
 | CLI サポート | `Cli/ConsoleUi.cs`, `Cli/CommandExitCodes.cs`, `Cli/SearchSnippetFormatter.cs`, `Cli/LineWidthFormatter.cs` | ユーザー向け出力、終了コード、一致中心スニペット、行幅クランプ。 |
 | ワークスペース解決 | `Cli/DbPathResolver.cs`, `Cli/GitHelper.cs`, `Cli/IndexFreshnessChecker.cs`, `Cli/WorkspaceMetadataEnricher.cs`, `Cli/GlobalToolLog.cs` | DB パス解決、git-aware な更新入力、DB/作業ツリー鮮度確認、workspace metadata、install log。 |
-| SQLite ストレージ | `Database/DbContext.cs`, `Database/DbWriter.cs`, `Database/DbReader.cs` | WAL 付き SQLite schema、batch write、古い file の cleanup、FTS5 search、symbol/reference lookup、excerpt、outline、inspect bundle、status、dependency query。 |
+| SQLite ストレージ | `Database/DbContext.cs`, `Database/DbConnectionFactory.cs`, `Database/DbPragmaPolicy.cs`, `Database/DbWriter.cs`, `Database/DbReader.cs` | WAL 付き SQLite schema、connection/retry と pragma policy、batch write、古い file の cleanup、FTS5 search、symbol/reference lookup、excerpt、outline、inspect bundle、status、dependency query。 |
 | リポジトリマップ | `Database/RepoMapBuilder.cs` | `map` 用の repo overview: file stats、entrypoint 候補、hotspot、module grouping。 |
 | ファイル走査 | `Indexer/Scanning/FileIndexer.cs`, `Indexer/Scanning/ChunkSplitter.cs` | full/update 共通の path filtering、ignore 処理、language detection、file record、80 行 chunk と 10 行 overlap。 |
 | シンボル抽出 | `Indexer/Symbols/SymbolExtractor.cs`, `Indexer/Symbols/SymbolExtractor.Lisp.cs`, `Indexer/Symbols/CSharpSymbolNameNormalizer.cs` | 対応言語の hybrid symbol extraction と C# persisted name canonicalization。 |
@@ -2670,7 +2670,7 @@ alternative action を同じ場所へ追加してください。
 
 | 項目 | policy |
 |---|---|
-| writable open pragma | `DbContext` は writable な index を WAL mode で開き、新規の空 DB では schema 作成前に `PRAGMA auto_vacuum=INCREMENTAL` を設定し、`PRAGMA application_id=0x43444958` (`CDIX`)、`PRAGMA synchronous=NORMAL`、`PRAGMA wal_autocheckpoint=1000` を固定します。 |
+| writable open pragma | `DbContext` は writable な index を WAL mode で開き、connection performance pragma を `DbPragmaPolicy` 経由で適用し、新規の空 DB では schema 作成前に `PRAGMA auto_vacuum=INCREMENTAL` を設定し、`PRAGMA application_id=0x43444958` (`CDIX`)、`PRAGMA synchronous=NORMAL`、`PRAGMA wal_autocheckpoint=1000` を固定します。 |
 | application id | application id は file-type detection tool が cdidx database と generic SQLite database を区別するための印です。 |
 | durable WAL file set | WAL が有効な場合、永続化された SQLite index は `.db` file と sibling の `.db-wal` / `.db-shm` file の組です。backup、diagnostics bundle、手動 copy では sibling が存在する場合に 3 file すべてを含めるか、live connection から SQLite の `.backup` command/API を使う必要があります。`codeindex.db` だけを copy すると、committed page がまだ `codeindex.db-wal` に残っているため stale snapshot になる可能性があります。 |
 | `synchronous=NORMAL` | WAL では `NORMAL` により 500 row 単位の indexing batch ごとの fsync 負荷を避けつつ、crash 後の database consistency を保ちます。 |

--- a/changelog.d/unreleased/3419.internal.md
+++ b/changelog.d/unreleased/3419.internal.md
@@ -1,0 +1,18 @@
+---
+category: internal
+issues:
+  - 3419
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileContentLoader.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - docs/large-file-decomposition-plan.md
+---
+
+## English
+
+- **FileIndexer content loading now lives behind a focused collaborator (#3419)** — file byte reading, decoding, line canonicalization, and checksum calculation now flow through `FileContentLoader`, leaving `FileIndexer` focused on traversal and record orchestration without changing indexed output.
+
+## 日本語
+
+- **FileIndexer の content loading を focused collaborator に切り出しました (#3419)** — ファイル byte 読み込み、decode、行 canonicalization、checksum 算出を `FileContentLoader` 経由にし、indexed output を変えずに `FileIndexer` が traversal と record orchestration に集中できるようにしました。

--- a/changelog.d/unreleased/3420.internal.md
+++ b/changelog.d/unreleased/3420.internal.md
@@ -1,0 +1,19 @@
+---
+category: internal
+issues:
+  - 3420
+affected:
+  - src/CodeIndex/Database/DbConnectionFactory.cs
+  - src/CodeIndex/Database/DbPragmaPolicy.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - tests/CodeIndex.Tests/DbConnectionPolicyTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **DbContext connection and pragma responsibilities now have focused collaborators (#3420)** — SQLite open/retry/read-only URI handling lives in `DbConnectionFactory`, connection performance pragma policy lives in `DbPragmaPolicy`, and `DbContext` keeps compatibility wrappers while continuing to orchestrate schema and migration flow.
+
+## 日本語
+
+- **DbContext の connection と pragma 責務を focused collaborator に分離しました (#3420)** — SQLite open/retry/read-only URI handling は `DbConnectionFactory` に、connection performance pragma policy は `DbPragmaPolicy` に置き、`DbContext` は互換 wrapper を保ちながら schema と migration flow の orchestration を継続します。

--- a/docs/large-file-decomposition-plan.md
+++ b/docs/large-file-decomposition-plan.md
@@ -47,6 +47,7 @@ focused tests for the behavior it moves.
 
 6. `FileIndexer.cs`
    - Separate path discovery and ignore policy from file content validation and record construction.
+   - Keep content loading, decoding, line normalization, and checksum logic in `FileContentLoader` so `FileIndexer` can stay focused on traversal and record orchestration.
    - Move filesystem-sensitive behavior behind testable helpers before changing indexing flow.
    - Keep cross-platform path, symlink, hidden/system attribute, and cleanup tests attached to each boundary move.
 
@@ -115,6 +116,7 @@ public behavior を維持し、移動した挙動に対応する focused test �
 
 6. `FileIndexer.cs`
    - path discovery と ignore policy を file content validation と record construction から分ける。
+   - content loading、decoding、line normalization、checksum logic は `FileContentLoader` に置き、`FileIndexer` は traversal と record orchestration に集中させる。
    - indexing flow を変更する前に、filesystem-sensitive behavior を testable helper の背後へ移す。
    - cross-platform path、symlink、hidden/system attribute、cleanup test を各 boundary move に付ける。
 

--- a/src/CodeIndex/Database/DbConnectionFactory.cs
+++ b/src/CodeIndex/Database/DbConnectionFactory.cs
@@ -1,0 +1,203 @@
+using CodeIndex.Cli;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Database;
+
+internal static class DbConnectionFactory
+{
+    // SQLITE_READONLY(8), SQLITE_CANTOPEN(14), SQLITE_IOERR(10). A read-only filesystem
+    // typically surfaces as CANTOPEN because -journal/-shm cannot be created.
+    // read-only FS では -journal / -shm を作れず CANTOPEN(14) を返すことが多い。
+    internal static bool IsReadOnlyOpenError(SqliteException ex) =>
+        ex.SqliteErrorCode is 8 or 14 or 10;
+
+    internal static SqliteConnection OpenWithRetry(
+        Func<SqliteConnection> createConnection,
+        Action<SqliteConnection> openConnection,
+        Action<int>? sleep = null,
+        int maxOpenAttempts = 5,
+        string? dbPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxOpenAttempts <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxOpenAttempts), maxOpenAttempts, "Must be at least 1.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        SqliteConnection? connection = null;
+        SqliteException? lastBusyError = null;
+        for (var attempt = 1; attempt <= maxOpenAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            connection?.Dispose();
+            connection = createConnection();
+            try
+            {
+                openConnection(connection);
+                return connection;
+            }
+            catch (SqliteException ex) when (IsTransientBusyError(ex))
+            {
+                // #1580: capture the busy error on every attempt — including the
+                // last — so the end-of-loop throw can wrap it in a structured
+                // CodeIndexException instead of leaking SqliteException to callers
+                // (which previously made the bottom `throw` unreachable).
+                // #1580: 末尾の throw を必ず通すために busy エラーを全試行で捕捉する。
+                lastBusyError = ex;
+                if (attempt < maxOpenAttempts)
+                {
+                    try
+                    {
+                        SleepBeforeRetry(50 * attempt, sleep, cancellationToken);
+                    }
+                    catch
+                    {
+                        connection.Dispose();
+                        throw;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                connection.Dispose();
+                throw;
+            }
+        }
+        connection?.Dispose();
+
+        // Issue #1580: surface the DB path and a recovery hint instead of a bare
+        // `InvalidOperationException("Failed to ...")` so the caller (CLI / MCP) can
+        // tell which database failed and which retry knob to suggest.
+        // #1580: 失敗した DB のパスとリカバリ手順を構造化して投げる。
+        throw new CodeIndexException(
+            code: CommandErrorCodes.DbLocked,
+            category: CodeIndexExceptionCategory.Database,
+            message: "Failed to open SQLite connection after retries.",
+            path: dbPath,
+            hint: "Another process holds a write lock on the database. If another cdidx index is running, wait for it to finish; otherwise check for other SQLite clients (e.g. backup tools, DB browsers) accessing the file, then retry.",
+            innerException: lastBusyError);
+    }
+
+    internal static string ToReadOnlyUri(string dbPath)
+    {
+        if (SqliteFileUri.StartsWithFileScheme(dbPath))
+        {
+            if (!SqliteFileUri.TryValidateBounds(dbPath, out var boundsError))
+                throw boundsError ?? new FormatException("Invalid SQLite file URI.");
+
+            return AppendReadOnlyQuery(dbPath);
+        }
+
+        var fileUri = new Uri(Path.GetFullPath(dbPath)).AbsoluteUri;
+        return $"{fileUri}?immutable=1&mode=ro";
+    }
+
+    // Best-effort: extract the filesystem path from a SQLite URI so -wal checks can run.
+    // Returns null if parsing fails; the caller simply skips the gate in that case.
+    // URI から filesystem path を取り出すベストエフォート。失敗したらゲートをスキップ。
+    internal static string? TryGetLocalPath(string uriText)
+    {
+        try
+        {
+            // Trim the query string (?immutable=1 etc.) before parsing so LocalPath is clean.
+            if (!SqliteFileUri.TryGetPathBeforeQuery(uriText, out var trimmed, out _))
+                return null;
+
+            var uri = new Uri(trimmed);
+            return uri.IsFile ? uri.LocalPath : null;
+        }
+        catch (UriFormatException)
+        {
+            return null;
+        }
+    }
+
+    internal static SqliteConnection OpenReadOnly(string dbPath)
+    {
+        // Attempt 1: Mode=ReadOnly. Works for most read-only FS scenarios and, crucially,
+        // still reads hot -wal state so nothing committed but not yet checkpointed is lost.
+        // 第一段: Mode=ReadOnly。多くの read-only 環境で動作し、hot -wal の未チェックポイント
+        // 済みコミットも正しく読める。
+        try
+        {
+            var roBuilder = new SqliteConnectionStringBuilder
+            {
+                DataSource = dbPath,
+                Mode = SqliteOpenMode.ReadOnly,
+            };
+            var conn = new SqliteConnection(roBuilder.ConnectionString);
+            conn.Open();
+            return conn;
+        }
+        catch (SqliteException)
+        {
+            // Attempt 2: immutable=1 URI. This bypasses -shm/-wal entirely, which is the only
+            // way to survive a sandbox that cannot touch side files. Trade-off documented:
+            // if the base DB has uncheckpointed WAL state, immutable will serve data that
+            // predates those commits. We warn to stderr so the caller can see it, but do not
+            // block — a file-size heuristic on `-wal` produces false positives (WAL files
+            // remain allocated after checkpoint), and real hot-WAL detection requires the
+            // very -shm/-wal access the sandbox is blocking. The explicit escape hatch
+            // `--db file:///...?immutable=1` is the user's way to opt into the same
+            // trade-off knowingly.
+            // サンドボックスで -shm/-wal に触れない場合の最終手段。hot WAL 誤判定を避けるため、
+            // ファイルサイズでの拒否はやめ、stderr 警告のみ出してフォールバック。
+            Console.Error.WriteLine("Warning: falling back to SQLite immutable=1 read-only open. " +
+                "If the base DB has uncheckpointed WAL state, the snapshot may be stale. " +
+                "Re-run cdidx on writable storage to checkpoint WAL if this matters.");
+
+            // Build the connection string directly instead of routing through
+            // SqliteConnectionStringBuilder. The builder quotes DataSource values that
+            // contain special characters, and the extra quoting was enough in some sandboxes
+            // (observed by Codex: raw sqlite3 file:///... ?immutable=1 succeeds while the
+            // builder-wrapped form fails with SQLITE_CANTOPEN). Uri.AbsoluteUri already
+            // percent-encodes everything unsafe in a connection-string context (spaces, %,
+            // ;, ", ', etc. all become %XX), so a raw concatenation is still injection-safe
+            // for this specific input shape. Mode=ReadOnly is redundant with immutable=1 but
+            // kept explicit so cdidx's intent is visible in logs / traces.
+            // builder は DataSource を quote して URI 解釈を壊すため直接組む。
+            // Uri.AbsoluteUri が全ての危険文字を %-エンコードするので raw 連結でも injection 安全。
+            var fileUri = new Uri(Path.GetFullPath(dbPath)).AbsoluteUri; // e.g. file:///abs/path.db
+            var rawConnStr = $"Data Source={fileUri}?immutable=1;Mode=ReadOnly";
+            var conn = new SqliteConnection(rawConnStr);
+            conn.Open();
+            return conn;
+        }
+    }
+
+    internal static bool IsTransientBusyError(SqliteException ex) =>
+        ex.SqliteErrorCode is 5 or 6;
+
+    internal static void SleepBeforeRetry(int milliseconds, Action<int>? sleep, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (sleep != null)
+        {
+            sleep(milliseconds);
+            cancellationToken.ThrowIfCancellationRequested();
+            return;
+        }
+
+        if (!cancellationToken.CanBeCanceled)
+        {
+            System.Threading.Thread.Sleep(milliseconds);
+            return;
+        }
+
+        if (cancellationToken.WaitHandle.WaitOne(milliseconds))
+            cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private static string AppendReadOnlyQuery(string uriText)
+    {
+        var separator = uriText.Contains('?', StringComparison.Ordinal) ? "&" : "?";
+        var result = uriText;
+        if (!uriText.Contains("immutable=1", StringComparison.OrdinalIgnoreCase))
+        {
+            result += $"{separator}immutable=1";
+            separator = "&";
+        }
+        if (!uriText.Contains("mode=ro", StringComparison.OrdinalIgnoreCase))
+            result += $"{separator}mode=ro";
+        return result;
+    }
+}

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -455,32 +455,7 @@ public class DbContext : IDisposable
     }
 
     public static string ToReadOnlyUri(string dbPath)
-    {
-        if (SqliteFileUri.StartsWithFileScheme(dbPath))
-        {
-            if (!SqliteFileUri.TryValidateBounds(dbPath, out var boundsError))
-                throw boundsError ?? new FormatException("Invalid SQLite file URI.");
-
-            return AppendReadOnlyQuery(dbPath);
-        }
-
-        var fileUri = new Uri(Path.GetFullPath(dbPath)).AbsoluteUri;
-        return $"{fileUri}?immutable=1&mode=ro";
-    }
-
-    private static string AppendReadOnlyQuery(string uriText)
-    {
-        var separator = uriText.Contains('?', StringComparison.Ordinal) ? "&" : "?";
-        var result = uriText;
-        if (!uriText.Contains("immutable=1", StringComparison.OrdinalIgnoreCase))
-        {
-            result += $"{separator}immutable=1";
-            separator = "&";
-        }
-        if (!uriText.Contains("mode=ro", StringComparison.OrdinalIgnoreCase))
-            result += $"{separator}mode=ro";
-        return result;
-    }
+        => DbConnectionFactory.ToReadOnlyUri(dbPath);
 
     private static void ApplyPrivateDatabaseFileModes(string dbPath)
     {
@@ -556,30 +531,15 @@ public class DbContext : IDisposable
 
     private void ApplyConnectionPerformancePragmas()
     {
-        Execute($"PRAGMA cache_size=-{ReadPositiveIntEnvironment(CacheSizeEnvironmentVariable, DefaultCacheSizeKb, MaxCacheSizeKb)}");
-        Execute("PRAGMA temp_store=MEMORY");
-        if (Environment.Is64BitProcess)
-            Execute($"PRAGMA mmap_size={ReadNonNegativeLongEnvironment(MmapSizeEnvironmentVariable, DefaultMmapSizeBytes, MaxMmapSizeBytes)}");
-    }
-
-    private static int ReadPositiveIntEnvironment(string name, int fallback, int maximum)
-    {
-        var value = Environment.GetEnvironmentVariable(name);
-        return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
-            && parsed > 0
-            && parsed <= maximum
-                ? parsed
-                : fallback;
-    }
-
-    private static long ReadNonNegativeLongEnvironment(string name, long fallback, long maximum)
-    {
-        var value = Environment.GetEnvironmentVariable(name);
-        return long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
-            && parsed >= 0
-            && parsed <= maximum
-                ? parsed
-                : fallback;
+        var settings = DbPragmaPolicy.ReadConnectionPragmaSettings(
+            CacheSizeEnvironmentVariable,
+            DefaultCacheSizeKb,
+            MaxCacheSizeKb,
+            MmapSizeEnvironmentVariable,
+            DefaultMmapSizeBytes,
+            MaxMmapSizeBytes,
+            Environment.Is64BitProcess);
+        DbPragmaPolicy.ApplyConnectionPerformancePragmas(Execute, settings);
     }
 
     private void ConfigureAutoVacuumForEmptyDatabase()
@@ -725,31 +685,13 @@ public class DbContext : IDisposable
     }
 
     internal static void ExecuteSynchronousPragmaWithFallback(Action<string> execute)
-    {
-        try
-        {
-            execute($"PRAGMA synchronous={DefaultSynchronousMode}");
-        }
-        catch (SqliteException ex) when (IsSafetyLevelTransactionError(ex))
-        {
-            // SQLite can reject PRAGMA synchronous while another pooled connection is in a
-            // transaction. Keep the connection usable; the setting is a durability/perf knob,
-            // not a schema precondition for readers.
-        }
-    }
+        => DbPragmaPolicy.ExecuteSynchronousPragmaWithFallback(execute, DefaultSynchronousMode);
 
     internal static bool IsSafetyLevelTransactionError(SqliteException ex) =>
-        ex.SqliteErrorCode == 1 &&
-        ex.Message.Contains("Safety level may not be changed inside a transaction", StringComparison.OrdinalIgnoreCase);
+        DbPragmaPolicy.IsSafetyLevelTransactionError(ex);
 
-    // SQLITE_READONLY(8), SQLITE_CANTOPEN(14), SQLITE_IOERR(10). A read-only filesystem
-    // typically surfaces as CANTOPEN because -journal/-shm cannot be created.
-    // read-only FS では -journal / -shm を作れず CANTOPEN(14) を返すことが多い。
     private static bool IsReadOnlyOpenError(SqliteException ex) =>
-        ex.SqliteErrorCode is 8 or 14 or 10;
-
-    private static bool IsTransientBusyError(SqliteException ex) =>
-        ex.SqliteErrorCode is 5 or 6;
+        DbConnectionFactory.IsReadOnlyOpenError(ex);
 
     internal static SqliteConnection OpenSqliteConnectionWithRetry(
         Func<SqliteConnection> createConnection,
@@ -758,157 +700,19 @@ public class DbContext : IDisposable
         int maxOpenAttempts = 5,
         string? dbPath = null,
         CancellationToken cancellationToken = default)
-    {
-        if (maxOpenAttempts <= 0)
-            throw new ArgumentOutOfRangeException(nameof(maxOpenAttempts), maxOpenAttempts, "Must be at least 1.");
+        => DbConnectionFactory.OpenWithRetry(
+            createConnection,
+            openConnection,
+            sleep,
+            maxOpenAttempts,
+            dbPath,
+            cancellationToken);
 
-        cancellationToken.ThrowIfCancellationRequested();
-        SqliteConnection? connection = null;
-        SqliteException? lastBusyError = null;
-        for (var attempt = 1; attempt <= maxOpenAttempts; attempt++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            connection?.Dispose();
-            connection = createConnection();
-            try
-            {
-                openConnection(connection);
-                return connection;
-            }
-            catch (SqliteException ex) when (IsTransientBusyError(ex))
-            {
-                // #1580: capture the busy error on every attempt — including the
-                // last — so the end-of-loop throw can wrap it in a structured
-                // CodeIndexException instead of leaking SqliteException to callers
-                // (which previously made the bottom `throw` unreachable).
-                // #1580: 末尾の throw を必ず通すために busy エラーを全試行で捕捉する。
-                lastBusyError = ex;
-                if (attempt < maxOpenAttempts)
-                {
-                    try
-                    {
-                        SleepBeforeRetry(50 * attempt, sleep, cancellationToken);
-                    }
-                    catch
-                    {
-                        connection.Dispose();
-                        throw;
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                connection.Dispose();
-                throw;
-            }
-        }
-        connection?.Dispose();
-
-        // Issue #1580: surface the DB path and a recovery hint instead of a bare
-        // `InvalidOperationException("Failed to ...")` so the caller (CLI / MCP) can
-        // tell which database failed and which retry knob to suggest.
-        // #1580: 失敗した DB のパスとリカバリ手順を構造化して投げる。
-        throw new CodeIndexException(
-            code: CommandErrorCodes.DbLocked,
-            category: CodeIndexExceptionCategory.Database,
-            message: "Failed to open SQLite connection after retries.",
-            path: dbPath,
-            hint: "Another process holds a write lock on the database. If another cdidx index is running, wait for it to finish; otherwise check for other SQLite clients (e.g. backup tools, DB browsers) accessing the file, then retry.",
-            innerException: lastBusyError);
-    }
-
-    private static void SleepBeforeRetry(int milliseconds, Action<int>? sleep, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        if (sleep != null)
-        {
-            sleep(milliseconds);
-            cancellationToken.ThrowIfCancellationRequested();
-            return;
-        }
-
-        if (!cancellationToken.CanBeCanceled)
-        {
-            System.Threading.Thread.Sleep(milliseconds);
-            return;
-        }
-
-        if (cancellationToken.WaitHandle.WaitOne(milliseconds))
-            cancellationToken.ThrowIfCancellationRequested();
-    }
-
-    // Best-effort: extract the filesystem path from a SQLite URI so -wal checks can run.
-    // Returns null if parsing fails; the caller simply skips the gate in that case.
-    // URI から filesystem path を取り出すベストエフォート。失敗したらゲートをスキップ。
     private static string? TryGetLocalPath(string uriText)
-    {
-        try
-        {
-            // Trim the query string (?immutable=1 etc.) before parsing so LocalPath is clean.
-            if (!SqliteFileUri.TryGetPathBeforeQuery(uriText, out var trimmed, out _))
-                return null;
-
-            var uri = new Uri(trimmed);
-            return uri.IsFile ? uri.LocalPath : null;
-        }
-        catch (UriFormatException)
-        {
-            return null;
-        }
-    }
+        => DbConnectionFactory.TryGetLocalPath(uriText);
 
     private static SqliteConnection OpenReadOnly(string dbPath)
-    {
-        // Attempt 1: Mode=ReadOnly. Works for most read-only FS scenarios and, crucially,
-        // still reads hot -wal state so nothing committed but not yet checkpointed is lost.
-        // 第一段: Mode=ReadOnly。多くの read-only 環境で動作し、hot -wal の未チェックポイント
-        // 済みコミットも正しく読める。
-        try
-        {
-            var roBuilder = new SqliteConnectionStringBuilder
-            {
-                DataSource = dbPath,
-                Mode = SqliteOpenMode.ReadOnly,
-            };
-            var conn = new SqliteConnection(roBuilder.ConnectionString);
-            conn.Open();
-            return conn;
-        }
-        catch (SqliteException)
-        {
-            // Attempt 2: immutable=1 URI. This bypasses -shm/-wal entirely, which is the only
-            // way to survive a sandbox that cannot touch side files. Trade-off documented:
-            // if the base DB has uncheckpointed WAL state, immutable will serve data that
-            // predates those commits. We warn to stderr so the caller can see it, but do not
-            // block — a file-size heuristic on `-wal` produces false positives (WAL files
-            // remain allocated after checkpoint), and real hot-WAL detection requires the
-            // very -shm/-wal access the sandbox is blocking. The explicit escape hatch
-            // `--db file:///...?immutable=1` is the user's way to opt into the same
-            // trade-off knowingly.
-            // サンドボックスで -shm/-wal に触れない場合の最終手段。hot WAL 誤判定を避けるため、
-            // ファイルサイズでの拒否はやめ、stderr 警告のみ出してフォールバック。
-            Console.Error.WriteLine("Warning: falling back to SQLite immutable=1 read-only open. " +
-                "If the base DB has uncheckpointed WAL state, the snapshot may be stale. " +
-                "Re-run cdidx on writable storage to checkpoint WAL if this matters.");
-
-            // Build the connection string directly instead of routing through
-            // SqliteConnectionStringBuilder. The builder quotes DataSource values that
-            // contain special characters, and the extra quoting was enough in some sandboxes
-            // (observed by Codex: raw sqlite3 file:///... ?immutable=1 succeeds while the
-            // builder-wrapped form fails with SQLITE_CANTOPEN). Uri.AbsoluteUri already
-            // percent-encodes everything unsafe in a connection-string context (spaces, %,
-            // ;, ", ', etc. all become %XX), so a raw concatenation is still injection-safe
-            // for this specific input shape. Mode=ReadOnly is redundant with immutable=1 but
-            // kept explicit so cdidx's intent is visible in logs / traces.
-            // builder は DataSource を quote して URI 解釈を壊すため直接組む。
-            // Uri.AbsoluteUri が全ての危険文字を %-エンコードするので raw 連結でも injection 安全。
-            var fileUri = new Uri(Path.GetFullPath(dbPath)).AbsoluteUri; // e.g. file:///abs/path.db
-            var rawConnStr = $"Data Source={fileUri}?immutable=1;Mode=ReadOnly";
-            var conn = new SqliteConnection(rawConnStr);
-            conn.Open();
-            return conn;
-        }
-    }
+        => DbConnectionFactory.OpenReadOnly(dbPath);
 
     internal static void RegisterConnectionFunctions(SqliteConnection connection)
     {
@@ -1411,9 +1215,9 @@ public class DbContext : IDisposable
                 registerConnectionFunctions(connection);
                 return;
             }
-            catch (SqliteException ex) when (IsTransientBusyError(ex) && attempt < maxAttempts)
+            catch (SqliteException ex) when (DbConnectionFactory.IsTransientBusyError(ex) && attempt < maxAttempts)
             {
-                SleepBeforeRetry(50 * attempt, sleep, cancellationToken);
+                DbConnectionFactory.SleepBeforeRetry(50 * attempt, sleep, cancellationToken);
             }
         }
     }

--- a/src/CodeIndex/Database/DbPragmaPolicy.cs
+++ b/src/CodeIndex/Database/DbPragmaPolicy.cs
@@ -1,0 +1,83 @@
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Database;
+
+internal static class DbPragmaPolicy
+{
+    internal static DbConnectionPragmaSettings ReadConnectionPragmaSettings(
+        string cacheSizeEnvironmentVariable,
+        int defaultCacheSizeKb,
+        int maxCacheSizeKb,
+        string mmapSizeEnvironmentVariable,
+        long defaultMmapSizeBytes,
+        long maxMmapSizeBytes,
+        bool is64BitProcess)
+    {
+        var cacheSizeKb = ReadPositiveIntEnvironment(
+            cacheSizeEnvironmentVariable,
+            defaultCacheSizeKb,
+            maxCacheSizeKb);
+        var mmapSizeBytes = is64BitProcess
+            ? ReadNonNegativeLongEnvironment(
+                mmapSizeEnvironmentVariable,
+                defaultMmapSizeBytes,
+                maxMmapSizeBytes)
+            : (long?)null;
+        return new DbConnectionPragmaSettings(cacheSizeKb, mmapSizeBytes);
+    }
+
+    internal static void ApplyConnectionPerformancePragmas(
+        Action<string> execute,
+        DbConnectionPragmaSettings settings)
+    {
+        execute($"PRAGMA cache_size=-{settings.CacheSizeKb}");
+        execute("PRAGMA temp_store=MEMORY");
+        if (settings.MmapSizeBytes.HasValue)
+            execute($"PRAGMA mmap_size={settings.MmapSizeBytes.Value}");
+    }
+
+    internal static void ExecuteSynchronousPragmaWithFallback(
+        Action<string> execute,
+        string synchronousMode)
+    {
+        try
+        {
+            execute($"PRAGMA synchronous={synchronousMode}");
+        }
+        catch (SqliteException ex) when (IsSafetyLevelTransactionError(ex))
+        {
+            // SQLite can reject PRAGMA synchronous while another pooled connection is in a
+            // transaction. Keep the connection usable; the setting is a durability/perf knob,
+            // not a schema precondition for readers.
+        }
+    }
+
+    internal static bool IsSafetyLevelTransactionError(SqliteException ex) =>
+        ex.SqliteErrorCode == 1 &&
+        ex.Message.Contains("Safety level may not be changed inside a transaction", StringComparison.OrdinalIgnoreCase);
+
+    private static int ReadPositiveIntEnvironment(string name, int fallback, int maximum)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
+            && parsed > 0
+            && parsed <= maximum
+                ? parsed
+                : fallback;
+    }
+
+    private static long ReadNonNegativeLongEnvironment(string name, long fallback, long maximum)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
+            && parsed >= 0
+            && parsed <= maximum
+                ? parsed
+                : fallback;
+    }
+}
+
+internal readonly record struct DbConnectionPragmaSettings(
+    int CacheSizeKb,
+    long? MmapSizeBytes);

--- a/src/CodeIndex/Indexer/Scanning/FileContentLoader.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileContentLoader.cs
@@ -1,0 +1,477 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CodeIndex.Indexer;
+
+internal sealed class FileContentLoader(long maxFileSizeBytes)
+{
+    private const int GitLfsPointerMaxBytes = 1024;
+
+    internal LoadedFileContent Load(
+        string absolutePath,
+        string normalizedRelativePath,
+        string relativePath,
+        CancellationToken cancellationToken)
+    {
+        var (bytes, sizeBytes, modifiedUtc) = ReadRawBytesWithSizeLimit(
+            absolutePath,
+            normalizedRelativePath,
+            cancellationToken);
+        var (content, warning) = DecodeIndexableContent(bytes, relativePath);
+        content = NormalizeLineEndings(content);
+        content = StripLineLeadingInvisibles(content);
+        if (IsGitLfsPointer(bytes))
+            content = string.Empty;
+
+        return new LoadedFileContent(
+            content,
+            bytes,
+            sizeBytes,
+            modifiedUtc,
+            FileIndexer.CountPhysicalLines(content),
+            ComputeChecksum(Encoding.UTF8.GetBytes(content)),
+            warning);
+    }
+
+    private (byte[] Bytes, long SizeBytes, DateTime ModifiedUtc) ReadRawBytesWithSizeLimit(
+        string absolutePath,
+        string normalizedRelativePath,
+        CancellationToken cancellationToken)
+    {
+        // Read raw bytes through a single FileStream and cap the accumulated payload at
+        // the configured max-file limit so a file that grew between the size probe and the read can no
+        // longer bypass the cap. Splitting `FileInfo.Length` from `File.ReadAllBytes`
+        // left a TOCTOU window where an attacker (or any build/log emitter rapidly
+        // appending to a generated file) could grow a 1 MB file to multi-GB between
+        // stat and read and force the indexer into an OOM-sized allocation; reading
+        // through one open handle removes the second stat call, and the read loop's
+        // running total guarantees we never accumulate more than the configured max-file bytes
+        // regardless of how aggressively a concurrent writer extends the file.
+        // ファイルを 1 本の FileStream で開き、設定された max-file byte 上限として累積バッファを
+        // 制限することで、サイズ確認と読み込みの間にファイルが肥大化しても上限を
+        // 回避できないようにする。
+        byte[] bytes;
+        long sizeBytes;
+        DateTime modifiedUtc;
+        var ioPath = LongPath.EnsureWindowsPrefix(absolutePath);
+        for (var attempt = 0; ; attempt++)
+        {
+            var modifiedBeforeRead = File.GetLastWriteTimeUtc(ioPath);
+            using (var stream = new FileStream(
+                ioPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 4096,
+                useAsync: false))
+            {
+                var initialLength = stream.Length;
+                if (initialLength > maxFileSizeBytes)
+                    throw new FileIndexer.FileTooLargeSkippedException(
+                        normalizedRelativePath,
+                        initialLength,
+                        maxFileSizeBytes,
+                        BuildFileTooLargeMessage(initialLength, grewDuringRead: false));
+
+                var initialCapacity = (int)Math.Min(initialLength, maxFileSizeBytes);
+                using var accumulator = new MemoryStream(initialCapacity);
+                var buffer = new byte[81920];
+                long total = 0;
+                int read;
+                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    total += read;
+                    if (total > maxFileSizeBytes)
+                        throw new FileIndexer.FileTooLargeSkippedException(
+                            normalizedRelativePath,
+                            total,
+                            maxFileSizeBytes,
+                            BuildFileTooLargeMessage(total, grewDuringRead: true));
+                    accumulator.Write(buffer, 0, read);
+                }
+                bytes = accumulator.ToArray();
+                sizeBytes = total;
+            }
+            modifiedUtc = File.GetLastWriteTimeUtc(ioPath);
+            if (modifiedUtc == modifiedBeforeRead || attempt > 0)
+                break;
+        }
+
+        return (bytes, sizeBytes, modifiedUtc);
+    }
+
+    private (string Content, string? Warning) DecodeIndexableContent(byte[] bytes, string relativePath)
+    {
+        var isUtf16Encoded = TryDetectUtf16Encoding(bytes, allowHeuristic: true, out var utf16BigEndian, out var hasUtf16Bom);
+
+        if (!isUtf16Encoded && ContainsIndexBlockingNullByte(bytes))
+            throw new FileIndexer.BinaryFileSkippedException($"{relativePath}: binary file skipped because it contains NULL bytes");
+
+        if (isUtf16Encoded)
+        {
+            var content = new UnicodeEncoding(utf16BigEndian, byteOrderMark: hasUtf16Bom, throwOnInvalidBytes: false)
+                .GetString(bytes);
+            return (content, null);
+        }
+
+        try
+        {
+            return (new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(bytes), null);
+        }
+        catch (DecoderFallbackException)
+        {
+            var content = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(bytes);
+            return (content, $"{relativePath}: contains invalid UTF-8 bytes (replaced with U+FFFD)");
+        }
+    }
+
+    private string BuildFileTooLargeMessage(long actualBytes, bool grewDuringRead)
+    {
+        var actual = FormatBytesForError(actualBytes);
+        var limit = FormatBytesForError(maxFileSizeBytes);
+        var observed = grewDuringRead
+            ? $"File too large (> {limit} limit; grew during read)"
+            : $"File too large ({actual} > {limit} limit)";
+        return $"{observed}. Override with --max-file-bytes <bytes> or {FileIndexer.MaxFileSizeEnvironmentVariable}=<bytes> when this source file is intentionally indexable.";
+    }
+
+    private static string FormatBytesForError(long bytes)
+    {
+        if (bytes % (1024L * 1024L) == 0)
+            return $"{bytes / 1024L / 1024L} MiB";
+        if (bytes % 1024L == 0)
+            return $"{bytes / 1024L} KiB";
+        return $"{bytes} bytes";
+    }
+
+    internal static string NormalizeLineEndings(string content)
+    {
+        var firstCarriageReturn = content.IndexOf('\r');
+        if (firstCarriageReturn < 0)
+            return content;
+
+        var builder = new StringBuilder(content.Length);
+        builder.Append(content, 0, firstCarriageReturn);
+
+        for (var index = firstCarriageReturn; index < content.Length; index++)
+        {
+            if (content[index] != '\r')
+            {
+                builder.Append(content[index]);
+                continue;
+            }
+
+            builder.Append('\n');
+            if (index + 1 < content.Length && content[index + 1] == '\n')
+                index++;
+        }
+
+        return builder.ToString();
+    }
+
+    internal static string StripLineLeadingInvisibles(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+            return content;
+        if (!content.Contains('\uFEFF') && !content.Contains('\u200B'))
+            return content;
+
+        var firstStripIndex = -1;
+        var atLineStart = true;
+        for (var i = 0; i < content.Length; i++)
+        {
+            var c = content[i];
+            if (IsLineLeadingInvisible(c) && atLineStart)
+            {
+                firstStripIndex = i;
+                break;
+            }
+            atLineStart = c == '\n';
+        }
+        if (firstStripIndex < 0)
+            return content;
+
+        var sb = new StringBuilder(content.Length - 1);
+        if (firstStripIndex > 0)
+            sb.Append(content, 0, firstStripIndex);
+        atLineStart = true;
+        for (var i = firstStripIndex + 1; i < content.Length; i++)
+        {
+            var c = content[i];
+            if (IsLineLeadingInvisible(c) && atLineStart)
+                continue;
+            sb.Append(c);
+            atLineStart = c == '\n';
+        }
+        return sb.ToString();
+    }
+
+    private static bool IsLineLeadingInvisible(char c) => c is '\uFEFF' or '\u200B';
+
+    internal static bool IsGitLfsPointer(byte[] rawBytes)
+    {
+        if (rawBytes.Length == 0 || rawBytes.Length >= GitLfsPointerMaxBytes)
+            return false;
+
+        var pointerText = Encoding.UTF8.GetString(rawBytes).Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var lines = pointerText.Split('\n');
+        if (lines.Length > 0 && lines[^1].Length == 0)
+            lines = lines[..^1];
+        if (lines.Length < 3)
+            return false;
+        if (!string.Equals(lines[0], "version https://git-lfs.github.com/spec/v1", StringComparison.Ordinal))
+            return false;
+
+        var lineIndex = 1;
+        while (lineIndex < lines.Length && lines[lineIndex].StartsWith("ext-", StringComparison.Ordinal))
+            lineIndex++;
+
+        if (lineIndex + 1 >= lines.Length)
+            return false;
+        if (!IsGitLfsSha256OidLine(lines[lineIndex]))
+            return false;
+        lineIndex++;
+        if (!IsGitLfsSizeLine(lines[lineIndex]))
+            return false;
+
+        return lineIndex == lines.Length - 1;
+    }
+
+    private static bool IsGitLfsSha256OidLine(string line)
+    {
+        const string prefix = "oid sha256:";
+        if (!line.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+
+        var hash = line.AsSpan(prefix.Length);
+        if (hash.Length != 64)
+            return false;
+        foreach (var c in hash)
+        {
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool IsGitLfsSizeLine(string line)
+    {
+        const string prefix = "size ";
+        if (!line.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+
+        var size = line.AsSpan(prefix.Length);
+        if (size.Length == 0)
+            return false;
+        foreach (var c in size)
+        {
+            if (c < '0' || c > '9')
+                return false;
+        }
+        return true;
+    }
+
+    internal static bool ContainsIndexBlockingNullByte(byte[] rawBytes)
+    {
+        return !TryDetectUtf16Encoding(rawBytes, allowHeuristic: true, out _, out _) && rawBytes.Any(b => b == 0);
+    }
+
+    internal static bool TryDetectUtf16Encoding(
+        byte[] rawBytes,
+        bool allowHeuristic,
+        out bool bigEndian,
+        out bool hasBom)
+    {
+        bigEndian = false;
+        hasBom = false;
+
+        if (rawBytes.Length >= 2 && rawBytes[0] == 0xFE && rawBytes[1] == 0xFF)
+        {
+            bigEndian = true;
+            hasBom = true;
+            return true;
+        }
+
+        if (rawBytes.Length >= 2 && rawBytes[0] == 0xFF && rawBytes[1] == 0xFE
+            && !(rawBytes.Length >= 4 && rawBytes[2] == 0x00 && rawBytes[3] == 0x00))
+        {
+            hasBom = true;
+            return true;
+        }
+
+        if (!allowHeuristic || rawBytes.Length < 4)
+            return false;
+
+        var sampleLength = Math.Min(rawBytes.Length, 4096);
+        sampleLength -= sampleLength % 2;
+        var pairs = sampleLength / 2;
+        if (pairs == 0)
+            return false;
+
+        var evenNulls = 0;
+        var oddNulls = 0;
+        var oddTextBytes = 0;
+        var evenTextBytes = 0;
+        for (var i = 0; i < sampleLength; i += 2)
+        {
+            if (rawBytes[i] == 0)
+                evenNulls++;
+            if (rawBytes[i + 1] == 0)
+                oddNulls++;
+            if (IsLikelyTextByte(rawBytes[i + 1]))
+                oddTextBytes++;
+            if (IsLikelyTextByte(rawBytes[i]))
+                evenTextBytes++;
+        }
+
+        const double NullParityThreshold = 0.30;
+        const double OppositeNullThreshold = 0.01;
+        const double TextByteThreshold = 0.80;
+        var beScore = (double)evenNulls / pairs;
+        var leScore = (double)oddNulls / pairs;
+        var beOppositeScore = (double)oddNulls / pairs;
+        var leOppositeScore = (double)evenNulls / pairs;
+
+        if (beScore >= NullParityThreshold
+            && beOppositeScore <= OppositeNullThreshold
+            && (double)oddTextBytes / pairs >= TextByteThreshold)
+        {
+            bigEndian = true;
+            return true;
+        }
+
+        if (leScore >= NullParityThreshold
+            && leOppositeScore <= OppositeNullThreshold
+            && (double)evenTextBytes / pairs >= TextByteThreshold)
+        {
+            bigEndian = false;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsLikelyTextByte(byte value)
+        => value is 0x09 or 0x0A or 0x0D || value >= 0x20;
+
+    internal static string ComputeChecksum(byte[] bytes)
+    {
+        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var pendingCarriageReturn = false;
+        AppendNormalizedChecksumBytes(hasher, bytes, ref pendingCarriageReturn);
+        FlushPendingChecksumCarriageReturn(hasher, ref pendingCarriageReturn);
+        return FinishChecksum(hasher);
+    }
+
+    internal static bool TryComputeChecksum(string filePath, long maxBytes, out string checksum)
+    {
+        if (maxBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "Maximum byte count must be non-negative.");
+
+        checksum = string.Empty;
+        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        using var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 81920,
+            options: FileOptions.SequentialScan);
+
+        var buffer = new byte[81920];
+        var pendingCarriageReturn = false;
+        long total = 0;
+        while (true)
+        {
+            var read = stream.Read(buffer, 0, buffer.Length);
+            if (read == 0)
+                break;
+
+            total += read;
+            if (total > maxBytes)
+                return false;
+
+            AppendNormalizedChecksumBytes(hasher, buffer.AsSpan(0, read), ref pendingCarriageReturn);
+        }
+
+        FlushPendingChecksumCarriageReturn(hasher, ref pendingCarriageReturn);
+        checksum = FinishChecksum(hasher);
+        return true;
+    }
+
+    private static void AppendNormalizedChecksumBytes(
+        IncrementalHash hasher,
+        ReadOnlySpan<byte> bytes,
+        ref bool pendingCarriageReturn)
+    {
+        Span<byte> normalized = stackalloc byte[4096];
+        var n = 0;
+
+        if (pendingCarriageReturn)
+        {
+            if (bytes.Length > 0 && bytes[0] == 0x0A)
+                bytes = bytes[1..];
+            normalized[n++] = 0x0A;
+            pendingCarriageReturn = false;
+        }
+
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            var b = bytes[i];
+            if (b == 0x0D)
+            {
+                if (i + 1 == bytes.Length)
+                {
+                    pendingCarriageReturn = true;
+                    continue;
+                }
+
+                normalized[n++] = 0x0A;
+                if (i + 1 < bytes.Length && bytes[i + 1] == 0x0A)
+                    i++;
+            }
+            else
+            {
+                normalized[n++] = b;
+            }
+
+            if (n == normalized.Length)
+            {
+                hasher.AppendData(normalized);
+                n = 0;
+            }
+        }
+
+        if (n > 0)
+            hasher.AppendData(normalized[..n]);
+    }
+
+    private static void FlushPendingChecksumCarriageReturn(IncrementalHash hasher, ref bool pendingCarriageReturn)
+    {
+        if (!pendingCarriageReturn)
+            return;
+
+        Span<byte> lineFeed = stackalloc byte[1];
+        lineFeed[0] = 0x0A;
+        hasher.AppendData(lineFeed);
+        pendingCarriageReturn = false;
+    }
+
+    private static string FinishChecksum(IncrementalHash hasher)
+    {
+        Span<byte> hash = stackalloc byte[32];
+        if (!hasher.TryGetHashAndReset(hash, out var written) || written != hash.Length)
+            throw new InvalidOperationException("SHA256 produced an unexpected hash length");
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+
+internal readonly record struct LoadedFileContent(
+    string Content,
+    byte[] RawBytes,
+    long SizeBytes,
+    DateTime ModifiedUtc,
+    int LineCount,
+    string Checksum,
+    string? Warning);

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -468,6 +468,7 @@ public class FileIndexer
     private readonly Func<string, IEnumerable<string>> _enumerateFiles;
     private readonly Dictionary<string, bool> _directoryIgnoreCaseCache;
     private readonly long _maxFileSizeBytes;
+    private readonly FileContentLoader _contentLoader;
     private readonly SymlinkPolicy _symlinkPolicy;
     // Submodule working-tree paths declared in <ignoreRuleRoot>/.gitmodules, relative to
     // _projectRoot and slash-normalized. Used to override SkipDirs so that submodules
@@ -1021,6 +1022,7 @@ public class FileIndexer
         _enumerateFiles = enumerateFiles ?? (dir => Directory.EnumerateFiles(LongPath.EnsureWindowsPrefix(dir)));
         _directoryIgnoreCaseCache = new Dictionary<string, bool>(StringComparer.Ordinal);
         _maxFileSizeBytes = ResolveMaxFileSizeBytes(maxFileSizeBytes);
+        _contentLoader = new FileContentLoader(_maxFileSizeBytes);
         _symlinkPolicy = symlinkPolicy;
         ExtractorPluginRegistry.LoadPatternConfigsForProjectRoot(_projectRoot);
         var pathComparer = _ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
@@ -3178,163 +3180,23 @@ public class FileIndexer
         var relativePath = Path.GetRelativePath(_projectRoot, absolutePath);
         var normalizedRelativePath = NormalizeIndexPath(relativePath);
 
-        var (bytes, sizeBytes, modifiedUtc) = ReadRawBytesWithSizeLimit(
+        var loaded = _contentLoader.Load(
             absolutePath,
             normalizedRelativePath,
+            relativePath,
             cancellationToken);
-        var (content, warning) = DecodeIndexableContent(bytes, relativePath);
-        // Normalize line endings to LF in one pass / 改行を1パスでLFに正規化
-        content = NormalizeLineEndings(content);
-        // Strip every line-leading UTF-8 BOM (U+FEFF): the leading BOM at offset 0
-        // and any BOM that immediately follows a `\n` (e.g. from accidental file
-        // concatenation or tool insertion). Leading BOM alone would make `^\s*`-
-        // anchored regexes silently miss line-1 declarations in BOM-prefixed
-        // Windows-authored sources; a BOM at the start of a mid-file line would
-        // additionally leak a phantom glyph through `search` / `excerpt` chunk
-        // output. Non-line-leading U+FEFF (Unicode 3.2+ ZWNBSP inside a string
-        // literal, identifier, or comment — e.g. `const s = "A\uFEFFB"`) is kept
-        // verbatim: stripping it would corrupt content fidelity for intentional
-        // mid-line ZWNBSP use. The checksum is computed after this canonicalization
-        // so freshness decisions match stored chunk/symbol line metadata. Closes #183/#1467.
-        // 行頭の UTF-8 BOM (U+FEFF) だけを剥がす — オフセット 0 の先頭 BOM と、
-        // `\n` の直後にある BOM (ファイル連結やツール挿入で発生) が対象。先頭 BOM
-        // だけでも行指向の `^\s*` 固定正規表現で BOM 付き Windows 作成ソースの
-        // 1 行目宣言を黙って取りこぼし、mid-file 行頭 BOM は `search` / `excerpt`
-        // のチャンク出力にそのまま幽霊グリフを漏らす。行頭以外の U+FEFF
-        // (Unicode 3.2+ の ZWNBSP を文字列リテラル・識別子・コメントで意図的に
-        // 使用しているケース、例: `const s = "A\uFEFFB"`) はそのまま保持する:
-        // これを剥がすと mid-line ZWNBSP の意図的利用に対して内容が壊れる。
-        // checksum はこの canonicalization 後に算出し、freshness 判定と保存される
-        // chunk / symbol 行メタデータを一致させる。Closes #183/#1467。
-        content = StripLineLeadingInvisibles(content);
-        if (IsGitLfsPointer(bytes))
-            content = string.Empty;
-        var lineCount = CountPhysicalLines(content);
-        var checksum = ComputeChecksum(Encoding.UTF8.GetBytes(content));
         var record = new FileRecord
         {
             Path = normalizedRelativePath,
-            Lang = TryDetectLanguage(absolutePath, content).Language,
-            Size = sizeBytes,
-            Lines = lineCount,
-            Checksum = checksum,
-            Modified = modifiedUtc,
-            Generated = IsGeneratedCodeFile(normalizedRelativePath, content),
+            Lang = TryDetectLanguage(absolutePath, loaded.Content).Language,
+            Size = loaded.SizeBytes,
+            Lines = loaded.LineCount,
+            Checksum = loaded.Checksum,
+            Modified = loaded.ModifiedUtc,
+            Generated = IsGeneratedCodeFile(normalizedRelativePath, loaded.Content),
         };
 
-        return (record, content, bytes, warning);
-    }
-
-    private (byte[] Bytes, long SizeBytes, DateTime ModifiedUtc) ReadRawBytesWithSizeLimit(
-        string absolutePath,
-        string normalizedRelativePath,
-        CancellationToken cancellationToken)
-    {
-        // Read raw bytes through a single FileStream and cap the accumulated payload at
-        // the configured max-file limit so a file that grew between the size probe and the read can no
-        // longer bypass the cap. Splitting `FileInfo.Length` from `File.ReadAllBytes`
-        // left a TOCTOU window where an attacker (or any build/log emitter rapidly
-        // appending to a generated file) could grow a 1 MB file to multi-GB between
-        // stat and read and force the indexer into an OOM-sized allocation; reading
-        // through one open handle removes the second stat call, and the read loop's
-        // running total guarantees we never accumulate more than the configured max-file bytes
-        // regardless of how aggressively a concurrent writer extends the file.
-        // ファイルを 1 本の FileStream で開き、設定された max-file byte 上限として累積バッファを
-        // 制限することで、サイズ確認と読み込みの間にファイルが肥大化しても上限を
-        // 回避できないようにする。`FileInfo.Length` と `File.ReadAllBytes` を分離して
-        // いた従来実装では、stat と read の間に攻撃者 (もしくは自動生成ファイルを高速
-        // に追記し続けるビルド/ログ系) が 1 MB のファイルを数 GB まで肥大化させて
-        // インデクサに巨大確保を強制できる TOCTOU 経路があったが、1 本のオープン
-        // ハンドルで読むことで 2 回目の stat を排除し、ループ側の総バイト数チェック
-        // により並行追記がどれほど激しくても設定上限以上の確保は発生しない。
-        byte[] bytes;
-        long sizeBytes;
-        DateTime modifiedUtc;
-        var ioPath = LongPath.EnsureWindowsPrefix(absolutePath);
-        for (var attempt = 0; ; attempt++)
-        {
-            var modifiedBeforeRead = File.GetLastWriteTimeUtc(ioPath);
-            using (var stream = new FileStream(
-                ioPath,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.Read,
-                bufferSize: 4096,
-                useAsync: false))
-            {
-                var initialLength = stream.Length;
-                if (initialLength > _maxFileSizeBytes)
-                    throw new FileTooLargeSkippedException(
-                        normalizedRelativePath,
-                        initialLength,
-                        _maxFileSizeBytes,
-                        BuildFileTooLargeMessage(initialLength, grewDuringRead: false));
-
-                // Pre-size the accumulator to the observed length but cap initial capacity
-                // at the configured limit so a tampered Length cannot force a huge up-front allocation.
-                // 初期容量は観測した長さに合わせるが設定上限で打ち切り、Length を偽装
-                // されても巨大な事前確保を起こさないようにする。
-                var initialCapacity = (int)Math.Min(initialLength, _maxFileSizeBytes);
-                using var accumulator = new MemoryStream(initialCapacity);
-                var buffer = new byte[81920];
-                long total = 0;
-                int read;
-                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    total += read;
-                    if (total > _maxFileSizeBytes)
-                        throw new FileTooLargeSkippedException(
-                            normalizedRelativePath,
-                            total,
-                            _maxFileSizeBytes,
-                            BuildFileTooLargeMessage(total, grewDuringRead: true));
-                    accumulator.Write(buffer, 0, read);
-                }
-                bytes = accumulator.ToArray();
-                sizeBytes = total;
-            }
-            modifiedUtc = File.GetLastWriteTimeUtc(ioPath);
-            if (modifiedUtc == modifiedBeforeRead || attempt > 0)
-                break;
-        }
-
-        return (bytes, sizeBytes, modifiedUtc);
-    }
-
-    private static (string Content, string? Warning) DecodeIndexableContent(byte[] bytes, string relativePath)
-    {
-        var isUtf16Encoded = TryDetectUtf16Encoding(bytes, allowHeuristic: true, out var utf16BigEndian, out var hasUtf16Bom);
-
-        if (!isUtf16Encoded && ContainsIndexBlockingNullByte(bytes))
-            throw new BinaryFileSkippedException($"{relativePath}: binary file skipped because it contains NULL bytes");
-
-        // BOM-based encoding detection: UTF-16 LE/BE source files are otherwise mangled
-        // by the UTF-8 decoder (every other byte is U+FFFD or NUL), silently dropping
-        // every symbol they declare. UTF-32 LE shares the first two bytes with UTF-16 LE
-        // (FF FE [00 00]), so we exclude that prefix from the UTF-16 LE path rather than
-        // misclassify a UTF-32 LE file as UTF-16 LE with embedded NULs. Closes #1540.
-        // BOM ベースのエンコーディング検出: UTF-16 LE/BE のソースファイルは UTF-8
-        // デコーダで毎バイト U+FFFD / NUL に変換され、ファイル内のシンボルが丸ごと
-        // 消える。UTF-32 LE は UTF-16 LE と先頭 2 バイトを共有する (FF FE [00 00])
-        // ため、UTF-16 LE 経路から除外し UTF-8 fallback に流す。Closes #1540.
-        if (isUtf16Encoded)
-        {
-            var content = new UnicodeEncoding(utf16BigEndian, byteOrderMark: hasUtf16Bom, throwOnInvalidBytes: false)
-                .GetString(bytes);
-            return (content, null);
-        }
-
-        try
-        {
-            return (new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(bytes), null);
-        }
-        catch (DecoderFallbackException)
-        {
-            // Fall back to replacement mode but warn / 置換モードにフォールバックし警告
-            var content = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(bytes);
-            return (content, $"{relativePath}: contains invalid UTF-8 bytes (replaced with U+FFFD)");
-        }
+        return (record, loaded.Content, loaded.RawBytes, loaded.Warning);
     }
 
     public FileRecord BuildSkippedFileRecord(string absolutePath)
@@ -3508,48 +3370,7 @@ public class FileIndexer
     }
 
     internal static string NormalizeLineEndings(string content)
-    {
-        var firstCarriageReturn = content.IndexOf('\r');
-        if (firstCarriageReturn < 0)
-            return content;
-
-        var builder = new StringBuilder(content.Length);
-        builder.Append(content, 0, firstCarriageReturn);
-
-        for (var index = firstCarriageReturn; index < content.Length; index++)
-        {
-            if (content[index] != '\r')
-            {
-                builder.Append(content[index]);
-                continue;
-            }
-
-            builder.Append('\n');
-            if (index + 1 < content.Length && content[index + 1] == '\n')
-                index++;
-        }
-
-        return builder.ToString();
-    }
-
-    private string BuildFileTooLargeMessage(long actualBytes, bool grewDuringRead)
-    {
-        var actual = FormatBytesForError(actualBytes);
-        var limit = FormatBytesForError(_maxFileSizeBytes);
-        var observed = grewDuringRead
-            ? $"File too large (> {limit} limit; grew during read)"
-            : $"File too large ({actual} > {limit} limit)";
-        return $"{observed}. Override with --max-file-bytes <bytes> or {MaxFileSizeEnvironmentVariable}=<bytes> when this source file is intentionally indexable.";
-    }
-
-    private static string FormatBytesForError(long bytes)
-    {
-        if (bytes % (1024L * 1024L) == 0)
-            return $"{bytes / 1024L / 1024L} MiB";
-        if (bytes % 1024L == 0)
-            return $"{bytes / 1024L} KiB";
-        return $"{bytes} bytes";
-    }
+        => FileContentLoader.NormalizeLineEndings(content);
 
     /// <summary>
     /// Strip every line-leading UTF-8 BOM (U+FEFF) and zero-width space (U+200B).
@@ -3560,125 +3381,10 @@ public class FileIndexer
     /// 行頭以外の不可視文字はそのまま保持する。
     /// </summary>
     internal static string StripLineLeadingInvisibles(string content)
-    {
-        if (string.IsNullOrEmpty(content))
-            return content;
-        // Fast path: invisible-free files (the dominant case) skip the line-tracking
-        // scan and return the input unchanged so no StringBuilder is allocated.
-        // 高速パス: 対象の不可視文字が一切無いファイル (支配的ケース) は行頭追跡走査を
-        // 回避し、入力をそのまま返して StringBuilder を確保しない。
-        if (!content.Contains('\uFEFF') && !content.Contains('\u200B'))
-            return content;
-
-        // A target invisible is present somewhere. Locate the first line-leading
-        // occurrence in a single pass; if every occurrence is mid-line, return
-        // the input unchanged so the no-strip path also avoids any allocation.
-        // 対象の不可視文字が含まれている。最初の「行頭」出現を 1 パスで探し、行頭
-        // 以外のみであれば入力をそのまま返し、「剥がし不要」のケースでも割り当てを
-        // 発生させない。
-        int firstStripIndex = -1;
-        bool atLineStart = true;
-        for (int i = 0; i < content.Length; i++)
-        {
-            char c = content[i];
-            if (IsLineLeadingInvisible(c) && atLineStart)
-            {
-                firstStripIndex = i;
-                break;
-            }
-            atLineStart = c == '\n';
-        }
-        if (firstStripIndex < 0)
-            return content;
-
-        // Allocate only after at least one line-leading invisible is confirmed.
-        // The capacity accounts for stripping at least the char at firstStripIndex.
-        // 少なくとも 1 つの行頭不可視文字が確定した時点で初めて確保する。容量は
-        // firstStripIndex の文字を必ず剥がす分を差し引いた値にしておく。
-        var sb = new StringBuilder(content.Length - 1);
-        if (firstStripIndex > 0)
-            sb.Append(content, 0, firstStripIndex);
-        // The char at firstStripIndex is itself a line-leading invisible; resume
-        // after it with atLineStart = true so consecutive BOMs at the same
-        // logical position (e.g. multiple markers right after `\n`) are stripped.
-        // firstStripIndex の文字自体が行頭不可視文字。直後から再開し atLineStart を
-        // true に戻すことで `\n` 直後に連続する marker も同じ論理位置として剥がす。
-        atLineStart = true;
-        for (int i = firstStripIndex + 1; i < content.Length; i++)
-        {
-            char c = content[i];
-            if (IsLineLeadingInvisible(c) && atLineStart)
-                continue;
-            sb.Append(c);
-            atLineStart = c == '\n';
-        }
-        return sb.ToString();
-    }
-
-    private static bool IsLineLeadingInvisible(char c) => c is '\uFEFF' or '\u200B';
+        => FileContentLoader.StripLineLeadingInvisibles(content);
 
     internal static bool IsGitLfsPointer(byte[] rawBytes)
-    {
-        if (rawBytes.Length == 0 || rawBytes.Length >= GitLfsPointerMaxBytes)
-            return false;
-
-        var pointerText = Encoding.UTF8.GetString(rawBytes).Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
-        var lines = pointerText.Split('\n');
-        if (lines.Length > 0 && lines[^1].Length == 0)
-            lines = lines[..^1];
-        if (lines.Length < 3)
-            return false;
-        if (!string.Equals(lines[0], "version https://git-lfs.github.com/spec/v1", StringComparison.Ordinal))
-            return false;
-
-        var lineIndex = 1;
-        while (lineIndex < lines.Length && lines[lineIndex].StartsWith("ext-", StringComparison.Ordinal))
-            lineIndex++;
-
-        if (lineIndex + 1 >= lines.Length)
-            return false;
-        if (!IsGitLfsSha256OidLine(lines[lineIndex]))
-            return false;
-        lineIndex++;
-        if (!IsGitLfsSizeLine(lines[lineIndex]))
-            return false;
-
-        return lineIndex == lines.Length - 1;
-    }
-
-    private static bool IsGitLfsSha256OidLine(string line)
-    {
-        const string prefix = "oid sha256:";
-        if (!line.StartsWith(prefix, StringComparison.Ordinal))
-            return false;
-
-        var hash = line.AsSpan(prefix.Length);
-        if (hash.Length != 64)
-            return false;
-        foreach (var c in hash)
-        {
-            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
-                return false;
-        }
-        return true;
-    }
-
-    private static bool IsGitLfsSizeLine(string line)
-    {
-        const string prefix = "size ";
-        if (!line.StartsWith(prefix, StringComparison.Ordinal))
-            return false;
-
-        var size = line.AsSpan(prefix.Length);
-        if (size.Length == 0)
-            return false;
-        foreach (var c in size)
-        {
-            if (c < '0' || c > '9')
-                return false;
-        }
-        return true;
-    }
+        => FileContentLoader.IsGitLfsPointer(rawBytes);
 
     /// <summary>
     /// Validate file content for encoding issues.
@@ -4200,87 +3906,14 @@ public class FileIndexer
     }
 
     internal static bool ContainsIndexBlockingNullByte(byte[] rawBytes)
-    {
-        return !TryDetectUtf16Encoding(rawBytes, allowHeuristic: true, out _, out _) && rawBytes.Any(b => b == 0);
-    }
+        => FileContentLoader.ContainsIndexBlockingNullByte(rawBytes);
 
     internal static bool TryDetectUtf16Encoding(
         byte[] rawBytes,
         bool allowHeuristic,
         out bool bigEndian,
         out bool hasBom)
-    {
-        bigEndian = false;
-        hasBom = false;
-
-        if (rawBytes.Length >= 2 && rawBytes[0] == 0xFE && rawBytes[1] == 0xFF)
-        {
-            bigEndian = true;
-            hasBom = true;
-            return true;
-        }
-
-        if (rawBytes.Length >= 2 && rawBytes[0] == 0xFF && rawBytes[1] == 0xFE
-            && !(rawBytes.Length >= 4 && rawBytes[2] == 0x00 && rawBytes[3] == 0x00))
-        {
-            hasBom = true;
-            return true;
-        }
-
-        if (!allowHeuristic || rawBytes.Length < 4)
-            return false;
-
-        var sampleLength = Math.Min(rawBytes.Length, 4096);
-        sampleLength -= sampleLength % 2;
-        var pairs = sampleLength / 2;
-        if (pairs == 0)
-            return false;
-
-        var evenNulls = 0;
-        var oddNulls = 0;
-        var oddTextBytes = 0;
-        var evenTextBytes = 0;
-        for (var i = 0; i < sampleLength; i += 2)
-        {
-            if (rawBytes[i] == 0)
-                evenNulls++;
-            if (rawBytes[i + 1] == 0)
-                oddNulls++;
-            if (IsLikelyTextByte(rawBytes[i + 1]))
-                oddTextBytes++;
-            if (IsLikelyTextByte(rawBytes[i]))
-                evenTextBytes++;
-        }
-
-        const double NullParityThreshold = 0.30;
-        const double OppositeNullThreshold = 0.01;
-        const double TextByteThreshold = 0.80;
-        var beScore = (double)evenNulls / pairs;
-        var leScore = (double)oddNulls / pairs;
-        var beOppositeScore = (double)oddNulls / pairs;
-        var leOppositeScore = (double)evenNulls / pairs;
-
-        if (beScore >= NullParityThreshold
-            && beOppositeScore <= OppositeNullThreshold
-            && (double)oddTextBytes / pairs >= TextByteThreshold)
-        {
-            bigEndian = true;
-            return true;
-        }
-
-        if (leScore >= NullParityThreshold
-            && leOppositeScore <= OppositeNullThreshold
-            && (double)evenTextBytes / pairs >= TextByteThreshold)
-        {
-            bigEndian = false;
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsLikelyTextByte(byte value)
-        => value is 0x09 or 0x0A or 0x0D || value >= 0x20;
+        => FileContentLoader.TryDetectUtf16Encoding(rawBytes, allowHeuristic, out bigEndian, out hasBom);
 
     internal sealed class BinaryFileSkippedException(string message) : InvalidOperationException(message);
 
@@ -4454,115 +4087,10 @@ public class FileIndexer
     /// 正規化後バイトのフルコピーを追加で確保しない。Closes #1544.
     /// </summary>
     internal static string ComputeChecksum(byte[] bytes)
-    {
-        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-        var pendingCarriageReturn = false;
-        AppendNormalizedChecksumBytes(hasher, bytes, ref pendingCarriageReturn);
-        FlushPendingChecksumCarriageReturn(hasher, ref pendingCarriageReturn);
-        return FinishChecksum(hasher);
-    }
+        => FileContentLoader.ComputeChecksum(bytes);
 
     internal static bool TryComputeChecksum(string filePath, long maxBytes, out string checksum)
-    {
-        if (maxBytes < 0)
-            throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "Maximum byte count must be non-negative.");
-
-        checksum = string.Empty;
-        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-        using var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: 81920,
-            options: FileOptions.SequentialScan);
-
-        var buffer = new byte[81920];
-        var pendingCarriageReturn = false;
-        long total = 0;
-        while (true)
-        {
-            var read = stream.Read(buffer, 0, buffer.Length);
-            if (read == 0)
-                break;
-
-            total += read;
-            if (total > maxBytes)
-                return false;
-
-            AppendNormalizedChecksumBytes(hasher, buffer.AsSpan(0, read), ref pendingCarriageReturn);
-        }
-
-        FlushPendingChecksumCarriageReturn(hasher, ref pendingCarriageReturn);
-        checksum = FinishChecksum(hasher);
-        return true;
-    }
-
-    private static void AppendNormalizedChecksumBytes(
-        IncrementalHash hasher,
-        ReadOnlySpan<byte> bytes,
-        ref bool pendingCarriageReturn)
-    {
-        Span<byte> normalized = stackalloc byte[4096];
-        var n = 0;
-
-        if (pendingCarriageReturn)
-        {
-            if (bytes.Length > 0 && bytes[0] == 0x0A)
-                bytes = bytes[1..];
-            normalized[n++] = 0x0A;
-            pendingCarriageReturn = false;
-        }
-
-        for (var i = 0; i < bytes.Length; i++)
-        {
-            var b = bytes[i];
-            if (b == 0x0D)
-            {
-                if (i + 1 == bytes.Length)
-                {
-                    pendingCarriageReturn = true;
-                    continue;
-                }
-
-                normalized[n++] = 0x0A;
-                if (i + 1 < bytes.Length && bytes[i + 1] == 0x0A)
-                    i++;
-            }
-            else
-            {
-                normalized[n++] = b;
-            }
-
-            if (n == normalized.Length)
-            {
-                hasher.AppendData(normalized);
-                n = 0;
-            }
-        }
-
-        if (n > 0)
-            hasher.AppendData(normalized[..n]);
-    }
-
-    private static void FlushPendingChecksumCarriageReturn(IncrementalHash hasher, ref bool pendingCarriageReturn)
-    {
-        if (!pendingCarriageReturn)
-            return;
-
-        Span<byte> lineFeed = stackalloc byte[1];
-        lineFeed[0] = 0x0A;
-        hasher.AppendData(lineFeed);
-        pendingCarriageReturn = false;
-    }
-
-    private static string FinishChecksum(IncrementalHash hasher)
-    {
-        Span<byte> hash = stackalloc byte[32];
-        if (!hasher.TryGetHashAndReset(hash, out var written) || written != hash.Length)
-            throw new InvalidOperationException("SHA256 produced an unexpected hash length");
-        return Convert.ToHexString(hash).ToLowerInvariant();
-    }
+        => FileContentLoader.TryComputeChecksum(filePath, maxBytes, out checksum);
 
     /// <summary>
     /// Try to infer a language from an extensionless script shebang.

--- a/tests/CodeIndex.Tests/DbConnectionPolicyTests.cs
+++ b/tests/CodeIndex.Tests/DbConnectionPolicyTests.cs
@@ -1,0 +1,63 @@
+using System.Data;
+using CodeIndex.Database;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Tests;
+
+public class DbConnectionPolicyTests
+{
+    [Fact]
+    public void DbConnectionFactory_OpenWithRetry_OpensConnection()
+    {
+        using var connection = DbConnectionFactory.OpenWithRetry(
+            () => new SqliteConnection("Data Source=:memory:"),
+            static connection => connection.Open(),
+            maxOpenAttempts: 1,
+            dbPath: ":memory:");
+
+        Assert.Equal(ConnectionState.Open, connection.State);
+    }
+
+    [Fact]
+    public void DbConnectionFactory_ToReadOnlyUri_AppendsOnlyMissingReadOnlyFlags()
+    {
+        var uri = DbConnectionFactory.ToReadOnlyUri("file:///tmp/codeindex.db?mode=ro");
+
+        Assert.Equal("file:///tmp/codeindex.db?mode=ro&immutable=1", uri);
+    }
+
+    [Fact]
+    public void DbPragmaPolicy_ApplyConnectionPerformancePragmas_EmitsConfiguredStatements()
+    {
+        var statements = new List<string>();
+
+        DbPragmaPolicy.ApplyConnectionPerformancePragmas(
+            statements.Add,
+            new DbConnectionPragmaSettings(CacheSizeKb: 4096, MmapSizeBytes: 8192));
+
+        Assert.Equal(
+            [
+                "PRAGMA cache_size=-4096",
+                "PRAGMA temp_store=MEMORY",
+                "PRAGMA mmap_size=8192",
+            ],
+            statements);
+    }
+
+    [Fact]
+    public void DbPragmaPolicy_ApplyConnectionPerformancePragmas_SkipsMmapWhenUnavailable()
+    {
+        var statements = new List<string>();
+
+        DbPragmaPolicy.ApplyConnectionPerformancePragmas(
+            statements.Add,
+            new DbConnectionPragmaSettings(CacheSizeKb: 2048, MmapSizeBytes: null));
+
+        Assert.Equal(
+            [
+                "PRAGMA cache_size=-2048",
+                "PRAGMA temp_store=MEMORY",
+            ],
+            statements);
+    }
+}

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -4340,6 +4340,30 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void FileContentLoader_Load_CanonicalizesContentBeforeChecksum()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var path = Path.Combine(tempDir, "sample.cs");
+            File.WriteAllBytes(path, Encoding.UTF8.GetBytes("a\r\n\uFEFFb\r"));
+
+            var loader = new FileContentLoader(FileIndexer.DefaultMaxFileSizeBytes);
+            var loaded = loader.Load(path, "sample.cs", "sample.cs", CancellationToken.None);
+
+            Assert.Equal("a\nb\n", loaded.Content);
+            Assert.Equal(FileIndexer.CountPhysicalLines(loaded.Content), loaded.LineCount);
+            Assert.Equal(FileIndexer.ComputeChecksum(Encoding.UTF8.GetBytes(loaded.Content)), loaded.Checksum);
+            Assert.Null(loaded.Warning);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void ComputeChecksum_MixedLineEndings_NormalizesToLf()
     {
         // Direct-call coverage: mixed CRLF / CR / LF lines all collapse to LF before


### PR DESCRIPTION
## Summary
- Extract file byte loading, decoding, line normalization, LFS pointer handling, and checksum calculation from `FileIndexer` into `FileContentLoader`.
- Extract SQLite connection/retry/read-only URI handling into `DbConnectionFactory` and connection pragma policy into `DbPragmaPolicy`, while keeping `DbContext` compatibility wrappers.
- Add focused tests and bilingual changelog fragments; update bilingual architecture/decomposition docs.

## Validation
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~FileIndexerTests|FullyQualifiedName~DbConnectionPolicyTests|FullyQualifiedName~OpenSqliteConnectionWithRetry|FullyQualifiedName~SynchronousPragma" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

Fixes #3419
Fixes #3420