### PR TITLE
Fix migration foreign key restore and case-stamp read-only checks

### DIFF
--- a/changelog.d/unreleased/3678.fixed.md
+++ b/changelog.d/unreleased/3678.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3678
+affected:
+  - src/CodeIndex/Database/DbContext.cs
+  - tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+---
+
+## English
+
+- **DB migrations now guard foreign-key restoration on failure paths (#3678)** — migration windows that temporarily change `PRAGMA foreign_keys` now restore the original setting through a shared boundary and report a structured database error if restoration itself fails.
+
+## 日本語
+
+- **DB マイグレーション失敗時の foreign-key 復元を保護しました (#3678)** — `PRAGMA foreign_keys` を一時変更する migration window は共通境界で元の設定を復元し、復元自体が失敗した場合は構造化された database error を報告するようになりました。

--- a/changelog.d/unreleased/3828.fixed.md
+++ b/changelog.d/unreleased/3828.fixed.md
@@ -1,0 +1,22 @@
+---
+category: fixed
+issues:
+  - 3828
+affected:
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - src/CodeIndex/Cli/IndexFreshnessChecker.cs
+  - src/CodeIndex/Cli/PathCasing.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Indexer/Scanning/CaseSensitivityProbeDirectory.cs
+  - tests/CodeIndex.Tests/DbPathResolverTests.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
+---
+
+## English
+
+- **Read-only query and status paths reuse the persisted case-sensitivity stamp (#3828)** — `workspace_path_case_sensitive` now seeds path comparisons and status freshness checks before filesystem write probes run, while probe cleanup failures downgrade to bounded `.cdidx/probes` diagnostics after a result is obtained.
+
+## 日本語
+
+- **読み取り専用の query/status 経路で永続化済み case-sensitivity stamp を再利用するようになりました (#3828)** — `workspace_path_case_sensitive` が filesystem write probe より先に path 比較と status freshness check を seed し、probe cleanup 失敗は結果取得後に `.cdidx/probes` の bounded diagnostic へ downgrade します。

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -173,6 +173,11 @@ public static class DbPathResolver
         if (indexedProjectRoot == null && !string.Equals(dbPath, fullDbPath, StringComparison.Ordinal))
             indexedProjectRoot = TryReadIndexedProjectRoot(fullDbPath);
 
+        var pathCaseSensitive = TryReadWorkspacePathCaseSensitive(dbPath);
+        if (!pathCaseSensitive.HasValue && !string.Equals(dbPath, fullDbPath, StringComparison.Ordinal))
+            pathCaseSensitive = TryReadWorkspacePathCaseSensitive(fullDbPath);
+        SeedPathCasingFromWorkspaceStamp(indexedProjectRoot, fullDbPath, pathCaseSensitive);
+
         var projectLocalRoot = TryResolveProjectLocalRoot(fullDbPath, dbPath, dbPathExplicit, indexedProjectRoot);
         if (projectLocalRoot != null)
             return projectLocalRoot;
@@ -287,6 +292,23 @@ public static class DbPathResolver
 
     private static string? TryReadIndexedProjectRoot(string dbPath)
         => TryReadMetaString(dbPath, CodeIndex.Database.DbContext.IndexedProjectRootMetaKey);
+
+    private static bool? TryReadWorkspacePathCaseSensitive(string dbPath)
+    {
+        var raw = TryReadMetaString(dbPath, CodeIndex.Database.DbContext.WorkspacePathCaseSensitiveMetaKey);
+        return bool.TryParse(raw, out var pathCaseSensitive) ? pathCaseSensitive : null;
+    }
+
+    private static void SeedPathCasingFromWorkspaceStamp(string? indexedProjectRoot, string fullDbPath, bool? pathCaseSensitive)
+    {
+        if (!pathCaseSensitive.HasValue)
+            return;
+
+        var ignoreCase = !pathCaseSensitive.Value;
+        if (!string.IsNullOrWhiteSpace(indexedProjectRoot))
+            PathCasing.SeedFromWorkspace(indexedProjectRoot, ignoreCase);
+        PathCasing.SeedFromReferencePath(fullDbPath, ignoreCase);
+    }
 
     /// <summary>
     /// Best-effort read of the persisted git HEAD commit stamped at the end of the

--- a/src/CodeIndex/Cli/IndexFreshnessChecker.cs
+++ b/src/CodeIndex/Cli/IndexFreshnessChecker.cs
@@ -13,7 +13,8 @@ internal static class IndexFreshnessChecker
     internal static IndexFreshnessCheckResult Check(
         DbReader reader,
         string? projectRoot,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool? pathCaseSensitive = null)
     {
         if (string.IsNullOrWhiteSpace(projectRoot))
         {
@@ -51,7 +52,11 @@ internal static class IndexFreshnessChecker
             HeadChanged = headChanged,
         };
 
-        var ignoreCase = GitHelper.ResolveIgnoreCase(projectRoot, cancellationToken);
+        var ignoreCase = pathCaseSensitive.HasValue
+            ? !pathCaseSensitive.Value
+            : GitHelper.ResolveIgnoreCase(projectRoot, cancellationToken);
+        if (pathCaseSensitive.HasValue)
+            PathCasing.SeedFromWorkspace(projectRoot, ignoreCase);
         var ignoreRuleRoot = GitHelper.TryGetRepositoryRoot(projectRoot, cancellationToken) ?? Path.GetFullPath(projectRoot);
         var indexer = new FileIndexer(projectRoot, ignoreCase, ignoreRuleRoot);
         var scan = indexer.ScanFilesDetailed(cancellationToken: cancellationToken);

--- a/src/CodeIndex/Cli/PathCasing.cs
+++ b/src/CodeIndex/Cli/PathCasing.cs
@@ -77,7 +77,15 @@ internal static class PathCasing
     {
         if (string.IsNullOrEmpty(workspaceRoot))
             return;
-        var anchor = ResolveAnchor(workspaceRoot);
+        SeedFromReferencePath(workspaceRoot, ignoreCase);
+        SeedFromReferencePath(Path.Combine(workspaceRoot, CaseSensitivityProbeDirectory.DataDirectoryName), ignoreCase);
+    }
+
+    public static void SeedFromReferencePath(string referencePath, bool ignoreCase)
+    {
+        if (string.IsNullOrEmpty(referencePath))
+            return;
+        var anchor = ResolveAnchor(referencePath);
         _ignoreCaseByAnchor[anchor] = ignoreCase;
     }
 

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -5981,7 +5981,7 @@ public static partial class QueryCommandRunner
                 status.MacProfileDiagnostics = macProfile.Diagnostics.ToList();
             if (options.CheckWorkspace)
             {
-                status.WorkspaceCheck = IndexFreshnessChecker.Check(reader, status.ProjectRoot, cancellationToken);
+                status.WorkspaceCheck = IndexFreshnessChecker.Check(reader, status.ProjectRoot, cancellationToken, status.PathCaseSensitive);
                 status.IndexMatchesWorkspace = status.WorkspaceCheck.Checked
                     ? status.WorkspaceCheck.MatchesWorkspace
                     : null;

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -3,6 +3,7 @@ using CodeIndex.Indexer;
 using CodeIndex.Models;
 using Microsoft.Data.Sqlite;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 
 namespace CodeIndex.Database;
 
@@ -105,6 +106,8 @@ public class DbContext : IDisposable
     private static readonly AsyncLocal<Action<SqliteCommand>?> ScopedPlannerStatisticsCommandCreatedForTesting = new();
     private static readonly AsyncLocal<Action<string, string>?> ScopedPlannerStatisticsCommandExecutedForTesting = new();
     private static readonly AsyncLocal<Action<string>?> ScopedWalCheckpointTruncateExecutedForTesting = new();
+    private static readonly AsyncLocal<Action<string>?> ScopedForeignKeysDisabledForTesting = new();
+    private static readonly AsyncLocal<Action<string, long>?> ScopedForeignKeysRestoringForTesting = new();
 
     internal static Action<string>? OptimizePragmaExecutedForTesting
     {
@@ -128,6 +131,18 @@ public class DbContext : IDisposable
     {
         get => ScopedWalCheckpointTruncateExecutedForTesting.Value;
         set => ScopedWalCheckpointTruncateExecutedForTesting.Value = value;
+    }
+
+    internal static Action<string>? ForeignKeysDisabledForTesting
+    {
+        get => ScopedForeignKeysDisabledForTesting.Value;
+        set => ScopedForeignKeysDisabledForTesting.Value = value;
+    }
+
+    internal static Action<string, long>? ForeignKeysRestoringForTesting
+    {
+        get => ScopedForeignKeysRestoringForTesting.Value;
+        set => ScopedForeignKeysRestoringForTesting.Value = value;
     }
 
     public SqliteConnection Connection => _connection;
@@ -2055,9 +2070,7 @@ public class DbContext : IDisposable
         const string oldSymbolReferences = "_symbol_references_file_line_key";
         var quotedOldReferenceLines = SqliteIdentifier.Quote(oldReferenceLines);
         var quotedOldSymbolReferences = SqliteIdentifier.Quote(oldSymbolReferences);
-        var foreignKeys = ReadPragmaLong("foreign_keys");
-        Execute("PRAGMA foreign_keys=OFF");
-        try
+        RunWithForeignKeysDisabledForMigration("EnsureReferenceLinesContextKey", () =>
         {
             Execute($"DROP TABLE IF EXISTS {quotedOldSymbolReferences}");
             Execute($"DROP TABLE IF EXISTS {quotedOldReferenceLines}");
@@ -2069,11 +2082,7 @@ public class DbContext : IDisposable
             Execute($"INSERT INTO symbol_references ({symbolReferencesColumns}) SELECT {symbolReferencesColumns} FROM {quotedOldSymbolReferences}");
             Execute($"DROP TABLE {quotedOldSymbolReferences}");
             Execute($"DROP TABLE {quotedOldReferenceLines}");
-        }
-        finally
-        {
-            Execute($"PRAGMA foreign_keys={foreignKeys}");
-        }
+        });
 
         _schemaCache?.Refresh();
     }
@@ -2159,20 +2168,48 @@ public class DbContext : IDisposable
             """;
         const string symbolReferencesColumns = "id, file_id, symbol_name, reference_kind, line, column_number, context, reference_line_id, container_kind, container_name, symbol_name_folded, container_name_folded, is_self_reference, is_mutual_recursion";
 
-        var foreignKeys = ReadPragmaLong("foreign_keys");
-        Execute("PRAGMA foreign_keys=OFF");
-        try
+        RunWithForeignKeysDisabledForMigration("EnsureKindCheckConstraintsCurrent", () =>
         {
             if (!TableCheckContainsAll("symbols", SymbolKindCatalog.SymbolKinds))
                 RebuildTableWithCurrentKindChecks("symbols", "_symbols_kind_check", symbolsCreateSql, symbolsColumns);
 
             if (!TableCheckContainsAll("symbol_references", SymbolKindCatalog.SymbolKinds.Concat(SymbolKindCatalog.ReferenceKinds)))
                 RebuildTableWithCurrentKindChecks("symbol_references", "_symbol_references_kind_check", symbolReferencesCreateSql, symbolReferencesColumns);
-        }
-        finally
+        });
+    }
+
+    private void RunWithForeignKeysDisabledForMigration(string operation, Action action)
+    {
+        var foreignKeys = ReadPragmaLong("foreign_keys");
+        Execute("PRAGMA foreign_keys=OFF");
+        ExceptionDispatchInfo? operationFailure = null;
+        try
         {
+            ForeignKeysDisabledForTesting?.Invoke(operation);
+            action();
+        }
+        catch (Exception ex)
+        {
+            operationFailure = ExceptionDispatchInfo.Capture(ex);
+        }
+
+        try
+        {
+            ForeignKeysRestoringForTesting?.Invoke(operation, foreignKeys);
             Execute($"PRAGMA foreign_keys={foreignKeys}");
         }
+        catch (Exception ex)
+        {
+            throw new CodeIndexException(
+                code: CommandErrorCodes.DbError,
+                category: CodeIndexExceptionCategory.Database,
+                message: $"Failed to restore PRAGMA foreign_keys after {operation}.",
+                path: _connection.DataSource,
+                hint: "Close other database connections, restore write access if needed, and rerun the command before trusting further migration work.",
+                innerException: ex);
+        }
+
+        operationFailure?.Throw();
     }
 
     private bool TableCheckContainsAll(string tableName, IEnumerable<string> allowedValues)

--- a/src/CodeIndex/Indexer/Scanning/CaseSensitivityProbeDirectory.cs
+++ b/src/CodeIndex/Indexer/Scanning/CaseSensitivityProbeDirectory.cs
@@ -11,6 +11,7 @@ internal static class CaseSensitivityProbeDirectory
         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
 
     internal static Action<string>? DeleteCreatedEmptyDirectoryForTesting { get; set; }
+    internal static Action<CaseSensitivityProbeCleanupDiagnostic>? CleanupDiagnosticSinkForTesting { get; set; }
 
     internal static ProbePathScope CreateProbePathScope(string projectRoot, string prefix)
     {
@@ -44,6 +45,7 @@ internal static class CaseSensitivityProbeDirectory
         private readonly string _dataDirectory;
         private readonly bool _createdProbeDirectory;
         private readonly bool _createdDataDirectory;
+        private readonly List<CaseSensitivityProbeCleanupDiagnostic> _cleanupDiagnostics = [];
         private bool _disposed;
 
         internal ProbePathScope(
@@ -64,6 +66,7 @@ internal static class CaseSensitivityProbeDirectory
 
         internal string ProjectRoot { get; }
         internal string Path { get; }
+        internal IReadOnlyList<CaseSensitivityProbeCleanupDiagnostic> CleanupDiagnostics => _cleanupDiagnostics;
 
         public void Dispose()
         {
@@ -92,13 +95,47 @@ internal static class CaseSensitivityProbeDirectory
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                throw new CaseSensitivityProbeException(
-                    "Failed to clean up filesystem case-sensitivity probe directory.",
-                    ProjectRoot,
-                    ex,
-                    cleanupPath: path);
+                RecordCleanupDiagnostic(path, ex);
             }
         }
+
+        private void RecordCleanupDiagnostic(string path, Exception ex)
+        {
+            var diagnostic = new CaseSensitivityProbeCleanupDiagnostic(
+                RelativePath: FormatCleanupRelativePath(path),
+                ExceptionType: ex.GetType().Name,
+                Message: "Failed to clean up filesystem case-sensitivity probe directory.");
+            _cleanupDiagnostics.Add(diagnostic);
+
+            if (CleanupDiagnosticSinkForTesting is { } sink)
+            {
+                sink(diagnostic);
+                return;
+            }
+
+            Console.Error.WriteLine(
+                $"Warning: {diagnostic.Message} path={diagnostic.RelativePath} exception={diagnostic.ExceptionType}. " +
+                $"Remove stale {DataDirectoryName}/{ProbeDirectoryName} entries when no cdidx process is running.");
+        }
+
+        private string FormatCleanupRelativePath(string path)
+        {
+            try
+            {
+                var relative = System.IO.Path.GetRelativePath(ProjectRoot, path);
+                if (!relative.StartsWith("..", StringComparison.Ordinal) && !System.IO.Path.IsPathRooted(relative))
+                    return NormalizeRelativePath(relative);
+            }
+            catch
+            {
+            }
+
+            return DataDirectoryName + "/" + ProbeDirectoryName;
+        }
+
+        private static string NormalizeRelativePath(string path)
+            => path.Replace(System.IO.Path.DirectorySeparatorChar, '/')
+                .Replace(System.IO.Path.AltDirectorySeparatorChar, '/');
     }
 
     internal readonly record struct ProbeDirectoryScope(
@@ -122,3 +159,8 @@ internal static class CaseSensitivityProbeDirectory
     }
 
 }
+
+internal readonly record struct CaseSensitivityProbeCleanupDiagnostic(
+    string RelativePath,
+    string ExceptionType,
+    string Message);

--- a/tests/CodeIndex.Tests/DbPathResolverTests.cs
+++ b/tests/CodeIndex.Tests/DbPathResolverTests.cs
@@ -492,6 +492,39 @@ public class DbPathResolverTests
     }
 
     [Fact]
+    public void ResolveProjectRootForQuery_StampedProjectLocalReadOnlyUriAvoidsPathCasingProbe_Issue3828()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_case_stamp");
+        var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+        var previousProbe = PathCasing.IgnoreCaseProbeForTesting;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db.Connection);
+                writer.SetMeta(DbContext.IndexedProjectRootMetaKey, projectRoot);
+                writer.SetMeta(DbContext.WorkspacePathCaseSensitiveMetaKey, "true");
+            }
+
+            PathCasing.ResetCacheForTests();
+            PathCasing.IgnoreCaseProbeForTesting = _ => throw new IOException("path casing probe should not run");
+
+            var readOnlyUri = new Uri(dbPath).AbsoluteUri + "?immutable=1";
+            var resolved = DbPathResolver.ResolveProjectRootForQuery(readOnlyUri, dbPathExplicit: true);
+
+            Assert.Equal(projectRoot, resolved);
+        }
+        finally
+        {
+            PathCasing.IgnoreCaseProbeForTesting = previousProbe;
+            PathCasing.ResetCacheForTests();
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ResolveProjectRootForQuery_ProjectLocalDbPrefersCdidxSiblingOverStoredMetadata()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_local");

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -141,28 +141,31 @@ public class FileIndexerTests
     }
 
     [Fact]
-    public void CaseSensitivityProbeDirectory_CleanupFailureThrows_Issue3439()
+    public void CaseSensitivityProbeDirectory_CleanupFailureDowngradesToDiagnostic_Issue3828()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx-case-probe-cleanup-{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDir);
         var previousDelete = CaseSensitivityProbeDirectory.DeleteCreatedEmptyDirectoryForTesting;
+        var previousSink = CaseSensitivityProbeDirectory.CleanupDiagnosticSinkForTesting;
+        var diagnostics = new List<CaseSensitivityProbeCleanupDiagnostic>();
         try
         {
-            using var scope = CaseSensitivityProbeDirectory.CreateProbePathScope(tempDir, "case-probe-test-");
+            var scope = CaseSensitivityProbeDirectory.CreateProbePathScope(tempDir, "case-probe-test-");
             CaseSensitivityProbeDirectory.DeleteCreatedEmptyDirectoryForTesting = path => throw new IOException($"blocked: {path}");
+            CaseSensitivityProbeDirectory.CleanupDiagnosticSinkForTesting = diagnostics.Add;
 
-            var ex = Assert.Throws<CaseSensitivityProbeException>(() => scope.Dispose());
+            scope.Dispose();
 
-            Assert.Equal(Path.GetFullPath(tempDir), ex.ProjectRoot);
-            Assert.NotNull(ex.CleanupPath);
-            Assert.EndsWith(
-                $"{CaseSensitivityProbeDirectory.DataDirectoryName}{Path.DirectorySeparatorChar}{CaseSensitivityProbeDirectory.ProbeDirectoryName}",
-                ex.CleanupPath);
-            Assert.IsType<IOException>(ex.InnerException);
+            Assert.Contains(scope.CleanupDiagnostics, diagnostic =>
+                diagnostic.RelativePath == $"{CaseSensitivityProbeDirectory.DataDirectoryName}/{CaseSensitivityProbeDirectory.ProbeDirectoryName}");
+            Assert.Contains(diagnostics, diagnostic =>
+                diagnostic.RelativePath == $"{CaseSensitivityProbeDirectory.DataDirectoryName}/{CaseSensitivityProbeDirectory.ProbeDirectoryName}");
+            Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.RelativePath.Contains(tempDir, StringComparison.Ordinal));
         }
         finally
         {
             CaseSensitivityProbeDirectory.DeleteCreatedEmptyDirectoryForTesting = previousDelete;
+            CaseSensitivityProbeDirectory.CleanupDiagnosticSinkForTesting = previousSink;
             TestProjectHelper.DeleteDirectory(tempDir);
         }
     }

--- a/tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
+++ b/tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
@@ -1,7 +1,10 @@
 using CodeIndex.Cli;
+using CodeIndex.Database;
+using CodeIndex.Indexer;
 
 namespace CodeIndex.Tests;
 
+[Collection("SQLite pool sensitive")]
 public class IndexFreshnessCheckerTests
 {
     [Fact]
@@ -36,5 +39,33 @@ public class IndexFreshnessCheckerTests
         var sample = IndexFreshnessChecker.FormatScanFailureSample("src/Broken.cs", exception);
 
         Assert.Equal("src/Broken.cs: probe-failed", sample);
+    }
+
+    [Fact]
+    public void Check_StampedPathCaseSensitivityAvoidsFilesystemWriteProbe_Issue3828()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_status_case_stamp");
+        var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+        var previousGitProbe = GitHelper.FileSystemIgnoreCaseProbeForTesting;
+        var previousIndexerProbe = FileIndexer.FileSystemIgnoreCaseProbeForTesting;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+            using var db = new DbContext(dbPath);
+            db.InitializeSchema();
+            var reader = new DbReader(db);
+            GitHelper.FileSystemIgnoreCaseProbeForTesting = _ => throw new IOException("git case probe should not run");
+            FileIndexer.FileSystemIgnoreCaseProbeForTesting = _ => throw new IOException("indexer case probe should not run");
+
+            var result = IndexFreshnessChecker.Check(reader, projectRoot, pathCaseSensitive: true);
+
+            Assert.True(result.Checked);
+        }
+        finally
+        {
+            GitHelper.FileSystemIgnoreCaseProbeForTesting = previousGitProbe;
+            FileIndexer.FileSystemIgnoreCaseProbeForTesting = previousIndexerProbe;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
     }
 }

--- a/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+++ b/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using CodeIndex.Cli;
 using CodeIndex.Database;
 using CodeIndex.Models;
@@ -198,6 +199,35 @@ public class LegacySchemaMigrationTests : IDisposable
             """;
         cmd.ExecuteNonQuery();
         SqliteConnection.ClearAllPools();
+    }
+
+    private static long ReadForeignKeys(DbContext db)
+    {
+        using var cmd = db.Connection.CreateCommand();
+        cmd.CommandText = "PRAGMA foreign_keys";
+        return Convert.ToInt64(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+    }
+
+    private static void SetForeignKeys(DbContext db, bool enabled)
+    {
+        using var cmd = db.Connection.CreateCommand();
+        cmd.CommandText = $"PRAGMA foreign_keys={(enabled ? 1 : 0)}";
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void InvokePrivateDbContextMethod(DbContext db, string methodName)
+    {
+        var method = typeof(DbContext).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        try
+        {
+            method!.Invoke(db, parameters: null);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+        }
     }
 
     [Fact]
@@ -463,6 +493,90 @@ public class LegacySchemaMigrationTests : IDisposable
         failingRead.CommandText = "SELECT start_line FROM symbols LIMIT 1";
         var ex = Assert.Throws<SqliteException>(() => failingRead.ExecuteReader());
         Assert.Contains("no such column", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void InitializeSchema_ForeignKeysRestoredWhenMigrationWindowFailsInsideTransaction_Issue3678()
+    {
+        using var db = new DbContext(_dbPath);
+        Assert.Equal(1, ReadForeignKeys(db));
+
+        var previousHook = DbContext.ForeignKeysDisabledForTesting;
+        DbContext.ForeignKeysDisabledForTesting = operation =>
+        {
+            if (operation == "EnsureKindCheckConstraintsCurrent")
+                throw new InvalidOperationException("injected kind-check migration failure");
+        };
+
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(db.InitializeSchema);
+
+            Assert.Contains("injected kind-check", ex.Message, StringComparison.Ordinal);
+            Assert.Equal(1, ReadForeignKeys(db));
+        }
+        finally
+        {
+            DbContext.ForeignKeysDisabledForTesting = previousHook;
+        }
+    }
+
+    [Fact]
+    public void MigrationWindow_ForeignKeysRestoredWhenFailureOccursOutsideActiveTransaction_Issue3678()
+    {
+        using var db = new DbContext(_dbPath);
+        db.InitializeSchema();
+        SetForeignKeys(db, enabled: false);
+        Assert.Equal(0, ReadForeignKeys(db));
+
+        var previousHook = DbContext.ForeignKeysDisabledForTesting;
+        DbContext.ForeignKeysDisabledForTesting = operation =>
+        {
+            if (operation == "EnsureKindCheckConstraintsCurrent")
+                throw new InvalidOperationException("injected direct migration failure");
+        };
+
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                InvokePrivateDbContextMethod(db, "EnsureKindCheckConstraintsCurrent"));
+
+            Assert.Contains("injected direct", ex.Message, StringComparison.Ordinal);
+            Assert.Equal(0, ReadForeignKeys(db));
+        }
+        finally
+        {
+            DbContext.ForeignKeysDisabledForTesting = previousHook;
+            SetForeignKeys(db, enabled: true);
+        }
+    }
+
+    [Fact]
+    public void InitializeSchema_ForeignKeyRestoreFailureReportsActionableDatabaseError_Issue3678()
+    {
+        using var db = new DbContext(_dbPath);
+        var previousHook = DbContext.ForeignKeysRestoringForTesting;
+        DbContext.ForeignKeysRestoringForTesting = (operation, _) =>
+        {
+            if (operation == "EnsureKindCheckConstraintsCurrent")
+                throw new InvalidOperationException("restore blocked");
+        };
+
+        try
+        {
+            var ex = Assert.Throws<CodeIndexException>(db.InitializeSchema);
+
+            Assert.Equal(CommandErrorCodes.DbError, ex.Code);
+            Assert.Equal(CodeIndexExceptionCategory.Database, ex.Category);
+            Assert.Contains("Failed to restore PRAGMA foreign_keys", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("EnsureKindCheckConstraintsCurrent", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("rerun the command", ex.Hint, StringComparison.OrdinalIgnoreCase);
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+        }
+        finally
+        {
+            DbContext.ForeignKeysRestoringForTesting = previousHook;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Restores `PRAGMA foreign_keys` through a shared migration guard and reports restore failures as actionable database errors.
- Reuses persisted `workspace_path_case_sensitive` stamps for read-only query/status path handling before filesystem write probes run.
- Downgrades successful case-probe cleanup failures to bounded `.cdidx/probes` diagnostics.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false --filter FullyQualifiedName~Issue3678`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false --filter FullyQualifiedName~Issue3828`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false --filter FullyQualifiedName~LegacySchemaMigrationTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false /nr:false --filter "FullyQualifiedName~DbPathResolverTests|FullyQualifiedName~FileIndexerTests|FullyQualifiedName~IndexFreshnessCheckerTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Scope Notes
- #3811 was excluded because it already had a work-started comment.
- No changes to `AGENT.md`, `CLAUDE.md`, or `AGENT_GUIDE.md`.

Fixes #3678
Fixes #3828