### PR TITLE
Add bounded CI performance smoke

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -75,7 +75,7 @@ The test project mirrors the production areas closely.
 - `ConcurrencyTests.cs`
   Concurrent read and read-during-write scenarios (WAL mode validation), including the issue #180 bug-catching snapshot-isolation regressions for all three multi-statement reader entry points: (1) `GetStatus` seeds `refs == files * refsPerFile` and asserts every concurrent observation preserves that invariant; (2) `AnalyzeSymbol` seeds one symbol `S` plus matching reference/caller pairs, toggles a second file symmetrically, and asserts `references.Count == callers.Count` across every `inspect`/`analyze_symbol` bundle; (3) `GetRepoMap` seeds a baseline modified timestamp and toggles a newer file, asserting `latest_modified == workspace_latest_modified` across every map call. Each test fails without the DEFERRED-transaction wrap on the matching reader and passes with it.
 - `PerformanceTests.cs`
-  Large-scale data benchmarks (10K+ files). Skip-by-default; run manually with `--filter`.
+  Bounded CI smoke coverage plus large-scale data benchmarks. `CiPerformanceSmoke_IndexAndSearchSmallFixture_StaysWithinBudget` runs in the default suite, so it is a blocking PR/CI check, but its broad budgets are intended to catch only severe indexing/search regressions rather than act as a benchmark. The 10K+ large-scale tests remain skip-by-default; run them manually with `--filter`.
 - `DbRecoveryTests.cs`
   Database corruption recovery and graceful degradation behavior. Filesystem setup failures for `cdidx index` (read-only DB files and unwritable DB parent directories) are covered in `IndexCommandRunnerTests.cs` so they exercise the same CLI JSON/stderr boundary users see.
 - `JsonOutputSnapshotTests.cs`, `JsonOutputSnapshotHelper.cs`
@@ -281,7 +281,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 - `ConcurrencyTests.cs`
   並行読み取りと書き込み中読み取りシナリオ（WALモード検証）。issue #180 の bug-catching な snapshot 隔離回帰テストを 3 つの multi-statement reader 経路について含む。(1) `GetStatus` は `refs == files * refsPerFile` の seed 不変条件を立て、並行観測が常にこの条件を維持することを要求する。(2) `AnalyzeSymbol` はシンボル `S` に対して reference/caller を対称に 1 対 1 で seed し、もう 1 ファイルを対称に toggle することで `inspect` / `analyze_symbol` bundle の `references.Count == callers.Count` を常に保証する。(3) `GetRepoMap` はベースラインの modified と新しい toggle 対象ファイルを用意し、`latest_modified == workspace_latest_modified` が常に一致することを要求する。各テストは対応する reader の DEFERRED transaction を外すと落ち、戻すと通ることを確認済み。
 - `PerformanceTests.cs`
-  大規模データベンチマーク（10K+ファイル）。デフォルトSkip。`--filter` で手動実行。
+  bounded な CI smoke と大規模データベンチマークを扱います。`CiPerformanceSmoke_IndexAndSearchSmallFixture_StaysWithinBudget` は通常 suite で実行されるため PR / CI の blocking check ですが、benchmark ではなく重大な indexing/search 退行だけを拾う広めの budget を使います。10K+ の大規模テストは引き続きデフォルト Skip で、`--filter` で手動実行します。
 - `DbRecoveryTests.cs`
   DB破損からの復旧とグレースフル劣化のテスト。`cdidx index` の filesystem setup failure（read-only DB file や書き込み不可の DB 親ディレクトリ）は、ユーザーが見る CLI JSON/stderr 境界を通すため `IndexCommandRunnerTests.cs` で扱います。
 - `JsonOutputSnapshotTests.cs`、`JsonOutputSnapshotHelper.cs`

--- a/changelog.d/unreleased/3384.added.md
+++ b/changelog.d/unreleased/3384.added.md
@@ -1,0 +1,16 @@
+---
+category: added
+issues:
+  - 3384
+affected:
+  - tests/CodeIndex.Tests/PerformanceTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Added a bounded CI performance smoke for indexing and search (#3384)** — the default test suite now includes a small deterministic smoke fixture with broad budgets so severe indexing or query regressions are caught without turning the skipped large-scale performance tests into PR gates.
+
+## 日本語
+
+- **indexing と search の bounded な CI performance smoke を追加しました (#3384)** — 通常のテスト suite に小さく決定的な smoke fixture を加え、広めの budget で重大な indexing / query 退行を検出しつつ、skip されている大規模 performance test を PR gate 化しないようにしました。

--- a/tests/CodeIndex.Tests/PerformanceTests.cs
+++ b/tests/CodeIndex.Tests/PerformanceTests.cs
@@ -14,11 +14,13 @@ namespace CodeIndex.Tests;
 public class PerformanceTests : IDisposable
 {
     private readonly string _dbPath;
+    private readonly string _projectRoot;
     private readonly DbContext _db;
 
     public PerformanceTests()
     {
         _dbPath = Path.Combine(Path.GetTempPath(), $"codeindex_perf_{Guid.NewGuid():N}.db");
+        _projectRoot = TestProjectHelper.CreateTempProject("cdidx_perf_smoke");
         _db = new DbContext(_dbPath);
         _db.InitializeSchema();
     }
@@ -113,6 +115,29 @@ public class PerformanceTests : IDisposable
     }
 
     [Fact]
+    public void CiPerformanceSmoke_IndexAndSearchSmallFixture_StaysWithinBudget()
+    {
+        WritePerformanceSmokeFixture(_projectRoot, fileCount: 120);
+        var writer = new DbWriter(_db.Connection);
+
+        var indexElapsed = MeasureElapsed(() => IndexScannedFiles(_projectRoot, writer));
+        var (files, chunks, symbols, references) = writer.GetCounts();
+
+        Assert.Equal(120, files);
+        Assert.True(chunks >= 120, $"Expected at least one chunk per file, got {chunks}");
+        Assert.True(symbols >= 240, $"Expected class and method symbols from the smoke fixture, got {symbols}");
+        Assert.True(references > 0, "Expected reference rows from the smoke fixture.");
+        Assert.True(indexElapsed < TimeSpan.FromSeconds(20), $"CI performance smoke indexing took {indexElapsed.TotalSeconds:F1}s");
+
+        var reader = new DbReader(_db.Connection);
+        List<SearchResult> results = [];
+        var searchElapsed = MeasureElapsed(() => results = reader.Search("Execute42", limit: 5));
+
+        Assert.Contains(results, result => result.Path.EndsWith("service42.cs", StringComparison.Ordinal));
+        Assert.True(searchElapsed < TimeSpan.FromSeconds(2), $"CI performance smoke search took {searchElapsed.TotalMilliseconds:F0}ms");
+    }
+
+    [Fact]
     public void SymbolExtraction_CsharpHotPath_StaysWithinAllocationBudget()
     {
         var content = BuildCSharpHotPathFixture(typeCount: 120);
@@ -146,6 +171,60 @@ public class PerformanceTests : IDisposable
         return GC.GetAllocatedBytesForCurrentThread() - before;
     }
 
+    private static TimeSpan MeasureElapsed(Action action)
+    {
+        var sw = Stopwatch.StartNew();
+        action();
+        sw.Stop();
+        return sw.Elapsed;
+    }
+
+    private static void WritePerformanceSmokeFixture(string projectRoot, int fileCount)
+    {
+        for (var i = 0; i < fileCount; i++)
+        {
+            var directory = Path.Combine(projectRoot, "src", $"module{i / 20}");
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, $"service{i}.cs"), BuildPerformanceSmokeSource(i));
+        }
+    }
+
+    private static void IndexScannedFiles(string projectRoot, DbWriter writer)
+    {
+        var indexer = new FileIndexer(projectRoot);
+        foreach (var filePath in indexer.ScanFiles())
+        {
+            var (record, content, rawBytes, _) = indexer.BuildRecordWithRawBytes(filePath);
+            var fileId = writer.UpsertFile(record);
+            writer.DeleteFileData(fileId);
+            writer.InsertChunks(ChunkSplitter.Split(fileId, content));
+            var symbols = SymbolExtractor.Extract(fileId, record.Lang, content, record.Path);
+            writer.InsertSymbols(symbols);
+            writer.InsertReferences(ReferenceExtractor.Extract(fileId, record.Lang, content, symbols, record.Path));
+            writer.InsertIssues(fileId, FileIndexer.ValidateContent(record.Path, rawBytes, content));
+        }
+    }
+
+    private static string BuildPerformanceSmokeSource(int index) => $$"""
+        namespace PerfSmoke.Module{{index / 20}};
+
+        public sealed class Service{{index}}
+        {
+            private readonly Dependency{{index}} dependency = new();
+
+            public int Execute{{index}}(int value)
+            {
+                var transformed = dependency.Transform(value);
+                return transformed + {{index}};
+            }
+        }
+
+        public sealed class Dependency{{index}}
+        {
+            public int Transform(int value) => value * 2;
+        }
+        """;
+
     private static string BuildCSharpHotPathFixture(int typeCount)
     {
         return string.Join(
@@ -169,5 +248,6 @@ public class PerformanceTests : IDisposable
         _db.Dispose();
         SqliteConnection.ClearAllPools();
         try { File.Delete(_dbPath); } catch { }
+        TestProjectHelper.DeleteDirectory(_projectRoot);
     }
 }


### PR DESCRIPTION
## Summary

- Add a default-suite bounded performance smoke that indexes a deterministic 120-file C# fixture and verifies search latency.
- Keep the existing 10K+ performance tests skip-by-default for manual benchmarking.
- Document the blocking PR/CI policy for the bounded smoke in both English and Japanese Testing Guide sections.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PerformanceTests.CiPerformanceSmoke_IndexAndSearchSmallFixture_StaysWithinBudget"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PerformanceTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --filter "FullyQualifiedName~PerformanceTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format whitespace CodeIndex.sln --verify-no-changes --no-restore --verbosity minimal`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and Changelog

- Updated `TESTING_GUIDE.md` English and Japanese sections.
- Added `changelog.d/unreleased/3384.added.md`.

## Review

- Adversarial review: No blocking/actionable issues found.

Fixes #3384