### PR TITLE
Harden private logs, metrics, and temp fallbacks

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1435,9 +1435,11 @@ lifecycle breadcrumbs to a per-user daily log. The log path follows
 `XDG_CACHE_HOME/cdidx/logs/`, `XDG_RUNTIME_DIR/cdidx/logs/`, then the
 platform default: `%LOCALAPPDATA%\cdidx\logs\` on Windows,
 `~/Library/Logs/cdidx/` on macOS, or `~/.local/state/cdidx/logs/` on Linux.
-Each candidate is probed with a create/write/delete round trip before the
-logger commits to it, so read-only state/cache/runtime mounts fall through to
-the next candidate instead of losing the first log write. The file name is
+If every platform candidate is unavailable, the final temp fallback is a
+hashed per-user `cdidx-u.../logs` directory under the OS temp root. Each
+candidate is probed with a create/write/delete round trip before the logger
+commits to it, so read-only state/cache/runtime mounts fall through to the
+next candidate instead of losing the first log write. The file name is
 `stderr-YYYYMMDD.log`, timestamps inside the file are ISO-8601 UTC
 (`yyyy-MM-ddTHH:mm:ss.fffZ`) using invariant culture, and the logger keeps
 only the newest 30 daily files. `CDIDX_LOG_FORMAT` / `--log-format` switch
@@ -2121,7 +2123,7 @@ flowchart TD
 | `Error: --json is not available on this trimmed build.` | Manual/custom build reached a reflection-based `JsonSerializer` path that is not covered by source generation | Use the official `install.sh` release or NuGet/global-tool build, omit `--json`, use MCP, or add the missing DTO to `CliJsonSerializerContext` before publishing |
 | `cdidx status` shows `Files: 0` on a repo that clearly has files | Index DB never built, or pointing at the wrong `--db` | Run `cdidx <projectPath>` first; verify `.cdidx/codeindex.db` exists |
 | Every command shows `index fresh` but results are obviously stale | You indexed a different working copy | Re-run `cdidx . --commits HEAD` or `cdidx . --files <paths>` |
-| The host swallowed stderr and the user only knows "cdidx did not work" | The shell or launcher captured/discarded terminal stderr | Inspect the daily persistent stderr log in the per-user `cdidx/logs/` directory (`stderr-YYYYMMDD.log`); disable with `CDIDX_DISABLE_PERSISTENT_LOG=1` only when you intentionally do not want breadcrumbs |
+| The host swallowed stderr and the user only knows "cdidx did not work" | The shell or launcher captured/discarded terminal stderr | Run `cdidx status --log-path` and inspect the daily persistent stderr log (`stderr-YYYYMMDD.log`) in that resolved per-user directory; disable with `CDIDX_DISABLE_PERSISTENT_LOG=1` only when you intentionally do not want breadcrumbs |
 
 ### Why this matters
 
@@ -3596,9 +3598,11 @@ mock に頼らないリリース前検証として、`install.sh --reinstall-rea
 `XDG_RUNTIME_DIR/cdidx/logs/`、platform default の順に選ばれます。
 platform default は Windows では `%LOCALAPPDATA%\cdidx\logs\`、macOS では
 `~/Library/Logs/cdidx/`、Linux では `~/.local/state/cdidx/logs/` です。
-各 candidate は logger が採用する前に create/write/delete の往復で probe
-されるため、read-only な state/cache/runtime mount は最初の log write を
-失うのではなく次の candidate へ fall through します。ファイル名は
+platform candidate がすべて使えない場合、最後の temp fallback は OS temp root
+配下のユーザー別 hashed `cdidx-u.../logs` ディレクトリです。各 candidate は
+logger が採用する前に create/write/delete の往復で probe されるため、
+read-only な state/cache/runtime mount は最初の log write を失うのではなく
+次の candidate へ fall through します。ファイル名は
 `stderr-YYYYMMDD.log`、ファイル内 timestamp は invariant culture の
 ISO-8601 UTC（`yyyy-MM-ddTHH:mm:ss.fffZ`）で、logger は新しい 30 日次
 ファイルだけを保持します。`CDIDX_LOG_FORMAT` / `--log-format` は text と
@@ -3957,7 +3961,7 @@ flowchart TD
 | `Error: --json is not available on this trimmed build.` | 手動/custom build が source generation 未対応の reflection-based `JsonSerializer` 経路に到達した | 公式 `install.sh` release または NuGet グローバルツール版を使う、`--json` を外す、MCP を使う、または publish 前に不足 DTO を `CliJsonSerializerContext` へ追加する |
 | 明らかにファイルのあるリポジトリで `cdidx status` が `Files: 0` | インデックス DB を作っていない、あるいは別の `--db` を指している | 先に `cdidx <projectPath>` を実行。`.cdidx/codeindex.db` の存在を確認 |
 | 全コマンドが `index fresh` だが結果は明らかに古い | 別の作業コピーにインデックスを張っている | `cdidx . --commits HEAD` または `cdidx . --files <paths>` を再実行 |
-| ホストが stderr を握りつぶし、ユーザーには「cdidx がうまく動かない」だけが見える | シェルやランチャーが端末 stderr を回収または破棄している | ユーザーごとの `cdidx/logs/` 配下にある日次の永続 stderr ログ（`stderr-YYYYMMDD.log`）を確認する。意図的に痕跡を残したくないときだけ `CDIDX_DISABLE_PERSISTENT_LOG=1` で無効化する |
+| ホストが stderr を握りつぶし、ユーザーには「cdidx がうまく動かない」だけが見える | シェルやランチャーが端末 stderr を回収または破棄している | `cdidx status --log-path` を実行し、解決されたユーザー別ディレクトリの日次永続 stderr ログ（`stderr-YYYYMMDD.log`）を確認する。意図的に痕跡を残したくないときだけ `CDIDX_DISABLE_PERSISTENT_LOG=1` で無効化する |
 
 ### なぜこれが重要か
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -745,9 +745,11 @@ hosts still leave traces. Local development runs from the repository's
 `src/CodeIndex/bin/...` or `tests/.../bin/...` outputs are excluded by default.
 Default locations are `%LOCALAPPDATA%\cdidx\logs\` on Windows,
 `~/Library/Logs/cdidx/` on macOS, and `$XDG_STATE_HOME/cdidx/logs/` (or
-`~/.local/state/cdidx/logs/`) on Linux. Logs use per-process filenames,
-rotate daily, rotate again when a file reaches 50 MiB by default, and keep the
-newest 30 files. Set `CDIDX_GLOBAL_TOOL_LOG_MAX_BYTES` or
+`~/.local/state/cdidx/logs/`) on Linux. If none of those roots can be used,
+the final temp fallback is a hashed per-user `cdidx-u.../logs` directory under
+the OS temp root. Logs use per-process filenames, rotate daily, rotate again
+when a file reaches 50 MiB by default, and keep the newest 30 files. Set
+`CDIDX_GLOBAL_TOOL_LOG_MAX_BYTES` or
 `--log-max-size-mb` to tune the size cap up to 1024 MiB / 1 GiB. Set
 `CDIDX_DISABLE_PERSISTENT_LOG=1` to opt out. The opt-out toggle accepts `1`,
 `true`, `yes`, or `on` case-insensitively.
@@ -1713,7 +1715,7 @@ Persistent lifecycle logs are written to the first available directory in this o
 5. Windows: `%LOCALAPPDATA%\cdidx\logs`
 6. macOS: `~/Library/Logs/cdidx`
 7. Linux and other Unix-like systems without an XDG log directory: `~/.local/state/cdidx/logs`
-8. fallback: the OS local-app-data directory, then the temp directory under `cdidx/logs`
+8. fallback: the OS local-app-data directory, then a hashed per-user `cdidx-u.../logs` directory under the temp root
 
 Run `cdidx status --log-path` to print the active log directory without opening the index database. Add `--json` to receive `{"log_path":"..."}`. Set `CDIDX_DISABLE_PERSISTENT_LOG=1` to disable persistent lifecycle logs.
 
@@ -4270,7 +4272,7 @@ MCP のレスポンスサイズ上限は、環境変数 override で guard が�
 5. Windows: `%LOCALAPPDATA%\cdidx\logs`
 6. macOS: `~/Library/Logs/cdidx`
 7. XDG のログディレクトリがない Linux などの Unix 系: `~/.local/state/cdidx/logs`
-8. fallback: OS の local-app-data ディレクトリ、それも無い場合は temp 配下の `cdidx/logs`
+8. fallback: OS の local-app-data ディレクトリ、それも無い場合は temp 配下のユーザー別 hashed `cdidx-u.../logs` ディレクトリ
 
 有効なログディレクトリだけを確認したい場合は `cdidx status --log-path` を実行してください。このコマンドは index database を開きません。`--json` を付けると `{"log_path":"..."}` を返します。永続 lifecycle log を無効化するには `CDIDX_DISABLE_PERSISTENT_LOG=1` を設定します。
 

--- a/changelog.d/unreleased/3675.security.md
+++ b/changelog.d/unreleased/3675.security.md
@@ -1,0 +1,22 @@
+---
+category: security
+issues:
+  - 3675
+affected:
+  - USER_GUIDE.md
+  - DEVELOPER_GUIDE.md
+  - src/CodeIndex/Cli/DataDirectorySecurity.cs
+  - src/CodeIndex/Cli/GlobalToolLog.cs
+  - src/CodeIndex/Cli/UpdateChecker.cs
+  - tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
+  - tests/CodeIndex.Tests/GlobalToolLogTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Temp fallback paths for update checks and global logs are now user-scoped (#3675)** — when platform cache/log roots are unavailable, cdidx uses a hashed `cdidx-u...` temp root, creates and validates that scope root with private permissions, and avoids shared `/tmp/cdidx/...` locations.
+
+## 日本語
+
+- **更新チェックと global log の temp fallback path をユーザー単位にしました (#3675)** — platform の cache/log ルートが使えない場合、共有 `/tmp/cdidx/...` ではなく hashed `cdidx-u...` temp ルートを使い、その scope root を private 権限で作成・検証します。

--- a/changelog.d/unreleased/3686.security.md
+++ b/changelog.d/unreleased/3686.security.md
@@ -1,0 +1,18 @@
+---
+category: security
+issues:
+  - 3686
+affected:
+  - src/CodeIndex/Cli/MetricsSink.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - tests/CodeIndex.Tests/MetricsSinkTests.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+---
+
+## English
+
+- **Generated metrics and suggestion-state directories now use private permissions (#3686)** — metrics parent directories and suggestion store, lock, and archive directories are routed through the shared sensitive-directory helper so local diagnostic state is not left group/world-readable on Unix-like systems.
+
+## 日本語
+
+- **生成される metrics と suggestion state のディレクトリを private 権限にしました (#3686)** — metrics の親ディレクトリと suggestion store、lock、archive のディレクトリを共有の sensitive-directory helper に通し、Unix 系環境でローカル診断 state が group/world-readable のまま残らないようにしました。

--- a/changelog.d/unreleased/3775.security.md
+++ b/changelog.d/unreleased/3775.security.md
@@ -1,0 +1,18 @@
+---
+category: security
+issues:
+  - 3775
+affected:
+  - src/CodeIndex/Cli/DataDirectorySecurity.cs
+  - src/CodeIndex/Mcp/AuditLogSink.cs
+  - tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
+  - tests/CodeIndex.Tests/AuditLogSinkTests.cs
+---
+
+## English
+
+- **Sensitive temp and MCP audit directories are created with private POSIX permissions (#3775)** — sensitive directory helpers now request `0700` at creation time on Unix-like systems, and MCP audit logs create their parent directories through the shared private-directory path.
+
+## 日本語
+
+- **機微な一時ディレクトリと MCP 監査ディレクトリを POSIX の private 権限で作成するようにしました (#3775)** — 機微なディレクトリ helper は Unix 系環境で作成時に `0700` を指定し、MCP 監査ログの親ディレクトリも共有の private ディレクトリ経路を通します。

--- a/changelog.d/unreleased/3776.security.md
+++ b/changelog.d/unreleased/3776.security.md
@@ -1,0 +1,18 @@
+---
+category: security
+issues:
+  - 3776
+affected:
+  - src/CodeIndex/Cli/AtomicFileWriter.cs
+  - src/CodeIndex/Cli/PrivateLogFile.cs
+  - tests/CodeIndex.Tests/AtomicFileWriterTests.cs
+  - tests/CodeIndex.Tests/GlobalToolLogTests.cs
+---
+
+## English
+
+- **Atomic replacement temp names and durability diagnostics are hardened (#3776)** — atomic writes now use bounded `.cdidx-...tmp` names for long targets, and private log rotation reuses the post-replace parent-directory flush diagnostic that states the target has already been replaced.
+
+## 日本語
+
+- **atomic replace の一時名と durability 診断を堅牢化しました (#3776)** — atomic write は長い target に対しても固定長の `.cdidx-...tmp` 名を使い、private log rotation も「target はすでに置換済み」と明示する置換後 parent-directory flush 診断を共有します。

--- a/changelog.d/unreleased/3824.security.md
+++ b/changelog.d/unreleased/3824.security.md
@@ -1,0 +1,18 @@
+---
+category: security
+issues:
+  - 3824
+affected:
+  - src/CodeIndex/Cli/PrivateLogFile.cs
+  - src/CodeIndex/Cli/MetricsSink.cs
+  - tests/CodeIndex.Tests/GlobalToolLogTests.cs
+  - tests/CodeIndex.Tests/MetricsSinkTests.cs
+---
+
+## English
+
+- **Private log and metrics persistence is more defensive (#3824)** — private log files reject symlink/reparse targets, existing-log hardening is deterministic and reports cap skips, and metrics now rotates before an event would exceed its size cap while disabling itself after repeated write or rotation failures.
+
+## 日本語
+
+- **private log と metrics 永続化をより防御的にしました (#3824)** — private log file は symlink/reparse target を拒否し、既存 log hardening は deterministic に cap 超過を報告します。metrics は event 書き込み前に size cap 超過を判定して rotate し、write/rotation 失敗が連続した場合は自身を無効化します。

--- a/src/CodeIndex/Cli/AtomicFileWriter.cs
+++ b/src/CodeIndex/Cli/AtomicFileWriter.cs
@@ -7,6 +7,8 @@ namespace CodeIndex.Cli;
 
 internal static class AtomicFileWriter
 {
+    internal const int MaxTempFileNameChars = 120;
+    private const int MaxTempStemChars = 48;
     internal static Action<string>? FlushParentDirectoryForTesting { get; set; }
 
     public enum WriteProfile
@@ -86,7 +88,7 @@ internal static class AtomicFileWriter
 
             File.Move(ioTempPath, ioTargetPath, overwrite: true);
             moved = true;
-            FlushParentDirectory(path);
+            FlushParentDirectoryAfterReplace(path);
         }
         catch
         {
@@ -115,7 +117,7 @@ internal static class AtomicFileWriter
     private static Action<string>? ResolveProfileModeCallback(WriteProfile profile)
         => profile == WriteProfile.Sensitive ? DataDirectorySecurity.ApplyPrivateFileMode : null;
 
-    private static void FlushParentDirectory(string path)
+    internal static void FlushParentDirectoryAfterReplace(string path)
     {
         var directory = Path.GetDirectoryName(Path.GetFullPath(path));
         if (string.IsNullOrEmpty(directory))
@@ -153,16 +155,27 @@ internal static class AtomicFileWriter
     }
 
     private static IOException BuildDirectoryFlushException(string path, int errno)
-        => new($"Atomic replace completed for {ConsoleUi.FormatBoundedValue(path)}, but the parent directory could not be flushed to disk (errno {errno}).");
+        => new($"Atomic replace completed for {ConsoleUi.FormatBoundedValue(path)}; the target file was already replaced, but the parent directory could not be flushed to disk (errno {errno}).");
 
     private static IOException BuildDirectoryFlushException(string path, Exception inner)
-        => new($"Atomic replace completed for {ConsoleUi.FormatBoundedValue(path)}, but the parent directory could not be flushed to disk ({CommandErrorWriter.FormatSanitizedException(inner)}).", inner);
+        => new($"Atomic replace completed for {ConsoleUi.FormatBoundedValue(path)}; the target file was already replaced, but the parent directory could not be flushed to disk ({CommandErrorWriter.FormatSanitizedException(inner)}).", inner);
+
+    internal static string BuildTempPathForTesting(string path) => BuildTempPath(path);
 
     private static string BuildTempPath(string path)
     {
         var directory = Path.GetDirectoryName(path);
         var fileName = Path.GetFileName(path);
-        var tempFileName = $".{fileName}.{Guid.NewGuid():N}.tmp";
+        var stem = Path.GetFileNameWithoutExtension(fileName);
+        if (string.IsNullOrWhiteSpace(stem))
+            stem = "target";
+        if (stem.Length > MaxTempStemChars)
+            stem = stem[..MaxTempStemChars];
+
+        var tempFileName = $".cdidx-{stem}.{Guid.NewGuid():N}.tmp";
+        if (tempFileName.Length > MaxTempFileNameChars)
+            tempFileName = $".cdidx-{Guid.NewGuid():N}.tmp";
+
         return string.IsNullOrEmpty(directory)
             ? tempFileName
             : Path.Combine(directory, tempFileName);

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using CodeIndex.Indexer;
 
@@ -44,9 +45,27 @@ internal static class DataDirectorySecurity
 
     public static DirectoryInfo CreateSensitiveTempDirectory(string prefix)
     {
-        var path = Path.Combine(Path.GetTempPath(), $"{prefix}{Guid.NewGuid():N}");
+        var path = Path.Combine(GetTempPath(), $"{prefix}{Guid.NewGuid():N}");
         return CreateSensitiveDirectory(path);
     }
+
+    public static string ResolveSensitiveTempFallbackDirectory(string purpose)
+        => Path.GetFullPath(Path.Combine(
+            ResolveSensitiveTempFallbackRootDirectory(),
+            NormalizeSensitiveTempFallbackPurpose(purpose)));
+
+    private static string ResolveSensitiveTempFallbackRootDirectory()
+    {
+        var identity = $"{Environment.UserName}\0{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(identity));
+        var scope = "cdidx-u" + Convert.ToHexString(hash, 0, 8).ToLowerInvariant();
+        return Path.GetFullPath(Path.Combine(GetTempPath(), scope));
+    }
+
+    private static string NormalizeSensitiveTempFallbackPurpose(string purpose)
+        => string.IsNullOrWhiteSpace(purpose)
+            ? "state"
+            : purpose.Trim();
 
     public static void ApplyPrivateMode(string path)
     {
@@ -69,14 +88,47 @@ internal static class DataDirectorySecurity
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             return Directory.CreateDirectory(path);
 
-        var directory = Directory.CreateDirectory(path, PrivateDirectoryMode);
+        var fullPath = Path.GetFullPath(path);
+        EnsureSensitiveTempFallbackRoot(fullPath);
+        RejectUnsafeDirectoryTarget(fullPath);
+
+        var directory = Directory.CreateDirectory(fullPath, PrivateDirectoryMode);
+        RejectUnsafeDirectoryTarget(directory.FullName);
         ApplyPrivateMode(directory.FullName);
         return directory;
     }
 
+    private static void EnsureSensitiveTempFallbackRoot(string path)
+    {
+        var root = ResolveSensitiveTempFallbackRootDirectory();
+        if (!IsSameDirectory(path, root) && !IsDirectoryDescendant(path, root))
+            return;
+
+        RejectUnsafeDirectoryTarget(root);
+        Directory.CreateDirectory(root, PrivateDirectoryMode);
+        RejectUnsafeDirectoryTarget(root);
+        ApplyPrivateMode(root);
+    }
+
+    private static void RejectUnsafeDirectoryTarget(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new IOException(
+                    $"Refusing to use symbolic link or reparse point directory {ConsoleUi.FormatBoundedValue(path)} for sensitive cdidx state.");
+            }
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+        }
+    }
+
     private static bool IsSharedDirectoryRoot(string path)
     {
-        if (IsSameDirectory(path, Path.GetTempPath()))
+        if (IsSameDirectory(path, GetTempPath()))
             return true;
 
         var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -106,8 +158,33 @@ internal static class DataDirectorySecurity
         }
     }
 
+    private static bool IsDirectoryDescendant(string path, string ancestor)
+    {
+        try
+        {
+            var normalizedPath = NormalizeDirectory(path);
+            var normalizedAncestor = NormalizeDirectory(ancestor);
+            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            return normalizedPath.Length > normalizedAncestor.Length
+                && normalizedPath.StartsWith(normalizedAncestor, comparison)
+                && IsDirectorySeparator(normalizedPath[normalizedAncestor.Length]);
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsDirectorySeparator(char value)
+        => value == Path.DirectorySeparatorChar || value == Path.AltDirectorySeparatorChar;
+
     private static string NormalizeDirectory(string path)
         => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    private static string GetTempPath() => Path.GetTempPath();
 
     public static void WritePrivateText(string path, string contents, Encoding? encoding = null)
     {

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -89,6 +89,9 @@ internal static class DataDirectorySecurity
             return Directory.CreateDirectory(path);
 
         var fullPath = Path.GetFullPath(path);
+        if (Directory.Exists(fullPath) && IsSharedDirectoryRoot(fullPath))
+            return new DirectoryInfo(fullPath);
+
         EnsureSensitiveTempFallbackRoot(fullPath);
         RejectUnsafeDirectoryTarget(fullPath);
 

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -100,6 +100,9 @@ internal static class DataDirectorySecurity
 
     private static void EnsureSensitiveTempFallbackRoot(string path)
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
         var root = ResolveSensitiveTempFallbackRootDirectory();
         if (!IsSameDirectory(path, root) && !IsDirectoryDescendant(path, root))
             return;

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -21,17 +21,25 @@ internal static class DataDirectorySecurity
 
     public static DirectoryInfo CreatePrivateDirectory(string path)
     {
-        var directory = Directory.CreateDirectory(path);
-        if (IsCdidxDirectory(directory.FullName))
-            ApplyPrivateMode(directory.FullName);
-        return directory;
+        return IsCdidxDirectory(path)
+            ? CreateDirectoryWithPrivateMode(path)
+            : Directory.CreateDirectory(path);
     }
 
     public static DirectoryInfo CreateSensitiveDirectory(string path)
     {
-        var directory = Directory.CreateDirectory(path);
-        ApplyPrivateMode(directory.FullName);
-        return directory;
+        return CreateDirectoryWithPrivateMode(path);
+    }
+
+    public static DirectoryInfo? CreateSensitiveParentDirectoryForFile(string path)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (string.IsNullOrWhiteSpace(directory))
+            return null;
+
+        return Directory.Exists(directory) && IsSharedDirectoryRoot(directory)
+            ? new DirectoryInfo(directory)
+            : CreateSensitiveDirectory(directory);
     }
 
     public static DirectoryInfo CreateSensitiveTempDirectory(string prefix)
@@ -55,6 +63,51 @@ internal static class DataDirectorySecurity
 
         File.SetUnixFileMode(path, PrivateFileMode);
     }
+
+    private static DirectoryInfo CreateDirectoryWithPrivateMode(string path)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Directory.CreateDirectory(path);
+
+        var directory = Directory.CreateDirectory(path, PrivateDirectoryMode);
+        ApplyPrivateMode(directory.FullName);
+        return directory;
+    }
+
+    private static bool IsSharedDirectoryRoot(string path)
+    {
+        if (IsSameDirectory(path, Path.GetTempPath()))
+            return true;
+
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(userProfile) && IsSameDirectory(path, userProfile))
+            return true;
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(localAppData) && IsSameDirectory(path, localAppData))
+            return true;
+
+        var pathRoot = Path.GetPathRoot(Path.GetFullPath(path));
+        return !string.IsNullOrWhiteSpace(pathRoot) && IsSameDirectory(path, pathRoot);
+    }
+
+    private static bool IsSameDirectory(string left, string right)
+    {
+        try
+        {
+            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            return string.Equals(NormalizeDirectory(left), NormalizeDirectory(right), comparison);
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+
+    private static string NormalizeDirectory(string path)
+        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     public static void WritePrivateText(string path, string contents, Encoding? encoding = null)
     {

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -303,8 +303,7 @@ internal static class GlobalToolLog
                 return fullPath;
         }
 
-        var fallback = Path.Combine(Path.GetTempPath(), "cdidx", "logs");
-        return Path.GetFullPath(fallback);
+        return ResolveTempFallbackLogDirectory();
     }
 
     internal static bool TryNormalizeLogDirectoryCandidate(string candidate, out string fullPath)
@@ -357,8 +356,13 @@ internal static class GlobalToolLog
         if (!string.IsNullOrWhiteSpace(fallback))
             yield return Path.Combine(fallback, "cdidx", "logs");
 
-        yield return Path.Combine(Path.GetTempPath(), "cdidx", "logs");
+        yield return ResolveTempFallbackLogDirectory();
     }
+
+    internal static string ResolveTempFallbackLogDirectoryForTesting() => ResolveTempFallbackLogDirectory();
+
+    private static string ResolveTempFallbackLogDirectory()
+        => DataDirectorySecurity.ResolveSensitiveTempFallbackDirectory("logs");
 
     private static bool CanWriteProbe(string directory)
     {

--- a/src/CodeIndex/Cli/MetricsSink.cs
+++ b/src/CodeIndex/Cli/MetricsSink.cs
@@ -40,9 +40,7 @@ internal static class MetricsSink
         try
         {
             var fullPath = Path.GetFullPath(path);
-            var directory = Path.GetDirectoryName(fullPath);
-            if (!string.IsNullOrEmpty(directory))
-                Directory.CreateDirectory(directory);
+            DataDirectorySecurity.CreateSensitiveParentDirectoryForFile(fullPath);
 
             long bytesWritten;
             using (var probe = PrivateLogFile.OpenAppend(fullPath, FileShare.ReadWrite))

--- a/src/CodeIndex/Cli/MetricsSink.cs
+++ b/src/CodeIndex/Cli/MetricsSink.cs
@@ -24,6 +24,8 @@ internal static class MetricsSink
     internal const int RotationKeep = 3;
     internal const int MaxStringFieldChars = 1024;
     internal const int MaxSerializedEventBytes = 8 * 1024;
+    internal const int MaxConsecutiveFailures = 3;
+    private const int MaxFailureDiagnosticChars = 192;
 
     internal static IDisposable? TryStart(string? explicitPath) =>
         TryStart(explicitPath, DefaultMaxBytes, CommandErrorWriter.WriteWarning);
@@ -67,6 +69,9 @@ internal static class MetricsSink
 
     internal static bool IsActive => CurrentSession.Value is not null;
 
+    internal static MetricsDiagnostics? SnapshotDiagnosticsForTesting()
+        => CurrentSession.Value?.SnapshotDiagnostics();
+
     internal static void Record(MetricsEvent evt)
     {
         var session = CurrentSession.Value;
@@ -82,12 +87,26 @@ internal static class MetricsSink
         return string.IsNullOrWhiteSpace(envValue) ? null : envValue;
     }
 
+    private static string FormatFailure(string reason, Exception exception)
+    {
+        var formatted = $"{reason}:{exception.GetType().Name}:{CommandErrorWriter.FormatSanitizedException(exception)}";
+        return formatted.Length <= MaxFailureDiagnosticChars
+            ? formatted
+            : formatted[..MaxFailureDiagnosticChars];
+    }
+
     internal sealed class Session : IDisposable
     {
         private readonly object _gate = new();
         private readonly Encoding _utf8NoBom = new UTF8Encoding(false);
         private readonly long _maxBytes;
         private long _bytesWritten;
+        private long _droppedEventCount;
+        private long _writeFailureCount;
+        private long _rotationFailureCount;
+        private int _consecutiveFailureCount;
+        private bool _disabledForFailures;
+        private string? _lastFailure;
         private bool _disposed;
 
         public Session(string path, long maxBytes, long bytesWritten)
@@ -99,28 +118,51 @@ internal static class MetricsSink
 
         public string Path { get; }
 
+        internal MetricsDiagnostics SnapshotDiagnostics()
+        {
+            lock (_gate)
+            {
+                return new MetricsDiagnostics(
+                    Path,
+                    _bytesWritten,
+                    _disposed,
+                    _disabledForFailures,
+                    _consecutiveFailureCount,
+                    _droppedEventCount,
+                    _writeFailureCount,
+                    _rotationFailureCount,
+                    _lastFailure);
+            }
+        }
+
         public void Write(MetricsEvent evt)
         {
             lock (_gate)
             {
-                if (_disposed)
+                if (_disposed || _disabledForFailures)
                     return;
 
                 try
                 {
-                    RotateIfNeededLocked();
                     var encoded = _utf8NoBom.GetBytes(SerializeEvent(evt) + Environment.NewLine);
+                    if (_bytesWritten > 0 && _bytesWritten + encoded.Length > _maxBytes && !RotateLocked("rotation_failure"))
+                        return;
+
                     using (var stream = PrivateLogFile.OpenAppend(Path, FileShare.ReadWrite))
                     {
                         stream.Write(encoded, 0, encoded.Length);
                         stream.Flush();
                     }
                     _bytesWritten += encoded.Length;
-                    RotateIfNeededLocked();
+                    _consecutiveFailureCount = 0;
+
+                    if (_bytesWritten >= _maxBytes)
+                        RotateLocked("rotation_failure");
                 }
-                catch
+                catch (Exception ex)
                 {
                     // Best-effort only / ベストエフォートのみ
+                    RecordFailureLocked("write_failure", ex);
                 }
             }
         }
@@ -137,13 +179,40 @@ internal static class MetricsSink
             }
         }
 
-        private void RotateIfNeededLocked()
+        private bool RotateLocked(string reason)
         {
-            if (_bytesWritten < _maxBytes)
-                return;
-
-            if (PrivateLogFile.TryRotateSlots(Path, RotationKeep))
+            var capturedFailure = default(Exception);
+            if (PrivateLogFile.TryRotateSlots(
+                Path,
+                RotationKeep,
+                onFailure: ex => capturedFailure = ex))
+            {
                 _bytesWritten = 0;
+                _consecutiveFailureCount = 0;
+                return true;
+            }
+
+            RecordFailureLocked(reason, capturedFailure ?? new IOException("metrics rotation failed"));
+            return false;
+        }
+
+        private void RecordFailureLocked(string reason, Exception exception)
+        {
+            _droppedEventCount++;
+            _consecutiveFailureCount++;
+            switch (reason)
+            {
+                case "write_failure":
+                    _writeFailureCount++;
+                    break;
+                case "rotation_failure":
+                    _rotationFailureCount++;
+                    break;
+            }
+
+            _lastFailure = FormatFailure(reason, exception);
+            if (_consecutiveFailureCount >= MaxConsecutiveFailures)
+                _disabledForFailures = true;
         }
     }
 
@@ -241,6 +310,17 @@ internal static class MetricsSink
 }
 
 internal readonly record struct BoundedMetricsString(string Text, int OriginalLength, bool Truncated);
+
+internal sealed record MetricsDiagnostics(
+    string Path,
+    long BytesWritten,
+    bool Disposed,
+    bool DisabledForFailures,
+    int ConsecutiveFailureCount,
+    long DroppedEventCount,
+    long WriteFailureCount,
+    long RotationFailureCount,
+    string? LastFailure);
 
 /// <summary>
 /// Structured metrics record emitted to the JSONL sink. Optional fields are omitted from

--- a/src/CodeIndex/Cli/PrivateLogFile.cs
+++ b/src/CodeIndex/Cli/PrivateLogFile.cs
@@ -157,18 +157,16 @@ internal static class PrivateLogFile
             {
                 var current = SlotPath(path, slot);
                 var next = SlotPath(path, slot + 1);
-                var ioCurrent = LongPath.EnsureWindowsPrefix(current);
-                if (!File.Exists(ioCurrent))
+                if (!File.Exists(LongPath.EnsureWindowsPrefix(current)))
                     continue;
-                MoveReplacing(ioCurrent, LongPath.EnsureWindowsPrefix(next));
+                MoveReplacing(current, next);
                 afterMove?.Invoke(next);
             }
 
-            var ioPath = LongPath.EnsureWindowsPrefix(path);
-            if (File.Exists(ioPath))
+            if (File.Exists(LongPath.EnsureWindowsPrefix(path)))
             {
                 var first = SlotPath(path, 1);
-                MoveReplacing(ioPath, LongPath.EnsureWindowsPrefix(first));
+                MoveReplacing(path, first);
                 afterMove?.Invoke(first);
             }
 
@@ -185,7 +183,10 @@ internal static class PrivateLogFile
         => slot <= 0 ? path : path + "." + slot.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
     private static void MoveReplacing(string sourcePath, string destinationPath)
-        => File.Move(sourcePath, destinationPath, overwrite: true);
+    {
+        File.Move(LongPath.EnsureWindowsPrefix(sourcePath), LongPath.EnsureWindowsPrefix(destinationPath), overwrite: true);
+        AtomicFileWriter.FlushParentDirectoryAfterReplace(destinationPath);
+    }
 
     private static void SafeDelete(string path, Action<Exception>? onCleanupFailure = null)
     {

--- a/src/CodeIndex/Cli/PrivateLogFile.cs
+++ b/src/CodeIndex/Cli/PrivateLogFile.cs
@@ -11,6 +11,8 @@ internal static class PrivateLogFile
 
     internal static FileStream OpenAppend(string path, FileShare share = FileShare.ReadWrite)
     {
+        RejectUnsafeTarget(path);
+
         if (OperatingSystem.IsWindows())
             return new FileStream(path, FileMode.Append, FileAccess.Write, share);
 
@@ -36,6 +38,7 @@ internal static class PrivateLogFile
 
         try
         {
+            RejectUnsafeTarget(path);
             File.SetUnixFileMode(path, PrivateFileMode);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
@@ -52,18 +55,59 @@ internal static class PrivateLogFile
         try
         {
             var hardened = 0;
-            foreach (var file in new DirectoryInfo(directory).EnumerateFiles(pattern, SearchOption.TopDirectoryOnly))
+            foreach (var file in SelectFirstByName(
+                new DirectoryInfo(directory).EnumerateFiles(pattern, SearchOption.TopDirectoryOnly),
+                MaxExistingFilesToHarden + 1))
             {
+                if (hardened >= MaxExistingFilesToHarden)
+                {
+                    ReportDiagnostic(diagnosticSink, "harden_existing_cap", "cap_exceeded", directory);
+                    break;
+                }
+
                 TrySetPrivatePermissions(file.FullName, diagnosticSink);
                 hardened++;
-                if (hardened >= MaxExistingFilesToHarden)
-                    break;
             }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             ReportDiagnostic(diagnosticSink, "harden_existing", directory, ex);
         }
+    }
+
+    private static IReadOnlyList<FileInfo> SelectFirstByName(IEnumerable<FileInfo> files, int retainedFileCount)
+    {
+        if (retainedFileCount <= 0)
+            return [];
+
+        var retained = new List<FileInfo>(retainedFileCount);
+        foreach (var file in files)
+            AddFirstByName(retained, file, retainedFileCount);
+
+        return retained;
+    }
+
+    private static void AddFirstByName(List<FileInfo> retained, FileInfo file, int retainedFileCount)
+    {
+        var insertAt = retained.FindIndex(existing => CompareHardenOrder(file, existing) < 0);
+        if (insertAt < 0)
+        {
+            if (retained.Count < retainedFileCount)
+                retained.Add(file);
+            return;
+        }
+
+        retained.Insert(insertAt, file);
+        if (retained.Count > retainedFileCount)
+            retained.RemoveAt(retained.Count - 1);
+    }
+
+    private static int CompareHardenOrder(FileInfo left, FileInfo right)
+    {
+        var name = string.Compare(left.Name, right.Name, StringComparison.Ordinal);
+        return name != 0
+            ? name
+            : string.Compare(left.FullName, right.FullName, StringComparison.Ordinal);
     }
 
     internal static void PruneOldFiles(string directory, string pattern, int retainedFileCount, Action<PrivateLogFileDiagnostic>? diagnosticSink = null)
@@ -222,6 +266,13 @@ internal static class PrivateLogFile
         string operation,
         string path,
         Exception exception)
+        => ReportDiagnostic(diagnosticSink, operation, ClassifyFailure(exception), path);
+
+    private static void ReportDiagnostic(
+        Action<PrivateLogFileDiagnostic>? diagnosticSink,
+        string operation,
+        string reason,
+        string path)
     {
         if (diagnosticSink is null)
             return;
@@ -230,12 +281,25 @@ internal static class PrivateLogFile
         {
             diagnosticSink(new PrivateLogFileDiagnostic(
                 operation,
-                ClassifyFailure(exception),
+                reason,
                 FormatDiagnosticTarget(path)));
         }
         catch
         {
             // Diagnostics must not make best-effort log hardening fail.
+        }
+    }
+
+    private static void RejectUnsafeTarget(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(LongPath.EnsureWindowsPrefix(path));
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+                throw new IOException("Refusing to use private log target because it is a symbolic link or reparse point.");
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
         }
     }
 

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -794,7 +794,7 @@ public class SuggestionStore
     {
         var dir = Path.GetDirectoryName(_filePath);
         if (!string.IsNullOrEmpty(dir))
-            Directory.CreateDirectory(dir);
+            DataDirectorySecurity.CreateSensitiveDirectory(dir);
 
         NormalizeRecordDefaults(records);
         AtomicFileWriter.WriteJson(_filePath, records, s_jsonOptions, AtomicFileWriter.WriteProfile.Sensitive);
@@ -876,7 +876,7 @@ public class SuggestionStore
     {
         var dir = Path.GetDirectoryName(_archivePath);
         if (!string.IsNullOrEmpty(dir))
-            DataDirectorySecurity.CreatePrivateDirectory(dir);
+            DataDirectorySecurity.CreateSensitiveDirectory(dir);
 
         var archiveLines = BuildBoundedArchiveLines(records);
         if (archiveLines.Count == 0)
@@ -1171,7 +1171,7 @@ public class SuggestionStore
     {
         var dir = Path.GetDirectoryName(_lockPath);
         if (!string.IsNullOrEmpty(dir))
-            DataDirectorySecurity.CreatePrivateDirectory(dir);
+            DataDirectorySecurity.CreateSensitiveDirectory(dir);
 
         // FileShare.None provides exclusive access across processes on all platforms.
         // The lock is held for the lifetime of the FileStream (released on Dispose).

--- a/src/CodeIndex/Cli/UpdateChecker.cs
+++ b/src/CodeIndex/Cli/UpdateChecker.cs
@@ -330,6 +330,11 @@ internal static class UpdateChecker
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
+        return ResolveDefaultCachePath(xdgCacheHome, home, localAppData);
+    }
+
+    internal static string ResolveDefaultCachePath(string? xdgCacheHome, string? home, string? localAppData)
+    {
         if (TryResolveCacheRoot(xdgCacheHome, "XDG_CACHE_HOME", out var xdgRoot))
             return Path.Combine(xdgRoot, "cdidx", "update-check.json");
 
@@ -339,7 +344,7 @@ internal static class UpdateChecker
         if (TryResolveCacheRoot(localAppData, "local application data", out var localAppDataRoot))
             return Path.Combine(localAppDataRoot, "cdidx", "update-check.json");
 
-        var root = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "cdidx", "cache"));
+        var root = DataDirectorySecurity.ResolveSensitiveTempFallbackDirectory("cache");
         return Path.Combine(root, "update-check.json");
     }
 

--- a/src/CodeIndex/Mcp/AuditLogSink.cs
+++ b/src/CodeIndex/Mcp/AuditLogSink.cs
@@ -5,6 +5,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
+using System.Threading.Channels;
 using CodeIndex.Cli;
 using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
@@ -43,6 +44,9 @@ internal sealed class AuditLogSink : IDisposable
     internal const int MaxAuditArgumentKeyChars = McpBoundedText.MaxDiagnosticDisplayChars;
     internal const int MaxRequestIdChars = 256;
     internal const int MaxSerializedEventBytes = 64 * 1024;
+    internal const int DefaultQueueCapacity = 1024;
+    internal const int MaxConfiguredQueueCapacity = 16 * 1024;
+    private static readonly TimeSpan DisposeWriterTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly Regex SecretValuePattern = new(
         "(?i)(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|sk-(?:proj-)?[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16}|://[^/\\s:@]+:[^/\\s:@]+@|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|authorization)=[^&\\s]+)",
@@ -52,20 +56,26 @@ internal sealed class AuditLogSink : IDisposable
         MaxDepth = MaxArgValueDepth + 1,
     };
 
-    private readonly object _gate = new();
     private readonly string _path;
     private readonly long _maxBytes;
     private readonly bool _includeValues;
+    private readonly int _queueCapacity;
+    private readonly Channel<byte[]> _recordQueue;
+    private readonly Task _writerTask;
     private readonly Encoding _utf8NoBom = new UTF8Encoding(false);
     private long _bytesWritten;
+    private long _pendingRecordCount;
     private long _droppedRecordCount;
+    private long _queueFullDropCount;
     private long _serializationFailureCount;
     private long _writeFailureCount;
     private long _rotationFailureCount;
     private long _rotationCleanupFailureCount;
     private string? _lastDropReason;
     private string? _lastRotationFailure;
-    private bool _disposed;
+    private int _disposed;
+
+    internal Action? BeforeWriteForTests { get; set; }
 
     internal sealed record AuditLogDiagnostics(
         string Path,
@@ -73,7 +83,10 @@ internal sealed class AuditLogSink : IDisposable
         long MaxBytes,
         long BytesWritten,
         bool Disposed,
+        int QueueCapacity,
+        long QueueDepth,
         long DroppedRecordCount,
+        long QueueFullDropCount,
         long SerializationFailureCount,
         long WriteFailureCount,
         long RotationFailureCount,
@@ -82,7 +95,7 @@ internal sealed class AuditLogSink : IDisposable
         string? LastDropReason,
         string? LastRotationFailure);
 
-    internal AuditLogSink(string path, long maxBytes, bool includeValues)
+    internal AuditLogSink(string path, long maxBytes, bool includeValues, int? queueCapacity = null)
     {
         if (string.IsNullOrWhiteSpace(path))
             throw new ArgumentException("Audit log path must be non-empty.", nameof(path));
@@ -94,6 +107,7 @@ internal sealed class AuditLogSink : IDisposable
         _path = System.IO.Path.GetFullPath(path);
         _maxBytes = maxBytes;
         _includeValues = includeValues;
+        _queueCapacity = ResolveQueueCapacity(queueCapacity);
         DataDirectorySecurity.CreateSensitiveParentDirectoryForFile(_path);
 
         // Probe-open at construction so misconfigured paths (existing directory, read-only
@@ -108,6 +122,14 @@ internal sealed class AuditLogSink : IDisposable
             _bytesWritten = probe.Length;
         }
         PrivateLogFile.TrySetPrivatePermissions(_path);
+        _recordQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(_queueCapacity)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait,
+            AllowSynchronousContinuations = false,
+        });
+        _writerTask = BackgroundTaskObserver.Run(DrainQueueAsync, "cdidx-mcp-audit", "audit log writer");
     }
 
     /// <summary>Path the sink writes to (absolute, post normalisation).</summary>
@@ -121,36 +143,37 @@ internal sealed class AuditLogSink : IDisposable
 
     internal AuditLogDiagnostics SnapshotDiagnostics()
     {
-        lock (_gate)
-        {
-            var droppedRecordCount = Interlocked.Read(ref _droppedRecordCount);
-            var serializationFailureCount = Interlocked.Read(ref _serializationFailureCount);
-            var writeFailureCount = Interlocked.Read(ref _writeFailureCount);
-            var rotationFailureCount = Interlocked.Read(ref _rotationFailureCount);
-            var rotationCleanupFailureCount = Interlocked.Read(ref _rotationCleanupFailureCount);
-            var rotationDegraded = rotationFailureCount > 0
-                || rotationCleanupFailureCount > 0
-                || _bytesWritten >= _maxBytes;
-            return new AuditLogDiagnostics(
-                _path,
-                _includeValues,
-                _maxBytes,
-                _bytesWritten,
-                _disposed,
-                droppedRecordCount,
-                serializationFailureCount,
-                writeFailureCount,
-                rotationFailureCount,
-                rotationCleanupFailureCount,
-                rotationDegraded,
-                Volatile.Read(ref _lastDropReason),
-                Volatile.Read(ref _lastRotationFailure));
-        }
+        var bytesWritten = Volatile.Read(ref _bytesWritten);
+        var droppedRecordCount = Interlocked.Read(ref _droppedRecordCount);
+        var serializationFailureCount = Interlocked.Read(ref _serializationFailureCount);
+        var writeFailureCount = Interlocked.Read(ref _writeFailureCount);
+        var rotationFailureCount = Interlocked.Read(ref _rotationFailureCount);
+        var rotationCleanupFailureCount = Interlocked.Read(ref _rotationCleanupFailureCount);
+        var rotationDegraded = rotationFailureCount > 0
+            || rotationCleanupFailureCount > 0
+            || bytesWritten >= _maxBytes;
+        return new AuditLogDiagnostics(
+            _path,
+            _includeValues,
+            _maxBytes,
+            bytesWritten,
+            Volatile.Read(ref _disposed) != 0,
+            _queueCapacity,
+            Math.Max(0, Interlocked.Read(ref _pendingRecordCount)),
+            droppedRecordCount,
+            Interlocked.Read(ref _queueFullDropCount),
+            serializationFailureCount,
+            writeFailureCount,
+            rotationFailureCount,
+            rotationCleanupFailureCount,
+            rotationDegraded,
+            Volatile.Read(ref _lastDropReason),
+            Volatile.Read(ref _lastRotationFailure));
     }
 
     internal void Record(AuditEvent evt)
     {
-        if (_disposed)
+        if (Volatile.Read(ref _disposed) != 0)
             return;
 
         string line;
@@ -166,37 +189,58 @@ internal sealed class AuditLogSink : IDisposable
         }
 
         var encoded = _utf8NoBom.GetBytes(line + "\n");
-        lock (_gate)
-        {
-            if (_disposed)
-                return;
+        Interlocked.Increment(ref _pendingRecordCount);
+        if (_recordQueue.Writer.TryWrite(encoded))
+            return;
 
+        Interlocked.Decrement(ref _pendingRecordCount);
+        if (Volatile.Read(ref _disposed) == 0)
+            RecordDropped("queue_full", new AuditLogQueueFullException());
+    }
+
+    private async Task DrainQueueAsync()
+    {
+        await foreach (var encoded in _recordQueue.Reader.ReadAllAsync().ConfigureAwait(false))
+        {
             try
             {
-                // Open + write + close per record so an external `tail -F` keeps following
-                // rotations and so the file is closed during rename. Audit volume is bounded
-                // by tool-call cadence (not loop hot paths), so the per-call open is cheap.
-                // 1 レコードごとに open/write/close する。外部 `tail -F` の rotation 追従と
-                // rename 中のロック回避のため。ツール呼び出し頻度はループのホットパスではない
-                // ので open のコストは許容範囲。
-                using (var stream = PrivateLogFile.OpenAppend(_path, FileShare.ReadWrite))
-                {
-                    stream.Write(encoded, 0, encoded.Length);
-                    stream.Flush();
-                }
-                _bytesWritten += encoded.Length;
-
-                if (_bytesWritten >= _maxBytes)
-                {
-                    RotateLocked();
-                }
+                WriteEncodedRecord(encoded);
             }
-            catch (Exception ex)
+            finally
             {
-                // Best-effort: a failing audit write must not break the tool call.
-                // ベストエフォート: 監査出力失敗で本体呼び出しを壊さない。
-                RecordDropped("write_failure", ex);
+                Interlocked.Decrement(ref _pendingRecordCount);
             }
+        }
+    }
+
+    private void WriteEncodedRecord(byte[] encoded)
+    {
+        try
+        {
+            BeforeWriteForTests?.Invoke();
+            // Open + write + close per record so an external `tail -F` keeps following
+            // rotations and so the file is closed during rename. The queue keeps this
+            // IO off the caller's hot path while preserving serialized file writes.
+            // 1 レコードごとに open/write/close する。queue により呼び出し側の hot path から
+            // IO を外しつつ、ファイル書き込みの直列性は維持する。
+            using (var stream = PrivateLogFile.OpenAppend(_path, FileShare.ReadWrite))
+            {
+                stream.Write(encoded, 0, encoded.Length);
+                stream.Flush();
+            }
+            var bytesWritten = Volatile.Read(ref _bytesWritten) + encoded.Length;
+            Volatile.Write(ref _bytesWritten, bytesWritten);
+
+            if (bytesWritten >= _maxBytes)
+            {
+                RotateLocked();
+            }
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a failing audit write must not break the tool call.
+            // ベストエフォート: 監査出力失敗で本体呼び出しを壊さない。
+            RecordDropped("write_failure", ex);
         }
     }
 
@@ -204,7 +248,7 @@ internal sealed class AuditLogSink : IDisposable
     /// Rotate the current file to `<path>.1`, cascading older files up to `RotationKeep` slots.
     /// `<path>.(RotationKeep-1)` is the oldest retained slot, and the previous oldest is
     /// deleted so a slow drain of the audit log cannot fill the disk.
-    /// Caller must hold `_gate`.
+    /// Caller must be the single audit queue writer.
     /// </summary>
     private void RotateLocked()
     {
@@ -213,7 +257,7 @@ internal sealed class AuditLogSink : IDisposable
             RotationKeep,
             onFailure: ex => RecordRotationFailure("rotation_failure", ex),
             onCleanupFailure: ex => RecordRotationFailure("rotation_cleanup_failure", ex)))
-            _bytesWritten = 0;
+            Volatile.Write(ref _bytesWritten, 0);
     }
 
     private void RecordDropped(string reason, Exception exception)
@@ -223,6 +267,9 @@ internal sealed class AuditLogSink : IDisposable
         {
             case "serialization_failure":
                 Interlocked.Increment(ref _serializationFailureCount);
+                break;
+            case "queue_full":
+                Interlocked.Increment(ref _queueFullDropCount);
                 break;
             case "write_failure":
                 Interlocked.Increment(ref _writeFailureCount);
@@ -254,10 +301,46 @@ internal sealed class AuditLogSink : IDisposable
 
     public void Dispose()
     {
-        lock (_gate)
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        _recordQueue.Writer.TryComplete();
+        try
         {
-            _disposed = true;
+            _writerTask.Wait(DisposeWriterTimeout);
         }
+        catch
+        {
+            // Disposal is best-effort; audit logging must not block process shutdown.
+            // dispose は best-effort。監査ログでプロセス終了を止めない。
+        }
+    }
+
+    internal bool WaitForIdle(TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (Interlocked.Read(ref _pendingRecordCount) > 0)
+        {
+            if (DateTimeOffset.UtcNow >= deadline)
+                return false;
+            Thread.Sleep(10);
+        }
+        return true;
+    }
+
+    private static int ResolveQueueCapacity(int? queueCapacity)
+    {
+        var capacity = queueCapacity ?? DefaultQueueCapacity;
+        if (capacity <= 0 || capacity > MaxConfiguredQueueCapacity)
+            throw new ArgumentOutOfRangeException(
+                nameof(queueCapacity),
+                capacity,
+                $"Audit log queue capacity must be between 1 and {MaxConfiguredQueueCapacity.ToString(CultureInfo.InvariantCulture)}.");
+        return capacity;
+    }
+
+    private sealed class AuditLogQueueFullException : Exception
+    {
     }
 
     internal static string SerializeEvent(AuditEvent evt, bool includeValues)

--- a/src/CodeIndex/Mcp/AuditLogSink.cs
+++ b/src/CodeIndex/Mcp/AuditLogSink.cs
@@ -90,9 +90,7 @@ internal sealed class AuditLogSink : IDisposable
         _path = System.IO.Path.GetFullPath(path);
         _maxBytes = maxBytes;
         _includeValues = includeValues;
-        var directory = System.IO.Path.GetDirectoryName(_path);
-        if (!string.IsNullOrEmpty(directory))
-            Directory.CreateDirectory(directory);
+        DataDirectorySecurity.CreateSensitiveParentDirectoryForFile(_path);
 
         // Probe-open at construction so misconfigured paths (existing directory, read-only
         // file, denied parent) fail loudly before ProgramRunner claims auditing is on.

--- a/tests/CodeIndex.Tests/AtomicFileWriterTests.cs
+++ b/tests/CodeIndex.Tests/AtomicFileWriterTests.cs
@@ -21,7 +21,7 @@ public class AtomicFileWriterTests
             AtomicFileWriter.WriteText(path, "new", Utf8NoBom);
 
             Assert.Equal("new", File.ReadAllText(path, Utf8NoBom));
-            Assert.Empty(Directory.GetFiles(projectRoot, ".settings.json.*.tmp"));
+            Assert.Empty(Directory.GetFiles(projectRoot, "*.tmp"));
         }
         finally
         {
@@ -53,7 +53,7 @@ public class AtomicFileWriterTests
             Assert.NotNull(modePath);
             Assert.NotEqual(path, modePath);
             Assert.Equal("old", File.ReadAllText(path, Utf8NoBom));
-            Assert.Empty(Directory.GetFiles(projectRoot, ".settings.json.*.tmp"));
+            Assert.Empty(Directory.GetFiles(projectRoot, "*.tmp"));
         }
         finally
         {
@@ -75,6 +75,7 @@ public class AtomicFileWriterTests
                 AtomicFileWriter.WriteText(path, "new", Utf8NoBom));
 
             Assert.Contains("Atomic replace completed", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("target file was already replaced", ex.Message, StringComparison.Ordinal);
             Assert.Contains("parent directory could not be flushed", ex.Message, StringComparison.Ordinal);
             Assert.Equal("new", File.ReadAllText(path, Utf8NoBom));
         }
@@ -102,7 +103,7 @@ public class AtomicFileWriterTests
 
             Assert.Equal(projectRoot, flushedDirectory);
             Assert.Contains("\"current_head\"", File.ReadAllText(path, Utf8NoBom), StringComparison.Ordinal);
-            Assert.Empty(Directory.GetFiles(projectRoot, ".scan-checkpoint.json.*.tmp"));
+            Assert.Empty(Directory.GetFiles(projectRoot, "*.tmp"));
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -113,6 +114,32 @@ public class AtomicFileWriterTests
         finally
         {
             AtomicFileWriter.FlushParentDirectoryForTesting = null;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void BuildTempPathForTesting_BoundsTempFileNameForLongTargets_Issue3776()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_long_name");
+        try
+        {
+            var targetName = new string('a', 240) + ".json";
+            var path = Path.Combine(projectRoot, targetName);
+
+            var tempPath = AtomicFileWriter.BuildTempPathForTesting(path);
+            var tempName = Path.GetFileName(tempPath);
+
+            Assert.Equal(projectRoot, Path.GetDirectoryName(tempPath));
+            Assert.StartsWith(".cdidx-", tempName, StringComparison.Ordinal);
+            Assert.EndsWith(".tmp", tempName, StringComparison.Ordinal);
+            Assert.True(
+                tempName.Length <= AtomicFileWriter.MaxTempFileNameChars,
+                $"temp file name was {tempName.Length} chars: {tempName}");
+            Assert.DoesNotContain(targetName, tempName, StringComparison.Ordinal);
+        }
+        finally
+        {
             TestProjectHelper.DeleteDirectory(projectRoot);
         }
     }

--- a/tests/CodeIndex.Tests/AuditLogSinkTests.cs
+++ b/tests/CodeIndex.Tests/AuditLogSinkTests.cs
@@ -402,6 +402,32 @@ public class AuditLogSinkTests
     }
 
     [Fact]
+    public void Constructor_OnUnixCreatesPrivateParentDirectory_Issue3775()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_audit_private_parent_{Guid.NewGuid():N}");
+        var directory = Path.Combine(root, "mcp-audit");
+        var path = Path.Combine(directory, "audit.jsonl");
+        try
+        {
+            using var sink = new AuditLogSink(path, AuditLogSink.DefaultMaxBytes, includeValues: false);
+
+            Assert.True(Directory.Exists(directory));
+            Assert.Equal(
+                DataDirectorySecurity.PrivateDirectoryMode,
+                File.GetUnixFileMode(directory) & DataDirectorySecurity.PermissionBits);
+            Assert.Equal(PrivateLogFile.PrivateFileMode, File.GetUnixFileMode(path));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Record_OnUnixCreatesPrivateLogFileAfterRotation()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/CodeIndex.Tests/AuditLogSinkTests.cs
+++ b/tests/CodeIndex.Tests/AuditLogSinkTests.cs
@@ -380,6 +380,7 @@ public class AuditLogSinkTests
                 ElapsedMs: 0.5,
                 ErrorCode: 0,
                 ErrorType: null));
+            WaitForAuditLogIdle(sink);
 
             var lines = File.ReadAllLines(path);
             Assert.Single(lines);
@@ -480,6 +481,7 @@ public class AuditLogSinkTests
 
             sink.Record(bigEvent);
             sink.Record(smallEvent);
+            WaitForAuditLogIdle(sink);
 
             Assert.Equal(PrivateLogFile.PrivateFileMode, File.GetUnixFileMode(rotation1));
             Assert.Equal(PrivateLogFile.PrivateFileMode, File.GetUnixFileMode(path));
@@ -527,6 +529,7 @@ public class AuditLogSinkTests
 
             for (var i = 0; i < 3; i++)
                 sink.Record(bigEvent);
+            WaitForAuditLogIdle(sink);
 
             Assert.True(File.Exists(rotation1), "first rotation slot should exist after rotation");
             Assert.True(File.Exists(rotation2), "second rotation slot should exist after three big writes");
@@ -571,6 +574,7 @@ public class AuditLogSinkTests
             // RotationKeep=3 なので path.3 は決して残らない（最古スロットが drop される）。
             for (var i = 0; i < 5; i++)
                 sink.Record(bigEvent);
+            WaitForAuditLogIdle(sink);
 
             Assert.True(File.Exists(rotation1));
             Assert.True(File.Exists(rotation2));
@@ -619,6 +623,7 @@ public class AuditLogSinkTests
                     ErrorCode: 0,
                     ErrorType: null)));
                 Assert.Null(ex);
+                WaitForAuditLogIdle(sink);
 
                 var diagnostics = sink.SnapshotDiagnostics();
                 Assert.Equal(1, diagnostics.DroppedRecordCount);
@@ -713,4 +718,9 @@ public class AuditLogSinkTests
                 Directory.Delete(path, recursive: true);
         }
     }
+
+    private static void WaitForAuditLogIdle(AuditLogSink sink)
+        => Assert.True(
+            sink.WaitForIdle(TimeSpan.FromSeconds(5)),
+            "Timed out waiting for the audit log writer to drain.");
 }

--- a/tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
+++ b/tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
@@ -122,6 +122,84 @@ public class DataDirectorySecurityTests
     }
 
     [Fact]
+    public void ResolveSensitiveTempFallbackDirectory_UsesUserScopedCdidxRoot_Issue3675()
+    {
+        var directory = DataDirectorySecurity.ResolveSensitiveTempFallbackDirectory("cache");
+
+        Assert.StartsWith(
+            Path.Combine(Path.GetTempPath(), "cdidx-u"),
+            directory,
+            StringComparison.Ordinal);
+        Assert.EndsWith(
+            Path.Combine("", "cache"),
+            directory,
+            StringComparison.Ordinal);
+        Assert.NotEqual(
+            Path.GetFullPath(Path.Combine(Path.GetTempPath(), "cdidx", "cache")),
+            directory);
+    }
+
+    [Fact]
+    public void CreateSensitiveDirectory_OnExistingTempFallbackScopeRoot_HardensRoot_Issue3675()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var directory = DataDirectorySecurity.ResolveSensitiveTempFallbackDirectory($"scope-{Guid.NewGuid():N}");
+        var scopeRoot = Directory.GetParent(directory)!.FullName;
+        if (Directory.Exists(scopeRoot) || File.Exists(scopeRoot))
+            return;
+
+        try
+        {
+            Directory.CreateDirectory(scopeRoot);
+            File.SetUnixFileMode(scopeRoot, DataDirectorySecurity.PermissionBits);
+
+            DataDirectorySecurity.CreateSensitiveDirectory(directory);
+
+            Assert.Equal(
+                DataDirectorySecurity.PrivateDirectoryMode,
+                File.GetUnixFileMode(scopeRoot) & DataDirectorySecurity.PermissionBits);
+            Assert.Equal(
+                DataDirectorySecurity.PrivateDirectoryMode,
+                File.GetUnixFileMode(directory) & DataDirectorySecurity.PermissionBits);
+        }
+        finally
+        {
+            DeletePathOrSymlink(scopeRoot);
+        }
+    }
+
+    [Fact]
+    public void CreateSensitiveDirectory_OnSymlinkedTempFallbackScopeRoot_RejectsRoot_Issue3675()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var directory = DataDirectorySecurity.ResolveSensitiveTempFallbackDirectory($"symlink-{Guid.NewGuid():N}");
+        var scopeRoot = Directory.GetParent(directory)!.FullName;
+        if (Directory.Exists(scopeRoot) || File.Exists(scopeRoot))
+            return;
+
+        var attackRoot = Path.Combine(Path.GetTempPath(), $"cdidx_sensitive_fallback_attack_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(attackRoot);
+            File.CreateSymbolicLink(scopeRoot, attackRoot);
+
+            var ex = Assert.Throws<IOException>(() => DataDirectorySecurity.CreateSensitiveDirectory(directory));
+
+            Assert.Contains("symbolic link or reparse point", ex.Message, StringComparison.Ordinal);
+            Assert.False(Directory.Exists(directory));
+        }
+        finally
+        {
+            DeletePathOrSymlink(scopeRoot);
+            DeletePathOrSymlink(attackRoot);
+        }
+    }
+
+    [Fact]
     public void WritePrivateText_OnPosix_Forces0600Mode()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -187,5 +265,27 @@ public class DataDirectorySecurityTests
             if (Directory.Exists(root))
                 Directory.Delete(root, recursive: true);
         }
+    }
+
+    private static void DeletePathOrSymlink(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                File.Delete(path);
+                return;
+            }
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return;
+        }
+
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+        else if (File.Exists(path))
+            File.Delete(path);
     }
 }

--- a/tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
+++ b/tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
@@ -61,6 +61,44 @@ public class DataDirectorySecurityTests
     }
 
     [Fact]
+    public void CreateSensitiveParentDirectoryForFile_OnPosix_Forces0700Mode_Issue3775()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_sensitive_parent_security_{Guid.NewGuid():N}");
+        var path = Path.Combine(root, "audit", "events.jsonl");
+        try
+        {
+            var directory = DataDirectorySecurity.CreateSensitiveParentDirectoryForFile(path);
+
+            Assert.NotNull(directory);
+            Assert.Equal(Path.GetDirectoryName(path), directory.FullName);
+            Assert.Equal(
+                DataDirectorySecurity.PrivateDirectoryMode,
+                File.GetUnixFileMode(directory.FullName) & DataDirectorySecurity.PermissionBits);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CreateSensitiveParentDirectoryForFile_OnExistingTempRoot_DoesNotHardenSharedRoot_Issue3775()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cdidx_direct_parent_{Guid.NewGuid():N}.jsonl");
+
+        var directory = DataDirectorySecurity.CreateSensitiveParentDirectoryForFile(path);
+
+        Assert.NotNull(directory);
+        Assert.Equal(
+            Path.GetFullPath(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            directory.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+    }
+
+    [Fact]
     public void CreateSensitiveTempDirectory_OnPosix_Forces0700Mode()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/tests/CodeIndex.Tests/GlobalToolLogTests.cs
+++ b/tests/CodeIndex.Tests/GlobalToolLogTests.cs
@@ -160,6 +160,39 @@ public class GlobalToolLogTests
     }
 
     [Fact]
+    public void PrivateLogFile_TryRotateSlots_ReportsPostReplaceFlushFailure_Issue3776()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"cdidx_private_log_rotate_flush_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "metrics.jsonl");
+        var failures = new List<Exception>();
+        try
+        {
+            File.WriteAllText(path, "current");
+            AtomicFileWriter.FlushParentDirectoryForTesting = _ => throw new IOException("flush denied");
+
+            var rotated = PrivateLogFile.TryRotateSlots(
+                path,
+                retainedFileCount: 3,
+                onFailure: failures.Add);
+
+            Assert.False(rotated);
+            var failure = Assert.Single(failures);
+            Assert.Contains("Atomic replace completed", failure.Message, StringComparison.Ordinal);
+            Assert.Contains("target file was already replaced", failure.Message, StringComparison.Ordinal);
+            Assert.Contains("parent directory could not be flushed", failure.Message, StringComparison.Ordinal);
+            Assert.False(File.Exists(path));
+            Assert.Equal("current", File.ReadAllText(path + ".1"));
+        }
+        finally
+        {
+            AtomicFileWriter.FlushParentDirectoryForTesting = null;
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void TryStart_WritesPrivateLogDiagnostics_Issue3475()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/CodeIndex.Tests/GlobalToolLogTests.cs
+++ b/tests/CodeIndex.Tests/GlobalToolLogTests.cs
@@ -447,6 +447,17 @@ public class GlobalToolLogTests
     }
 
     [Fact]
+    public void ResolveTempFallbackLogDirectory_UsesPrivateTempFallback_Issue3675()
+    {
+        var directory = GlobalToolLog.ResolveTempFallbackLogDirectoryForTesting();
+
+        Assert.Equal(DataDirectorySecurity.ResolveSensitiveTempFallbackDirectory("logs"), directory);
+        Assert.NotEqual(
+            Path.GetFullPath(Path.Combine(Path.GetTempPath(), "cdidx", "logs")),
+            directory);
+    }
+
+    [Fact]
     public void TryNormalizeLogDirectoryCandidate_ReturnsFalseForInvalidPath()
     {
         var invalid = "bad" + '\0' + "path";

--- a/tests/CodeIndex.Tests/GlobalToolLogTests.cs
+++ b/tests/CodeIndex.Tests/GlobalToolLogTests.cs
@@ -43,6 +43,36 @@ public class GlobalToolLogTests
     }
 
     [Fact]
+    public void PrivateLogFile_OpenAppend_OnUnixRejectsSymlinkTargets_Issue3824()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var directory = Path.Combine(Path.GetTempPath(), $"cdidx_private_log_symlink_{Guid.NewGuid():N}");
+        var target = Path.Combine(directory, "target.log");
+        var link = Path.Combine(directory, "link.log");
+        try
+        {
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(target, "target");
+            File.CreateSymbolicLink(link, target);
+
+            var ex = Assert.Throws<IOException>(() =>
+            {
+                using var _ = PrivateLogFile.OpenAppend(link);
+            });
+
+            Assert.Contains("symbolic link or reparse point", ex.Message, StringComparison.Ordinal);
+            Assert.Equal("target", File.ReadAllText(target));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void PrivateLogFile_HardenExisting_CapsBestEffortWork_Issue3027()
     {
         if (OperatingSystem.IsWindows())
@@ -51,6 +81,7 @@ public class GlobalToolLogTests
         var directory = Path.Combine(Path.GetTempPath(), $"cdidx_private_log_harden_{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
         var fileCount = PrivateLogFile.MaxExistingFilesToHarden + 2;
+        var diagnostics = new List<PrivateLogFileDiagnostic>();
         try
         {
             for (var i = 0; i < fileCount; i++)
@@ -60,7 +91,7 @@ public class GlobalToolLogTests
                 File.SetUnixFileMode(path, PermissionBits);
             }
 
-            PrivateLogFile.HardenExisting(directory, "stderr-*.log");
+            PrivateLogFile.HardenExisting(directory, "stderr-*.log", diagnostics.Add);
 
             var privateCount = 0;
             for (var i = 0; i < fileCount; i++)
@@ -71,6 +102,11 @@ public class GlobalToolLogTests
             }
 
             Assert.Equal(PrivateLogFile.MaxExistingFilesToHarden, privateCount);
+            Assert.Equal(PrivateLogFile.PrivateFileMode, File.GetUnixFileMode(Path.Combine(directory, "stderr-0000.log")) & PermissionBits);
+            Assert.NotEqual(PrivateLogFile.PrivateFileMode, File.GetUnixFileMode(Path.Combine(directory, $"stderr-{fileCount - 1:D4}.log")) & PermissionBits);
+            var diagnostic = Assert.Single(diagnostics, item => item.Operation == "harden_existing_cap");
+            Assert.Equal("cap_exceeded", diagnostic.Reason);
+            Assert.DoesNotContain(directory, diagnostic.Target, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/MetricsSinkTests.cs
+++ b/tests/CodeIndex.Tests/MetricsSinkTests.cs
@@ -195,6 +195,88 @@ public class MetricsSinkTests
     }
 
     [Fact]
+    public void Record_RotatesBeforeNextEventWouldExceedMaxBytes_Issue3824()
+    {
+        var metricsPath = Path.Combine(Path.GetTempPath(), $"cdidx_metrics_pre_rotate_{Guid.NewGuid():N}.jsonl");
+        try
+        {
+            var first = new MetricsEvent(
+                Timestamp: DateTimeOffset.UtcNow,
+                Tool: "search",
+                Source: "cli",
+                ElapsedMs: 1.0,
+                ExitCode: 0,
+                Error: new string('x', 600));
+            var second = new MetricsEvent(
+                Timestamp: DateTimeOffset.UtcNow,
+                Tool: "status",
+                Source: "cli",
+                ElapsedMs: 1.0,
+                ExitCode: 0);
+            var firstBytes = Encoding.UTF8.GetByteCount(MetricsSink.SerializeEvent(first) + Environment.NewLine);
+            var secondBytes = Encoding.UTF8.GetByteCount(MetricsSink.SerializeEvent(second) + Environment.NewLine);
+
+            using var session = MetricsSink.TryStartForTesting(metricsPath, maxBytes: firstBytes + secondBytes - 1);
+            Assert.NotNull(session);
+
+            MetricsSink.Record(first);
+            Assert.False(File.Exists(metricsPath + ".1"));
+
+            MetricsSink.Record(second);
+
+            Assert.Contains("\"tool\":\"search\"", File.ReadAllText(metricsPath + ".1"), StringComparison.Ordinal);
+            Assert.Contains("\"tool\":\"status\"", File.ReadAllText(metricsPath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            foreach (var path in new[] { metricsPath, metricsPath + ".1", metricsPath + ".2" })
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Record_DisablesSessionAfterRepeatedWriteFailures_Issue3824()
+    {
+        var metricsPath = Path.Combine(Path.GetTempPath(), $"cdidx_metrics_failure_{Guid.NewGuid():N}.jsonl");
+        try
+        {
+            using var session = MetricsSink.TryStartForTesting(metricsPath, maxBytes: 1024 * 1024);
+            Assert.NotNull(session);
+            File.Delete(metricsPath);
+            Directory.CreateDirectory(metricsPath);
+
+            for (var i = 0; i < MetricsSink.MaxConsecutiveFailures + 2; i++)
+            {
+                MetricsSink.Record(new MetricsEvent(
+                    Timestamp: DateTimeOffset.UtcNow,
+                    Tool: "search",
+                    Source: "cli",
+                    ElapsedMs: 1.0,
+                    ExitCode: 0));
+            }
+
+            var diagnostics = Assert.IsType<MetricsDiagnostics>(MetricsSink.SnapshotDiagnosticsForTesting());
+            Assert.True(diagnostics.DisabledForFailures);
+            Assert.Equal(MetricsSink.MaxConsecutiveFailures, diagnostics.ConsecutiveFailureCount);
+            Assert.Equal(MetricsSink.MaxConsecutiveFailures, diagnostics.DroppedEventCount);
+            Assert.Equal(MetricsSink.MaxConsecutiveFailures, diagnostics.WriteFailureCount);
+            Assert.Equal(0, diagnostics.RotationFailureCount);
+            Assert.StartsWith("write_failure:", diagnostics.LastFailure!, StringComparison.Ordinal);
+            Assert.True(diagnostics.LastFailure!.Length <= 192);
+        }
+        finally
+        {
+            if (File.Exists(metricsPath))
+                File.Delete(metricsPath);
+            if (Directory.Exists(metricsPath))
+                Directory.Delete(metricsPath);
+        }
+    }
+
+    [Fact]
     public void Run_WithEnvVarFallback_StillEmitsMetrics()
     {
         var metricsPath = Path.Combine(Path.GetTempPath(), $"cdidx_metrics_env_{Guid.NewGuid():N}.jsonl");

--- a/tests/CodeIndex.Tests/MetricsSinkTests.cs
+++ b/tests/CodeIndex.Tests/MetricsSinkTests.cs
@@ -125,6 +125,34 @@ public class MetricsSinkTests
     }
 
     [Fact]
+    public void Run_WithMetricsFlag_OnUnixCreatesPrivateParentDirectory_Issue3686()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_metrics_private_parent_{Guid.NewGuid():N}");
+        var metricsDirectory = Path.Combine(root, "metrics");
+        var metricsPath = Path.Combine(metricsDirectory, "events.jsonl");
+        try
+        {
+            var (exitCode, _, _) = CaptureConsole(() => ProgramRunner.Run(
+                ["--metrics", metricsPath, "definitely-not-a-command"],
+                appVersion: "1.10.0"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(
+                DataDirectorySecurity.PrivateDirectoryMode,
+                File.GetUnixFileMode(metricsDirectory) & DataDirectorySecurity.PermissionBits);
+            Assert.Equal(PrivateLogFile.PrivateFileMode, File.GetUnixFileMode(metricsPath));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Record_RotatesMetricsLogAtMaxBytes()
     {
         var metricsPath = Path.Combine(Path.GetTempPath(), $"cdidx_metrics_rotate_{Guid.NewGuid():N}.jsonl");

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1149,6 +1149,22 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void UpdateChecker_ResolveDefaultCachePath_UsesPrivateTempFallback_Issue3675()
+    {
+        var path = UpdateChecker.ResolveDefaultCachePath(
+            xdgCacheHome: null,
+            home: null,
+            localAppData: null);
+
+        Assert.Equal(
+            Path.Combine(DataDirectorySecurity.ResolveSensitiveTempFallbackDirectory("cache"), "update-check.json"),
+            path);
+        Assert.NotEqual(
+            Path.GetFullPath(Path.Combine(Path.GetTempPath(), "cdidx", "cache", "update-check.json")),
+            path);
+    }
+
+    [Fact]
     public void UpdateChecker_Check_RateLimitResponseReportsRetryMetadata_Issue3822()
     {
         lock (TestConsoleLock.Gate)

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -369,6 +369,19 @@ public class SuggestionStoreTests : IDisposable
         AssertPrivateFileMode(filePath);
     }
 
+    [Fact]
+    public void TryAdd_OnPosixCreatesPrivateStoreDirectory_Issue3686()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        Assert.True(_store.TryAdd(MakeRecord("other", null, "Private suggestion directory")));
+
+        Assert.Equal(
+            DataDirectorySecurity.PrivateDirectoryMode,
+            File.GetUnixFileMode(_tempDir) & DataDirectorySecurity.PermissionBits);
+    }
+
     // --- LoadAll tests / LoadAll テスト ---
 
     [Fact]


### PR DESCRIPTION
## Summary
- Harden sensitive directory creation so audit, metrics, suggestion state, and temp fallback roots use private permissions.
- Scope temp fallbacks for update checks and global logs to hashed per-user roots, and document the updated fallback path.
- Harden atomic replacement temp names, parent-directory flush diagnostics, private log symlink rejection, bounded hardening, and metrics failure handling.

## Validation
- `git diff --check origin/main..HEAD`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --framework net8.0 -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false -p:RunAnalyzers=false /nr:false`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --framework net9.0 -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false -p:RunAnalyzers=false /nr:false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --framework net8.0 --filter "FullyQualifiedName~DataDirectorySecurityTests|FullyQualifiedName~GlobalToolLogTests|FullyQualifiedName~ProgramRunnerTests|FullyQualifiedName~MetricsSinkTests|FullyQualifiedName~AuditLogSinkTests|FullyQualifiedName~SuggestionStoreTests|FullyQualifiedName~UpdateChecker"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --framework net9.0 --filter "FullyQualifiedName~DataDirectorySecurityTests|FullyQualifiedName~GlobalToolLogTests|FullyQualifiedName~ProgramRunnerTests|FullyQualifiedName~MetricsSinkTests|FullyQualifiedName~AuditLogSinkTests|FullyQualifiedName~SuggestionStoreTests|FullyQualifiedName~UpdateChecker"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --framework net8.0 --filter "FullyQualifiedName~DataDirectorySecurityTests"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review completed; findings were addressed.

Fixes #3824
Fixes #3776
Fixes #3775
Fixes #3686
Fixes #3675