### PR TITLE
Fix main CI duplicate request token declaration

### DIFF
--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -3177,7 +3177,6 @@ public partial class McpServer
                     .ToList();
             }
             status.Version = _version;
-            var requestToken = _currentRequestToken.Value;
             requestToken.ThrowIfCancellationRequested();
             status.UpdateCheck = runUpdateCheck
                 ? (StatusUpdateCheckForTesting ?? UpdateChecker.Check)(_version, requestToken)


### PR DESCRIPTION
## Summary
- Remove the duplicate `requestToken` local declaration in MCP status handling that broke Release builds after #3854 merged.

## CI Root Cause
- `Build and Test / build (windows-latest, net9.0)` failed with `CS0128: A local variable or function named 'requestToken' is already defined in this scope` at `src/CodeIndex/Mcp/McpToolHandlers.cs(3180,17)`.
- `CodeQL / Analyze (csharp)` failed for the same build error during its solution build.

## Validation
- `dotnet restore CodeIndex.sln --locked-mode`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --configuration Release --framework net9.0 --no-restore -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln --configuration Release --no-restore -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --configuration Release --no-build --filter ToolsCall_StatusUpdateCheck_UsesRequestCancellationToken_Issue3658 -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check origin/main...HEAD`
- `dotnet build -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

No changelog fragment: this is a CI build repair for an already-merged change and does not alter user-visible behavior.

Refs #3854