### PR TITLE
Fix filesystem traversal diagnostics

### DIFF
--- a/changelog.d/unreleased/3707.fixed.md
+++ b/changelog.d/unreleased/3707.fixed.md
@@ -1,0 +1,22 @@
+---
+category: fixed
+issues:
+  - 3707
+affected:
+  - src/CodeIndex/Cli/FileSystemTraversalFailure.cs
+  - src/CodeIndex/Cli/SolutionProjectResolver.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+---
+
+## English
+
+- **Filesystem traversal failures now use shared expected-exception classification (#3707)** — project discovery, marker fingerprint traversal, checkpoint inspection, and import cleanup now handle permission, unsupported-path, invalid-path, path-too-long, and I/O traversal failures through the same bounded diagnostic paths.
+
+## 日本語
+
+- **ファイルシステム走査失敗の expected exception 分類を共通化しました (#3707)** — project discovery、marker fingerprint traversal、checkpoint inspection、import cleanup は、permission / unsupported path / invalid path / path too long / I/O の走査失敗を同じ上限付き diagnostic 経路で扱うようになりました。

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -833,11 +833,7 @@ public static class DbCommandRunner
         => new(code, message, ConsoleUi.FormatBoundedValue(path));
 
     private static bool IsRecoverableFilesystemException(Exception ex)
-        => ex is IOException
-            or UnauthorizedAccessException
-            or ArgumentException
-            or NotSupportedException
-            or PathTooLongException;
+        => FileSystemTraversalFailure.IsExpected(ex);
 
     private static bool IsRecoverableRestoreException(Exception ex)
         => IsRecoverableFilesystemException(ex) || ex is InvalidOperationException;

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -1184,11 +1184,7 @@ internal static class ExportImportCommandRunner
     }
 
     private static bool IsRecoverableReplacementException(Exception ex)
-        => ex is IOException
-            or UnauthorizedAccessException
-            or ArgumentException
-            or NotSupportedException
-            or PathTooLongException;
+        => FileSystemTraversalFailure.IsExpected(ex);
 
     private static void DeleteSqliteSidecars(string dbPath, string? cleanupDescription = null)
     {
@@ -1210,7 +1206,7 @@ internal static class ExportImportCommandRunner
             else
                 File.Delete(path);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
             if (!string.IsNullOrWhiteSpace(cleanupDescription))
                 CommandErrorWriter.WriteStderr($"Warning: failed to delete {cleanupDescription} {ConsoleUi.FormatBoundedValue(path)} ({CommandErrorWriter.FormatSanitizedException(ex)}).");
@@ -1226,7 +1222,7 @@ internal static class ExportImportCommandRunner
 
             Directory.Delete(path);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
             if (!string.IsNullOrWhiteSpace(cleanupDescription))
                 CommandErrorWriter.WriteStderr($"Warning: failed to delete {cleanupDescription} {ConsoleUi.FormatBoundedValue(path)} ({CommandErrorWriter.FormatSanitizedException(ex)}).");

--- a/src/CodeIndex/Cli/FileSystemTraversalFailure.cs
+++ b/src/CodeIndex/Cli/FileSystemTraversalFailure.cs
@@ -1,0 +1,24 @@
+namespace CodeIndex.Cli;
+
+internal static class FileSystemTraversalFailure
+{
+    internal static bool IsExpected(Exception ex)
+        => ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException
+            or PathTooLongException;
+
+    internal static string DescribeReason(Exception ex)
+        => ex switch
+        {
+            UnauthorizedAccessException => "permissions",
+            PathTooLongException => "a path that is too long",
+            ArgumentException => "an invalid path",
+            NotSupportedException => "an unsupported path",
+            _ => "an I/O error",
+        };
+
+    internal static string ExceptionTypeName(Exception ex)
+        => ex.GetType().Name;
+}

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -49,6 +49,8 @@ internal static class SolutionProjectResolver
     internal const long MaxSolutionFileBytes = 8L * 1024 * 1024;
     internal const int MaxSolutionLineChars = 16 * 1024;
     internal const int MaxSolutionProjectReferences = 4096;
+    internal static Func<string, IEnumerable<string>>? EnumerateDirectoriesForTesting { get; set; }
+    internal static Func<string, IEnumerable<string>>? EnumerateFilesForTesting { get; set; }
 
     public static IReadOnlyList<DotNetProjectInfo> ResolveProjects(string workspaceRoot, string? solutionPath = null)
         => ResolveProjects(workspaceRoot, solutionPath, SolutionProjectResolverLimits.Default);
@@ -258,7 +260,7 @@ internal static class SolutionProjectResolver
     }
 
     private static bool IsExpectedFilesystemDiscoveryException(Exception ex)
-        => ex is IOException or UnauthorizedAccessException or NotSupportedException;
+        => FileSystemTraversalFailure.IsExpected(ex);
 
     private static void AddAutomaticSolutionDiscoveryDiagnostic(
         string workspaceRoot,
@@ -267,12 +269,7 @@ internal static class SolutionProjectResolver
         SolutionProjectResolverLimits limits,
         IList<string>? traversalDiagnostics)
     {
-        var reason = ex switch
-        {
-            UnauthorizedAccessException => "permissions",
-            NotSupportedException => "an unsupported path",
-            _ => "an I/O error",
-        };
+        var reason = FileSystemTraversalFailure.DescribeReason(ex);
         AddTraversalDiagnostic(
             workspaceRoot,
             directory,
@@ -400,13 +397,15 @@ internal static class SolutionProjectResolver
 
             return indexer.EvaluatePathFilter(directory, isDirectory: true).ShouldSkip;
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
-            AddTraversalDiagnostic(workspaceRoot, directory, "directory filters", "permissions", limits, traversalDiagnostics);
-        }
-        catch (IOException)
-        {
-            AddTraversalDiagnostic(workspaceRoot, directory, "directory filters", "an I/O error", limits, traversalDiagnostics);
+            AddTraversalDiagnostic(
+                workspaceRoot,
+                directory,
+                "directory filters",
+                FileSystemTraversalFailure.DescribeReason(ex),
+                limits,
+                traversalDiagnostics);
         }
 
         return true;
@@ -423,13 +422,15 @@ internal static class SolutionProjectResolver
         {
             return !indexer.EvaluatePathFilter(file).ShouldSkip;
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
-            AddTraversalDiagnostic(workspaceRoot, file, "file filters", "permissions", limits, traversalDiagnostics);
-        }
-        catch (IOException)
-        {
-            AddTraversalDiagnostic(workspaceRoot, file, "file filters", "an I/O error", limits, traversalDiagnostics);
+            AddTraversalDiagnostic(
+                workspaceRoot,
+                file,
+                "file filters",
+                FileSystemTraversalFailure.DescribeReason(ex),
+                limits,
+                traversalDiagnostics);
         }
 
         return false;
@@ -446,7 +447,7 @@ internal static class SolutionProjectResolver
             directory,
             "subdirectories",
             ProjectTraversalEntryKind.Directory,
-            Directory.EnumerateDirectories,
+            EnumerateDirectoriesForTesting ?? Directory.EnumerateDirectories,
             limits,
             budget,
             traversalDiagnostics);
@@ -462,7 +463,7 @@ internal static class SolutionProjectResolver
             directory,
             "files",
             ProjectTraversalEntryKind.File,
-            Directory.EnumerateFiles,
+            EnumerateFilesForTesting ?? Directory.EnumerateFiles,
             limits,
             budget,
             traversalDiagnostics);
@@ -482,14 +483,15 @@ internal static class SolutionProjectResolver
         {
             entries = enumerate(LongPath.EnsureWindowsPrefix(directory));
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
-            AddTraversalDiagnostic(workspaceRoot, directory, entryKind, "permissions", limits, traversalDiagnostics);
-            yield break;
-        }
-        catch (IOException)
-        {
-            AddTraversalDiagnostic(workspaceRoot, directory, entryKind, "an I/O error", limits, traversalDiagnostics);
+            AddTraversalDiagnostic(
+                workspaceRoot,
+                directory,
+                entryKind,
+                FileSystemTraversalFailure.DescribeReason(ex),
+                limits,
+                traversalDiagnostics);
             yield break;
         }
 
@@ -503,14 +505,15 @@ internal static class SolutionProjectResolver
                     yield break;
                 entry = LongPath.RemoveWindowsPrefix(enumerator.Current);
             }
-            catch (UnauthorizedAccessException)
+            catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
             {
-                AddTraversalDiagnostic(workspaceRoot, directory, entryKind, "permissions", limits, traversalDiagnostics);
-                yield break;
-            }
-            catch (IOException)
-            {
-                AddTraversalDiagnostic(workspaceRoot, directory, entryKind, "an I/O error", limits, traversalDiagnostics);
+                AddTraversalDiagnostic(
+                    workspaceRoot,
+                    directory,
+                    entryKind,
+                    FileSystemTraversalFailure.DescribeReason(ex),
+                    limits,
+                    traversalDiagnostics);
                 yield break;
             }
 

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1985,19 +1985,13 @@ public class FileIndexer
                     pendingDirectories.Push(new ProjectMarkerFingerprintDirectory(subDir, activeIgnoreRules, IsProjectRoot: false));
                 }
             }
-            catch (UnauthorizedAccessException)
+            catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
             {
-                AddProjectMarkerTraversalWarning(errors, currentDirectory, nameof(UnauthorizedAccessException));
+                var exceptionType = FileSystemTraversalFailure.ExceptionTypeName(ex);
+                AddProjectMarkerTraversalWarning(errors, currentDirectory, exceptionType);
                 MarkProjectMarkerTraversalTruncated(
                     traversalState,
-                    $"traversal failed with {nameof(UnauthorizedAccessException)}");
-            }
-            catch (IOException)
-            {
-                AddProjectMarkerTraversalWarning(errors, currentDirectory, nameof(IOException));
-                MarkProjectMarkerTraversalTruncated(
-                    traversalState,
-                    $"traversal failed with {nameof(IOException)}");
+                    $"traversal failed with {exceptionType}");
             }
         }
     }
@@ -2450,16 +2444,11 @@ public class FileIndexer
             RecordDanglingFileSystemEntries(dir, scanState, cancellationToken);
             fullyScanned &= EnumerateSubdirectories(dir, scanState, activeIgnoreRules, passthrough, continueOnError, cancellationToken, depth);
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
-            // Skip inaccessible directories / アクセス不可ディレクトリはスキップ
-            scanState.Errors.Add(new ScanError(ToRelativePath(dir), "Could not scan directory due to permissions."));
-            fullyScanned = false;
-        }
-        catch (IOException)
-        {
-            // Skip on I/O errors / I/Oエラー時はスキップ
-            scanState.Errors.Add(new ScanError(ToRelativePath(dir), "Could not scan directory due to an I/O error."));
+            scanState.Errors.Add(new ScanError(
+                ToRelativePath(dir),
+                $"Could not scan directory due to {FileSystemTraversalFailure.DescribeReason(ex)}."));
             fullyScanned = false;
         }
 

--- a/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
@@ -567,8 +567,18 @@ public class DbCommandRunnerTests
         }
     }
 
-    [Fact]
-    public void Run_CheckpointJsonReportsRecoverableFileEnumerationFailure_Issue3833()
+    public static IEnumerable<object[]> RecoverableTraversalFailures()
+    {
+        yield return [new IOException("secret local enumeration path")];
+        yield return [new UnauthorizedAccessException("secret local enumeration path")];
+        yield return [new NotSupportedException("secret local enumeration path")];
+        yield return [new PathTooLongException("secret local enumeration path")];
+        yield return [new ArgumentException("secret local enumeration path")];
+    }
+
+    [Theory]
+    [MemberData(nameof(RecoverableTraversalFailures))]
+    public void Run_CheckpointJsonReportsRecoverableFileEnumerationFailure_Issue3833(Exception exception)
     {
         var root = Path.Combine(Path.GetTempPath(), $"cdidx_db_checkpoint_enum_{Guid.NewGuid():N}");
         var dbPath = Path.Combine(root, "codeindex.db");
@@ -576,7 +586,7 @@ public class DbCommandRunnerTests
         {
             Directory.CreateDirectory(root);
             File.WriteAllText(dbPath, "db");
-            DbCommandRunner.EnumerateCheckpointFileNamesForTesting = _ => throw new IOException("secret local enumeration path");
+            DbCommandRunner.EnumerateCheckpointFileNamesForTesting = _ => throw exception;
 
             var (checkpointExit, json) = RunAndCaptureJson(["checkpoint", "enum", "--db", dbPath, "--json"]);
 

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -914,15 +914,25 @@ public class FileIndexerTests
         }
     }
 
-    [Fact]
-    public void GetProjectMarkerFingerprint_TraversalFailureReportsWarning_Issue3473()
+    public static IEnumerable<object[]> ProjectMarkerTraversalFailures()
+    {
+        yield return [new IOException("blocked")];
+        yield return [new UnauthorizedAccessException("blocked")];
+        yield return [new NotSupportedException("blocked")];
+        yield return [new PathTooLongException("blocked")];
+        yield return [new ArgumentException("blocked")];
+    }
+
+    [Theory]
+    [MemberData(nameof(ProjectMarkerTraversalFailures))]
+    public void GetProjectMarkerFingerprint_TraversalFailureReportsWarning_Issue3473(Exception exception)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_msbuild_marker_warning_{Guid.NewGuid():N}");
         var previousEnumerator = FileIndexer.EnumerateProjectMarkerDirectoriesForTesting;
         try
         {
             Directory.CreateDirectory(tempDir);
-            FileIndexer.EnumerateProjectMarkerDirectoriesForTesting = _ => throw new IOException("blocked");
+            FileIndexer.EnumerateProjectMarkerDirectoriesForTesting = _ => throw exception;
             var indexer = new FileIndexer(tempDir, ignoreCase: false);
 
             var result = indexer.GetProjectMarkerFingerprintResultForTesting("msbuild", maxDirectories: 10, maxMarkerFiles: 100);
@@ -931,6 +941,7 @@ public class FileIndexerTests
             var warning = Assert.Single(result.Warnings);
             Assert.Equal(".", warning.Path);
             Assert.Contains("Project marker discovery skipped this subtree", warning.Message, StringComparison.Ordinal);
+            Assert.Contains(exception.GetType().Name, warning.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2636,6 +2636,48 @@ public sealed class Caller
         }
     }
 
+    public static IEnumerable<object[]> SolutionProjectTraversalFailures()
+    {
+        yield return [new IOException("blocked"), "an I/O error"];
+        yield return [new UnauthorizedAccessException("blocked"), "permissions"];
+        yield return [new NotSupportedException("blocked"), "an unsupported path"];
+        yield return [new PathTooLongException("blocked"), "a path that is too long"];
+        yield return [new ArgumentException("blocked"), "an invalid path"];
+    }
+
+    [Theory]
+    [MemberData(nameof(SolutionProjectTraversalFailures))]
+    public void ResolveProjects_FallbackTraversalReportsExpectedFilesystemDiagnostics_Issue3707(
+        Exception exception,
+        string expectedReason)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_fallback_exception");
+        var previousEnumerateDirectories = SolutionProjectResolver.EnumerateDirectoriesForTesting;
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            SolutionProjectResolver.EnumerateDirectoriesForTesting = _ => throw exception;
+            var diagnostics = new List<string>();
+
+            var projects = SolutionProjectResolver.ResolveProjects(
+                projectRoot,
+                solutionPath: null,
+                SolutionProjectResolverLimits.Default,
+                diagnostics);
+
+            Assert.Empty(projects);
+            var diagnostic = Assert.Single(diagnostics);
+            Assert.Contains("Could not enumerate subdirectories in .", diagnostic, StringComparison.Ordinal);
+            Assert.Contains(expectedReason, diagnostic, StringComparison.Ordinal);
+            Assert.DoesNotContain("blocked", diagnostic, StringComparison.Ordinal);
+        }
+        finally
+        {
+            SolutionProjectResolver.EnumerateDirectoriesForTesting = previousEnumerateDirectories;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Fact]
     public void ResolveProjects_RejectsFallbackDiscoveryDirectoryTraversalLimit()
     {


### PR DESCRIPTION
## Summary
- Added a shared filesystem traversal failure classifier for expected permission, unsupported-path, invalid-path, path-too-long, and I/O failures.
- Routed project discovery, project marker traversal, checkpoint inspection, and import cleanup through the shared classification.
- Expanded focused tests to cover the expected traversal failure categories.

## Validation
- `dotnet build src/CodeIndex/CodeIndex.csproj -p:UseSharedCompilation=false` passed after merging latest `origin/main`.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --no-build --filter "FullyQualifiedName~DbCommandRunnerTests|FullyQualifiedName~IndexCommandRunnerTests|FullyQualifiedName~FileIndexerTests"` passed: 871 passed, 2 skipped, 873 total.
- `dotnet run --project tools/CodeIndex.Changelog -- check` passed: validated 121 changelog fragments.
- `git diff --check origin/main...HEAD` passed.
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` passed after refreshing the local index (`index_matches_workspace: true`, no failed checks).

## Documentation and Changelog
- Added `changelog.d/unreleased/3707.fixed.md`.
- No README/developer-guide update was needed; this aligns existing traversal diagnostics without adding a new user-facing command or option.

Fixes #3707

## Follow-up Candidates
- None.