### PR TITLE
[codex] Harden suggestion store retention and submit errors

### DIFF
--- a/changelog.d/unreleased/3809.fixed.md
+++ b/changelog.d/unreleased/3809.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3809
+affected:
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+---
+
+## English
+
+- **Hardened suggestion store retention and submit-error persistence (#3809)** — paged reads now stop after the requested result count, pruning avoids repeated list removals, corrupt backups no longer overwrite earlier `.bak` evidence, archive trimming reports bounded oversized-record diagnostics, and persisted submit errors are redacted and bounded.
+
+## 日本語
+
+- **SuggestionStore の保持処理と送信エラー保存を堅牢化しました (#3809)** — ページ読み込みは要求件数に到達した時点で停止し、prune は繰り返しの list 削除を避け、破損バックアップは既存の `.bak` 証跡を上書きせず、archive の切り詰めでは oversized record の診断を bounded に報告し、保存される送信エラーは redaction と上限適用を通すようになりました。

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -54,6 +54,18 @@ public class SuggestionStore
     private static readonly Regex s_namedSecretRegex = new(@"(?i)(^|[^\p{L}\p{N}_-])(?<name>[\p{L}\p{N}_-]*(?:password|passwd|pwd|secret|token|api[-_]?key|access[-_]?key|credential)[\p{L}\p{N}_-]*)=(?<value>[^&\s]+)", RegexOptions.Compiled | RegexOptions.CultureInvariant, RedactionRegexTimeout);
     private static readonly Regex s_highEntropyTokenRegex = new(@"\b(?=[A-Za-z0-9._~+/=-]{32,}\b)(?=.*[A-Z])(?=.*[a-z])(?=.*\d)[A-Za-z0-9._~+/=-]+\b", RegexOptions.Compiled | RegexOptions.CultureInvariant, RedactionRegexTimeout);
 
+    internal sealed record ArchiveBuildResult(
+        IReadOnlyList<byte[]> Lines,
+        int DroppedByCapCount,
+        int OversizedDroppedCount,
+        long LargestOversizedRecordBytes);
+
+    private readonly record struct ArchiveWriteResult(
+        int ArchivedCount,
+        int DroppedByCapCount,
+        int OversizedDroppedCount,
+        long LargestOversizedRecordBytes);
+
     private static readonly HashSet<string> s_dedupStopWords = new(StringComparer.Ordinal)
     {
         "a",
@@ -359,7 +371,7 @@ public class SuggestionStore
             }
 
             var issueUrl = submitResult.IssueUrl;
-            StampSubmitResult(found, submitResult);
+            var persistedSubmitError = StampSubmitResult(found, submitResult);
             if (issueUrl != null)
                 MarkSubmitted(found, issueUrl, reservation.AttemptedAt.Value);
 
@@ -369,7 +381,7 @@ public class SuggestionStore
                 reservation.AlreadySubmitted,
                 found.Status,
                 issueUrl ?? found.UpstreamUrl,
-                submitResult.Error,
+                persistedSubmitError,
                 reservation.DuplicateOfHash,
                 reservation.DuplicateScore,
                 found.Hash);
@@ -378,10 +390,10 @@ public class SuggestionStore
 
     /// <summary>
     /// Load all suggestions from disk. Returns an empty list if the file
-    /// does not exist or is empty. Corrupt files are preserved as .bak.
+    /// does not exist or is empty. Corrupt files are preserved as .bak or a timestamped backup.
     /// Throws IOException on transient file access errors (fail-closed).
     /// ディスクから全提案を読み込む。ファイルが存在しないか空の場合は空リストを返す。
-    /// 破損ファイルは .bak として保存される。
+    /// 破損ファイルは .bak またはタイムスタンプ付きバックアップとして保存される。
     /// 一時的なファイルアクセスエラーでは IOException をスローする（fail-closed）。
     /// </summary>
     public List<SuggestionRecord> LoadAll()
@@ -490,8 +502,8 @@ public class SuggestionStore
         }
         catch (JsonException)
         {
-            // Corrupt file — preserve as .bak so history is not lost.
-            // 壊れたファイル — 履歴を失わないよう .bak として保存。
+            // Corrupt file — preserve a backup so history is not lost.
+            // 壊れたファイル — 履歴を失わないようバックアップとして保存。
             PreserveCorruptFile();
             return new List<SuggestionRecord>();
         }
@@ -761,10 +773,9 @@ public class SuggestionStore
                 continue;
             }
 
-            if (take.HasValue && results.Count >= take.Value)
-                continue;
-
             results.Add(record);
+            if (take.HasValue && results.Count >= take.Value)
+                break;
         }
 
         return results;
@@ -835,34 +846,56 @@ public class SuggestionStore
         var maxAge = ResolveMaxAge();
         var maxCount = ResolveMaxCount();
         var cutoff = GetUtcNow().Subtract(maxAge);
-        var pruned = records
-            .Where(record => record.CreatedAt != default && record.CreatedAt < cutoff)
-            .ToList();
+        var pruned = new List<SuggestionRecord>();
+        var retained = new List<SuggestionRecord>(records.Count);
 
-        foreach (var record in pruned)
-            records.Remove(record);
+        foreach (var record in records)
+        {
+            if (record.CreatedAt != default && record.CreatedAt < cutoff)
+            {
+                pruned.Add(record);
+                continue;
+            }
 
-        var overflow = records.Count - maxCount;
+            retained.Add(record);
+        }
+
+        var overflow = retained.Count - maxCount;
         if (overflow > 0)
         {
-            var excess = records
-                .OrderBy(record => record.CreatedAt == default ? DateTime.MinValue : record.CreatedAt)
+            var excess = retained
+                .Select((record, index) => (record, index))
+                .OrderBy(item => item.record.CreatedAt == default ? DateTime.MinValue : item.record.CreatedAt)
+                .ThenBy(item => item.index)
                 .Take(overflow)
-                .ToList();
-            pruned.AddRange(excess);
-            foreach (var record in excess)
-                records.Remove(record);
+                .ToArray();
+            pruned.AddRange(excess.Select(item => item.record));
+
+            var excessIndexes = excess
+                .Select(item => item.index)
+                .ToHashSet();
+            var compacted = new List<SuggestionRecord>(maxCount);
+            for (var i = 0; i < retained.Count; i++)
+            {
+                if (!excessIndexes.Contains(i))
+                    compacted.Add(retained[i]);
+            }
+
+            retained = compacted;
         }
 
         if (pruned.Count == 0)
             return false;
 
-        var archivedCount = ArchivePrunedRecords(pruned);
+        records.Clear();
+        records.AddRange(retained);
+
+        var archiveResult = ArchivePrunedRecords(pruned);
         try
         {
-            var message = archivedCount == pruned.Count
+            var message = archiveResult.ArchivedCount == pruned.Count
                 ? $"[cdidx] Pruned {pruned.Count} stale suggestion record(s) to {_archivePath}."
-                : $"[cdidx] Pruned {pruned.Count} stale suggestion record(s); archived latest {archivedCount} to {_archivePath} after applying the {MaxSuggestionArchiveBytes} byte archive cap.";
+                : BuildArchiveDropMessage(pruned.Count, archiveResult);
             ConsoleUi.TryWriteErrorLine(message);
         }
         catch (ObjectDisposedException)
@@ -872,17 +905,38 @@ public class SuggestionStore
         return true;
     }
 
-    private int ArchivePrunedRecords(IEnumerable<SuggestionRecord> records)
+    private string BuildArchiveDropMessage(int prunedCount, ArchiveWriteResult archiveResult)
+    {
+        var droppedCount = prunedCount - archiveResult.ArchivedCount;
+        var archiveTarget = archiveResult.ArchivedCount == 0
+            ? "archived 0 record(s)"
+            : $"archived latest {archiveResult.ArchivedCount} to {_archivePath}";
+        var message = $"[cdidx] Pruned {prunedCount} stale suggestion record(s); {archiveTarget} and dropped {droppedCount} after applying the {MaxSuggestionArchiveBytes} byte archive cap.";
+        if (archiveResult.OversizedDroppedCount > 0)
+        {
+            message += $" Dropped {archiveResult.OversizedDroppedCount} oversized record(s) larger than the archive cap; largest serialized record was {archiveResult.LargestOversizedRecordBytes} bytes.";
+        }
+
+        return message;
+    }
+
+    private ArchiveWriteResult ArchivePrunedRecords(IEnumerable<SuggestionRecord> records)
     {
         var dir = Path.GetDirectoryName(_archivePath);
         if (!string.IsNullOrEmpty(dir))
             DataDirectorySecurity.CreatePrivateDirectory(dir);
 
-        var archiveLines = BuildBoundedArchiveLines(records);
-        if (archiveLines.Count == 0)
-            return 0;
+        var archive = BuildBoundedArchiveLines(records);
+        if (archive.Lines.Count == 0)
+        {
+            return new ArchiveWriteResult(
+                0,
+                archive.DroppedByCapCount,
+                archive.OversizedDroppedCount,
+                archive.LargestOversizedRecordBytes);
+        }
 
-        var pendingBytes = archiveLines.Sum(line => (long)line.Length);
+        var pendingBytes = archive.Lines.Sum(line => (long)line.Length);
         RotateArchiveIfNeeded(pendingBytes);
 
         var options = new FileStreamOptions
@@ -896,27 +950,44 @@ public class SuggestionStore
 
         using var stream = new FileStream(_archivePath, options);
         DataDirectorySecurity.ApplyPrivateFileMode(_archivePath);
-        foreach (var line in archiveLines)
+        foreach (var line in archive.Lines)
             stream.Write(line, 0, line.Length);
 
-        return archiveLines.Count;
+        return new ArchiveWriteResult(
+            archive.Lines.Count,
+            archive.DroppedByCapCount,
+            archive.OversizedDroppedCount,
+            archive.LargestOversizedRecordBytes);
     }
 
-    private static List<byte[]> BuildBoundedArchiveLines(IEnumerable<SuggestionRecord> records)
+    internal static ArchiveBuildResult BuildBoundedArchiveLines(IEnumerable<SuggestionRecord> records)
     {
         var lines = new Queue<byte[]>();
         var totalBytes = 0L;
+        var droppedByCapCount = 0;
+        var oversizedDroppedCount = 0;
+        var largestOversizedRecordBytes = 0L;
         foreach (var record in records)
         {
             var line = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(record, s_jsonOptions) + Environment.NewLine);
+            if (line.Length > MaxSuggestionArchiveBytes)
+            {
+                oversizedDroppedCount++;
+                largestOversizedRecordBytes = Math.Max(largestOversizedRecordBytes, line.Length);
+                continue;
+            }
+
             lines.Enqueue(line);
             totalBytes += line.Length;
 
             while (totalBytes > MaxSuggestionArchiveBytes && lines.Count > 0)
+            {
                 totalBytes -= lines.Dequeue().Length;
+                droppedByCapCount++;
+            }
         }
 
-        return lines.ToList();
+        return new ArchiveBuildResult(lines.ToList(), droppedByCapCount, oversizedDroppedCount, largestOversizedRecordBytes);
     }
 
     private void RotateArchiveIfNeeded(long pendingBytes)
@@ -959,14 +1030,15 @@ public class SuggestionStore
     {
         record.LastSubmitAttempt = timestamp;
         record.SubmitAttemptCount++;
-        record.LastSubmitError = string.IsNullOrWhiteSpace(error) ? null : error;
+        record.LastSubmitError = RedactSubmitErrorForPersistence(error);
         record.NextRetryAt = nextRetryAt;
     }
 
-    private static void StampSubmitResult(SuggestionRecord record, SubmitAttemptResult result)
+    private static string? StampSubmitResult(SuggestionRecord record, SubmitAttemptResult result)
     {
-        record.LastSubmitError = string.IsNullOrWhiteSpace(result.Error) ? null : result.Error;
+        record.LastSubmitError = RedactSubmitErrorForPersistence(result.Error);
         record.NextRetryAt = result.NextRetryAt;
+        return record.LastSubmitError;
     }
 
     private static SuggestionRecord CloneForSubmit(SuggestionRecord record) => new()
@@ -1111,6 +1183,18 @@ public class SuggestionStore
         return RedactSensitiveText(value, out redactedTypes);
     }
 
+    private static string? RedactSubmitErrorForPersistence(string? error)
+    {
+        if (string.IsNullOrWhiteSpace(error))
+            return null;
+
+        var redacted = RedactSensitiveText(error, out var redactedTypes);
+        if (redactedTypes.Count > 0)
+            WriteRedactionWarning(redactedTypes);
+
+        return redacted;
+    }
+
     private static void WriteRedactionWarning(IReadOnlyCollection<string> redactedTypes)
     {
         try
@@ -1196,20 +1280,21 @@ public class SuggestionStore
     }
 
     /// <summary>
-    /// Preserve a corrupt suggestions file by renaming it to .bak.
+    /// Preserve a corrupt suggestions file by renaming it to .bak or a timestamped backup.
     /// This prevents silent data loss — the corrupt file can be inspected
-    /// or recovered manually.
-    /// 破損した suggestions ファイルを .bak にリネームして保存する。
+    /// or recovered manually, without overwriting previous corrupt evidence.
+    /// 破損した suggestions ファイルを .bak またはタイムスタンプ付きバックアップにリネームして保存する。
     /// サイレントなデータ消失を防ぐ — 破損ファイルは手動で検査・復旧できる。
+    /// 以前の破損証跡を上書きしない。
     /// </summary>
     private void PreserveCorruptFile()
     {
         try
         {
-            var backupPath = _filePath + ".bak";
+            var backupPath = GetCorruptBackupPath();
             if (File.Exists(LongPath.EnsureWindowsPrefix(_filePath)))
             {
-                File.Move(LongPath.EnsureWindowsPrefix(_filePath), LongPath.EnsureWindowsPrefix(backupPath), overwrite: true);
+                File.Move(LongPath.EnsureWindowsPrefix(_filePath), LongPath.EnsureWindowsPrefix(backupPath), overwrite: false);
                 DataDirectorySecurity.ApplyPrivateFileMode(backupPath);
             }
         }
@@ -1218,5 +1303,29 @@ public class SuggestionStore
             // Best-effort — if we can't rename, continue with empty list.
             // ベストエフォート — リネームできなければ空リストで続行。
         }
+    }
+
+    private string GetCorruptBackupPath()
+    {
+        var primary = _filePath + ".bak";
+        if (!PathExists(primary))
+            return primary;
+
+        var timestamp = _timeProvider.GetUtcNow().UtcDateTime.ToString("yyyyMMddHHmmssfffffff", CultureInfo.InvariantCulture);
+        for (var attempt = 0; attempt < 1000; attempt++)
+        {
+            var suffix = attempt == 0 ? timestamp : $"{timestamp}.{attempt}";
+            var candidate = $"{primary}.{suffix}";
+            if (!PathExists(candidate))
+                return candidate;
+        }
+
+        return $"{primary}.{timestamp}.{Guid.NewGuid():N}";
+    }
+
+    private static bool PathExists(string path)
+    {
+        var ioPath = LongPath.EnsureWindowsPrefix(path);
+        return File.Exists(ioPath) || Directory.Exists(ioPath);
     }
 }

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -149,16 +149,16 @@ public class SuggestionStoreTests : IDisposable
     }
 
     [Fact]
-    public void LoadPage_TooManyRecordsAfterPage_PreservesBackupAndReturnsEmpty()
+    public void LoadPage_TakeStopsBeforeLaterExcessRecords()
     {
         var path = Path.Combine(_tempDir, "suggestions-codeindex.json");
         WriteEmptyRecordStore(path, SuggestionStore.MaxSuggestionStoreRecords + 1);
 
         var records = _store.Load(skip: 0, take: 1);
 
-        Assert.Empty(records);
-        Assert.False(File.Exists(path));
-        Assert.True(File.Exists(path + ".bak"));
+        Assert.Single(records);
+        Assert.True(File.Exists(path));
+        Assert.False(File.Exists(path + ".bak"));
     }
 
     // --- TryAdd tests / TryAdd テスト ---
@@ -555,6 +555,23 @@ public class SuggestionStoreTests : IDisposable
     }
 
     [Fact]
+    public void TryAddAndSubmit_Failure_RedactsAndBoundsPersistedSubmitError()
+    {
+        var record = MakeRecord("other", null, "Submission stores redacted error");
+        var tailSecret = "tail-secret-should-not-persist";
+        var error = "api_key=" + new string('a', SuggestionStore.RedactionFieldLengthLimit) + tailSecret;
+
+        var result = _store.TryAddAndSubmit(record,
+            _ => SuggestionStore.SubmitAttemptResult.Failure(error));
+
+        var stored = Assert.Single(_store.LoadAll());
+        Assert.Contains("api_key=[REDACTED:credential]", stored.LastSubmitError);
+        Assert.Contains(SuggestionStore.RedactionTruncationMarker, stored.LastSubmitError);
+        Assert.DoesNotContain(tailSecret, stored.LastSubmitError);
+        Assert.Equal(stored.LastSubmitError, result.SubmissionError);
+    }
+
+    [Fact]
     public async Task TryAddAndSubmit_SlowSubmission_DoesNotHoldFileLock()
     {
         var record = MakeRecord("other", null, "Slow remote submission");
@@ -938,6 +955,26 @@ public class SuggestionStoreTests : IDisposable
     }
 
     [Fact]
+    public void CorruptFile_ExistingBackupIsNotOverwritten()
+    {
+        var filePath = Path.Combine(_tempDir, "suggestions-codeindex.json");
+        var backupPath = filePath + ".bak";
+        File.WriteAllText(backupPath, "first corrupt backup");
+        File.WriteAllText(filePath, "{second corrupt json[[[");
+
+        var all = _store.LoadAll();
+
+        Assert.Empty(all);
+        Assert.Equal("first corrupt backup", File.ReadAllText(backupPath));
+        var timestampedBackup = Assert.Single(
+            Directory
+                .EnumerateFiles(_tempDir, "suggestions-codeindex.json.bak.*")
+                .Where(path => !string.Equals(path, backupPath, StringComparison.Ordinal)));
+        Assert.Contains("{second corrupt json[[[", File.ReadAllText(timestampedBackup));
+        Assert.False(File.Exists(filePath), "Original corrupt file should be removed");
+    }
+
+    [Fact]
     public void CorruptFile_OnPosixHardensBackupFileMode()
     {
         if (OperatingSystem.IsWindows())
@@ -1063,6 +1100,22 @@ public class SuggestionStoreTests : IDisposable
         Assert.Equal(SuggestionStore.MaxSuggestionArchiveBytes, new FileInfo(rotatedPath).Length);
         Assert.Contains("Old suggestion", File.ReadAllText(archivePath));
         Assert.True(new FileInfo(archivePath).Length <= SuggestionStore.MaxSuggestionArchiveBytes);
+    }
+
+    [Fact]
+    public void BuildBoundedArchiveLines_DropsOversizedRecordWithBoundedDiagnostics()
+    {
+        var oversized = MakeRecord(
+            "other",
+            null,
+            new string('x', SuggestionStore.MaxSuggestionArchiveBytes + 1));
+
+        var archive = SuggestionStore.BuildBoundedArchiveLines([oversized]);
+
+        Assert.Empty(archive.Lines);
+        Assert.Equal(0, archive.DroppedByCapCount);
+        Assert.Equal(1, archive.OversizedDroppedCount);
+        Assert.True(archive.LargestOversizedRecordBytes > SuggestionStore.MaxSuggestionArchiveBytes);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Stop paged suggestion reads once the requested `take` count is satisfied.
- Rework suggestion pruning to rebuild retained records instead of repeatedly removing from the list.
- Preserve additional corrupt-store evidence with timestamped backups, report bounded archive-drop diagnostics, and redact/bound persisted submit errors.
- Add focused `SuggestionStoreTests` coverage.

## Root Cause
SuggestionStore retention paths kept doing avoidable work after bounded reads, removed pruned records one at a time, overwrote corrupt `.bak` evidence, and persisted submit errors without passing them through the existing redaction boundary.

## Documentation / Changelog
- Added bilingual changelog fragment: `changelog.d/unreleased/3809.fixed.md`.
- No AGENTS.md, CLAUDE.md, or AGENT_GUIDE.md changes.

## Validation
- `dotnet build src/CodeIndex/CodeIndex.csproj --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false /nr:false`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:TargetFramework=net8.0 -p:RunAnalyzers=false -p:UseSharedCompilation=false -p:BuildInParallel=false /nr:false /m:1`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --framework net8.0 --filter FullyQualifiedName~SuggestionStoreTests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Notes
- `dotnet format CodeIndex.sln --verify-no-changes` and the changed-file `--include` variant were attempted but hung in this environment and were interrupted.
- External `codex exec` adversarial review was attempted but failed due usage limit; adversarial review was completed in-session with no blocking/actionable findings.

## Follow-up Candidates
- None.

Fixes #3809