### PR TITLE
Fix GitHelper cancellation test threshold

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -61,7 +61,7 @@ The test project mirrors the production areas closely.
 - `HttpMcpTransportTests.cs`
   HTTP MCP transport behavior, including authentication responses, warm server reuse, concurrent requests, and request logging. Request-log assertions must validate recorded contents without assuming callback order between independently handled HTTP requests.
 - `GitHelperTests.cs`
-  Git-specific behavior, including worktrees and commit-based updates.
+  Git-specific behavior, including worktrees, commit-based updates, and cancellation of git subprocesses. Cancellation wall-clock assertions should stay below the fake git scripts' natural 5-second completion while leaving room for macOS CI scheduling and process-cleanup overhead.
 - `WorkspaceMetadataEnricherTests.cs`
   Workspace freshness and git metadata enrichment behavior.
 - `SuggestionStoreTests.cs`
@@ -269,7 +269,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 - `HttpMcpTransportTests.cs`
   HTTP MCP transport の挙動。認証レスポンス、warm server reuse、並行リクエスト、リクエストログを含みます。リクエストログの assertion は、独立に処理される HTTP リクエスト間の callback 順序を仮定せず、記録内容を検証してください。
 - `GitHelperTests.cs`
-  worktree や commit ベース更新を含む Git まわりのテスト。
+  worktree や commit ベース更新、git subprocess の cancellation を含む Git まわりのテスト。Cancellation の wall-clock assertion は fake git script が自然完了する 5 秒未満に保ちつつ、macOS CI の scheduling や process cleanup の遅れを許容する余裕を持たせます。
 - `WorkspaceMetadataEnricherTests.cs`
   ワークスペース鮮度と git メタデータ付与のテスト。
 - `SuggestionStoreTests.cs`

--- a/changelog.d/unreleased/3643.fixed.md
+++ b/changelog.d/unreleased/3643.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3643
+affected:
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **GitHelper cancellation tests now tolerate macOS CI cleanup jitter (#3643)** — cancellation assertions keep a bounded wall-clock limit while allowing small scheduling and process-cleanup overhead above the previous two-second cutoff.
+
+## 日本語
+
+- **GitHelper の cancellation テストが macOS CI の cleanup 揺れを許容するようになりました (#3643)** — cancellation の assertion は wall-clock の上限を維持しつつ、従来の 2 秒閾値を少し超える scheduling や process cleanup の遅れを許容します。

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -11,6 +11,9 @@ namespace CodeIndex.Tests;
 [Collection("SQLite pool sensitive")]
 public class GitHelperTests : IDisposable
 {
+    // Keep below the fake git scripts' 5-second sleep so missed cancellation still fails.
+    private static readonly TimeSpan GitCancellationWallClockLimit = TimeSpan.FromSeconds(4);
+
     private readonly string _tempDir;
 
     public GitHelperTests()
@@ -622,7 +625,9 @@ public class GitHelperTests : IDisposable
 
             stopwatch.Stop();
             Assert.Equal(cts.Token, ex.CancellationToken);
-            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), $"Cancellation took {stopwatch.Elapsed}.");
+            Assert.True(
+                stopwatch.Elapsed < GitCancellationWallClockLimit,
+                $"Cancellation took {stopwatch.Elapsed}, expected less than {GitCancellationWallClockLimit}.");
         }
         finally
         {
@@ -655,7 +660,9 @@ public class GitHelperTests : IDisposable
 
             stopwatch.Stop();
             Assert.Equal(cts.Token, ex.CancellationToken);
-            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), $"Cancellation took {stopwatch.Elapsed}.");
+            Assert.True(
+                stopwatch.Elapsed < GitCancellationWallClockLimit,
+                $"Cancellation took {stopwatch.Elapsed}, expected less than {GitCancellationWallClockLimit}.");
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Relax GitHelper cancellation wall-clock assertions from 2 seconds to a shared 4-second bound that still stays below the fake git scripts' 5-second natural completion.
- Document the GitHelper cancellation test contract in both English and Japanese sections of `TESTING_GUIDE.md`.
- Add changelog fragment `changelog.d/unreleased/3643.fixed.md`.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~GitHelperTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Updated `TESTING_GUIDE.md` in English and Japanese.
- Added `changelog.d/unreleased/3643.fixed.md`.
- Did not edit `CHANGELOG.md`.

## Follow-up candidates

- None.

Fixes #3643