### PR TITLE
Fix SymbolExtractor runaway guard flakiness

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -50,6 +50,8 @@ The test project mirrors the production areas closely.
   exercise watch-loop startup and shutdown under redirected console output. These tests wait for the watch start line before cancelling and always cancel/drain the dedicated watch task before restoring `Console.Out` / `Console.Error`; do not replace that synchronization with fixed sleeps because full-suite load can delay the long-running task startup.
 - `SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget`
   is a coarse runaway guard for the real `InstallScriptTests.cs` C# extraction fixture. Its wall-clock budget is intentionally broader than a benchmark so slower or noisy CI hosts do not fail the suite for ordinary variance.
+- `SymbolExtractorTests.Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget` and `Extract_CSharp_ReferenceExtractorFixture_CompletesWithinPracticalBudget`
+  are broad runaway guards for known large symbol-extraction fixtures. Keep their budgets generous enough for full-suite load; tighten them only with focused optimization evidence, not as benchmark thresholds.
 - `IndexCommandRunnerTests.RunBackfillFold_PublishedTrimmedBinary_SerializesSuccessAndErrorJson`
   publishes a trimmed RID-specific CLI and runs whichever entry point the SDK emits (`cdidx.dll` through `dotnet` or the native `cdidx`/`cdidx.exe` apphost). Its publish smoke disables NuGet vulnerability auditing because package advisory validation is covered by the normal build/test workflow's package vulnerability check, not by this runtime serialization test. It is reported as skipped on macOS arm64 while SDK/ILLink can crash before exercising `cdidx` (#2586). Do not assume every SDK/runtime pair writes a `cdidx.dll` into self-contained publish output.
 - `QueryCommandRunnerTests.RunPublishedTrimmedCli_SerializesQueryJsonAndErrorJson`
@@ -258,6 +260,8 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
   リダイレクトした console 出力の下で watch loop の起動と停止を検証する。これらのテストは watch start 行を待ってからキャンセルし、`Console.Out` / `Console.Error` を戻す前に専用 watch task を必ず cancel/drain する。full suite の負荷で long-running task の起動が遅れることがあるため、この同期を固定 sleep に戻さないこと。
 - `SymbolExtractorTests.Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget`
   は実ファイル `InstallScriptTests.cs` を C# 抽出に通す coarse な runaway guard です。wall-clock の予算は benchmark より意図的に広く取り、遅い / 混雑した CI host で通常の揺れだけにより suite が失敗しないようにしています。
+- `SymbolExtractorTests.Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget` と `Extract_CSharp_ReferenceExtractorFixture_CompletesWithinPracticalBudget`
+  は既知の大きな symbol extraction fixture に対する広めの runaway guard です。full suite の負荷に耐えるよう budget は十分広く保ち、benchmark 閾値としてではなく、焦点を絞った最適化根拠がある場合にだけ締めてください。
 - `IndexCommandRunnerTests.RunBackfillFold_PublishedTrimmedBinary_SerializesSuccessAndErrorJson`
   は trimmed な RID 固有 CLI を publish し、SDK が生成した entry point（`dotnet` 経由の `cdidx.dll`、または native の `cdidx`/`cdidx.exe` apphost）を実行します。この publish smoke は NuGet 脆弱性監査を無効化します。package advisory の検証は通常の build/test workflow の package vulnerability check が担い、この runtime serialization テストの責務ではないためです。macOS arm64 では SDK/ILLink が `cdidx` に到達する前にクラッシュし得るため、このテストは skipped として報告されます（#2586）。self-contained publish output に常に `cdidx.dll` が出るとは仮定しないでください。
 - `QueryCommandRunnerTests.RunPublishedTrimmedCli_SerializesQueryJsonAndErrorJson`

--- a/changelog.d/unreleased/3864.fixed.md
+++ b/changelog.d/unreleased/3864.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3864
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+  - tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Symbol extractor runaway guards are less prone to noisy full-suite failures (#3864)** — exported JavaScript object literal property extraction now scans identifier keys without repeatedly slicing the remaining line, and the C# `ReferenceExtractor.cs` fixture guard uses a broader coarse budget for loaded hosts.
+
+## 日本語
+
+- **Symbol extractor の runaway guard が full suite の負荷で失敗しにくくなりました (#3864)** — export された JavaScript object literal の property 抽出は残り行の slice を繰り返さず identifier key を走査し、C# の `ReferenceExtractor.cs` fixture guard は負荷のある host 向けに coarse な budget を広げました。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
@@ -4526,18 +4526,22 @@ public static partial class SymbolExtractor
                     if (scanColumn >= sanitizedLine.Length)
                         break;
 
-                    var remainingLine = sanitizedLine[scanColumn..];
-                    if (remainingLine.StartsWith("...", StringComparison.Ordinal))
+                    if (scanColumn + 2 < sanitizedLine.Length
+                        && sanitizedLine[scanColumn] == '.'
+                        && sanitizedLine[scanColumn + 1] == '.'
+                        && sanitizedLine[scanColumn + 2] == '.')
                     {
                         scanColumn += 3;
                         skippingPropertyValue = true;
                         continue;
                     }
 
-                    var propertyMatch = JavaScriptTypeScriptExportedObjectLiteralPropertyRegex.Match(remainingLine);
-                    if (propertyMatch.Success)
+                    if (TryReadJavaScriptTypeScriptIdentifierObjectLiteralKeyName(
+                            sanitizedLine,
+                            scanColumn,
+                            out var propertyName,
+                            out var identifierValueStartColumn))
                     {
-                        var propertyName = propertyMatch.Groups["name"].Value;
                         AddJavaScriptTypeScriptCommonJsExportObjectLiteralSymbol(
                             fileId,
                             rawLines,
@@ -4545,9 +4549,9 @@ public static partial class SymbolExtractor
                             seenNames,
                             propertyName,
                             lineIndex,
-                            scanColumn + propertyMatch.Index,
+                            scanColumn,
                             signature);
-                        scanColumn += propertyMatch.Length;
+                        scanColumn = identifierValueStartColumn;
                         skippingPropertyValue = true;
                         continue;
                     }
@@ -4600,20 +4604,22 @@ public static partial class SymbolExtractor
                         continue;
                     }
 
-                    var shorthandMatch = JavaScriptTypeScriptExportedObjectLiteralShorthandPropertyRegex.Match(remainingLine);
-                    if (shorthandMatch.Success)
+                    if (TryReadJavaScriptTypeScriptShorthandObjectLiteralKeyName(
+                            sanitizedLine,
+                            scanColumn,
+                            out var shorthandPropertyName,
+                            out var shorthandEndColumn))
                     {
-                        var propertyName = shorthandMatch.Groups["name"].Value;
                         AddJavaScriptTypeScriptCommonJsExportObjectLiteralSymbol(
                             fileId,
                             rawLines,
                             symbols,
                             seenNames,
-                            propertyName,
+                            shorthandPropertyName,
                             lineIndex,
-                            scanColumn + shorthandMatch.Index,
+                            scanColumn,
                             signature);
-                        scanColumn += shorthandMatch.Length;
+                        scanColumn = shorthandEndColumn;
                         continue;
                     }
                 }
@@ -4772,18 +4778,22 @@ public static partial class SymbolExtractor
                         if (scanColumn >= sanitizedLine.Length)
                             break;
 
-                        var remainingLine = sanitizedLine[scanColumn..];
-                        if (remainingLine.StartsWith("...", StringComparison.Ordinal))
+                        if (scanColumn + 2 < sanitizedLine.Length
+                            && sanitizedLine[scanColumn] == '.'
+                            && sanitizedLine[scanColumn + 1] == '.'
+                            && sanitizedLine[scanColumn + 2] == '.')
                         {
                             scanColumn += 3;
                             skippingPropertyValue = true;
                             continue;
                         }
 
-                        var propertyMatch = JavaScriptTypeScriptExportedObjectLiteralPropertyRegex.Match(remainingLine);
-                        if (propertyMatch.Success)
+                        if (TryReadJavaScriptTypeScriptIdentifierObjectLiteralKeyName(
+                                sanitizedLine,
+                                scanColumn,
+                                out var propertyName,
+                                out var identifierValueStartColumn))
                         {
-                            var propertyName = propertyMatch.Groups["name"].Value;
                             AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
                                 fileId,
                                 rawLines,
@@ -4792,9 +4802,9 @@ public static partial class SymbolExtractor
                                 target.ContainerName,
                                 propertyName,
                                 lineIndex,
-                                scanColumn + propertyMatch.Index);
+                                scanColumn);
 
-                            scanColumn += propertyMatch.Length;
+                            scanColumn = identifierValueStartColumn;
                             skippingPropertyValue = true;
                             continue;
                         }
@@ -4849,21 +4859,23 @@ public static partial class SymbolExtractor
                             continue;
                         }
 
-                        var shorthandMatch = JavaScriptTypeScriptExportedObjectLiteralShorthandPropertyRegex.Match(remainingLine);
-                        if (shorthandMatch.Success)
+                        if (TryReadJavaScriptTypeScriptShorthandObjectLiteralKeyName(
+                                sanitizedLine,
+                                scanColumn,
+                                out var shorthandPropertyName,
+                                out var shorthandEndColumn))
                         {
-                            var propertyName = shorthandMatch.Groups["name"].Value;
                             AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
                                 fileId,
                                 rawLines,
                                 symbols,
                                 existingContainerSymbolNames,
                                 target.ContainerName,
-                                propertyName,
+                                shorthandPropertyName,
                                 lineIndex,
-                                scanColumn + shorthandMatch.Index);
+                                scanColumn);
 
-                            scanColumn += shorthandMatch.Length;
+                            scanColumn = shorthandEndColumn;
                             continue;
                         }
                     }
@@ -4931,6 +4943,58 @@ public static partial class SymbolExtractor
                 Visibility = "export",
             },
             rawLines[lineIndex]);
+    }
+
+    private static bool TryReadJavaScriptTypeScriptIdentifierObjectLiteralKeyName(
+        string sanitizedLine,
+        int startColumn,
+        out string propertyName,
+        out int valueStartColumn)
+    {
+        propertyName = string.Empty;
+        valueStartColumn = startColumn;
+
+        var probe = startColumn;
+        if (!TryReadJavaScriptTypeScriptIdentifierToken(sanitizedLine, ref probe, out propertyName))
+            return false;
+
+        while (probe < sanitizedLine.Length && char.IsWhiteSpace(sanitizedLine[probe]))
+            probe++;
+
+        if (probe >= sanitizedLine.Length || sanitizedLine[probe] != ':')
+        {
+            propertyName = string.Empty;
+            return false;
+        }
+
+        valueStartColumn = probe + 1;
+        return true;
+    }
+
+    private static bool TryReadJavaScriptTypeScriptShorthandObjectLiteralKeyName(
+        string sanitizedLine,
+        int startColumn,
+        out string propertyName,
+        out int endColumn)
+    {
+        propertyName = string.Empty;
+        endColumn = startColumn;
+
+        var probe = startColumn;
+        if (!TryReadJavaScriptTypeScriptIdentifierToken(sanitizedLine, ref probe, out propertyName))
+            return false;
+
+        while (probe < sanitizedLine.Length && char.IsWhiteSpace(sanitizedLine[probe]))
+            probe++;
+
+        if (probe < sanitizedLine.Length && sanitizedLine[probe] is not ',' and not '}')
+        {
+            propertyName = string.Empty;
+            return false;
+        }
+
+        endColumn = probe;
+        return true;
     }
 
     private static bool TryReadJavaScriptTypeScriptLiteralObjectLiteralKeyName(
@@ -5099,6 +5163,90 @@ public static partial class SymbolExtractor
         }
 
         return false;
+    }
+
+    private static bool StartsJavaScriptTypeScriptFunctionAssignmentValue(string rhs, int startColumn)
+    {
+        var index = SkipJavaScriptTypeScriptWhitespace(rhs, Math.Max(0, startColumn));
+        while (index < rhs.Length)
+        {
+            if (IsJavaScriptTypeScriptKeywordAt(rhs, index, "function")
+                || StartsJavaScriptTypeScriptAsyncFunctionAssignmentValue(rhs, index)
+                || StartsJavaScriptTypeScriptGenericArrowAssignmentValue(rhs, index)
+                || StartsJavaScriptTypeScriptArrowAssignmentValue(rhs, index))
+            {
+                return true;
+            }
+
+            if (rhs[index] != '(')
+                return false;
+
+            index = SkipJavaScriptTypeScriptWhitespace(rhs, index + 1);
+        }
+
+        return false;
+    }
+
+    private static bool StartsJavaScriptTypeScriptAsyncFunctionAssignmentValue(string rhs, int startColumn)
+    {
+        if (!IsJavaScriptTypeScriptKeywordAt(rhs, startColumn, "async"))
+            return false;
+
+        var functionColumn = SkipJavaScriptTypeScriptWhitespace(rhs, startColumn + "async".Length);
+        return IsJavaScriptTypeScriptKeywordAt(rhs, functionColumn, "function");
+    }
+
+    private static bool StartsJavaScriptTypeScriptGenericArrowAssignmentValue(string rhs, int startColumn)
+    {
+        var index = SkipJavaScriptTypeScriptWhitespace(rhs, startColumn);
+        if (IsJavaScriptTypeScriptKeywordAt(rhs, index, "async"))
+            index = SkipJavaScriptTypeScriptWhitespace(rhs, index + "async".Length);
+
+        if (index >= rhs.Length || rhs[index] != '<')
+            return false;
+
+        return StartsJavaScriptTypeScriptGenericArrowAssignmentValue(rhs[index..]);
+    }
+
+    private static bool StartsJavaScriptTypeScriptArrowAssignmentValue(string rhs, int startColumn)
+    {
+        var index = SkipJavaScriptTypeScriptWhitespace(rhs, startColumn);
+        if (IsJavaScriptTypeScriptKeywordAt(rhs, index, "async"))
+            index = SkipJavaScriptTypeScriptWhitespace(rhs, index + "async".Length);
+
+        if (index >= rhs.Length)
+            return false;
+
+        if (rhs[index] == '(')
+        {
+            var parameterListEnd = rhs.IndexOf(')', index + 1);
+            if (parameterListEnd < 0)
+                return false;
+
+            var arrowColumn = SkipJavaScriptTypeScriptWhitespace(rhs, parameterListEnd + 1);
+            return arrowColumn + 1 < rhs.Length
+                && rhs[arrowColumn] == '='
+                && rhs[arrowColumn + 1] == '>';
+        }
+
+        if (!IsJavaScriptTypeScriptIdentifierStart(rhs[index]))
+            return false;
+
+        while (index < rhs.Length && IsJavaScriptTypeScriptIdentifierPart(rhs[index]))
+            index++;
+
+        index = SkipJavaScriptTypeScriptWhitespace(rhs, index);
+        return index + 1 < rhs.Length
+            && rhs[index] == '='
+            && rhs[index + 1] == '>';
+    }
+
+    private static int SkipJavaScriptTypeScriptWhitespace(string text, int index)
+    {
+        while (index < text.Length && char.IsWhiteSpace(text[index]))
+            index++;
+
+        return index;
     }
 
     private static bool StartsJavaScriptTypeScriptArrowFunctionAssignmentValue(string rhs)
@@ -7852,7 +8000,7 @@ public static partial class SymbolExtractor
                             valueStartColumn++;
 
                         if (valueStartColumn < sanitizedLine.Length
-                            && StartsJavaScriptTypeScriptFunctionAssignmentValue(sanitizedLine[valueStartColumn..]))
+                            && StartsJavaScriptTypeScriptFunctionAssignmentValue(sanitizedLine, valueStartColumn))
                         {
                             var propertyName = sanitizedLine[propertyStartColumn..propertyEndColumn];
                             if (seenMethodStarts.Add((i + 1, propertyStartColumn)))

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.cs
@@ -760,14 +760,6 @@ public static partial class SymbolExtractor
         $@"^(?:async\s+)?(?:\([^)]*\)|{JavaScriptTypeScriptIdentifierPattern})\s*=>",
         RegexOptions.Compiled);
 
-    private static readonly Regex JavaScriptTypeScriptExportedObjectLiteralPropertyRegex = new(
-        $@"^\s*(?<name>{JavaScriptTypeScriptIdentifierPattern})\s*:",
-        RegexOptions.Compiled);
-
-    private static readonly Regex JavaScriptTypeScriptExportedObjectLiteralShorthandPropertyRegex = new(
-        $@"^\s*(?<name>{JavaScriptTypeScriptIdentifierPattern})\s*(?:(?=,)|(?=}})|$)",
-        RegexOptions.Compiled);
-
     private static readonly Regex SvelteReactivePropertyRegex = new(
         @"^\s*\$:\s*(?<name>\w+)\s*=",
         RegexOptions.Compiled);

--- a/tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
@@ -6614,7 +6614,8 @@ public partial class SymbolExtractorTests
         // issue #2710/#2711/#2717 regression: full self-indexing could spend minutes
         // repeatedly rebuilding the same multi-line C# member candidate while scanning large
         // extractor sources. Keep this as a broad runaway guard for the realistic file that
-        // reproduced the stall on origin/main.
+        // reproduced the stall on origin/main. This is a coarse guard, not a benchmark, so
+        // leave room for slower or noisy full-suite hosts.
         var path = Path.Combine(GetRepositoryRoot(), "src", "CodeIndex", "Indexer", "References", "ReferenceExtractor.cs");
         var content = File.ReadAllText(path);
 
@@ -6624,7 +6625,7 @@ public partial class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "ReferenceExtractor");
         Assert.Contains(symbols, s => s.Kind == "function" && s.Name == "Extract");
-        var runawayBudget = TimeSpan.FromSeconds(30);
+        var runawayBudget = TimeSpan.FromSeconds(60);
         Assert.True(
             stopwatch.Elapsed < runawayBudget,
             $"ReferenceExtractor.cs extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");


### PR DESCRIPTION
## Summary

- Avoid repeated tail slicing while scanning exported JavaScript/CommonJS object literal property keys.
- Avoid repeated tail slicing in object-literal method detection before checking function-like property values.
- Treat the C# `ReferenceExtractor.cs` fixture performance test as a broad runaway guard for loaded full-suite hosts.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj -p:UseSharedCompilation=false -maxcpucount:1`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false -maxcpucount:1 --framework net8.0`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false -maxcpucount:1 --framework net9.0`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --framework net8.0 --filter "FullyQualifiedName~Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget|FullyQualifiedName~Extract_CSharp_ReferenceExtractorFixture_CompletesWithinPracticalBudget"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --framework net9.0 --filter "FullyQualifiedName~Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget|FullyQualifiedName~Extract_CSharp_ReferenceExtractorFixture_CompletesWithinPracticalBudget"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog

- Updated `TESTING_GUIDE.md` in both English and Japanese sections.
- Added `changelog.d/unreleased/3864.fixed.md`.

## Review

No blocking/actionable issues found.

## Follow-up candidates

None.

Fixes #3864