### PR TITLE
Fix durability and cleanup warning reporting

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -58,6 +58,7 @@ Development contracts:
 | `.cdidx/` | Created with mode `0700`. |
 | `codeindex.db` plus WAL/SHM sidecars | Mode `0600` is applied when the files exist. |
 | `suggestions-*.json` suggestion stores | Written atomically with owner-only mode `0600` on POSIX. |
+| Atomic file writes | `AtomicFileWriter` writes to a sibling temp file, applies the requested POSIX mode before replacement, flushes file contents, renames over the target, and fsyncs the parent directory on Unix. If the parent directory flush fails after replacement, the command fails explicitly so callers know the file was replaced but directory durability was not confirmed. Windows skips directory fsync because the helper only promises it on supported Unix platforms. |
 | Index lock metadata sidecars and active workspace `active.json` | Written as owner-only files and read through small bounded buffers so stale or corrupted diagnostics cannot expose local paths more broadly or force unbounded allocation. |
 | Checkpoint roots, snapshot directories, manifest files, copied DB/WAL/SHM snapshots, and restore staging/backup directories | Forced owner-only on POSIX. |
 | `status --json` | Reports `data_dir_mode` and `db_file_mode` when the platform exposes Unix file modes. |
@@ -2243,6 +2244,7 @@ net9 CI lane に合わせる場合は `FRAMEWORK=net9.0 make test` を使いま�
 | `.cdidx/` | mode `0700` で作成。 |
 | `codeindex.db` と WAL/SHM sidecar | ファイルが存在する場合は mode `0600` を適用。 |
 | `suggestions-*.json` suggestion store | POSIX では owner-only の mode `0600` で atomic write します。 |
+| atomic file write | `AtomicFileWriter` は sibling temp file に書き込み、要求された POSIX mode を置換前に適用し、file content を flush してから target へ rename し、Unix では parent directory を fsync します。置換後に parent directory flush が失敗した場合、file は置換済みだが directory durability を確認できていないことが caller に分かるよう command は明示的に失敗します。Windows では、この helper の directory fsync 保証は supported Unix platform に限定されるため skip します。 |
 | index lock metadata sidecar と active workspace の `active.json` | owner-only file として書き、stale / corrupt diagnostic が local path を広く漏らしたり unbounded allocation を強制したりしないよう小さな bounded buffer で読みます。 |
 | database checkpoint root、snapshot directory、manifest file、copy された DB/WAL/SHM snapshot、restore staging/backup directory | POSIX では owner-only に固定。 |
 | `status --json` | platform が Unix file mode を公開する場合、`data_dir_mode` と `db_file_mode` を報告。 |

--- a/changelog.d/unreleased/3409.fixed.md
+++ b/changelog.d/unreleased/3409.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3409
+affected:
+  - src/CodeIndex/Cli/AtomicFileWriter.cs
+  - tests/CodeIndex.Tests/AtomicFileWriterTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Atomic file writes now apply permissions before replacement and surface durability failures (#3409)** — `AtomicFileWriter` applies requested POSIX modes to the temp file before rename, fsyncs the parent directory on Unix after replacement, and throws a bounded error when the file was replaced but directory durability could not be confirmed.
+
+## 日本語
+
+- **Atomic file write が置換前に権限を適用し、耐久化失敗を明示するようになりました (#3409)** — `AtomicFileWriter` は rename 前の temp file に要求された POSIX mode を適用し、Unix では置換後に parent directory を fsync し、file は置換済みだが directory durability を確認できなかった場合は bounded な error を返します。

--- a/changelog.d/unreleased/3463.fixed.md
+++ b/changelog.d/unreleased/3463.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3463
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Scan checkpoint persistence failures now surface as bounded index warnings (#3463)** — full scans continue when best-effort checkpoint save or delete fails, but human output and JSON `warnings` now report the checkpoint operation, bounded path, and sanitized exception type.
+
+## 日本語
+
+- **scan checkpoint 永続化の失敗を bounded な index warning として報告するようになりました (#3463)** — best-effort な checkpoint save / delete に失敗しても full scan は継続しつつ、human output と JSON `warnings` に checkpoint 操作、bounded path、sanitized exception type を出力します。

--- a/changelog.d/unreleased/3464.fixed.md
+++ b/changelog.d/unreleased/3464.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3464
+affected:
+  - src/CodeIndex/Cli/HookCommandRunner.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+---
+
+## English
+
+- **Hook install and uninstall cleanup failures now report bounded warnings (#3464)** — hook commands now include the affected hook path category and sanitized exception type in human warnings and JSON `warnings` when staged-hook cleanup or managed-hook deletion fails.
+
+## 日本語
+
+- **hook install / uninstall の cleanup 失敗を bounded warning として報告するようになりました (#3464)** — staged hook cleanup や managed hook deletion に失敗した場合、hook command は影響を受けた hook path category と sanitized exception type を human warning と JSON `warnings` に含めます。

--- a/src/CodeIndex/Cli/AtomicFileWriter.cs
+++ b/src/CodeIndex/Cli/AtomicFileWriter.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using CodeIndex.Indexer;
@@ -6,6 +7,8 @@ namespace CodeIndex.Cli;
 
 internal static class AtomicFileWriter
 {
+    internal static Action<string>? FlushParentDirectoryForTesting { get; set; }
+
     public static void WriteText(string path, string contents, Encoding encoding, Action<string>? applyFileMode = null)
     {
         Write(
@@ -44,7 +47,7 @@ internal static class AtomicFileWriter
 
             File.Move(ioTempPath, ioTargetPath, overwrite: true);
             moved = true;
-            applyFileMode?.Invoke(ioTargetPath);
+            FlushParentDirectory(path);
         }
         catch
         {
@@ -53,6 +56,49 @@ internal static class AtomicFileWriter
             throw;
         }
     }
+
+    private static void FlushParentDirectory(string path)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (string.IsNullOrEmpty(directory))
+            return;
+
+        if (FlushParentDirectoryForTesting != null)
+        {
+            try
+            {
+                FlushParentDirectoryForTesting(directory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                throw BuildDirectoryFlushException(path, ex);
+            }
+            return;
+        }
+
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var fd = UnixOpen(directory, flags: 0);
+        if (fd < 0)
+            throw BuildDirectoryFlushException(path, Marshal.GetLastPInvokeError());
+
+        try
+        {
+            if (UnixFsync(fd) != 0)
+                throw BuildDirectoryFlushException(path, Marshal.GetLastPInvokeError());
+        }
+        finally
+        {
+            _ = UnixClose(fd);
+        }
+    }
+
+    private static IOException BuildDirectoryFlushException(string path, int errno)
+        => new($"Atomic replace completed for {ConsoleUi.FormatBoundedValue(path)}, but the parent directory could not be flushed to disk (errno {errno}).");
+
+    private static IOException BuildDirectoryFlushException(string path, Exception inner)
+        => new($"Atomic replace completed for {ConsoleUi.FormatBoundedValue(path)}, but the parent directory could not be flushed to disk ({CommandErrorWriter.FormatSanitizedException(inner)}).", inner);
 
     private static string BuildTempPath(string path)
     {
@@ -74,4 +120,13 @@ internal static class AtomicFileWriter
         {
         }
     }
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+    private static extern int UnixOpen(string path, int flags);
+
+    [DllImport("libc", EntryPoint = "fsync", SetLastError = true)]
+    private static extern int UnixFsync(int fd);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int UnixClose(int fd);
 }

--- a/src/CodeIndex/Cli/HookCommandRunner.cs
+++ b/src/CodeIndex/Cli/HookCommandRunner.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
@@ -11,6 +12,8 @@ public static class HookCommandRunner
     private const string BeginMarker = "# BEGIN CDIDX MANAGED PRE-COMMIT";
     private const string EndMarker = "# END CDIDX MANAGED PRE-COMMIT";
     internal const int MaxHookMarkerBytes = 64 * 1024;
+    internal static Action<string>? DeleteFileForTesting { get; set; }
+    internal static Action<string, string, string?>? ReplaceFileForTesting { get; set; }
 
     public static int Run(string[] args, JsonSerializerOptions jsonOptions)
     {
@@ -91,6 +94,7 @@ public static class HookCommandRunner
 
     private static int Install(HookCommandOptions options, JsonSerializerOptions jsonOptions, string projectPath, string hooksDir, string hookPath, string chainedHookPath)
     {
+        var warnings = new List<HookCommandWarningJsonResult>();
         Directory.CreateDirectory(LongPath.EnsureWindowsPrefix(hooksDir));
 
         var ioHookPath = LongPath.EnsureWindowsPrefix(hookPath);
@@ -102,18 +106,29 @@ public static class HookCommandRunner
                 if (File.Exists(ioChainedHookPath) && !options.Force)
                     return WriteResult(options.Json, jsonOptions, "error", $"chained hook already exists: {chainedHookPath}", projectPath, hookPath, chainedHookPath, CommandExitCodes.UsageError);
 
-                ReplaceCustomHookWithManagedHook(hooksDir, hookPath, chainedHookPath, projectPath);
-                return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, chainedHookPath, CommandExitCodes.Success);
+                try
+                {
+                    ReplaceCustomHookWithManagedHook(hooksDir, hookPath, chainedHookPath, projectPath, warnings);
+                }
+                catch (Exception ex) when (IsHookFileOperationException(ex))
+                {
+                    RecordHookWarning(warnings, "chained_hook_backup", chainedHookPath, "failed to back up existing hook", ex);
+                    var message = $"failed to install cdidx pre-commit hook ({CommandErrorWriter.FormatSanitizedException(ex)})";
+                    return WriteResult(options.Json, jsonOptions, "error", message, projectPath, hookPath, chainedHookPath, CommandExitCodes.InstallError, warnings);
+                }
+
+                return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, chainedHookPath, CommandExitCodes.Success, warnings);
             }
         }
 
         AtomicFileWriter.WriteText(hookPath, BuildHookScript(chainedHookPath, projectPath), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), MakeExecutable);
 
-        return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, File.Exists(ioChainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success);
+        return WriteResult(options.Json, jsonOptions, "installed", "cdidx pre-commit hook installed", projectPath, hookPath, File.Exists(ioChainedHookPath) ? chainedHookPath : null, CommandExitCodes.Success, warnings);
     }
 
     private static int Uninstall(HookCommandOptions options, JsonSerializerOptions jsonOptions, string projectPath, string hookPath, string chainedHookPath)
     {
+        var warnings = new List<HookCommandWarningJsonResult>();
         var ioHookPath = LongPath.EnsureWindowsPrefix(hookPath);
         var ioChainedHookPath = LongPath.EnsureWindowsPrefix(chainedHookPath);
         if (!File.Exists(ioHookPath))
@@ -124,15 +139,24 @@ public static class HookCommandRunner
 
         if (File.Exists(ioChainedHookPath))
         {
-            File.Replace(ioChainedHookPath, ioHookPath, destinationBackupFileName: null, ignoreMetadataErrors: true);
-            MakeExecutable(ioHookPath);
+            try
+            {
+                ReplaceFile(ioChainedHookPath, ioHookPath, destinationBackupFileName: null);
+                MakeExecutable(ioHookPath);
+            }
+            catch (Exception ex) when (IsHookFileOperationException(ex))
+            {
+                RecordHookWarning(warnings, "chained_hook_backup", chainedHookPath, "failed to restore chained hook backup", ex);
+                return WriteResult(options.Json, jsonOptions, "error", "failed to restore chained pre-commit hook", projectPath, hookPath, chainedHookPath, CommandExitCodes.InstallError, warnings);
+            }
         }
         else
         {
-            File.Delete(ioHookPath);
+            if (!TryDeleteFile(ioHookPath, hookPath, "managed_hook", warnings))
+                return WriteResult(options.Json, jsonOptions, "error", "failed to delete managed pre-commit hook", projectPath, hookPath, null, CommandExitCodes.InstallError, warnings);
         }
 
-        return WriteResult(options.Json, jsonOptions, "uninstalled", "cdidx pre-commit hook uninstalled", projectPath, hookPath, null, CommandExitCodes.Success);
+        return WriteResult(options.Json, jsonOptions, "uninstalled", "cdidx pre-commit hook uninstalled", projectPath, hookPath, null, CommandExitCodes.Success, warnings);
     }
 
     private static int Status(HookCommandOptions options, JsonSerializerOptions jsonOptions, string projectPath, string hookPath, string chainedHookPath)
@@ -161,7 +185,12 @@ public static class HookCommandRunner
         return content is not null && IsManagedHook(content);
     }
 
-    private static void ReplaceCustomHookWithManagedHook(string hooksDir, string hookPath, string chainedHookPath, string projectPath)
+    private static void ReplaceCustomHookWithManagedHook(
+        string hooksDir,
+        string hookPath,
+        string chainedHookPath,
+        string projectPath,
+        List<HookCommandWarningJsonResult> warnings)
     {
         var stagedHookPath = Path.Combine(hooksDir, $".{HookName}.{Guid.NewGuid():N}.tmp");
         var ioStagedHookPath = LongPath.EnsureWindowsPrefix(stagedHookPath);
@@ -172,14 +201,14 @@ public static class HookCommandRunner
         try
         {
             WriteStagedHookScript(ioStagedHookPath, chainedHookPath, projectPath);
-            File.Replace(ioStagedHookPath, ioHookPath, ioChainedHookPath, ignoreMetadataErrors: true);
+            ReplaceFile(ioStagedHookPath, ioHookPath, ioChainedHookPath);
             stagedHookMoved = true;
             MakeExecutable(ioHookPath);
         }
         finally
         {
             if (!stagedHookMoved)
-                TryDeleteFile(ioStagedHookPath);
+                TryDeleteFile(ioStagedHookPath, stagedHookPath, "staged_hook_temp", warnings);
         }
     }
 
@@ -203,16 +232,55 @@ public static class HookCommandRunner
         MakeExecutable(ioStagedHookPath);
     }
 
-    private static void TryDeleteFile(string ioPath)
+    private static void ReplaceFile(string sourceFileName, string destinationFileName, string? destinationBackupFileName)
+    {
+        if (ReplaceFileForTesting != null)
+            ReplaceFileForTesting(sourceFileName, destinationFileName, destinationBackupFileName);
+        else
+            File.Replace(sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors: true);
+    }
+
+    private static bool TryDeleteFile(
+        string ioPath,
+        string displayPath,
+        string category,
+        List<HookCommandWarningJsonResult> warnings)
     {
         try
         {
             if (File.Exists(ioPath))
-                File.Delete(ioPath);
+            {
+                if (DeleteFileForTesting != null)
+                    DeleteFileForTesting(ioPath);
+                else
+                    File.Delete(ioPath);
+            }
+
+            return true;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (Exception ex) when (IsHookFileOperationException(ex))
         {
+            RecordHookWarning(warnings, category, displayPath, $"failed to delete {category}", ex);
+            return false;
         }
+    }
+
+    private static bool IsHookFileOperationException(Exception ex)
+        => ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException
+            or PathTooLongException;
+
+    private static void RecordHookWarning(
+        List<HookCommandWarningJsonResult> warnings,
+        string category,
+        string path,
+        string action,
+        Exception ex)
+    {
+        var message = $"{action} {ConsoleUi.FormatBoundedValue(path)} ({CommandErrorWriter.FormatSanitizedException(ex)}).";
+        warnings.Add(new HookCommandWarningJsonResult(category, path, message));
     }
 
     private static string BuildHookScript(string chainedHookPath, string projectPath)
@@ -249,25 +317,44 @@ fi
             UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
     }
 
-    private static int WriteResult(bool json, JsonSerializerOptions jsonOptions, string status, string message, string projectPath, string? hookPath, string? chainedHookPath, int exitCode)
+    private static int WriteResult(
+        bool json,
+        JsonSerializerOptions jsonOptions,
+        string status,
+        string message,
+        string projectPath,
+        string? hookPath,
+        string? chainedHookPath,
+        int exitCode,
+        IReadOnlyList<HookCommandWarningJsonResult>? warnings = null)
     {
+        var hasWarnings = warnings is { Count: > 0 };
         if (json)
         {
             Console.WriteLine(JsonSerializer.Serialize(
-                new HookCommandJsonResult(status, message, projectPath, hookPath, chainedHookPath),
+                new HookCommandJsonResult(status, message, projectPath, hookPath, chainedHookPath, hasWarnings ? warnings : null),
                 CliJsonSerializerContextFactory.Create(jsonOptions).HookCommandJsonResult));
-        }
-        else if (exitCode == CommandExitCodes.Success)
-        {
-            CommandErrorWriter.WriteStdout(message);
-            if (hookPath != null)
-                CommandErrorWriter.WriteStdout($"Hook: {hookPath}");
-            if (chainedHookPath != null)
-                CommandErrorWriter.WriteStdout($"Chained hook: {chainedHookPath}");
         }
         else
         {
-            CommandErrorWriter.WriteStderr($"Error: {message}");
+            if (hasWarnings)
+            {
+                foreach (var warning in warnings!)
+                    CommandErrorWriter.WriteWarning(warning.Message);
+            }
+
+            if (exitCode == CommandExitCodes.Success)
+            {
+                CommandErrorWriter.WriteStdout(message);
+                if (hookPath != null)
+                    CommandErrorWriter.WriteStdout($"Hook: {hookPath}");
+                if (chainedHookPath != null)
+                    CommandErrorWriter.WriteStdout($"Chained hook: {chainedHookPath}");
+            }
+            else
+            {
+                CommandErrorWriter.WriteStderr($"Error: {message}");
+            }
         }
 
         return exitCode;
@@ -279,9 +366,15 @@ fi
 
 public sealed record HookCommandOptions(string? Command, string? ProjectPath, bool Json, bool Force, bool ShowHelp, string? ParseError);
 
+public sealed record HookCommandWarningJsonResult(
+    [property: JsonPropertyName("category")] string Category,
+    [property: JsonPropertyName("path")] string Path,
+    [property: JsonPropertyName("message")] string Message);
+
 public sealed record HookCommandJsonResult(
     string Status,
     string Message,
     string ProjectPath,
     string? HookPath,
-    string? ChainedHookPath);
+    string? ChainedHookPath,
+    IReadOnlyList<HookCommandWarningJsonResult>? Warnings = null);

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -335,7 +335,13 @@ public static partial class IndexCommandRunner
 
     private static HashSet<string> EmptyScanCheckpointDirectories() => new(StringComparer.Ordinal);
 
-    private static void SaveScanCheckpoint(string path, string? currentHead, IReadOnlySet<string> directories)
+    private static void SaveScanCheckpoint(
+        string path,
+        string? currentHead,
+        IReadOnlySet<string> directories,
+        List<CliJsonMessage> warningList,
+        bool json,
+        bool quiet)
     {
         try
         {
@@ -350,29 +356,60 @@ public static partial class IndexCommandRunner
                     .Where(directory => directory.Length > 0)
                     .OrderBy(directory => directory, StringComparer.Ordinal)
                     .ToList());
-            AtomicFileWriter.WriteJson(path, checkpoint, new JsonSerializerOptions { WriteIndented = true });
+            if (WriteScanCheckpointForTesting != null)
+                WriteScanCheckpointForTesting(path);
+            else
+                AtomicFileWriter.WriteJson(path, checkpoint, new JsonSerializerOptions { WriteIndented = true });
         }
-        catch (IOException)
+        catch (Exception ex) when (IsScanCheckpointPersistenceException(ex))
         {
-        }
-        catch (UnauthorizedAccessException)
-        {
+            RecordScanCheckpointPersistenceWarning(path, "save", ex, warningList, json, quiet);
         }
     }
 
-    private static void DeleteScanCheckpoint(string path)
+    private static void DeleteScanCheckpoint(
+        string path,
+        List<CliJsonMessage> warningList,
+        bool json,
+        bool quiet)
     {
         try
         {
             if (File.Exists(path))
-                File.Delete(path);
+            {
+                if (DeleteScanCheckpointForTesting != null)
+                    DeleteScanCheckpointForTesting(path);
+                else
+                    File.Delete(path);
+            }
         }
-        catch (IOException)
+        catch (Exception ex) when (IsScanCheckpointPersistenceException(ex))
         {
+            RecordScanCheckpointPersistenceWarning(path, "delete", ex, warningList, json, quiet);
         }
-        catch (UnauthorizedAccessException)
-        {
-        }
+    }
+
+    private static bool IsScanCheckpointPersistenceException(Exception ex)
+        => ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException
+            or PathTooLongException;
+
+    private static void RecordScanCheckpointPersistenceWarning(
+        string path,
+        string operation,
+        Exception ex,
+        List<CliJsonMessage> warningList,
+        bool json,
+        bool quiet)
+    {
+        var message =
+            $"scan checkpoint {operation} failed for {ConsoleUi.FormatBoundedValue(path)} " +
+            $"({CommandErrorWriter.FormatSanitizedException(ex)}); continuing without failing the scan.";
+        warningList.Add(new CliJsonMessage("<scan_checkpoint>", message));
+        if (!json && !quiet)
+            ConsoleUi.PrintWarning(message);
     }
 
     private sealed record FullScanDiscoveryResult(
@@ -651,7 +688,13 @@ public static partial class IndexCommandRunner
             .ToHashSet(StringComparer.Ordinal);
         if (scanResult.HadErrors)
         {
-            SaveScanCheckpoint(scanCheckpointPath, currentHeadForCheckpoint, scanResult.CheckpointedDirectories);
+            SaveScanCheckpoint(
+                scanCheckpointPath,
+                currentHeadForCheckpoint,
+                scanResult.CheckpointedDirectories,
+                warningList,
+                options.Json,
+                options.Quiet);
             retainedPaths.UnionWith(scanResult.ProbeFailedFilePaths.Select(FileIndexer.NormalizeIndexPath));
 
             foreach (var relPath in scanResult.NonIndexablePaths)
@@ -690,7 +733,7 @@ public static partial class IndexCommandRunner
             {
                 purged = writer.PurgeFilesOutsideRetainedSet(retainedPaths);
             }
-            DeleteScanCheckpoint(scanCheckpointPath);
+            DeleteScanCheckpoint(scanCheckpointPath, warningList, options.Json, options.Quiet);
         }
         if (purged > 0)
             WriteProjectRootOnce();

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -38,6 +38,8 @@ public static partial class IndexCommandRunner
     internal static Action<bool, string?>? FullScanExtractionSchedulingForTesting { get; set; }
     internal static Func<TimeSpan>? IndexExtractionStallTimeoutForTesting { get; set; }
     internal static Action? HotspotFamilyUpdateRestampReadyForCommitForTesting { get; set; }
+    internal static Action<string>? WriteScanCheckpointForTesting { get; set; }
+    internal static Action<string>? DeleteScanCheckpointForTesting { get; set; }
     internal static Func<bool> IsInputRedirectedForTesting { get; set; } = () => Console.IsInputRedirected;
     internal static Func<string?> ReadLineForTesting { get; set; } = Console.ReadLine;
 

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -499,6 +499,8 @@ internal sealed record VersionInfoJsonResult(
 [JsonSerializable(typeof(IndexWatchRecoveryCommandJsonResult))]
 [JsonSerializable(typeof(ExportImportCommandRunner.ImportResult))]
 [JsonSerializable(typeof(HookCommandJsonResult))]
+[JsonSerializable(typeof(HookCommandWarningJsonResult))]
+[JsonSerializable(typeof(List<HookCommandWarningJsonResult>))]
 [JsonSerializable(typeof(JsonStreamDoneResult))]
 [JsonSerializable(typeof(LanguageEntryJsonResult))]
 [JsonSerializable(typeof(LanguagesJsonResult))]

--- a/tests/CodeIndex.Tests/AtomicFileWriterTests.cs
+++ b/tests/CodeIndex.Tests/AtomicFileWriterTests.cs
@@ -1,0 +1,86 @@
+using System.Text;
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+[Collection("SQLite pool sensitive")]
+public class AtomicFileWriterTests
+{
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    [Fact]
+    public void WriteText_ReplacesFileAndFlushesParentDirectoryWhenSupported()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_replace");
+        try
+        {
+            var path = Path.Combine(projectRoot, "settings.json");
+            File.WriteAllText(path, "old", Utf8NoBom);
+
+            AtomicFileWriter.WriteText(path, "new", Utf8NoBom);
+
+            Assert.Equal("new", File.ReadAllText(path, Utf8NoBom));
+            Assert.Empty(Directory.GetFiles(projectRoot, ".settings.json.*.tmp"));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void WriteText_ModeFailureBeforeReplace_LeavesExistingFile()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_mode_failure");
+        try
+        {
+            var path = Path.Combine(projectRoot, "settings.json");
+            File.WriteAllText(path, "old", Utf8NoBom);
+            string? modePath = null;
+
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                AtomicFileWriter.WriteText(
+                    path,
+                    "new",
+                    Utf8NoBom,
+                    tempPath =>
+                    {
+                        modePath = tempPath;
+                        throw new UnauthorizedAccessException("mode denied");
+                    }));
+
+            Assert.NotNull(modePath);
+            Assert.NotEqual(path, modePath);
+            Assert.Equal("old", File.ReadAllText(path, Utf8NoBom));
+            Assert.Empty(Directory.GetFiles(projectRoot, ".settings.json.*.tmp"));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void WriteText_ParentDirectoryFlushFailure_ReportsPostReplaceDurabilityFailure()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_flush_failure");
+        try
+        {
+            var path = Path.Combine(projectRoot, "settings.json");
+            File.WriteAllText(path, "old", Utf8NoBom);
+            AtomicFileWriter.FlushParentDirectoryForTesting = _ => throw new IOException("flush failed");
+
+            var ex = Assert.Throws<IOException>(() =>
+                AtomicFileWriter.WriteText(path, "new", Utf8NoBom));
+
+            Assert.Contains("Atomic replace completed", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("parent directory could not be flushed", ex.Message, StringComparison.Ordinal);
+            Assert.Equal("new", File.ReadAllText(path, Utf8NoBom));
+        }
+        finally
+        {
+            AtomicFileWriter.FlushParentDirectoryForTesting = null;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
@@ -172,6 +172,114 @@ public class HookCommandRunnerTests
     }
 
     [Fact]
+    public void Hooks_InstallJson_ReportsStagedHookCleanupFailure()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("hook_install_cleanup_warning");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            var hooksDir = Path.Combine(projectRoot, ".git", "hooks");
+            Directory.CreateDirectory(hooksDir);
+            var hookPath = Path.Combine(hooksDir, "pre-commit");
+            File.WriteAllText(hookPath, "#!/bin/sh\necho existing\n");
+            HookCommandRunner.ReplaceFileForTesting = (_, _, _) => throw new IOException("replace denied");
+            HookCommandRunner.DeleteFileForTesting = _ => throw new IOException("delete denied");
+
+            var (exitCode, stdout, stderr) = RunHooksAndCaptureStreams(["install", "--project", projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.InstallError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = JsonDocument.Parse(stdout);
+            Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+            var warnings = document.RootElement.GetProperty("warnings");
+            Assert.Equal(2, warnings.GetArrayLength());
+            var warning = warnings[0];
+            Assert.Equal("staged_hook_temp", warning.GetProperty("category").GetString());
+            Assert.Contains(".pre-commit.", warning.GetProperty("path").GetString(), StringComparison.Ordinal);
+            Assert.Contains("failed to delete staged_hook_temp", warning.GetProperty("message").GetString(), StringComparison.Ordinal);
+            Assert.Contains("IOException", warning.GetProperty("message").GetString(), StringComparison.Ordinal);
+            var backupWarning = warnings[1];
+            Assert.Equal("chained_hook_backup", backupWarning.GetProperty("category").GetString());
+            Assert.Contains("pre-commit.cdidx-chain", backupWarning.GetProperty("path").GetString(), StringComparison.Ordinal);
+            Assert.Contains("failed to back up existing hook", backupWarning.GetProperty("message").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            HookCommandRunner.ReplaceFileForTesting = null;
+            HookCommandRunner.DeleteFileForTesting = null;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Hooks_UninstallJson_ReportsManagedHookDeleteFailure()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("hook_uninstall_cleanup_warning");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            var installExit = RunHooksAndCaptureStreams(["install", "--project", projectRoot]).ExitCode;
+            var hookPath = Path.Combine(projectRoot, ".git", "hooks", "pre-commit");
+            Assert.Equal(CommandExitCodes.Success, installExit);
+            Assert.True(File.Exists(hookPath));
+            HookCommandRunner.DeleteFileForTesting = _ => throw new IOException("delete denied");
+
+            var (exitCode, stdout, stderr) = RunHooksAndCaptureStreams(["uninstall", "--project", projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.InstallError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.True(File.Exists(hookPath));
+            using var document = JsonDocument.Parse(stdout);
+            Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+            var warning = document.RootElement.GetProperty("warnings")[0];
+            Assert.Equal("managed_hook", warning.GetProperty("category").GetString());
+            Assert.Equal(hookPath, warning.GetProperty("path").GetString());
+            Assert.Contains("failed to delete managed_hook", warning.GetProperty("message").GetString(), StringComparison.Ordinal);
+            Assert.Contains("IOException", warning.GetProperty("message").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            HookCommandRunner.DeleteFileForTesting = null;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Hooks_UninstallJson_ReportsChainedHookBackupFailure()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("hook_uninstall_backup_warning");
+        try
+        {
+            TestProjectHelper.InitializeGitRepo(projectRoot);
+            var hooksDir = Path.Combine(projectRoot, ".git", "hooks");
+            Directory.CreateDirectory(hooksDir);
+            var hookPath = Path.Combine(hooksDir, "pre-commit");
+            var chainedHookPath = Path.Combine(hooksDir, "pre-commit.cdidx-chain");
+            File.WriteAllText(hookPath, "#!/bin/sh\necho existing\n");
+            Assert.Equal(CommandExitCodes.Success, RunHooksAndCaptureStreams(["install", "--project", projectRoot]).ExitCode);
+            Assert.True(File.Exists(chainedHookPath));
+            HookCommandRunner.ReplaceFileForTesting = (_, _, _) => throw new IOException("restore denied");
+
+            var (exitCode, stdout, stderr) = RunHooksAndCaptureStreams(["uninstall", "--project", projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.InstallError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = JsonDocument.Parse(stdout);
+            Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+            var warning = document.RootElement.GetProperty("warnings")[0];
+            Assert.Equal("chained_hook_backup", warning.GetProperty("category").GetString());
+            Assert.Equal(chainedHookPath, warning.GetProperty("path").GetString());
+            Assert.Contains("failed to restore chained hook backup", warning.GetProperty("message").GetString(), StringComparison.Ordinal);
+            Assert.Contains("IOException", warning.GetProperty("message").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            HookCommandRunner.ReplaceFileForTesting = null;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Hooks_Uninstall_RestoresChainedPreCommitHook()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("hook_uninstall_chain");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -7359,6 +7359,104 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void Run_FullScan_ReportsCheckpointSaveFailureAsWarning()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        var secretDir = Path.Combine(projectRoot, "secret");
+        try
+        {
+            RunGit(projectRoot, "init");
+            RunGit(projectRoot, "config", "user.email", "test@example.com");
+            RunGit(projectRoot, "config", "user.name", "Test");
+            Directory.CreateDirectory(secretDir);
+            File.WriteAllText(Path.Combine(secretDir, "a.cs"), "public class A { }\n");
+            RunGit(projectRoot, "add", ".");
+            RunGit(projectRoot, "commit", "-m", "initial");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            SetUnixPermissions(secretDir, UnixFileMode.None);
+            IndexCommandRunner.WriteScanCheckpointForTesting = _ => throw new IOException("checkpoint save denied");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("partial", json.GetProperty("status").GetString());
+            Assert.Equal(1, json.GetProperty("summary").GetProperty("errors").GetInt32());
+            Assert.Contains(
+                json.GetProperty("warnings").EnumerateArray(),
+                warning =>
+                    warning.GetProperty("file").GetString() == "<scan_checkpoint>"
+                    && warning.GetProperty("message").GetString()!.Contains("scan checkpoint save failed", StringComparison.Ordinal)
+                    && warning.GetProperty("message").GetString()!.Contains("IOException", StringComparison.Ordinal));
+        }
+        finally
+        {
+            IndexCommandRunner.WriteScanCheckpointForTesting = null;
+            if (Directory.Exists(secretDir))
+                SetUnixPermissions(secretDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_FullScan_ReportsCheckpointDeleteFailureAsWarning()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        var secretDir = Path.Combine(projectRoot, "secret");
+        try
+        {
+            RunGit(projectRoot, "init");
+            RunGit(projectRoot, "config", "user.email", "test@example.com");
+            RunGit(projectRoot, "config", "user.name", "Test");
+            Directory.CreateDirectory(secretDir);
+            File.WriteAllText(Path.Combine(secretDir, "a.cs"), "public class A { }\n");
+            RunGit(projectRoot, "add", ".");
+            RunGit(projectRoot, "commit", "-m", "initial");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            SetUnixPermissions(secretDir, UnixFileMode.None);
+            var (partialExitCode, partialJson) = RunAndCaptureJson([projectRoot, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, partialExitCode);
+            Assert.Equal("partial", partialJson.GetProperty("status").GetString());
+
+            var checkpointPath = Path.Combine(projectRoot, ".cdidx", "scan-checkpoint.json");
+            Assert.True(File.Exists(checkpointPath));
+
+            SetUnixPermissions(secretDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            IndexCommandRunner.DeleteScanCheckpointForTesting = _ => throw new IOException("checkpoint delete denied");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.Contains(
+                json.GetProperty("warnings").EnumerateArray(),
+                warning =>
+                    warning.GetProperty("file").GetString() == "<scan_checkpoint>"
+                    && warning.GetProperty("message").GetString()!.Contains("scan checkpoint delete failed", StringComparison.Ordinal)
+                    && warning.GetProperty("message").GetString()!.Contains("IOException", StringComparison.Ordinal));
+            Assert.True(File.Exists(checkpointPath));
+        }
+        finally
+        {
+            IndexCommandRunner.DeleteScanCheckpointForTesting = null;
+            if (Directory.Exists(secretDir))
+                SetUnixPermissions(secretDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_FullScan_IgnoresOversizedCheckpoint()
     {
         var projectRoot = CreateTempProject();


### PR DESCRIPTION
## Summary
- Make atomic replacements apply requested file mode before rename and flush the parent directory after replace, with bounded post-replace durability errors.
- Report scan checkpoint save/delete failures as non-fatal warnings in human and JSON output.
- Report hook cleanup/restore/delete failures as structured warnings in human and JSON output.
- Add changelog fragments for all three fixes and document the AtomicFileWriter contract in both English and Japanese sections of DEVELOPER_GUIDE.md.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~AtomicFileWriterTests|FullyQualifiedName~HookCommandRunnerTests|FullyQualifiedName~IndexCommandRunnerTests.Run_FullScan_ReportsCheckpoint|FullyQualifiedName~IndexCommandRunnerTests.Run_FullScan_WritesCheckpoint" -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Notes
- Full local `dotnet test CodeIndex.sln -p:UseSharedCompilation=false` had one net8.0 failure in `ReleaseWorkflowTests.PackageNormalizeCli_JsonReportsBoundedFriendlyFailure`; the same test passed when rerun directly for net8.0/net9.0, and the full net9.0 suite passed.

Fixes #3409
Fixes #3463
Fixes #3464