### PR TITLE
Fix bounded extraction hardening issues

### DIFF
--- a/changelog.d/unreleased/3657.fixed.md
+++ b/changelog.d/unreleased/3657.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 3657
+affected:
+  - src/CodeIndex/Cli/DataDirectorySecurity.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+  - src/CodeIndex/Lsp/LspServer.cs
+  - src/CodeIndex/Mcp/HttpMcpTransport.cs
+  - tests/CodeIndex.Tests/LspServerTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- Added explicit size guards and call-site bounds for JSON parsing and text materialization paths.
+
+## 日本語
+
+- JSON parsing と text materialization 経路に、明示的なサイズガードと呼び出し箇所の上限根拠を追加しました。

--- a/changelog.d/unreleased/3661.fixed.md
+++ b/changelog.d/unreleased/3661.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 3661
+affected:
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- Added regression coverage that built-in symbol extractor regex tables use `BoundedRegex` instances with explicit match timeouts.
+
+## 日本語
+
+- 組み込みシンボル抽出 regex テーブルが明示的な match timeout を持つ `BoundedRegex` 実体を使うことを回帰テストで確認するようにしました。

--- a/changelog.d/unreleased/3713.fixed.md
+++ b/changelog.d/unreleased/3713.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3713
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- Centralized Dockerfile JSON-form parsing budgets so extraction and validation share the same bounded parser.
+
+## 日本語
+
+- Dockerfile JSON form の parsing budget を集約し、抽出と検証で同じ bounded parser を共有するようにしました。

--- a/changelog.d/unreleased/3721.fixed.md
+++ b/changelog.d/unreleased/3721.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3721
+affected:
+  - src/CodeIndex/Indexer/BoundedRegex.cs
+  - src/CodeIndex/Indexer/Extensibility/ConfiguredSymbolExtractor.cs
+  - src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PatternConfig.cs
+  - tests/CodeIndex.Tests/SymbolExtractorConfiguredPatternTests.cs
+---
+
+## English
+
+- Routed configured symbol extraction regex construction through the shared bounded regex factory while preserving timeout-based pattern disabling.
+
+## 日本語
+
+- 設定ファイル由来のシンボル抽出 regex 生成を共有の bounded regex factory に通し、timeout 後にパターンを無効化する挙動を維持しました。

--- a/changelog.d/unreleased/3801.fixed.md
+++ b/changelog.d/unreleased/3801.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3801
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.BuildAutomation.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- Added XML/MSBuild extraction depth and element-count budgets, prohibited DTD declarations, and surfaced validation warnings when XML structure budgets are exceeded.
+
+## 日本語
+
+- XML/MSBuild 抽出に depth と element count の budget を追加し、DTD 宣言を禁止して、XML 構造 budget 超過時に validation warning を出すようにしました。

--- a/changelog.d/unreleased/3808.fixed.md
+++ b/changelog.d/unreleased/3808.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3808
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- Added JSON/YAML structured-data extraction budgets for depth, symbol count, path length, and signature length, and improved JSON duplicate-key line mapping.
+
+## 日本語
+
+- JSON/YAML の構造化データ抽出に depth、symbol count、path length、signature length の budget を追加し、JSON duplicate key の行番号対応を改善しました。

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -98,6 +98,7 @@ internal static class DataDirectorySecurity
     {
         using var stream = new MemoryStream(bytes);
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        // DecodeText is reached only from ReadTextWithinLimit after ReadBytesWithinLimit enforces maxBytes.
         return reader.ReadToEnd();
     }
 

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -355,6 +355,7 @@ internal static partial class ProgramRunner
 
         buffer.Position = 0;
         using var reader = new StreamReader(buffer, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        // The loop above rejects streams beyond TestExtractorMaxInputBytes before this materializes text.
         content = reader.ReadToEnd();
         return true;
     }

--- a/src/CodeIndex/Indexer/BoundedRegex.cs
+++ b/src/CodeIndex/Indexer/BoundedRegex.cs
@@ -63,6 +63,12 @@ internal sealed class BoundedRegex : BclRegex
     internal static RegexTimeoutCaptureScope CaptureTimeouts(string? language, string patternFamily) =>
         new(language, patternFamily);
 
+    internal static BoundedRegex CreateExtractionRegex(string pattern, RegexOptions options) =>
+        CreateExtractionRegex(pattern, options, DefaultMatchTimeout);
+
+    internal static BoundedRegex CreateExtractionRegex(string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+        new(pattern, options | RegexOptions.CultureInvariant, matchTimeout);
+
     public BoundedRegex(string pattern)
         : base(pattern, RegexOptions.None, DefaultMatchTimeout)
     {

--- a/src/CodeIndex/Indexer/Extensibility/ConfiguredSymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Extensibility/ConfiguredSymbolExtractor.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using CodeIndex.Cli;
 using CodeIndex.Models;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer.Extensibility;
 
@@ -19,6 +20,8 @@ internal sealed class ConfiguredSymbolExtractor(
 
     public IReadOnlyCollection<string> FileExtensions { get; } = fileExtensions;
 
+    internal IReadOnlyList<PatternRule> PatternsForTests => patterns;
+
     public IReadOnlyList<SymbolRecord> Extract(long fileId, string source, ExtractionContext context)
     {
         var symbols = new List<SymbolRecord>();
@@ -34,7 +37,13 @@ internal sealed class ConfiguredSymbolExtractor(
                 Match match;
                 try
                 {
+                    using var regexTimeouts = Regex.CaptureTimeouts(Language, "configured_symbol_extraction");
                     match = pattern.Regex.Match(line);
+                    if (regexTimeouts.HasTimeouts)
+                    {
+                        DisablePatternAfterTimeout(pattern);
+                        continue;
+                    }
                 }
                 catch (RegexMatchTimeoutException)
                 {

--- a/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PatternConfig.cs
+++ b/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PatternConfig.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using CodeIndex.Diagnostics;
 using Microsoft.Win32.SafeHandles;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Indexer.Extensibility;
 
@@ -99,9 +100,9 @@ public static partial class ExtractorPluginRegistry
                             Regex regex;
                             try
                             {
-                                regex = new Regex(
+                                regex = Regex.CreateExtractionRegex(
                                     value,
-                                    RegexOptions.Compiled | RegexOptions.CultureInvariant,
+                                    RegexOptions.Compiled,
                                     PatternRegexTimeout);
                             }
                             catch (ArgumentException)

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -3756,13 +3756,30 @@ public class FileIndexer
             AddRawByteContentIssues(issues, relativePath, rawBytes);
 
         AddOversizeContentIssues(issues, relativePath, content);
-        if (language == "dockerfile"
-            || (language == null && TryDetectLanguage(relativePath, content).Language == "dockerfile"))
+        var effectiveLanguage = language ?? TryDetectLanguage(relativePath, content).Language;
+        if (effectiveLanguage is "xml" or "msbuild")
+            AddXmlStructureIssues(issues, relativePath, content);
+        if (effectiveLanguage == "dockerfile")
         {
             AddDockerfileJsonFormIssues(issues, relativePath, content);
         }
 
         return issues;
+    }
+
+    private static void AddXmlStructureIssues(List<FileIssue> issues, string relativePath, string content)
+    {
+        if (!SymbolExtractor.TryGetXmlStructureIssue(content, out var issue))
+            return;
+
+        issues.Add(new FileIssue
+        {
+            Path = relativePath,
+            Kind = issue.Kind,
+            Line = issue.Line,
+            Message = issue.Message,
+            Severity = FileIssue.SeverityWarning,
+        });
     }
 
     private static void AddDockerfileJsonFormIssues(List<FileIssue> issues, string relativePath, string content)

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -114,10 +114,6 @@ public class FileIndexer
     private const int MaxGitmodulesLines = 4096;
     private const int MaxProjectMarkerTraversalWarnings = 32;
     private static readonly string[] IgnoreFileNames = [".gitignore", ".cdidxignore"];
-    private static readonly JsonDocumentOptions DockerfileJsonFormIssueDocumentOptions = new()
-    {
-        MaxDepth = SymbolExtractor.DockerfileJsonFormMaxDepth,
-    };
     private const int MaxIgnoreFileBytes = 256 * 1024;
     private const int MaxIgnoreFileLines = 8192;
     private const int MaxIgnoreRulesPerFile = 4096;
@@ -3834,7 +3830,7 @@ public class FileIndexer
     {
         try
         {
-            using var document = JsonDocument.Parse(payload, DockerfileJsonFormIssueDocumentOptions);
+            using var document = SymbolExtractor.ParseDockerfileJsonFormPayload(payload);
             if (document.RootElement.ValueKind != JsonValueKind.Array)
                 return true;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.BuildAutomation.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.BuildAutomation.cs
@@ -5,6 +5,11 @@ namespace CodeIndex.Indexer;
 
 public static partial class SymbolExtractor
 {
+    internal const int XmlExtractionMaxDepth = 64;
+    internal const int XmlExtractionMaxElements = 4096;
+
+    internal readonly record struct XmlStructureIssue(string Kind, int Line, string Message);
+
     private static readonly HashSet<string> MsBuildContainerElements = new(StringComparer.OrdinalIgnoreCase)
     {
         "Project",
@@ -33,22 +38,19 @@ public static partial class SymbolExtractor
         var symbols = new List<SymbolRecord>();
         var elementStack = new Stack<string>();
         var targetStack = new Stack<int>();
-
-        var settings = new XmlReaderSettings
-        {
-            DtdProcessing = DtdProcessing.Ignore,
-            IgnoreComments = true,
-            IgnoreProcessingInstructions = true,
-            XmlResolver = null,
-        };
+        var elementCount = 0;
 
         try
         {
-            using var reader = XmlReader.Create(new StringReader(content), settings);
+            using var reader = XmlReader.Create(new StringReader(content), CreateExtractionXmlReaderSettings());
             while (reader.Read())
             {
                 if (reader.NodeType == XmlNodeType.Element)
                 {
+                    elementCount++;
+                    if (elementCount > XmlExtractionMaxElements || reader.Depth + 1 > XmlExtractionMaxDepth)
+                        return symbols;
+
                     var elementName = reader.LocalName;
                     var lineNumber = reader is IXmlLineInfo lineInfo && lineInfo.HasLineInfo()
                         ? lineInfo.LineNumber
@@ -101,6 +103,71 @@ public static partial class SymbolExtractor
 
         return symbols;
     }
+
+    internal static bool TryGetXmlStructureIssue(string content, out XmlStructureIssue issue)
+    {
+        issue = default;
+        var elementCount = 0;
+
+        try
+        {
+            using var reader = XmlReader.Create(new StringReader(content), CreateExtractionXmlReaderSettings());
+            while (reader.Read())
+            {
+                if (reader.NodeType != XmlNodeType.Element)
+                    continue;
+
+                elementCount++;
+                var lineNumber = reader is IXmlLineInfo lineInfo && lineInfo.HasLineInfo()
+                    ? lineInfo.LineNumber
+                    : 1;
+
+                if (reader.Depth + 1 > XmlExtractionMaxDepth)
+                {
+                    issue = new XmlStructureIssue(
+                        "xml_structure_budget_exceeded",
+                        lineNumber,
+                        $"XML element depth exceeds the extraction limit of {XmlExtractionMaxDepth}; symbol extraction is capped.");
+                    return true;
+                }
+
+                if (elementCount > XmlExtractionMaxElements)
+                {
+                    issue = new XmlStructureIssue(
+                        "xml_structure_budget_exceeded",
+                        lineNumber,
+                        $"XML element count exceeds the extraction limit of {XmlExtractionMaxElements}; symbol extraction is capped.");
+                    return true;
+                }
+            }
+        }
+        catch (XmlException ex) when (IsDtdProhibitedException(ex))
+        {
+            issue = new XmlStructureIssue(
+                "xml_dtd_prohibited",
+                Math.Max(1, ex.LineNumber),
+                "XML DTD declarations are prohibited during extraction.");
+            return true;
+        }
+        catch (XmlException)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static XmlReaderSettings CreateExtractionXmlReaderSettings() => new()
+    {
+        DtdProcessing = DtdProcessing.Prohibit,
+        IgnoreComments = true,
+        IgnoreProcessingInstructions = true,
+        XmlResolver = null,
+    };
+
+    private static bool IsDtdProhibitedException(XmlException ex) =>
+        ex.Message.Contains("DTD", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("DOCTYPE", StringComparison.OrdinalIgnoreCase);
 
     private static int? TryAddMsBuildElementSymbol(
         long fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
@@ -9,10 +9,15 @@ public static partial class SymbolExtractor
     internal const int DockerfileJsonFormMaxDepth = 8;
     internal const int DockerfileJsonFormMaxItems = 128;
     internal const int DockerfileJsonFormMaxStringLength = 4096;
-    private static readonly JsonDocumentOptions DockerfileJsonFormDocumentOptions = new()
-    {
-        MaxDepth = DockerfileJsonFormMaxDepth,
-    };
+
+    internal static JsonDocument ParseDockerfileJsonFormPayload(string payload)
+        => JsonDocument.Parse(payload, CreateDockerfileJsonFormDocumentOptions());
+
+    internal static JsonDocumentOptions CreateDockerfileJsonFormDocumentOptions()
+        => new()
+        {
+            MaxDepth = DockerfileJsonFormMaxDepth,
+        };
 
     private static void AddDockerfileAdditionalEnvSymbols(
         long fileId,
@@ -311,7 +316,7 @@ public static partial class SymbolExtractor
     {
         try
         {
-            using var document = JsonDocument.Parse(body, DockerfileJsonFormDocumentOptions);
+            using var document = ParseDockerfileJsonFormPayload(body);
             if (document.RootElement.ValueKind != JsonValueKind.Array)
                 return;
 
@@ -416,7 +421,7 @@ public static partial class SymbolExtractor
 
         try
         {
-            using var document = JsonDocument.Parse(body, DockerfileJsonFormDocumentOptions);
+            using var document = ParseDockerfileJsonFormPayload(body);
             if (document.RootElement.ValueKind != JsonValueKind.Array)
                 return;
 
@@ -570,7 +575,7 @@ public static partial class SymbolExtractor
 
         try
         {
-            using var document = JsonDocument.Parse(body[jsonStart..], DockerfileJsonFormDocumentOptions);
+            using var document = ParseDockerfileJsonFormPayload(body[jsonStart..]);
             if (document.RootElement.ValueKind != JsonValueKind.Array)
                 return null;
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -684,6 +684,9 @@ public static partial class SymbolExtractor
             return [];
 
         var rawText = string.Join('\n', lines);
+        if (TryGetXmlStructureIssue(rawText, out _))
+            return [];
+
         var lineStarts = new int[lines.Length];
         var lineCursor = 0;
         for (var i = 0; i < lines.Length; i++)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using CodeIndex.Models;
@@ -7,12 +8,32 @@ namespace CodeIndex.Indexer;
 
 public static partial class SymbolExtractor
 {
+    internal const int StructuredDataMaxJsonDepth = 64;
+    internal const int StructuredDataMaxYamlDepth = 64;
+    internal const int StructuredDataMaxSymbols = 4096;
+    internal const int StructuredDataMaxPathLength = 1024;
+    internal const int StructuredDataMaxSignatureLength = 512;
+
+    private static readonly JsonDocumentOptions StructuredJsonDocumentOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip,
+        MaxDepth = StructuredDataMaxJsonDepth,
+    };
+
+    private static readonly JsonReaderOptions StructuredJsonReaderOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip,
+        MaxDepth = StructuredDataMaxJsonDepth,
+    };
+
     private static readonly Regex JsonFallbackPropertyRegex = new(
         @"^\s*""(?<name>(?:\\.|[^""\\])+)""\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly Regex YamlMappingKeyRegex = new(
-        @"^(?<indent>[ \t]*)(?:-\s*)?(?:""(?<double>(?:[^""]|"""")+)""|'(?<single>(?:[^']|'')+)'|(?<plain>[A-Za-z0-9_.-][A-Za-z0-9_. -]*))\s*:\s*(?<value>.*)$",
+        @"^(?<indent>[ ]*)(?:-\s*)?(?:""(?<double>(?:[^""]|"""")+)""|'(?<single>(?:[^']|'')+)'|(?<plain>[A-Za-z0-9_.-][A-Za-z0-9_. -]*))\s*:\s*(?<value>.*)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private readonly record struct YamlPathFrame(int Indent, string Path);
@@ -25,14 +46,23 @@ public static partial class SymbolExtractor
 
         try
         {
-            using var document = JsonDocument.Parse(content, new JsonDocumentOptions
-            {
-                AllowTrailingCommas = true,
-                CommentHandling = JsonCommentHandling.Skip,
-            });
+            using var document = JsonDocument.Parse(content, StructuredJsonDocumentOptions);
+            var propertyLines = BuildJsonPropertyLineQueues(content, lineStarts);
 
             if (document.RootElement.ValueKind == JsonValueKind.Object)
-                ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, document.RootElement, parentPath: null, ref searchOffset, symbols);
+            {
+                ExtractJsonObjectSymbols(
+                    fileId,
+                    content,
+                    lines,
+                    lineStarts,
+                    document.RootElement,
+                    parentPath: null,
+                    ref searchOffset,
+                    symbols,
+                    propertyLines);
+            }
+
             return symbols;
         }
         catch (JsonException)
@@ -49,31 +79,43 @@ public static partial class SymbolExtractor
         JsonElement element,
         string? parentPath,
         ref int searchOffset,
-        List<SymbolRecord> symbols)
+        List<SymbolRecord> symbols,
+        Dictionary<string, Queue<int>> propertyLines)
     {
         foreach (var property in element.EnumerateObject())
         {
+            if (symbols.Count >= StructuredDataMaxSymbols)
+                return;
+
             var name = string.IsNullOrEmpty(parentPath)
                 ? property.Name
                 : parentPath + "." + property.Name;
-            var propertyOffset = FindJsonPropertyOffset(content, property.Name, ref searchOffset);
-            var line = FindLineNumberForOffset(lineStarts, propertyOffset);
+            if (name.Length > StructuredDataMaxPathLength)
+                continue;
+
+            var line = TryDequeueJsonPropertyLine(propertyLines, property.Name, out var mappedLine)
+                ? mappedLine
+                : FindLineNumberForOffset(lineStarts, FindJsonPropertyOffset(content, property.Name, ref searchOffset));
             var kind = property.Value.ValueKind is JsonValueKind.Object or JsonValueKind.Array
                 ? "namespace"
                 : "property";
 
-            symbols.Add(CreateStructuredDataSymbol(fileId, kind, name, line, lines, parentPath));
+            if (!TryAddStructuredDataSymbol(fileId, kind, name, line, lines, parentPath, symbols))
+                return;
 
             if (property.Value.ValueKind == JsonValueKind.Object)
             {
-                ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, property.Value, name, ref searchOffset, symbols);
+                ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, property.Value, name, ref searchOffset, symbols, propertyLines);
             }
             else if (property.Value.ValueKind == JsonValueKind.Array)
             {
                 foreach (var item in property.Value.EnumerateArray())
                 {
+                    if (symbols.Count >= StructuredDataMaxSymbols)
+                        return;
+
                     if (item.ValueKind == JsonValueKind.Object)
-                        ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, item, name, ref searchOffset, symbols);
+                        ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, item, name, ref searchOffset, symbols, propertyLines);
                 }
             }
         }
@@ -84,6 +126,9 @@ public static partial class SymbolExtractor
         var symbols = new List<SymbolRecord>();
         for (var i = 0; i < lines.Length; i++)
         {
+            if (symbols.Count >= StructuredDataMaxSymbols)
+                break;
+
             var match = JsonFallbackPropertyRegex.Match(lines[i]);
             if (!match.Success)
                 continue;
@@ -92,7 +137,10 @@ public static partial class SymbolExtractor
             if (string.IsNullOrWhiteSpace(name))
                 continue;
 
-            symbols.Add(CreateStructuredDataSymbol(fileId, "property", name, i + 1, lines, parentPath: null));
+            if (name.Length > StructuredDataMaxPathLength)
+                continue;
+
+            _ = TryAddStructuredDataSymbol(fileId, "property", name, i + 1, lines, parentPath: null, symbols);
         }
 
         return symbols;
@@ -106,6 +154,9 @@ public static partial class SymbolExtractor
 
         for (var i = 0; i < lines.Length; i++)
         {
+            if (symbols.Count >= StructuredDataMaxSymbols)
+                break;
+
             var line = lines[i];
             if (string.IsNullOrWhiteSpace(line))
                 continue;
@@ -135,11 +186,15 @@ public static partial class SymbolExtractor
 
             var parentPath = stack.Count == 0 ? null : stack[^1].Path;
             var path = string.IsNullOrEmpty(parentPath) ? key : parentPath + "." + key;
+            if (stack.Count >= StructuredDataMaxYamlDepth || path.Length > StructuredDataMaxPathLength)
+                continue;
+
             var value = StripYamlInlineComment(match.Groups["value"].Value).Trim();
             var isContainer = value.Length == 0 || value is "|" or ">" or "|-" or ">-" or "|+" or ">+";
             var kind = isContainer ? "namespace" : "property";
 
-            symbols.Add(CreateStructuredDataSymbol(fileId, kind, path, i + 1, lines, parentPath));
+            if (!TryAddStructuredDataSymbol(fileId, kind, path, i + 1, lines, parentPath, symbols))
+                break;
 
             if (isContainer)
             {
@@ -150,6 +205,22 @@ public static partial class SymbolExtractor
         }
 
         return symbols;
+    }
+
+    private static bool TryAddStructuredDataSymbol(
+        long fileId,
+        string kind,
+        string name,
+        int line,
+        string[] lines,
+        string? parentPath,
+        List<SymbolRecord> symbols)
+    {
+        if (symbols.Count >= StructuredDataMaxSymbols)
+            return false;
+
+        symbols.Add(CreateStructuredDataSymbol(fileId, kind, name, line, lines, parentPath));
+        return true;
     }
 
     private static SymbolRecord CreateStructuredDataSymbol(
@@ -169,11 +240,59 @@ public static partial class SymbolExtractor
             Line = line,
             StartLine = line,
             EndLine = line,
-            Signature = lines.Length == 0 ? null : lines[signatureIndex].Trim(),
+            Signature = lines.Length == 0 ? null : LimitStructuredDataSignature(lines[signatureIndex].Trim()),
             ContainerKind = parentPath == null ? null : "namespace",
             ContainerName = parentPath,
             ContainerQualifiedName = parentPath,
         };
+    }
+
+    private static string LimitStructuredDataSignature(string signature) =>
+        signature.Length <= StructuredDataMaxSignatureLength
+            ? signature
+            : signature[..StructuredDataMaxSignatureLength];
+
+    private static Dictionary<string, Queue<int>> BuildJsonPropertyLineQueues(string content, int[] lineStarts)
+    {
+        var propertyLines = new Dictionary<string, Queue<int>>(StringComparer.Ordinal);
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var reader = new Utf8JsonReader(bytes, StructuredJsonReaderOptions);
+        while (reader.Read())
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                continue;
+
+            var name = reader.GetString();
+            if (string.IsNullOrEmpty(name))
+                continue;
+
+            var byteOffset = (int)Math.Min(reader.TokenStartIndex, bytes.Length);
+            var charOffset = Encoding.UTF8.GetCharCount(bytes.AsSpan(0, byteOffset));
+            if (!propertyLines.TryGetValue(name, out var lines))
+            {
+                lines = new Queue<int>();
+                propertyLines.Add(name, lines);
+            }
+
+            lines.Enqueue(FindLineNumberForOffset(lineStarts, charOffset));
+        }
+
+        return propertyLines;
+    }
+
+    private static bool TryDequeueJsonPropertyLine(
+        Dictionary<string, Queue<int>> propertyLines,
+        string propertyName,
+        out int line)
+    {
+        if (propertyLines.TryGetValue(propertyName, out var lines) && lines.Count > 0)
+        {
+            line = lines.Dequeue();
+            return true;
+        }
+
+        line = 0;
+        return false;
     }
 
     private static int FindJsonPropertyOffset(string content, string propertyName, ref int searchOffset)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
@@ -13,6 +13,7 @@ public static partial class SymbolExtractor
     internal const int StructuredDataMaxSymbols = 4096;
     internal const int StructuredDataMaxPathLength = 1024;
     internal const int StructuredDataMaxSignatureLength = 512;
+    internal const int StructuredDataMaxJsonParseChars = 1_000_000;
 
     private static readonly JsonDocumentOptions StructuredJsonDocumentOptions = new()
     {
@@ -40,6 +41,12 @@ public static partial class SymbolExtractor
 
     private static List<SymbolRecord> ExtractJsonSymbols(long fileId, string content, string[] lines)
     {
+        // JsonDocument.Parse builds a full DOM, so large JSON files use the capped line fallback.
+        if (content.Length > StructuredDataMaxJsonParseChars)
+        {
+            return ExtractJsonFallbackSymbols(fileId, lines);
+        }
+
         var symbols = new List<SymbolRecord>();
         var lineStarts = BuildLineStarts(lines);
         var searchOffset = 0;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
@@ -97,12 +97,16 @@ public static partial class SymbolExtractor
             var name = string.IsNullOrEmpty(parentPath)
                 ? property.Name
                 : parentPath + "." + property.Name;
-            if (name.Length > StructuredDataMaxPathLength)
-                continue;
-
             var line = TryDequeueJsonPropertyLine(propertyLines, property.Name, out var mappedLine)
                 ? mappedLine
                 : FindLineNumberForOffset(lineStarts, FindJsonPropertyOffset(content, property.Name, ref searchOffset));
+
+            if (name.Length > StructuredDataMaxPathLength)
+            {
+                DrainJsonPropertyLines(property.Value, propertyLines);
+                continue;
+            }
+
             var kind = property.Value.ValueKind is JsonValueKind.Object or JsonValueKind.Array
                 ? "namespace"
                 : "property";
@@ -125,6 +129,23 @@ public static partial class SymbolExtractor
                         ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, item, name, ref searchOffset, symbols, propertyLines);
                 }
             }
+        }
+    }
+
+    private static void DrainJsonPropertyLines(JsonElement element, Dictionary<string, Queue<int>> propertyLines)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                _ = TryDequeueJsonPropertyLine(propertyLines, property.Name, out _);
+                DrainJsonPropertyLines(property.Value, propertyLines);
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+                DrainJsonPropertyLines(item, propertyLines);
         }
     }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
@@ -54,7 +54,7 @@ public static partial class SymbolExtractor
         try
         {
             using var document = JsonDocument.Parse(content, StructuredJsonDocumentOptions);
-            var propertyLines = BuildJsonPropertyLineQueues(content, lineStarts);
+            var propertyLines = BuildJsonPropertyLineQueues(content);
 
             if (document.RootElement.ValueKind == JsonValueKind.Object)
             {
@@ -259,10 +259,11 @@ public static partial class SymbolExtractor
             ? signature
             : signature[..StructuredDataMaxSignatureLength];
 
-    private static Dictionary<string, Queue<int>> BuildJsonPropertyLineQueues(string content, int[] lineStarts)
+    private static Dictionary<string, Queue<int>> BuildJsonPropertyLineQueues(string content)
     {
         var propertyLines = new Dictionary<string, Queue<int>>(StringComparer.Ordinal);
         var bytes = Encoding.UTF8.GetBytes(content);
+        var byteLineStarts = BuildUtf8LineStarts(bytes);
         var reader = new Utf8JsonReader(bytes, StructuredJsonReaderOptions);
         while (reader.Read())
         {
@@ -273,18 +274,29 @@ public static partial class SymbolExtractor
             if (string.IsNullOrEmpty(name))
                 continue;
 
-            var byteOffset = (int)Math.Min(reader.TokenStartIndex, bytes.Length);
-            var charOffset = Encoding.UTF8.GetCharCount(bytes.AsSpan(0, byteOffset));
+            var byteOffset = (int)Math.Min(reader.TokenStartIndex, (long)bytes.Length);
             if (!propertyLines.TryGetValue(name, out var lines))
             {
                 lines = new Queue<int>();
                 propertyLines.Add(name, lines);
             }
 
-            lines.Enqueue(FindLineNumberForOffset(lineStarts, charOffset));
+            lines.Enqueue(FindLineNumberForOffset(byteLineStarts, byteOffset));
         }
 
         return propertyLines;
+    }
+
+    private static int[] BuildUtf8LineStarts(byte[] bytes)
+    {
+        var starts = new List<int> { 0 };
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            if (bytes[i] == (byte)'\n')
+                starts.Add(i + 1);
+        }
+
+        return starts.ToArray();
     }
 
     private static bool TryDequeueJsonPropertyLine(

--- a/src/CodeIndex/Lsp/LspServer.cs
+++ b/src/CodeIndex/Lsp/LspServer.cs
@@ -160,6 +160,11 @@ internal sealed class LspServer : IDisposable
 
     internal JsonObject? HandleMessage(string payload)
     {
+        // Run() normally obtains payloads through TryReadMessage, but internal callers can bypass
+        // that frame reader; keep JsonDocument.Parse under the same byte budget either way.
+        if (payload.Length > MaxLspFrameBytes || Encoding.UTF8.GetByteCount(payload) > MaxLspFrameBytes)
+            return Error(null, -32700, "Parse error");
+
         JsonDocument document;
         try
         {

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -549,6 +549,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             buffer.Write(scratch, 0, read);
         }
 
+        // ToArray/GetString materializes only after Content-Length and streaming reads have both
+        // enforced _maxRequestBodyBytes.
         return (context.Request.ContentEncoding ?? Encoding.UTF8).GetString(buffer.ToArray());
     }
 
@@ -1184,6 +1186,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     {
         try
         {
+            // HandleContextAsync calls this only with a body returned by TryReadRequestBodyAsync,
+            // so the full JSON parse is bounded by the HTTP request-body byte limit.
             using var doc = JsonDocument.Parse(body, JsonFrameParser.CreateDocumentOptions(McpServer.MaxJsonDepth));
             if (!doc.RootElement.TryGetProperty("id", out var id))
                 return null;

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -5719,6 +5719,21 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void ValidateContent_DockerfileJsonFormsBeyondParserDepthLimit_EmitValidationIssue_Issue3713()
+    {
+        var depth = SymbolExtractor.DockerfileJsonFormMaxDepth + 1;
+        var content = "VOLUME " + new string('[', depth) + "\"/too-deep\"" + new string(']', depth) + "\n";
+        var rawBytes = Encoding.UTF8.GetBytes(content);
+
+        var issues = FileIndexer.ValidateContent("Dockerfile", rawBytes, content, "dockerfile");
+
+        var issue = Assert.Single(issues, i => i.Kind == "dockerfile_json_form_invalid");
+        Assert.Equal(1, issue.Line);
+        Assert.Equal(FileIssue.SeverityWarning, issue.Severity);
+        Assert.Contains("VOLUME", issue.Message);
+    }
+
+    [Fact]
     public void ValidateContent_MsBuildXmlBudgetExceeded_EmitsValidationIssue_Issue3801()
     {
         var depth = SymbolExtractor.XmlExtractionMaxDepth + 2;

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -5718,6 +5718,39 @@ public class FileIndexerTests
         Assert.Contains(instruction, issue.Message);
     }
 
+    [Fact]
+    public void ValidateContent_MsBuildXmlBudgetExceeded_EmitsValidationIssue_Issue3801()
+    {
+        var depth = SymbolExtractor.XmlExtractionMaxDepth + 2;
+        var content = "<Project>" + string.Concat(Enumerable.Repeat("<PropertyGroup>", depth))
+            + string.Concat(Enumerable.Repeat("</PropertyGroup>", depth)) + "</Project>";
+        var rawBytes = Encoding.UTF8.GetBytes(content);
+
+        var issues = FileIndexer.ValidateContent("App.csproj", rawBytes, content, "msbuild");
+
+        var issue = Assert.Single(issues, i => i.Kind == "xml_structure_budget_exceeded");
+        Assert.Equal(FileIssue.SeverityWarning, issue.Severity);
+        Assert.Contains("depth", issue.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateContent_XmlDtd_EmitsValidationIssue_Issue3801()
+    {
+        const string content = """
+            <!DOCTYPE root [
+              <!ENTITY injected "value">
+            ]>
+            <root />
+            """;
+        var rawBytes = Encoding.UTF8.GetBytes(content);
+
+        var issues = FileIndexer.ValidateContent("app.config", rawBytes, content, "xml");
+
+        var issue = Assert.Single(issues, i => i.Kind == "xml_dtd_prohibited");
+        Assert.Equal(FileIssue.SeverityWarning, issue.Severity);
+        Assert.Contains("DTD", issue.Message, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("VOLUME")]
     [InlineData("COPY")]

--- a/tests/CodeIndex.Tests/LspServerTests.cs
+++ b/tests/CodeIndex.Tests/LspServerTests.cs
@@ -391,6 +391,29 @@ public class LspServerTests
     }
 
     [Fact]
+    public void HandleMessage_OverMaxPayload_ReturnsParseError_Issue3657()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_lsp_oversized_payload");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            using var db = new DbContext(dbPath);
+            using var server = new LspServer(new DbReader(db), "1.2.3", ProgramRunner.CreateDefaultJsonOptions(), projectRoot);
+            var request = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"" + new string('m', LspServer.MaxLspFrameBytes) + "\"}";
+
+            var response = server.HandleMessage(request);
+
+            Assert.NotNull(response);
+            Assert.Equal(-32700, response!["error"]!["code"]!.GetValue<int>());
+            Assert.Null(response["id"]);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void HandleMessage_UnknownMethod_TruncatesMethodName_Issue3205()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_lsp_unknown_method_3205");

--- a/tests/CodeIndex.Tests/SymbolExtractorConfiguredPatternTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorConfiguredPatternTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using CodeIndex.Indexer;
 using CodeIndex.Indexer.Extensibility;
 
@@ -109,6 +110,37 @@ public partial class SymbolExtractorTests
 
                 Assert.Contains("Skipped pattern config", stderr, StringComparison.Ordinal);
                 Assert.Contains("invalid regex", stderr, StringComparison.Ordinal);
+            }
+            finally
+            {
+                ExtractorPluginRegistry.ResetForTests();
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void Extract_ConfiguredPatternYaml_UsesSharedBoundedRegexFactory_Issue3721()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_patterns_bounded_{Guid.NewGuid():N}");
+            try
+            {
+                WritePatternConfig(
+                    tempDir,
+                    "language: \"toydsl\"\nextensions:\n  - extension: \".toy\"\npatterns:\n  - kind: \"class\"\n    regex: \"^entity (?<name>\\\\w+)\"\n");
+                ExtractorPluginRegistry.ReloadForTests();
+                ExtractorPluginRegistry.LoadPatternConfigsForProjectRoot(tempDir);
+
+                Assert.True(ExtractorPluginRegistry.TryGetSymbolExtractor("toydsl", out var extractor));
+                var configured = Assert.IsType<ConfiguredSymbolExtractor>(extractor);
+                var pattern = Assert.Single(configured.PatternsForTests);
+
+                Assert.IsType<BoundedRegex>(pattern.Regex);
+                Assert.Equal(ExtractorPluginRegistry.PatternRegexTimeout, pattern.Regex.MatchTimeout);
+                Assert.True((pattern.Regex.Options & RegexOptions.CultureInvariant) != 0);
             }
             finally
             {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -16067,6 +16067,49 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_MsBuild_CapsBroadXmlElementTables_Issue3801()
+    {
+        var items = Enumerable.Range(0, SymbolExtractor.XmlExtractionMaxElements + 8)
+            .Select(i => $"  <PackageReference Include=\"Pkg{i}\" />");
+        var content = "<Project>\n<ItemGroup>\n" + string.Join('\n', items) + "\n</ItemGroup>\n</Project>\n";
+
+        var symbols = SymbolExtractor.Extract(1, "msbuild", content);
+
+        Assert.DoesNotContain(symbols, s => s.Name == "Pkg" + (SymbolExtractor.XmlExtractionMaxElements + 7));
+        Assert.True(symbols.Count <= SymbolExtractor.XmlExtractionMaxElements);
+    }
+
+    [Fact]
+    public void Extract_MsBuild_CapsDeepXmlElementTrees_Issue3801()
+    {
+        var depth = SymbolExtractor.XmlExtractionMaxDepth + 4;
+        var content = "<Project>" + string.Concat(Enumerable.Repeat("<PropertyGroup>", depth))
+            + "<TargetFramework>net8.0</TargetFramework>"
+            + string.Concat(Enumerable.Repeat("</PropertyGroup>", depth)) + "</Project>";
+
+        var exception = Record.Exception(() => SymbolExtractor.Extract(1, "msbuild", content));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Extract_MsBuild_ProhibitsDtdDeclarations_Issue3801()
+    {
+        const string content = """
+            <!DOCTYPE Project [
+              <!ENTITY injected "value">
+            ]>
+            <Project>
+              <Target Name="Build" />
+            </Project>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "msbuild", content);
+
+        Assert.Empty(symbols);
+    }
+
+    [Fact]
     public void GetContractVersion_DockerfileSpecificKinds_UsesDedicatedVersion()
     {
         Assert.Equal(SymbolExtractor.DockerfileContractVersion, SymbolExtractor.GetContractVersion("dockerfile"));
@@ -18333,6 +18376,41 @@ public partial class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "Sample.MainWindow");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "SaveButton");
         Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "StatusText");
+    }
+
+    [Fact]
+    public void Extract_Xml_CapsDeepXamlElementTrees_Issue3801()
+    {
+        var depth = SymbolExtractor.XmlExtractionMaxDepth + 4;
+        var content = "<ContentPage x:Class=\"Sample.MainWindow\" "
+            + "xmlns=\"http://schemas.microsoft.com/dotnet/2021/maui\" "
+            + "xmlns:x=\"http://schemas.microsoft.com/winfx/2009/xaml\">"
+            + string.Concat(Enumerable.Repeat("<Grid x:Name=\"NestedGrid\">", depth))
+            + string.Concat(Enumerable.Repeat("</Grid>", depth))
+            + "</ContentPage>";
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Empty(symbols);
+    }
+
+    [Fact]
+    public void Extract_Xml_ProhibitsDtdDeclarations_Issue3801()
+    {
+        const string content = """
+            <!DOCTYPE ContentPage [
+              <!ENTITY injected "value">
+            ]>
+            <ContentPage x:Class="Sample.MainWindow"
+                    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+                <Button x:Name="SaveButton" />
+            </ContentPage>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Empty(symbols);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -569,6 +569,46 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Json_UsesReaderOffsetsForEscapedDuplicateKeys_Issue3808()
+    {
+        const string content = """
+            {
+              "key": 1,
+              "\u006bey": 2
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "json", content)
+            .Where(symbol => symbol.Name == "key")
+            .ToList();
+
+        Assert.Equal([2, 3], symbols.Select(symbol => symbol.Line).ToArray());
+    }
+
+    [Fact]
+    public void Extract_Json_CapsBroadObjects_Issue3808()
+    {
+        var properties = Enumerable.Range(0, SymbolExtractor.StructuredDataMaxSymbols + 8)
+            .Select(i => $"\"p{i}\": {i}");
+        var content = "{" + string.Join(", ", properties) + "}";
+
+        var symbols = SymbolExtractor.Extract(1, "json", content);
+
+        Assert.Equal(SymbolExtractor.StructuredDataMaxSymbols, symbols.Count);
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "p" + (SymbolExtractor.StructuredDataMaxSymbols + 7));
+    }
+
+    [Fact]
+    public void Extract_Json_CapsStructuredSignatureLength_Issue3808()
+    {
+        var content = "{\"key\":\"" + new string('x', SymbolExtractor.StructuredDataMaxSignatureLength + 80) + "\"}";
+
+        var symbol = Assert.Single(SymbolExtractor.Extract(1, "json", content));
+
+        Assert.True(symbol.Signature!.Length <= SymbolExtractor.StructuredDataMaxSignatureLength);
+    }
+
+    [Fact]
     public void Extract_Yaml_IndexesIndentedConfigurationKeyPaths()
     {
         const string content = """
@@ -597,6 +637,29 @@ public partial class SymbolExtractorTests
         Assert.Contains(symbols, symbol => symbol.Kind == "property" && symbol.Name == "jobs.build.runs-on");
         Assert.Contains(symbols, symbol => symbol.Kind == "property" && symbol.Name == "jobs.build.steps.uses");
         Assert.DoesNotContain(symbols, symbol => symbol.Name.Contains("jobs.fake", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_Yaml_CapsBroadMappings_Issue3808()
+    {
+        var content = string.Join('\n', Enumerable.Range(0, SymbolExtractor.StructuredDataMaxSymbols + 8)
+            .Select(i => $"key{i}: value"));
+
+        var symbols = SymbolExtractor.Extract(1, "yaml", content);
+
+        Assert.Equal(SymbolExtractor.StructuredDataMaxSymbols, symbols.Count);
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "key" + (SymbolExtractor.StructuredDataMaxSymbols + 7));
+    }
+
+    [Fact]
+    public void Extract_Yaml_DoesNotTreatTabIndentationAsStructure_Issue3808()
+    {
+        const string content = "root:\n\tbad: nope\n  good: yes\n";
+
+        var symbols = SymbolExtractor.Extract(1, "yaml", content);
+
+        Assert.Contains(symbols, symbol => symbol.Name == "root.good");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name.Contains("bad", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -609,6 +609,27 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Json_UsesFallbackBeyondParseSizeGuard_Issue3657()
+    {
+        var padding = string.Join(
+            '\n',
+            Enumerable.Repeat(new string(' ', 1024), (SymbolExtractor.StructuredDataMaxJsonParseChars / 1024) + 1));
+        var content = $$"""
+            {
+              "root": {
+                "leaf": "ok"
+              }
+              {{padding}}
+            }
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "json", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "property" && symbol.Name == "leaf");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "root.leaf");
+    }
+
+    [Fact]
     public void Extract_Yaml_IndexesIndentedConfigurationKeyPaths()
     {
         const string content = """

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -599,6 +599,32 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Json_CapsDeepObjects_Issue3808()
+    {
+        var depth = SymbolExtractor.StructuredDataMaxJsonDepth + 4;
+        var builder = new StringBuilder();
+        builder.AppendLine("{");
+        for (var i = 0; i < depth; i++)
+        {
+            builder.Append(' ', (i + 1) * 2)
+                .Append('"')
+                .Append('n')
+                .Append(i)
+                .AppendLine("\": {");
+        }
+
+        builder.Append(' ', (depth + 1) * 2).AppendLine("\"leaf\": 0");
+        for (var i = depth; i >= 0; i--)
+            builder.Append(' ', i * 2).AppendLine("}");
+
+        var symbols = SymbolExtractor.Extract(1, "json", builder.ToString());
+
+        Assert.Contains(symbols, symbol => symbol.Name == "n0");
+        Assert.DoesNotContain(symbols, symbol => symbol.Name == "n0.n1");
+        Assert.True(symbols.Count <= SymbolExtractor.StructuredDataMaxSymbols);
+    }
+
+    [Fact]
     public void Extract_Json_CapsStructuredSignatureLength_Issue3808()
     {
         var content = "{\"key\":\"" + new string('x', SymbolExtractor.StructuredDataMaxSignatureLength + 80) + "\"}";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -625,6 +625,26 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_Json_SkippedOverlongSubtreesDoNotStealDuplicateKeyLines_Issue3808()
+    {
+        var longName = new string('a', SymbolExtractor.StructuredDataMaxPathLength + 1);
+        var content = $$"""
+            {
+              "{{longName}}": {
+                "dup": "skipped"
+              },
+              "dup": "root"
+            }
+            """;
+
+        var symbol = Assert.Single(
+            SymbolExtractor.Extract(1, "json", content),
+            candidate => candidate.Name == "dup");
+
+        Assert.Equal(5, symbol.Line);
+    }
+
+    [Fact]
     public void Extract_Json_CapsStructuredSignatureLength_Issue3808()
     {
         var content = "{\"key\":\"" + new string('x', SymbolExtractor.StructuredDataMaxSignatureLength + 80) + "\"}";

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -47,6 +47,25 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void BuiltInSymbolRegexes_UseBoundedRegexInstances_Issue3661()
+    {
+        var regexes = EnumerateStaticRegexValues(
+            typeof(SymbolExtractor).Assembly.GetTypes().Where(IsSymbolRegexOwnerType))
+            .ToList();
+
+        Assert.NotEmpty(regexes);
+
+        var unboundedInstances = regexes
+            .Where(item => item.Regex is not BoundedRegex)
+            .Select(item => item.Path)
+            .ToList();
+
+        Assert.True(
+            unboundedInstances.Count == 0,
+            "Built-in symbol regex tables must use BoundedRegex instances: " + string.Join(", ", unboundedInstances));
+    }
+
+    [Fact]
     public void BuiltInSymbolRegexes_UseDefaultBacktrackingPolicy_Issue3479()
     {
         var regexes = EnumerateStaticRegexValues(


### PR DESCRIPTION
## Summary

- Harden JSON/YAML structured-data extraction with parse, depth, symbol, path, and signature bounds, including duplicate-key line mapping safeguards.
- Add XML/MSBuild/XAML structure-budget and DTD handling with validation warnings.
- Centralize configured extractor regex construction through the bounded regex factory and cover built-in regex tables.
- Centralize Dockerfile JSON-form parsing and guard LSP/direct materialization paths.
- Add unreleased changelog fragments for each fixed issue.

## Fixed Issues

Fixes #3808
Fixes #3801
Fixes #3713
Fixes #3721
Fixes #3661
Fixes #3657

## Related

Refs #3862

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore -m:1 -p:UseSharedCompilation=false -p:BuildInParallel=false /nr:false --filter "FullyQualifiedName~Issue3808"` passed: 7 tests.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --framework net8.0 --filter "FullyQualifiedName~Issue3808|FullyQualifiedName~Issue3801|FullyQualifiedName~Issue3721|FullyQualifiedName~Issue3713|FullyQualifiedName~Issue3657|FullyQualifiedName~Issue3661"` passed: 19 tests.
- `dotnet run --project tools/CodeIndex.Changelog -- check` passed.
- `git diff --check origin/main..HEAD` passed.
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index /Users/widthdom/Projects/mine/cdidx/CodeIndex6th` completed.
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` passed with index fresh.

## Review Notes

- No requested issue was excluded for prior work-start comments.
- `AGENT.md`, `CLAUDE.md`, and `AGENT_GUIDE.md` were not changed.
- Codex adversarial review found one #3808 JSON line-queue issue; it was fixed in this branch. The required rerun after that fix is pending because `codex exec` hit the account usage limit until 7:09 AM, so this PR is intentionally draft.
- Full `dotnet test CodeIndex.sln --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false /nr:false` was attempted earlier but the harness terminated it with exit code 143 before a failure summary.