### PR TITLE
Fix bounded sidecar readers and sanitized config diagnostics

### DIFF
--- a/changelog.d/unreleased/3706.fixed.md
+++ b/changelog.d/unreleased/3706.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 3706
+affected:
+  - src/CodeIndex/BoundedLineReader.cs
+  - src/CodeIndex/Cli/SolutionProjectResolver.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Small config and sidecar readers now share bounded UTF-8 line handling (#3706)** — language-map overrides, `.gitmodules`, and solution parsing now use the shared bounded line reader so byte, line-count, and line-length failures are handled consistently.
+
+## 日本語
+
+- **小さな設定ファイルと sidecar の読み取りで bounded UTF-8 line 処理を共有しました (#3706)** — language-map override、`.gitmodules`、solution 解析が共通の bounded line reader を使うようになり、byte・行数・行長の上限超過を一貫して扱います。

--- a/changelog.d/unreleased/3819.fixed.md
+++ b/changelog.d/unreleased/3819.fixed.md
@@ -1,0 +1,23 @@
+---
+category: fixed
+issues:
+  - 3819
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Sidecar config diagnostics now sanitize config paths (#3819)** — TypeScript path-alias and language-map warnings now sanitize config paths before writing diagnostics, while preserving per-file warning de-duplication internally.
+
+- **`.gitmodules` submodule parsing is bounded and quote-aware (#3819)** — parsing now caps accepted submodule paths and preserves `#` / `;` characters inside quoted path values instead of treating them as inline comments.
+
+## 日本語
+
+- **sidecar config diagnostics の config path をサニタイズするようになりました (#3819)** — TypeScript path-alias と language-map の警告は、診断出力前に config path をサニタイズするようになりました。内部の per-file warning 重複排除は維持しています。
+
+- **`.gitmodules` の submodule 解析を bounded かつ quote-aware にしました (#3819)** — 受け入れる submodule path 数に上限を設け、quoted path 値の中にある `#` / `;` を inline comment として扱わず保持します。

--- a/src/CodeIndex/BoundedLineReader.cs
+++ b/src/CodeIndex/BoundedLineReader.cs
@@ -22,6 +22,23 @@ internal sealed class BoundedLineLengthException : IOException
     internal int MaxUtf8Bytes { get; }
 }
 
+internal enum BoundedTextFileReadFailureKind
+{
+    None,
+    BytesExceeded,
+    LinesExceeded,
+    LineLengthExceeded,
+    ReadFailed,
+}
+
+internal readonly record struct BoundedTextFileReadFailure(
+    BoundedTextFileReadFailureKind Kind,
+    string Reason,
+    int? LineNumber = null,
+    int? CharactersRead = null,
+    int? Limit = null,
+    string? ExceptionType = null);
+
 internal static class WorkerProtocolLineLimits
 {
     // Worker requests carry source content as JSON. Keep this above the default 4 MiB source
@@ -48,6 +65,119 @@ internal static class WorkerProtocolLineLimits
 
 internal static class BoundedLineReader
 {
+    internal static bool TryReadUtf8File(
+        string path,
+        int maxBytes,
+        int maxLines,
+        int maxLineCharacters,
+        out IReadOnlyList<string> lines,
+        out BoundedTextFileReadFailure failure,
+        Func<string, Stream>? openFile = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        if (maxBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "Maximum file bytes must be positive.");
+        if (maxLines <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLines), maxLines, "Maximum line count must be positive.");
+        if (maxLineCharacters <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLineCharacters), maxLineCharacters, "Maximum line characters must be positive.");
+
+        lines = [];
+        failure = default;
+
+        try
+        {
+            using var stream = openFile?.Invoke(path)
+                ?? new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete,
+                    bufferSize: 8192,
+                    useAsync: false);
+
+            if (stream.CanSeek && stream.Length > maxBytes)
+            {
+                failure = new(
+                    BoundedTextFileReadFailureKind.BytesExceeded,
+                    $"it exceeds {maxBytes} bytes",
+                    Limit: maxBytes);
+                return false;
+            }
+
+            using var accumulator = new MemoryStream(stream.CanSeek ? (int)Math.Min(stream.Length, maxBytes) : 0);
+            var buffer = new byte[8192];
+            long total = 0;
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                total += read;
+                if (total > maxBytes)
+                {
+                    failure = new(
+                        BoundedTextFileReadFailureKind.BytesExceeded,
+                        $"it exceeds {maxBytes} bytes",
+                        Limit: maxBytes);
+                    return false;
+                }
+
+                accumulator.Write(buffer, 0, read);
+            }
+
+            var text = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(accumulator.ToArray());
+            if (text.Length > 0 && text[0] == '\uFEFF')
+                text = text[1..];
+
+            var result = new List<string>();
+            using var reader = new StringReader(text);
+            while (true)
+            {
+                string? line;
+                try
+                {
+                    line = ReadLine(reader, maxLineCharacters, maxBytes);
+                }
+                catch (BoundedLineLengthException ex)
+                {
+                    var lineNumber = result.Count + 1;
+                    failure = new(
+                        BoundedTextFileReadFailureKind.LineLengthExceeded,
+                        $"line {lineNumber} exceeds {maxLineCharacters} characters",
+                        lineNumber,
+                        ex.CharactersRead,
+                        maxLineCharacters);
+                    return false;
+                }
+
+                if (line == null)
+                    break;
+
+                if (result.Count >= maxLines)
+                {
+                    failure = new(
+                        BoundedTextFileReadFailureKind.LinesExceeded,
+                        $"it exceeds {maxLines} lines",
+                        Limit: maxLines);
+                    return false;
+                }
+
+                result.Add(line);
+            }
+
+            lines = result;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            var reason = $"it could not be read ({ex.GetType().Name}: {CollapseLineBreaks(ex.Message)})";
+            failure = new(
+                BoundedTextFileReadFailureKind.ReadFailed,
+                reason,
+                ExceptionType: ex.GetType().Name);
+            return false;
+        }
+    }
+
     internal static string? ReadLine(TextReader reader, int maxCharacters, int maxUtf8Bytes)
     {
         ArgumentNullException.ThrowIfNull(reader);
@@ -184,4 +314,7 @@ internal static class BoundedLineReader
                 throw new BoundedLineLengthException(_charactersRead, _utf8BytesRead, _maxCharacters, _maxUtf8Bytes);
         }
     }
+
+    private static string CollapseLineBreaks(string value)
+        => value.Replace('\r', ' ').Replace('\n', ' ');
 }

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -47,6 +47,7 @@ internal readonly record struct SolutionProjectResolverLimits(
 internal static class SolutionProjectResolver
 {
     internal const long MaxSolutionFileBytes = 8L * 1024 * 1024;
+    internal const int MaxSolutionFileLines = 65536;
     internal const int MaxSolutionLineChars = 16 * 1024;
     internal const int MaxSolutionProjectReferences = 4096;
 
@@ -287,20 +288,26 @@ internal static class SolutionProjectResolver
         string workspaceRoot,
         FileIndexer indexer)
     {
-        RejectOversizedSolutionFile(solutionPath);
+        var prefixedSolutionPath = LongPath.EnsureWindowsPrefix(solutionPath);
+        if (!BoundedLineReader.TryReadUtf8File(
+                prefixedSolutionPath,
+                checked((int)MaxSolutionFileBytes),
+                MaxSolutionFileLines,
+                MaxSolutionLineChars,
+                out var solutionLines,
+                out var readFailure))
+        {
+            ThrowSolutionReadFailure(solutionPath, readFailure);
+        }
+
         var root = Path.GetFullPath(workspaceRoot);
         var solutionDir = Path.GetDirectoryName(solutionPath) ?? workspaceRoot;
         var projects = new List<DotNetProjectInfo>();
         var lineNumber = 0;
         var projectReferenceCount = 0;
-        foreach (var line in File.ReadLines(LongPath.EnsureWindowsPrefix(solutionPath)))
+        foreach (var line in solutionLines)
         {
             lineNumber++;
-            if (line.Length > MaxSolutionLineChars)
-            {
-                throw new InvalidOperationException(
-                    $"solution line is too long at {solutionPath}:{lineNumber}: {line.Length} characters exceeds limit {MaxSolutionLineChars}.");
-            }
 
             if (!TryParseSolutionProjectLine(line, out var name, out var projectPath))
                 continue;
@@ -328,6 +335,30 @@ internal static class SolutionProjectResolver
             .OrderBy(project => project.Name, StringComparer.OrdinalIgnoreCase)
             .ThenBy(project => project.ProjectPath, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static void ThrowSolutionReadFailure(string solutionPath, BoundedTextFileReadFailure failure)
+    {
+        if (failure.Kind == BoundedTextFileReadFailureKind.BytesExceeded)
+        {
+            throw new InvalidOperationException(
+                $"solution file is too large: {solutionPath} exceeds limit {MaxSolutionFileBytes} bytes.");
+        }
+
+        if (failure.Kind == BoundedTextFileReadFailureKind.LinesExceeded)
+        {
+            throw new InvalidOperationException(
+                $"solution file contains too many lines at {solutionPath}: limit {MaxSolutionFileLines} exceeded.");
+        }
+
+        if (failure.Kind == BoundedTextFileReadFailureKind.LineLengthExceeded)
+        {
+            throw new InvalidOperationException(
+                $"solution line is too long at {solutionPath}:{failure.LineNumber}: {failure.CharactersRead} characters exceeds limit {MaxSolutionLineChars}.");
+        }
+
+        throw new InvalidOperationException(
+            $"solution file could not be read at {solutionPath}: {failure.Reason}.");
     }
 
     private static DotNetProjectInfo BuildProjectInfo(string fullProjectPath, string workspaceRoot, string? solutionName = null)
@@ -630,16 +661,6 @@ internal static class SolutionProjectResolver
         return extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase)
             || extension.Equals(".fsproj", StringComparison.OrdinalIgnoreCase)
             || extension.Equals(".vbproj", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static void RejectOversizedSolutionFile(string solutionPath)
-    {
-        var length = new FileInfo(LongPath.EnsureWindowsPrefix(solutionPath)).Length;
-        if (length > MaxSolutionFileBytes)
-        {
-            throw new InvalidOperationException(
-                $"solution file is too large: {solutionPath} is {length} bytes; limit is {MaxSolutionFileBytes} bytes.");
-        }
     }
 
     private static bool TryParseSolutionProjectLine(string line, out string name, out string projectPath)

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -3091,6 +3091,15 @@ public class FileIndexer
                 if (readFailure.ExceptionType is nameof(FileNotFoundException) or nameof(DirectoryNotFoundException))
                     return true;
 
+                if (readFailure.ExceptionType == nameof(UnauthorizedAccessException))
+                {
+                    if (!File.Exists(prefixedIgnorePath))
+                        throw new UnauthorizedAccessException(readFailure.Reason);
+
+                    errors.Add(new ScanError(ToRelativePath(ignorePath), $"Could not read {ignoreFileName} due to permissions.", ScanIssueSeverity.Warning));
+                    return true;
+                }
+
                 errors.Add(new ScanError(
                     ToRelativePath(ignorePath),
                     $"Could not safely read {ignoreFileName} because {skippedReason}."));

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -112,6 +112,7 @@ public class FileIndexer
     private const int GitLfsPointerMaxBytes = 1024;
     private const int MaxGitmodulesBytes = 256 * 1024;
     private const int MaxGitmodulesLines = 4096;
+    private const int MaxGitmodulesLineChars = 16 * 1024;
     private const int MaxProjectMarkerTraversalWarnings = 32;
     private static readonly string[] IgnoreFileNames = [".gitignore", ".cdidxignore"];
     private static readonly JsonDocumentOptions DockerfileJsonFormIssueDocumentOptions = new()
@@ -3087,8 +3088,12 @@ public class FileIndexer
                     MaxIgnoreFileBytes,
                     MaxIgnoreFileLines,
                     out var lines,
-                    out var skippedReason))
+                    out var skippedReason,
+                    out var readFailure))
             {
+                if (readFailure.ExceptionType is nameof(FileNotFoundException) or nameof(DirectoryNotFoundException))
+                    return true;
+
                 errors.Add(new ScanError(
                     ToRelativePath(ignorePath),
                     $"Could not safely read {ignoreFileName} because {skippedReason}."));
@@ -3241,7 +3246,8 @@ public class FileIndexer
                         MaxGitmodulesBytes,
                         MaxGitmodulesLines,
                         out lines,
-                        out var skippedReason))
+                        out var skippedReason,
+                        out _))
                 {
                     warnings.Add(new ScanError(
                         NormalizeIgnorePath(Path.GetRelativePath(projectRoot, gitmodulesPath)),
@@ -3306,61 +3312,18 @@ public class FileIndexer
         int maxBytes,
         int maxLines,
         out IReadOnlyList<string> lines,
-        out string skippedReason)
+        out string skippedReason,
+        out BoundedTextFileReadFailure failure)
     {
-        lines = [];
-        skippedReason = string.Empty;
-
-        using var stream = new FileStream(
+        var success = BoundedLineReader.TryReadUtf8File(
             path,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.ReadWrite | FileShare.Delete,
-            bufferSize: 8192,
-            useAsync: false);
-
-        if (stream.Length > maxBytes)
-        {
-            skippedReason = $"it exceeds {maxBytes} bytes";
-            return false;
-        }
-
-        using var accumulator = new MemoryStream((int)Math.Min(stream.Length, maxBytes));
-        var buffer = new byte[8192];
-        long total = 0;
-        int read;
-        while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-        {
-            total += read;
-            if (total > maxBytes)
-            {
-                skippedReason = $"it exceeds {maxBytes} bytes";
-                return false;
-            }
-
-            accumulator.Write(buffer, 0, read);
-        }
-
-        var text = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(accumulator.ToArray());
-        var result = new List<string>();
-        using var reader = new StringReader(text);
-        string? line;
-        while ((line = reader.ReadLine()) != null)
-        {
-            if (result.Count == 0 && line.Length > 0 && line[0] == '\uFEFF')
-                line = line[1..];
-
-            if (result.Count >= maxLines)
-            {
-                skippedReason = $"it exceeds {maxLines} lines";
-                return false;
-            }
-
-            result.Add(line);
-        }
-
-        lines = result;
-        return true;
+            maxBytes,
+            maxLines,
+            MaxGitmodulesLineChars,
+            out lines,
+            out failure);
+        skippedReason = success ? string.Empty : failure.Reason;
+        return success;
     }
 
     // Tolerant .gitmodules reader: yields each declared submodule's "path = ..." value.

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -113,6 +113,7 @@ public class FileIndexer
     private const int MaxGitmodulesBytes = 256 * 1024;
     private const int MaxGitmodulesLines = 4096;
     private const int MaxGitmodulesLineChars = 16 * 1024;
+    internal const int MaxGitmodulesSubmodulePaths = 1024;
     private const int MaxProjectMarkerTraversalWarnings = 32;
     private static readonly string[] IgnoreFileNames = [".gitignore", ".cdidxignore"];
     private static readonly JsonDocumentOptions DockerfileJsonFormIssueDocumentOptions = new()
@@ -3257,6 +3258,7 @@ public class FileIndexer
                 }
             }
 
+            var submodulePathCount = 0;
             foreach (var rawSubmodulePath in ParseSubmodulePathsFromGitmodules(lines))
             {
                 string absolute;
@@ -3277,10 +3279,22 @@ public class FileIndexer
                     continue;
                 }
 
-                submodulePaths.Add(relativeToProject);
-                var segments = relativeToProject.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                for (var i = 1; i < segments.Length; i++)
-                    ancestorPaths.Add(string.Join('/', segments, 0, i));
+                if (submodulePathCount >= MaxGitmodulesSubmodulePaths)
+                {
+                    warnings.Add(new ScanError(
+                        NormalizeIgnorePath(Path.GetRelativePath(projectRoot, gitmodulesPath)),
+                        $"Stopped parsing .gitmodules submodule paths after {MaxGitmodulesSubmodulePaths} entries.",
+                        ScanIssueSeverity.Warning));
+                    break;
+                }
+
+                submodulePathCount++;
+                if (submodulePaths.Add(relativeToProject))
+                {
+                    var segments = relativeToProject.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    for (var i = 1; i < segments.Length; i++)
+                        ancestorPaths.Add(string.Join('/', segments, 0, i));
+                }
             }
         }
         catch (IOException ex)
@@ -3370,10 +3384,7 @@ public class FileIndexer
             if (!string.Equals(key, "path", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var value = line[(equalsIndex + 1)..].Trim();
-            var commentIndex = value.IndexOfAny(['#', ';']);
-            if (commentIndex >= 0)
-                value = value[..commentIndex].Trim();
+            var value = StripGitmodulesInlineComment(line[(equalsIndex + 1)..]);
             if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
                 value = value[1..^1];
             if (value.Length == 0)
@@ -3383,6 +3394,38 @@ public class FileIndexer
 
             yield return value;
         }
+    }
+
+    private static string StripGitmodulesInlineComment(string value)
+    {
+        var inQuotes = false;
+        var escaping = false;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (escaping)
+            {
+                escaping = false;
+                continue;
+            }
+
+            if (inQuotes && ch == '\\')
+            {
+                escaping = true;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (!inQuotes && ch is '#' or ';')
+                return value[..i].Trim();
+        }
+
+        return value.Trim();
     }
 
     internal static string NormalizeIgnorePath(string path)

--- a/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+++ b/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
@@ -1,4 +1,5 @@
 using CodeIndex.Cli;
+using CodeIndex.Diagnostics;
 
 namespace CodeIndex.Indexer;
 
@@ -20,11 +21,13 @@ internal static class LanguageMapOverrides
     internal static IReadOnlyDictionary<string, string> LoadEffectiveMapFromPathsForTesting(
         IEnumerable<string> configPaths,
         Action<string>? reportWarning = null)
-        => LoadEffectiveMapFromPaths(configPaths, reportWarning);
+        => LoadEffectiveMapFromPaths(
+            configPaths,
+            reportWarning == null ? null : (message, _) => reportWarning(message));
 
     private static IReadOnlyDictionary<string, string> LoadEffectiveMapFromPaths(
         IEnumerable<string> configPaths,
-        Action<string>? reportWarning)
+        Action<string, string?>? reportWarning)
     {
         var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var path in configPaths)
@@ -66,14 +69,16 @@ internal static class LanguageMapOverrides
     private static void LoadInto(
         string path,
         Dictionary<string, string> target,
-        Action<string>? reportWarning)
+        Action<string, string?>? reportWarning)
     {
         if (!File.Exists(path))
             return;
 
         if (!TryReadBoundedUtf8Lines(path, out var lines, out var skippedReason))
         {
-            reportWarning?.Invoke($"Skipped language-map override file {path} because {skippedReason}.");
+            reportWarning?.Invoke(
+                $"Skipped language-map override file {DiagnosticSanitizer.ForPath(path)} because {DiagnosticSanitizer.ForMessage(skippedReason)}.",
+                $"{path}\n{skippedReason}");
             return;
         }
 
@@ -95,7 +100,9 @@ internal static class LanguageMapOverrides
             {
                 if (entryCount >= MaxOverrideEntries)
                 {
-                    reportWarning?.Invoke($"Ignored remaining language-map override entries in {path} because the loaded entry count exceeds {MaxOverrideEntries}.");
+                    reportWarning?.Invoke(
+                        $"Ignored remaining language-map override entries in {DiagnosticSanitizer.ForPath(path)} because the loaded entry count exceeds {MaxOverrideEntries}.",
+                        $"{path}\nentry-count");
                     return;
                 }
 
@@ -120,11 +127,11 @@ internal static class LanguageMapOverrides
         return success;
     }
 
-    private static void ReportWarningOnce(string message)
+    private static void ReportWarningOnce(string message, string? dedupeKey)
     {
         lock (WarningLock)
         {
-            if (!ReportedWarnings.Add(message))
+            if (!ReportedWarnings.Add(dedupeKey ?? message))
                 return;
         }
 

--- a/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+++ b/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using CodeIndex.Cli;
 
 namespace CodeIndex.Indexer;
@@ -8,6 +7,7 @@ internal static class LanguageMapOverrides
     internal const string WorkspaceFileName = ".cdidx-langmap.yaml";
     private const int MaxOverrideFileBytes = 128 * 1024;
     private const int MaxOverrideFileLines = 16384;
+    private const int MaxOverrideLineChars = 16 * 1024;
     private const int MaxOverrideEntries = 4096;
     private static readonly object WarningLock = new();
     private static readonly HashSet<string> ReportedWarnings = new(StringComparer.Ordinal);
@@ -108,77 +108,17 @@ internal static class LanguageMapOverrides
 
     private static bool TryReadBoundedUtf8Lines(string path, out IReadOnlyList<string> lines, out string skippedReason)
     {
-        lines = [];
-        skippedReason = string.Empty;
-
-        try
-        {
-            using var stream = OpenOverrideFileForTesting?.Invoke(path)
-                ?? new FileStream(
-                    path,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.ReadWrite | FileShare.Delete,
-                    bufferSize: 8192,
-                    useAsync: false);
-
-            if (stream.Length > MaxOverrideFileBytes)
-            {
-                skippedReason = $"it exceeds {MaxOverrideFileBytes} bytes";
-                return false;
-            }
-
-            using var accumulator = new MemoryStream((int)Math.Min(stream.Length, MaxOverrideFileBytes));
-            var buffer = new byte[8192];
-            long total = 0;
-            int read;
-            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-            {
-                total += read;
-                if (total > MaxOverrideFileBytes)
-                {
-                    skippedReason = $"it exceeds {MaxOverrideFileBytes} bytes";
-                    return false;
-                }
-
-                accumulator.Write(buffer, 0, read);
-            }
-
-            var text = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(accumulator.ToArray());
-            if (text.Length > 0 && text[0] == '\uFEFF')
-                text = text[1..];
-
-            var result = new List<string>();
-            using var reader = new StringReader(text);
-            string? line;
-            while ((line = reader.ReadLine()) != null)
-            {
-                if (result.Count >= MaxOverrideFileLines)
-                {
-                    skippedReason = $"it exceeds {MaxOverrideFileLines} lines";
-                    return false;
-                }
-
-                result.Add(line);
-            }
-
-            lines = result;
-            return true;
-        }
-        catch (IOException ex)
-        {
-            skippedReason = $"it could not be read ({ex.GetType().Name}: {CollapseLineBreaks(ex.Message)})";
-            return false;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            skippedReason = $"it could not be read ({ex.GetType().Name}: {CollapseLineBreaks(ex.Message)})";
-            return false;
-        }
+        var success = BoundedLineReader.TryReadUtf8File(
+            path,
+            MaxOverrideFileBytes,
+            MaxOverrideFileLines,
+            MaxOverrideLineChars,
+            out lines,
+            out var failure,
+            OpenOverrideFileForTesting);
+        skippedReason = success ? string.Empty : failure.Reason;
+        return success;
     }
-
-    private static string CollapseLineBreaks(string value)
-        => value.Replace('\r', ' ').Replace('\n', ' ');
 
     private static void ReportWarningOnce(string message)
     {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using CodeIndex.Cli;
+using CodeIndex.Diagnostics;
 
 namespace CodeIndex.Indexer;
 
@@ -56,8 +57,9 @@ public static partial class SymbolExtractor
 
         if (moduleName.Length > MaxTypeScriptPathAliasModuleSpecifierLength)
         {
-            ReportTypeScriptPathAliasWarningOnce(
-                $"Skipped TypeScript path alias resolution in config {config.ConfigPath} for module specifiers longer than {MaxTypeScriptPathAliasModuleSpecifierLength} characters.");
+            ReportTypeScriptPathAliasConfigWarningOnce(
+                config.ConfigPath,
+                $"Skipped TypeScript path alias resolution in config {DiagnosticSanitizer.ForPath(config.ConfigPath)} for module specifiers longer than {MaxTypeScriptPathAliasModuleSpecifierLength} characters.");
             return moduleName;
         }
 
@@ -70,8 +72,9 @@ public static partial class SymbolExtractor
             {
                 if (!TrySubstituteTypeScriptPathAliasTarget(target, wildcard, out var substituted))
                 {
-                    ReportTypeScriptPathAliasWarningOnce(
-                        $"Skipped TypeScript path alias target substitution in config {config.ConfigPath} longer than {MaxTypeScriptPathAliasSubstitutedTargetLength} characters.");
+                    ReportTypeScriptPathAliasConfigWarningOnce(
+                        config.ConfigPath,
+                        $"Skipped TypeScript path alias target substitution in config {DiagnosticSanitizer.ForPath(config.ConfigPath)} longer than {MaxTypeScriptPathAliasSubstitutedTargetLength} characters.");
                     continue;
                 }
 
@@ -136,11 +139,10 @@ public static partial class SymbolExtractor
 
         if (depth > MaxTypeScriptPathAliasExtendsDepth)
         {
-            ReportTypeScriptPathAliasWarningOnce(
-                FormatTypeScriptPathAliasConfigSkippedMessage(
-                    configPath,
-                    TypeScriptPathAliasDiagnosticDepthLimit,
-                    $"the extends depth exceeds {MaxTypeScriptPathAliasExtendsDepth}"));
+            ReportTypeScriptPathAliasConfigSkippedWarning(
+                configPath,
+                TypeScriptPathAliasDiagnosticDepthLimit,
+                $"the extends depth exceeds {MaxTypeScriptPathAliasExtendsDepth}");
             return null;
         }
 
@@ -153,8 +155,7 @@ public static partial class SymbolExtractor
                     out var configText,
                     out var skippedReason))
             {
-                ReportTypeScriptPathAliasWarningOnce(
-                    FormatTypeScriptPathAliasConfigSkippedMessage(configPath, skippedReason));
+                ReportTypeScriptPathAliasConfigSkippedWarning(configPath, skippedReason);
                 return null;
             }
 
@@ -164,20 +165,18 @@ public static partial class SymbolExtractor
         }
         catch (JsonException)
         {
-            ReportTypeScriptPathAliasWarningOnce(
-                FormatTypeScriptPathAliasConfigSkippedMessage(
-                    configPath,
-                    TypeScriptPathAliasDiagnosticJsonInvalid,
-                    $"it could not be parsed as JSON within the {MaxTypeScriptPathAliasConfigJsonDepth}-level depth limit"));
+            ReportTypeScriptPathAliasConfigSkippedWarning(
+                configPath,
+                TypeScriptPathAliasDiagnosticJsonInvalid,
+                $"it could not be parsed as JSON within the {MaxTypeScriptPathAliasConfigJsonDepth}-level depth limit");
             return null;
         }
         catch
         {
-            ReportTypeScriptPathAliasWarningOnce(
-                FormatTypeScriptPathAliasConfigSkippedMessage(
-                    configPath,
-                    TypeScriptPathAliasDiagnosticReadFailed,
-                    "it could not be read"));
+            ReportTypeScriptPathAliasConfigSkippedWarning(
+                configPath,
+                TypeScriptPathAliasDiagnosticReadFailed,
+                "it could not be read");
             return null;
         }
 
@@ -268,26 +267,30 @@ public static partial class SymbolExtractor
 
                     if (rulesTruncated)
                     {
-                        ReportTypeScriptPathAliasWarningOnce(
-                            $"Truncated TypeScript path alias rules in config {configPath} to {MaxTypeScriptPathAliasRules} entries.");
+                        ReportTypeScriptPathAliasConfigWarningOnce(
+                            configPath,
+                            $"Truncated TypeScript path alias rules in config {DiagnosticSanitizer.ForPath(configPath)} to {MaxTypeScriptPathAliasRules} entries.");
                     }
 
                     if (targetsTruncated)
                     {
-                        ReportTypeScriptPathAliasWarningOnce(
-                            $"Truncated TypeScript path alias targets in config {configPath} to {MaxTypeScriptPathAliasTotalTargets} total entries and {MaxTypeScriptPathAliasTargetsPerRule} entries per rule.");
+                        ReportTypeScriptPathAliasConfigWarningOnce(
+                            configPath,
+                            $"Truncated TypeScript path alias targets in config {DiagnosticSanitizer.ForPath(configPath)} to {MaxTypeScriptPathAliasTotalTargets} total entries and {MaxTypeScriptPathAliasTargetsPerRule} entries per rule.");
                     }
 
                     if (ignoredLongPattern)
                     {
-                        ReportTypeScriptPathAliasWarningOnce(
-                            $"Ignored TypeScript path alias rules in config {configPath} with patterns longer than {MaxTypeScriptPathAliasPatternLength} characters.");
+                        ReportTypeScriptPathAliasConfigWarningOnce(
+                            configPath,
+                            $"Ignored TypeScript path alias rules in config {DiagnosticSanitizer.ForPath(configPath)} with patterns longer than {MaxTypeScriptPathAliasPatternLength} characters.");
                     }
 
                     if (ignoredLongTarget)
                     {
-                        ReportTypeScriptPathAliasWarningOnce(
-                            $"Ignored TypeScript path alias targets in config {configPath} longer than {MaxTypeScriptPathAliasTargetLength} characters.");
+                        ReportTypeScriptPathAliasConfigWarningOnce(
+                            configPath,
+                            $"Ignored TypeScript path alias targets in config {DiagnosticSanitizer.ForPath(configPath)} longer than {MaxTypeScriptPathAliasTargetLength} characters.");
                     }
                 }
             }
@@ -370,16 +373,29 @@ public static partial class SymbolExtractor
         FormatTypeScriptPathAliasConfigSkippedMessage(configPath, reason.Code, reason.Reason);
 
     private static string FormatTypeScriptPathAliasConfigSkippedMessage(string configPath, string code, string reason) =>
-        $"Skipped TypeScript path alias config {configPath} [{code}] because {reason}.";
+        $"Skipped TypeScript path alias config {DiagnosticSanitizer.ForPath(configPath)} [{DiagnosticSanitizer.ForMessage(code)}] because {DiagnosticSanitizer.ForMessage(reason)}.";
+
+    private static void ReportTypeScriptPathAliasConfigSkippedWarning(
+        string configPath,
+        TypeScriptPathAliasConfigSkippedReason reason) =>
+        ReportTypeScriptPathAliasConfigSkippedWarning(configPath, reason.Code, reason.Reason);
+
+    private static void ReportTypeScriptPathAliasConfigSkippedWarning(string configPath, string code, string reason)
+        => ReportTypeScriptPathAliasWarningOnce(
+            FormatTypeScriptPathAliasConfigSkippedMessage(configPath, code, reason),
+            $"{configPath}\n{code}\n{reason}");
 
     private static bool IsTypeScriptPathAliasConfigReadException(Exception exception) =>
         exception is IOException or UnauthorizedAccessException or NotSupportedException;
 
-    private static void ReportTypeScriptPathAliasWarningOnce(string message)
+    private static void ReportTypeScriptPathAliasConfigWarningOnce(string configPath, string message)
+        => ReportTypeScriptPathAliasWarningOnce(message, $"{configPath}\n{message}");
+
+    private static void ReportTypeScriptPathAliasWarningOnce(string message, string? dedupeKey = null)
     {
         lock (TypeScriptPathAliasWarningLock)
         {
-            if (!TypeScriptPathAliasReportedWarnings.Add(message))
+            if (!TypeScriptPathAliasReportedWarnings.Add(dedupeKey ?? message))
                 return;
         }
 

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -757,6 +757,30 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void LanguageMapOverrides_WarningsSanitizeConfigPath_Issue3819()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_sanitize_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "secret-langmap.yaml");
+            File.WriteAllText(configPath, new string('x', 16 * 1024 + 1));
+
+            var warnings = new List<string>();
+            _ = LanguageMapOverrides.LoadEffectiveMapFromPathsForTesting([configPath], warnings.Add);
+
+            var warning = Assert.Single(warnings);
+            Assert.Contains("secret-langmap.yaml", warning, StringComparison.Ordinal);
+            Assert.DoesNotContain(tempDir, warning, StringComparison.Ordinal);
+            Assert.DoesNotContain(tempDir.Replace('\\', '/'), warning, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
     public void LanguageMapOverrides_EntryCountCapTruncatesRemainingOverridesWithWarning()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_entries_{Guid.NewGuid():N}");
@@ -4391,6 +4415,80 @@ public class FileIndexerTests
                 error => error.Path == ".gitmodules"
                     && error.Severity == FileIndexer.ScanIssueSeverity.Warning
                     && error.Message.Contains("exceeds", StringComparison.OrdinalIgnoreCase));
+            Assert.False(result.HadErrors);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ScanFiles_GitmodulesQuotedPathPreservesCommentCharacters_Issue3819()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(
+                Path.Combine(tempDir, ".gitmodules"),
+                """
+                [submodule "quoted"]
+                    path = "vendor/hash#semi;module" # trailing comment
+                """);
+
+            var submoduleDir = Path.Combine(tempDir, "vendor", "hash#semi;module");
+            Directory.CreateDirectory(submoduleDir);
+            File.WriteAllText(Path.Combine(submoduleDir, ".git"), "gitdir: ../../.git/modules/quoted\n");
+            File.WriteAllText(Path.Combine(submoduleDir, "lib.py"), "def quoted(): pass");
+
+            var files = new FileIndexer(tempDir).ScanFiles();
+            var rel = files.Select(f => Path.GetRelativePath(tempDir, f).Replace('\\', '/')).ToHashSet();
+
+            Assert.Contains("vendor/hash#semi;module/lib.py", rel);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ScanFilesDetailed_GitmodulesSubmodulePathCapWarns_Issue3819()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(Path.Combine(tempDir, "app.py"), "print('hello')");
+
+            var maxPaths = FileIndexer.MaxGitmodulesSubmodulePaths;
+            var gitmodules = new StringBuilder();
+            for (var i = 0; i <= maxPaths; i++)
+            {
+                gitmodules.AppendLine($"[submodule \"m{i}\"]");
+                gitmodules.AppendLine($"    path = vendor/m{i}");
+            }
+
+            File.WriteAllText(Path.Combine(tempDir, ".gitmodules"), gitmodules.ToString());
+
+            var overflowDir = Path.Combine(tempDir, "vendor", $"m{maxPaths}");
+            Directory.CreateDirectory(overflowDir);
+            File.WriteAllText(Path.Combine(overflowDir, ".git"), $"gitdir: ../../.git/modules/m{maxPaths}\n");
+            File.WriteAllText(Path.Combine(overflowDir, "lib.py"), "def over_cap(): pass");
+
+            var result = new FileIndexer(tempDir).ScanFilesDetailed();
+            var rel = result.Files.Select(f => Path.GetRelativePath(tempDir, f).Replace('\\', '/')).ToHashSet();
+
+            Assert.Contains("app.py", rel);
+            Assert.DoesNotContain($"vendor/m{maxPaths}/lib.py", rel);
+            Assert.Contains(
+                result.Errors,
+                error => error.Path == ".gitmodules"
+                    && error.Severity == FileIndexer.ScanIssueSeverity.Warning
+                    && error.Message.Contains($"after {maxPaths}", StringComparison.Ordinal));
             Assert.False(result.HadErrors);
         }
         finally

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -731,6 +731,32 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void LanguageMapOverrides_OverlongLineSkipsOverridesWithWarning_Issue3706()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_line_length_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var overlongLinePath = Path.Combine(tempDir, "long-line-langmap.yaml");
+            var fallbackPath = Path.Combine(tempDir, "fallback-langmap.yaml");
+            File.WriteAllText(overlongLinePath, new string('x', 16 * 1024 + 1));
+            File.WriteAllText(fallbackPath, "entries:\n- extension: ok\n  language: ruby\n");
+
+            var warnings = new List<string>();
+            var map = LanguageMapOverrides.LoadEffectiveMapFromPathsForTesting(
+                new[] { overlongLinePath, fallbackPath },
+                warnings.Add);
+
+            Assert.Equal("ruby", map[".ok"]);
+            Assert.Contains(warnings, warning => warning.Contains("line 1 exceeds", StringComparison.Ordinal));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
     public void LanguageMapOverrides_EntryCountCapTruncatesRemainingOverridesWithWarning()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_entries_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2549,6 +2549,28 @@ public sealed class Caller
     }
 
     [Fact]
+    public void ResolveProjects_RejectsTooManySolutionLines_Issue3706()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_line_count_limit");
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projectRoot, "Repo.sln"),
+                string.Concat(Enumerable.Repeat("# comment\n", SolutionProjectResolver.MaxSolutionFileLines + 1)));
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => SolutionProjectResolver.ResolveProjects(projectRoot, "Repo.sln"));
+
+            Assert.Contains("solution file contains too many lines", ex.Message);
+            Assert.Contains(SolutionProjectResolver.MaxSolutionFileLines.ToString(CultureInfo.InvariantCulture), ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ResolveProjects_RejectsTooManySolutionProjectReferences_Issue3064()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_project_limit");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19284,6 +19284,30 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScript_TsconfigWarningSanitizesConfigPath_Issue3819()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_sanitize_symbols");
+        try
+        {
+            WriteFile(projectRoot, "tsconfig.json", "{ invalid json");
+            var sourcePath = WriteFile(projectRoot, "src/main.ts", "import { Button } from \"@/components/Button\";\n");
+
+            List<SymbolRecord> symbols = [];
+            var stderr = ConsoleCapture.CaptureError(() =>
+                symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath));
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "@/components/Button");
+            Assert.Contains("Skipped TypeScript path alias config tsconfig.json", stderr, StringComparison.Ordinal);
+            Assert.DoesNotContain(projectRoot, stderr, StringComparison.Ordinal);
+            Assert.DoesNotContain(projectRoot.Replace('\\', '/'), stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Extract_TypeScript_UnreadableTsconfigSkipsPathAliasesWithReadFailedWarning_Issue3438()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_unreadable_symbols");


### PR DESCRIPTION
## Summary
- Add a shared bounded UTF-8 line reader for small config, sidecar, and solution file readers.
- Sanitize language-map and TypeScript path-alias config warning paths.
- Bound parsed `.gitmodules` submodule paths and preserve `#` / `;` inside quoted path values.
- Merge latest `origin/main` and preserve existing unreadable ignore-directory diagnostics after bounded sidecar reads.

Fixes #3706
Fixes #3819

## Validation
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1 --filter "FullyQualifiedName~Run_DryRun_FullScan_ReportsUnreadableDirectory|FullyQualifiedName~Run_FullScan_PurgesStaleRowsWithinListedDirectoriesEvenWhenAnotherDirectoryIsUnreadable|FullyQualifiedName~Run_FullScan_PurgesDeletedFilesWithinFullyScannedDirectoriesEvenWhenAnotherDirectoryIsUnreadable|FullyQualifiedName~Run_UpdateMode_WithCommits_SkipsMutationWhenIgnoreRulesAreUnreadable|FullyQualifiedName~Run_UpdateMode_WithFiles_SkipsMutationWhenIgnoreRulesAreUnreadable|FullyQualifiedName~Run_UpdateMode_WithFiles_UnreadableIgnoreRulesDemoteReadinessForChangedIndexedFile|FullyQualifiedName~Run_FullScan_PurgesDeletedFilesWhenUnreadableDescendantExistsUnderSameParentDirectory"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1 --filter "FullyQualifiedName~LanguageMapOverrides_OverlongLineSkipsOverridesWithWarning_Issue3706|FullyQualifiedName~LanguageMapOverrides_WarningsSanitizeConfigPath_Issue3819|FullyQualifiedName~ScanFilesDetailed_OversizedGitmodulesSkipsSubmodulePassthroughWithWarning|FullyQualifiedName~ScanFiles_GitmodulesQuotedPathPreservesCommentCharacters_Issue3819|FullyQualifiedName~ScanFilesDetailed_GitmodulesSubmodulePathCapWarns_Issue3819|FullyQualifiedName~ResolveProjects_RejectsTooManySolutionLines_Issue3706|FullyQualifiedName~ResolveProjects_RejectsOverlongSolutionLine_Issue3064|FullyQualifiedName~Extract_TypeScript_TsconfigWarningSanitizesConfigPath_Issue3819|FullyQualifiedName~Extract_TypeScript_MalformedTsconfigSkipsPathAliasesWithWarning|FullyQualifiedName~Extract_TypeScript_DeepTsconfigJsonSkipsPathAliasesWithWarning"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: No blocking/actionable issues found.