### PR TITLE
Add symbol extraction for Cython, HDL, and shaders

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1771,10 +1771,10 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 | Dockerfile | `Dockerfile`, `Containerfile`, `Dockerfile.<suffix>`, `Containerfile.<suffix>` | yes |
 | Assembly | `.s`, `.S`, `.asm`, `.nasm` | yes |
 | CUDA | `.cu`, `.cuh` | yes |
-| GLSL | `.glsl`, `.vert`, `.frag` | -- |
-| HLSL | `.hlsl` | -- |
-| WGSL | `.wgsl` | -- |
-| Metal | `.metal` | -- |
+| GLSL | `.glsl`, `.vert`, `.frag` | yes |
+| HLSL | `.hlsl` | yes |
+| WGSL | `.wgsl` | yes |
+| Metal | `.metal` | yes |
 | Verilog | `.v` | yes |
 | SystemVerilog | `.sv`, `.svh` | yes |
 | VHDL | `.vhd`, `.vhdl` | yes |
@@ -1810,6 +1810,7 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 
 - C/C++ headers: `.h` stays on the C path unless the file has clear C++ markers such as `namespace`, `template`, `using`, `class`, or `std::`; those headers are promoted to `cpp` at index time.
 - Cython and CUDA: Cython `cdef` / `cpdef` declarations, `cimport` entries, and extern declarations are indexed as symbols. CUDA files reuse C++ symbols and classify `__global__`, `__device__`, and `__host__` functions with CUDA-specific sub-kinds.
+- Shaders: GLSL, HLSL, Metal, and WGSL entry points, structs, type aliases, resource bindings, constant buffers, samplers, textures, and uniform/input/output declarations are indexed as symbols.
 - HDL: Verilog, SystemVerilog, and VHDL module/package/type/function/resource declarations are indexed as symbols. References and graph queries are not advertised for HDL yet.
 - SQL: query-time `--lang tsql` is accepted as a SQL alias, and T-SQL aggregate, assembly, and XML schema collection declarations are searchable.
 - R: function assignments, S4/R6 class declarations, validity/generic/method declarations, inherit vectors, public/private/active methods, and `library` / `require` imports are indexed.
@@ -1844,6 +1845,7 @@ commands and when to fall back to `search`.
 | Cython | `cdef` / `cpdef` declarations, cimports, extern declarations | none yet | Cython native-extension declarations are searchable as symbols; use `search` for call/reference questions. |
 | C / C++ / Objective-C / Swift / Rust / Go / Zig | functions, types, methods, imports/modules | calls, constructors, macro invocations where supported, type references | C++ templates/macros and Rust macro expansion are not evaluated; Rust macro invocations are still reference edges. |
 | CUDA | C++-style functions/types plus CUDA kernel/device/host sub-kinds | none yet | CUDA kernel/device/host declarations are indexed as C++-style symbols with CUDA sub-kinds; use `search` for call/reference questions. |
+| GLSL / HLSL / Metal / WGSL | entry points, structs, type aliases, resource bindings, constant buffers, samplers, textures, uniforms/inputs/outputs | none yet | Shader entry points and resource declarations are searchable as symbols; use `search` for data-flow, binding compatibility, and call/reference questions. |
 | Verilog / SystemVerilog / VHDL | modules, packages, interfaces, classes, functions/tasks/processes, types, signals/parameters | none yet | HDL declarations are available to `symbols`, `definition`, `outline`, and symbol-aware `search`; use plain `search` for netlist/reference questions. |
 | Shell / PowerShell / Batch / Makefile / CMake / Justfile / MSBuild / Gradle | functions, labels, targets, recipes, tasks, imports where applicable | command-style calls, target dependencies, and control-flow targets | Runtime command construction is not resolved. |
 | SQL / Terraform / Dockerfile | statements/resources/stages/labels | table/resource/stage references, Dockerfile stage dependencies, Terraform dotted refs | SQL hotspot grouping defaults to statements; Dockerfile `COPY --from=<stage>` follows named stages. |
@@ -4233,10 +4235,10 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 | Dockerfile | `Dockerfile`, `Containerfile`, `Dockerfile.<suffix>`, `Containerfile.<suffix>` | yes |
 | Assembly | `.s`, `.S`, `.asm`, `.nasm` | yes |
 | CUDA | `.cu`, `.cuh` | yes |
-| GLSL | `.glsl`, `.vert`, `.frag` | -- |
-| HLSL | `.hlsl` | -- |
-| WGSL | `.wgsl` | -- |
-| Metal | `.metal` | -- |
+| GLSL | `.glsl`, `.vert`, `.frag` | yes |
+| HLSL | `.hlsl` | yes |
+| WGSL | `.wgsl` | yes |
+| Metal | `.metal` | yes |
 | Verilog | `.v` | yes |
 | SystemVerilog | `.sv`, `.svh` | yes |
 | VHDL | `.vhd`, `.vhdl` | yes |
@@ -4272,6 +4274,7 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 
 - C/C++ ヘッダー: `.h` は既定では C として扱います。`namespace`、`template`、`using`、`class`、`std::` などの明確な C++ マーカーがある場合だけ、index 時に `cpp` へ昇格します。
 - Cython と CUDA: Cython の `cdef` / `cpdef` 宣言、`cimport`、extern 宣言をシンボルとして索引します。CUDA ファイルは C++ のシンボル抽出を再利用し、`__global__`、`__device__`、`__host__` 関数に CUDA 固有の sub-kind を付けます。
+- Shaders: GLSL、HLSL、Metal、WGSL の entry point、struct、type alias、resource binding、constant buffer、sampler、texture、uniform/input/output 宣言をシンボルとして索引します。
 - HDL: Verilog、SystemVerilog、VHDL の module / package / type / function / resource 宣言をシンボルとして索引します。HDL の references と graph queries はまだ対応として広告しません。
 - SQL: クエリ時の `--lang tsql` は SQL の別名です。T-SQL の aggregate、assembly、XML schema collection 宣言も検索対象です。
 - R: 関数代入、S4/R6 class 宣言、validity/generic/method 宣言、inherit vector、public/private/active method、`library` / `require` import を索引します。
@@ -4303,6 +4306,7 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 | Cython | `cdef` / `cpdef` 宣言、cimport、extern 宣言 | まだなし | Cython の native extension 宣言はシンボルとして検索できます。call/reference の調査には `search` を使ってください。 |
 | C / C++ / Objective-C / Swift / Rust / Go / Zig | function、type、method、import/module | call、constructor、対応言語の macro invocation、type reference | C++ template/macro と Rust macro expansion は評価しません。Rust macro invocation 自体は reference edge です。 |
 | CUDA | C++ 風の function/type と CUDA kernel/device/host sub-kind | まだなし | CUDA の kernel / device / host 宣言は CUDA sub-kind 付きの C++ 風シンボルとして索引します。call/reference の調査には `search` を使ってください。 |
+| GLSL / HLSL / Metal / WGSL | entry point、struct、type alias、resource binding、constant buffer、sampler、texture、uniform/input/output | まだなし | Shader entry point と resource 宣言はシンボルとして検索できます。data-flow、binding compatibility、call/reference の調査には `search` を使ってください。 |
 | Verilog / SystemVerilog / VHDL | module、package、interface、class、function/task/process、type、signal/parameter | まだなし | HDL 宣言は `symbols`、`definition`、`outline`、symbol-aware `search` で使えます。netlist / reference の調査には通常の `search` を使ってください。 |
 | Shell / PowerShell / Batch / Makefile / CMake / Justfile / MSBuild / Gradle | function、label、target、recipe、task、対応言語の import | command-style call、target dependency、control-flow target | runtime で組み立てられる command は解決しません。 |
 | SQL / Terraform / Dockerfile | statement/resource/stage/label | table/resource/stage reference、Dockerfile stage dependency、Terraform dotted refs | SQL hotspot grouping は既定で statement、Dockerfile `COPY --from=<stage>` は named stage を追跡します。 |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1729,7 +1729,7 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 | Language | Extensions | Symbols |
 |---|---|:---:|
 | Python | `.py`, `.pyi`, `.pyw`, `BUILD`, `BUILD.bazel`, `WORKSPACE`, `WORKSPACE.bazel` (Bazel Starlark) | yes |
-| Cython | `.pyx`, `.pxd` | -- |
+| Cython | `.pyx`, `.pxd` | yes |
 | JavaScript | `.js`, `.jsx`, `.cjs`, `.mjs` | yes |
 | TypeScript | `.ts`, `.tsx`, `.cts`, `.mts` | yes |
 | C# | `.cs` | yes |
@@ -1770,7 +1770,7 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 | Makefile | `Makefile`, `GNUmakefile`, `Makefile.<suffix>`, `GNUmakefile.<suffix>`, `.mk` | yes |
 | Dockerfile | `Dockerfile`, `Containerfile`, `Dockerfile.<suffix>`, `Containerfile.<suffix>` | yes |
 | Assembly | `.s`, `.S`, `.asm`, `.nasm` | yes |
-| CUDA | `.cu`, `.cuh` | -- |
+| CUDA | `.cu`, `.cuh` | yes |
 | GLSL | `.glsl`, `.vert`, `.frag` | -- |
 | HLSL | `.hlsl` | -- |
 | WGSL | `.wgsl` | -- |
@@ -1809,6 +1809,7 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 **Symbol notes**
 
 - C/C++ headers: `.h` stays on the C path unless the file has clear C++ markers such as `namespace`, `template`, `using`, `class`, or `std::`; those headers are promoted to `cpp` at index time.
+- Cython and CUDA: Cython `cdef` / `cpdef` declarations, `cimport` entries, and extern declarations are indexed as symbols. CUDA files reuse C++ symbols and classify `__global__`, `__device__`, and `__host__` functions with CUDA-specific sub-kinds.
 - SQL: query-time `--lang tsql` is accepted as a SQL alias, and T-SQL aggregate, assembly, and XML schema collection declarations are searchable.
 - R: function assignments, S4/R6 class declarations, validity/generic/method declarations, inherit vectors, public/private/active methods, and `library` / `require` imports are indexed.
 - Markdown, JSON/YAML, and CSS: Markdown heading and local-anchor symbols are indexed; JSON/YAML configuration keys are indexed as structural key paths; CSS variables, placeholders, and `@extend` references are indexed.
@@ -1839,7 +1840,9 @@ commands and when to fall back to `search`.
 | Java / Kotlin / Scala | packages/imports, classes/interfaces, methods, properties | calls, constructors, annotations, type references | Kotlin inline lambda body modeling is limited; verify with `references` before relying on deep call chains. |
 | JavaScript / TypeScript / Vue / Svelte | functions, classes, exports, imports, variables | calls, constructors, static/dynamic imports, workers, service workers | Dynamic property calls and computed module specifiers are best-effort. `cdidx references render --lang typescript` |
 | Python / Ruby / PHP / Perl / R | functions, classes/modules, imports where supported | calls, constructors, decorators/annotations where supported | Dynamic dispatch and metaprogramming may require `search`. PHPDoc/static import patterns are indexed when statically visible. |
+| Cython | `cdef` / `cpdef` declarations, cimports, extern declarations | none yet | Cython native-extension declarations are searchable as symbols; use `search` for call/reference questions. |
 | C / C++ / Objective-C / Swift / Rust / Go / Zig | functions, types, methods, imports/modules | calls, constructors, macro invocations where supported, type references | C++ templates/macros and Rust macro expansion are not evaluated; Rust macro invocations are still reference edges. |
+| CUDA | C++-style functions/types plus CUDA kernel/device/host sub-kinds | none yet | CUDA kernel/device/host declarations are indexed as C++-style symbols with CUDA sub-kinds; use `search` for call/reference questions. |
 | Shell / PowerShell / Batch / Makefile / CMake / Justfile / MSBuild / Gradle | functions, labels, targets, recipes, tasks, imports where applicable | command-style calls, target dependencies, and control-flow targets | Runtime command construction is not resolved. |
 | SQL / Terraform / Dockerfile | statements/resources/stages/labels | table/resource/stage references, Dockerfile stage dependencies, Terraform dotted refs | SQL hotspot grouping defaults to statements; Dockerfile `COPY --from=<stage>` follows named stages. |
 | Markdown / HTML / CSS / Sass / Stylus / XAML / GraphQL / Protobuf | headings, anchors, selectors, UI elements, schema types/messages where supported | links/assets/components, local anchors, CSS/Sass/Stylus imports, variables, mixins/functions, XAML resources/bindings/handlers, schema references where supported | Use `search` for prose and generated markup. |
@@ -4186,7 +4189,7 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 | 言語 | 拡張子 | シンボル |
 |---|---|:---:|
 | Python | `.py`, `.pyi`, `.pyw`, `BUILD`, `BUILD.bazel`, `WORKSPACE`, `WORKSPACE.bazel`（Bazel Starlark） | yes |
-| Cython | `.pyx`, `.pxd` | -- |
+| Cython | `.pyx`, `.pxd` | yes |
 | JavaScript | `.js`, `.jsx`, `.cjs`, `.mjs` | yes |
 | TypeScript | `.ts`, `.tsx`, `.cts`, `.mts` | yes |
 | C# | `.cs` | yes |
@@ -4227,7 +4230,7 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 | Makefile | `Makefile`, `GNUmakefile`, `Makefile.<suffix>`, `GNUmakefile.<suffix>`, `.mk` | yes |
 | Dockerfile | `Dockerfile`, `Containerfile`, `Dockerfile.<suffix>`, `Containerfile.<suffix>` | yes |
 | Assembly | `.s`, `.S`, `.asm`, `.nasm` | yes |
-| CUDA | `.cu`, `.cuh` | -- |
+| CUDA | `.cu`, `.cuh` | yes |
 | GLSL | `.glsl`, `.vert`, `.frag` | -- |
 | HLSL | `.hlsl` | -- |
 | WGSL | `.wgsl` | -- |
@@ -4266,6 +4269,7 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 **シンボル抽出メモ**
 
 - C/C++ ヘッダー: `.h` は既定では C として扱います。`namespace`、`template`、`using`、`class`、`std::` などの明確な C++ マーカーがある場合だけ、index 時に `cpp` へ昇格します。
+- Cython と CUDA: Cython の `cdef` / `cpdef` 宣言、`cimport`、extern 宣言をシンボルとして索引します。CUDA ファイルは C++ のシンボル抽出を再利用し、`__global__`、`__device__`、`__host__` 関数に CUDA 固有の sub-kind を付けます。
 - SQL: クエリ時の `--lang tsql` は SQL の別名です。T-SQL の aggregate、assembly、XML schema collection 宣言も検索対象です。
 - R: 関数代入、S4/R6 class 宣言、validity/generic/method 宣言、inherit vector、public/private/active method、`library` / `require` import を索引します。
 - Markdown、JSON/YAML、CSS: Markdown の heading / local anchor、JSON/YAML の configuration key path、CSS の variable、placeholder、`@extend` をシンボルとして扱います。
@@ -4293,7 +4297,9 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 | Java / Kotlin / Scala | package/import、class/interface、method、property | call、constructor、annotation、type reference | Kotlin inline lambda body の modeling は限定的です。深い call chain を信頼する前に `references` で確認してください。 |
 | JavaScript / TypeScript / Vue / Svelte | function、class、export、import、variable | call、constructor、static/dynamic import、worker、service worker | dynamic property call と computed module specifier は best-effort です。`cdidx references render --lang typescript` |
 | Python / Ruby / PHP / Perl / R | function、class/module、対応言語の import | call、constructor、対応言語の decorator/annotation | dynamic dispatch と metaprogramming は `search` が必要な場合があります。PHPDoc/static import pattern は静的に見える範囲で索引されます。 |
+| Cython | `cdef` / `cpdef` 宣言、cimport、extern 宣言 | まだなし | Cython の native extension 宣言はシンボルとして検索できます。call/reference の調査には `search` を使ってください。 |
 | C / C++ / Objective-C / Swift / Rust / Go / Zig | function、type、method、import/module | call、constructor、対応言語の macro invocation、type reference | C++ template/macro と Rust macro expansion は評価しません。Rust macro invocation 自体は reference edge です。 |
+| CUDA | C++ 風の function/type と CUDA kernel/device/host sub-kind | まだなし | CUDA の kernel / device / host 宣言は CUDA sub-kind 付きの C++ 風シンボルとして索引します。call/reference の調査には `search` を使ってください。 |
 | Shell / PowerShell / Batch / Makefile / CMake / Justfile / MSBuild / Gradle | function、label、target、recipe、task、対応言語の import | command-style call、target dependency、control-flow target | runtime で組み立てられる command は解決しません。 |
 | SQL / Terraform / Dockerfile | statement/resource/stage/label | table/resource/stage reference、Dockerfile stage dependency、Terraform dotted refs | SQL hotspot grouping は既定で statement、Dockerfile `COPY --from=<stage>` は named stage を追跡します。 |
 | Markdown / HTML / CSS / Sass / Stylus / XAML / GraphQL / Protobuf | heading、anchor、selector、UI element、対応 schema type/message | link/asset/component、local anchor、CSS/Sass/Stylus の import・variable・mixin/function、XAML resource / binding / handler、対応 schema reference | prose や generated markup には `search` を使ってください。 |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1775,9 +1775,9 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 | HLSL | `.hlsl` | -- |
 | WGSL | `.wgsl` | -- |
 | Metal | `.metal` | -- |
-| Verilog | `.v` | -- |
-| SystemVerilog | `.sv`, `.svh` | -- |
-| VHDL | `.vhd`, `.vhdl` | -- |
+| Verilog | `.v` | yes |
+| SystemVerilog | `.sv`, `.svh` | yes |
+| VHDL | `.vhd`, `.vhdl` | yes |
 | Common Lisp | `.lisp`, `.lsp`, `.cl` | yes |
 | Racket | `.rkt` | yes |
 | Pascal | `.pas`, `.pp`, `.dpr` | -- |
@@ -1810,6 +1810,7 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 
 - C/C++ headers: `.h` stays on the C path unless the file has clear C++ markers such as `namespace`, `template`, `using`, `class`, or `std::`; those headers are promoted to `cpp` at index time.
 - Cython and CUDA: Cython `cdef` / `cpdef` declarations, `cimport` entries, and extern declarations are indexed as symbols. CUDA files reuse C++ symbols and classify `__global__`, `__device__`, and `__host__` functions with CUDA-specific sub-kinds.
+- HDL: Verilog, SystemVerilog, and VHDL module/package/type/function/resource declarations are indexed as symbols. References and graph queries are not advertised for HDL yet.
 - SQL: query-time `--lang tsql` is accepted as a SQL alias, and T-SQL aggregate, assembly, and XML schema collection declarations are searchable.
 - R: function assignments, S4/R6 class declarations, validity/generic/method declarations, inherit vectors, public/private/active methods, and `library` / `require` imports are indexed.
 - Markdown, JSON/YAML, and CSS: Markdown heading and local-anchor symbols are indexed; JSON/YAML configuration keys are indexed as structural key paths; CSS variables, placeholders, and `@extend` references are indexed.
@@ -1843,6 +1844,7 @@ commands and when to fall back to `search`.
 | Cython | `cdef` / `cpdef` declarations, cimports, extern declarations | none yet | Cython native-extension declarations are searchable as symbols; use `search` for call/reference questions. |
 | C / C++ / Objective-C / Swift / Rust / Go / Zig | functions, types, methods, imports/modules | calls, constructors, macro invocations where supported, type references | C++ templates/macros and Rust macro expansion are not evaluated; Rust macro invocations are still reference edges. |
 | CUDA | C++-style functions/types plus CUDA kernel/device/host sub-kinds | none yet | CUDA kernel/device/host declarations are indexed as C++-style symbols with CUDA sub-kinds; use `search` for call/reference questions. |
+| Verilog / SystemVerilog / VHDL | modules, packages, interfaces, classes, functions/tasks/processes, types, signals/parameters | none yet | HDL declarations are available to `symbols`, `definition`, `outline`, and symbol-aware `search`; use plain `search` for netlist/reference questions. |
 | Shell / PowerShell / Batch / Makefile / CMake / Justfile / MSBuild / Gradle | functions, labels, targets, recipes, tasks, imports where applicable | command-style calls, target dependencies, and control-flow targets | Runtime command construction is not resolved. |
 | SQL / Terraform / Dockerfile | statements/resources/stages/labels | table/resource/stage references, Dockerfile stage dependencies, Terraform dotted refs | SQL hotspot grouping defaults to statements; Dockerfile `COPY --from=<stage>` follows named stages. |
 | Markdown / HTML / CSS / Sass / Stylus / XAML / GraphQL / Protobuf | headings, anchors, selectors, UI elements, schema types/messages where supported | links/assets/components, local anchors, CSS/Sass/Stylus imports, variables, mixins/functions, XAML resources/bindings/handlers, schema references where supported | Use `search` for prose and generated markup. |
@@ -4235,9 +4237,9 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 | HLSL | `.hlsl` | -- |
 | WGSL | `.wgsl` | -- |
 | Metal | `.metal` | -- |
-| Verilog | `.v` | -- |
-| SystemVerilog | `.sv`, `.svh` | -- |
-| VHDL | `.vhd`, `.vhdl` | -- |
+| Verilog | `.v` | yes |
+| SystemVerilog | `.sv`, `.svh` | yes |
+| VHDL | `.vhd`, `.vhdl` | yes |
 | Common Lisp | `.lisp`, `.lsp`, `.cl` | yes |
 | Racket | `.rkt` | yes |
 | Pascal | `.pas`, `.pp`, `.dpr` | -- |
@@ -4270,6 +4272,7 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 
 - C/C++ ヘッダー: `.h` は既定では C として扱います。`namespace`、`template`、`using`、`class`、`std::` などの明確な C++ マーカーがある場合だけ、index 時に `cpp` へ昇格します。
 - Cython と CUDA: Cython の `cdef` / `cpdef` 宣言、`cimport`、extern 宣言をシンボルとして索引します。CUDA ファイルは C++ のシンボル抽出を再利用し、`__global__`、`__device__`、`__host__` 関数に CUDA 固有の sub-kind を付けます。
+- HDL: Verilog、SystemVerilog、VHDL の module / package / type / function / resource 宣言をシンボルとして索引します。HDL の references と graph queries はまだ対応として広告しません。
 - SQL: クエリ時の `--lang tsql` は SQL の別名です。T-SQL の aggregate、assembly、XML schema collection 宣言も検索対象です。
 - R: 関数代入、S4/R6 class 宣言、validity/generic/method 宣言、inherit vector、public/private/active method、`library` / `require` import を索引します。
 - Markdown、JSON/YAML、CSS: Markdown の heading / local anchor、JSON/YAML の configuration key path、CSS の variable、placeholder、`@extend` をシンボルとして扱います。
@@ -4300,6 +4303,7 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 | Cython | `cdef` / `cpdef` 宣言、cimport、extern 宣言 | まだなし | Cython の native extension 宣言はシンボルとして検索できます。call/reference の調査には `search` を使ってください。 |
 | C / C++ / Objective-C / Swift / Rust / Go / Zig | function、type、method、import/module | call、constructor、対応言語の macro invocation、type reference | C++ template/macro と Rust macro expansion は評価しません。Rust macro invocation 自体は reference edge です。 |
 | CUDA | C++ 風の function/type と CUDA kernel/device/host sub-kind | まだなし | CUDA の kernel / device / host 宣言は CUDA sub-kind 付きの C++ 風シンボルとして索引します。call/reference の調査には `search` を使ってください。 |
+| Verilog / SystemVerilog / VHDL | module、package、interface、class、function/task/process、type、signal/parameter | まだなし | HDL 宣言は `symbols`、`definition`、`outline`、symbol-aware `search` で使えます。netlist / reference の調査には通常の `search` を使ってください。 |
 | Shell / PowerShell / Batch / Makefile / CMake / Justfile / MSBuild / Gradle | function、label、target、recipe、task、対応言語の import | command-style call、target dependency、control-flow target | runtime で組み立てられる command は解決しません。 |
 | SQL / Terraform / Dockerfile | statement/resource/stage/label | table/resource/stage reference、Dockerfile stage dependency、Terraform dotted refs | SQL hotspot grouping は既定で statement、Dockerfile `COPY --from=<stage>` は named stage を追跡します。 |
 | Markdown / HTML / CSS / Sass / Stylus / XAML / GraphQL / Protobuf | heading、anchor、selector、UI element、対応 schema type/message | link/asset/component、local anchor、CSS/Sass/Stylus の import・variable・mixin/function、XAML resource / binding / handler、対応 schema reference | prose や generated markup には `search` を使ってください。 |

--- a/changelog.d/unreleased/3530.added.md
+++ b/changelog.d/unreleased/3530.added.md
@@ -1,0 +1,20 @@
+---
+category: added
+issues:
+  - 3530
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cuda.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Cython and CUDA files now expose native-extension symbols (#3530)** - `cdidx` extracts Cython `cdef` / `cpdef` declarations, `cimport` entries, and CUDA kernel/device/host functions so `.pyx`, `.pxd`, `.cu`, and `.cuh` files are no longer search-only.
+
+## 日本語
+
+- **Cython と CUDA ファイルが native extension のシンボルを公開するようになりました (#3530)** - `cdidx` は Cython の `cdef` / `cpdef` 宣言、`cimport`、CUDA の kernel / device / host 関数を抽出し、`.pyx`、`.pxd`、`.cu`、`.cuh` が search-only ではなくなりました。

--- a/changelog.d/unreleased/3532.added.md
+++ b/changelog.d/unreleased/3532.added.md
@@ -1,0 +1,18 @@
+---
+category: added
+issues:
+  - 3532
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **HDL files now expose declaration symbols (#3532)** - Verilog, SystemVerilog, and VHDL files report modules, packages, interfaces, classes, functions/tasks/processes, types, signals, parameters, and imports through symbol extraction.
+
+## 日本語
+
+- **HDL ファイルが宣言シンボルを公開するようになりました (#3532)** - Verilog、SystemVerilog、VHDL ファイルで module、package、interface、class、function/task/process、type、signal、parameter、import を symbol extraction から取得できます。

--- a/changelog.d/unreleased/3533.added.md
+++ b/changelog.d/unreleased/3533.added.md
@@ -1,0 +1,18 @@
+---
+category: added
+issues:
+  - 3533
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Shader files now expose entry-point and resource symbols (#3533)** - GLSL, HLSL, Metal, and WGSL files report shader entry points, structs, type aliases, constant buffers, samplers, textures, resource bindings, and uniform/input/output declarations through symbol extraction.
+
+## 日本語
+
+- **Shader ファイルが entry point と resource シンボルを公開するようになりました (#3533)** - GLSL、HLSL、Metal、WGSL ファイルで shader entry point、struct、type alias、constant buffer、sampler、texture、resource binding、uniform/input/output 宣言を symbol extraction から取得できます。

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -128,14 +128,10 @@ public class FileIndexer
         [".py"] = "python",
         [".pyi"] = "python",  // Python type stub (PEP 561) / Python 型スタブ
         [".pyw"] = "python",  // Windowed Python script / Windows 用 Python スクリプト
-        // Cython's `.pyx` / `.pxd` live in their own search-only bucket: they extend Python syntax
-        // with `cdef class` / `cpdef` / `cdef` forms that the Python regex extractor cannot parse,
-        // so mapping them to `python` would advertise `symbol_extraction=true` while emitting zero
-        // symbols — the same "advertised contract vs. actual behavior" gap that sunk the earlier
-        // `.sass` / `.styl` → `css` mapping.
-        // Cython の `.pyx` / `.pxd` は `cdef class` / `cpdef` / `cdef` を含み Python 用正規表現では
-        // 拾えない。python にマップすると `symbol_extraction=true` と広告しつつ 0 件しか出ない
-        // 齟齬になるため、`.sass` / `.styl` と同じく独立の search-only バケットに分ける。
+        // Cython keeps its own bucket because it extends Python with native declarations
+        // (`cdef`, `cpdef`, `cimport`) that need Cython-specific symbol patterns.
+        // Cython は `cdef` / `cpdef` / `cimport` など Python を拡張した native 宣言を持つため、
+        // Python ではなく Cython 専用の symbol pattern を使う独立 bucket にする。
         [".pyx"] = "cython",  // Cython source / Cython ソース
         [".pxd"] = "cython",  // Cython declaration / Cython 宣言
         [".js"] = "javascript",

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cuda.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Cuda.cs
@@ -1,0 +1,40 @@
+using CodeIndex.Models;
+
+namespace CodeIndex.Indexer;
+
+public static partial class SymbolExtractor
+{
+    private static void ClassifyCudaFunctionSubKinds(IEnumerable<SymbolRecord> symbols)
+    {
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Kind != "function")
+                continue;
+
+            var subKind = ResolveCudaFunctionSubKind(symbol.Signature);
+            if (subKind != null)
+                symbol.SubKind = subKind;
+        }
+    }
+
+    private static string? ResolveCudaFunctionSubKind(string? signature)
+    {
+        if (string.IsNullOrWhiteSpace(signature))
+            return null;
+
+        var hasGlobal = signature.Contains("__global__", StringComparison.Ordinal);
+        if (hasGlobal)
+            return "cuda_kernel";
+
+        var hasDevice = signature.Contains("__device__", StringComparison.Ordinal);
+        var hasHost = signature.Contains("__host__", StringComparison.Ordinal);
+        if (hasDevice && hasHost)
+            return "cuda_host_device";
+        if (hasDevice)
+            return "cuda_device";
+        if (hasHost)
+            return "cuda_host";
+
+        return null;
+    }
+}

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -117,6 +117,11 @@ public static partial class SymbolExtractor
     private const string JavaReturnTypePattern =
         @"(?:" + JavaQualifiedIdentifierPattern + @"(?:\s*<[^;=(){}]+>)?(?:\s*\[\s*\])*)";
     private const string KotlinIdentifierPattern = @"(?:\w+|`[^`\r\n]+`)";
+    private const string CythonIdentifierPattern = @"[A-Za-z_]\w*";
+    private const string CythonDottedIdentifierPattern = CythonIdentifierPattern + @"(?:\." + CythonIdentifierPattern + @")*";
+    private const string CythonDeclarationPrefixPattern = @"(?:(?:public|readonly|api|inline|extern|nogil|const|volatile)\s+)*";
+    private const string CythonNativeReturnTypePattern =
+        @"(?<returnType>(?:(?:const|volatile|unsigned|signed|long|short|int|double|float|char|void|bint|object|Py_ssize_t|size_t|" + CythonDottedIdentifierPattern + @")(?:\s*[*&])?\s+)+)";
     private static readonly Regex RPacmanPackageLoaderStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?p_load\s*\(",
         RegexOptions.Compiled);
@@ -777,6 +782,23 @@ public static partial class SymbolExtractor
             new("property", new Regex(@"^\s*(?<name>\w+)\s*:\s*(?:(?:typing|typing_extensions)\.)?Final(?:\[[^\]]+\])?\s*=", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:from\s+(?<name>(?:\.+[\w.]*|[\w.]+))\s+import\b|import\s+(?<name>[\w.]+))", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*(?:[_\p{L}]\w*\s*=\s*)?(?:importlib\.import_module|importlib\.util\.find_spec|__import__)\s*\(\s*['""](?<name>[^'""]+)['""]", RegexOptions.Compiled), BodyStyle.None),
+        ],
+        ["cython"] =
+        [
+            new("import", new Regex(@"^\s*from\s+(?<name>" + CythonDottedIdentifierPattern + @")\s+cimport\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*cimport\s+(?<name>" + CythonDottedIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*import\s+(?<name>" + CythonDottedIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*include\s+(?:'(?<name>[^']+)'|""(?<name>[^""]+)"")", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*cdef\s+extern\s+from\s+(?:'(?<name>[^']+)'|""(?<name>[^""]+)"")", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("class", new Regex(@"^\s*cdef\s+class\s+(?<name>" + CythonIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Indent),
+            new("class", new Regex(@"^\s*class\s+(?<name>" + CythonIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Indent),
+            new("struct", new Regex(@"^\s*(?:ctypedef\s+)?cdef\s+struct\s+(?<name>" + CythonIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Indent),
+            new("enum", new Regex(@"^\s*(?:ctypedef\s+)?cdef\s+enum\s+(?<name>" + CythonIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Indent),
+            new("typealias", new Regex(@"^\s*ctypedef\s+(?!(?:struct|enum|union)\b)(?<returnType>.+?)\s+(?<name>" + CythonIdentifierPattern + @")\s*$", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(@"^\s*(?:cdef|cpdef)\s+(?!(?:class|struct|enum|extern)\b)" + CythonDeclarationPrefixPattern + @"(?:(?<returnType>[\w.<>*,\[\]\s]+?)\s+)?(?<name>" + CythonIdentifierPattern + @")\s*(?:\[[^\]]+\]\s*)?\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Indent, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(@"^\s*(?:async\s+)?def\s+(?<name>" + CythonIdentifierPattern + @")\s*(?:\[[^\]]*\])?\s*(?:\(|\[)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Indent),
+            new("function", new Regex(@"^\s*" + CythonNativeReturnTypePattern + @"(?<name>" + CythonIdentifierPattern + @")\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            new("property", new Regex(@"^\s*cdef\s+(?!(?:class|struct|enum|extern)\b)" + CythonDeclarationPrefixPattern + @"(?<returnType>.+?)\s+(?<name>" + CythonIdentifierPattern + @")\s*(?::|=|$)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
         ],
         ["cobol"] =
         [
@@ -2092,7 +2114,7 @@ public static partial class SymbolExtractor
     /// </summary>
     public static IReadOnlyCollection<string> GetSupportedLanguages()
       => PatternCache.Keys
-          .Concat(new[] { "commonlisp", "racket", "vue", "svelte", "markdown", "json", "yaml", "xml", "razor", "blazor", "cshtml", "solidity" })
+          .Concat(new[] { "commonlisp", "racket", "vue", "svelte", "markdown", "json", "yaml", "xml", "razor", "blazor", "cshtml", "solidity", "cuda" })
           .Concat(ExtractorPluginRegistry.SymbolLanguages)
           .Distinct(StringComparer.Ordinal)
           .ToArray();
@@ -2107,7 +2129,9 @@ public static partial class SymbolExtractor
             ? "typescript"
             : lang is "razor" or "blazor" or "cshtml"
                 ? "csharp"
-                : lang;
+                : lang == "cuda"
+                    ? "cpp"
+                    : lang;
     }
 
     private static string? NormalizePluginLanguage(string? lang)
@@ -4084,6 +4108,8 @@ public static partial class SymbolExtractor
             ExtractCppSameLineClassBodyMembers(fileId, lines, symbols);
         if (lang == "cpp")
             ExtractCppFriendDeclarationSymbols(fileId, lines, symbols);
+        if (string.Equals(NormalizePluginLanguage(originalLang), "cuda", StringComparison.Ordinal))
+            ClassifyCudaFunctionSubKinds(symbols);
         if (lang == "python")
             ExtractPythonAllExportSymbols(fileId, lines, symbols, pythonModulePrefix);
         if (lang == "python")

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -129,6 +129,10 @@ public static partial class SymbolExtractor
     private static readonly Regex HdlInlineParameterRegex = new(
         @"\b(?:parameter|localparam)\s+(?:type\s+)?" + HdlDeclaratorPrefixPattern + @"(?<name>" + HdlIdentifierPattern + @")\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private const string ShaderIdentifierPattern = @"[A-Za-z_]\w*";
+    private const string ShaderTypePattern = @"[\w:<>,]+(?:\s*[*&])?(?:\s*\[[^\]\r\n]+\])?";
+    private const string ShaderAttributePrefixPattern = @"(?:(?:layout\s*\([^)]*\)|\[[^\]\r\n]+\]|@\w+(?:\([^)]*\))?)\s*)*";
+    private const string ShaderFunctionStartBlacklistPattern = @"^(?!\s*(?:if|for|while|switch|return|discard)\b)";
     private static readonly Regex RPacmanPackageLoaderStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?p_load\s*\(",
         RegexOptions.Compiled);
@@ -1869,6 +1873,35 @@ public static partial class SymbolExtractor
             new("function", new Regex(@"^\s*(?<name>" + VhdlIdentifierPattern + @")\s*:\s*process\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             new("typealias", new Regex(@"^\s*(?:type|subtype)\s+(?<name>" + VhdlIdentifierPattern + @")\s+is\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
             new("property", new Regex(@"^\s*(?:signal|constant|variable|generic|port)\s+(?<name>" + VhdlIdentifierPattern + @")\s*:", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+        ],
+        ["glsl"] =
+        [
+            new("struct", new Regex(@"^\s*struct\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
+            new("property", new Regex(@"^\s*" + ShaderAttributePrefixPattern + @"(?:uniform|buffer)\s+(?:(?<returnType>" + ShaderTypePattern + @")\s+)?(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
+            new("property", new Regex(@"^\s*" + ShaderAttributePrefixPattern + @"(?:in|out|attribute|varying)\s+(?<returnType>" + ShaderTypePattern + @")\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(ShaderFunctionStartBlacklistPattern + @"\s*" + ShaderAttributePrefixPattern + @"(?<returnType>" + ShaderTypePattern + @")\s+(?<name>" + ShaderIdentifierPattern + @")\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
+        ],
+        ["hlsl"] =
+        [
+            new("struct", new Regex(@"^\s*struct\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
+            new("property", new Regex(@"^\s*(?:cbuffer|tbuffer)\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
+            new("property", new Regex(@"^\s*(?:globallycoherent\s+)?(?:RW)?(?:Texture\w*|Buffer|StructuredBuffer|RWStructuredBuffer|ByteAddressBuffer|RWByteAddressBuffer|Sampler\w*)\s*(?:<[^>\r\n]+>)?\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?:groupshared|static|uniform)\s+(?<returnType>" + ShaderTypePattern + @")\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(ShaderFunctionStartBlacklistPattern + @"\s*" + ShaderAttributePrefixPattern + @"(?<returnType>" + ShaderTypePattern + @")\s+(?<name>" + ShaderIdentifierPattern + @")\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
+        ],
+        ["metal"] =
+        [
+            new("struct", new Regex(@"^\s*struct\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
+            new("property", new Regex(@"^\s*(?:constant|device|threadgroup)\s+(?<returnType>" + ShaderTypePattern + @")\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(ShaderFunctionStartBlacklistPattern + @"\s*(?:kernel|vertex|fragment)\s+(?<returnType>" + ShaderTypePattern + @")\s+(?<name>" + ShaderIdentifierPattern + @")\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(ShaderFunctionStartBlacklistPattern + @"\s*(?<returnType>" + ShaderTypePattern + @")\s+(?<name>" + ShaderIdentifierPattern + @")\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace, ReturnTypeGroup: "returnType"),
+        ],
+        ["wgsl"] =
+        [
+            new("struct", new Regex(@"^\s*struct\s+(?<name>" + ShaderIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
+            new("typealias", new Regex(@"^\s*alias\s+(?<name>" + ShaderIdentifierPattern + @")\s*=", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?:@\w+(?:\([^)]*\))?\s*)*(?:var(?:<[^>\r\n]+>)?|let|const|override)\s+(?<name>" + ShaderIdentifierPattern + @")\s*:", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?:@\w+(?:\([^)]*\))?\s*)*fn\s+(?<name>" + ShaderIdentifierPattern + @")\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.Brace),
         ],
         ["shell"] =
         [

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -122,6 +122,13 @@ public static partial class SymbolExtractor
     private const string CythonDeclarationPrefixPattern = @"(?:(?:public|readonly|api|inline|extern|nogil|const|volatile)\s+)*";
     private const string CythonNativeReturnTypePattern =
         @"(?<returnType>(?:(?:const|volatile|unsigned|signed|long|short|int|double|float|char|void|bint|object|Py_ssize_t|size_t|" + CythonDottedIdentifierPattern + @")(?:\s*[*&])?\s+)+)";
+    private const string HdlIdentifierPattern = @"[A-Za-z_$][A-Za-z0-9_$]*";
+    private const string HdlDeclaratorPrefixPattern =
+        @"(?:(?:signed|unsigned|automatic|static|wire|reg|logic|bit|byte|shortint|int|longint|integer|time|real|realtime|string|chandle|event)\s+|\[[^\]\r\n]+\]\s+)*";
+    private const string VhdlIdentifierPattern = @"[A-Za-z][A-Za-z0-9_]*";
+    private static readonly Regex HdlInlineParameterRegex = new(
+        @"\b(?:parameter|localparam)\s+(?:type\s+)?" + HdlDeclaratorPrefixPattern + @"(?<name>" + HdlIdentifierPattern + @")\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex RPacmanPackageLoaderStartRegex = new(
         @"^\s*(?:(?:[\w.]+)::)?p_load\s*\(",
         RegexOptions.Compiled);
@@ -1821,6 +1828,47 @@ public static partial class SymbolExtractor
             new("class",    new Regex(@"^\s*service\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.Brace),
             new("function", new Regex(@"^\s*rpc\s+(?<name>\w+)", RegexOptions.Compiled), BodyStyle.None),
             new("import",   new Regex(@"^\s*import\s+""(?<name>[^""]+)"";", RegexOptions.Compiled), BodyStyle.None),
+        ],
+        ["verilog"] =
+        [
+            new("module", new Regex(@"^\s*(?:module|macromodule|primitive)\s+(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*function\s+(?:automatic\s+|static\s+)?(?:(?<returnType>[\w$:\[\]\s]+?)\s+)?(?<name>" + HdlIdentifierPattern + @")\s*(?:\(|;)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(@"^\s*task\s+(?:automatic\s+|static\s+)?(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?:parameter|localparam)\s+(?:type\s+)?" + HdlDeclaratorPrefixPattern + @"(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?:input|output|inout|wire|reg|logic)\s+" + HdlDeclaratorPrefixPattern + @"(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*`include\s+""(?<name>[^""]+)""", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+        ],
+        ["systemverilog"] =
+        [
+            new("module", new Regex(@"^\s*(?:module|macromodule|primitive|program)\s+(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("interface", new Regex(@"^\s*interface\s+(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("package", new Regex(@"^\s*package\s+(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("class", new Regex(@"^\s*(?:virtual\s+)?class\s+(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("enum", new Regex(@"^\s*typedef\s+enum\b[^\r\n]*\s+(?<name>" + HdlIdentifierPattern + @")\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("struct", new Regex(@"^\s*typedef\s+struct\b[^\r\n]*\s+(?<name>" + HdlIdentifierPattern + @")\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("typealias", new Regex(@"^\s*typedef\s+(?!(?:enum|struct|union)\b)[^\r\n]*\s+(?<name>" + HdlIdentifierPattern + @")\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*function\s+(?:automatic\s+|static\s+|virtual\s+)?(?:(?<returnType>[\w$:\[\]\s]+?)\s+)?(?<name>" + HdlIdentifierPattern + @")\s*(?:\(|;)", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None, ReturnTypeGroup: "returnType"),
+            new("function", new Regex(@"^\s*task\s+(?:automatic\s+|static\s+|virtual\s+)?(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?:parameter|localparam)\s+(?:type\s+)?" + HdlDeclaratorPrefixPattern + @"(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?:input|output|inout|wire|reg|logic|rand|randc)\s+" + HdlDeclaratorPrefixPattern + @"(?<name>" + HdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*import\s+(?<name>" + HdlIdentifierPattern + @"(?:::(?:" + HdlIdentifierPattern + @"|\*))?)\s*;", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*`include\s+""(?<name>[^""]+)""", RegexOptions.Compiled | RegexOptions.CultureInvariant), BodyStyle.None),
+        ],
+        ["vhdl"] =
+        [
+            new("import", new Regex(@"^\s*library\s+(?<name>" + VhdlIdentifierPattern + @")\s*;", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("import", new Regex(@"^\s*use\s+(?<name>" + VhdlIdentifierPattern + @"(?:\." + VhdlIdentifierPattern + @")*)\s*;", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("module", new Regex(@"^\s*entity\s+(?<name>" + VhdlIdentifierPattern + @")\s+is\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("module", new Regex(@"^\s*architecture\s+(?<name>" + VhdlIdentifierPattern + @")\s+of\s+" + VhdlIdentifierPattern + @"\s+is\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("package", new Regex(@"^\s*package\s+body\s+(?<name>" + VhdlIdentifierPattern + @")\s+is\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("package", new Regex(@"^\s*package\s+(?<name>" + VhdlIdentifierPattern + @")\s+is\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("module", new Regex(@"^\s*component\s+(?<name>" + VhdlIdentifierPattern + @")\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("module", new Regex(@"^\s*configuration\s+(?<name>" + VhdlIdentifierPattern + @")\s+of\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*function\s+(?<name>" + VhdlIdentifierPattern + @")\s*(?:\(|return\b)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*procedure\s+(?<name>" + VhdlIdentifierPattern + @")\s*(?:\(|is\b)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("function", new Regex(@"^\s*(?<name>" + VhdlIdentifierPattern + @")\s*:\s*process\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("typealias", new Regex(@"^\s*(?:type|subtype)\s+(?<name>" + VhdlIdentifierPattern + @")\s+is\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
+            new("property", new Regex(@"^\s*(?:signal|constant|variable|generic|port)\s+(?<name>" + VhdlIdentifierPattern + @")\s*:", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), BodyStyle.None),
         ],
         ["shell"] =
         [
@@ -4108,6 +4156,8 @@ public static partial class SymbolExtractor
             ExtractCppSameLineClassBodyMembers(fileId, lines, symbols);
         if (lang == "cpp")
             ExtractCppFriendDeclarationSymbols(fileId, lines, symbols);
+        if (lang is "verilog" or "systemverilog")
+            ExtractHdlInlineParameterSymbols(fileId, lines, symbols);
         if (string.Equals(NormalizePluginLanguage(originalLang), "cuda", StringComparison.Ordinal))
             ClassifyCudaFunctionSubKinds(symbols);
         if (lang == "python")
@@ -4167,6 +4217,44 @@ public static partial class SymbolExtractor
             ExpandShellAliasSymbols(fileId, lines, symbols);
         PopulateDeclaredContainerQualifiedNames(symbols);
         return symbols;
+    }
+
+    private static void ExtractHdlInlineParameterSymbols(long fileId, string[] lines, List<SymbolRecord> symbols)
+    {
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            if (!line.Contains("parameter", StringComparison.Ordinal))
+                continue;
+
+            foreach (Match match in HdlInlineParameterRegex.Matches(line))
+            {
+                var name = match.Groups["name"].Value.Trim();
+                if (name.Length == 0)
+                    continue;
+
+                var lineNumber = index + 1;
+                if (symbols.Any(symbol =>
+                    symbol.StartLine == lineNumber
+                    && symbol.Kind == "property"
+                    && string.Equals(symbol.Name, name, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                symbols.Add(new SymbolRecord
+                {
+                    FileId = fileId,
+                    Kind = "property",
+                    Name = name,
+                    Line = lineNumber,
+                    StartLine = lineNumber,
+                    StartColumn = match.Groups["name"].Index,
+                    EndLine = lineNumber,
+                    Signature = line.Trim(),
+                });
+            }
+        }
     }
 
     private static bool? TryClassifyCSharpExtractorMetadataTarget(string? lang, string kind, string? signature)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2134,7 +2134,7 @@ public partial class QueryCommandRunnerTests
         var languages = document.RootElement.GetProperty("languages").EnumerateArray().ToList();
 
         Assert.NotEmpty(languages);
-        Assert.Contains(languages, lang => lang.GetProperty("lang").GetString() == "cython");
+        Assert.Contains(languages, lang => lang.GetProperty("lang").GetString() == "groovy");
         Assert.All(languages, lang =>
         {
             Assert.False(lang.GetProperty("symbol_extraction").GetBoolean());
@@ -2188,6 +2188,27 @@ public partial class QueryCommandRunnerTests
         Assert.Contains(".mts", typescript.GetProperty("extensions").EnumerateArray().Select(ext => ext.GetString()));
         Assert.Contains(".m", objc.GetProperty("extensions").EnumerateArray().Select(ext => ext.GetString()));
         Assert.Contains(".mm", objc.GetProperty("extensions").EnumerateArray().Select(ext => ext.GetString()));
+    }
+
+    [Fact]
+    public void RunLanguages_JsonReportsCythonAndCudaSymbolExtraction_Issue3530()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunLanguages(["--json"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+
+        using var document = ParseJsonOutput(stdout);
+        var languages = document.RootElement.GetProperty("languages");
+        var cython = languages.EnumerateArray().Single(lang => lang.GetProperty("lang").GetString() == "cython");
+        var cuda = languages.EnumerateArray().Single(lang => lang.GetProperty("lang").GetString() == "cuda");
+
+        Assert.True(cython.GetProperty("symbol_extraction").GetBoolean());
+        Assert.False(cython.GetProperty("reference_extraction").GetBoolean());
+        Assert.False(cython.GetProperty("graph_queries").GetBoolean());
+        Assert.True(cuda.GetProperty("symbol_extraction").GetBoolean());
+        Assert.False(cuda.GetProperty("reference_extraction").GetBoolean());
+        Assert.False(cuda.GetProperty("graph_queries").GetBoolean());
     }
 
     [Fact]
@@ -2268,11 +2289,9 @@ public partial class QueryCommandRunnerTests
     public void RunLanguages_Json_SearchOnlyBucketsAdvertiseZeroSymbolAndGraphSupport()
     {
         // Search-only languages that intentionally live outside richer extractors
-        // (Cython .pyx/.pxd and the newly added extension-only languages) must advertise
-        // symbol_extraction=false / graph_queries=false so AI clients can tell the difference
+        // must advertise symbol_extraction=false / graph_queries=false so AI clients can tell the difference
         // between "indexed with symbols" and "indexed for search only".
         // 意図的に richer な抽出器の対象外になっている search-only 言語
-        // （Cython の .pyx/.pxd と新規追加の拡張子ベース言語）は、
         // symbol_extraction=false / graph_queries=false で広告しなければならない。
         // こうしないと、AI クライアントが「シンボル付きインデックス」と「検索のみインデックス」を区別できない。
         var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunLanguages(["--json"], _jsonOptions));
@@ -2282,20 +2301,6 @@ public partial class QueryCommandRunnerTests
         using var document = ParseJsonOutput(stdout);
         var languages = document.RootElement.GetProperty("languages").EnumerateArray()
             .ToDictionary(entry => entry.GetProperty("lang").GetString()!, entry => entry);
-
-        foreach (var searchOnly in new[] { "cython" })
-        {
-            Assert.True(languages.ContainsKey(searchOnly), $"expected '{searchOnly}' to be listed");
-            var entry = languages[searchOnly];
-            Assert.False(entry.GetProperty("symbol_extraction").GetBoolean(),
-                $"{searchOnly} must advertise symbol_extraction=false");
-            Assert.False(entry.GetProperty("reference_extraction").GetBoolean(),
-                $"{searchOnly} must advertise reference_extraction=false");
-            Assert.False(entry.GetProperty("graph_queries").GetBoolean(),
-                $"{searchOnly} must advertise graph_queries=false");
-            Assert.Contains("missing-symbols", entry.GetProperty("capability_gaps").EnumerateArray().Select(gap => gap.GetString()));
-            Assert.Contains("missing-references", entry.GetProperty("capability_gaps").EnumerateArray().Select(gap => gap.GetString()));
-        }
 
         foreach (var searchOnly in new[] { "crystal", "clojure", "d", "erlang", "julia", "nim", "ocaml", "tcl" })
         {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2231,6 +2231,25 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunLanguages_JsonReportsShaderSymbolExtraction_Issue3533()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunLanguages(["--json"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+
+        using var document = ParseJsonOutput(stdout);
+        var languages = document.RootElement.GetProperty("languages");
+        foreach (var language in new[] { "glsl", "hlsl", "metal", "wgsl" })
+        {
+            var entry = languages.EnumerateArray().Single(lang => lang.GetProperty("lang").GetString() == language);
+            Assert.True(entry.GetProperty("symbol_extraction").GetBoolean());
+            Assert.False(entry.GetProperty("reference_extraction").GetBoolean());
+            Assert.False(entry.GetProperty("graph_queries").GetBoolean());
+        }
+    }
+
+    [Fact]
     public void RunLanguages_JsonListsHtmlWithSymbolExtractionAndAllExtensions()
     {
         // Pin the #215 surface: `cdidx languages --json` must report html with

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2212,6 +2212,25 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunLanguages_JsonReportsHdlSymbolExtraction_Issue3532()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunLanguages(["--json"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+
+        using var document = ParseJsonOutput(stdout);
+        var languages = document.RootElement.GetProperty("languages");
+        foreach (var language in new[] { "verilog", "systemverilog", "vhdl" })
+        {
+            var entry = languages.EnumerateArray().Single(lang => lang.GetProperty("lang").GetString() == language);
+            Assert.True(entry.GetProperty("symbol_extraction").GetBoolean());
+            Assert.False(entry.GetProperty("reference_extraction").GetBoolean());
+            Assert.False(entry.GetProperty("graph_queries").GetBoolean());
+        }
+    }
+
+    [Fact]
     public void RunLanguages_JsonListsHtmlWithSymbolExtractionAndAllExtensions()
     {
         // Pin the #215 surface: `cdidx languages --json` must report html with

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -312,6 +312,117 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_ShaderLanguages_DetectsEntryPointsAndResources_Issue3533()
+    {
+        const string glsl = """
+            layout(location = 0) in vec3 position;
+            layout(set = 0, binding = 0) uniform sampler2D diffuseMap;
+
+            struct Light {
+                vec3 color;
+            };
+
+            void main()
+            {
+            }
+            """;
+        const string hlsl = """
+            cbuffer FrameData : register(b0)
+            {
+                float4 Tint;
+            };
+
+            Texture2D<float4> DiffuseTexture : register(t0);
+            SamplerState LinearSampler : register(s0);
+
+            struct VertexOut
+            {
+                float4 Position : SV_Position;
+            };
+
+            float4 PSMain(VertexOut input) : SV_Target
+            {
+                return DiffuseTexture.Sample(LinearSampler, input.Position.xy);
+            }
+            """;
+        const string metal = """
+            struct VertexOut {
+                float4 position [[position]];
+            };
+
+            constant float4 Tint;
+
+            vertex VertexOut vertex_main(uint vid [[vertex_id]])
+            {
+                return VertexOut();
+            }
+
+            fragment float4 fragment_main(VertexOut in [[stage_in]])
+            {
+                return Tint;
+            }
+
+            kernel void compute_main(device float4* values [[buffer(0)]])
+            {
+            }
+            """;
+        const string wgsl = """
+            struct VertexOut {
+                @builtin(position) position: vec4<f32>,
+            }
+
+            alias Index = u32;
+            @group(0) @binding(0) var diffuse_texture: texture_2d<f32>;
+            override WorkgroupSize: u32 = 64;
+
+            @vertex
+            fn vs_main() -> VertexOut
+            {
+                return VertexOut();
+            }
+
+            @fragment fn fs_main() -> @location(0) vec4<f32>
+            {
+                return vec4<f32>();
+            }
+            """;
+
+        var glslSymbols = SymbolExtractor.Extract(1, "glsl", glsl);
+        var hlslSymbols = SymbolExtractor.Extract(2, "hlsl", hlsl);
+        var metalSymbols = SymbolExtractor.Extract(3, "metal", metal);
+        var wgslSymbols = SymbolExtractor.Extract(4, "wgsl", wgsl);
+
+        Assert.Contains(glslSymbols, symbol => symbol.Kind == "property" && symbol.Name == "position");
+        Assert.Contains(glslSymbols, symbol => symbol.Kind == "property" && symbol.Name == "diffuseMap");
+        Assert.Contains(glslSymbols, symbol => symbol.Kind == "struct" && symbol.Name == "Light");
+        Assert.Contains(glslSymbols, symbol => symbol.Kind == "function" && symbol.Name == "main");
+
+        Assert.Contains(hlslSymbols, symbol => symbol.Kind == "property" && symbol.Name == "FrameData");
+        Assert.Contains(hlslSymbols, symbol => symbol.Kind == "property" && symbol.Name == "DiffuseTexture");
+        Assert.Contains(hlslSymbols, symbol => symbol.Kind == "property" && symbol.Name == "LinearSampler");
+        Assert.Contains(hlslSymbols, symbol => symbol.Kind == "struct" && symbol.Name == "VertexOut");
+        Assert.Contains(hlslSymbols, symbol => symbol.Kind == "function" && symbol.Name == "PSMain");
+
+        Assert.Contains(metalSymbols, symbol => symbol.Kind == "struct" && symbol.Name == "VertexOut");
+        Assert.Contains(metalSymbols, symbol => symbol.Kind == "property" && symbol.Name == "Tint");
+        Assert.Contains(metalSymbols, symbol => symbol.Kind == "function" && symbol.Name == "vertex_main");
+        Assert.Contains(metalSymbols, symbol => symbol.Kind == "function" && symbol.Name == "fragment_main");
+        Assert.Contains(metalSymbols, symbol => symbol.Kind == "function" && symbol.Name == "compute_main");
+        Assert.DoesNotContain(metalSymbols, symbol => symbol.Kind == "function" && symbol.Name == "VertexOut");
+
+        Assert.Contains(wgslSymbols, symbol => symbol.Kind == "struct" && symbol.Name == "VertexOut");
+        Assert.Contains(wgslSymbols, symbol => symbol.Kind == "typealias" && symbol.Name == "Index");
+        Assert.Contains(wgslSymbols, symbol => symbol.Kind == "property" && symbol.Name == "diffuse_texture");
+        Assert.Contains(wgslSymbols, symbol => symbol.Kind == "property" && symbol.Name == "WorkgroupSize");
+        Assert.Contains(wgslSymbols, symbol => symbol.Kind == "function" && symbol.Name == "vs_main");
+        Assert.Contains(wgslSymbols, symbol => symbol.Kind == "function" && symbol.Name == "fs_main");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "glsl");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "hlsl");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "metal");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "wgsl");
+    }
+
+    [Fact]
     public void Extract_ConfiguredPatternYaml_HandlesOutOfTreeLanguage()
     {
         lock (TestConsoleLock.Gate)
@@ -508,15 +619,18 @@ public partial class SymbolExtractorTests
             ["fsharp"] = "module Demo\nlet run x = x + 1\n",
             ["go"] = "package demo\nfunc Run() int { return 1 }\n",
             ["gradle"] = "task buildDocs {\n}\n",
+            ["glsl"] = "uniform mat4 model;\nvec4 run(vec4 value) { return model * value; }\n",
             ["graphql"] = "type Query { answer: Int }\nquery GetAnswer { answer }\n",
             ["haskell"] = "module Demo where\nrun :: Int -> Int\nrun x = x + 1\n",
             ["html"] = "<div id=\"app\"></div>\n<script>function run() { return 1; }</script>\n",
+            ["hlsl"] = "cbuffer Params { float4 color; }\nfloat4 run(float4 value) { return value * color; }\n",
             ["java"] = "package demo; public class Service { int run() { return 1; } }\n",
             ["javascript"] = "export function run() { return 1; }\n",
             ["justfile"] = "build:\n    echo build\n",
             ["kotlin"] = "package demo\nclass Service { fun run(): Int = 1 }\n",
             ["lua"] = "local function run()\n  return 1\nend\n",
             ["makefile"] = "build:\n\t@echo build\n",
+            ["metal"] = "struct VertexOut { float4 position; };\nvertex VertexOut run(uint id) { return VertexOut(); }\n",
             ["msbuild"] = "<Project><Target Name=\"Build\" /></Project>\n",
             ["objc"] = "@interface Service\n- (void)run;\n@end\n",
             ["pascal"] = "unit Demo;\ninterface\nprocedure Run;\nimplementation\nprocedure Run; begin end;\nend.\n",
@@ -544,6 +658,7 @@ public partial class SymbolExtractorTests
             ["verilog"] = "module demo #(parameter WIDTH = 8) (input clk);\nfunction run; run = WIDTH; endfunction\nendmodule\n",
             ["vhdl"] = "library ieee;\nentity demo is\nend demo;\narchitecture rtl of demo is\nsignal ready : std_logic;\nbegin\nend rtl;\n",
             ["vue"] = "<script setup lang=\"ts\">\nfunction run() { return 1 }\n</script>\n",
+            ["wgsl"] = "@group(0) @binding(0) var<uniform> params: mat4x4<f32>;\nfn run() -> vec4<f32> { return vec4<f32>(); }\n",
             ["zig"] = "pub fn run() i32 { return 1; }\n",
         };
 

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -221,6 +221,97 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Hdl_DetectsVerilogSystemVerilogAndVhdlSymbols_Issue3532()
+    {
+        const string verilog = """
+            `include "defs.vh"
+            module fifo #(parameter int WIDTH = 8) (
+                input logic clk,
+                output logic [WIDTH-1:0] data_o
+            );
+                localparam int Depth = 16;
+                function automatic int occupancy(input int count);
+                    occupancy = count;
+                endfunction
+                task reset_fifo;
+                endtask
+            endmodule
+            """;
+        const string systemVerilog = """
+            package bus_pkg;
+                typedef enum logic [1:0] { Idle, Busy } state_t;
+                typedef struct packed { logic valid; } packet_t;
+                import util_pkg::*;
+            endpackage
+
+            interface bus_if(input logic clk);
+            endinterface
+
+            virtual class Driver;
+                rand bit enabled;
+                function void run();
+                endfunction
+            endclass
+            """;
+        const string vhdl = """
+            library ieee;
+            use ieee.std_logic_1164.all;
+
+            entity Fifo is
+                generic Width : natural := 8;
+                port clk : in std_logic;
+            end Fifo;
+
+            architecture rtl of Fifo is
+                type state_t is (Idle, Busy);
+                signal counter : unsigned(7 downto 0);
+                function next_state return state_t is
+                begin
+                    return Idle;
+                end function;
+            begin
+                main : process
+                begin
+                    null;
+                end process;
+            end rtl;
+            """;
+
+        var verilogSymbols = SymbolExtractor.Extract(1, "verilog", verilog);
+        var systemVerilogSymbols = SymbolExtractor.Extract(2, "systemverilog", systemVerilog);
+        var vhdlSymbols = SymbolExtractor.Extract(3, "vhdl", vhdl);
+
+        Assert.Contains(verilogSymbols, symbol => symbol.Kind == "import" && symbol.Name == "defs.vh");
+        Assert.Contains(verilogSymbols, symbol => symbol.Kind == "module" && symbol.Name == "fifo");
+        Assert.Contains(verilogSymbols, symbol => symbol.Kind == "property" && symbol.Name == "WIDTH");
+        Assert.Contains(verilogSymbols, symbol => symbol.Kind == "property" && symbol.Name == "clk");
+        Assert.Contains(verilogSymbols, symbol => symbol.Kind == "property" && symbol.Name == "Depth");
+        Assert.Contains(verilogSymbols, symbol => symbol.Kind == "function" && symbol.Name == "occupancy");
+        Assert.Contains(verilogSymbols, symbol => symbol.Kind == "function" && symbol.Name == "reset_fifo");
+
+        Assert.Contains(systemVerilogSymbols, symbol => symbol.Kind == "package" && symbol.Name == "bus_pkg");
+        Assert.Contains(systemVerilogSymbols, symbol => symbol.Kind == "enum" && symbol.Name == "state_t");
+        Assert.Contains(systemVerilogSymbols, symbol => symbol.Kind == "struct" && symbol.Name == "packet_t");
+        Assert.Contains(systemVerilogSymbols, symbol => symbol.Kind == "import" && symbol.Name == "util_pkg::*");
+        Assert.Contains(systemVerilogSymbols, symbol => symbol.Kind == "interface" && symbol.Name == "bus_if");
+        Assert.Contains(systemVerilogSymbols, symbol => symbol.Kind == "class" && symbol.Name == "Driver");
+        Assert.Contains(systemVerilogSymbols, symbol => symbol.Kind == "property" && symbol.Name == "enabled");
+        Assert.Contains(systemVerilogSymbols, symbol => symbol.Kind == "function" && symbol.Name == "run");
+
+        Assert.Contains(vhdlSymbols, symbol => symbol.Kind == "import" && symbol.Name == "ieee");
+        Assert.Contains(vhdlSymbols, symbol => symbol.Kind == "import" && symbol.Name == "ieee.std_logic_1164.all");
+        Assert.Contains(vhdlSymbols, symbol => symbol.Kind == "module" && symbol.Name == "Fifo");
+        Assert.Contains(vhdlSymbols, symbol => symbol.Kind == "module" && symbol.Name == "rtl");
+        Assert.Contains(vhdlSymbols, symbol => symbol.Kind == "typealias" && symbol.Name == "state_t");
+        Assert.Contains(vhdlSymbols, symbol => symbol.Kind == "property" && symbol.Name == "counter");
+        Assert.Contains(vhdlSymbols, symbol => symbol.Kind == "function" && symbol.Name == "next_state");
+        Assert.Contains(vhdlSymbols, symbol => symbol.Kind == "function" && symbol.Name == "main");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "verilog");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "systemverilog");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "vhdl");
+    }
+
+    [Fact]
     public void Extract_ConfiguredPatternYaml_HandlesOutOfTreeLanguage()
     {
         lock (TestConsoleLock.Gate)
@@ -446,9 +537,12 @@ public partial class SymbolExtractorTests
             ["stylus"] = "primary = #3366cc\nrounded(radius)\n  border-radius radius\n.button\n  rounded(4px)\n",
             ["svelte"] = "<script>\n  export let name;\n  function run() { return name; }\n</script>\n",
             ["swift"] = "class Service { func run() -> Int { 1 } }\n",
+            ["systemverilog"] = "module demo #(parameter int WIDTH = 8) (input logic clk);\nfunction int run(); return WIDTH; endfunction\nendmodule\n",
             ["terraform"] = "resource \"local_file\" \"demo\" {\n  filename = \"demo.txt\"\n}\n",
             ["typescript"] = "export class Service { run(): number { return 1; } }\n",
             ["vb"] = "Public Class Service\n  Public Sub Run()\n  End Sub\nEnd Class\n",
+            ["verilog"] = "module demo #(parameter WIDTH = 8) (input clk);\nfunction run; run = WIDTH; endfunction\nendmodule\n",
+            ["vhdl"] = "library ieee;\nentity demo is\nend demo;\narchitecture rtl of demo is\nsignal ready : std_logic;\nbegin\nend rtl;\n",
             ["vue"] = "<script setup lang=\"ts\">\nfunction run() { return 1 }\n</script>\n",
             ["zig"] = "pub fn run() i32 { return 1; }\n",
         };

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -154,6 +154,73 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Cython_DetectsNativeDeclarations_Issue3530()
+    {
+        const string content = """
+            cimport numpy as cnp
+            from libc.stdlib cimport malloc
+            cdef extern from "math.h":
+                double sqrt(double)
+
+            cdef public int exported_count
+            ctypedef unsigned long size_t_alias
+
+            cdef class NativeThing:
+                cdef int value
+                cpdef int update(self, int delta):
+                    return delta
+
+            cpdef double distance(double x):
+                return x
+
+            cdef int helper(int x) nogil:
+                return x
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cython", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "import" && symbol.Name == "numpy");
+        Assert.Contains(symbols, symbol => symbol.Kind == "import" && symbol.Name == "libc.stdlib");
+        Assert.Contains(symbols, symbol => symbol.Kind == "import" && symbol.Name == "math.h");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "sqrt");
+        Assert.Contains(symbols, symbol => symbol.Kind == "property" && symbol.Name == "exported_count");
+        Assert.Contains(symbols, symbol => symbol.Kind == "typealias" && symbol.Name == "size_t_alias");
+        Assert.Contains(symbols, symbol => symbol.Kind == "class" && symbol.Name == "NativeThing");
+        Assert.Contains(symbols, symbol => symbol.Kind == "property" && symbol.Name == "value");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "update");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "distance");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "helper");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "cython");
+    }
+
+    [Fact]
+    public void Extract_Cuda_DetectsKernelAndDeviceFunctions_Issue3530()
+    {
+        const string content = """
+            #include <cuda_runtime.h>
+
+            struct Params { int count; };
+
+            template <typename T>
+            __global__ void saxpy(T *out, const T *in)
+            {
+            }
+
+            __device__ float weight(float x) { return x; }
+            __host__ __device__ inline float clamp(float x) { return x; }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "cuda", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "import" && symbol.Name == "cuda_runtime.h");
+        Assert.Contains(symbols, symbol => symbol.Kind == "struct" && symbol.Name == "Params");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "saxpy" && symbol.SubKind == "cuda_kernel");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "weight" && symbol.SubKind == "cuda_device");
+        Assert.Contains(symbols, symbol => symbol.Kind == "function" && symbol.Name == "clamp" && symbol.SubKind == "cuda_host_device");
+        Assert.Contains(SymbolExtractor.GetSupportedLanguages(), lang => lang == "cuda");
+    }
+
+    [Fact]
     public void Extract_ConfiguredPatternYaml_HandlesOutOfTreeLanguage()
     {
         lock (TestConsoleLock.Gate)
@@ -342,6 +409,7 @@ public partial class SymbolExtractorTests
             ["cpp"] = "namespace demo { int answer() { return 42; } }\n",
             ["csharp"] = "namespace Demo; public class Service { public int Run() => 1; }\n",
             ["css"] = ".card { color: red; }\n@keyframes fade { from { opacity: 0; } }\n",
+            ["cython"] = "cdef class Service:\n    cpdef int run(self):\n        return 1\n",
             ["dart"] = "class Service { int run() => 1; }\n",
             ["dockerfile"] = "FROM alpine AS build\nARG VERSION=1\n",
             ["elixir"] = "defmodule Demo do\n  def run do\n    :ok\n  end\nend\n",


### PR DESCRIPTION
## Summary
- Add Cython and CUDA symbol extraction, including CUDA kernel/device/host sub-kinds.
- Add Verilog, SystemVerilog, and VHDL declaration symbol extraction.
- Add GLSL, HLSL, Metal, and WGSL shader entry-point/resource symbol extraction.
- Update bilingual user docs and changelog fragments for the new symbol-only language support.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~Issue353|FullyQualifiedName~BuiltInSymbolRegexes|FullyQualifiedName~Extract_AllPatternLanguages_IsDeterministicUnderParallelCalls|FullyQualifiedName~RunLanguages_Json_SearchOnlyBucketsAdvertiseZeroSymbolAndGraphSupport"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SymbolExtractorTests|FullyQualifiedName~QueryCommandRunnerTests" --no-restore` (adversarial review run)
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll languages --json --capability symbols`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Fixes
Fixes #3530
Fixes #3532
Fixes #3533
