### PR TITLE
Fix package normalize stderr capture flake

### DIFF
--- a/changelog.d/unreleased/3631.fixed.md
+++ b/changelog.d/unreleased/3631.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3631
+affected:
+  - tools/CodeIndex.PackageNormalize/PackageNormalizeCli.cs
+  - tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+---
+
+## English
+
+- **Package normalize dry-run tests no longer capture unrelated stderr (#3631)** — release workflow tests now invoke the package normalizer with dedicated output writers so MCP telemetry from other test activity cannot make dry-run stderr assertions flaky.
+
+## 日本語
+
+- **Package normalize の dry-run テストが無関係な stderr を捕捉しないようになりました (#3631)** — release workflow テストは package normalizer を専用の出力 writer で実行するため、他のテスト活動からの MCP telemetry が dry-run の stderr アサーションを不安定にしなくなりました。

--- a/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
@@ -237,8 +237,7 @@ public class ReleaseWorkflowTests
             CreateMinimalNuGetPackage(packagePath, "random.psmdcp");
             var beforeHash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(packagePath)));
 
-            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
-                PackageNormalizeCli.Run(["--dry-run", "--summary", packagePath]));
+            var (exitCode, stdout, stderr) = RunPackageNormalizeCli(["--dry-run", "--summary", packagePath]);
 
             var afterHash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(packagePath)));
             Assert.Equal(0, exitCode);
@@ -268,8 +267,7 @@ public class ReleaseWorkflowTests
             var missingPackagePath = Path.Combine(projectRoot, "missing.nupkg");
             CreateMinimalNuGetPackage(packagePath, "random.psmdcp");
 
-            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
-                PackageNormalizeCli.Run(["--dry-run", "--json", "--continue-on-error", missingPackagePath, packagePath]));
+            var (exitCode, stdout, stderr) = RunPackageNormalizeCli(["--dry-run", "--json", "--continue-on-error", missingPackagePath, packagePath]);
 
             Assert.Equal(1, exitCode);
             Assert.Empty(stderr);
@@ -303,7 +301,7 @@ public class ReleaseWorkflowTests
             .Select(index => $"package-{index}.nupkg")
             .ToArray();
 
-        var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() => PackageNormalizeCli.Run(args));
+        var (exitCode, stdout, stderr) = RunPackageNormalizeCli(args);
 
         Assert.Equal(1, exitCode);
         Assert.Empty(stdout);
@@ -318,8 +316,7 @@ public class ReleaseWorkflowTests
         {
             var missingPackagePath = Path.Combine(projectRoot, "missing.nupkg");
 
-            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
-                PackageNormalizeCli.Run(["--json", missingPackagePath]));
+            var (exitCode, stdout, stderr) = RunPackageNormalizeCli(["--json", missingPackagePath]);
 
             Assert.Equal(1, exitCode);
             Assert.Empty(stderr);
@@ -350,8 +347,7 @@ public class ReleaseWorkflowTests
                 ("package/services/metadata/core-properties/random.psmdcp", ""),
                 (longEntryName, "payload"));
 
-            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
-                PackageNormalizeCli.Run(["--json", packagePath]));
+            var (exitCode, stdout, stderr) = RunPackageNormalizeCli(["--json", packagePath]);
 
             Assert.Equal(1, exitCode);
             Assert.Empty(stderr);
@@ -736,6 +732,14 @@ public class ReleaseWorkflowTests
         }
 
         throw new InvalidOperationException("Could not locate repository root / リポジトリルートを特定できませんでした");
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunPackageNormalizeCli(string[] args)
+    {
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var exitCode = PackageNormalizeCli.Run(args, stdout, stderr);
+        return (exitCode, stdout.ToString(), stderr.ToString());
     }
 
     private static void CreateMinimalNuGetPackage(string packagePath, string corePropertiesFileName)

--- a/tools/CodeIndex.PackageNormalize/PackageNormalizeCli.cs
+++ b/tools/CodeIndex.PackageNormalize/PackageNormalizeCli.cs
@@ -6,18 +6,20 @@ namespace CodeIndex.PackageNormalize;
 
 public static class PackageNormalizeCli
 {
-    public static int Run(string[] args)
+    public static int Run(string[] args) => Run(args, Console.Out, Console.Error);
+
+    internal static int Run(string[] args, TextWriter stdout, TextWriter stderr)
     {
         if (args.Any(arg => arg is "-h" or "--help"))
         {
-            WriteUsage();
+            WriteUsage(stderr);
             return 0;
         }
 
         if (!PackageNormalizeOptions.TryParse(args, out var options, out var parseError))
         {
-            Console.Error.WriteLine($"Error: {parseError}");
-            WriteUsage();
+            stderr.WriteLine($"Error: {parseError}");
+            WriteUsage(stderr);
             return 1;
         }
 
@@ -38,14 +40,14 @@ public static class PackageNormalizeCli
                         summary.Skipped++;
                         results.Add(new PackageNormalizePackageResult(packagePath, "would_normalize", null, warnings));
                         if (!options.Json)
-                            Console.WriteLine($"Would normalize {packagePath}");
+                            stdout.WriteLine($"Would normalize {packagePath}");
                     }
                     else
                     {
                         summary.Unchanged++;
                         results.Add(new PackageNormalizePackageResult(packagePath, "unchanged", null, warnings));
                         if (!options.Json)
-                            Console.WriteLine($"Unchanged {packagePath}");
+                            stdout.WriteLine($"Unchanged {packagePath}");
                     }
                 }
                 else
@@ -55,8 +57,8 @@ public static class PackageNormalizeCli
                     results.Add(new PackageNormalizePackageResult(packagePath, "normalized", null, warnings));
                     if (!options.Json)
                     {
-                        Console.WriteLine($"Normalized {packagePath}");
-                        WriteWarnings(warnings);
+                        stdout.WriteLine($"Normalized {packagePath}");
+                        WriteWarnings(stderr, warnings);
                     }
                 }
             }
@@ -67,8 +69,8 @@ public static class PackageNormalizeCli
                 results.Add(new PackageNormalizePackageResult(packagePath, "failed", error, warnings));
                 if (!options.Json)
                 {
-                    Console.Error.WriteLine($"Failed {PackageNormalizeDiagnostics.FormatPath(packagePath)}: {error}");
-                    WriteWarnings(warnings);
+                    stderr.WriteLine($"Failed {PackageNormalizeDiagnostics.FormatPath(packagePath)}: {error}");
+                    WriteWarnings(stderr, warnings);
                 }
 
                 if (!options.ContinueOnError)
@@ -78,7 +80,7 @@ public static class PackageNormalizeCli
 
         if (options.Json)
         {
-            Console.WriteLine(JsonSerializer.Serialize(
+            stdout.WriteLine(JsonSerializer.Serialize(
                 new PackageNormalizeJsonResult(
                     options.DryRun,
                     options.ContinueOnError,
@@ -92,22 +94,22 @@ public static class PackageNormalizeCli
         }
         else if (options.Summary)
         {
-            Console.WriteLine(
+            stdout.WriteLine(
                 $"Summary: inspected={summary.Inspected} normalized={summary.Normalized} unchanged={summary.Unchanged} failed={summary.Failed} skipped={summary.Skipped}");
         }
 
         return summary.Failed == 0 ? 0 : 1;
     }
 
-    private static void WriteUsage()
+    private static void WriteUsage(TextWriter error)
     {
-        Console.Error.WriteLine("Usage: dotnet run --project tools/CodeIndex.PackageNormalize -- [--dry-run|--check] [--summary] [--json] [--continue-on-error] <package.nupkg|package.snupkg> [...]");
+        error.WriteLine("Usage: dotnet run --project tools/CodeIndex.PackageNormalize -- [--dry-run|--check] [--summary] [--json] [--continue-on-error] <package.nupkg|package.snupkg> [...]");
     }
 
-    private static void WriteWarnings(IReadOnlyList<string> warnings)
+    private static void WriteWarnings(TextWriter error, IReadOnlyList<string> warnings)
     {
         foreach (var warning in warnings)
-            Console.Error.WriteLine($"Warning: {warning}");
+            error.WriteLine($"Warning: {warning}");
     }
 }
 


### PR DESCRIPTION
## Summary

- Add an internal writer-injection overload for `PackageNormalizeCli.Run` while keeping the public console-backed entry point unchanged.
- Update release workflow package-normalize CLI tests to use dedicated stdout/stderr writers instead of global `ConsoleCapture`.
- Add changelog fragment `changelog.d/unreleased/3631.fixed.md`.

## Validation

- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files tools/CodeIndex.PackageNormalize/PackageNormalizeCli.cs tests/CodeIndex.Tests/ReleaseWorkflowTests.cs changelog.d/unreleased/3631.fixed.md --json`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReleaseWorkflowTests.PackageNormalizeCli_DryRunDoesNotRewritePackage"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ReleaseWorkflowTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet test`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and changelog

- Added `changelog.d/unreleased/3631.fixed.md`.
- No user-facing docs were changed because this only adjusts test isolation and an internal testable CLI overload.

Fixes #3631