### PR TITLE
[codex] Stabilize legacy symbol worker env hook test

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -46,6 +46,8 @@ The test project mirrors the production areas closely.
   CLI parsing, command execution, and installer behavior. Query command coverage is split by command family with partial `QueryCommandRunnerTests` classes so shared console and fixture helpers stay centralized. `ProgramCliTests.cs` covers top-level entrypoint behavior that must be exercised through a subprocess, while `InstallScriptTests.cs` runs focused bash snippets against `install.sh` in library mode to lock in release-installer regressions without performing real network installs.
 - `IndexCommandRunnerTests.Run_CancelDuringFreshIndex_ReturnsInterruptedJson`, `Run_CancelDuringDryRunScan_ReturnsInterruptedJson`, and `Run_CancelBeforeFreshScan_ReturnsInterruptedJson`
   exercise the same in-process cancellation paths used after Ctrl-C/SIGINT wiring, including scan-time cancellation, so interrupted index runs keep returning the canonical JSON error contract.
+- `IndexCommandRunnerTests.SymbolExtractionWorker_LegacyEnvironmentHooksAreIgnored_Issue3398`
+  launches the isolated symbol worker to prove legacy worker environment variables are ignored. Its callback budget includes process startup and is intentionally wider than ordinary in-process checks so local process load does not turn the legacy-env regression check into a timeout flake (#3863).
 - `IndexWatchRunnerTests.RunCore_CancellationToken_StopsImmediately` and `RunCore_EmitsHumanFriendlyStartStop_WhenJsonDisabled`
   exercise watch-loop startup and shutdown under redirected console output. These tests wait for the watch start line before cancelling and always cancel/drain the dedicated watch task before restoring `Console.Out` / `Console.Error`; do not replace that synchronization with fixed sleeps because full-suite load can delay the long-running task startup.
 - `SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget`
@@ -254,6 +256,8 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
   CLI の引数解析、コマンド実行、installer 挙動のテスト。Query command coverage は command family ごとの partial `QueryCommandRunnerTests` class に分割し、共有 console / fixture helper は一箇所に保ちます。`ProgramCliTests.cs` はグローバル引数の解釈や完全な CLI 起動フローのように subprocess 経由で確認すべき Program エントリポイント挙動を扱い、`InstallScriptTests.cs` は `install.sh` を library mode で source した bash snippet を実行して、実ネットワーク install を行わずに release installer の回帰を固定する。
 - `IndexCommandRunnerTests.Run_CancelDuringFreshIndex_ReturnsInterruptedJson`、`Run_CancelDuringDryRunScan_ReturnsInterruptedJson`、`Run_CancelBeforeFreshScan_ReturnsInterruptedJson`
   Ctrl-C/SIGINT 配線後に使われる in-process cancellation 経路を、scan 中のキャンセルも含めて検証し、interrupted index run が標準の JSON error contract を返し続けることを固定する。
+- `IndexCommandRunnerTests.SymbolExtractionWorker_LegacyEnvironmentHooksAreIgnored_Issue3398`
+  isolated symbol worker を起動し、legacy worker 環境変数が無視されることを検証します。この callback budget はプロセス起動時間も含むため、通常の in-process チェックより意図的に広く取り、ローカル負荷で legacy-env 回帰テストが timeout flake にならないようにします（#3863）。
 - `IndexWatchRunnerTests.RunCore_CancellationToken_StopsImmediately` と `RunCore_EmitsHumanFriendlyStartStop_WhenJsonDisabled`
   リダイレクトした console 出力の下で watch loop の起動と停止を検証する。これらのテストは watch start 行を待ってからキャンセルし、`Console.Out` / `Console.Error` を戻す前に専用 watch task を必ず cancel/drain する。full suite の負荷で long-running task の起動が遅れることがあるため、この同期を固定 sleep に戻さないこと。
 - `SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget`

--- a/changelog.d/unreleased/3863.internal.md
+++ b/changelog.d/unreleased/3863.internal.md
@@ -1,0 +1,16 @@
+---
+category: internal
+issues:
+  - 3863
+affected:
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Stabilized the legacy symbol worker environment hook regression test (#3863)**: the isolated worker regression test now uses a named startup-inclusive callback budget so local process load does not turn the legacy-environment check into a timeout flake.
+
+## 日本語
+
+- **legacy symbol worker 環境 hook 回帰テストを安定化しました (#3863)**: isolated worker の回帰テストで、プロセス起動時間を含む名前付き callback budget を使うようにし、ローカル負荷によって legacy environment チェックが timeout flake になることを防ぎます。

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -40,6 +40,8 @@ public sealed class SkipOnMacOsArm64TheoryAttribute : TheoryAttribute
 [Collection("SQLite pool sensitive")]
 public class IndexCommandRunnerTests
 {
+    private static readonly TimeSpan LegacyEnvironmentHookWorkerBudget = TimeSpan.FromSeconds(30);
+
     private readonly JsonSerializerOptions _jsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -350,7 +352,7 @@ public class IndexCommandRunnerTests
                     "public class App { }\n",
                     Path.Combine(projectRoot, "App.cs"),
                     projectRoot,
-                    TimeSpan.FromSeconds(5));
+                    LegacyEnvironmentHookWorkerBudget);
 
                 Assert.True(result.Success, result.WorkerError);
                 Assert.False(result.TimedOut);


### PR DESCRIPTION
## Summary

- Increase the legacy symbol worker environment-hook regression test callback budget to a named 30-second startup-inclusive budget.
- Document the worker startup budget in both the English and Japanese testing guide sections.
- Add the #3863 changelog fragment.

## Root Cause

The regression test used a 5-second callback timeout that also covered isolated worker process startup. Under local process load, startup could consume the budget before the worker callback completed.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter FullyQualifiedName~SymbolExtractionWorker_LegacyEnvironmentHooksAreIgnored_Issue3398 -m:1 -nr:false -p:UseSharedCompilation=false --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: No blocking/actionable issues found.

## Scope Notes

- Skipped #3836, #3821, and #3790 because each had an existing work-started comment on branch `fix-issue3836-3759-3821-3790`.
- No additional issues were created.

Fixes #3863
