### PR TITLE
Fix report manifests, metadata targets, and git diagnostics

### DIFF
--- a/changelog.d/unreleased/3434.fixed.md
+++ b/changelog.d/unreleased/3434.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3434
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+---
+
+## English
+
+- **Git helper failures now carry structured bounded diagnostics (#3434)** — process start failures, non-zero exits, timeouts, cancellations, capture failures, and incomplete output capture are classified with `GitCommandFailureKind` and redacted 512-character diagnostics instead of unbounded stderr text.
+
+## 日本語
+
+- **Git helper の失敗が構造化された bounded diagnostics を返すようになりました (#3434)** — process start failure、non-zero exit、timeout、cancellation、capture failure、不完全な output capture を `GitCommandFailureKind` で分類し、無制限の stderr ではなく redaction 済み 512 文字 diagnostics として返します。

--- a/changelog.d/unreleased/3524.fixed.md
+++ b/changelog.d/unreleased/3524.fixed.md
@@ -1,0 +1,27 @@
+---
+category: fixed
+issues:
+  - 3524
+affected:
+  - src/CodeIndex/Cli/DiffCommandRunner.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbReader.Dependencies.cs
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Database/DegradationReasonCodes.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Models/QueryResults.cs
+  - src/CodeIndex/Models/SymbolRecord.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
+---
+
+## English
+
+- **C# metadata-target detection now uses first-class extractor provenance (#3524)** — direct `Attribute` bases are stamped as extractor-owned metadata targets, writer-resolved transitive targets are stored separately, readiness requires the new `metadata_target_source` column, and legacy naming/signature heuristics remain only the degraded fallback path.
+
+## 日本語
+
+- **C# metadata-target 検出が first-class extractor provenance を使うようになりました (#3524)** — 直接 `Attribute` を継承する型は extractor 由来の metadata target として stamp し、writer が推移的に解決した target は別 source として保存します。readiness は新しい `metadata_target_source` 列を要求し、legacy の naming/signature heuristic は縮退時だけ使います。

--- a/changelog.d/unreleased/3555.added.md
+++ b/changelog.d/unreleased/3555.added.md
@@ -1,0 +1,16 @@
+---
+category: added
+issues:
+  - 3555
+affected:
+  - src/CodeIndex/Cli/ReportCommandRunner.cs
+  - tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+---
+
+## English
+
+- **Report bundles now include a support diagnostics manifest (#3555)** — generated support archives include `support-manifest.json` with bundle contents, redaction counts, omission reasons, readiness flags, schema/config/hook/extractor diagnostics, and bounded limit metadata while keeping local paths redacted.
+
+## 日本語
+
+- **report bundle に support diagnostics manifest を追加しました (#3555)** — 生成される support archive に `support-manifest.json` を含め、bundle 内容、redaction 件数、省略理由、readiness flag、schema/config/hook/extractor diagnostics、bounded limit metadata を記録しつつ、ローカルパスは redaction されたままにします。

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -243,51 +243,6 @@ public static class DiffCommandRunner
             value
         """;
 
-    private const string SymbolRowsSql = """
-        SELECT
-            COALESCE(files.path, ''),
-            symbols.kind,
-            symbols.sub_kind,
-            symbols.name,
-            symbols.name_folded,
-            symbols.line,
-            symbols.start_line,
-            symbols.start_column,
-            symbols.end_line,
-            symbols.body_start_line,
-            symbols.body_end_line,
-            symbols.signature,
-            symbols.container_kind,
-            symbols.container_name,
-            symbols.container_qualified_name,
-            symbols.family_key,
-            symbols.visibility,
-            symbols.return_type,
-            symbols.is_metadata_target
-        FROM symbols
-        LEFT JOIN files ON files.id = symbols.file_id
-        ORDER BY
-            COALESCE(files.path, ''),
-            symbols.kind,
-            symbols.sub_kind,
-            symbols.name,
-            symbols.name_folded,
-            symbols.line,
-            symbols.start_line,
-            symbols.start_column,
-            symbols.end_line,
-            symbols.body_start_line,
-            symbols.body_end_line,
-            symbols.signature,
-            symbols.container_kind,
-            symbols.container_name,
-            symbols.container_qualified_name,
-            symbols.family_key,
-            symbols.visibility,
-            symbols.return_type,
-            symbols.is_metadata_target
-        """;
-
     private const string ReferenceRowsSql = """
         SELECT
             COALESCE(files.path, ''),
@@ -345,6 +300,8 @@ public static class DiffCommandRunner
 
         using var leftConnection = OpenReadOnlyConnection(options.LeftDb!);
         using var rightConnection = OpenReadOnlyConnection(options.RightDb!);
+        var leftSymbolRowsSql = BuildSymbolRowsSql(leftConnection);
+        var rightSymbolRowsSql = BuildSymbolRowsSql(rightConnection);
 
         if (!options.SummaryOnly)
         {
@@ -356,7 +313,7 @@ public static class DiffCommandRunner
 
         if (options.Detailed)
         {
-            var symbolDiff = DiffOrderedRows(leftConnection, rightConnection, SymbolRowsSql, options.Limit);
+            var symbolDiff = DiffOrderedRows(leftConnection, rightConnection, leftSymbolRowsSql, rightSymbolRowsSql, options.Limit);
             symbolsOnlyInLeft = symbolDiff.OnlyInLeft;
             symbolsOnlyInRight = symbolDiff.OnlyInRight;
             identical = identical && symbolDiff.Equal;
@@ -370,7 +327,7 @@ public static class DiffCommandRunner
                 RowsEqual(leftConnection, rightConnection, ReferenceLineRowsSql) &&
                 RowsEqual(leftConnection, rightConnection, FileIssueRowsSql) &&
                 RowsEqual(leftConnection, rightConnection, MetaRowsSql) &&
-                (options.Detailed || RowsEqual(leftConnection, rightConnection, SymbolRowsSql)) &&
+                (options.Detailed || RowsEqual(leftConnection, rightConnection, leftSymbolRowsSql, rightSymbolRowsSql)) &&
                 RowsEqual(leftConnection, rightConnection, ReferenceRowsSql);
         }
 
@@ -419,14 +376,22 @@ public static class DiffCommandRunner
     }
 
     private static OrderedRowsDiff DiffOrderedRows(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql, int limit)
+        => DiffOrderedRows(leftConnection, rightConnection, sql, sql, limit);
+
+    private static OrderedRowsDiff DiffOrderedRows(
+        SqliteConnection leftConnection,
+        SqliteConnection rightConnection,
+        string leftSql,
+        string rightSql,
+        int limit)
     {
         if (limit == 0)
-            return new OrderedRowsDiff(RowsEqual(leftConnection, rightConnection, sql), [], []);
+            return new OrderedRowsDiff(RowsEqual(leftConnection, rightConnection, leftSql, rightSql), [], []);
 
         using var leftCommand = leftConnection.CreateCommand();
-        leftCommand.CommandText = sql;
+        leftCommand.CommandText = leftSql;
         using var rightCommand = rightConnection.CreateCommand();
-        rightCommand.CommandText = sql;
+        rightCommand.CommandText = rightSql;
         using var leftReader = leftCommand.ExecuteReader();
         using var rightReader = rightCommand.ExecuteReader();
 
@@ -523,11 +488,14 @@ public static class DiffCommandRunner
     }
 
     private static bool RowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql)
+        => RowsEqual(leftConnection, rightConnection, sql, sql);
+
+    private static bool RowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string leftSql, string rightSql)
     {
         using var leftCommand = leftConnection.CreateCommand();
-        leftCommand.CommandText = sql;
+        leftCommand.CommandText = leftSql;
         using var rightCommand = rightConnection.CreateCommand();
-        rightCommand.CommandText = sql;
+        rightCommand.CommandText = rightSql;
         using var leftReader = leftCommand.ExecuteReader();
         using var rightReader = rightCommand.ExecuteReader();
 
@@ -702,6 +670,76 @@ public static class DiffCommandRunner
         using var command = connection.CreateCommand();
         command.CommandText = $"SELECT COUNT(*) FROM {table}";
         return Convert.ToInt64(command.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static bool ColumnExists(SqliteConnection connection, string table, string column)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = $"PRAGMA table_info({table})";
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            if (!reader.IsDBNull(1) && string.Equals(reader.GetString(1), column, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private static string BuildSymbolRowsSql(SqliteConnection connection)
+    {
+        var metadataTargetExpr = ColumnExists(connection, "symbols", "is_metadata_target")
+            ? "symbols.is_metadata_target"
+            : "NULL";
+        var metadataTargetSourceExpr = ColumnExists(connection, "symbols", "metadata_target_source")
+            ? "symbols.metadata_target_source"
+            : "NULL";
+
+        return $$"""
+            SELECT
+                COALESCE(files.path, ''),
+                symbols.kind,
+                symbols.sub_kind,
+                symbols.name,
+                symbols.name_folded,
+                symbols.line,
+                symbols.start_line,
+                symbols.start_column,
+                symbols.end_line,
+                symbols.body_start_line,
+                symbols.body_end_line,
+                symbols.signature,
+                symbols.container_kind,
+                symbols.container_name,
+                symbols.container_qualified_name,
+                symbols.family_key,
+                symbols.visibility,
+                symbols.return_type,
+                {{metadataTargetExpr}},
+                {{metadataTargetSourceExpr}}
+            FROM symbols
+            LEFT JOIN files ON files.id = symbols.file_id
+            ORDER BY
+                COALESCE(files.path, ''),
+                symbols.kind,
+                symbols.sub_kind,
+                symbols.name,
+                symbols.name_folded,
+                symbols.line,
+                symbols.start_line,
+                symbols.start_column,
+                symbols.end_line,
+                symbols.body_start_line,
+                symbols.body_end_line,
+                symbols.signature,
+                symbols.container_kind,
+                symbols.container_name,
+                symbols.container_qualified_name,
+                symbols.family_key,
+                symbols.visibility,
+                symbols.return_type,
+                {{metadataTargetExpr}},
+                {{metadataTargetSourceExpr}}
+            """;
     }
 
     private static string EncodeRow(object?[] values)

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
@@ -23,13 +24,36 @@ public enum GitHeadCommitState
     Error,
 }
 
-public sealed record GitHeadCommitResult(GitHeadCommitState State, string? Sha = null, string? Reason = null)
+public enum GitCommandFailureKind
+{
+    None,
+    TrustedGitUnavailable,
+    StartFailed,
+    ExitCode,
+    TimedOut,
+    Cancelled,
+    CaptureLimitExceeded,
+    CaptureFailed,
+    OutputCaptureIncomplete,
+    Exception,
+}
+
+public sealed record GitHeadCommitResult(
+    GitHeadCommitState State,
+    string? Sha = null,
+    string? Reason = null,
+    GitCommandFailureKind FailureKind = GitCommandFailureKind.None,
+    string? Diagnostic = null)
 {
     public static GitHeadCommitResult None { get; } = new(GitHeadCommitState.None);
     public static GitHeadCommitResult NotARepo { get; } = new(GitHeadCommitState.NotARepo);
     public static GitHeadCommitResult DetachedHead(string sha) => new(GitHeadCommitState.DetachedHead, sha);
     public static GitHeadCommitResult Resolved(string sha) => new(GitHeadCommitState.Resolved, sha);
-    public static GitHeadCommitResult Error(string reason) => new(GitHeadCommitState.Error, Reason: reason);
+    public static GitHeadCommitResult Error(
+        string reason,
+        GitCommandFailureKind failureKind = GitCommandFailureKind.Exception,
+        string? diagnostic = null)
+        => new(GitHeadCommitState.Error, Reason: reason, FailureKind: failureKind, Diagnostic: diagnostic);
 }
 
 /// <summary>
@@ -54,6 +78,7 @@ public static class GitHelper
     };
 
     internal const int MaxCapturedGitOutputChars = 1024 * 1024;
+    internal const int MaxGitFailureDiagnosticChars = 512;
     private const int GitCaptureReadBufferChars = 8192;
     private static readonly TimeSpan DefaultGitCommandTimeout = TimeSpan.FromSeconds(60);
     private static readonly AsyncLocal<TimeSpan?> GitCommandTimeoutOverride = new();
@@ -437,7 +462,7 @@ public static class GitHelper
 
         var headResult = RunGitCapturingResult(projectRoot, gitEnvironmentOverrides, cancellationToken, "rev-parse", "--verify", "HEAD^{commit}");
         if (headResult.StartError != null)
-            return GitHeadCommitResult.Error(headResult.StartError);
+            return GitHeadCommitResult.Error(headResult.StartError, headResult.FailureKind, headResult.Diagnostic);
 
         var sha = headResult.Output?.Trim();
         if (headResult.ExitCode != 0)
@@ -445,7 +470,7 @@ public static class GitHelper
             var reason = NormalizeGitError(headResult.Error);
             return IsMissingHeadError(reason)
                 ? GitHeadCommitResult.None
-                : GitHeadCommitResult.Error(reason);
+                : GitHeadCommitResult.Error(reason, headResult.FailureKind, headResult.Diagnostic);
         }
 
         if (string.IsNullOrWhiteSpace(sha))
@@ -453,9 +478,12 @@ public static class GitHelper
 
         var branchResult = RunGitCapturingResult(projectRoot, gitEnvironmentOverrides, cancellationToken, "rev-parse", "--abbrev-ref", "HEAD");
         if (branchResult.StartError != null)
-            return GitHeadCommitResult.Error(branchResult.StartError);
+            return GitHeadCommitResult.Error(branchResult.StartError, branchResult.FailureKind, branchResult.Diagnostic);
         if (branchResult.ExitCode != 0)
-            return GitHeadCommitResult.Error(NormalizeGitError(branchResult.Error));
+            return GitHeadCommitResult.Error(
+                NormalizeGitError(branchResult.Error),
+                branchResult.FailureKind,
+                branchResult.Diagnostic);
 
         var branch = branchResult.Output?.Trim();
         return string.Equals(branch, "HEAD", StringComparison.Ordinal)
@@ -713,7 +741,27 @@ public static class GitHelper
     private static string? TryRunGit(string projectRoot, CancellationToken cancellationToken, params string[] args)
         => TryRunGit(projectRoot, gitEnvironmentOverrides: null, cancellationToken, args);
 
-    private readonly record struct GitCommandResult(int? ExitCode, string? Output, string? Error, string? StartError);
+    internal readonly record struct GitCommandResult(
+        int? ExitCode,
+        string? Output,
+        string? Error,
+        GitCommandFailureKind FailureKind,
+        string? Diagnostic)
+    {
+        public string? StartError
+            => FailureKind is GitCommandFailureKind.TrustedGitUnavailable
+                or GitCommandFailureKind.StartFailed
+                or GitCommandFailureKind.Exception
+                ? Diagnostic
+                : null;
+    }
+
+    private readonly record struct GitProcessCaptureResult(
+        int? ExitCode,
+        string Output,
+        string Error,
+        GitCommandFailureKind FailureKind,
+        string? Diagnostic);
 
     private static string? TryRunGit(string projectRoot, IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides, params string[] args)
         => TryRunGit(projectRoot, gitEnvironmentOverrides, CancellationToken.None, args);
@@ -771,7 +819,15 @@ public static class GitHelper
         {
             var psi = TryCreateGitStartInfo(projectRoot);
             if (psi == null)
-                return new GitCommandResult(null, null, null, TrustedGitUnavailableMessage);
+            {
+                var diagnostic = FormatGitDiagnostic(TrustedGitUnavailableMessage);
+                return new GitCommandResult(
+                    null,
+                    null,
+                    diagnostic,
+                    GitCommandFailureKind.TrustedGitUnavailable,
+                    diagnostic);
+            }
 
             foreach (var arg in args)
                 psi.ArgumentList.Add(arg);
@@ -787,10 +843,15 @@ public static class GitHelper
                 }
             }
 
-            var result = RunProcessCapturingOutput(psi, cancellationToken);
+            var result = RunProcessCapturingResult(psi, cancellationToken);
             return result == null
-                ? new GitCommandResult(null, null, null, "Failed to start git process / gitプロセスの起動に失敗")
-                : new GitCommandResult(result.Value.ExitCode, result.Value.Output, result.Value.Error, null);
+                ? new GitCommandResult(null, null, null, GitCommandFailureKind.StartFailed, "Failed to start git process / gitプロセスの起動に失敗")
+                : new GitCommandResult(
+                    result.Value.ExitCode,
+                    result.Value.Output,
+                    result.Value.Error,
+                    result.Value.FailureKind,
+                    result.Value.Diagnostic);
         }
         catch (OperationCanceledException)
         {
@@ -798,9 +859,17 @@ public static class GitHelper
         }
         catch (Exception ex)
         {
-            return new GitCommandResult(null, null, null, ex.Message);
+            var diagnostic = FormatGitDiagnostic($"git helper exception: {DiagnosticRedactor.ClassifyException(ex)}: {ex.Message}");
+            return new GitCommandResult(null, null, diagnostic, GitCommandFailureKind.Exception, diagnostic);
         }
     }
+
+    internal static GitCommandResult RunGitCapturingResultForTests(
+        string projectRoot,
+        IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides,
+        CancellationToken cancellationToken = default,
+        params string[] args)
+        => RunGitCapturingResult(projectRoot, gitEnvironmentOverrides, cancellationToken, args);
 
     private static string NormalizeGitError(string? error)
     {
@@ -822,58 +891,117 @@ public static class GitHelper
         ProcessStartInfo psi,
         CancellationToken cancellationToken = default)
     {
+        var result = RunProcessCapturingResult(psi, cancellationToken);
+        if (result == null || result.Value.FailureKind == GitCommandFailureKind.StartFailed)
+            return null;
+
+        return (result.Value.ExitCode ?? GitProcessFailureExitCode, result.Value.Output, result.Value.Error);
+    }
+
+    private static GitProcessCaptureResult? RunProcessCapturingResult(
+        ProcessStartInfo psi,
+        CancellationToken cancellationToken = default)
+    {
         cancellationToken.ThrowIfCancellationRequested();
         using var process = new Process { StartInfo = psi };
         var stdout = new StringBuilder();
         var stderr = new StringBuilder();
-        string? failureReason = null;
+        GitCommandFailureKind failureKind = GitCommandFailureKind.None;
+        string? failureDiagnostic = null;
         var failureLock = new object();
 
-        void MarkFailure(string reason)
+        void MarkFailure(GitCommandFailureKind kind, string diagnostic)
         {
             lock (failureLock)
             {
-                if (failureReason != null)
+                if (failureKind != GitCommandFailureKind.None)
                     return;
-                failureReason = reason;
+                failureKind = kind;
+                failureDiagnostic = FormatGitDiagnostic(diagnostic);
             }
             TryKillProcessTree(process);
         }
 
-        if (!process.Start())
-            return null;
+        try
+        {
+            if (!process.Start())
+            {
+                var diagnostic = FormatGitDiagnostic("git process did not start.");
+                return new GitProcessCaptureResult(
+                    null,
+                    string.Empty,
+                    diagnostic,
+                    GitCommandFailureKind.StartFailed,
+                    diagnostic);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or IOException or UnauthorizedAccessException)
+        {
+            var diagnostic = FormatGitDiagnostic($"git process start failed: {DiagnosticRedactor.ClassifyException(ex)}: {ex.Message}");
+            return new GitProcessCaptureResult(
+                null,
+                string.Empty,
+                diagnostic,
+                GitCommandFailureKind.StartFailed,
+                diagnostic);
+        }
 
         var stdoutTask = Task.Run(() => ReadCapturedStream(process.StandardOutput, stdout, "stdout", MarkFailure));
         var stderrTask = Task.Run(() => ReadCapturedStream(process.StandardError, stderr, "stderr", MarkFailure));
         var exited = WaitForGitExit(process, GitCommandTimeout, cancellationToken, out var cancelled);
         if (!exited)
         {
-            MarkFailure(cancelled
+            MarkFailure(
+                cancelled ? GitCommandFailureKind.Cancelled : GitCommandFailureKind.TimedOut,
+                cancelled
                 ? "git command cancelled."
                 : $"git command timed out after {FormatDuration(GitCommandTimeout)}.");
             if (!process.WaitForExit(ToWaitMilliseconds(GitKillWaitTimeout)))
             {
                 if (cancelled)
                     cancellationToken.ThrowIfCancellationRequested();
-                return (GitProcessFailureExitCode, ReadCaptured(stdout), CombineCapturedError(ReadCaptured(stderr), failureReason!));
+                return new GitProcessCaptureResult(
+                    GitProcessFailureExitCode,
+                    ReadCaptured(stdout),
+                    CombineCapturedError(ReadCaptured(stderr), failureDiagnostic!),
+                    failureKind,
+                    failureDiagnostic);
             }
-            process.WaitForExit();
         }
         else
         {
-            process.WaitForExit();
+            _ = process.WaitForExit(0);
         }
         if (!WaitForCaptureReaders(stdoutTask, stderrTask))
-            MarkFailure("git command output capture did not finish.");
+            MarkFailure(GitCommandFailureKind.OutputCaptureIncomplete, "git command output capture did not finish.");
 
         var output = ReadCaptured(stdout);
         var error = ReadCaptured(stderr);
         if (cancelled)
             cancellationToken.ThrowIfCancellationRequested();
-        if (failureReason != null)
-            return (GitProcessFailureExitCode, output, CombineCapturedError(error, failureReason));
+        if (failureKind != GitCommandFailureKind.None)
+            return new GitProcessCaptureResult(
+                GitProcessFailureExitCode,
+                output,
+                CombineCapturedError(error, failureDiagnostic!),
+                failureKind,
+                failureDiagnostic);
 
-        return (process.ExitCode, output, error);
+        var exitCode = process.ExitCode;
+        if (exitCode != 0)
+        {
+            var diagnostic = FormatGitDiagnostic(string.IsNullOrWhiteSpace(error)
+                ? $"git command exited with {exitCode.ToString(CultureInfo.InvariantCulture)} and no stderr."
+                : error);
+            return new GitProcessCaptureResult(
+                exitCode,
+                output,
+                diagnostic,
+                GitCommandFailureKind.ExitCode,
+                diagnostic);
+        }
+
+        return new GitProcessCaptureResult(exitCode, output, error, GitCommandFailureKind.None, null);
     }
 
     private static bool WaitForGitExit(
@@ -929,7 +1057,7 @@ public static class GitHelper
         TextReader reader,
         StringBuilder builder,
         string streamName,
-        Action<string> markFailure)
+        Action<GitCommandFailureKind, string> markFailure)
     {
         var buffer = new char[GitCaptureReadBufferChars];
         try
@@ -945,7 +1073,9 @@ public static class GitHelper
         }
         catch (IOException ex)
         {
-            markFailure($"git command {streamName} read failed: {ex.Message}");
+            markFailure(
+                GitCommandFailureKind.CaptureFailed,
+                $"git command {streamName} read failed: {DiagnosticRedactor.ClassifyException(ex)}");
         }
         catch (ObjectDisposedException)
         {
@@ -957,14 +1087,14 @@ public static class GitHelper
         StringBuilder builder,
         ReadOnlySpan<char> data,
         string streamName,
-        Action<string> markFailure)
+        Action<GitCommandFailureKind, string> markFailure)
     {
         lock (builder)
         {
             var remaining = MaxCapturedGitOutputChars - builder.Length;
             if (remaining <= 0)
             {
-                markFailure(BuildCaptureLimitMessage(streamName));
+                markFailure(GitCommandFailureKind.CaptureLimitExceeded, BuildCaptureLimitMessage(streamName));
                 return false;
             }
 
@@ -977,17 +1107,22 @@ public static class GitHelper
             builder.Append(data[..Math.Min(data.Length, remaining)]);
         }
 
-        markFailure(BuildCaptureLimitMessage(streamName));
+        markFailure(GitCommandFailureKind.CaptureLimitExceeded, BuildCaptureLimitMessage(streamName));
         return false;
     }
 
     private static string BuildCaptureLimitMessage(string streamName)
         => $"git command captured {streamName} exceeded {MaxCapturedGitOutputChars.ToString(CultureInfo.InvariantCulture)} characters.";
 
+    private static string FormatGitDiagnostic(string diagnostic)
+        => DiagnosticRedactor.BoundDiagnosticText(
+            DiagnosticRedactor.RedactSensitiveText(diagnostic, "[redacted]", redactPaths: true),
+            MaxGitFailureDiagnosticChars);
+
     private static string CombineCapturedError(string stderr, string diagnostic)
-        => string.IsNullOrWhiteSpace(stderr)
+        => FormatGitDiagnostic(string.IsNullOrWhiteSpace(stderr)
             ? diagnostic
-            : stderr.TrimEnd('\r', '\n') + "\n" + diagnostic;
+            : stderr.TrimEnd('\r', '\n') + "\n" + diagnostic);
 
     private static int ToWaitMilliseconds(TimeSpan timeout)
     {

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -452,8 +452,14 @@ public static class GitHelper
         IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides,
         CancellationToken cancellationToken = default)
     {
-        var repositoryRoot = TryGetRepositoryRoot(projectRoot, gitEnvironmentOverrides, cancellationToken);
-        if (repositoryRoot == null)
+        var repositoryRoot = TryGetRepositoryRootResult(projectRoot, gitEnvironmentOverrides, cancellationToken);
+        if (repositoryRoot.FailureKind != GitCommandFailureKind.None)
+        {
+            var diagnostic = repositoryRoot.Diagnostic ?? "git could not resolve the repository root";
+            return GitHeadCommitResult.Error(diagnostic, repositoryRoot.FailureKind, diagnostic);
+        }
+
+        if (repositoryRoot.Root == null)
         {
             return HasGitMetadataEntry(projectRoot)
                 ? GitHeadCommitResult.Error("git repository metadata is present, but git could not resolve the repository root")
@@ -712,21 +718,39 @@ public static class GitHelper
         string projectPath,
         IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides,
         CancellationToken cancellationToken = default)
+        => TryGetRepositoryRootResult(projectPath, gitEnvironmentOverrides, cancellationToken).Root;
+
+    private static GitRepositoryRootResult TryGetRepositoryRootResult(
+        string projectPath,
+        IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides,
+        CancellationToken cancellationToken = default)
     {
-        var cdup = TryRunGit(projectPath, gitEnvironmentOverrides, cancellationToken, "rev-parse", "--show-cdup");
-        if (cdup != null)
+        var cdup = RunGitCapturingResult(projectPath, gitEnvironmentOverrides, cancellationToken, "rev-parse", "--show-cdup");
+        if (cdup.FailureKind == GitCommandFailureKind.None)
         {
-            var value = cdup.Trim();
-            return string.IsNullOrEmpty(value)
+            var value = cdup.Output?.Trim() ?? string.Empty;
+            var root = string.IsNullOrEmpty(value)
                 ? Path.GetFullPath(projectPath)
                 : Path.GetFullPath(Path.Combine(projectPath, value));
+            return GitRepositoryRootResult.Resolved(root);
         }
+        if (IsGitInfrastructureFailure(cdup.FailureKind))
+            return GitRepositoryRootResult.Failure(cdup.FailureKind, cdup.Diagnostic);
 
-        var isBare = TryRunGit(projectPath, gitEnvironmentOverrides, cancellationToken, "rev-parse", "--is-bare-repository")?.Trim();
-        return string.Equals(isBare, "true", StringComparison.OrdinalIgnoreCase)
-            ? Path.GetFullPath(projectPath)
-            : null;
+        var isBare = RunGitCapturingResult(projectPath, gitEnvironmentOverrides, cancellationToken, "rev-parse", "--is-bare-repository");
+        if (isBare.FailureKind == GitCommandFailureKind.None
+            && string.Equals(isBare.Output?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return GitRepositoryRootResult.Resolved(Path.GetFullPath(projectPath));
+        }
+        if (IsGitInfrastructureFailure(isBare.FailureKind))
+            return GitRepositoryRootResult.Failure(isBare.FailureKind, isBare.Diagnostic);
+
+        return GitRepositoryRootResult.NotARepo;
     }
+
+    private static bool IsGitInfrastructureFailure(GitCommandFailureKind failureKind)
+        => failureKind is not GitCommandFailureKind.None and not GitCommandFailureKind.ExitCode;
 
     private static bool HasGitMetadataEntry(string projectRoot)
     {
@@ -754,6 +778,17 @@ public static class GitHelper
                 or GitCommandFailureKind.Exception
                 ? Diagnostic
                 : null;
+    }
+
+    private readonly record struct GitRepositoryRootResult(
+        string? Root,
+        GitCommandFailureKind FailureKind,
+        string? Diagnostic)
+    {
+        public static GitRepositoryRootResult NotARepo { get; } = new(null, GitCommandFailureKind.None, null);
+        public static GitRepositoryRootResult Resolved(string root) => new(root, GitCommandFailureKind.None, null);
+        public static GitRepositoryRootResult Failure(GitCommandFailureKind failureKind, string? diagnostic)
+            => new(null, failureKind, diagnostic);
     }
 
     private readonly record struct GitProcessCaptureResult(

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -166,8 +166,14 @@ public static class ReportCommandRunner
         var redactions = ReportRedactionSummary.Empty;
         if (options.IncludeLog && options.LogLines > 0)
         {
-            var logText = BuildRecentLogTail(options.LogLines, options.IncludeArgs, out var linesIncluded, out redactions);
+            var logText = BuildRecentLogTail(
+                options.LogLines,
+                options.IncludeArgs,
+                out var linesIncluded,
+                out redactions,
+                out var logTailTruncated);
             bundle.LogLinesIncluded = linesIncluded;
+            bundle.LogTailTruncated = logTailTruncated;
             bundle.AddText("log/stderr-recent.log", logText);
         }
 
@@ -311,8 +317,17 @@ public static class ReportCommandRunner
         bool includeArgs,
         out int linesIncluded,
         out ReportRedactionSummary redactions)
+        => BuildRecentLogTail(maxLines, includeArgs, out linesIncluded, out redactions, out _);
+
+    internal static string BuildRecentLogTail(
+        int maxLines,
+        bool includeArgs,
+        out int linesIncluded,
+        out ReportRedactionSummary redactions,
+        out bool logTailTruncated)
     {
         linesIncluded = 0;
+        logTailTruncated = false;
         var redactionCounter = new ReportRedactionCounter();
         var logDir = GlobalToolLog.ResolveLogDirectoryForReport();
         if (string.IsNullOrWhiteSpace(logDir) || !Directory.Exists(logDir))
@@ -322,7 +337,9 @@ public static class ReportCommandRunner
         }
 
         var logFiles = SelectRecentLogFiles(
-            new DirectoryInfo(logDir).EnumerateFiles("stderr-*.log", SearchOption.TopDirectoryOnly));
+            new DirectoryInfo(logDir).EnumerateFiles("stderr-*.log", SearchOption.TopDirectoryOnly),
+            out var olderLogFilesOmitted);
+        logTailTruncated = olderLogFilesOmitted;
         if (logFiles.Count == 0)
         {
             redactions = redactionCounter.ToSummary();
@@ -333,16 +350,22 @@ public static class ReportCommandRunner
         foreach (var file in logFiles)
         {
             if (collected.Count >= maxLines)
+            {
+                logTailTruncated = true;
                 break;
-            IReadOnlyList<string> lines;
+            }
+            ReportLogTailReadResult result;
             try
             {
-                lines = ReadLogFileTailLines(file.FullName, maxLines - collected.Count);
+                result = ReadLogFileTailLinesResult(file.FullName, maxLines - collected.Count);
             }
             catch (IOException)
             {
                 continue;
             }
+            if (result.LinesTruncated || result.BytesTruncated)
+                logTailTruncated = true;
+            var lines = result.Lines;
             for (var i = lines.Count - 1; i >= 0 && collected.Count < maxLines; i--)
                 collected.AddFirst(lines[i]);
         }
@@ -412,7 +435,7 @@ public static class ReportCommandRunner
             log.Add("lifecycle_log_skipped_by_option");
         else if (bundle.LogLinesIncluded == 0)
             log.Add("lifecycle_log_unavailable_or_empty");
-        else
+        else if (bundle.LogTailTruncated)
             log.Add("older_log_lines_outside_tail_limit");
         if (!options.IncludeArgs)
             log.Add("literal_args");
@@ -595,9 +618,10 @@ public static class ReportCommandRunner
             degradedFields.Add(field);
     }
 
-    private static IReadOnlyList<FileInfo> SelectRecentLogFiles(IEnumerable<FileInfo> files)
+    private static IReadOnlyList<FileInfo> SelectRecentLogFiles(IEnumerable<FileInfo> files, out bool olderLogFilesOmitted)
     {
         var recent = new List<FileInfo>(MaxRecentLogFiles);
+        olderLogFilesOmitted = false;
         foreach (var file in files)
         {
             var insertAt = recent.FindIndex(
@@ -606,21 +630,29 @@ public static class ReportCommandRunner
             {
                 if (recent.Count < MaxRecentLogFiles)
                     recent.Add(file);
+                else
+                    olderLogFilesOmitted = true;
                 continue;
             }
 
             recent.Insert(insertAt, file);
             if (recent.Count > MaxRecentLogFiles)
+            {
+                olderLogFilesOmitted = true;
                 recent.RemoveAt(recent.Count - 1);
+            }
         }
 
         return recent;
     }
 
     internal static IReadOnlyList<string> ReadLogFileTailLines(string path, int maxLines)
+        => ReadLogFileTailLinesResult(path, maxLines).Lines;
+
+    private static ReportLogTailReadResult ReadLogFileTailLinesResult(string path, int maxLines)
     {
         if (maxLines <= 0)
-            return [];
+            return new ReportLogTailReadResult([], LinesTruncated: false, BytesTruncated: false);
 
         using var stream = File.OpenRead(path);
         var startOffset = Math.Max(0, stream.Length - MaxLogFileTailBytes);
@@ -636,11 +668,15 @@ public static class ReportCommandRunner
         {
             var firstNewline = text.IndexOf('\n', StringComparison.Ordinal);
             if (firstNewline < 0)
-                return [];
+                return new ReportLogTailReadResult([], LinesTruncated: false, BytesTruncated: true);
             text = text[(firstNewline + 1)..];
         }
 
-        return TakeLastLines(text, maxLines);
+        var lines = TakeLastLines(text, maxLines + 1);
+        var linesTruncated = lines.Count > maxLines;
+        if (linesTruncated)
+            lines = lines.Skip(1).ToArray();
+        return new ReportLogTailReadResult(lines, linesTruncated, startOffset > 0);
     }
 
     private static IReadOnlyList<string> TakeLastLines(string text, int maxLines)
@@ -798,12 +834,18 @@ internal sealed class ReportBundle
     public bool DbIncluded { get; set; }
     public string? DbPath { get; set; }
     public int LogLinesIncluded { get; set; }
+    public bool LogTailTruncated { get; set; }
 
     public void AddText(string name, string content) =>
         Files.Add((name, Encoding.UTF8.GetBytes(content)));
 }
 
 internal sealed record ReportSchemaTable(string Name, long RowCount, bool RowCountTruncated = false);
+
+internal sealed record ReportLogTailReadResult(
+    IReadOnlyList<string> Lines,
+    bool LinesTruncated,
+    bool BytesTruncated);
 
 internal sealed class ReportRedactionCounter
 {

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -4,7 +4,10 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using CodeIndex.Diagnostics;
+using CodeIndex.Database;
 using CodeIndex.Indexer;
+using CodeIndex.Indexer.Extensibility;
+using CodeIndex.Indexer.Hooks;
 using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Cli;
@@ -31,6 +34,7 @@ public static class ReportCommandRunner
     internal const string RedactedPlaceholder = "[redacted]";
     internal const UnixFileMode BundleFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
     private const string TruncatedTableNameSuffix = "...[truncated]";
+    private const int SupportManifestVersion = 1;
 
     public static int Run(string[] cmdArgs, JsonSerializerOptions jsonOptions, string? appVersion = null)
     {
@@ -150,21 +154,27 @@ public static class ReportCommandRunner
                 $"process-architecture: {RuntimeInformation.ProcessArchitecture}",
                 "") + "\n");
 
-        var (schemaText, tables, dbPath, dbIncluded) = BuildSchemaSummary(options.DbPath);
+        var (schemaText, tables, dbPath, dbIncluded, schemaTablesTruncated) = BuildSchemaSummary(options.DbPath);
         bundle.SchemaTables = tables;
+        bundle.SchemaTablesTruncated = schemaTablesTruncated;
         bundle.DbIncluded = dbIncluded;
         bundle.DbPath = dbPath;
         bundle.AddText("schema.txt", schemaText);
 
         bundle.LogIncluded = options.IncludeLog;
         bundle.LogLinesIncluded = 0;
+        var redactions = ReportRedactionSummary.Empty;
         if (options.IncludeLog && options.LogLines > 0)
         {
-            var logText = BuildRecentLogTail(options.LogLines, options.IncludeArgs, out var linesIncluded);
+            var logText = BuildRecentLogTail(options.LogLines, options.IncludeArgs, out var linesIncluded, out redactions);
             bundle.LogLinesIncluded = linesIncluded;
             bundle.AddText("log/stderr-recent.log", logText);
         }
 
+        var supportManifest = BuildSupportManifest(options, bundle, nowUtc, redactions);
+        bundle.AddText(
+            "support-manifest.json",
+            JsonSerializer.Serialize(supportManifest, ReportSupportManifestJsonContext.Default.ReportSupportManifest));
         bundle.AddText("README.md", BuildReadme(version, options.IncludeLog, options.IncludeArgs));
         return bundle;
     }
@@ -183,6 +193,7 @@ public static class ReportCommandRunner
         sb.AppendLine("- `version.txt` — cdidx version only.");
         sb.AppendLine("- `env.txt` — human-readable OS / runtime summary.");
         sb.AppendLine("- `schema.txt` — capped SQLite table list and bounded row counts (no table row contents).");
+        sb.AppendLine("- `support-manifest.json` — machine-readable redaction, omission, readiness, and diagnostic summary.");
         if (includeLog)
         {
             sb.AppendLine(
@@ -205,13 +216,18 @@ public static class ReportCommandRunner
         return sb.ToString();
     }
 
-    internal static (string Text, List<ReportSchemaTable> Tables, string? DbPath, bool DbIncluded) BuildSchemaSummary(string dbPath)
+    internal static (
+        string Text,
+        List<ReportSchemaTable> Tables,
+        string? DbPath,
+        bool DbIncluded,
+        bool TablesTruncated) BuildSchemaSummary(string dbPath)
     {
         var normalizedDbPath = DbPathResolver.NormalizeDbPath(dbPath);
         if (!File.Exists(LongPath.EnsureWindowsPrefix(normalizedDbPath)))
         {
             var missingText = $"no SQLite index found at: {RedactedPlaceholder}\nRun `cdidx index <projectPath>` first if you want schema details attached.\n";
-            return (missingText, new List<ReportSchemaTable>(), normalizedDbPath, false);
+            return (missingText, new List<ReportSchemaTable>(), normalizedDbPath, false, false);
         }
 
         var tables = new List<ReportSchemaTable>();
@@ -268,7 +284,7 @@ public static class ReportCommandRunner
         foreach (var t in tables)
             sb.AppendLine($"{t.Name} | {FormatSchemaRowCount(t)}");
 
-        return (sb.ToString(), tables, normalizedDbPath, true);
+        return (sb.ToString(), tables, normalizedDbPath, true, tableListTruncated);
     }
 
     private static string FormatSchemaTableName(string name)
@@ -288,16 +304,30 @@ public static class ReportCommandRunner
     }
 
     internal static string BuildRecentLogTail(int maxLines, bool includeArgs, out int linesIncluded)
+        => BuildRecentLogTail(maxLines, includeArgs, out linesIncluded, out _);
+
+    internal static string BuildRecentLogTail(
+        int maxLines,
+        bool includeArgs,
+        out int linesIncluded,
+        out ReportRedactionSummary redactions)
     {
         linesIncluded = 0;
+        var redactionCounter = new ReportRedactionCounter();
         var logDir = GlobalToolLog.ResolveLogDirectoryForReport();
         if (string.IsNullOrWhiteSpace(logDir) || !Directory.Exists(logDir))
+        {
+            redactions = redactionCounter.ToSummary();
             return $"no cdidx lifecycle log directory found (looked at: {RedactedPlaceholder}).\n";
+        }
 
         var logFiles = SelectRecentLogFiles(
             new DirectoryInfo(logDir).EnumerateFiles("stderr-*.log", SearchOption.TopDirectoryOnly));
         if (logFiles.Count == 0)
+        {
+            redactions = redactionCounter.ToSummary();
             return $"no cdidx lifecycle log files found in: {RedactedPlaceholder}\n";
+        }
 
         var collected = new LinkedList<string>();
         foreach (var file in logFiles)
@@ -323,10 +353,246 @@ public static class ReportCommandRunner
         sb.AppendLine();
         foreach (var line in collected)
         {
-            sb.AppendLine(RedactLogLine(line, includeArgs));
+            var redacted = RedactLogLine(line, includeArgs);
+            redactionCounter.Observe(line, redacted);
+            sb.AppendLine(redacted);
         }
         linesIncluded = collected.Count;
+        redactions = redactionCounter.ToSummary();
         return sb.ToString();
+    }
+
+    internal static ReportSupportManifest BuildSupportManifest(
+        ReportCommandOptions options,
+        ReportBundle bundle,
+        DateTimeOffset generatedAtUtc,
+        ReportRedactionSummary redactions)
+    {
+        var readiness = BuildReadinessSnapshot(bundle.DbPath, bundle.DbIncluded);
+        var diagnostics = BuildDiagnosticSummary();
+        var omissions = BuildOmissionSummary(options, bundle, readiness);
+        return new ReportSupportManifest(
+            ManifestVersion: SupportManifestVersion,
+            GeneratedAtUtc: generatedAtUtc.ToString("O"),
+            Limits: new ReportManifestLimits(
+                MaxSchemaTables,
+                MaxSchemaTableNameDisplayChars,
+                MaxSchemaRowCountScanRows,
+                MaxLogLines,
+                MaxLogFileTailBytes,
+                MaxRecentLogFiles),
+            Bundle: new ReportManifestBundle(
+                DbIncluded: bundle.DbIncluded,
+                LogIncluded: bundle.LogIncluded,
+                IncludeArgs: options.IncludeArgs,
+                Files: bundle.Files.Count + 2,
+                SchemaTables: bundle.SchemaTables.Count,
+                LogLinesIncluded: bundle.LogLinesIncluded),
+            Redactions: redactions,
+            Omissions: omissions,
+            Readiness: readiness,
+            Diagnostics: diagnostics);
+    }
+
+    private static ReportManifestOmissions BuildOmissionSummary(
+        ReportCommandOptions options,
+        ReportBundle bundle,
+        ReportReadinessSnapshot readiness)
+    {
+        var schema = new List<string> { "database_path", "table_row_contents" };
+        if (!bundle.DbIncluded)
+            schema.Add("schema_unavailable_no_database");
+        if (bundle.SchemaTablesTruncated)
+            schema.Add("schema_tables_after_limit");
+        if (bundle.SchemaTables.Any(static t => t.RowCountTruncated))
+            schema.Add("row_counts_after_scan_limit");
+
+        var log = new List<string> { "log_source_directory" };
+        if (!options.IncludeLog)
+            log.Add("lifecycle_log_skipped_by_option");
+        else if (bundle.LogLinesIncluded == 0)
+            log.Add("lifecycle_log_unavailable_or_empty");
+        else
+            log.Add("older_log_lines_outside_tail_limit");
+        if (!options.IncludeArgs)
+            log.Add("literal_args");
+
+        var status = new List<string>();
+        if (readiness.Source != "database")
+            status.Add("readiness_snapshot_unavailable");
+        status.Add("raw_config_values");
+        status.Add("diagnostic_paths");
+
+        return new ReportManifestOmissions(schema, log, status);
+    }
+
+    private static ReportReadinessSnapshot BuildReadinessSnapshot(string? dbPath, bool dbIncluded)
+    {
+        if (!dbIncluded || string.IsNullOrWhiteSpace(dbPath))
+        {
+            return ReportReadinessSnapshot.Unavailable(
+                "database_unavailable",
+                ["readiness_unavailable"]);
+        }
+
+        try
+        {
+            var normalizedDbPath = DbPathResolver.NormalizeDbPath(dbPath);
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = normalizedDbPath,
+                Mode = SqliteOpenMode.ReadOnly,
+            }.ConnectionString;
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+            var tables = LoadTableNames(connection);
+            var symbolColumns = LoadColumnNames(connection, "symbols");
+            var meta = tables.Contains("codeindex_meta")
+                ? LoadCodeIndexMeta(connection)
+                : new Dictionary<string, string?>(StringComparer.Ordinal);
+            var userVersion = ReadUserVersion(connection);
+
+            var graphTableAvailable = tables.Contains("symbol_references");
+            var issuesTableAvailable = tables.Contains("file_issues");
+            var fileIssuesDataCurrent = issuesTableAvailable && (userVersion & DbContext.IssuesReadyFlag) == DbContext.IssuesReadyFlag;
+            var migrationInProgress = string.Equals(GetMeta(meta, DbContext.BatchInProgressMetaKey), "true", StringComparison.OrdinalIgnoreCase);
+            var hasCSharpFiles = CountFilesByLanguage(connection, "csharp") > 0;
+            var hasSqlFiles = CountFilesByLanguage(connection, "sql") > 0;
+            var csharpSymbolNameReady = !hasCSharpFiles || string.Equals(
+                GetMeta(meta, DbContext.CSharpSymbolNameContractVersionMetaKey),
+                DbContext.CSharpSymbolNameContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                StringComparison.Ordinal);
+            var csharpMetadataTargetReady = !hasCSharpFiles
+                || (symbolColumns.Contains("is_metadata_target")
+                    && symbolColumns.Contains("metadata_target_source")
+                    && string.Equals(
+                        GetMeta(meta, DbContext.GetMetadataTargetVersionMetaKey("csharp")),
+                        DbContext.MetadataTargetVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        StringComparison.Ordinal));
+            var sqlGraphContractReady = !hasSqlFiles || string.Equals(
+                GetMeta(meta, DbContext.SqlGraphContractVersionMetaKey),
+                DbContext.SqlGraphContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                StringComparison.Ordinal);
+            var hotspotFamilyReady = string.Equals(
+                GetMeta(meta, DbContext.HotspotFamilyVersionMetaKey),
+                DbContext.HotspotFamilyVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                StringComparison.Ordinal);
+            var foldReady = (userVersion & DbContext.FoldReadyFlag) == DbContext.FoldReadyFlag
+                && symbolColumns.Contains("name_folded");
+
+            var degradedFields = new List<string>();
+            AddIfFalse(degradedFields, graphTableAvailable, "graph_table_available");
+            AddIfFalse(degradedFields, issuesTableAvailable, "issues_table_available");
+            AddIfFalse(degradedFields, fileIssuesDataCurrent, "file_issues_data_current");
+            if (migrationInProgress)
+                degradedFields.Add("migration_in_progress");
+            AddIfFalse(degradedFields, csharpSymbolNameReady, "csharp_symbol_name_ready");
+            AddIfFalse(degradedFields, csharpMetadataTargetReady, "csharp_metadata_target_ready");
+            AddIfFalse(degradedFields, sqlGraphContractReady, "sql_graph_contract_ready");
+            AddIfFalse(degradedFields, hotspotFamilyReady, "hotspot_family_ready");
+            AddIfFalse(degradedFields, foldReady, "fold_ready");
+
+            return new ReportReadinessSnapshot(
+                Source: "database",
+                UnavailableReason: null,
+                GraphTableAvailable: graphTableAvailable,
+                IssuesTableAvailable: issuesTableAvailable,
+                FileIssuesDataCurrent: fileIssuesDataCurrent,
+                MigrationInProgress: migrationInProgress,
+                CSharpSymbolNameReady: csharpSymbolNameReady,
+                CSharpMetadataTargetReady: csharpMetadataTargetReady,
+                SqlGraphContractReady: sqlGraphContractReady,
+                HotspotFamilyReady: hotspotFamilyReady,
+                FoldReady: foldReady,
+                DegradedFields: degradedFields.Count == 0 ? null : degradedFields);
+        }
+        catch (Exception ex) when (ex is SqliteException or IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            return ReportReadinessSnapshot.Unavailable(
+                "read_failed",
+                ["readiness_unavailable"]);
+        }
+    }
+
+    private static ReportDiagnosticSummary BuildDiagnosticSummary()
+    {
+        var extractorStatus = ExtractorPluginRegistry.GetStatusSnapshot();
+        var hookSnapshot = PostExtractionHookRunner.DiscoverDefaultMetadata();
+        return new ReportDiagnosticSummary(
+            Extractors: new ReportExtractorDiagnosticSummary(
+                extractorStatus.PluginAssemblyCount,
+                extractorStatus.PatternConfigCount,
+                extractorStatus.SymbolExtractorCount,
+                extractorStatus.ReferenceExtractorCount,
+                extractorStatus.SkippedFileCount,
+                extractorStatus.DiagnosticCount,
+                extractorStatus.DiagnosticsTruncated),
+            Hooks: new ReportHookDiagnosticSummary(
+                hookSnapshot.Hooks.Count,
+                hookSnapshot.Diagnostics.Count,
+                (long)Math.Ceiling(hookSnapshot.CallbackBudget.TotalMilliseconds)),
+            Config: new ReportConfigDiagnosticSummary(
+                RawValuesIncluded: false,
+                Notes: ["raw_config_values_not_collected"]));
+    }
+
+    private static HashSet<string> LoadTableNames(SqliteConnection connection)
+    {
+        var tables = new HashSet<string>(StringComparer.Ordinal);
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table'";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            tables.Add(reader.GetString(0));
+        return tables;
+    }
+
+    private static HashSet<string> LoadColumnNames(SqliteConnection connection, string tableName)
+    {
+        var columns = new HashSet<string>(StringComparer.Ordinal);
+        if (!LoadTableNames(connection).Contains(tableName))
+            return columns;
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"PRAGMA table_info(\"{tableName.Replace("\"", "\"\"", StringComparison.Ordinal)}\")";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            columns.Add(reader.GetString(1));
+        return columns;
+    }
+
+    private static Dictionary<string, string?> LoadCodeIndexMeta(SqliteConnection connection)
+    {
+        var meta = new Dictionary<string, string?>(StringComparer.Ordinal);
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT key, value FROM codeindex_meta";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            meta[reader.GetString(0)] = reader.IsDBNull(1) ? null : reader.GetString(1);
+        return meta;
+    }
+
+    private static int ReadUserVersion(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA user_version";
+        return Convert.ToInt32(cmd.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static long CountFilesByLanguage(SqliteConnection connection, string lang)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM files WHERE lang = $lang";
+        cmd.Parameters.AddWithValue("$lang", lang);
+        return Convert.ToInt64(cmd.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static string? GetMeta(Dictionary<string, string?> meta, string key)
+        => meta.TryGetValue(key, out var value) ? value : null;
+
+    private static void AddIfFalse(List<string> degradedFields, bool value, string field)
+    {
+        if (!value)
+            degradedFields.Add(field);
     }
 
     private static IReadOnlyList<FileInfo> SelectRecentLogFiles(IEnumerable<FileInfo> files)
@@ -527,6 +793,7 @@ internal sealed class ReportBundle
 {
     public List<(string Name, byte[] Bytes)> Files { get; } = new();
     public List<ReportSchemaTable> SchemaTables { get; set; } = new();
+    public bool SchemaTablesTruncated { get; set; }
     public bool LogIncluded { get; set; }
     public bool DbIncluded { get; set; }
     public string? DbPath { get; set; }
@@ -537,6 +804,158 @@ internal sealed class ReportBundle
 }
 
 internal sealed record ReportSchemaTable(string Name, long RowCount, bool RowCountTruncated = false);
+
+internal sealed class ReportRedactionCounter
+{
+    private readonly Dictionary<string, int> categories = new(StringComparer.Ordinal);
+    private int total;
+
+    public void Observe(string rawLine, string redactedLine)
+    {
+        var placeholders = CountOccurrences(redactedLine, ReportCommandRunner.RedactedPlaceholder);
+        if (placeholders == 0)
+            return;
+
+        total += placeholders;
+        var categorized = 0;
+        categorized += CountKeyRedaction(redactedLine, "args", "args");
+        categorized += CountKeyRedaction(redactedLine, "cwd", "path_fields");
+        categorized += CountKeyRedaction(redactedLine, "process_path", "path_fields");
+        categorized += CountKeyRedaction(redactedLine, "base_dir", "path_fields");
+        categorized += CountKeyRedaction(redactedLine, "db", "path_fields");
+        categorized += CountKeyRedaction(redactedLine, "path", "path_fields");
+        var uncategorized = placeholders - categorized;
+        if (uncategorized > 0)
+            Add("sensitive_values", uncategorized);
+
+        if (!string.Equals(rawLine, redactedLine, StringComparison.Ordinal) && redactedLine.Contains("://", StringComparison.Ordinal))
+            Add("url_or_query", 1);
+    }
+
+    public ReportRedactionSummary ToSummary()
+        => new(total, categories.Count == 0 ? new Dictionary<string, int>(StringComparer.Ordinal) : new Dictionary<string, int>(categories, StringComparer.Ordinal));
+
+    private int CountKeyRedaction(string line, string key, string category)
+    {
+        var count = CountOccurrences(line, key + "=" + ReportCommandRunner.RedactedPlaceholder);
+        if (count > 0)
+            Add(category, count);
+        return count;
+    }
+
+    private void Add(string category, int count)
+    {
+        if (count <= 0)
+            return;
+        categories[category] = categories.TryGetValue(category, out var existing) ? existing + count : count;
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var offset = 0;
+        while (offset < text.Length)
+        {
+            var index = text.IndexOf(value, offset, StringComparison.Ordinal);
+            if (index < 0)
+                break;
+            count++;
+            offset = index + value.Length;
+        }
+        return count;
+    }
+}
+
+internal sealed record ReportSupportManifest(
+    int ManifestVersion,
+    string GeneratedAtUtc,
+    ReportManifestLimits Limits,
+    ReportManifestBundle Bundle,
+    ReportRedactionSummary Redactions,
+    ReportManifestOmissions Omissions,
+    ReportReadinessSnapshot Readiness,
+    ReportDiagnosticSummary Diagnostics);
+
+internal sealed record ReportManifestLimits(
+    int MaxSchemaTables,
+    int MaxSchemaTableNameDisplayChars,
+    int MaxSchemaRowCountScanRows,
+    int MaxLogLines,
+    int MaxLogFileTailBytes,
+    int MaxRecentLogFiles);
+
+internal sealed record ReportManifestBundle(
+    bool DbIncluded,
+    bool LogIncluded,
+    bool IncludeArgs,
+    int Files,
+    int SchemaTables,
+    int LogLinesIncluded);
+
+internal sealed record ReportRedactionSummary(int Total, Dictionary<string, int> Categories)
+{
+    public static ReportRedactionSummary Empty { get; } = new(0, new Dictionary<string, int>(StringComparer.Ordinal));
+}
+
+internal sealed record ReportManifestOmissions(
+    List<string> Schema,
+    List<string> Log,
+    List<string> Status);
+
+internal sealed record ReportReadinessSnapshot(
+    string Source,
+    string? UnavailableReason,
+    bool? GraphTableAvailable,
+    bool? IssuesTableAvailable,
+    bool? FileIssuesDataCurrent,
+    bool? MigrationInProgress,
+    [property: System.Text.Json.Serialization.JsonPropertyName("csharp_symbol_name_ready")]
+    bool? CSharpSymbolNameReady,
+    [property: System.Text.Json.Serialization.JsonPropertyName("csharp_metadata_target_ready")]
+    bool? CSharpMetadataTargetReady,
+    bool? SqlGraphContractReady,
+    bool? HotspotFamilyReady,
+    bool? FoldReady,
+    List<string>? DegradedFields)
+{
+    public static ReportReadinessSnapshot Unavailable(string reason, List<string> degradedFields)
+        => new(
+            Source: "unavailable",
+            UnavailableReason: reason,
+            GraphTableAvailable: null,
+            IssuesTableAvailable: null,
+            FileIssuesDataCurrent: null,
+            MigrationInProgress: null,
+            CSharpSymbolNameReady: null,
+            CSharpMetadataTargetReady: null,
+            SqlGraphContractReady: null,
+            HotspotFamilyReady: null,
+            FoldReady: null,
+            DegradedFields: degradedFields);
+}
+
+internal sealed record ReportDiagnosticSummary(
+    ReportExtractorDiagnosticSummary Extractors,
+    ReportHookDiagnosticSummary Hooks,
+    ReportConfigDiagnosticSummary Config);
+
+internal sealed record ReportExtractorDiagnosticSummary(
+    int PluginAssemblyCount,
+    int PatternConfigCount,
+    int SymbolExtractorCount,
+    int ReferenceExtractorCount,
+    int SkippedFileCount,
+    int DiagnosticCount,
+    bool DiagnosticsTruncated);
+
+internal sealed record ReportHookDiagnosticSummary(
+    int HookCount,
+    int DiagnosticCount,
+    long CallbackBudgetMs);
+
+internal sealed record ReportConfigDiagnosticSummary(
+    bool RawValuesIncluded,
+    List<string> Notes);
 
 internal sealed record ReportMetadata(
     string Version,
@@ -554,3 +973,10 @@ internal sealed record ReportMetadata(
     DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
 [System.Text.Json.Serialization.JsonSerializable(typeof(ReportMetadata))]
 internal partial class ReportMetadataJsonContext : System.Text.Json.Serialization.JsonSerializerContext;
+
+[System.Text.Json.Serialization.JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = System.Text.Json.Serialization.JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+[System.Text.Json.Serialization.JsonSerializable(typeof(ReportSupportManifest))]
+internal partial class ReportSupportManifestJsonContext : System.Text.Json.Serialization.JsonSerializerContext;

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -58,6 +58,7 @@ public class DbContext : IDisposable
         ("symbols", "visibility"),
         ("symbols", "return_type"),
         ("symbols", "is_metadata_target"),
+        ("symbols", "metadata_target_source"),
         ("symbols", "name_folded"),
     ];
     private static readonly string[] ReadMigrationRequiredIndexes =
@@ -1541,12 +1542,12 @@ public class DbContext : IDisposable
     // `cdidx status` の `path_case_sensitive` で診断できるようにする。
     public const string WorkspacePathCaseSensitiveMetaKey = "workspace_path_case_sensitive";
     // Authoritative `symbols.is_metadata_target` flag readiness, per language. Stamped at the
-    // end of a successful index pass once the writer's metadata-target resolver has classified
-    // every class-like row for that language. Readers fall back to the legacy heuristic when
-    // the per-language stamp is absent or its version does not match. Issue #435.
-    // 言語別 metadata-target 列の正式 readiness。index 終端で resolver が当該言語の class-like
-    // 行を全部分類した後にだけ stamp する。stamp が無い・version 不一致の言語については
-    // reader が legacy ヒューリスティックにフォールバックする。Issue #435。
+    // end of a successful index pass once extractor facts and the writer resolver have
+    // classified every class-like row for that language. Readers fall back to the legacy
+    // heuristic when the per-language stamp is absent or its version does not match. Issue #3524.
+    // 言語別 metadata-target 列の正式 readiness。index 終端で extractor fact と writer resolver が
+    // 当該言語の class-like 行を全部分類した後にだけ stamp する。stamp が無い・version 不一致の
+    // 言語については reader が legacy ヒューリスティックにフォールバックする。Issue #3524。
     // Version 2 (#435 iter 5) made the writer-side resolver import-aware: unqualified base
     // identifiers now resolve through the deriving file's `using Namespace;` / `using Alias =
     // FQN;` directives (plus `global using` aggregated across the repo) before falling back
@@ -1632,7 +1633,16 @@ public class DbContext : IDisposable
     // まで抜け落ち、`[FooAttribute]` の edge が落ちていた。iter-8 DB はこの展開なしで
     // index されたため、再 index で `::` 対応の resolver が `is_metadata_target` を
     // republish するまで reader を legacy 経路へ縮退させる。
-    public const int MetadataTargetVersion = 6;
+    // Version 7 (#3524) persists metadata-target provenance in
+    // `symbols.metadata_target_source` so readers and diagnostics can tell direct extractor
+    // facts from writer-resolved transitive targets. Iter-6 DBs only stored the flattened
+    // `is_metadata_target` bit, so they must degrade until reindexed with source-aware
+    // storage.
+    // バージョン 7 (#3524) で `symbols.metadata_target_source` に provenance を保存する。
+    // extractor が直接検出した fact と writer が推移的に解決した target を reader / diagnostics
+    // が区別できるようにするため、平坦な `is_metadata_target` だけを持つ iter-6 DB は
+    // source-aware storage で再 index されるまで縮退させる。
+    public const int MetadataTargetVersion = 7;
     public static string GetMetadataTargetVersionMetaKey(string lang) => $"metadata_target_version_{lang}";
     // Audit trail: cdidx version string (e.g. "1.22.0") that produced the most recent
     // successful end-of-index pass on this DB. Readers use it to surface "DB written by
@@ -1770,7 +1780,8 @@ public class DbContext : IDisposable
                 family_key      TEXT,
                 visibility      TEXT,
                 return_type     TEXT,
-                is_metadata_target INTEGER
+                is_metadata_target INTEGER,
+                metadata_target_source TEXT
             )");
 
                 // Indexed references table / 参照インデックステーブル
@@ -1991,10 +2002,11 @@ public class DbContext : IDisposable
                     visibility      TEXT,
                     return_type     TEXT,
                     is_metadata_target INTEGER,
+                    metadata_target_source TEXT,
                     name_folded     TEXT
                 )
                 """,
-                "id, file_id, kind, sub_kind, name, line, start_line, start_column, end_line, body_start_line, body_end_line, signature, container_kind, container_name, container_qualified_name, family_key, visibility, return_type, is_metadata_target, name_folded");
+                "id, file_id, kind, sub_kind, name, line, start_line, start_column, end_line, body_start_line, body_end_line, signature, container_kind, container_name, container_qualified_name, family_key, visibility, return_type, is_metadata_target, metadata_target_source, name_folded");
             RebuildReferenceLineTablesWithRequiredFileId();
             RebuildTableWithRequiredFileId(
                 "file_issues",
@@ -2263,10 +2275,11 @@ public class DbContext : IDisposable
                 visibility      TEXT,
                 return_type     TEXT,
                 is_metadata_target INTEGER,
+                metadata_target_source TEXT,
                 name_folded     TEXT
             )
             """;
-        const string symbolsColumns = "id, file_id, kind, sub_kind, name, line, start_line, start_column, end_line, body_start_line, body_end_line, signature, container_kind, container_name, container_qualified_name, family_key, visibility, return_type, is_metadata_target, name_folded";
+        const string symbolsColumns = "id, file_id, kind, sub_kind, name, line, start_line, start_column, end_line, body_start_line, body_end_line, signature, container_kind, container_name, container_qualified_name, family_key, visibility, return_type, is_metadata_target, metadata_target_source, name_folded";
         var symbolReferencesCreateSql =
             $"""
             CREATE TABLE symbol_references (
@@ -2633,6 +2646,7 @@ public class DbContext : IDisposable
         yield return ("EnsureColumn symbols.visibility", () => EnsureColumn("symbols", "visibility", "TEXT"));
         yield return ("EnsureColumn symbols.return_type", () => EnsureColumn("symbols", "return_type", "TEXT"));
         yield return ("EnsureColumn symbols.is_metadata_target", () => EnsureColumn("symbols", "is_metadata_target", "INTEGER"));
+        yield return ("EnsureColumn symbols.metadata_target_source", () => EnsureColumn("symbols", "metadata_target_source", "TEXT"));
         yield return ("CREATE INDEX idx_symbols_name_nocase",
             () => Execute("CREATE INDEX IF NOT EXISTS idx_symbols_name_nocase ON symbols(name COLLATE NOCASE)"));
 

--- a/src/CodeIndex/Database/DbReader.Dependencies.cs
+++ b/src/CodeIndex/Database/DbReader.Dependencies.cs
@@ -49,15 +49,11 @@ public partial class DbReader
     // TRUE when a `(symbols s, files <fileAlias>)` row should be counted as a
     // plausible metadata target (`[Attribute]` / `@Annotation` / `@decorator`).
     // Rules by language:
-    //   - C# (`csharp`): only `kind = 'class'` with an inheritance clause
-    //     (`signature LIKE '%: %'`). Transitive base-type resolution is not
-    //     available at SQL time, so "has any inheritance clause" is the
-    //     portable approximation for direct `: Attribute` plus indirect
-    //     `: BaseAudit` where `BaseAudit` itself derives from Attribute.
-    //     Extractor-driven authoritative `is_metadata_target` classification is
-    //     tracked as a follow-up (issue #435) and would let `deps` / `impact`
-    //     reject non-attribute classes like `class MyAuditAttribute : BaseService`
-    //     that this heuristic cannot distinguish.
+    //   - C# (`csharp`): ready DBs use the authoritative `is_metadata_target`
+    //     value stamped from extractor facts plus the writer resolver. Degraded
+    //     DBs fall back to the legacy inheritance-clause heuristic
+    //     (`signature LIKE '%: %'`) because transitive base-type resolution is not
+    //     available at SQL time.
     //     For legacy-migration DBs whose `signature` column exists but stores
     //     NULL for individual C# class rows, fall back to the canonical C#
     //     attribute-naming convention (`name LIKE '%Attribute'`). This is
@@ -77,14 +73,9 @@ public partial class DbReader
     //     class-like declaration, so keep the original class-like candidate
     //     set (`class` / `struct` / `interface`).
     // `deps` と `impact` で共有する言語別 metadata-target 適格性判定。
-    // C# は `kind = 'class'` かつ継承節を持つ行を対象とする（直接/間接の Attribute 継承を
-    // ポータブルに近似するため）。signature 列は存在するが値が NULL の legacy-migration
-    // DB では C# の命名規約 `name LIKE '%Attribute'` にフォールバック — 従来の
-    // 無条件許容より厳密で、NULL-signature の全 class を metadata target 扱いしない。
-    // signature 列自体が無い旧 DB も同じ命名規約ヒューリスティックを使う。
-    // extractor 主導の authoritative な `is_metadata_target` 判定は follow-up（issue #435）
-    // として追跡しており、schema 化すれば `class MyAuditAttribute : BaseService` のような
-    // 非 attribute 継承も厳密に除外できるが、現状のヒューリスティックでは判別できない。
+    // C# は ready DB では extractor/resolver が stamp した `is_metadata_target` を使う。
+    // degraded DB では継承節と命名規約の legacy heuristic に縮退し、signature 列自体が無い旧 DB
+    // では命名規約 `name LIKE '%Attribute'` のみに落とす。
     // JS / TS は decorator が runtime entity (class / factory function) のみ対象。
     // TypeScript の `interface` は型定義で runtime decorator target にならないため除外し、
     // 同名 `interface` が本物の `function` / `class` provider を曖昧化するのを防ぐ。
@@ -105,11 +96,11 @@ public partial class DbReader
         // NULL signature は C# 命名規約 `name LIKE '%Attribute'` に縮退 — 従来の
         // 無条件許容より厳密で、legacy-migration DB で任意の NULL-signature class が
         // metadata target 扱いされるのを防ぐ。signature 列欠落 DB も同じ命名規約を使う。
-        // Authoritative column takes precedence once the writer's resolver has stamped the
-        // current `metadata_target_version_csharp` version. Drops the `: %` heuristic for C#
-        // so non-attribute classes like `class MyAuditAttribute : BaseService` no longer fake
-        // ambiguity against a sibling real `class MyAuditAttribute : Attribute`. Issue #435.
-        // writer の resolver が current version を stamp 済みの DB では authoritative 列を優先し、
+        // Authoritative column takes precedence once the writer has stamped the current
+        // `metadata_target_version_csharp` version. Drops the `: %` heuristic for C# so
+        // non-attribute classes like `class MyAuditAttribute : BaseService` no longer fake
+        // ambiguity against a sibling real `class MyAuditAttribute : Attribute`. Issue #3524.
+        // writer が current version を stamp 済みの DB では authoritative 列を優先し、
         // `class MyAuditAttribute : BaseService` のような非 Attribute 派生を ambiguity から除外する。
         // Three-way branch keyed off the `is_metadata_target` column presence, not
         // `signature`. Branch (2) (legacy heuristic) must only fire when both the new

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -108,14 +108,13 @@ public partial class DbReader : IDisposable
     // #86: name_folded 列が全行埋まっているか（fold 経路を使えるか）。
     internal readonly bool _foldReady;
     internal readonly bool _csharpSymbolNameContractCurrent;
-    // #435: True when `symbols.is_metadata_target` has been populated for every C# class-like
-    // row by the writer's resolver and the stamp in `codeindex_meta` matches the current
-    // version. Readers that enforce metadata-target eligibility prefer this column over the
-    // legacy `signature LIKE '%: %'` heuristic when the flag is true; otherwise they continue
-    // to fall back to the heuristic so legacy / partial DBs do not silently miss edges.
-    // #435: C# の authoritative `is_metadata_target` が全行 populate されて stamp 一致したときのみ
-    // true。true なら reader は legacy ヒューリスティックではなく列を使う。false の DB では
-    // 従来どおり `signature LIKE '%: %'` にフォールバックする。
+    // #3524: True when `symbols.is_metadata_target` has been populated from extractor facts
+    // plus the writer resolver for every C# class-like row and the stamp in `codeindex_meta`
+    // matches the current version. Readers that enforce metadata-target eligibility prefer
+    // this column over the legacy `signature LIKE '%: %'` heuristic when the flag is true.
+    // #3524: C# の authoritative `is_metadata_target` が extractor fact と writer resolver から
+    // 全行 populate されて stamp 一致したときのみ true。true なら reader は legacy
+    // ヒューリスティックではなく列を使う。
     internal readonly bool _csharpMetadataTargetReady;
     internal readonly string? _csharpMetadataTargetDegradedReason;
     internal readonly bool _sqlGraphContractCurrent;
@@ -540,16 +539,18 @@ public partial class DbReader : IDisposable
             TryGetMetaString(_conn, DbContext.CSharpSymbolNameContractVersionMetaKey),
             DbContext.CSharpSymbolNameContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
             StringComparison.Ordinal);
-        var hasMetadataTargetColumn = _symbolColumns.Contains("is_metadata_target");
+        var hasMetadataTargetStorage =
+            _symbolColumns.Contains("is_metadata_target")
+            && _symbolColumns.Contains("metadata_target_source");
         var metadataTargetStampCurrent = string.Equals(
             TryGetMetaString(_conn, DbContext.GetMetadataTargetVersionMetaKey("csharp")),
             DbContext.MetadataTargetVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
             StringComparison.Ordinal);
-        _csharpMetadataTargetReady = hasMetadataTargetColumn
+        _csharpMetadataTargetReady = hasMetadataTargetStorage
             && metadataTargetStampCurrent;
         _csharpMetadataTargetDegradedReason = _csharpMetadataTargetReady
             ? null
-            : !hasMetadataTargetColumn
+            : !hasMetadataTargetStorage
                 ? DegradationReasonCodes.CSharpMetadataTargetMissingColumn
                 : DegradationReasonCodes.CSharpMetadataTargetStampOutdated;
         _sqlGraphContractCurrent = string.Equals(

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1095,7 +1095,7 @@ public class DbWriter
                     body_start_line, body_end_line, signature,
                     container_kind, container_name, container_qualified_name, family_key,
                     visibility, return_type,
-                    is_metadata_target,
+                    is_metadata_target, metadata_target_source,
                     name_folded
                 )
                 VALUES ");
@@ -1114,7 +1114,7 @@ public class DbWriter
                     @bodyStartLine{suffix}, @bodyEndLine{suffix}, @signature{suffix},
                     @containerKind{suffix}, @containerName{suffix}, @containerQualifiedName{suffix}, @familyKey{suffix},
                     @visibility{suffix}, @returnType{suffix},
-                    @isMetadataTarget{suffix},
+                    @isMetadataTarget{suffix}, @metadataTargetSource{suffix},
                     @nameFolded{suffix}
                 )");
             cmd.Parameters.Add($"@fid{suffix}", SqliteType.Integer).Value = symbol.FileId;
@@ -1137,6 +1137,7 @@ public class DbWriter
             cmd.Parameters.Add($"@isMetadataTarget{suffix}", SqliteType.Integer).Value = symbol.IsMetadataTarget.HasValue
                 ? (symbol.IsMetadataTarget.Value ? 1 : 0)
                 : (object)DBNull.Value;
+            cmd.Parameters.Add($"@metadataTargetSource{suffix}", SqliteType.Text).Value = (object?)symbol.MetadataTargetSource ?? DBNull.Value;
             cmd.Parameters.Add($"@nameFolded{suffix}", SqliteType.Text).Value = FoldedNameDbValue(symbol.Name, foldedNameCache);
         }
 
@@ -2243,16 +2244,14 @@ public class DbWriter
     }
 
     /// <summary>
-    /// Recompute `symbols.is_metadata_target` for every C# class-like row by parsing the
-    /// signature column for inheritance clauses and running a fixed-point iteration that
-    /// promotes any class transitively deriving from `System.Attribute`. Out-of-repo bases
-    /// whose name ends with `Attribute` (the BCL convention) are also treated as targets so
-    /// `class FooAttribute : SomeBaseAttribute` is captured even when `SomeBaseAttribute`
-    /// itself is in the BCL. Non-target rows are written as 0 so reader switching does not
-    /// confuse "no resolver pass yet" with "resolver decided not a target". Issue #435.
-    /// C# class-like 行の `is_metadata_target` を signature の継承句から再計算する。
-    /// `System.Attribute` 由来は再帰的に target、リポ外で末尾が `Attribute` の base 型も
-    /// target 扱い。target でない行は明示的に 0 で書き、reader で「未解決」と区別する。
+    /// Recompute `symbols.is_metadata_target` for every C# class-like row from extractor-owned
+    /// direct facts plus a fixed-point resolver for transitive `System.Attribute` inheritance.
+    /// Out-of-repo bases whose name ends with `Attribute` (the BCL convention) remain a bounded
+    /// resolver fallback. Non-target rows are written as 0 so reader switching does not confuse
+    /// "no resolver pass yet" with "resolver decided not a target". Issue #3524.
+    /// C# class-like 行の `is_metadata_target` を extractor 由来の直接 fact と transitive
+    /// resolver から再計算する。リポ外で末尾が `Attribute` の base 型は bounded fallback として
+    /// target 扱いを残す。target でない行は明示的に 0 で書き、reader で「未解決」と区別する。
     /// </summary>
     public void ResolveCSharpMetadataTargets()
     {
@@ -2321,7 +2320,11 @@ public class DbWriter
         // 集約して、ファイルを跨ぐ拡張も拾う。Issue #435 codex review iter 5。
         var (perFileImports, globalImports) = LoadCSharpImportsByFile();
 
-        var targets = new HashSet<long>();
+        var extractorTargets = rows
+            .Where(row => row.ExtractorMetadataTarget)
+            .Select(row => row.Id)
+            .ToHashSet();
+        var targets = new HashSet<long>(extractorTargets);
         bool changed = true;
         while (changed)
         {
@@ -2343,48 +2346,77 @@ public class DbWriter
 
         using var txn = !IsInTransaction() ? BeginTransaction() : null;
         using var update = _conn.CreateCommand();
-        update.CommandText = "UPDATE symbols SET is_metadata_target = @flag WHERE id = @id";
+        bool hasMetadataTargetSource = ColumnExists("symbols", "metadata_target_source");
+        update.CommandText = hasMetadataTargetSource
+            ? "UPDATE symbols SET is_metadata_target = @flag, metadata_target_source = @source WHERE id = @id"
+            : "UPDATE symbols SET is_metadata_target = @flag WHERE id = @id";
         var pFlag = update.Parameters.Add("@flag", SqliteType.Integer);
+        var pSource = hasMetadataTargetSource ? update.Parameters.Add("@source", SqliteType.Text) : null;
         var pId = update.Parameters.Add("@id", SqliteType.Integer);
         update.Prepare();
         foreach (var row in rows)
         {
-            pFlag.Value = targets.Contains(row.Id) ? 1 : 0;
+            bool target = targets.Contains(row.Id);
+            pFlag.Value = target ? 1 : 0;
+            if (pSource != null)
+            {
+                pSource.Value = extractorTargets.Contains(row.Id)
+                    ? SymbolRecord.MetadataTargetSourceExtractor
+                    : target
+                        ? SymbolRecord.MetadataTargetSourceResolver
+                        : DBNull.Value;
+            }
             pId.Value = row.Id;
             update.ExecuteNonQuery();
         }
         txn?.Commit();
     }
 
-    private List<(long Id, long FileId, string Name, string? Signature, string? QualifiedName)> LoadCSharpClassRows()
+    private List<CSharpClassRow> LoadCSharpClassRows()
     {
-        var rows = new List<(long Id, long FileId, string Name, string? Signature, string? QualifiedName)>();
+        var rows = new List<CSharpClassRow>();
         if (!ColumnExists("symbols", "signature") || !ColumnExists("symbols", "is_metadata_target"))
             return rows;
         bool hasQualified = ColumnExists("symbols", "container_qualified_name");
+        bool hasMetadataTargetSource = ColumnExists("symbols", "metadata_target_source");
 
         using var cmd = _conn.CreateCommand();
         cmd.CommandText = hasQualified
-            ? @"SELECT s.id, s.file_id, s.name, s.signature, s.container_qualified_name
+            ? $@"SELECT s.id, s.file_id, s.name, s.signature, s.container_qualified_name,
+                    s.is_metadata_target, {(hasMetadataTargetSource ? "s.metadata_target_source" : "NULL")}
                 FROM symbols s
                 JOIN files f ON f.id = s.file_id
                 WHERE f.lang = 'csharp' AND s.kind = 'class' AND s.name IS NOT NULL"
-            : @"SELECT s.id, s.file_id, s.name, s.signature, NULL
+            : $@"SELECT s.id, s.file_id, s.name, s.signature, NULL,
+                    s.is_metadata_target, {(hasMetadataTargetSource ? "s.metadata_target_source" : "NULL")}
                 FROM symbols s
                 JOIN files f ON f.id = s.file_id
                 WHERE f.lang = 'csharp' AND s.kind = 'class' AND s.name IS NOT NULL";
         using var reader = cmd.ExecuteTrackedReader();
         while (reader.TrackedRead())
         {
-            rows.Add((
+            bool extractorMetadataTarget = !reader.IsDBNull(5)
+                && reader.GetInt64(5) == 1
+                && !reader.IsDBNull(6)
+                && string.Equals(reader.GetString(6), SymbolRecord.MetadataTargetSourceExtractor, StringComparison.Ordinal);
+            rows.Add(new CSharpClassRow(
                 reader.GetInt64(0),
                 reader.GetInt64(1),
                 reader.GetString(2),
                 reader.IsDBNull(3) ? null : reader.GetString(3),
-                reader.IsDBNull(4) ? null : reader.GetString(4)));
+                reader.IsDBNull(4) ? null : reader.GetString(4),
+                extractorMetadataTarget));
         }
         return rows;
     }
+
+    private sealed record CSharpClassRow(
+        long Id,
+        long FileId,
+        string Name,
+        string? Signature,
+        string? QualifiedName,
+        bool ExtractorMetadataTarget);
 
     // Per-file import set for C# unqualified-base resolution. `Namespaces` lists each
     // `using Foo.Bar;` target so `class X : Base` can probe `Foo.Bar.Base` in the qualified

--- a/src/CodeIndex/Database/DegradationReasonCodes.cs
+++ b/src/CodeIndex/Database/DegradationReasonCodes.cs
@@ -187,7 +187,7 @@ public static class DegradationReasonCodes
                 "Run `cdidx index <projectPath> --rebuild` for a full rebuild."),
             CSharpMetadataTargetMissingColumn => new(
                 code,
-                "C# metadata attribute dependency edges are degraded because the symbols.is_metadata_target column is missing.",
+                "C# metadata attribute dependency edges are degraded because metadata-target storage columns are missing.",
                 "Run `cdidx index <projectPath> --rebuild` to recreate the index with metadata-target storage.",
                 "Run `cdidx index <projectPath>` after upgrading if the DB can be migrated in place."),
             CSharpMetadataTargetStampOutdated => new(

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
@@ -486,6 +486,7 @@ public sealed class PostExtractionHookRunner : IDisposable
             Visibility = symbol.Visibility,
             ReturnType = symbol.ReturnType,
             IsMetadataTarget = symbol.IsMetadataTarget,
+            MetadataTargetSource = symbol.MetadataTargetSource,
             SameLineSignatureOccurrenceIndex = symbol.SameLineSignatureOccurrenceIndex,
         }).ToList();
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -3395,6 +3395,7 @@ public static partial class SymbolExtractor
                                 && pattern.BodyStyle == BodyStyle.None
                                 ? TryExpandFortranParameterDeclaratorList(patternMatchLine, match)
                                 : null;
+                            var csharpMetadataTarget = TryClassifyCSharpExtractorMetadataTarget(lang, pattern.Kind, signature);
 
                             if (pythonImportEntries != null)
                             {
@@ -3619,6 +3620,10 @@ public static partial class SymbolExtractor
                                             SubKind = pythonSubKind ?? ResolveLanguageSubKind(lang, kind, signature, patternMatchLine),
                                             Visibility = TryGetGroup(match, pattern.VisibilityGroup),
                                             ReturnType = NormalizeMetadata(rawReturnType),
+                                            IsMetadataTarget = csharpMetadataTarget,
+                                            MetadataTargetSource = csharpMetadataTarget == true
+                                                ? SymbolRecord.MetadataTargetSourceExtractor
+                                                : null,
                                         },
                                     line);
 
@@ -4167,6 +4172,157 @@ public static partial class SymbolExtractor
             ExpandShellAliasSymbols(fileId, lines, symbols);
         PopulateDeclaredContainerQualifiedNames(symbols);
         return symbols;
+    }
+
+    private static bool? TryClassifyCSharpExtractorMetadataTarget(string? lang, string kind, string? signature)
+    {
+        if (!string.Equals(lang, "csharp", StringComparison.Ordinal) || kind != "class")
+            return null;
+
+        foreach (var baseIdentifier in ParseCSharpExtractorBaseIdentifiers(signature))
+        {
+            var normalized = StripCSharpVerbatimIdentifierPrefixes(baseIdentifier);
+            if (string.Equals(normalized, "Attribute", StringComparison.Ordinal)
+                || string.Equals(normalized, "System.Attribute", StringComparison.Ordinal)
+                || string.Equals(normalized, "global::System.Attribute", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return null;
+    }
+
+    private static List<string> ParseCSharpExtractorBaseIdentifiers(string? signature)
+    {
+        var result = new List<string>();
+        if (string.IsNullOrEmpty(signature))
+            return result;
+
+        int colonIdx = FindCSharpExtractorBaseListColon(signature);
+        if (colonIdx < 0)
+            return result;
+
+        int genericDepth = 0;
+        var current = new StringBuilder();
+        for (int i = colonIdx + 1; i < signature.Length; i++)
+        {
+            char c = signature[i];
+            if (c == '<')
+            {
+                genericDepth++;
+                current.Append(c);
+                continue;
+            }
+            if (c == '>')
+            {
+                if (genericDepth > 0)
+                    genericDepth--;
+                current.Append(c);
+                continue;
+            }
+            if (c == '{')
+                break;
+            if (genericDepth == 0 && c == ',')
+            {
+                AddCSharpExtractorBaseIdentifier(result, current.ToString());
+                current.Clear();
+                continue;
+            }
+            if (genericDepth == 0 && (c == 'w' || c == 'W') && LooksLikeCSharpWhereKeyword(signature, i))
+            {
+                AddCSharpExtractorBaseIdentifier(result, current.ToString());
+                return result;
+            }
+            current.Append(c);
+        }
+
+        AddCSharpExtractorBaseIdentifier(result, current.ToString());
+        return result;
+    }
+
+    private static int FindCSharpExtractorBaseListColon(string signature)
+    {
+        int genericDepth = 0;
+        int parenDepth = 0;
+        for (int i = 0; i < signature.Length; i++)
+        {
+            char c = signature[i];
+            if (c == '<') { genericDepth++; continue; }
+            if (c == '>') { if (genericDepth > 0) genericDepth--; continue; }
+            if (c == '(') { parenDepth++; continue; }
+            if (c == ')') { if (parenDepth > 0) parenDepth--; continue; }
+            if (c == '{')
+                return -1;
+            if (genericDepth == 0 && parenDepth == 0 && (c == 'w' || c == 'W')
+                && LooksLikeCSharpWhereKeyword(signature, i))
+            {
+                return -1;
+            }
+            if (c == ':' && genericDepth == 0 && parenDepth == 0)
+            {
+                if (i + 1 < signature.Length && signature[i + 1] == ':')
+                {
+                    i++;
+                    continue;
+                }
+                if (i > 0 && signature[i - 1] == ':')
+                    continue;
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static bool LooksLikeCSharpWhereKeyword(string signature, int i)
+    {
+        if (i + 5 > signature.Length)
+            return false;
+        if (string.Compare(signature, i, "where", 0, 5, StringComparison.OrdinalIgnoreCase) != 0)
+            return false;
+        if (i > 0)
+        {
+            char prev = signature[i - 1];
+            if (char.IsLetterOrDigit(prev) || prev == '_')
+                return false;
+        }
+        if (i + 5 < signature.Length)
+        {
+            char next = signature[i + 5];
+            if (char.IsLetterOrDigit(next) || next == '_')
+                return false;
+        }
+        return true;
+    }
+
+    private static void AddCSharpExtractorBaseIdentifier(List<string> result, string raw)
+    {
+        var trimmed = raw.Trim();
+        if (trimmed.Length == 0)
+            return;
+
+        int cut = trimmed.Length;
+        for (int i = 0; i < trimmed.Length; i++)
+        {
+            char c = trimmed[i];
+            if (c == '<' || char.IsWhiteSpace(c))
+            {
+                cut = i;
+                break;
+            }
+        }
+        var head = trimmed[..cut];
+        if (head.Length > 0)
+            result.Add(head);
+    }
+
+    private static string StripCSharpVerbatimIdentifierPrefixes(string value)
+    {
+        if (value.IndexOf('@', StringComparison.Ordinal) < 0)
+            return value;
+        return value.Replace(".@", ".", StringComparison.Ordinal)
+            .Replace("::@", "::", StringComparison.Ordinal)
+            .TrimStart('@');
     }
 
     private static void ClassifyScalaCompanions(List<SymbolRecord> symbols)

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -977,14 +977,13 @@ public class StatusResult
     public bool CSharpSymbolNameReady { get; set; } = true;
     /// <summary>
     /// True when every indexed C# class row carries an authoritative `is_metadata_target`
-    /// value stamped under the current `metadata_target_version_csharp` contract. False
-    /// means the `deps` / `impact` metadata-attribute edges fall back to the legacy
-    /// `signature LIKE '%: %'` heuristic (or the `name LIKE '%Attribute'` suffix heuristic
-    /// on truly-legacy DBs missing the `is_metadata_target` column), which silently drops
-    /// impostor classes like `class FooAttribute : BaseService`. Run `cdidx index .` once
-    /// to let the authoritative resolver rewrite the stamp (#435).
-    /// true のとき deps / impact の metadata-attribute edge は persisted な
-    /// `is_metadata_target` 列を使い、false のとき legacy heuristic 経路で縮退する。
+    /// value stamped under the current `metadata_target_version_csharp` contract from
+    /// extractor facts plus the writer resolver. False means the `deps` / `impact`
+    /// metadata-attribute edges fall back to the legacy `signature LIKE '%: %'` heuristic
+    /// (or the `name LIKE '%Attribute'` suffix heuristic on truly-legacy DBs missing the
+    /// `is_metadata_target` column). Run `cdidx index .` once to restamp the contract (#3524).
+    /// true のとき deps / impact の metadata-attribute edge は extractor fact と writer resolver が
+    /// stamp した persisted な `is_metadata_target` 列を使い、false のとき legacy heuristic 経路で縮退する。
     /// </summary>
     [JsonPropertyName("csharp_metadata_target_ready")]
     public bool CSharpMetadataTargetReady { get; set; } = true;

--- a/src/CodeIndex/Models/SymbolRecord.cs
+++ b/src/CodeIndex/Models/SymbolRecord.cs
@@ -6,6 +6,9 @@ namespace CodeIndex.Models;
 /// </summary>
 public class SymbolRecord
 {
+    public const string MetadataTargetSourceExtractor = "extractor";
+    public const string MetadataTargetSourceResolver = "resolver";
+
     public long Id { get; set; }
     public long FileId { get; set; }
 
@@ -66,6 +69,12 @@ public class SymbolRecord
     /// gating される resolver が full populate した後にだけ trust される。
     /// </summary>
     public bool? IsMetadataTarget { get; set; }
+
+    /// <summary>
+    /// Provenance for `IsMetadataTarget` when known (`extractor` or `resolver`).
+    /// `IsMetadataTarget` の由来（分かる場合は `extractor` または `resolver`）。
+    /// </summary>
+    public string? MetadataTargetSource { get; set; }
 
     /// <summary>0-based occurrence index of the same signature on the same raw line / 同一 raw 行・同一 signature 内での 0-based 出現順</summary>
     public int? SameLineSignatureOccurrenceIndex { get; set; }

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -9729,6 +9729,72 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void ResolveCSharpMetadataTargets_SeedsExtractorOwnedMetadataTargets_Issue3524()
+    {
+        InsertIndexedFile("src/A/DirectAttribute.cs", "csharp",
+            """
+            namespace A
+            {
+                public class DirectAttribute : System.Attribute
+                {
+                }
+            }
+            """);
+        InsertIndexedFile("src/A/ChildAttribute.cs", "csharp",
+            """
+            namespace A
+            {
+                public class ChildAttribute : DirectAttribute
+                {
+                }
+            }
+            """);
+        InsertIndexedFile("src/A/Svc.cs", "csharp",
+            """
+            namespace A
+            {
+                [Child]
+                public class Svc
+                {
+                }
+            }
+            """);
+
+        _writer.ResolveCSharpMetadataTargets();
+        _writer.MarkMetadataTargetReady("csharp");
+        var resolverReader = new DbReader(_db.Connection);
+
+        using (var cmd = _db.Connection.CreateCommand())
+        {
+            cmd.CommandText = @"
+                SELECT s.is_metadata_target, s.metadata_target_source
+                FROM symbols s
+                JOIN files f ON f.id = s.file_id
+                WHERE f.path = 'src/A/DirectAttribute.cs' AND s.kind = 'class' AND s.name = 'DirectAttribute'";
+            using var reader = cmd.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(1L, reader.GetInt64(0));
+            Assert.Equal(SymbolRecord.MetadataTargetSourceExtractor, reader.GetString(1));
+        }
+
+        using (var cmd = _db.Connection.CreateCommand())
+        {
+            cmd.CommandText = @"
+                SELECT s.is_metadata_target, s.metadata_target_source
+                FROM symbols s
+                JOIN files f ON f.id = s.file_id
+                WHERE f.path = 'src/A/ChildAttribute.cs' AND s.kind = 'class' AND s.name = 'ChildAttribute'";
+            using var reader = cmd.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(1L, reader.GetInt64(0));
+            Assert.Equal(SymbolRecord.MetadataTargetSourceResolver, reader.GetString(1));
+        }
+
+        var dependencies = resolverReader.GetFileDependencies(limit: 10, lang: "csharp");
+        Assert.Contains(dependencies, d => d.SourcePath == "src/A/Svc.cs" && d.TargetPath == "src/A/ChildAttribute.cs");
+    }
+
+    [Fact]
     public void ResolveCSharpMetadataTargets_DoesNotMistakeGenericConstraintForBaseList()
     {
         // issue #435 codex review iter 1: `class Foo<T> where T : Attribute {}` has no
@@ -13122,6 +13188,20 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void GetStatus_DistinguishesCSharpMetadataTargetSourceMissingColumn_Issue3524()
+    {
+        InsertIndexedFile("src/LegacySource.cs", "csharp", "public class LegacySource { }\n");
+        _writer.MarkMetadataTargetReady("csharp");
+        RecreateSymbolsTableWithoutMetadataTargetSourceColumn();
+        var freshReader = new DbReader(_db.Connection);
+
+        var status = freshReader.GetStatus();
+
+        Assert.False(status.CSharpMetadataTargetReady);
+        Assert.Equal(DegradationReasonCodes.CSharpMetadataTargetMissingColumn, status.CSharpMetadataTargetDegradedReason);
+    }
+
+    [Fact]
     public void GetStatus_ExposesCSharpMetadataTargetReadyTrueWhenContractStampCurrent()
     {
         // Happy path: C# files are indexed and the current-version stamp is present, so the
@@ -13278,6 +13358,52 @@ public class DbReaderTests : IDisposable
                 start_column, end_line, body_start_line,
                 body_end_line, signature, container_kind, container_name,
                 container_qualified_name, family_key, visibility, return_type
+            FROM symbols_old;
+            DROP TABLE symbols_old;
+            PRAGMA foreign_keys = ON;
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    private void RecreateSymbolsTableWithoutMetadataTargetSourceColumn()
+    {
+        using var cmd = _db.Connection.CreateCommand();
+        cmd.CommandText = """
+            PRAGMA foreign_keys = OFF;
+            ALTER TABLE symbols RENAME TO symbols_old;
+            CREATE TABLE symbols (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_id         INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                kind            TEXT,
+                sub_kind        TEXT,
+                name            TEXT,
+                name_folded     TEXT,
+                line            INTEGER,
+                start_line      INTEGER,
+                start_column    INTEGER,
+                end_line        INTEGER,
+                body_start_line INTEGER,
+                body_end_line   INTEGER,
+                signature       TEXT,
+                container_kind  TEXT,
+                container_name  TEXT,
+                container_qualified_name TEXT,
+                family_key      TEXT,
+                visibility      TEXT,
+                return_type     TEXT,
+                is_metadata_target INTEGER
+            );
+            INSERT INTO symbols (
+                id, file_id, kind, sub_kind, name, name_folded, line, start_line,
+                start_column, end_line, body_start_line,
+                body_end_line, signature, container_kind, container_name,
+                container_qualified_name, family_key, visibility, return_type, is_metadata_target
+            )
+            SELECT
+                id, file_id, kind, sub_kind, name, name_folded, line, start_line,
+                start_column, end_line, body_start_line,
+                body_end_line, signature, container_kind, container_name,
+                container_qualified_name, family_key, visibility, return_type, is_metadata_target
             FROM symbols_old;
             DROP TABLE symbols_old;
             PRAGMA foreign_keys = ON;

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -278,6 +278,33 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_DetailedJsonHandlesLegacySymbolRowsWithoutMetadataTargetSource_Issue3524()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_metadata_source_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_metadata_source_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class Same { }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class Same { }");
+            RecreateSymbolsTableWithoutMetadataTargetSourceColumn(leftDb);
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--json", "--detailed", "--limit", "1"]);
+
+            Assert.Equal(0, exitCode);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal("identical", document.RootElement.GetProperty("status").GetString());
+            Assert.True(document.RootElement.GetProperty("identical").GetBoolean());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
     public void Run_ReturnsSuccessForSeparatelyBuiltIdenticalDatabases_Issue1724()
     {
         var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_identical_left");
@@ -713,6 +740,52 @@ public class DiffCommandRunnerTests
             )
             """,
             command => command.Parameters.AddWithValue("$context", context));
+    }
+
+    private static void RecreateSymbolsTableWithoutMetadataTargetSourceColumn(string dbPath)
+    {
+        ExecuteNonQuery(
+            dbPath,
+            """
+            PRAGMA foreign_keys = OFF;
+            ALTER TABLE symbols RENAME TO symbols_old;
+            CREATE TABLE symbols (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_id         INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                kind            TEXT,
+                sub_kind        TEXT,
+                name            TEXT,
+                name_folded     TEXT,
+                line            INTEGER,
+                start_line      INTEGER,
+                start_column    INTEGER,
+                end_line        INTEGER,
+                body_start_line INTEGER,
+                body_end_line   INTEGER,
+                signature       TEXT,
+                container_kind  TEXT,
+                container_name  TEXT,
+                container_qualified_name TEXT,
+                family_key      TEXT,
+                visibility      TEXT,
+                return_type     TEXT,
+                is_metadata_target INTEGER
+            );
+            INSERT INTO symbols (
+                id, file_id, kind, sub_kind, name, name_folded, line, start_line,
+                start_column, end_line, body_start_line,
+                body_end_line, signature, container_kind, container_name,
+                container_qualified_name, family_key, visibility, return_type, is_metadata_target
+            )
+            SELECT
+                id, file_id, kind, sub_kind, name, name_folded, line, start_line,
+                start_column, end_line, body_start_line,
+                body_end_line, signature, container_kind, container_name,
+                container_qualified_name, family_key, visibility, return_type, is_metadata_target
+            FROM symbols_old;
+            DROP TABLE symbols_old;
+            PRAGMA foreign_keys = ON;
+            """);
     }
 
     private static void ExecuteNonQuery(string dbPath, string sql, Action<SqliteCommand>? configure = null)

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -796,6 +796,39 @@ exit 7
     }
 
     [Fact]
+    public void TryGetHeadCommitResult_RootDiscoveryTimeoutReportsStructuredFailure_Issue3434()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo-head-root-timeout");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-head-root-timeout");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatHangsForAnyCommand(fakeGitDir);
+
+        var oldGitExecutablePath = GitHelper.GitExecutablePathOverride;
+        var oldTimeout = GitHelper.GitCommandTimeout;
+        GitHelper.GitExecutablePathOverride = Path.Combine(fakeGitDir, "git");
+        GitHelper.GitCommandTimeout = TimeSpan.FromMilliseconds(100);
+        try
+        {
+            var actual = GitHelper.TryGetHeadCommitResult(repoDir);
+
+            Assert.Equal(GitHeadCommitState.Error, actual.State);
+            Assert.Null(actual.Sha);
+            Assert.Equal(GitCommandFailureKind.TimedOut, actual.FailureKind);
+            Assert.Contains("timed out", actual.Diagnostic);
+            Assert.NotEqual(GitHeadCommitState.NotARepo, actual.State);
+        }
+        finally
+        {
+            GitHelper.GitCommandTimeout = oldTimeout;
+            GitHelper.GitExecutablePathOverride = oldGitExecutablePath;
+        }
+    }
+
+    [Fact]
     public void TryGetHeadCommitResult_ReturnsNoneForUnbornHead()
     {
         var repoDir = CreateGitRepo();

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -485,6 +485,115 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public void RunGitCapturingResult_NonZeroExitReportsStructuredBoundedDiagnostic_Issue3434()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo-git-structured-failure");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-structured-failure");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatFailsWithLongSensitiveStderr(fakeGitDir);
+
+        var oldGitExecutablePath = GitHelper.GitExecutablePathOverride;
+        GitHelper.GitExecutablePathOverride = Path.Combine(fakeGitDir, "git");
+        try
+        {
+            var result = GitHelper.RunGitCapturingResultForTests(
+                repoDir,
+                gitEnvironmentOverrides: null,
+                CancellationToken.None,
+                "status");
+
+            Assert.Equal(23, result.ExitCode);
+            Assert.Equal(GitCommandFailureKind.ExitCode, result.FailureKind);
+            Assert.Equal(result.Diagnostic, result.Error);
+            Assert.NotNull(result.Diagnostic);
+            Assert.Contains("[redacted]", result.Diagnostic);
+            Assert.Contains("truncated", result.Diagnostic);
+            Assert.True(result.Diagnostic!.Length < 700, result.Diagnostic);
+            Assert.DoesNotContain("/Users/example/private", result.Diagnostic);
+        }
+        finally
+        {
+            GitHelper.GitExecutablePathOverride = oldGitExecutablePath;
+        }
+    }
+
+    [Fact]
+    public void RunGitCapturingResult_TimeoutReportsStructuredFailure_Issue3434()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo-git-structured-timeout");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-structured-timeout");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatHangsForAnyCommand(fakeGitDir);
+
+        var oldGitExecutablePath = GitHelper.GitExecutablePathOverride;
+        var oldTimeout = GitHelper.GitCommandTimeout;
+        GitHelper.GitExecutablePathOverride = Path.Combine(fakeGitDir, "git");
+        GitHelper.GitCommandTimeout = TimeSpan.FromMilliseconds(100);
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var result = GitHelper.RunGitCapturingResultForTests(
+                repoDir,
+                gitEnvironmentOverrides: null,
+                CancellationToken.None,
+                "status");
+            stopwatch.Stop();
+
+            Assert.Equal(-1, result.ExitCode);
+            Assert.Equal(GitCommandFailureKind.TimedOut, result.FailureKind);
+            Assert.Contains("timed out", result.Diagnostic);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), $"Timeout took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            GitHelper.GitCommandTimeout = oldTimeout;
+            GitHelper.GitExecutablePathOverride = oldGitExecutablePath;
+        }
+    }
+
+    [Fact]
+    public void RunGitCapturingResult_StartFailureReportsStructuredRedactedDiagnostic_Issue3434()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo-git-start-failure");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-start-failure");
+        Directory.CreateDirectory(fakeGitDir);
+        var fakeGitPath = WriteNonExecutableFakeGit(fakeGitDir);
+
+        var oldGitExecutablePath = GitHelper.GitExecutablePathOverride;
+        GitHelper.GitExecutablePathOverride = fakeGitPath;
+        try
+        {
+            var result = GitHelper.RunGitCapturingResultForTests(
+                repoDir,
+                gitEnvironmentOverrides: null,
+                CancellationToken.None,
+                "status");
+
+            Assert.Null(result.ExitCode);
+            Assert.Equal(GitCommandFailureKind.StartFailed, result.FailureKind);
+            Assert.NotNull(result.Diagnostic);
+            Assert.DoesNotContain(fakeGitDir, result.Diagnostic);
+            Assert.True(result.Diagnostic!.Length < 700, result.Diagnostic);
+        }
+        finally
+        {
+            GitHelper.GitExecutablePathOverride = oldGitExecutablePath;
+        }
+    }
+
+    [Fact]
     public void GetChangedFilesFromCommit_CancelDuringGitCommand_ThrowsOperationCanceled()
     {
         if (OperatingSystem.IsWindows())
@@ -1137,6 +1246,39 @@ exit 1
 """);
         if (!OperatingSystem.IsWindows())
             File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static void WriteFakeGitThatFailsWithLongSensitiveStderr(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, """
+#!/bin/sh
+perl -e 'print STDERR "/Users/example/private/repo/.git/config " . ("x" x 2000)'
+exit 23
+""");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static void WriteFakeGitThatHangsForAnyCommand(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, """
+#!/bin/sh
+sleep 5
+exit 0
+""");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static string WriteNonExecutableFakeGit(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, "#!/bin/sh\nexit 0\n");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        return script;
     }
 
     private static void WriteFakeGitThatHangsOnRevParse(string directory)

--- a/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
@@ -160,6 +160,7 @@ public class ReportCommandRunnerTests
             Assert.Contains("version.txt", entries.Keys);
             Assert.Contains("env.txt", entries.Keys);
             Assert.Contains("schema.txt", entries.Keys);
+            Assert.Contains("support-manifest.json", entries.Keys);
             Assert.Contains("README.md", entries.Keys);
             Assert.DoesNotContain("log/stderr-recent.log", entries.Keys);
 
@@ -167,6 +168,19 @@ public class ReportCommandRunnerTests
             Assert.Contains("no SQLite index found", schemaText);
             Assert.Contains($"no SQLite index found at: {ReportCommandRunner.RedactedPlaceholder}", schemaText);
             Assert.DoesNotContain(missingDb, schemaText);
+
+            using var manifest = ReadJsonEntry(entries, "support-manifest.json");
+            var root = manifest.RootElement;
+            Assert.Equal(1, root.GetProperty("manifest_version").GetInt32());
+            Assert.Equal(entries.Count, root.GetProperty("bundle").GetProperty("files").GetInt32());
+            Assert.False(root.GetProperty("bundle").GetProperty("db_included").GetBoolean());
+            Assert.False(root.GetProperty("bundle").GetProperty("log_included").GetBoolean());
+            Assert.Equal(0, root.GetProperty("redactions").GetProperty("total").GetInt32());
+            Assert.Equal("unavailable", root.GetProperty("readiness").GetProperty("source").GetString());
+            Assert.Equal("database_unavailable", root.GetProperty("readiness").GetProperty("unavailable_reason").GetString());
+            Assert.True(JsonArrayContains(root.GetProperty("omissions").GetProperty("schema"), "schema_unavailable_no_database"));
+            Assert.True(JsonArrayContains(root.GetProperty("omissions").GetProperty("log"), "lifecycle_log_skipped_by_option"));
+            Assert.DoesNotContain(missingDb, root.GetRawText());
         }
         finally
         {
@@ -289,6 +303,16 @@ public class ReportCommandRunnerTests
             Assert.Contains($"database: {ReportCommandRunner.RedactedPlaceholder}", schemaText);
             Assert.DoesNotContain(dbPath, schemaText);
             Assert.DoesNotContain("no SQLite index found", schemaText);
+
+            using var manifest = ReadJsonEntry(entries, "support-manifest.json");
+            var readiness = manifest.RootElement.GetProperty("readiness");
+            Assert.Equal("database", readiness.GetProperty("source").GetString());
+            Assert.True(readiness.GetProperty("graph_table_available").GetBoolean());
+            Assert.True(readiness.GetProperty("issues_table_available").GetBoolean());
+            Assert.False(readiness.GetProperty("fold_ready").GetBoolean());
+            Assert.True(JsonArrayContains(readiness.GetProperty("degraded_fields"), "fold_ready"));
+            Assert.False(readiness.GetProperty("migration_in_progress").GetBoolean());
+            Assert.DoesNotContain(dbPath, manifest.RootElement.GetRawText());
         }
         finally
         {
@@ -309,9 +333,10 @@ public class ReportCommandRunnerTests
             SqliteConnection.ClearAllPools();
 
             var dbUri = new Uri(dbPath).AbsoluteUri + "?immutable=1";
-            var (schemaText, tables, reportedDbPath, dbIncluded) = ReportCommandRunner.BuildSchemaSummary(dbUri);
+            var (schemaText, tables, reportedDbPath, dbIncluded, tablesTruncated) = ReportCommandRunner.BuildSchemaSummary(dbUri);
 
             Assert.True(dbIncluded);
+            Assert.False(tablesTruncated);
             Assert.Equal(Path.GetFullPath(dbPath), reportedDbPath);
             Assert.Contains(tables, table => table.Name == "files");
             Assert.Contains("files", schemaText);
@@ -342,9 +367,10 @@ public class ReportCommandRunnerTests
                 }
             }
 
-            var (schemaText, tables, _, dbIncluded) = ReportCommandRunner.BuildSchemaSummary(dbPath);
+            var (schemaText, tables, _, dbIncluded, tablesTruncated) = ReportCommandRunner.BuildSchemaSummary(dbPath);
 
             Assert.True(dbIncluded);
+            Assert.True(tablesTruncated);
             Assert.Equal(ReportCommandRunner.MaxSchemaTables, tables.Count);
             Assert.Contains($"tables  : {ReportCommandRunner.MaxSchemaTables} (capped; additional tables omitted)", schemaText);
             Assert.Contains($"limits  : table entries <= {ReportCommandRunner.MaxSchemaTables}", schemaText);
@@ -392,10 +418,11 @@ public class ReportCommandRunnerTests
                 transaction.Commit();
             }
 
-            var (schemaText, tables, _, dbIncluded) = ReportCommandRunner.BuildSchemaSummary(dbPath);
+            var (schemaText, tables, _, dbIncluded, tablesTruncated) = ReportCommandRunner.BuildSchemaSummary(dbPath);
             var table = Assert.Single(tables);
 
             Assert.True(dbIncluded);
+            Assert.False(tablesTruncated);
             Assert.Equal(ReportCommandRunner.MaxSchemaRowCountScanRows, table.RowCount);
             Assert.True(table.RowCountTruncated);
             Assert.True(table.Name.Length <= ReportCommandRunner.MaxSchemaTableNameDisplayChars);
@@ -460,6 +487,18 @@ public class ReportCommandRunnerTests
             Assert.DoesNotContain("/Users/widthdom/secret/.cdidx/config.json", logText);
             Assert.DoesNotContain("SELECT * FROM secret", logText);
             Assert.Contains("session_start", logText);
+
+            using var manifest = ReadJsonEntry(entries, "support-manifest.json");
+            var root = manifest.RootElement;
+            Assert.Equal(entries.Count, root.GetProperty("bundle").GetProperty("files").GetInt32());
+            Assert.True(root.GetProperty("bundle").GetProperty("log_included").GetBoolean());
+            Assert.Equal(8, root.GetProperty("bundle").GetProperty("log_lines_included").GetInt32());
+            Assert.True(root.GetProperty("redactions").GetProperty("total").GetInt32() >= 6);
+            var categories = root.GetProperty("redactions").GetProperty("categories");
+            Assert.True(categories.GetProperty("args").GetInt32() >= 1);
+            Assert.True(categories.GetProperty("path_fields").GetInt32() >= 5);
+            Assert.DoesNotContain(logDir, root.GetRawText());
+            Assert.DoesNotContain("/Users/widthdom/secret", root.GetRawText());
         }
         finally
         {
@@ -831,6 +870,112 @@ public class ReportCommandRunnerTests
         Assert.Equal(line, redacted);
     }
 
+    [Fact]
+    public void BuildSupportManifest_DoesNotReportSchemaTableOmissionAtExactLimit_Issue3555()
+    {
+        var bundle = new ReportBundle
+        {
+            DbIncluded = false,
+            LogIncluded = false,
+            SchemaTables = Enumerable.Range(0, ReportCommandRunner.MaxSchemaTables)
+                .Select(i => new ReportSchemaTable($"table_{i:D3}", 0))
+                .ToList(),
+        };
+        var options = new ReportCommandOptions { IncludeLog = false };
+
+        var manifest = ReportCommandRunner.BuildSupportManifest(
+            options,
+            bundle,
+            DateTimeOffset.UnixEpoch,
+            ReportRedactionSummary.Empty);
+
+        Assert.DoesNotContain("schema_tables_after_limit", manifest.Omissions.Schema);
+
+        bundle.SchemaTablesTruncated = true;
+        var truncatedManifest = ReportCommandRunner.BuildSupportManifest(
+            options,
+            bundle,
+            DateTimeOffset.UnixEpoch,
+            ReportRedactionSummary.Empty);
+
+        Assert.Contains("schema_tables_after_limit", truncatedManifest.Omissions.Schema);
+    }
+
+    [Fact]
+    public void Run_WithMetadataTargetSourceMissing_ManifestReadinessIsDegraded_Issue3555()
+    {
+        var workDir = CreateWorkDir();
+        var dbPath = Path.Combine(workDir, "legacy-source.db");
+        try
+        {
+            using (var db = new DbContext(dbPath))
+                db.InitializeSchema();
+            using (var connection = new SqliteConnection(new SqliteConnectionStringBuilder { DataSource = dbPath }.ConnectionString))
+            {
+                connection.Open();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $"""
+                    INSERT INTO files (path, lang, size, lines, checksum, modified)
+                    VALUES ('src/Legacy.cs', 'csharp', 1, 1, 'legacy', '2026-01-01T00:00:00Z');
+                    INSERT OR REPLACE INTO codeindex_meta (key, value)
+                    VALUES ('{DbContext.GetMetadataTargetVersionMetaKey("csharp")}', '{DbContext.MetadataTargetVersion}');
+                    PRAGMA foreign_keys = OFF;
+                    ALTER TABLE symbols RENAME TO symbols_old;
+                    CREATE TABLE symbols (
+                        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                        file_id         INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                        kind            TEXT,
+                        sub_kind        TEXT,
+                        name            TEXT,
+                        name_folded     TEXT,
+                        line            INTEGER,
+                        start_line      INTEGER,
+                        start_column    INTEGER,
+                        end_line        INTEGER,
+                        body_start_line INTEGER,
+                        body_end_line   INTEGER,
+                        signature       TEXT,
+                        container_kind  TEXT,
+                        container_name  TEXT,
+                        container_qualified_name TEXT,
+                        family_key      TEXT,
+                        visibility      TEXT,
+                        return_type     TEXT,
+                        is_metadata_target INTEGER
+                    );
+                    DROP TABLE symbols_old;
+                    PRAGMA foreign_keys = ON;
+                    """;
+                cmd.ExecuteNonQuery();
+            }
+            SqliteConnection.ClearAllPools();
+
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var (exitCode, _, _) = RunAndCaptureStreams([
+                "--output", output,
+                "--db", dbPath,
+                "--no-log",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var entries = ReadTarGzEntries(output);
+            using var manifest = ReadJsonEntry(entries, "support-manifest.json");
+            var readiness = manifest.RootElement.GetProperty("readiness");
+
+            Assert.True(
+                readiness.TryGetProperty("csharp_metadata_target_ready", out var csharpMetadataTargetReady),
+                readiness.GetRawText());
+            Assert.False(readiness.TryGetProperty("c_sharp_metadata_target_ready", out _), readiness.GetRawText());
+            Assert.False(csharpMetadataTargetReady.GetBoolean());
+            Assert.True(JsonArrayContains(readiness.GetProperty("degraded_fields"), "csharp_metadata_target_ready"));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDirectory(workDir);
+        }
+    }
+
     private (int ExitCode, string StdOut, string StdErr) RunAndCaptureStreams(string[] args)
     {
         lock (TestConsoleLock.Gate)
@@ -911,6 +1056,20 @@ public class ReportCommandRunnerTests
             entries[entry.Name] = buffer.ToArray();
         }
         return entries;
+    }
+
+    private static JsonDocument ReadJsonEntry(Dictionary<string, byte[]> entries, string name)
+        => JsonDocument.Parse(entries[name]);
+
+    private static bool JsonArrayContains(JsonElement array, string value)
+    {
+        foreach (var item in array.EnumerateArray())
+        {
+            if (string.Equals(item.GetString(), value, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
     }
 
     private static Dictionary<string, UnixFileMode> ReadTarGzEntryModes(string path)

--- a/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ReportCommandRunnerTests.cs
@@ -508,6 +508,85 @@ public class ReportCommandRunnerTests
     }
 
     [Fact]
+    public void Run_WithFullyIncludedShortLog_DoesNotReportTailOmission_Issue3555()
+    {
+        var workDir = CreateWorkDir();
+        var logDir = Path.Combine(workDir, "logs");
+        Directory.CreateDirectory(logDir);
+        File.WriteAllText(
+            Path.Combine(logDir, "stderr-20260519.log"),
+            string.Join('\n',
+                "2026-05-19T03:00:00Z [INFO] first",
+                "2026-05-19T03:00:01Z [INFO] second",
+                ""));
+
+        var previousLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+        try
+        {
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var (exitCode, _, _) = RunAndCaptureStreams([
+                "--output", output,
+                "--db", Path.Combine(workDir, "missing.db"),
+                "--log-lines", "20",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var entries = ReadTarGzEntries(output);
+            using var manifest = ReadJsonEntry(entries, "support-manifest.json");
+            var logOmissions = manifest.RootElement.GetProperty("omissions").GetProperty("log");
+
+            Assert.Equal(2, manifest.RootElement.GetProperty("bundle").GetProperty("log_lines_included").GetInt32());
+            Assert.False(JsonArrayContains(logOmissions, "older_log_lines_outside_tail_limit"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", previousLogDir);
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
+    public void Run_WithTruncatedLog_ReportsTailOmission_Issue3555()
+    {
+        var workDir = CreateWorkDir();
+        var logDir = Path.Combine(workDir, "logs");
+        Directory.CreateDirectory(logDir);
+        File.WriteAllText(
+            Path.Combine(logDir, "stderr-20260520.log"),
+            string.Join('\n',
+                "2026-05-20T03:00:00Z [INFO] omitted",
+                "2026-05-20T03:00:01Z [INFO] kept-one",
+                "2026-05-20T03:00:02Z [INFO] kept-two",
+                ""));
+
+        var previousLogDir = Environment.GetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR");
+        Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", logDir);
+        try
+        {
+            var output = Path.Combine(workDir, "bundle.tgz");
+            var (exitCode, _, _) = RunAndCaptureStreams([
+                "--output", output,
+                "--db", Path.Combine(workDir, "missing.db"),
+                "--log-lines", "2",
+            ]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var entries = ReadTarGzEntries(output);
+            using var manifest = ReadJsonEntry(entries, "support-manifest.json");
+            var logOmissions = manifest.RootElement.GetProperty("omissions").GetProperty("log");
+
+            Assert.Equal(2, manifest.RootElement.GetProperty("bundle").GetProperty("log_lines_included").GetInt32());
+            Assert.True(JsonArrayContains(logOmissions, "older_log_lines_outside_tail_limit"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CDIDX_GLOBAL_TOOL_LOG_DIR", previousLogDir);
+            TryDeleteDirectory(workDir);
+        }
+    }
+
+    [Fact]
     public void BuildRecentLogTail_LargeLogReadsBoundedTail_Issue2837()
     {
         var workDir = CreateWorkDir();

--- a/tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
@@ -283,6 +283,41 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_CSharp_DirectAttributeClassesStampExtractorMetadataTarget_Issue3524()
+    {
+        var content = """
+            public sealed class BareAttribute : Attribute
+            {
+            }
+
+            public sealed class QualifiedAttribute : System.Attribute
+            {
+            }
+
+            public sealed class GlobalQualifiedAttribute : global::System.Attribute
+            {
+            }
+
+            public sealed class GenericConstraintOnly<T> where T : Attribute
+            {
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "csharp", content);
+
+        foreach (var name in new[] { "BareAttribute", "QualifiedAttribute", "GlobalQualifiedAttribute" })
+        {
+            var symbol = Assert.Single(symbols.Where(s => s.Kind == "class" && s.Name == name));
+            Assert.True(symbol.IsMetadataTarget);
+            Assert.Equal(SymbolRecord.MetadataTargetSourceExtractor, symbol.MetadataTargetSource);
+        }
+
+        var constraintOnly = Assert.Single(symbols.Where(s => s.Kind == "class" && s.Name == "GenericConstraintOnly"));
+        Assert.Null(constraintOnly.IsMetadataTarget);
+        Assert.Null(constraintOnly.MetadataTargetSource);
+    }
+
+    [Fact]
     public void Extract_CSharp_RawStringFixturesDoNotLeakPhantomSymbols()
     {
         var content = """""


### PR DESCRIPTION
## Summary
- Add a support manifest to report bundles with redaction, omission, readiness, and diagnostic summaries.
- Persist C# metadata target provenance and use source-aware readiness/diff behavior.
- Return structured, bounded git process failures and propagate root-discovery failures.

## Tests
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReportCommandRunnerTests|FullyQualifiedName~GitHelperTests|FullyQualifiedName~DiffCommandRunnerTests|FullyQualifiedName~Issue3524" -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check origin/main..HEAD`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Fixes #3555
Fixes #3524
Fixes #3434