### PR TITLE
Fix installer upgrade failure handling

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1202,7 +1202,7 @@ See [Exit codes](USER_GUIDE.md#exit-codes) in USER_GUIDE.
 
 ## Error code taxonomy
 
-Process exit codes are coarse (`0` success including valid zero-row queries, `1` usage, `2` not-found or strict zero-row query, `3` db, `4` feature-unavailable, `5` stale). Query commands return `0` for genuine zero-row results by default and reserve `2` for missing indexed data or callers that opt into `--strict-not-found`. Scripts, oncall runbooks, and AI agents that need to react to *which* failure happened — not just the bucket — should read the stable `Exxx_NAME` taxonomy emitted on every CLI / MCP error path. The user-facing table lives in [Error codes](USER_GUIDE.md#error-codes); this section captures the developer contract.
+Process exit codes are coarse (`0` success including valid zero-row queries, `1` usage, `2` not-found or strict zero-row query, `3` db, `4` feature-unavailable, `5` stale, `6` transient db, `7` invalid argument, `8` signal cancellation, `9` install/upgrade installer failure, `99` unhandled exception). Query commands return `0` for genuine zero-row results by default and reserve `2` for missing indexed data or callers that opt into `--strict-not-found`. Scripts, oncall runbooks, and AI agents that need to react to *which* failure happened — not just the bucket — should read the stable `Exxx_NAME` taxonomy emitted on every CLI / MCP error path. The user-facing table lives in [Error codes](USER_GUIDE.md#error-codes); this section captures the developer contract.
 
 **Where it surfaces**
 
@@ -3415,7 +3415,7 @@ USER_GUIDEの[終了コード](USER_GUIDE.md#終了コード)セクションを�
 
 ## エラーコード taxonomy
 
-プロセス終了コード（`0` 成功、`1` 引数、`2` 未検出、`3` DB、`4` 機能未提供、`5` stale）は粗い分類です。スクリプト・オンコール runbook・AI エージェントが「どのバケットか」だけでなく「どの失敗か」で分岐したい場合は、CLI / MCP のすべてのエラー経路で発行される安定した `Exxx_NAME` taxonomy を読んでください。利用者向けの一覧は [エラーコード](USER_GUIDE.md#エラーコード) にあります。本節は開発者向けの契約をまとめます。
+プロセス終了コード（`0` 成功、`1` 引数、`2` 未検出、`3` DB、`4` 機能未提供、`5` stale、`6` 一時的 DB、`7` 不正な引数値、`8` シグナルキャンセル、`9` install / upgrade installer 失敗、`99` 想定外例外）は粗い分類です。スクリプト・オンコール runbook・AI エージェントが「どのバケットか」だけでなく「どの失敗か」で分岐したい場合は、CLI / MCP のすべてのエラー経路で発行される安定した `Exxx_NAME` taxonomy を読んでください。利用者向けの一覧は [エラーコード](USER_GUIDE.md#エラーコード) にあります。本節は開発者向けの契約をまとめます。
 
 **どこに出るか**
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1410,6 +1410,7 @@ If a query itself begins with `-`, pass it as `--query <query>` or `-- <query>`.
 | `6` | Transient database error (SQLite `BUSY` / `LOCKED` / `READONLY`, retry with backoff after fixing the transient holder or mount state) |
 | `7` | Invalid argument value (for example invalid `--kind`, `--color`, or `--metrics`) |
 | `8` | Cancelled by signal / Ctrl-C (`SIGINT` / `SIGTERM`-style cancellation path) |
+| `9` | Install or upgrade installer failure (for example a failed `install.sh` start, timeout, download, checksum, or preparation step) |
 | `99` | Unhandled exception after command dispatch; run `cdidx report` and inspect the lifecycle log |
 
 ### Error codes
@@ -3860,6 +3861,7 @@ raw match density を正確に測る、といった理由で全 raw chunk hit �
 | `6` | 一時的なデータベースエラー（SQLite `BUSY` / `LOCKED` / `READONLY`。一時的な保持者や mount 状態を解消してから backoff 付き retry 推奨） |
 | `7` | 引数値が不正（例: 不正な `--kind`、`--color`、`--metrics`） |
 | `8` | シグナル / Ctrl-C によるキャンセル（`SIGINT` / `SIGTERM` 系のキャンセル経路） |
+| `9` | install / upgrade installer の失敗（例: `install.sh` 起動失敗、timeout、download、checksum、準備処理の失敗） |
 | `99` | コマンド dispatch 後の想定外例外。`cdidx report` とライフサイクルログを確認 |
 
 ### エラーコード

--- a/changelog.d/unreleased/3372.fixed.md
+++ b/changelog.d/unreleased/3372.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3372
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Upgrade cleanup now reports installer script deletion failures (#3372)** — `cdidx upgrade` emits a bounded warning when the downloaded temporary `install.sh` cannot be deleted, while keeping JSON stdout parseable.
+
+## 日本語
+
+- **upgrade cleanup が installer script の削除失敗を報告するようになりました (#3372)** — `cdidx upgrade` はダウンロードした一時 `install.sh` を削除できない場合に bounded warning を出し、JSON stdout は parse 可能なまま保ちます。

--- a/changelog.d/unreleased/3373.fixed.md
+++ b/changelog.d/unreleased/3373.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3373
+affected:
+  - src/CodeIndex/Cli/CommandExitCodes.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Upgrade preparation failures no longer report database errors (#3373)** — installer startup, timeout, and pre-install download or verification failures now return a dedicated install error exit code instead of `DatabaseError`.
+
+## 日本語
+
+- **upgrade preparation failure を database error として報告しないようにしました (#3373)** — installer 起動、timeout、install 前の download / verification failure は `DatabaseError` ではなく専用の install error exit code を返します。

--- a/changelog.d/unreleased/3376.fixed.md
+++ b/changelog.d/unreleased/3376.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3376
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Upgrade installer output capture is now bounded (#3376)** — JSON-mode upgrades drain suppressed installer stdout and stderr through fixed-size buffers instead of retaining unbounded output in memory.
+
+## 日本語
+
+- **upgrade installer の出力 capture を bounded にしました (#3376)** — JSON mode の upgrade は suppress した installer stdout/stderr を固定サイズ buffer で drain し、無制限にメモリへ保持しないようになりました。

--- a/changelog.d/unreleased/3377.fixed.md
+++ b/changelog.d/unreleased/3377.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 3377
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+---
+
+## English
+
+- **Upgrade installer timeout timers are now cancellable (#3377)** — `RunInstallerProcess` links its timeout delay to caller cancellation and cancels the delay when the installer exits first, avoiding leftover uncancellable timer work.
+
+## 日本語
+
+- **upgrade installer の timeout timer を cancel 可能にしました (#3377)** — `RunInstallerProcess` は timeout delay を呼び出し側 cancellation と連動させ、installer が先に終了した場合も delay を cancel するため、cancel できない timer 処理を残しません。

--- a/changelog.d/unreleased/3500.fixed.md
+++ b/changelog.d/unreleased/3500.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3500
+affected:
+  - install.sh
+  - install_modules/40-uninstall.sh
+  - tests/CodeIndex.Tests/InstallScriptTests.cs
+---
+
+## English
+
+- **Installer uninstall now reports removal failures (#3500)** — uninstall checks file, license-directory, and cache-directory removals, avoids successful removal messages for failed paths, and exits nonzero when cleanup is incomplete.
+
+## 日本語
+
+- **installer の uninstall が削除失敗を報告するようになりました (#3500)** — uninstall は file、license directory、cache directory の削除結果を確認し、失敗した path に成功メッセージを出さず、cleanup が不完全な場合は nonzero で終了します。

--- a/changelog.d/unreleased/3501.fixed.md
+++ b/changelog.d/unreleased/3501.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3501
+affected:
+  - install.sh
+  - install_modules/30-path-guidance.sh
+  - tests/CodeIndex.Tests/InstallScriptTests.cs
+---
+
+## English
+
+- **Installer PATH profile edits are backed up and replaced atomically (#3501)** — `CDIDX_INSTALL_UPDATE_PATH=1` now writes shell profile updates through a same-directory temporary file, backs up existing profiles, and reports the recovery paths when setup fails.
+
+## 日本語
+
+- **installer の PATH profile 編集をバックアップ付きの atomic 置換にしました (#3501)** — `CDIDX_INSTALL_UPDATE_PATH=1` は shell profile 更新を同一ディレクトリの一時ファイル経由で書き、既存 profile をバックアップし、準備に失敗した場合は復旧用 path を報告します。

--- a/install.sh
+++ b/install.sh
@@ -1629,27 +1629,41 @@ candidate_shell_profile() {
 append_path_to_shell_profile() {
     local profile_path
     profile_path="$(candidate_shell_profile)"
+    local profile_update_path
+    profile_update_path="$profile_path"
+    if [ -L "$profile_path" ]; then
+        local link_target
+        if ! link_target="$(readlink "$profile_path")" || [ -z "$link_target" ]; then
+            report_error "Failed to resolve symlinked shell profile: ${profile_path}"
+            return 1
+        fi
+        case "$link_target" in
+            /*) profile_update_path="$link_target" ;;
+            *) profile_update_path="$(dirname "$profile_path")/${link_target}" ;;
+        esac
+    fi
+
     local profile_dir
-    profile_dir="$(dirname "$profile_path")"
+    profile_dir="$(dirname "$profile_update_path")"
     if ! mkdir -p "$profile_dir"; then
         report_error "Failed to create shell profile directory: ${profile_dir}"
         return 1
     fi
 
-    if [ -f "$profile_path" ] && grep -F "export PATH=\"${INSTALL_DIR}:\$PATH\"" "$profile_path" >/dev/null 2>&1; then
-        info "PATH export already present in ${profile_path}"
+    if [ -f "$profile_update_path" ] && grep -F "export PATH=\"${INSTALL_DIR}:\$PATH\"" "$profile_update_path" >/dev/null 2>&1; then
+        info "PATH export already present in ${profile_update_path}"
         return 0
     fi
 
     local tmp_path
-    if ! tmp_path="$(mktemp "${profile_path}.cdidx-tmp.XXXXXX")"; then
-        report_error "Failed to create temporary shell profile file next to ${profile_path}"
+    if ! tmp_path="$(mktemp "${profile_update_path}.cdidx-tmp.XXXXXX")"; then
+        report_error "Failed to create temporary shell profile file next to ${profile_update_path}"
         return 1
     fi
 
-    if [ -f "$profile_path" ]; then
-        if ! cp -p "$profile_path" "$tmp_path"; then
-            report_error "Failed to copy ${profile_path} before updating PATH."
+    if [ -f "$profile_update_path" ]; then
+        if ! cp -p "$profile_update_path" "$tmp_path"; then
+            report_error "Failed to copy ${profile_update_path} before updating PATH."
             rm -f "$tmp_path"
             return 1
         fi
@@ -1670,27 +1684,27 @@ append_path_to_shell_profile() {
         return 1
     }
 
-    if [ -f "$profile_path" ]; then
+    if [ -f "$profile_update_path" ]; then
         local backup_path
-        if ! backup_path="$(mktemp "${profile_path}.cdidx-backup.XXXXXX")"; then
-            report_error "Failed to create shell profile backup path for ${profile_path}"
+        if ! backup_path="$(mktemp "${profile_update_path}.cdidx-backup.XXXXXX")"; then
+            report_error "Failed to create shell profile backup path for ${profile_update_path}"
             rm -f "$tmp_path"
             return 1
         fi
-        if ! cp -p "$profile_path" "$backup_path"; then
-            report_error "Failed to back up ${profile_path} to ${backup_path}"
+        if ! cp -p "$profile_update_path" "$backup_path"; then
+            report_error "Failed to back up ${profile_update_path} to ${backup_path}"
             rm -f "$tmp_path" "$backup_path"
             return 1
         fi
-        info "Backed up ${profile_path} to ${backup_path}"
+        info "Backed up ${profile_update_path} to ${backup_path}"
     fi
 
-    if ! mv -f "$tmp_path" "$profile_path"; then
-        report_error "Failed to atomically replace ${profile_path}. Temporary file preserved at ${tmp_path}"
+    if ! mv -f "$tmp_path" "$profile_update_path"; then
+        report_error "Failed to atomically replace ${profile_update_path}. Temporary file preserved at ${tmp_path}"
         return 1
     fi
 
-    info "Added ${INSTALL_DIR} to PATH in ${profile_path}"
+    info "Added ${INSTALL_DIR} to PATH in ${profile_update_path}"
 }
 
 check_path() {

--- a/install.sh
+++ b/install.sh
@@ -1762,6 +1762,28 @@ check_path() {
     fi
 }
 
+remove_uninstall_file() {
+    local path="$1"
+    if rm -f "$path"; then
+        info "Removed ${path}"
+        return 0
+    fi
+
+    report_error "Failed to remove install file during uninstall: ${path}"
+    return 1
+}
+
+remove_uninstall_directory() {
+    local path="$1"
+    if rm -rf "$path"; then
+        info "Removed ${path}"
+        return 0
+    fi
+
+    report_error "Failed to remove install directory during uninstall: ${path}"
+    return 1
+}
+
 uninstall_cdidx() {
     info "cdidx uninstaller"
     if ! validate_normal_install_dir; then
@@ -1770,6 +1792,7 @@ uninstall_cdidx() {
     acquire_install_lock
 
     local removed=0
+    local removal_failed=0
     local path
     local cache_dir=""
     if [ "$PURGE_CACHE_ON_UNINSTALL" = "1" ]; then
@@ -1789,24 +1812,35 @@ uninstall_cdidx() {
         "${INSTALL_DIR}/TRADEMARKS.md" \
         "${INSTALL_DIR}/MANIFEST.sha256"; do
         if [ -e "$path" ]; then
-            rm -f "$path"
-            info "Removed ${path}"
-            removed=1
+            if remove_uninstall_file "$path"; then
+                removed=1
+            else
+                removal_failed=1
+            fi
         fi
     done
 
     if [ -d "${INSTALL_DIR}/LICENSES" ]; then
-        rm -rf "${INSTALL_DIR}/LICENSES"
-        info "Removed ${INSTALL_DIR}/LICENSES"
-        removed=1
+        if remove_uninstall_directory "${INSTALL_DIR}/LICENSES"; then
+            removed=1
+        else
+            removal_failed=1
+        fi
     fi
 
     if [ "$PURGE_CACHE_ON_UNINSTALL" = "1" ]; then
         if [ -d "$cache_dir" ]; then
-            rm -rf "$cache_dir"
-            info "Removed ${cache_dir}"
-            removed=1
+            if remove_uninstall_directory "$cache_dir"; then
+                removed=1
+            else
+                removal_failed=1
+            fi
         fi
+    fi
+
+    if [ "$removal_failed" = "1" ]; then
+        report_error "Uninstall incomplete because one or more files or directories could not be removed."
+        return 1
     fi
 
     if [ "$removed" = "0" ]; then

--- a/install.sh
+++ b/install.sh
@@ -1629,17 +1629,66 @@ candidate_shell_profile() {
 append_path_to_shell_profile() {
     local profile_path
     profile_path="$(candidate_shell_profile)"
-    mkdir -p "$(dirname "$profile_path")"
+    local profile_dir
+    profile_dir="$(dirname "$profile_path")"
+    if ! mkdir -p "$profile_dir"; then
+        report_error "Failed to create shell profile directory: ${profile_dir}"
+        return 1
+    fi
 
     if [ -f "$profile_path" ] && grep -F "export PATH=\"${INSTALL_DIR}:\$PATH\"" "$profile_path" >/dev/null 2>&1; then
         info "PATH export already present in ${profile_path}"
         return 0
     fi
 
+    local tmp_path
+    if ! tmp_path="$(mktemp "${profile_path}.cdidx-tmp.XXXXXX")"; then
+        report_error "Failed to create temporary shell profile file next to ${profile_path}"
+        return 1
+    fi
+
+    if [ -f "$profile_path" ]; then
+        if ! cp -p "$profile_path" "$tmp_path"; then
+            report_error "Failed to copy ${profile_path} before updating PATH."
+            rm -f "$tmp_path"
+            return 1
+        fi
+    else
+        if ! : > "$tmp_path"; then
+            report_error "Failed to initialize temporary shell profile file: ${tmp_path}"
+            rm -f "$tmp_path"
+            return 1
+        fi
+    fi
+
     {
         printf '\n# Added by cdidx installer\n'
         printf 'export PATH="%s:$PATH"\n' "$INSTALL_DIR"
-    } >> "$profile_path"
+    } >> "$tmp_path" || {
+        report_error "Failed to append PATH update to temporary shell profile file: ${tmp_path}"
+        rm -f "$tmp_path"
+        return 1
+    }
+
+    if [ -f "$profile_path" ]; then
+        local backup_path
+        if ! backup_path="$(mktemp "${profile_path}.cdidx-backup.XXXXXX")"; then
+            report_error "Failed to create shell profile backup path for ${profile_path}"
+            rm -f "$tmp_path"
+            return 1
+        fi
+        if ! cp -p "$profile_path" "$backup_path"; then
+            report_error "Failed to back up ${profile_path} to ${backup_path}"
+            rm -f "$tmp_path" "$backup_path"
+            return 1
+        fi
+        info "Backed up ${profile_path} to ${backup_path}"
+    fi
+
+    if ! mv -f "$tmp_path" "$profile_path"; then
+        report_error "Failed to atomically replace ${profile_path}. Temporary file preserved at ${tmp_path}"
+        return 1
+    fi
 
     info "Added ${INSTALL_DIR} to PATH in ${profile_path}"
 }

--- a/install_modules/30-path-guidance.sh
+++ b/install_modules/30-path-guidance.sh
@@ -45,17 +45,66 @@ candidate_shell_profile() {
 append_path_to_shell_profile() {
     local profile_path
     profile_path="$(candidate_shell_profile)"
-    mkdir -p "$(dirname "$profile_path")"
+    local profile_dir
+    profile_dir="$(dirname "$profile_path")"
+    if ! mkdir -p "$profile_dir"; then
+        report_error "Failed to create shell profile directory: ${profile_dir}"
+        return 1
+    fi
 
     if [ -f "$profile_path" ] && grep -F "export PATH=\"${INSTALL_DIR}:\$PATH\"" "$profile_path" >/dev/null 2>&1; then
         info "PATH export already present in ${profile_path}"
         return 0
     fi
 
+    local tmp_path
+    if ! tmp_path="$(mktemp "${profile_path}.cdidx-tmp.XXXXXX")"; then
+        report_error "Failed to create temporary shell profile file next to ${profile_path}"
+        return 1
+    fi
+
+    if [ -f "$profile_path" ]; then
+        if ! cp -p "$profile_path" "$tmp_path"; then
+            report_error "Failed to copy ${profile_path} before updating PATH."
+            rm -f "$tmp_path"
+            return 1
+        fi
+    else
+        if ! : > "$tmp_path"; then
+            report_error "Failed to initialize temporary shell profile file: ${tmp_path}"
+            rm -f "$tmp_path"
+            return 1
+        fi
+    fi
+
     {
         printf '\n# Added by cdidx installer\n'
         printf 'export PATH="%s:$PATH"\n' "$INSTALL_DIR"
-    } >> "$profile_path"
+    } >> "$tmp_path" || {
+        report_error "Failed to append PATH update to temporary shell profile file: ${tmp_path}"
+        rm -f "$tmp_path"
+        return 1
+    }
+
+    if [ -f "$profile_path" ]; then
+        local backup_path
+        if ! backup_path="$(mktemp "${profile_path}.cdidx-backup.XXXXXX")"; then
+            report_error "Failed to create shell profile backup path for ${profile_path}"
+            rm -f "$tmp_path"
+            return 1
+        fi
+        if ! cp -p "$profile_path" "$backup_path"; then
+            report_error "Failed to back up ${profile_path} to ${backup_path}"
+            rm -f "$tmp_path" "$backup_path"
+            return 1
+        fi
+        info "Backed up ${profile_path} to ${backup_path}"
+    fi
+
+    if ! mv -f "$tmp_path" "$profile_path"; then
+        report_error "Failed to atomically replace ${profile_path}. Temporary file preserved at ${tmp_path}"
+        return 1
+    fi
 
     info "Added ${INSTALL_DIR} to PATH in ${profile_path}"
 }

--- a/install_modules/30-path-guidance.sh
+++ b/install_modules/30-path-guidance.sh
@@ -45,27 +45,41 @@ candidate_shell_profile() {
 append_path_to_shell_profile() {
     local profile_path
     profile_path="$(candidate_shell_profile)"
+    local profile_update_path
+    profile_update_path="$profile_path"
+    if [ -L "$profile_path" ]; then
+        local link_target
+        if ! link_target="$(readlink "$profile_path")" || [ -z "$link_target" ]; then
+            report_error "Failed to resolve symlinked shell profile: ${profile_path}"
+            return 1
+        fi
+        case "$link_target" in
+            /*) profile_update_path="$link_target" ;;
+            *) profile_update_path="$(dirname "$profile_path")/${link_target}" ;;
+        esac
+    fi
+
     local profile_dir
-    profile_dir="$(dirname "$profile_path")"
+    profile_dir="$(dirname "$profile_update_path")"
     if ! mkdir -p "$profile_dir"; then
         report_error "Failed to create shell profile directory: ${profile_dir}"
         return 1
     fi
 
-    if [ -f "$profile_path" ] && grep -F "export PATH=\"${INSTALL_DIR}:\$PATH\"" "$profile_path" >/dev/null 2>&1; then
-        info "PATH export already present in ${profile_path}"
+    if [ -f "$profile_update_path" ] && grep -F "export PATH=\"${INSTALL_DIR}:\$PATH\"" "$profile_update_path" >/dev/null 2>&1; then
+        info "PATH export already present in ${profile_update_path}"
         return 0
     fi
 
     local tmp_path
-    if ! tmp_path="$(mktemp "${profile_path}.cdidx-tmp.XXXXXX")"; then
-        report_error "Failed to create temporary shell profile file next to ${profile_path}"
+    if ! tmp_path="$(mktemp "${profile_update_path}.cdidx-tmp.XXXXXX")"; then
+        report_error "Failed to create temporary shell profile file next to ${profile_update_path}"
         return 1
     fi
 
-    if [ -f "$profile_path" ]; then
-        if ! cp -p "$profile_path" "$tmp_path"; then
-            report_error "Failed to copy ${profile_path} before updating PATH."
+    if [ -f "$profile_update_path" ]; then
+        if ! cp -p "$profile_update_path" "$tmp_path"; then
+            report_error "Failed to copy ${profile_update_path} before updating PATH."
             rm -f "$tmp_path"
             return 1
         fi
@@ -86,27 +100,27 @@ append_path_to_shell_profile() {
         return 1
     }
 
-    if [ -f "$profile_path" ]; then
+    if [ -f "$profile_update_path" ]; then
         local backup_path
-        if ! backup_path="$(mktemp "${profile_path}.cdidx-backup.XXXXXX")"; then
-            report_error "Failed to create shell profile backup path for ${profile_path}"
+        if ! backup_path="$(mktemp "${profile_update_path}.cdidx-backup.XXXXXX")"; then
+            report_error "Failed to create shell profile backup path for ${profile_update_path}"
             rm -f "$tmp_path"
             return 1
         fi
-        if ! cp -p "$profile_path" "$backup_path"; then
-            report_error "Failed to back up ${profile_path} to ${backup_path}"
+        if ! cp -p "$profile_update_path" "$backup_path"; then
+            report_error "Failed to back up ${profile_update_path} to ${backup_path}"
             rm -f "$tmp_path" "$backup_path"
             return 1
         fi
-        info "Backed up ${profile_path} to ${backup_path}"
+        info "Backed up ${profile_update_path} to ${backup_path}"
     fi
 
-    if ! mv -f "$tmp_path" "$profile_path"; then
-        report_error "Failed to atomically replace ${profile_path}. Temporary file preserved at ${tmp_path}"
+    if ! mv -f "$tmp_path" "$profile_update_path"; then
+        report_error "Failed to atomically replace ${profile_update_path}. Temporary file preserved at ${tmp_path}"
         return 1
     fi
 
-    info "Added ${INSTALL_DIR} to PATH in ${profile_path}"
+    info "Added ${INSTALL_DIR} to PATH in ${profile_update_path}"
 }
 
 check_path() {

--- a/install_modules/40-uninstall.sh
+++ b/install_modules/40-uninstall.sh
@@ -1,4 +1,26 @@
 
+remove_uninstall_file() {
+    local path="$1"
+    if rm -f "$path"; then
+        info "Removed ${path}"
+        return 0
+    fi
+
+    report_error "Failed to remove install file during uninstall: ${path}"
+    return 1
+}
+
+remove_uninstall_directory() {
+    local path="$1"
+    if rm -rf "$path"; then
+        info "Removed ${path}"
+        return 0
+    fi
+
+    report_error "Failed to remove install directory during uninstall: ${path}"
+    return 1
+}
+
 uninstall_cdidx() {
     info "cdidx uninstaller"
     if ! validate_normal_install_dir; then
@@ -7,6 +29,7 @@ uninstall_cdidx() {
     acquire_install_lock
 
     local removed=0
+    local removal_failed=0
     local path
     local cache_dir=""
     if [ "$PURGE_CACHE_ON_UNINSTALL" = "1" ]; then
@@ -26,24 +49,35 @@ uninstall_cdidx() {
         "${INSTALL_DIR}/TRADEMARKS.md" \
         "${INSTALL_DIR}/MANIFEST.sha256"; do
         if [ -e "$path" ]; then
-            rm -f "$path"
-            info "Removed ${path}"
-            removed=1
+            if remove_uninstall_file "$path"; then
+                removed=1
+            else
+                removal_failed=1
+            fi
         fi
     done
 
     if [ -d "${INSTALL_DIR}/LICENSES" ]; then
-        rm -rf "${INSTALL_DIR}/LICENSES"
-        info "Removed ${INSTALL_DIR}/LICENSES"
-        removed=1
+        if remove_uninstall_directory "${INSTALL_DIR}/LICENSES"; then
+            removed=1
+        else
+            removal_failed=1
+        fi
     fi
 
     if [ "$PURGE_CACHE_ON_UNINSTALL" = "1" ]; then
         if [ -d "$cache_dir" ]; then
-            rm -rf "$cache_dir"
-            info "Removed ${cache_dir}"
-            removed=1
+            if remove_uninstall_directory "$cache_dir"; then
+                removed=1
+            else
+                removal_failed=1
+            fi
         fi
+    fi
+
+    if [ "$removal_failed" = "1" ]; then
+        report_error "Uninstall incomplete because one or more files or directories could not be removed."
+        return 1
     fi
 
     if [ "$removed" = "0" ]; then

--- a/src/CodeIndex/Cli/CommandExitCodes.cs
+++ b/src/CodeIndex/Cli/CommandExitCodes.cs
@@ -15,6 +15,7 @@ public static class CommandExitCodes
     public const int TransientDatabaseError = 6;
     public const int InvalidArgument = 7;
     public const int CancelledBySignal = 8;
+    public const int InstallError = 9;
     public const int UnhandledException = 99;
     public const int ExUsage = 64;
     public const int Interrupted = CancelledBySignal;

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -3521,13 +3521,19 @@ internal static class ProgramRunner
         try
         {
             var waitTask = process.WaitForExitAsync(cancellationToken);
-            var timeoutTask = Task.Delay(ToWaitMilliseconds(timeout));
-            if (Task.WhenAny(waitTask, timeoutTask).GetAwaiter().GetResult() == waitTask)
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var timeoutTask = Task.Delay(ToWaitMilliseconds(timeout), timeoutCts.Token);
+            var completedTask = Task.WhenAny(waitTask, timeoutTask).GetAwaiter().GetResult();
+            if (completedTask == waitTask)
             {
+                timeoutCts.Cancel();
                 waitTask.GetAwaiter().GetResult();
                 outputDrainTask.GetAwaiter().GetResult();
                 return process.ExitCode;
             }
+
+            if (cancellationToken.IsCancellationRequested)
+                waitTask.GetAwaiter().GetResult();
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -45,6 +45,7 @@ internal static class ProgramRunner
     internal static Func<HttpClient> UpgradeHttpClientFactory { get; set; } = CreateUpgradeHttpClient;
     internal static Action<string>? TestExtractorFileLengthCheckedForTesting { get; set; }
     internal static Action<string>? DeleteInstallDirectoryWriteProbeForTesting { get; set; }
+    internal static Action<string>? DeleteUpgradeInstallerScriptForTesting { get; set; }
 
     private sealed record CommandRunContext(
         JsonSerializerOptions JsonOptions,
@@ -3360,7 +3361,7 @@ internal static class ProgramRunner
         finally
         {
             if (scriptPath != null)
-                try { File.Delete(scriptPath); } catch { }
+                TryDeleteUpgradeInstallerScript(scriptPath);
             if (scriptDirectory != null)
                 try { Directory.Delete(scriptDirectory, recursive: true); } catch { }
         }
@@ -3584,6 +3585,24 @@ internal static class ProgramRunner
         var buffer = new char[InstallerSuppressedOutputDrainBufferChars];
         while (await reader.ReadAsync(buffer.AsMemory()).ConfigureAwait(false) > 0)
         {
+        }
+    }
+
+    private static void TryDeleteUpgradeInstallerScript(string scriptPath)
+    {
+        try
+        {
+            if (!File.Exists(scriptPath))
+                return;
+
+            if (DeleteUpgradeInstallerScriptForTesting != null)
+                DeleteUpgradeInstallerScriptForTesting(scriptPath);
+            else
+                File.Delete(scriptPath);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Warning: failed to delete upgrade installer script {ConsoleUi.FormatBoundedValue(scriptPath)} ({CommandErrorWriter.FormatSanitizedException(ex)}).");
         }
     }
 

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -29,6 +29,7 @@ internal static class ProgramRunner
     private const string ReleaseChecksumAssetName = "sha256sums.txt";
     private const long MaxInstallerScriptBytes = 1024 * 1024;
     internal const long MaxReleaseChecksumBytes = 256 * 1024;
+    private const int InstallerSuppressedOutputDrainBufferChars = 4096;
     internal const int WorkspaceVersionPinMaxBytes = 4096;
     internal const int WorkspaceVersionPinMaxSkippedBlankLines = 16;
     internal const int WorkspaceVersionPinMaxLineChars = 256;
@@ -3515,7 +3516,7 @@ internal static class ProgramRunner
         }
 
         var outputDrainTask = suppressOutput
-            ? Task.WhenAll(process.StandardOutput.ReadToEndAsync(), process.StandardError.ReadToEndAsync())
+            ? DrainSuppressedInstallerOutputAsync(process)
             : Task.CompletedTask;
 
         try
@@ -3571,6 +3572,19 @@ internal static class ProgramRunner
         if (!suppressOutput)
             Console.Error.WriteLine("Hint: rerun `install.sh` manually for the desired release.");
         return CommandExitCodes.DatabaseError;
+    }
+
+    private static Task DrainSuppressedInstallerOutputAsync(Process process)
+        => Task.WhenAll(
+            DrainSuppressedInstallerOutputAsync(process.StandardOutput),
+            DrainSuppressedInstallerOutputAsync(process.StandardError));
+
+    private static async Task DrainSuppressedInstallerOutputAsync(TextReader reader)
+    {
+        var buffer = new char[InstallerSuppressedOutputDrainBufferChars];
+        while (await reader.ReadAsync(buffer.AsMemory()).ConfigureAwait(false) > 0)
+        {
+        }
     }
 
     private static UpgradeJsonResult CreateUpgradeJsonResult(

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -3355,7 +3355,7 @@ internal static class ProgramRunner
                 Console.Error.WriteLine($"Error: upgrade failed before install.sh completed ({ex.GetType().Name}: {ex.Message}).");
                 Console.Error.WriteLine("Hint: rerun `install.sh` manually for the desired release.");
             }
-            return CommandExitCodes.DatabaseError;
+            return CommandExitCodes.InstallError;
         }
         finally
         {
@@ -3512,7 +3512,7 @@ internal static class ProgramRunner
         {
             if (!suppressOutput)
                 Console.Error.WriteLine("Error: failed to start install.sh for upgrade.");
-            return CommandExitCodes.DatabaseError;
+            return CommandExitCodes.InstallError;
         }
 
         var outputDrainTask = suppressOutput
@@ -3571,7 +3571,7 @@ internal static class ProgramRunner
         }
         if (!suppressOutput)
             Console.Error.WriteLine("Hint: rerun `install.sh` manually for the desired release.");
-        return CommandExitCodes.DatabaseError;
+        return CommandExitCodes.InstallError;
     }
 
     private static Task DrainSuppressedInstallerOutputAsync(Process process)

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -118,6 +118,41 @@ public sealed class InstallScriptTests : IDisposable
         Assert.True(File.Exists(binaryPath));
     }
 
+    [Fact]
+    public void PathProfileUpdate_BacksUpAndAtomicallyReplacesProfile_Issue3501()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var home = Path.Combine(_tempRoot, "path_profile_home");
+        Directory.CreateDirectory(home);
+        var profilePath = Path.Combine(home, ".zshrc");
+        File.WriteAllText(profilePath, "export EXISTING=1\n");
+        var installDir = Path.Combine(_tempRoot, "path_profile_bin");
+        Directory.CreateDirectory(installDir);
+
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            "append_path_to_shell_profile",
+            new Dictionary<string, string?>
+            {
+                ["CDIDX_INSTALL_DIR"] = installDir,
+                ["HOME"] = home,
+                ["SHELL"] = "/bin/zsh",
+            });
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        Assert.Contains("Backed up", stdout);
+        Assert.Contains("Added", stdout);
+        var backups = Directory.GetFiles(home, ".zshrc.cdidx-backup.*");
+        Assert.Single(backups);
+        Assert.Equal("export EXISTING=1\n", File.ReadAllText(backups[0]));
+        var profile = File.ReadAllText(profilePath);
+        Assert.Contains("export EXISTING=1", profile);
+        Assert.Contains($"export PATH=\"{installDir}:$PATH\"", profile);
+        Assert.Empty(Directory.GetFiles(home, ".zshrc.cdidx-tmp.*"));
+    }
+
     [Theory]
     [InlineData("/")]
     [InlineData("/usr/local")]

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -89,6 +89,77 @@ public sealed class InstallScriptTests : IDisposable
     }
 
     [Fact]
+    public void Uninstall_ReportsFileRemovalFailureWithoutSuccessMessage_Issue3500()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var installDir = Path.Combine(_tempRoot, "uninstall_failure_bin");
+        Directory.CreateDirectory(installDir);
+        Directory.CreateDirectory(Path.Combine(installDir, "cdidx"));
+
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            """
+            if uninstall_cdidx; then
+                echo "UNINSTALL_OK"
+            else
+                echo "UNINSTALL_FAILED:$?"
+            fi
+            """,
+            new Dictionary<string, string?>
+            {
+                ["CDIDX_INSTALL_DIR"] = installDir,
+            });
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("UNINSTALL_FAILED:1", stdout);
+        Assert.DoesNotContain($"Removed {Path.Combine(installDir, "cdidx")}", stdout);
+        Assert.DoesNotContain("Uninstall complete", stdout);
+        Assert.Contains("Failed to remove install file during uninstall", stderr);
+        Assert.Contains("Uninstall incomplete", stderr);
+        Assert.True(Directory.Exists(Path.Combine(installDir, "cdidx")));
+    }
+
+    [Fact]
+    public void Uninstall_ReportsDirectoryRemovalFailureWithoutSuccessMessage_Issue3500()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var installDir = Path.Combine(_tempRoot, "uninstall_directory_failure_bin");
+        var licensesDir = Path.Combine(installDir, "LICENSES");
+        Directory.CreateDirectory(licensesDir);
+
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            """
+            rm() {
+                if [ "$#" -eq 2 ] && [ "$1" = "-rf" ] && [ "$2" = "${INSTALL_DIR}/LICENSES" ]; then
+                    return 1
+                fi
+                command rm "$@"
+            }
+
+            if uninstall_cdidx; then
+                echo "UNINSTALL_OK"
+            else
+                echo "UNINSTALL_FAILED:$?"
+            fi
+            """,
+            new Dictionary<string, string?>
+            {
+                ["CDIDX_INSTALL_DIR"] = installDir,
+            });
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("UNINSTALL_FAILED:1", stdout);
+        Assert.DoesNotContain($"Removed {licensesDir}", stdout);
+        Assert.DoesNotContain("Uninstall complete", stdout);
+        Assert.Contains("Failed to remove install directory during uninstall", stderr);
+        Assert.Contains("Uninstall incomplete", stderr);
+        Assert.True(Directory.Exists(licensesDir));
+    }
+
+    [Fact]
     public void UninstallPurgeCache_RejectsUnsafeCacheRootBeforeRemovingInstall_Issue3499()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -224,6 +224,46 @@ public sealed class InstallScriptTests : IDisposable
         Assert.Empty(Directory.GetFiles(home, ".zshrc.cdidx-tmp.*"));
     }
 
+    [Fact]
+    public void PathProfileUpdate_PreservesSymlinkedProfile_Issue3501()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var home = Path.Combine(_tempRoot, "path_profile_symlink_home");
+        var dotfiles = Path.Combine(home, "dotfiles");
+        Directory.CreateDirectory(dotfiles);
+        var targetPath = Path.Combine(dotfiles, "zshrc");
+        File.WriteAllText(targetPath, "export EXISTING=1\n");
+        var profilePath = Path.Combine(home, ".zshrc");
+        File.CreateSymbolicLink(profilePath, Path.Combine("dotfiles", "zshrc"));
+        var installDir = Path.Combine(_tempRoot, "path_profile_symlink_bin");
+        Directory.CreateDirectory(installDir);
+
+        var (exitCode, stdout, stderr) = RunInstallerSnippet(
+            "append_path_to_shell_profile",
+            new Dictionary<string, string?>
+            {
+                ["CDIDX_INSTALL_DIR"] = installDir,
+                ["HOME"] = home,
+                ["SHELL"] = "/bin/zsh",
+            });
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        Assert.NotNull(File.ResolveLinkTarget(profilePath, returnFinalTarget: false));
+        Assert.Contains("Backed up", stdout);
+        Assert.Contains(targetPath, stdout);
+        var backups = Directory.GetFiles(dotfiles, "zshrc.cdidx-backup.*");
+        Assert.Single(backups);
+        Assert.Equal("export EXISTING=1\n", File.ReadAllText(backups[0]));
+        var profile = File.ReadAllText(targetPath);
+        Assert.Contains("export EXISTING=1", profile);
+        Assert.Contains($"export PATH=\"{installDir}:$PATH\"", profile);
+        Assert.Empty(Directory.GetFiles(home, ".zshrc.cdidx-tmp.*"));
+        Assert.Empty(Directory.GetFiles(home, ".zshrc.cdidx-backup.*"));
+    }
+
     [Theory]
     [InlineData("/")]
     [InlineData("/usr/local")]

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1036,7 +1036,7 @@ sleep 5
                 var (exitCode, stdout, stderr) = CaptureConsole(() =>
                     ProgramRunner.RunInstallerProcess(startInfo, TimeSpan.FromMilliseconds(100)));
 
-                Assert.Equal(CommandExitCodes.DatabaseError, exitCode);
+                Assert.Equal(CommandExitCodes.InstallError, exitCode);
                 Assert.Empty(stdout);
                 Assert.Contains("install.sh timed out", stderr);
                 Assert.Contains("rerun `install.sh` manually", stderr);
@@ -1124,6 +1124,48 @@ exit 0
             finally
             {
                 TestProjectHelper.DeleteDirectory(root);
+            }
+        }
+    }
+
+    [Fact]
+    public void RunUpgrade_JsonPreparationFailure_UsesInstallError_Issue3373()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        lock (TestConsoleLock.Gate)
+        {
+            using var env = EnvironmentVariableScope.Capture("XDG_CACHE_HOME", UpdateChecker.DisableEnvVar);
+            var cacheRoot = Path.Combine(Path.GetTempPath(), $"cdidx_update_cache_{Guid.NewGuid():N}");
+            env.Set("XDG_CACHE_HOME", cacheRoot);
+            env.Set(UpdateChecker.DisableEnvVar, null);
+            WriteFreshUpdateCheckCache(cacheRoot, "v9.9.9");
+
+            var previousFactory = ProgramRunner.UpgradeHttpClientFactory;
+            ProgramRunner.UpgradeHttpClientFactory = () => new HttpClient(
+                new StaticResponseHandler(new ByteArrayContent(Encoding.UTF8.GetBytes("missing installer checksum\n"))))
+            {
+                Timeout = Timeout.InfiniteTimeSpan,
+            };
+
+            try
+            {
+                var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                    ["upgrade", "--json"],
+                    appVersion: "1.10.0"));
+
+                Assert.Equal(CommandExitCodes.InstallError, exitCode);
+                Assert.Empty(stderr);
+                using var doc = JsonDocument.Parse(stdout);
+                var root = doc.RootElement;
+                Assert.False(root.GetProperty("install_attempted").GetBoolean());
+                Assert.Equal("InvalidDataException", root.GetProperty("error").GetString());
+            }
+            finally
+            {
+                ProgramRunner.UpgradeHttpClientFactory = previousFactory;
+                TestProjectHelper.DeleteDirectory(cacheRoot);
             }
         }
     }

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1086,6 +1086,49 @@ sleep 30
     }
 
     [Fact]
+    public void RunInstallerProcess_SuppressedOutputDrainsLargeStreams_Issue3376()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        lock (TestConsoleLock.Gate)
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"cdidx_installer_output_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(root);
+            var script = Path.Combine(root, "install.sh");
+            try
+            {
+                File.WriteAllText(script, """
+#!/bin/sh
+i=0
+while [ "$i" -lt 2000 ]; do
+  printf 'stdout-line-%04d-abcdefghijklmnopqrstuvwxyz\n' "$i"
+  printf 'stderr-line-%04d-abcdefghijklmnopqrstuvwxyz\n' "$i" >&2
+  i=$((i + 1))
+done
+exit 0
+""");
+                File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+                var startInfo = ProgramRunner.CreateInstallerProcessStartInfo(script, "v1.27.0", root);
+
+                var (exitCode, stdout, stderr) = CaptureConsole(() =>
+                    ProgramRunner.RunInstallerProcess(
+                        startInfo,
+                        TimeSpan.FromSeconds(10),
+                        suppressOutput: true));
+
+                Assert.Equal(CommandExitCodes.Success, exitCode);
+                Assert.Empty(stdout);
+                Assert.Empty(stderr);
+            }
+            finally
+            {
+                TestProjectHelper.DeleteDirectory(root);
+            }
+        }
+    }
+
+    [Fact]
     public async Task DownloadInstallerScriptAsync_CancelsStalledBody()
     {
         var path = Path.Combine(Path.GetTempPath(), $"cdidx-install-timeout-{Guid.NewGuid():N}.sh");

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1304,6 +1304,56 @@ exit 0
     }
 
     [Fact]
+    public void RunUpgrade_InstallerScriptCleanupFailure_EmitsWarning_Issue3372()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        lock (TestConsoleLock.Gate)
+        {
+            using var env = EnvironmentVariableScope.Capture("XDG_CACHE_HOME", UpdateChecker.DisableEnvVar);
+            var cacheRoot = Path.Combine(Path.GetTempPath(), $"cdidx_update_cache_{Guid.NewGuid():N}");
+            env.Set("XDG_CACHE_HOME", cacheRoot);
+            env.Set(UpdateChecker.DisableEnvVar, null);
+            WriteFreshUpdateCheckCache(cacheRoot, "v9.9.9");
+
+            var installerScript = "#!/bin/sh\nexit 0\n";
+            var installerSha256 = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(installerScript))).ToLowerInvariant();
+            var checksumManifest = $"{installerSha256}  install.sh\n";
+            var previousFactory = ProgramRunner.UpgradeHttpClientFactory;
+            var previousDelete = ProgramRunner.DeleteUpgradeInstallerScriptForTesting;
+            ProgramRunner.UpgradeHttpClientFactory = () => new HttpClient(
+                new UpgradeAssetResponseHandler(
+                    checksumManifest,
+                    installerScript,
+                    _ => { }))
+            {
+                Timeout = Timeout.InfiniteTimeSpan,
+            };
+            ProgramRunner.DeleteUpgradeInstallerScriptForTesting = _ => throw new IOException("delete denied");
+
+            try
+            {
+                var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+                    ["upgrade", "--json"],
+                    appVersion: "1.10.0"));
+
+                Assert.Equal(CommandExitCodes.Success, exitCode);
+                using var doc = JsonDocument.Parse(stdout);
+                Assert.True(doc.RootElement.GetProperty("install_succeeded").GetBoolean());
+                Assert.Contains("Warning: failed to delete upgrade installer script", stderr);
+                Assert.Contains("IOException", stderr);
+            }
+            finally
+            {
+                ProgramRunner.UpgradeHttpClientFactory = previousFactory;
+                ProgramRunner.DeleteUpgradeInstallerScriptForTesting = previousDelete;
+                TestProjectHelper.DeleteDirectory(cacheRoot);
+            }
+        }
+    }
+
+    [Fact]
     public void UpdateChecker_Check_WritesCacheWithPrivateModes_Issue3411()
     {
         using var env = EnvironmentVariableScope.Capture(UpdateChecker.DisableEnvVar);


### PR DESCRIPTION
## Summary

- Back up and atomically replace installer PATH profile updates, including symlinked shell profile targets.
- Report uninstall file/directory removal failures and upgrade installer cleanup deletion failures.
- Make installer timeout waiting cancellable, bound suppressed stdout/stderr draining, and classify upgrade preparation/download/start/timeout failures as install errors.
- Add focused tests and changelog fragments for each handled issue, plus exit-code documentation for `InstallError`.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~InstallScriptTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ProgramRunnerTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~PathProfileUpdate -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: no blocking/actionable issues found

Fixes #3501
Fixes #3500
Fixes #3377
Fixes #3376
Fixes #3373
Fixes #3372
